### PR TITLE
feat: add GitHub → Paperclip sync script

### DIFF
--- a/scripts/sync-issue-to-paperclip.js
+++ b/scripts/sync-issue-to-paperclip.js
@@ -1,0 +1,111 @@
+const https = require('https');
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const PAPERCLIP_API_KEY = process.env.PAPERCLIP_API_KEY;
+const PAPERCLIP_COMPANY_ID = process.env.PAPERCLIP_COMPANY_ID;
+const PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL;
+
+async function makeRequest(url, method, body, headers) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url);
+    const options = {
+      hostname: urlObj.hostname,
+      port: urlObj.port || 443,
+      path: urlObj.pathname + urlObj.search,
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode, data: JSON.parse(data) });
+        } catch {
+          resolve({ status: res.statusCode, data });
+        }
+      });
+    });
+
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function mapPriority(labels) {
+  const priorityLabels = ['critical', 'high', 'medium', 'low'];
+  for (const label of labels) {
+    if (priorityLabels.includes(label.name.toLowerCase())) {
+      return label.name.toLowerCase();
+    }
+  }
+  return 'medium';
+}
+
+function mapLabels(labels) {
+  return labels.map((l) => l.name);
+}
+
+async function createOrUpdatePaperclipIssue(issue) {
+  const payload = {
+    companyId: PAPERCLIP_COMPANY_ID,
+    title: issue.title,
+    description: issue.body || '',
+    priority: mapPriority(issue.labels || []),
+    labels: mapLabels(issue.labels || []),
+  };
+
+  const response = await makeRequest(
+    `${PAPERCLIP_API_URL}/api/issues`,
+    'POST',
+    payload,
+    { Authorization: `Bearer ${PAPERCLIP_API_KEY}` }
+  );
+
+  return response;
+}
+
+async function addCommentToGitHubIssue(issueNumber, body) {
+  const response = await makeRequest(
+    `https://api.github.com/repos/${process.env.GITHUB_REPOSITORY}/issues/${issueNumber}/comments`,
+    'POST',
+    { body },
+    { Authorization: `token ${GITHUB_TOKEN}`, Accept: 'application/vnd.github.v3+json' }
+  );
+
+  return response;
+}
+
+async function main() {
+  const issue = process.env.GITHUB_CONTEXT
+    ? JSON.parse(process.env.GITHUB_CONTEXT).payload?.issue
+    : require('./github.context.json')?.payload?.issue;
+
+  if (!issue) {
+    console.log('No issue data found in payload');
+    process.exit(0);
+  }
+
+  console.log(`Processing issue #${issue.number}: ${issue.title}`);
+
+  try {
+    const pcResponse = await createOrUpdatePaperclipIssue(issue);
+    console.log('Paperclip response:', JSON.stringify(pcResponse.data, null, 2));
+
+    if (pcResponse.data?.id) {
+      const comment = `📋 Synced to Paperclip: [View Issue](${PAPERCLIP_API_URL}/issues/${pcResponse.data.id})`;
+      await addCommentToGitHubIssue(issue.number, comment);
+      console.log('Added Paperclip link comment to GitHub issue');
+    }
+  } catch (error) {
+    console.error('Error syncing to Paperclip:', error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds `scripts/sync-issue-to-paperclip.js` — a Node.js script that syncs GitHub issues to Paperclip.

## What was added

- `scripts/sync-issue-to-paperclip.js` — sync script (111 lines)

## What needs to be added manually

The workflow file needs to be added directly on GitHub (or with a PAT that has `workflow` scope):

**`.github/workflows/sync-to-paperclip.yml`**
```yaml
name: Sync GitHub Issues to Paperclip

on:
  issues:
    types: [opened, closed, labeled]

jobs:
  sync:
    runs-on: ubuntu-latest
    steps:
      - name: Sync issue to Paperclip
        run: node scripts/sync-issue-to-paperclip.js
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          PAPERCLIP_API_KEY: ${{ secrets.PAPERCLIP_API_KEY }}
          PAPERCLIP_COMPANY_ID: ${{ secrets.PAPERCLIP_COMPANY_ID }}
          PAPERCLIP_API_URL: ${{ secrets.PAPERCLIP_API_URL }}
```

**`.github/workflows/add-secrets.md`** — instructions doc for adding secrets.

## Secrets needed (add in GitHub Settings → Secrets):

| Secret | Value |
|--------|-------|
| `PAPERCLIP_API_KEY` | `pcp_0c68806e62d412ce0173c229c526d7152055732c70484ead` |
| `PAPERCLIP_COMPANY_ID` | `83f48c75-de79-4e05-bfa2-1631611b5be7` |
| `PAPERCLIP_API_URL` | `https://surgeon-navigation-grateful-intelligent.trycloudflare.com` |