### PR TITLE
fix: audio background playback

### DIFF
--- a/src/components/music/EqualizerPanel.tsx
+++ b/src/components/music/EqualizerPanel.tsx
@@ -17,6 +17,7 @@ export default function EqualizerPanel() {
   const handleGainChange = useCallback((index: number, value: number) => {
     const eq = getEqualizer()
     eq.setGain(index, value)
+    eq.connectIfActive()
     setGains(eq.getGains())
     setActivePreset(null)
   }, [])
@@ -24,6 +25,7 @@ export default function EqualizerPanel() {
   const handlePreset = useCallback((name: string) => {
     const eq = getEqualizer()
     eq.applyPreset(name)
+    eq.connectIfActive()
     setGains(eq.getGains())
     setActivePreset(name)
   }, [])

--- a/src/lib/music/equalizer.ts
+++ b/src/lib/music/equalizer.ts
@@ -20,9 +20,26 @@ export class AudioEqualizer {
   private connectedSources = new Map<HTMLAudioElement, MediaElementAudioSourceNode>()
   private activeElement: HTMLAudioElement | null = null
   private gains: number[] = [0, 0, 0, 0, 0]
+  private visibilityHandler: (() => void) | null = null
 
   constructor() {
     this.loadSettings()
+  }
+
+  /** Returns true if any EQ band is non-zero (not flat) */
+  isActive(): boolean {
+    return this.gains.some(g => g !== 0)
+  }
+
+  /** Connect to the currently playing audio element (called when EQ settings change) */
+  connectIfActive() {
+    if (this.isActive() && !this.activeElement) {
+      // Look for the active audio element via the global refs set by HTMLAudioProvider
+      const audioA = (globalThis as Record<string, unknown>).__zao_audio_a as HTMLAudioElement | undefined
+      const audioB = (globalThis as Record<string, unknown>).__zao_audio_b as HTMLAudioElement | undefined
+      const active = audioA && !audioA.paused ? audioA : audioB && !audioB.paused ? audioB : null
+      if (active) this.connect(active)
+    }
   }
 
   private ensureContext() {
@@ -44,6 +61,14 @@ export class AudioEqualizer {
         this.filters[i].connect(this.filters[i + 1])
       }
       this.filters[this.filters.length - 1].connect(this.context.destination)
+
+      // Resume AudioContext when returning to the app — browsers suspend it in background
+      this.visibilityHandler = () => {
+        if (!document.hidden && this.context?.state === 'suspended') {
+          this.context.resume().catch(() => {})
+        }
+      }
+      document.addEventListener('visibilitychange', this.visibilityHandler)
     }
   }
 
@@ -115,7 +140,18 @@ export class AudioEqualizer {
     } catch {}
   }
 
+  /** Resume the AudioContext — call on user interaction or visibility change */
+  resume() {
+    if (this.context?.state === 'suspended') {
+      this.context.resume().catch(() => {})
+    }
+  }
+
   destroy() {
+    if (this.visibilityHandler) {
+      document.removeEventListener('visibilitychange', this.visibilityHandler)
+      this.visibilityHandler = null
+    }
     this.connectedSources.forEach((source) => {
       try { source.disconnect() } catch {}
     })

--- a/src/providers/audio/HTMLAudioProvider.test.tsx
+++ b/src/providers/audio/HTMLAudioProvider.test.tsx
@@ -59,6 +59,8 @@ vi.stubGlobal('Audio', vi.fn(() => stableMockAudio));
 vi.mock('@/lib/music/equalizer', () => ({
   getEqualizer: () => ({
     connect: vi.fn(),
+    isActive: () => false,
+    resume: vi.fn(),
   }),
 }));
 

--- a/src/providers/audio/HTMLAudioProvider.tsx
+++ b/src/providers/audio/HTMLAudioProvider.tsx
@@ -16,8 +16,10 @@ export function HTMLAudioProvider({ children }: { children: ReactNode }) {
   // Refs to avoid stale closures in the main useEffect
   const crossfadeRef = useRef(state.crossfade);
   const volumeRef = useRef(state.volume);
+  const statusRef = useRef(state.status);
   crossfadeRef.current = state.crossfade;
   volumeRef.current = state.volume;
+  statusRef.current = state.status;
 
   const getActive = () => (activeAudioRef.current === 'A' ? audioA : audioB)!;
   const getInactive = () => (activeAudioRef.current === 'A' ? audioB : audioA)!;
@@ -137,8 +139,12 @@ export function HTMLAudioProvider({ children }: { children: ReactNode }) {
           activeAudioRef.current = activeAudioRef.current === 'A' ? 'B' : 'A';
           activeUrlRef.current = url;
 
-          // Connect EQ to the new active element
-          try { getEqualizer().connect(inactive); } catch {}
+          // Only route through EQ if user has non-flat settings — avoids AudioContext
+          // capturing audio output, which breaks background playback
+          const eq = getEqualizer();
+          if (eq.isActive()) {
+            try { eq.connect(inactive); } catch {}
+          }
 
           // Fade: ramp new up, old down
           performCrossfade(crossfadeSec);
@@ -153,8 +159,12 @@ export function HTMLAudioProvider({ children }: { children: ReactNode }) {
         active.src = url;
         active.volume = volumeRef.current;
         active.load();
-        // Connect EQ to the active element
-        try { getEqualizer().connect(active); } catch {}
+        // Only route through EQ if user has non-flat settings — avoids AudioContext
+        // capturing audio output, which breaks background playback
+        const eq = getEqualizer();
+        if (eq.isActive()) {
+          try { eq.connect(active); } catch {}
+        }
         active.play().then(() => {
           console.log('[Audio] Play started, volume:', active.volume, 'paused:', active.paused);
         }).catch((err) => {
@@ -227,6 +237,25 @@ export function HTMLAudioProvider({ children }: { children: ReactNode }) {
       crossfadeTimerRef.current = null;
     }
   }
+
+  // Resume AudioContext and audio playback when returning from background
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.hidden) return;
+      // Resume AudioContext if EQ captured the audio output
+      const eq = getEqualizer();
+      eq.resume();
+
+      // On some mobile browsers, the audio element gets paused when backgrounded
+      // even though MediaSession is set up. Re-trigger play if state says "playing".
+      const active = getActive();
+      if (active && active.src && active.paused && statusRef.current === 'playing') {
+        active.play().catch(() => {});
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // React to new audio/soundxyz tracks
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Audio was going silent when switching tabs or backgrounding the app because the equalizer eagerly routed all audio through a Web Audio API AudioContext via `createMediaElementSource()` — browsers suspend AudioContexts in background tabs
- EQ connection is now lazy: only routes through AudioContext when the user has non-flat EQ settings
- Added `visibilitychange` handler to resume AudioContext and re-trigger audio playback when returning to the app
- EqualizerPanel now connects audio on-demand when EQ settings first change

## Test plan
- [x] All 364 Vitest tests pass (0 failures)
- [x] Type check passes (tsc --noEmit)
- [ ] Manual: play audio, switch tabs, confirm audio continues
- [ ] Manual: play audio, adjust EQ, switch tabs, confirm audio resumes on return
- [ ] Manual: test on iOS Safari PWA

🤖 Generated with [Claude Code](https://claude.com/claude-code)