### PR TITLE
fix: GitHub-to-Paperclip sync handles close/reopen/label events

### DIFF
--- a/scripts/sync-issue-to-paperclip.js
+++ b/scripts/sync-issue-to-paperclip.js
@@ -1,4 +1,5 @@
 const https = require('https');
+const fs = require('fs');
 
 // GitHub Actions provides these via the @actions/github context
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -8,34 +9,28 @@ const PAPERCLIP_API_URL = process.env.PAPERCLIP_API_URL || 'https://paperclip.za
 
 // GitHub Actions injects GITHUB_EVENT_PATH which contains the webhook payload
 const eventPath = process.env.GITHUB_EVENT_PATH;
-const eventName = process.env.GITHUB_EVENT_NAME;
 
-let issueData;
-
-if (eventPath) {
-  const fs = require('fs');
-  issueData = JSON.parse(fs.readFileSync(eventPath, 'utf8')).issue;
-} else {
+if (!eventPath) {
   console.error('GITHUB_EVENT_PATH not set — cannot get issue data');
   process.exit(1);
 }
 
-const issue = issueData;
-const action = process.env.GITHUB_ACTION_PATH ? 'unknown' : eventName;
+const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+const issue = event.issue;
+const action = event.action; // "opened", "closed", "labeled", "reopened", etc.
 
-async function makeRequest(url, method, body, headers = {}) {
+async function makeRequest(url, method, body) {
   return new Promise((resolve, reject) => {
     const urlObj = new URL(url);
     const options = {
       hostname: urlObj.hostname,
       port: urlObj.port || 443,
       path: urlObj.pathname + urlObj.search,
-      method: method,
+      method,
       headers: {
         'Authorization': `Bearer ${PAPERCLIP_API_KEY}`,
         'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        ...headers
+        'Accept': 'application/json'
       }
     };
 
@@ -44,9 +39,9 @@ async function makeRequest(url, method, body, headers = {}) {
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
         try {
-          resolve(JSON.parse(data));
+          resolve({ status: res.statusCode, body: JSON.parse(data) });
         } catch {
-          resolve(data);
+          resolve({ status: res.statusCode, body: data });
         }
       });
     });
@@ -66,55 +61,27 @@ function mapPriority(labels) {
   return 'medium';
 }
 
-function mapStatus(action) {
-  // action is from GITHUB_EVENT_NAME: issues, pull_request, etc.
-  // We care about the issue action type
-  if (issue.action === 'opened') return 'in_progress';
-  if (issue.action === 'closed') return 'done';
-  return null; // no status change for other events
+function buildDescription(issue) {
+  return `${issue.body || ''}\n\n---\n**Source:** GitHub Issue #${issue.number}\n**Labels:** ${issue.labels.map(l => l.name).join(', ') || 'none'}\n**Author:** ${issue.user.login}\n**URL:** ${issue.html_url}`;
 }
 
-async function syncIssue() {
-  const issueId = issue.id;
-  const issueNumber = issue.number;
-  const title = `[GitHub #${issueNumber}] ${issue.title}`;
-  const description = `${issue.body || ''}\n\n---\n**Source:** GitHub Issue #${issueNumber}\n**Labels:** ${issue.labels.map(l => l.name).join(', ') || 'none'}\n**Author:** ${issue.user.login}\n**URL:** ${issue.html_url}`;
-  const priority = mapPriority(issue.labels);
-  const paperclipStatus = mapStatus(issue.action);
-  const labelNames = issue.labels.map(l => l.name);
+async function findPaperclipIssue(githubNumber) {
+  // Search Paperclip issues for one whose title contains "[GitHub #XX]"
+  const searchTitle = `[GitHub #${githubNumber}]`;
+  const url = `${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues?q=${encodeURIComponent(searchTitle)}`;
+  const result = await makeRequest(url, 'GET');
 
-  console.log(`Syncing GitHub Issue #${issueNumber}: ${issue.title}`);
-  console.log(`  Action: ${issue.action}`);
-  console.log(`  Priority: ${priority}`);
-  console.log(`  Paperclip Status: ${paperclipStatus}`);
-
-  try {
-    // Try to create the issue
-    const result = await makeRequest(
-      `${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues`,
-      'POST',
-      {
-        title,
-        description,
-        priority,
-        status: 'todo',
-        labels: labelNames
-      }
-    );
-
-    if (result && result.id) {
-      console.log(`Created Paperclip issue: ${result.identifier} (${result.id})`);
-      console.log(`View at: ${PAPERCLIP_API_URL}/THE/dashboard`);
-
-      // Add a comment back to GitHub
-      await addGitHubComment(issueNumber, `Synced to Paperclip: ${result.identifier}`);
-    } else {
-      console.log('Paperclip API response:', result);
+  if (result.status !== 200 || !Array.isArray(result.body)) {
+    // Fallback: list all non-done issues and filter manually
+    const fallbackUrl = `${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues?status=todo,in_progress,blocked,backlog`;
+    const fallback = await makeRequest(fallbackUrl, 'GET');
+    if (fallback.status === 200 && Array.isArray(fallback.body)) {
+      return fallback.body.find(i => i.title.includes(searchTitle));
     }
-  } catch (error) {
-    console.error('Error syncing to Paperclip:', error.message);
-    process.exit(1);
+    return null;
   }
+
+  return result.body.find(i => i.title.includes(searchTitle));
 }
 
 async function addGitHubComment(issueNumber, body) {
@@ -134,24 +101,99 @@ async function addGitHubComment(issueNumber, body) {
     }
   };
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const req = https.request(options, (res) => {
       let data = '';
       res.on('data', chunk => data += chunk);
       res.on('end', () => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           console.log('Added comment to GitHub issue');
-          resolve();
         } else {
           console.log('Comment failed:', res.statusCode, data.substring(0, 200));
-          resolve(); // Don't fail the whole workflow for a comment
         }
+        resolve(); // Don't fail the whole workflow for a comment
       });
     });
-    req.on('error', reject);
+    req.on('error', () => resolve());
     req.write(JSON.stringify({ body }));
     req.end();
   });
+}
+
+async function syncIssue() {
+  const issueNumber = issue.number;
+  const title = `[GitHub #${issueNumber}] ${issue.title}`;
+  const description = buildDescription(issue);
+  const priority = mapPriority(issue.labels);
+  const labelNames = issue.labels.map(l => l.name);
+
+  console.log(`Syncing GitHub Issue #${issueNumber}: ${issue.title}`);
+  console.log(`  Action: ${action}`);
+  console.log(`  Priority: ${priority}`);
+
+  if (action === 'closed') {
+    // Find existing Paperclip issue and close it
+    console.log(`  Looking up Paperclip issue for GitHub #${issueNumber}...`);
+    const existing = await findPaperclipIssue(issueNumber);
+
+    if (existing) {
+      console.log(`  Found ${existing.identifier} (${existing.id}) — closing...`);
+      const result = await makeRequest(
+        `${PAPERCLIP_API_URL}/api/issues/${existing.id}`,
+        'PATCH',
+        { status: 'done', comment: `Closed via GitHub issue #${issueNumber} close event.` }
+      );
+      if (result.status === 200) {
+        console.log(`  Closed ${existing.identifier}`);
+        await addGitHubComment(issueNumber, `Paperclip issue ${existing.identifier} closed.`);
+      } else {
+        console.log(`  Failed to close: HTTP ${result.status}`, result.body);
+      }
+    } else {
+      console.log(`  No matching Paperclip issue found for GitHub #${issueNumber} — nothing to close.`);
+    }
+    return;
+  }
+
+  if (action === 'opened' || action === 'reopened') {
+    // Create new Paperclip issue
+    const result = await makeRequest(
+      `${PAPERCLIP_API_URL}/api/companies/${PAPERCLIP_COMPANY_ID}/issues`,
+      'POST',
+      { title, description, priority, status: 'todo', labels: labelNames }
+    );
+
+    if (result.status >= 200 && result.status < 300 && result.body && result.body.id) {
+      console.log(`Created Paperclip issue: ${result.body.identifier} (${result.body.id})`);
+      await addGitHubComment(issueNumber, `Synced to Paperclip: ${result.body.identifier}`);
+    } else {
+      console.log('Paperclip API response:', result.status, result.body);
+    }
+    return;
+  }
+
+  if (action === 'labeled') {
+    // Update priority on existing Paperclip issue if it exists
+    const existing = await findPaperclipIssue(issueNumber);
+    if (existing) {
+      console.log(`  Found ${existing.identifier} — updating priority to ${priority}...`);
+      const result = await makeRequest(
+        `${PAPERCLIP_API_URL}/api/issues/${existing.id}`,
+        'PATCH',
+        { priority }
+      );
+      if (result.status === 200) {
+        console.log(`  Updated ${existing.identifier} priority to ${priority}`);
+      } else {
+        console.log(`  Failed to update: HTTP ${result.status}`, result.body);
+      }
+    } else {
+      console.log(`  No matching Paperclip issue for GitHub #${issueNumber} — skipping label update.`);
+    }
+    return;
+  }
+
+  console.log(`  Unhandled action "${action}" — skipping.`);
 }
 
 syncIssue().catch(err => {


### PR DESCRIPTION
## Summary
- Fix sync script to handle `closed` events by finding the existing Paperclip issue (via title search) and PATCHing it to `done`
- Handle `reopened` events by creating a new Paperclip issue
- Handle `labeled` events by updating priority on existing Paperclip issues
- Fix `action` detection: read `event.action` from webhook payload instead of `GITHUB_EVENT_NAME`

## What was broken
The old script called `POST /api/companies/{id}/issues` (create) on every event — including close events. This meant closing a GitHub issue either created a duplicate in Paperclip or failed silently, leaving 28+ stale open issues.

## Test plan
- [ ] Close a test GitHub issue → verify Paperclip issue transitions to `done`
- [ ] Open a new GitHub issue → verify Paperclip issue created with `todo` status
- [ ] Add a `critical` label to an existing issue → verify Paperclip priority updates
- [ ] Check workflow runs succeed in Actions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)