### PR TITLE
feat: add @zao/plugin-farcaster-notifications

### DIFF
--- a/plugins/zao-plugin-farcaster-notifications/package.json
+++ b/plugins/zao-plugin-farcaster-notifications/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@zao/plugin-farcaster-notifications",
+  "version": "0.1.0",
+  "description": "Paperclip plugin for bidirectional Farcaster integration via Neynar API",
+  "type": "module",
+  "main": "./dist/index.js",
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch"
+  },
+  "peerDependencies": {
+    "@paperclipai/plugin-sdk": "*",
+    "@paperclipai/shared": "*"
+  },
+  "devDependencies": {
+    "@paperclipai/plugin-sdk": "^2026.318.0",
+    "@paperclipai/shared": "^2026.318.0",
+    "@types/node": "^25.5.0",
+    "typescript": "^5.7.0"
+  },
+  "files": [
+    "dist/"
+  ]
+}

--- a/plugins/zao-plugin-farcaster-notifications/src/manifest.ts
+++ b/plugins/zao-plugin-farcaster-notifications/src/manifest.ts
@@ -1,0 +1,163 @@
+const manifest = {
+  id: "zao.farcaster-notifications",
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "ZAO Farcaster Notifications",
+  description:
+    "Bidirectional Farcaster integration for Paperclip agents — search, read, and post casts via Neynar API.",
+  author: "ZAO <team@zaoos.com>",
+  categories: ["automation"] as const,
+
+  capabilities: ["agent.tools.register", "http.outbound"],
+
+  entrypoints: {
+    worker: "./dist/worker.js",
+  },
+
+  instanceConfigSchema: {
+    type: "object" as const,
+    properties: {
+      neynarApiKey: {
+        type: "string" as const,
+        description: "Neynar API key",
+      },
+      signerUuid: {
+        type: "string" as const,
+        description: "Neynar managed signer UUID for posting",
+      },
+      defaultChannelId: {
+        type: "string" as const,
+        description: "Default channel to post to (e.g. zaos)",
+      },
+    },
+    required: ["neynarApiKey"],
+  },
+
+  tools: [
+    {
+      name: "search-farcaster-casts",
+      displayName: "Search Farcaster Casts",
+      description:
+        "Search recent Farcaster casts by keyword, channel, or user FID via Neynar API.",
+      parametersSchema: {
+        type: "object" as const,
+        properties: {
+          query: {
+            type: "string" as const,
+            description: "Search query (keywords or phrase)",
+          },
+          channelId: {
+            type: "string" as const,
+            description: "Filter by channel ID (e.g. zaos)",
+          },
+          authorFid: {
+            type: "number" as const,
+            description: "Filter by author FID",
+          },
+          limit: {
+            type: "number" as const,
+            description: "Max results to return (default 10, max 25)",
+          },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "get-farcaster-cast",
+      displayName: "Get Farcaster Cast",
+      description: "Fetch a single Farcaster cast by its hash.",
+      parametersSchema: {
+        type: "object" as const,
+        properties: {
+          hash: {
+            type: "string" as const,
+            description: "Cast hash (0x-prefixed)",
+          },
+        },
+        required: ["hash"],
+      },
+    },
+    {
+      name: "watch-farcaster-channel",
+      displayName: "Watch Farcaster Channel",
+      description:
+        "Fetch the latest casts from a Farcaster channel. Returns recent activity to surface to the agent.",
+      parametersSchema: {
+        type: "object" as const,
+        properties: {
+          channelId: {
+            type: "string" as const,
+            description: "Channel ID to watch (e.g. zaos, music)",
+          },
+          limit: {
+            type: "number" as const,
+            description: "Number of recent casts to return (default 10, max 25)",
+          },
+        },
+        required: ["channelId"],
+      },
+    },
+    {
+      name: "post-farcaster-cast",
+      displayName: "Post Farcaster Cast",
+      description:
+        "Post a new cast to Farcaster via Neynar. Requires signer UUID in plugin config.",
+      parametersSchema: {
+        type: "object" as const,
+        properties: {
+          text: {
+            type: "string" as const,
+            description: "Cast text content (max 320 characters)",
+          },
+          channelId: {
+            type: "string" as const,
+            description:
+              "Channel to post in. Falls back to defaultChannelId from config.",
+          },
+          embeds: {
+            type: "array" as const,
+            items: {
+              type: "object" as const,
+              properties: {
+                url: { type: "string" as const },
+              },
+            },
+            description: "Optional URL embeds",
+          },
+        },
+        required: ["text"],
+      },
+    },
+    {
+      name: "reply-farcaster-cast",
+      displayName: "Reply to Farcaster Cast",
+      description: "Reply to an existing Farcaster cast. Requires signer UUID in plugin config.",
+      parametersSchema: {
+        type: "object" as const,
+        properties: {
+          parentHash: {
+            type: "string" as const,
+            description: "Hash of the cast to reply to (0x-prefixed)",
+          },
+          text: {
+            type: "string" as const,
+            description: "Reply text content (max 320 characters)",
+          },
+          embeds: {
+            type: "array" as const,
+            items: {
+              type: "object" as const,
+              properties: {
+                url: { type: "string" as const },
+              },
+            },
+            description: "Optional URL embeds",
+          },
+        },
+        required: ["parentHash", "text"],
+      },
+    },
+  ],
+};
+
+export default manifest;

--- a/plugins/zao-plugin-farcaster-notifications/src/worker.ts
+++ b/plugins/zao-plugin-farcaster-notifications/src/worker.ts
@@ -1,0 +1,303 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import manifest from "./manifest.js";
+
+const NEYNAR_BASE = "https://api.neynar.com/v2/farcaster";
+
+interface PluginConfig {
+  neynarApiKey: string;
+  signerUuid?: string;
+  defaultChannelId?: string;
+}
+
+interface NeynarCast {
+  hash: string;
+  author: { fid: number; username: string; display_name: string };
+  text: string;
+  timestamp: string;
+  reactions: { likes_count: number; recasts_count: number };
+  replies: { count: number };
+  channel?: { id: string; name: string };
+  embeds?: Array<{ url?: string }>;
+}
+
+let config: PluginConfig = { neynarApiKey: "" };
+
+function toolMeta(name: string) {
+  const tool = manifest.tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Unknown tool: ${name}`);
+  return {
+    displayName: tool.displayName,
+    description: tool.description,
+    parametersSchema: tool.parametersSchema,
+  };
+}
+
+async function neynarGet(
+  path: string,
+  params: Record<string, string>,
+): Promise<unknown> {
+  const url = new URL(`${NEYNAR_BASE}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v) url.searchParams.set(k, v);
+  }
+  const res = await fetch(url.toString(), {
+    headers: {
+      accept: "application/json",
+      "x-api-key": config.neynarApiKey,
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Neynar API error ${res.status}: ${body}`);
+  }
+  return res.json();
+}
+
+async function neynarPost(
+  path: string,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await fetch(`${NEYNAR_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "x-api-key": config.neynarApiKey,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Neynar API error ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function formatCast(cast: NeynarCast): string {
+  const channel = cast.channel ? ` in /${cast.channel.id}` : "";
+  return [
+    `**@${cast.author.username}**${channel} — ${cast.timestamp}`,
+    cast.text,
+    `> likes: ${cast.reactions.likes_count}  recasts: ${cast.reactions.recasts_count}  replies: ${cast.replies.count}  |  \`${cast.hash.slice(0, 10)}\``,
+  ].join("\n");
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    const rawConfig = (await ctx.config.get()) as Record<string, unknown>;
+    if (typeof rawConfig.neynarApiKey !== "string" || !rawConfig.neynarApiKey) {
+      ctx.logger.error("neynarApiKey is required in plugin config");
+      return;
+    }
+    config = {
+      neynarApiKey: rawConfig.neynarApiKey,
+      signerUuid:
+        typeof rawConfig.signerUuid === "string"
+          ? rawConfig.signerUuid
+          : undefined,
+      defaultChannelId:
+        typeof rawConfig.defaultChannelId === "string"
+          ? rawConfig.defaultChannelId
+          : undefined,
+    };
+
+    // --- Inbound tools ---
+
+    ctx.tools.register(
+      "search-farcaster-casts",
+      toolMeta("search-farcaster-casts"),
+      async (raw: unknown) => {
+        const params = raw as {
+          query: string;
+          channelId?: string;
+          authorFid?: number;
+          limit?: number;
+        };
+        const limit = Math.min(params.limit ?? 10, 25);
+
+        const queryParams: Record<string, string> = {
+          q: params.query,
+          limit: String(limit),
+        };
+        if (params.channelId) queryParams.channel_id = params.channelId;
+        if (params.authorFid)
+          queryParams.author_fid = String(params.authorFid);
+
+        const data = (await neynarGet("/cast/search", queryParams)) as {
+          result: { casts: NeynarCast[] };
+        };
+        const casts = data.result.casts;
+
+        if (casts.length === 0) {
+          return { content: `No casts found for "${params.query}".` };
+        }
+
+        return {
+          content: `Found ${casts.length} cast(s):\n\n${casts.map(formatCast).join("\n\n---\n\n")}`,
+          data: {
+            count: casts.length,
+            casts: casts.map((c) => ({
+              hash: c.hash,
+              author: c.author.username,
+              fid: c.author.fid,
+              text: c.text.slice(0, 200),
+              timestamp: c.timestamp,
+            })),
+          },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "get-farcaster-cast",
+      toolMeta("get-farcaster-cast"),
+      async (raw: unknown) => {
+        const params = raw as { hash: string };
+        const data = (await neynarGet("/cast", {
+          identifier: params.hash,
+          type: "hash",
+        })) as { cast: NeynarCast };
+        const cast = data.cast;
+
+        return {
+          content: formatCast(cast),
+          data: {
+            hash: cast.hash,
+            author: cast.author.username,
+            fid: cast.author.fid,
+            text: cast.text,
+            timestamp: cast.timestamp,
+            likes: cast.reactions.likes_count,
+            recasts: cast.reactions.recasts_count,
+            replies: cast.replies.count,
+          },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "watch-farcaster-channel",
+      toolMeta("watch-farcaster-channel"),
+      async (raw: unknown) => {
+        const params = raw as { channelId: string; limit?: number };
+        const limit = Math.min(params.limit ?? 10, 25);
+
+        const data = (await neynarGet("/feed/channels", {
+          channel_ids: params.channelId,
+          limit: String(limit),
+          with_recasts: "false",
+        })) as { casts: NeynarCast[] };
+        const casts = data.casts;
+
+        if (!casts || casts.length === 0) {
+          return {
+            content: `No recent casts in /${params.channelId}.`,
+          };
+        }
+
+        return {
+          content: `Latest ${casts.length} cast(s) in /${params.channelId}:\n\n${casts.map(formatCast).join("\n\n---\n\n")}`,
+          data: {
+            channelId: params.channelId,
+            count: casts.length,
+            casts: casts.map((c) => ({
+              hash: c.hash,
+              author: c.author.username,
+              fid: c.author.fid,
+              text: c.text.slice(0, 200),
+              timestamp: c.timestamp,
+            })),
+          },
+        };
+      },
+    );
+
+    // --- Outbound tools ---
+
+    ctx.tools.register(
+      "post-farcaster-cast",
+      toolMeta("post-farcaster-cast"),
+      async (raw: unknown) => {
+        const params = raw as {
+          text: string;
+          channelId?: string;
+          embeds?: Array<{ url?: string }>;
+        };
+        if (!config.signerUuid) {
+          return {
+            content:
+              "Cannot post: signerUuid is not configured. Add it to the plugin instance config.",
+          };
+        }
+
+        if (params.text.length > 320) {
+          return {
+            content: `Cast text too long (${params.text.length}/320 chars). Shorten the text.`,
+          };
+        }
+
+        const channelId = params.channelId ?? config.defaultChannelId;
+
+        const body: Record<string, unknown> = {
+          signer_uuid: config.signerUuid,
+          text: params.text,
+        };
+        if (channelId) body.channel_id = channelId;
+        if (params.embeds?.length) body.embeds = params.embeds;
+
+        const data = (await neynarPost("/cast", body)) as {
+          cast: NeynarCast;
+        };
+
+        return {
+          content: `Cast posted successfully${channelId ? ` in /${channelId}` : ""}.\nHash: \`${data.cast.hash}\``,
+          data: { hash: data.cast.hash },
+        };
+      },
+    );
+
+    ctx.tools.register(
+      "reply-farcaster-cast",
+      toolMeta("reply-farcaster-cast"),
+      async (raw: unknown) => {
+        const params = raw as {
+          parentHash: string;
+          text: string;
+          embeds?: Array<{ url?: string }>;
+        };
+        if (!config.signerUuid) {
+          return {
+            content:
+              "Cannot reply: signerUuid is not configured. Add it to the plugin instance config.",
+          };
+        }
+
+        if (params.text.length > 320) {
+          return {
+            content: `Reply text too long (${params.text.length}/320 chars). Shorten the text.`,
+          };
+        }
+
+        const body: Record<string, unknown> = {
+          signer_uuid: config.signerUuid,
+          text: params.text,
+          parent: params.parentHash,
+        };
+        if (params.embeds?.length) body.embeds = params.embeds;
+
+        const data = (await neynarPost("/cast", body)) as {
+          cast: NeynarCast;
+        };
+
+        return {
+          content: `Reply posted successfully.\nHash: \`${data.cast.hash}\``,
+          data: { hash: data.cast.hash, parentHash: params.parentHash },
+        };
+      },
+    );
+
+    ctx.logger.info("ZAO Farcaster Notifications plugin loaded");
+  },
+});
+
+runWorker(plugin, import.meta.url);

--- a/plugins/zao-plugin-farcaster-notifications/tsconfig.json
+++ b/plugins/zao-plugin-farcaster-notifications/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds `@zao/plugin-farcaster-notifications` Paperclip plugin with 5 tools for bidirectional Farcaster integration via Neynar v2 API
- **Inbound:** `search-farcaster-casts`, `get-farcaster-cast`, `watch-farcaster-channel`
- **Outbound:** `post-farcaster-cast`, `reply-farcaster-cast`
- Configurable via `neynarApiKey`, `signerUuid`, and `defaultChannelId`

Closes #53

## Test plan

- [ ] `npm run build` in `plugins/zao-plugin-farcaster-notifications/` compiles cleanly
- [ ] Install plugin via Paperclip skill scan and verify tools appear
- [ ] Test search/get/watch tools with real Neynar API key
- [ ] Test post/reply tools with valid signer UUID
- [ ] Verify API key is never exposed in tool responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)