### PR TITLE
fix: community page build timeout

### DIFF
--- a/src/app/(auth)/community/page.tsx
+++ b/src/app/(auth)/community/page.tsx
@@ -22,6 +22,7 @@ export const metadata: Metadata = {
   other: { 'fc:miniapp': miniAppEmbed },
 };
 
+export const dynamic = 'force-dynamic';
 export const revalidate = 300;
 
 async function fetchCommunityMembers() {


### PR DESCRIPTION
## Summary
- Adds `force-dynamic` to `/community` page to prevent Vercel build timeout
- Static generation was failing (3x 60s timeout) trying to reach Supabase at build time

## Test plan
- [ ] Vercel build passes without community page timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)