### PR TITLE
fix(auth): add auth bypass protections to stream and 100ms token endpoints

### DIFF
--- a/src/app/api/100ms/token/route.ts
+++ b/src/app/api/100ms/token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import jwt from 'jsonwebtoken';
+import { logAuditEvent, getClientIp } from '@/lib/db/audit-log';
 
 const TokenSchema = z.object({
   userId: z.string().min(1),
@@ -33,6 +34,16 @@ export async function POST(req: NextRequest) {
     }
 
     const { userId, role, roomId } = parsed.data;
+
+    // Verify requested userId matches session user's FID
+    if (userId !== String(session.fid)) {
+      return NextResponse.json({ error: 'Forbidden: cannot generate token for another user' }, { status: 403 });
+    }
+
+    // Role validation — non-admins cannot request host role
+    if (role === 'host' && !session.isAdmin) {
+      return NextResponse.json({ error: 'Forbidden: only admins can request host role' }, { status: 403 });
+    }
 
     // Generate management token
     const managementToken = jwt.sign(
@@ -93,6 +104,16 @@ export async function POST(req: NextRequest) {
       appSecret,
       { algorithm: 'HS256', expiresIn: '24h', jwtid: crypto.randomUUID() }
     );
+
+    // Audit log token generation
+    logAuditEvent({
+      actorFid: session.fid,
+      action: '100ms.token.generate',
+      targetType: 'user',
+      targetId: userId,
+      details: { userId, role, roomId: hmsRoomId },
+      ipAddress: getClientIp(req),
+    });
 
     return NextResponse.json({ token: appToken, roomId: hmsRoomId });
   } catch (error) {

--- a/src/app/api/stream/token/route.ts
+++ b/src/app/api/stream/token/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { StreamClient } from '@stream-io/node-sdk';
 import { z } from 'zod';
+import { logAuditEvent, getClientIp } from '@/lib/db/audit-log';
 
 const TokenSchema = z.object({
   userId: z.string().min(1),
@@ -29,8 +30,23 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'userId is required' }, { status: 400 });
     }
 
+    // Verify requested userId matches session user's FID
+    if (parsed.data.userId !== String(session.fid)) {
+      return NextResponse.json({ error: 'Forbidden: cannot generate token for another user' }, { status: 403 });
+    }
+
     const client = new StreamClient(apiKey, apiSecret);
     const token = client.generateUserToken({ user_id: parsed.data.userId });
+
+    // Audit log token generation
+    logAuditEvent({
+      actorFid: session.fid,
+      action: 'stream.token.generate',
+      targetType: 'user',
+      targetId: parsed.data.userId,
+      details: { userId: parsed.data.userId },
+      ipAddress: getClientIp(req),
+    });
 
     return NextResponse.json({ token });
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes CRITICAL auth bypass vulnerabilities in `/api/stream/token` and `/api/100ms/token`.

## Changes

### Issue #36 — /api/stream/token
- ✅ Already had session check
- ✅ Added **userId verification** — rejects if `userId !== String(session.fid)` (403 Forbidden)
- ✅ Rate limiting already covered by middleware
- ✅ Added **audit logging** (`stream.token.generate`)

### Issue #37 — /api/100ms/token
- ✅ Already had session check
- ✅ Added **userId verification** — rejects if `userId !== String(session.fid)` (403 Forbidden)
- ✅ Added **role validation** — rejects if `role === "host" && !session.isAdmin` (403 Forbidden)
- ✅ Added **audit logging** (`100ms.token.generate`)

## Security

- Session auth required on both endpoints
- Users can only generate tokens for their own FID
- 100ms host role elevation blocked for non-admins
- Audit trail added for token generation events

Closes #36
Closes #37