### PR TITLE
feat: ZAO Stock team dashboard + meeting agenda

### DIFF
--- a/docs/superpowers/plans/2026-04-10-zaostock-team-dashboard.md
+++ b/docs/superpowers/plans/2026-04-10-zaostock-team-dashboard.md
@@ -1,0 +1,1221 @@
+# ZAO Stock Team Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a password-gated team dashboard at `/stock/team` where the ZAO Stock crew can track goals, todos, and roles - plus clean up the public `/stock` page.
+
+**Architecture:** Separate iron-session cookie for stock team auth (doesn't interfere with main app auth). Three Supabase tables (team members, goals, todos). Server components for the page shell, client components for interactive pieces. All API routes under `/api/stock/team/`.
+
+**Tech Stack:** Next.js App Router, iron-session, Supabase (direct queries), Zod, bcrypt (via Web Crypto API - no new deps), Tailwind CSS v4
+
+---
+
+## File Structure
+
+**Create:**
+- `supabase/migrations/20260410_stock_team_dashboard.sql` - 3 tables + seed data
+- `src/lib/auth/stock-team-session.ts` - iron-session config for stock team
+- `src/app/api/stock/team/login/route.ts` - POST login
+- `src/app/api/stock/team/logout/route.ts` - POST logout
+- `src/app/api/stock/team/members/route.ts` - GET members
+- `src/app/api/stock/team/goals/route.ts` - GET + PATCH goals
+- `src/app/api/stock/team/todos/route.ts` - GET + POST + PATCH todos
+- `src/app/stock/team/page.tsx` - server component, checks session, shows login or dashboard
+- `src/app/stock/team/LoginForm.tsx` - client component, password form
+- `src/app/stock/team/Dashboard.tsx` - client component, main dashboard
+- `src/app/stock/team/GoalsBoard.tsx` - client component, goals status board
+- `src/app/stock/team/TodoList.tsx` - client component, todo list with CRUD
+- `src/app/stock/team/TeamRoles.tsx` - client component, team + roles display
+- `scripts/seed-stock-team.ts` - seed team members with passwords
+
+**Modify:**
+- `src/app/stock/page.tsx` - remove artist placeholder grid
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/20260410_stock_team_dashboard.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Stock Team Dashboard tables
+-- 3 tables: team members, goals, todos
+
+-- Team members (password auth, not Farcaster)
+CREATE TABLE IF NOT EXISTS stock_team_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT '',
+  scope TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Goals / milestones with status tracking
+CREATE TABLE IF NOT EXISTS stock_goals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'tbd' CHECK (status IN ('locked', 'wip', 'tbd')),
+  details TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL DEFAULT 'general' CHECK (category IN ('venue', 'funding', 'artists', 'production', 'logistics', 'marketing', 'general')),
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Todos with ownership and notes
+CREATE TABLE IF NOT EXISTS stock_todos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  owner_id UUID REFERENCES stock_team_members(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'todo' CHECK (status IN ('todo', 'in_progress', 'done')),
+  notes TEXT DEFAULT '',
+  created_by UUID REFERENCES stock_team_members(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed goals from the confirmed planning docs
+INSERT INTO stock_goals (title, status, details, category, sort_order) VALUES
+  ('Date confirmed', 'locked', 'October 3, 2026', 'venue', 1),
+  ('Official status', 'locked', 'Part of Art of Ellsworth: Maine Craft Weekend (9th annual, statewide promo)', 'venue', 2),
+  ('Venue', 'wip', 'Franklin Street Parklet, rented from Heart of Ellsworth', 'venue', 3),
+  ('Weather backup', 'tbd', 'Wallace Events tent rental - not yet contacted', 'logistics', 4),
+  ('Steve Peer', 'tbd', 'Local music anchor (37 years in Ellsworth, 430 house concerts) - not yet pitched for co-curation', 'artists', 5),
+  ('Funding path', 'tbd', 'New Media Commons / Fractured Atlas 501c3 fiscal sponsorship. Tax-deductible donations. Need to identify specific grant/sponsor targets.', 'funding', 6),
+  ('Budget', 'tbd', 'Goal $25K, minimum viable $5K. No money committed yet.', 'funding', 7),
+  ('Sound / PA vendor', 'tbd', 'Need local Ellsworth/Bangor vendor. No quotes yet.', 'production', 8),
+  ('Contracts', 'tbd', 'Team member agreements - need to define what these look like.', 'logistics', 9),
+  ('Local sponsor list', 'tbd', '10-20 businesses in Ellsworth + Bangor area to approach.', 'funding', 10),
+  ('Press', 'wip', 'Connection at Ellsworth American (local newspaper).', 'marketing', 11);
+
+-- Enable RLS
+ALTER TABLE stock_team_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE stock_goals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE stock_todos ENABLE ROW LEVEL SECURITY;
+
+-- Service role can do everything (all access is server-side via API routes)
+CREATE POLICY "Service role full access" ON stock_team_members FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access" ON stock_goals FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access" ON stock_todos FOR ALL USING (true) WITH CHECK (true);
+```
+
+- [ ] **Step 2: Run the migration against Supabase**
+
+Run: `npx supabase db push` or apply via Supabase dashboard SQL editor.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260410_stock_team_dashboard.sql
+git commit -m "feat(stock): add team dashboard database tables + seed goals"
+```
+
+---
+
+### Task 2: Seed Script for Team Members
+
+**Files:**
+- Create: `scripts/seed-stock-team.ts`
+
+- [ ] **Step 1: Write the seed script**
+
+This script hashes passwords using Node's built-in crypto (scrypt) and inserts team members. Zaal runs it once and shares passwords via DM.
+
+```typescript
+import { createClient } from '@supabase/supabase-js';
+import { scryptSync, randomBytes } from 'crypto';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE env vars. Run with: npx tsx scripts/seed-stock-team.ts');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+const TEAM = [
+  { name: 'Zaal', role: 'Curation / Community / Local Logistics', scope: 'Artist lineup, promo, venue, permits, Heart of Ellsworth relationship', password: 'CHANGE_ME_1' },
+  { name: 'FailOften', role: 'Technical Build / Funding Structure', scope: 'Installations, visuals, production tech, grant/sponsor paths via NMC/ENTERACT', password: 'CHANGE_ME_2' },
+  { name: 'AttaBotty', role: 'Production / Sponsorships / Event-Day Ops', scope: 'On-site production, staging, sound coordination, sponsor outreach', password: 'CHANGE_ME_3' },
+  { name: 'DaNici', role: 'TBD', scope: '', password: 'CHANGE_ME_4' },
+  { name: 'Hurric4n3Ike', role: 'Live Entertainment', scope: 'WaveWarZ, live performances, DJ sets', password: 'CHANGE_ME_5' },
+  { name: 'DCoop', role: 'ZAOVille (DMV)', scope: 'DMV coordination, separate team/venue/artists', password: 'CHANGE_ME_6' },
+];
+
+async function seed() {
+  console.log('Seeding stock team members...\n');
+  console.log('=== SAVE THESE PASSWORDS - SHARE VIA DM ===\n');
+
+  for (const member of TEAM) {
+    // Generate a random password if still placeholder
+    const password = member.password.startsWith('CHANGE_ME')
+      ? randomBytes(4).toString('hex') // 8-char hex password
+      : member.password;
+
+    const password_hash = hashPassword(password);
+
+    const { error } = await supabase
+      .from('stock_team_members')
+      .upsert({ name: member.name, password_hash, role: member.role, scope: member.scope }, { onConflict: 'name' });
+
+    if (error) {
+      console.error(`Failed to seed ${member.name}:`, error.message);
+    } else {
+      console.log(`${member.name}: ${password}`);
+    }
+  }
+
+  console.log('\n=== DONE ===');
+}
+
+seed();
+```
+
+- [ ] **Step 2: Run the seed script**
+
+Run: `npx tsx scripts/seed-stock-team.ts`
+
+Save the printed passwords - share them with each team member via DM.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/seed-stock-team.ts
+git commit -m "feat(stock): add team member seed script"
+```
+
+---
+
+### Task 3: Stock Team Session Auth
+
+**Files:**
+- Create: `src/lib/auth/stock-team-session.ts`
+
+- [ ] **Step 1: Write the session module**
+
+```typescript
+import { getIronSession, IronSession } from 'iron-session';
+import { cookies } from 'next/headers';
+import { ENV } from '@/lib/env';
+
+export interface StockTeamPayload {
+  memberId?: string;
+  memberName?: string;
+}
+
+const stockTeamSessionOptions = {
+  password: ENV.SESSION_SECRET,
+  cookieName: 'stock_team_session',
+  cookieOptions: {
+    secure: process.env.NODE_ENV === 'production',
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+};
+
+export async function getStockTeamSession(): Promise<IronSession<StockTeamPayload>> {
+  const cookieStore = await cookies();
+  return getIronSession<StockTeamPayload>(cookieStore, stockTeamSessionOptions);
+}
+
+export async function getStockTeamMember(): Promise<{ memberId: string; memberName: string } | null> {
+  const session = await getStockTeamSession();
+  if (!session.memberId || !session.memberName) return null;
+  return { memberId: session.memberId, memberName: session.memberName };
+}
+
+export async function saveStockTeamSession(memberId: string, memberName: string) {
+  const session = await getStockTeamSession();
+  session.memberId = memberId;
+  session.memberName = memberName;
+  await session.save();
+}
+
+export async function clearStockTeamSession() {
+  const session = await getStockTeamSession();
+  session.destroy();
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/auth/stock-team-session.ts
+git commit -m "feat(stock): add stock team session auth module"
+```
+
+---
+
+### Task 4: Login + Logout API Routes
+
+**Files:**
+- Create: `src/app/api/stock/team/login/route.ts`
+- Create: `src/app/api/stock/team/logout/route.ts`
+
+- [ ] **Step 1: Write the login route**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { scryptSync } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { saveStockTeamSession } from '@/lib/auth/stock-team-session';
+
+const loginSchema = z.object({
+  name: z.string().min(1),
+  password: z.string().min(1),
+});
+
+function verifyPassword(password: string, stored: string): boolean {
+  const [salt, hash] = stored.split(':');
+  const result = scryptSync(password, salt, 64).toString('hex');
+  return result === hash;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = loginSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Name and password required' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { data: member, error } = await supabase
+      .from('stock_team_members')
+      .select('id, name, password_hash')
+      .ilike('name', parsed.data.name)
+      .single();
+
+    if (error || !member) {
+      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    }
+
+    if (!verifyPassword(parsed.data.password, member.password_hash)) {
+      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    }
+
+    await saveStockTeamSession(member.id, member.name);
+    return NextResponse.json({ success: true, name: member.name });
+  } catch {
+    return NextResponse.json({ error: 'Login failed' }, { status: 500 });
+  }
+}
+```
+
+- [ ] **Step 2: Write the logout route**
+
+```typescript
+import { NextResponse } from 'next/server';
+import { clearStockTeamSession } from '@/lib/auth/stock-team-session';
+
+export async function POST() {
+  await clearStockTeamSession();
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/stock/team/login/route.ts src/app/api/stock/team/logout/route.ts
+git commit -m "feat(stock): add team login/logout API routes"
+```
+
+---
+
+### Task 5: Members, Goals, Todos API Routes
+
+**Files:**
+- Create: `src/app/api/stock/team/members/route.ts`
+- Create: `src/app/api/stock/team/goals/route.ts`
+- Create: `src/app/api/stock/team/todos/route.ts`
+
+- [ ] **Step 1: Write the members route**
+
+```typescript
+import { NextResponse } from 'next/server';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_team_members')
+    .select('id, name, role, scope')
+    .order('created_at');
+
+  if (error) return NextResponse.json({ error: 'Failed to load team' }, { status: 500 });
+  return NextResponse.json({ members: data });
+}
+```
+
+- [ ] **Step 2: Write the goals route**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_goals')
+    .select('*')
+    .order('sort_order');
+
+  if (error) return NextResponse.json({ error: 'Failed to load goals' }, { status: 500 });
+  return NextResponse.json({ goals: data });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['locked', 'wip', 'tbd']).optional(),
+  details: z.string().optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_goals').update(updates).eq('id', id);
+  if (error) return NextResponse.json({ error: 'Failed to update goal' }, { status: 500 });
+
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 3: Write the todos route**
+
+```typescript
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const owner = request.nextUrl.searchParams.get('owner');
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('stock_todos')
+    .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+    .order('status')
+    .order('created_at', { ascending: false });
+
+  if (owner) {
+    query = query.eq('owner_id', owner);
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: 'Failed to load todos' }, { status: 500 });
+
+  return NextResponse.json({ todos: data });
+}
+
+const createSchema = z.object({
+  title: z.string().min(1).max(500),
+  owner_id: z.string().uuid().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_todos')
+    .insert({
+      title: parsed.data.title,
+      owner_id: parsed.data.owner_id || null,
+      created_by: member.memberId,
+    })
+    .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create todo' }, { status: 500 });
+  return NextResponse.json({ todo: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['todo', 'in_progress', 'done']).optional(),
+  notes: z.string().max(2000).optional(),
+  owner_id: z.string().uuid().nullable().optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_todos')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update todo' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/stock/team/members/route.ts src/app/api/stock/team/goals/route.ts src/app/api/stock/team/todos/route.ts
+git commit -m "feat(stock): add team members, goals, todos API routes"
+```
+
+---
+
+### Task 6: Login Form Component
+
+**Files:**
+- Create: `src/app/stock/team/LoginForm.tsx`
+
+- [ ] **Step 1: Write the login form**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function LoginForm() {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/stock/team/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Login failed');
+        setLoading(false);
+        return;
+      }
+
+      router.refresh();
+    } catch {
+      setError('Network error');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-white">ZAO Stock Team</h1>
+          <p className="text-sm text-gray-400 mt-1">Sign in to access the dashboard</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-lg px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-[#f5a623]/50"
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-lg px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-[#f5a623]/50"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors disabled:opacity-50"
+          >
+            {loading ? 'Signing in...' : 'Sign In'}
+          </button>
+          {error && <p className="text-red-400 text-xs text-center">{error}</p>}
+        </form>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/LoginForm.tsx
+git commit -m "feat(stock): add team login form component"
+```
+
+---
+
+### Task 7: Goals Board Component
+
+**Files:**
+- Create: `src/app/stock/team/GoalsBoard.tsx`
+
+- [ ] **Step 1: Write the goals board**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+interface Goal {
+  id: string;
+  title: string;
+  status: 'locked' | 'wip' | 'tbd';
+  details: string;
+  category: string;
+  sort_order: number;
+}
+
+const STATUS_STYLES: Record<string, { label: string; bg: string; text: string }> = {
+  locked: { label: 'LOCKED', bg: 'bg-emerald-500/10', text: 'text-emerald-400' },
+  wip: { label: 'WIP', bg: 'bg-amber-500/10', text: 'text-amber-400' },
+  tbd: { label: 'TBD', bg: 'bg-red-500/10', text: 'text-red-400' },
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  venue: 'Venue',
+  funding: 'Funding',
+  artists: 'Artists',
+  production: 'Production',
+  logistics: 'Logistics',
+  marketing: 'Marketing',
+  general: 'General',
+};
+
+export function GoalsBoard({ goals: initialGoals }: { goals: Goal[] }) {
+  const [goals, setGoals] = useState(initialGoals);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDetails, setEditDetails] = useState('');
+
+  async function updateGoal(id: string, updates: Partial<Pick<Goal, 'status' | 'details'>>) {
+    const res = await fetch('/api/stock/team/goals', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setGoals((prev) => prev.map((g) => (g.id === id ? { ...g, ...updates } : g)));
+    }
+  }
+
+  function startEdit(goal: Goal) {
+    setEditingId(goal.id);
+    setEditDetails(goal.details);
+  }
+
+  function saveEdit(id: string) {
+    updateGoal(id, { details: editDetails });
+    setEditingId(null);
+  }
+
+  // Group by category
+  const grouped = goals.reduce<Record<string, Goal[]>>((acc, g) => {
+    (acc[g.category] ||= []).push(g);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-bold text-white">Status Board</h2>
+      {Object.entries(grouped).map(([cat, items]) => (
+        <div key={cat}>
+          <h3 className="text-xs text-gray-500 uppercase tracking-wider mb-2 px-1">
+            {CATEGORY_LABELS[cat] || cat}
+          </h3>
+          <div className="space-y-2">
+            {items.map((goal) => {
+              const style = STATUS_STYLES[goal.status];
+              return (
+                <div key={goal.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-sm font-medium text-white">{goal.title}</span>
+                        <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${style.bg} ${style.text}`}>
+                          {style.label}
+                        </span>
+                      </div>
+                      {editingId === goal.id ? (
+                        <div className="flex gap-2 mt-2">
+                          <input
+                            value={editDetails}
+                            onChange={(e) => setEditDetails(e.target.value)}
+                            className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
+                            onKeyDown={(e) => e.key === 'Enter' && saveEdit(goal.id)}
+                            autoFocus
+                          />
+                          <button onClick={() => saveEdit(goal.id)} className="text-xs text-[#f5a623] font-medium">Save</button>
+                          <button onClick={() => setEditingId(null)} className="text-xs text-gray-500">Cancel</button>
+                        </div>
+                      ) : (
+                        <p
+                          className="text-xs text-gray-400 cursor-pointer hover:text-gray-300"
+                          onClick={() => startEdit(goal)}
+                          title="Click to edit"
+                        >
+                          {goal.details || 'Click to add details...'}
+                        </p>
+                      )}
+                    </div>
+                    <select
+                      value={goal.status}
+                      onChange={(e) => updateGoal(goal.id, { status: e.target.value as Goal['status'] })}
+                      className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+                    >
+                      <option value="locked">Locked</option>
+                      <option value="wip">WIP</option>
+                      <option value="tbd">TBD</option>
+                    </select>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/GoalsBoard.tsx
+git commit -m "feat(stock): add goals board component"
+```
+
+---
+
+### Task 8: Todo List Component
+
+**Files:**
+- Create: `src/app/stock/team/TodoList.tsx`
+
+- [ ] **Step 1: Write the todo list**
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+
+interface Member { id: string; name: string; }
+interface Todo {
+  id: string;
+  title: string;
+  status: 'todo' | 'in_progress' | 'done';
+  notes: string;
+  owner: Member | null;
+  creator: Member | null;
+  created_at: string;
+}
+
+const STATUS_ORDER = { todo: 0, in_progress: 1, done: 2 };
+
+export function TodoList({ todos: initialTodos, members, currentMemberId }: {
+  todos: Todo[];
+  members: Member[];
+  currentMemberId: string;
+}) {
+  const [todos, setTodos] = useState(() =>
+    [...initialTodos].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
+  );
+  const [filter, setFilter] = useState<'all' | 'mine' | string>('all');
+  const [newTitle, setNewTitle] = useState('');
+  const [newOwner, setNewOwner] = useState<string>('');
+  const [editNotesId, setEditNotesId] = useState<string | null>(null);
+  const [editNotesVal, setEditNotesVal] = useState('');
+
+  const filtered = todos.filter((t) => {
+    if (filter === 'all') return true;
+    if (filter === 'mine') return t.owner?.id === currentMemberId;
+    return t.owner?.id === filter;
+  });
+
+  async function createTodo(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    const res = await fetch('/api/stock/team/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTitle.trim(), owner_id: newOwner || null }),
+    });
+    if (res.ok) {
+      const { todo } = await res.json();
+      setTodos((prev) => [todo, ...prev]);
+      setNewTitle('');
+      setNewOwner('');
+    }
+  }
+
+  async function updateTodo(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/todos', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setTodos((prev) =>
+        prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
+          .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
+      );
+    }
+  }
+
+  function cycleStatus(todo: Todo) {
+    const next = { todo: 'in_progress', in_progress: 'done', done: 'todo' } as const;
+    updateTodo(todo.id, { status: next[todo.status] });
+  }
+
+  const statusIcon = { todo: '', in_progress: '~', done: '\u2713' };
+  const statusColor = {
+    todo: 'border-gray-600',
+    in_progress: 'border-amber-500 bg-amber-500/10',
+    done: 'border-emerald-500 bg-emerald-500/20 text-emerald-400',
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-white">Todos</h2>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+        >
+          <option value="all">All</option>
+          <option value="mine">Mine</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Create new */}
+      <form onSubmit={createTodo} className="flex gap-2">
+        <input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="Add a todo..."
+          className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <select
+          value={newOwner}
+          onChange={(e) => setNewOwner(e.target.value)}
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-2 py-2 text-xs text-gray-400 focus:outline-none"
+        >
+          <option value="">Unassigned</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <button type="submit" className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2 text-sm transition-colors">
+          Add
+        </button>
+      </form>
+
+      {/* List */}
+      <div className="space-y-2">
+        {filtered.map((todo) => (
+          <div key={todo.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
+            <div className="flex items-start gap-3">
+              <button
+                onClick={() => cycleStatus(todo)}
+                className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${statusColor[todo.status]}`}
+                title={`Status: ${todo.status}. Click to cycle.`}
+              >
+                {statusIcon[todo.status]}
+              </button>
+              <div className="flex-1 min-w-0">
+                <p className={`text-sm ${todo.status === 'done' ? 'text-gray-500 line-through' : 'text-white'}`}>
+                  {todo.title}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  {todo.owner && (
+                    <span className="text-[10px] font-medium text-[#f5a623] bg-[#f5a623]/10 px-2 py-0.5 rounded-full">
+                      {todo.owner.name}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => { setEditNotesId(editNotesId === todo.id ? null : todo.id); setEditNotesVal(todo.notes || ''); }}
+                    className="text-[10px] text-gray-500 hover:text-gray-400"
+                  >
+                    {todo.notes ? 'notes' : '+ note'}
+                  </button>
+                </div>
+                {editNotesId === todo.id && (
+                  <div className="mt-2 flex gap-2">
+                    <input
+                      value={editNotesVal}
+                      onChange={(e) => setEditNotesVal(e.target.value)}
+                      placeholder="Add a note..."
+                      className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
+                      onKeyDown={(e) => { if (e.key === 'Enter') { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); } }}
+                      autoFocus
+                    />
+                    <button onClick={() => { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); }} className="text-xs text-[#f5a623]">Save</button>
+                  </div>
+                )}
+                {editNotesId !== todo.id && todo.notes && (
+                  <p className="text-xs text-gray-500 mt-1 italic">{todo.notes}</p>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-gray-500 text-center py-4">No todos yet</p>
+        )}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/TodoList.tsx
+git commit -m "feat(stock): add todo list component with CRUD"
+```
+
+---
+
+### Task 9: Team Roles Component
+
+**Files:**
+- Create: `src/app/stock/team/TeamRoles.tsx`
+
+- [ ] **Step 1: Write the team roles component**
+
+```tsx
+'use client';
+
+interface Member {
+  id: string;
+  name: string;
+  role: string;
+  scope: string;
+}
+
+export function TeamRoles({ members }: { members: Member[] }) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-bold text-white">Team</h2>
+      <div className="space-y-2">
+        {members.map((m) => (
+          <div key={m.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
+            <div className="flex items-baseline gap-2">
+              <span className="text-sm font-medium text-[#f5a623]">{m.name}</span>
+              <span className="text-xs text-gray-400">{m.role}</span>
+            </div>
+            {m.scope && <p className="text-xs text-gray-500 mt-1">{m.scope}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/TeamRoles.tsx
+git commit -m "feat(stock): add team roles component"
+```
+
+---
+
+### Task 10: Dashboard Wrapper Component
+
+**Files:**
+- Create: `src/app/stock/team/Dashboard.tsx`
+
+- [ ] **Step 1: Write the dashboard wrapper**
+
+```tsx
+'use client';
+
+import { GoalsBoard } from './GoalsBoard';
+import { TodoList } from './TodoList';
+import { TeamRoles } from './TeamRoles';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  memberName: string;
+  memberId: string;
+  goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
+  todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
+  members: Array<{ id: string; name: string; role: string; scope: string }>;
+}
+
+export function Dashboard({ memberName, memberId, goals, todos, members }: Props) {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch('/api/stock/team/logout', { method: 'POST' });
+    router.refresh();
+  }
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-bold text-white">ZAO Stock Team</h1>
+            <p className="text-xs text-gray-400">October 3, 2026 - Ellsworth, ME</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-[#f5a623] font-medium">{memberName}</span>
+            <button onClick={handleLogout} className="text-xs text-gray-500 hover:text-gray-300">
+              Logout
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-8 pb-16">
+        <GoalsBoard goals={goals} />
+        <hr className="border-white/[0.06]" />
+        <TodoList todos={todos} members={members.map((m) => ({ id: m.id, name: m.name }))} currentMemberId={memberId} />
+        <hr className="border-white/[0.06]" />
+        <TeamRoles members={members} />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/Dashboard.tsx
+git commit -m "feat(stock): add dashboard wrapper component"
+```
+
+---
+
+### Task 11: Team Page (Server Component)
+
+**Files:**
+- Create: `src/app/stock/team/page.tsx`
+
+- [ ] **Step 1: Write the page**
+
+This is the server component that checks auth and loads data.
+
+```tsx
+import { Metadata } from 'next';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { LoginForm } from './LoginForm';
+import { Dashboard } from './Dashboard';
+
+export const metadata: Metadata = {
+  title: 'ZAO Stock Team Dashboard',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function StockTeamPage() {
+  const member = await getStockTeamMember();
+
+  if (!member) {
+    return <LoginForm />;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const [goalsRes, todosRes, membersRes] = await Promise.allSettled([
+    supabase.from('stock_goals').select('*').order('sort_order'),
+    supabase
+      .from('stock_todos')
+      .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+      .order('status')
+      .order('created_at', { ascending: false }),
+    supabase.from('stock_team_members').select('id, name, role, scope').order('created_at'),
+  ]);
+
+  const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
+  const todos = todosRes.status === 'fulfilled' ? todosRes.value.data || [] : [];
+  const members = membersRes.status === 'fulfilled' ? membersRes.value.data || [] : [];
+
+  return (
+    <Dashboard
+      memberName={member.memberName}
+      memberId={member.memberId}
+      goals={goals}
+      todos={todos}
+      members={members}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/team/page.tsx
+git commit -m "feat(stock): add team dashboard page with auth gate"
+```
+
+---
+
+### Task 12: Update Public Stock Page
+
+**Files:**
+- Modify: `src/app/stock/page.tsx:112-133`
+
+- [ ] **Step 1: Remove the artist placeholder grid**
+
+Remove lines 112-133 (the Lineup section with the 6 placeholder cards and the "10 artists" text):
+
+```tsx
+        {/* Lineup */}
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Lineup</p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] p-4 flex flex-col items-center justify-center aspect-square"
+              >
+                <div className="w-12 h-12 rounded-full bg-[#1a2a3a] flex items-center justify-center mb-3">
+                  <svg className="w-6 h-6 text-gray-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
+                  </svg>
+                </div>
+                <p className="text-sm text-gray-500 font-medium">Coming Soon</p>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-gray-500 text-center">
+            10 artists performing equal sets &middot; DJs between sets &middot; Full lineup TBA
+          </p>
+        </section>
+```
+
+Replace with a simpler lineup teaser:
+
+```tsx
+        {/* Lineup */}
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Lineup</p>
+          <div className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] p-5 text-center">
+            <p className="text-sm text-gray-300">Full lineup coming soon</p>
+            <p className="text-xs text-gray-500 mt-1">Artists performing equal sets with DJs between</p>
+          </div>
+        </section>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/stock/page.tsx
+git commit -m "feat(stock): simplify lineup section on public page"
+```
+
+---
+
+### Task 13: Test, Verify, Push
+
+- [ ] **Step 1: Run lint**
+
+Run: `npm run lint`
+
+Fix any errors.
+
+- [ ] **Step 2: Run build**
+
+Run: `npm run build`
+
+Fix any type errors.
+
+- [ ] **Step 3: Manual verification**
+
+1. Visit `/stock` - confirm lineup section is simplified, everything else works
+2. Visit `/stock/team` - confirm login form appears
+3. Run seed script, login with a team member password
+4. Confirm dashboard loads with goals, todos, team roles
+5. Create a todo, check it off, add a note
+6. Update a goal's status and details
+
+- [ ] **Step 4: Commit any fixes**
+
+- [ ] **Step 5: Push and create PR**
+
+```bash
+git push -u origin ws/zaostock-agenda-0410-1415
+```
+
+Then create PR to main.

--- a/docs/superpowers/specs/2026-04-10-zaostock-team-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-10-zaostock-team-dashboard-design.md
@@ -1,0 +1,179 @@
+# ZAO Stock Team Dashboard
+
+**Date:** 2026-04-10
+**Status:** Design
+
+## What we're building
+
+Two things:
+
+1. **Update `/stock`** (public) - clean up the placeholder artist grid, keep everything else
+2. **Build `/stock/team`** (password-gated) - a working dashboard where the ZAO Stock team can see status, todos, roles, and goals at any time without needing to be on a call
+
+From the 3/31 standup (Zaal's words): "a landing page website, and then we'll also have a page for collaborators and contributors. So like, we have a place where anyone can go at any time to see like where we're at."
+
+## Context: The structure
+
+From the standup and FailOften's framework doc:
+
+- **ZAO** = talent network, programming, community, events, sponsorship relationships
+- **New Media Commons (NMC)** = fiscal sponsorship through Fractured Atlas (501c3). Tax-deductible donations. Opens doors to $10K-$100K grants from banks/corps especially Q3/Q4
+- **ENTERACT** = FailOften's creative agency. Execution layer - projection mapping, installations, consultation, operating procedures. Sliding scale per project/contract
+
+Funding model: sponsors (not ticket sales). Three lanes: paid (client has budget), sponsored (ZAO brings sponsors), funded (grants/tax-deductible/institutional).
+
+## Part 1: `/stock` page updates
+
+**Remove:**
+- The 6-placeholder artist grid ("Coming Soon" cards)
+- The "10 artists performing equal sets" text below it
+
+**Keep everything else as-is.** The page is already accurate on date, venue, countdown, about, RSVP, sponsorship, past events, fundraising links.
+
+## Part 2: `/stock/team` dashboard
+
+### Auth
+
+Simple password login. No Farcaster/wallet auth needed.
+
+- Zaal creates team members in Supabase (name + password)
+- Team member goes to `/stock/team`, enters name + password
+- Session stored in an httpOnly cookie (`stock_team_session`, 30-day TTL)
+- iron-session, same pattern as main app but separate cookie name so it doesn't interfere
+
+### Database (3 tables)
+
+**`stock_team_members`**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| name | text | "Zaal", "FailOften", "AttaBotty", "Cole" |
+| password_hash | text | bcrypt |
+| role | text | "Curation", "Technical Build", "Production", etc. |
+| scope | text | Brief description of what they own |
+| created_at | timestamptz | |
+
+**`stock_todos`**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| title | text | |
+| owner_id | uuid | FK to stock_team_members, nullable (unassigned) |
+| status | text | "todo", "in_progress", "done" |
+| notes | text | nullable, anyone can add context |
+| created_by | uuid | FK to stock_team_members |
+| created_at | timestamptz | |
+| updated_at | timestamptz | |
+
+**`stock_goals`**
+| Column | Type | Notes |
+|--------|------|-------|
+| id | uuid | PK |
+| title | text | e.g. "Venue confirmed" |
+| status | text | "locked", "wip", "tbd" |
+| details | text | Current state / context |
+| category | text | "venue", "funding", "artists", "production", "logistics", "marketing" |
+| sort_order | int | Display order |
+
+### Seed data
+
+**Goals** (pre-populated):
+- Venue: Franklin St Parklet via Heart of Ellsworth (wip)
+- Date: October 3, 2026 (locked)
+- Official status: Part of Art of Ellsworth Maine Craft Weekend (locked)
+- Weather backup: Wallace Events tent rental (tbd)
+- Steve Peer: Pitch for co-curation (tbd)
+- Funding: Identify grant/sponsor paths via NMC (tbd)
+- Budget: Draft minimum viable + stretch (tbd)
+- Sound/PA: Local vendor research Ellsworth/Bangor (tbd)
+- Contracts: Define team member agreements (tbd)
+- Sponsor list: 10-20 local businesses in Ellsworth + Bangor (tbd)
+- Press: Ellsworth American connection (wip)
+
+**Team members** (seeded via migration script, passwords set by Zaal):
+- Zaal - Curation / Community / Local Logistics
+- FailOften - Technical Build / Funding Structure / ENTERACT
+- AttaBotty (Cole) - Production / Sponsorships / Event-Day Ops
+- DaNici - TBD
+- Hurric4n3Ike - Live Entertainment
+- DCoop - ZAOVille (DMV) coordination
+
+### Dashboard layout
+
+Single scrollable page, mobile-first, dark theme (navy/gold).
+
+**1. Header**
+- "ZAO Stock Team" + logged-in member name + logout link
+
+**2. Status board**
+- Goals grouped by category
+- Each shows title, status badge (locked/wip/tbd), and details
+- Editable details field - any team member can update
+
+**3. Team + Roles**
+- Simple list: name, role, scope
+- Not editable from the UI (Zaal manages via Supabase)
+
+**4. Todos**
+- Filter by: all / mine / by owner
+- Each todo shows: title, owner, status, notes
+- Any team member can: create new todos, update status (todo/in_progress/done), add notes
+- Sort: incomplete first, then by created_at
+
+### API routes
+
+All routes check the `stock_team_session` cookie.
+
+| Route | Method | What |
+|-------|--------|------|
+| `/api/stock/team/login` | POST | Validate name + password, set session cookie |
+| `/api/stock/team/logout` | POST | Clear session cookie |
+| `/api/stock/team/members` | GET | List team members + roles |
+| `/api/stock/team/goals` | GET | List all goals |
+| `/api/stock/team/goals` | PATCH | Update goal details/status |
+| `/api/stock/team/todos` | GET | List todos (optional ?owner= filter) |
+| `/api/stock/team/todos` | POST | Create todo |
+| `/api/stock/team/todos` | PATCH | Update todo status/notes/owner |
+
+### Auth helper
+
+```typescript
+// src/lib/auth/stock-team-session.ts
+// Separate iron-session config for stock team
+// Cookie: stock_team_session, 30-day TTL
+// Payload: { memberId: string, name: string }
+```
+
+### Permissions
+
+- Any authenticated team member can view everything
+- Any team member can create todos, update todo status/notes, update goal details
+- Team member management (add/remove people) is done directly in Supabase by Zaal - no admin UI for now
+
+## What this is NOT
+
+- Not a project management tool - no due dates, no priority levels, no Gantt charts
+- Not a communication tool - use Discord for that
+- Not public - team only
+- No admin UI for member management yet - Supabase dashboard is fine for now
+
+## Files to create/modify
+
+**Modify:**
+- `src/app/stock/page.tsx` - remove artist placeholder grid
+
+**Create:**
+- `src/lib/auth/stock-team-session.ts` - session config
+- `src/app/stock/team/page.tsx` - dashboard page
+- `src/app/stock/team/LoginForm.tsx` - password login form
+- `src/app/stock/team/Dashboard.tsx` - main dashboard component
+- `src/app/stock/team/TodoList.tsx` - todo list with create/update
+- `src/app/stock/team/GoalsBoard.tsx` - goals status board
+- `src/app/stock/team/TeamRoles.tsx` - team + roles display
+- `src/app/api/stock/team/login/route.ts`
+- `src/app/api/stock/team/logout/route.ts`
+- `src/app/api/stock/team/members/route.ts`
+- `src/app/api/stock/team/goals/route.ts`
+- `src/app/api/stock/team/todos/route.ts`
+- `supabase/migrations/20260410_stock_team_dashboard.sql`
+- `scripts/seed-stock-team.ts` - seed script for initial goals + team members

--- a/scripts/seed-stock-team.ts
+++ b/scripts/seed-stock-team.ts
@@ -1,0 +1,54 @@
+import { createClient } from '@supabase/supabase-js';
+import { scryptSync, randomBytes } from 'crypto';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE env vars. Run with: npx tsx scripts/seed-stock-team.ts');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+const TEAM = [
+  { name: 'Zaal', role: 'Curation / Community / Local Logistics', scope: 'Artist lineup, promo, venue, permits, Heart of Ellsworth relationship', password: 'CHANGE_ME_1' },
+  { name: 'FailOften', role: 'Technical Build / Funding Structure', scope: 'Installations, visuals, production tech, grant/sponsor paths via NMC/ENTERACT', password: 'CHANGE_ME_2' },
+  { name: 'AttaBotty', role: 'Production / Sponsorships / Event-Day Ops', scope: 'On-site production, staging, sound coordination, sponsor outreach', password: 'CHANGE_ME_3' },
+  { name: 'DaNici', role: 'TBD', scope: '', password: 'CHANGE_ME_4' },
+  { name: 'Hurric4n3Ike', role: 'Live Entertainment', scope: 'WaveWarZ, live performances, DJ sets', password: 'CHANGE_ME_5' },
+  { name: 'DCoop', role: 'ZAOVille (DMV)', scope: 'DMV coordination, separate team/venue/artists', password: 'CHANGE_ME_6' },
+];
+
+async function seed() {
+  console.log('Seeding stock team members...\n');
+  console.log('=== SAVE THESE PASSWORDS - SHARE VIA DM ===\n');
+
+  for (const member of TEAM) {
+    const password = member.password.startsWith('CHANGE_ME')
+      ? randomBytes(4).toString('hex')
+      : member.password;
+
+    const password_hash = hashPassword(password);
+
+    const { error } = await supabase
+      .from('stock_team_members')
+      .upsert({ name: member.name, password_hash, role: member.role, scope: member.scope }, { onConflict: 'name' });
+
+    if (error) {
+      console.error(`Failed to seed ${member.name}:`, error.message);
+    } else {
+      console.log(`${member.name}: ${password}`);
+    }
+  }
+
+  console.log('\n=== DONE ===');
+}
+
+seed();

--- a/src/app/api/stock/team/goals/route.ts
+++ b/src/app/api/stock/team/goals/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_goals')
+    .select('*')
+    .order('sort_order');
+
+  if (error) return NextResponse.json({ error: 'Failed to load goals' }, { status: 500 });
+  return NextResponse.json({ goals: data });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['locked', 'wip', 'tbd']).optional(),
+  details: z.string().optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_goals').update(updates).eq('id', id);
+  if (error) return NextResponse.json({ error: 'Failed to update goal' }, { status: 500 });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/stock/team/login/route.ts
+++ b/src/app/api/stock/team/login/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { scryptSync } from 'crypto';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { saveStockTeamSession } from '@/lib/auth/stock-team-session';
+
+const loginSchema = z.object({
+  name: z.string().min(1),
+  password: z.string().min(1),
+});
+
+function verifyPassword(password: string, stored: string): boolean {
+  const [salt, hash] = stored.split(':');
+  const result = scryptSync(password, salt, 64).toString('hex');
+  return result === hash;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = loginSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Name and password required' }, { status: 400 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { data: member, error } = await supabase
+      .from('stock_team_members')
+      .select('id, name, password_hash')
+      .ilike('name', parsed.data.name)
+      .single();
+
+    if (error || !member) {
+      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    }
+
+    if (!verifyPassword(parsed.data.password, member.password_hash)) {
+      return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 });
+    }
+
+    await saveStockTeamSession(member.id, member.name);
+    return NextResponse.json({ success: true, name: member.name });
+  } catch {
+    return NextResponse.json({ error: 'Login failed' }, { status: 500 });
+  }
+}

--- a/src/app/api/stock/team/logout/route.ts
+++ b/src/app/api/stock/team/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { clearStockTeamSession } from '@/lib/auth/stock-team-session';
+
+export async function POST() {
+  await clearStockTeamSession();
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/stock/team/members/route.ts
+++ b/src/app/api/stock/team/members/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_team_members')
+    .select('id, name, role, scope')
+    .order('created_at');
+
+  if (error) return NextResponse.json({ error: 'Failed to load team' }, { status: 500 });
+  return NextResponse.json({ members: data });
+}

--- a/src/app/api/stock/team/todos/route.ts
+++ b/src/app/api/stock/team/todos/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const owner = request.nextUrl.searchParams.get('owner');
+  const supabase = getSupabaseAdmin();
+
+  let query = supabase
+    .from('stock_todos')
+    .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+    .order('status')
+    .order('created_at', { ascending: false });
+
+  if (owner) {
+    query = query.eq('owner_id', owner);
+  }
+
+  const { data, error } = await query;
+  if (error) return NextResponse.json({ error: 'Failed to load todos' }, { status: 500 });
+
+  return NextResponse.json({ todos: data });
+}
+
+const createSchema = z.object({
+  title: z.string().min(1).max(500),
+  owner_id: z.string().uuid().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_todos')
+    .insert({
+      title: parsed.data.title,
+      owner_id: parsed.data.owner_id || null,
+      created_by: member.memberId,
+    })
+    .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create todo' }, { status: 500 });
+  return NextResponse.json({ todo: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['todo', 'in_progress', 'done']).optional(),
+  notes: z.string().max(2000).optional(),
+  owner_id: z.string().uuid().nullable().optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_todos')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update todo' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/stock/page.tsx
+++ b/src/app/stock/page.tsx
@@ -111,24 +111,10 @@ export default function StockPage() {
         {/* Lineup */}
         <section className="space-y-3">
           <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Lineup</p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] p-4 flex flex-col items-center justify-center aspect-square"
-              >
-                <div className="w-12 h-12 rounded-full bg-[#1a2a3a] flex items-center justify-center mb-3">
-                  <svg className="w-6 h-6 text-gray-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 9l10.5-3m0 6.553v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 11-.99-3.467l2.31-.66a2.25 2.25 0 001.632-2.163zm0 0V2.25L9 5.25v10.303m0 0v3.75a2.25 2.25 0 01-1.632 2.163l-1.32.377a1.803 1.803 0 01-.99-3.467l2.31-.66A2.25 2.25 0 009 15.553z" />
-                  </svg>
-                </div>
-                <p className="text-sm text-gray-500 font-medium">Coming Soon</p>
-              </div>
-            ))}
+          <div className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] p-5 text-center">
+            <p className="text-sm text-gray-300">Full lineup coming soon</p>
+            <p className="text-xs text-gray-500 mt-1">Artists performing equal sets with DJs between</p>
           </div>
-          <p className="text-xs text-gray-500 text-center">
-            10 artists performing equal sets &middot; DJs between sets &middot; Full lineup TBA
-          </p>
         </section>
 
         {/* RSVP */}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { GoalsBoard } from './GoalsBoard';
+import { TodoList } from './TodoList';
+import { TeamRoles } from './TeamRoles';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  memberName: string;
+  memberId: string;
+  goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
+  todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
+  members: Array<{ id: string; name: string; role: string; scope: string }>;
+}
+
+export function Dashboard({ memberName, memberId, goals, todos, members }: Props) {
+  const router = useRouter();
+
+  async function handleLogout() {
+    await fetch('/api/stock/team/logout', { method: 'POST' });
+    router.refresh();
+  }
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div>
+            <h1 className="text-lg font-bold text-white">ZAO Stock Team</h1>
+            <p className="text-xs text-gray-400">October 3, 2026 - Ellsworth, ME</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-[#f5a623] font-medium">{memberName}</span>
+            <button onClick={handleLogout} className="text-xs text-gray-500 hover:text-gray-300">
+              Logout
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-8 pb-16">
+        <GoalsBoard goals={goals} />
+        <hr className="border-white/[0.06]" />
+        <TodoList todos={todos} members={members.map((m) => ({ id: m.id, name: m.name }))} currentMemberId={memberId} />
+        <hr className="border-white/[0.06]" />
+        <TeamRoles members={members} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/GoalsBoard.tsx
+++ b/src/app/stock/team/GoalsBoard.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Goal {
+  id: string;
+  title: string;
+  status: 'locked' | 'wip' | 'tbd';
+  details: string;
+  category: string;
+  sort_order: number;
+}
+
+const STATUS_STYLES: Record<string, { label: string; bg: string; text: string }> = {
+  locked: { label: 'LOCKED', bg: 'bg-emerald-500/10', text: 'text-emerald-400' },
+  wip: { label: 'WIP', bg: 'bg-amber-500/10', text: 'text-amber-400' },
+  tbd: { label: 'TBD', bg: 'bg-red-500/10', text: 'text-red-400' },
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  venue: 'Venue',
+  funding: 'Funding',
+  artists: 'Artists',
+  production: 'Production',
+  logistics: 'Logistics',
+  marketing: 'Marketing',
+  general: 'General',
+};
+
+export function GoalsBoard({ goals: initialGoals }: { goals: Goal[] }) {
+  const [goals, setGoals] = useState(initialGoals);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDetails, setEditDetails] = useState('');
+
+  async function updateGoal(id: string, updates: Partial<Pick<Goal, 'status' | 'details'>>) {
+    const res = await fetch('/api/stock/team/goals', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setGoals((prev) => prev.map((g) => (g.id === id ? { ...g, ...updates } : g)));
+    }
+  }
+
+  function startEdit(goal: Goal) {
+    setEditingId(goal.id);
+    setEditDetails(goal.details);
+  }
+
+  function saveEdit(id: string) {
+    updateGoal(id, { details: editDetails });
+    setEditingId(null);
+  }
+
+  const grouped = goals.reduce<Record<string, Goal[]>>((acc, g) => {
+    (acc[g.category] ||= []).push(g);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-bold text-white">Status Board</h2>
+      {Object.entries(grouped).map(([cat, items]) => (
+        <div key={cat}>
+          <h3 className="text-xs text-gray-500 uppercase tracking-wider mb-2 px-1">
+            {CATEGORY_LABELS[cat] || cat}
+          </h3>
+          <div className="space-y-2">
+            {items.map((goal) => {
+              const style = STATUS_STYLES[goal.status];
+              return (
+                <div key={goal.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="text-sm font-medium text-white">{goal.title}</span>
+                        <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${style.bg} ${style.text}`}>
+                          {style.label}
+                        </span>
+                      </div>
+                      {editingId === goal.id ? (
+                        <div className="flex gap-2 mt-2">
+                          <input
+                            value={editDetails}
+                            onChange={(e) => setEditDetails(e.target.value)}
+                            className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
+                            onKeyDown={(e) => e.key === 'Enter' && saveEdit(goal.id)}
+                            autoFocus
+                          />
+                          <button onClick={() => saveEdit(goal.id)} className="text-xs text-[#f5a623] font-medium">Save</button>
+                          <button onClick={() => setEditingId(null)} className="text-xs text-gray-500">Cancel</button>
+                        </div>
+                      ) : (
+                        <p
+                          className="text-xs text-gray-400 cursor-pointer hover:text-gray-300"
+                          onClick={() => startEdit(goal)}
+                          title="Click to edit"
+                        >
+                          {goal.details || 'Click to add details...'}
+                        </p>
+                      )}
+                    </div>
+                    <select
+                      value={goal.status}
+                      onChange={(e) => updateGoal(goal.id, { status: e.target.value as Goal['status'] })}
+                      className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+                    >
+                      <option value="locked">Locked</option>
+                      <option value="wip">WIP</option>
+                      <option value="tbd">TBD</option>
+                    </select>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stock/team/LoginForm.tsx
+++ b/src/app/stock/team/LoginForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function LoginForm() {
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const res = await fetch('/api/stock/team/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || 'Login failed');
+        setLoading(false);
+        return;
+      }
+
+      router.refresh();
+    } catch {
+      setError('Network error');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <h1 className="text-2xl font-bold text-white">ZAO Stock Team</h1>
+          <p className="text-sm text-gray-400 mt-1">Sign in to access the dashboard</p>
+        </div>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            placeholder="Your name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+            className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-lg px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-[#f5a623]/50"
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-lg px-4 py-3 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-[#f5a623]/50"
+          />
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors disabled:opacity-50"
+          >
+            {loading ? 'Signing in...' : 'Sign In'}
+          </button>
+          {error && <p className="text-red-400 text-xs text-center">{error}</p>}
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/TeamRoles.tsx
+++ b/src/app/stock/team/TeamRoles.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+interface Member {
+  id: string;
+  name: string;
+  role: string;
+  scope: string;
+}
+
+export function TeamRoles({ members }: { members: Member[] }) {
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-bold text-white">Team</h2>
+      <div className="space-y-2">
+        {members.map((m) => (
+          <div key={m.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
+            <div className="flex items-baseline gap-2">
+              <span className="text-sm font-medium text-[#f5a623]">{m.name}</span>
+              <span className="text-xs text-gray-400">{m.role}</span>
+            </div>
+            {m.scope && <p className="text-xs text-gray-500 mt-1">{m.scope}</p>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/TodoList.tsx
+++ b/src/app/stock/team/TodoList.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Member { id: string; name: string; }
+interface Todo {
+  id: string;
+  title: string;
+  status: 'todo' | 'in_progress' | 'done';
+  notes: string;
+  owner: Member | null;
+  creator: Member | null;
+  created_at: string;
+}
+
+const STATUS_ORDER = { todo: 0, in_progress: 1, done: 2 };
+
+export function TodoList({ todos: initialTodos, members, currentMemberId }: {
+  todos: Todo[];
+  members: Member[];
+  currentMemberId: string;
+}) {
+  const [todos, setTodos] = useState(() =>
+    [...initialTodos].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
+  );
+  const [filter, setFilter] = useState<'all' | 'mine' | string>('all');
+  const [newTitle, setNewTitle] = useState('');
+  const [newOwner, setNewOwner] = useState<string>('');
+  const [editNotesId, setEditNotesId] = useState<string | null>(null);
+  const [editNotesVal, setEditNotesVal] = useState('');
+
+  const filtered = todos.filter((t) => {
+    if (filter === 'all') return true;
+    if (filter === 'mine') return t.owner?.id === currentMemberId;
+    return t.owner?.id === filter;
+  });
+
+  async function createTodo(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim()) return;
+    const res = await fetch('/api/stock/team/todos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: newTitle.trim(), owner_id: newOwner || null }),
+    });
+    if (res.ok) {
+      const { todo } = await res.json();
+      setTodos((prev) => [todo, ...prev]);
+      setNewTitle('');
+      setNewOwner('');
+    }
+  }
+
+  async function updateTodo(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/todos', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setTodos((prev) =>
+        prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
+          .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
+      );
+    }
+  }
+
+  function cycleStatus(todo: Todo) {
+    const next = { todo: 'in_progress', in_progress: 'done', done: 'todo' } as const;
+    updateTodo(todo.id, { status: next[todo.status] });
+  }
+
+  const statusIcon = { todo: '', in_progress: '~', done: '\u2713' };
+  const statusColor = {
+    todo: 'border-gray-600',
+    in_progress: 'border-amber-500 bg-amber-500/10',
+    done: 'border-emerald-500 bg-emerald-500/20 text-emerald-400',
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-white">Todos</h2>
+        <select
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+        >
+          <option value="all">All</option>
+          <option value="mine">Mine</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <form onSubmit={createTodo} className="flex gap-2">
+        <input
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          placeholder="Add a todo..."
+          className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <select
+          value={newOwner}
+          onChange={(e) => setNewOwner(e.target.value)}
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-2 py-2 text-xs text-gray-400 focus:outline-none"
+        >
+          <option value="">Unassigned</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <button type="submit" className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2 text-sm transition-colors">
+          Add
+        </button>
+      </form>
+
+      <div className="space-y-2">
+        {filtered.map((todo) => (
+          <div key={todo.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
+            <div className="flex items-start gap-3">
+              <button
+                onClick={() => cycleStatus(todo)}
+                className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${statusColor[todo.status]}`}
+                title={`Status: ${todo.status}. Click to cycle.`}
+              >
+                {statusIcon[todo.status]}
+              </button>
+              <div className="flex-1 min-w-0">
+                <p className={`text-sm ${todo.status === 'done' ? 'text-gray-500 line-through' : 'text-white'}`}>
+                  {todo.title}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  {todo.owner && (
+                    <span className="text-[10px] font-medium text-[#f5a623] bg-[#f5a623]/10 px-2 py-0.5 rounded-full">
+                      {todo.owner.name}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => { setEditNotesId(editNotesId === todo.id ? null : todo.id); setEditNotesVal(todo.notes || ''); }}
+                    className="text-[10px] text-gray-500 hover:text-gray-400"
+                  >
+                    {todo.notes ? 'notes' : '+ note'}
+                  </button>
+                </div>
+                {editNotesId === todo.id && (
+                  <div className="mt-2 flex gap-2">
+                    <input
+                      value={editNotesVal}
+                      onChange={(e) => setEditNotesVal(e.target.value)}
+                      placeholder="Add a note..."
+                      className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
+                      onKeyDown={(e) => { if (e.key === 'Enter') { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); } }}
+                      autoFocus
+                    />
+                    <button onClick={() => { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); }} className="text-xs text-[#f5a623]">Save</button>
+                  </div>
+                )}
+                {editNotesId !== todo.id && todo.notes && (
+                  <p className="text-xs text-gray-500 mt-1 italic">{todo.notes}</p>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-gray-500 text-center py-4">No todos yet</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -1,0 +1,46 @@
+import { Metadata } from 'next';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { LoginForm } from './LoginForm';
+import { Dashboard } from './Dashboard';
+
+export const metadata: Metadata = {
+  title: 'ZAO Stock Team Dashboard',
+  robots: { index: false, follow: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function StockTeamPage() {
+  const member = await getStockTeamMember();
+
+  if (!member) {
+    return <LoginForm />;
+  }
+
+  const supabase = getSupabaseAdmin();
+
+  const [goalsRes, todosRes, membersRes] = await Promise.allSettled([
+    supabase.from('stock_goals').select('*').order('sort_order'),
+    supabase
+      .from('stock_todos')
+      .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
+      .order('status')
+      .order('created_at', { ascending: false }),
+    supabase.from('stock_team_members').select('id, name, role, scope').order('created_at'),
+  ]);
+
+  const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
+  const todos = todosRes.status === 'fulfilled' ? todosRes.value.data || [] : [];
+  const members = membersRes.status === 'fulfilled' ? membersRes.value.data || [] : [];
+
+  return (
+    <Dashboard
+      memberName={member.memberName}
+      memberId={member.memberId}
+      goals={goals}
+      todos={todos}
+      members={members}
+    />
+  );
+}

--- a/src/lib/auth/stock-team-session.ts
+++ b/src/lib/auth/stock-team-session.ts
@@ -1,0 +1,42 @@
+import { getIronSession, IronSession } from 'iron-session';
+import { cookies } from 'next/headers';
+import { ENV } from '@/lib/env';
+
+export interface StockTeamPayload {
+  memberId?: string;
+  memberName?: string;
+}
+
+const stockTeamSessionOptions = {
+  password: ENV.SESSION_SECRET,
+  cookieName: 'stock_team_session',
+  cookieOptions: {
+    secure: process.env.NODE_ENV === 'production',
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+  },
+};
+
+export async function getStockTeamSession(): Promise<IronSession<StockTeamPayload>> {
+  const cookieStore = await cookies();
+  return getIronSession<StockTeamPayload>(cookieStore, stockTeamSessionOptions);
+}
+
+export async function getStockTeamMember(): Promise<{ memberId: string; memberName: string } | null> {
+  const session = await getStockTeamSession();
+  if (!session.memberId || !session.memberName) return null;
+  return { memberId: session.memberId, memberName: session.memberName };
+}
+
+export async function saveStockTeamSession(memberId: string, memberName: string) {
+  const session = await getStockTeamSession();
+  session.memberId = memberId;
+  session.memberName = memberName;
+  await session.save();
+}
+
+export async function clearStockTeamSession() {
+  const session = await getStockTeamSession();
+  session.destroy();
+}

--- a/supabase/migrations/20260410_stock_team_dashboard.sql
+++ b/supabase/migrations/20260410_stock_team_dashboard.sql
@@ -1,0 +1,53 @@
+-- Stock Team Dashboard tables
+-- 3 tables: team members, goals, todos
+
+CREATE TABLE IF NOT EXISTS stock_team_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT '',
+  scope TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS stock_goals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'tbd' CHECK (status IN ('locked', 'wip', 'tbd')),
+  details TEXT NOT NULL DEFAULT '',
+  category TEXT NOT NULL DEFAULT 'general' CHECK (category IN ('venue', 'funding', 'artists', 'production', 'logistics', 'marketing', 'general')),
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS stock_todos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  owner_id UUID REFERENCES stock_team_members(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'todo' CHECK (status IN ('todo', 'in_progress', 'done')),
+  notes TEXT DEFAULT '',
+  created_by UUID REFERENCES stock_team_members(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO stock_goals (title, status, details, category, sort_order) VALUES
+  ('Date confirmed', 'locked', 'October 3, 2026', 'venue', 1),
+  ('Official status', 'locked', 'Part of Art of Ellsworth: Maine Craft Weekend (9th annual, statewide promo)', 'venue', 2),
+  ('Venue', 'wip', 'Franklin Street Parklet, rented from Heart of Ellsworth', 'venue', 3),
+  ('Weather backup', 'tbd', 'Wallace Events tent rental - not yet contacted', 'logistics', 4),
+  ('Steve Peer', 'tbd', 'Local music anchor (37 years in Ellsworth, 430 house concerts) - not yet pitched for co-curation', 'artists', 5),
+  ('Funding path', 'tbd', 'New Media Commons / Fractured Atlas 501c3 fiscal sponsorship. Tax-deductible donations. Need to identify specific grant/sponsor targets.', 'funding', 6),
+  ('Budget', 'tbd', 'Goal $25K, minimum viable $5K. No money committed yet.', 'funding', 7),
+  ('Sound / PA vendor', 'tbd', 'Need local Ellsworth/Bangor vendor. No quotes yet.', 'production', 8),
+  ('Contracts', 'tbd', 'Team member agreements - need to define what these look like.', 'logistics', 9),
+  ('Local sponsor list', 'tbd', '10-20 businesses in Ellsworth + Bangor area to approach.', 'funding', 10),
+  ('Press', 'wip', 'Connection at Ellsworth American (local newspaper).', 'marketing', 11);
+
+ALTER TABLE stock_team_members ENABLE ROW LEVEL SECURITY;
+ALTER TABLE stock_goals ENABLE ROW LEVEL SECURITY;
+ALTER TABLE stock_todos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON stock_team_members FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access" ON stock_goals FOR ALL USING (true) WITH CHECK (true);
+CREATE POLICY "Service role full access" ON stock_todos FOR ALL USING (true) WITH CHECK (true);

--- a/tmp/zaostock-failoften-agenda-0410.html
+++ b/tmp/zaostock-failoften-agenda-0410.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>ZAO Stock - Sync w/ FailOften</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+  :root {
+    --navy: #0a1628;
+    --navy-light: #0f1f38;
+    --gold: #f5a623;
+    --gold-dim: rgba(245, 166, 35, 0.1);
+    --green: #34d399;
+    --green-dim: rgba(52, 211, 153, 0.12);
+    --red: #f87171;
+    --red-dim: rgba(248, 113, 113, 0.1);
+    --yellow: #fbbf24;
+    --yellow-dim: rgba(251, 191, 36, 0.1);
+    --text: #e2e8f0;
+    --text-dim: #94a3b8;
+    --text-muted: #64748b;
+    --border: rgba(255,255,255,0.06);
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: var(--navy);
+    color: var(--text);
+    font-family: 'Inter', -apple-system, sans-serif;
+    line-height: 1.65;
+    padding: 48px 64px 120px;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  /* Header */
+  .header {
+    margin-bottom: 48px;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border);
+  }
+  .header h1 {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--gold);
+    margin-bottom: 4px;
+  }
+  .header p {
+    font-size: 14px;
+    color: var(--text-muted);
+  }
+
+  /* Sections */
+  .section {
+    margin-bottom: 40px;
+  }
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+  .section-head h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #fff;
+  }
+  .section-head .time {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+
+  /* Diagram */
+  .diagram {
+    display: flex;
+    gap: 16px;
+    margin: 16px 0 20px;
+  }
+  .entity {
+    flex: 1;
+    background: var(--navy-light);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px 20px;
+  }
+  .entity h3 {
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: 2px;
+  }
+  .entity .sub {
+    font-size: 12px;
+    color: var(--text-muted);
+    font-style: italic;
+    margin-bottom: 10px;
+  }
+  .entity ul {
+    list-style: none;
+    font-size: 13px;
+    color: var(--text-dim);
+  }
+  .entity ul li { padding: 2px 0; }
+  .entity ul li::before {
+    content: '-';
+    margin-right: 8px;
+    color: var(--text-muted);
+  }
+  .e-zao h3 { color: var(--gold); }
+  .e-nmc h3 { color: var(--green); }
+  .e-ent h3 { color: #60a5fa; }
+
+  .connector {
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+    font-size: 16px;
+    flex-shrink: 0;
+  }
+
+  .oneliner {
+    font-size: 14px;
+    color: var(--text-dim);
+    margin: 12px 0;
+    padding: 12px 16px;
+    background: var(--gold-dim);
+    border-radius: 8px;
+    border-left: 3px solid var(--gold);
+  }
+
+  /* Lanes */
+  .lanes {
+    display: flex;
+    gap: 12px;
+    margin: 12px 0;
+  }
+  .lane {
+    flex: 1;
+    padding: 12px 16px;
+    border-radius: 8px;
+    font-size: 13px;
+  }
+  .lane strong { display: block; margin-bottom: 2px; font-size: 13px; }
+  .lane-1 { background: var(--green-dim); }
+  .lane-1 strong { color: var(--green); }
+  .lane-2 { background: var(--yellow-dim); }
+  .lane-2 strong { color: var(--yellow); }
+  .lane-3 { background: rgba(96,165,250,0.1); }
+  .lane-3 strong { color: #60a5fa; }
+  .lane p { color: var(--text-dim); }
+
+  /* Questions */
+  .questions {
+    margin: 12px 0;
+    padding: 0;
+    list-style: none;
+  }
+  .questions li {
+    font-size: 14px;
+    color: var(--text-dim);
+    padding: 4px 0;
+    padding-left: 20px;
+    position: relative;
+  }
+  .questions li::before {
+    content: '?';
+    position: absolute;
+    left: 0;
+    color: var(--gold);
+    font-weight: 700;
+    font-size: 13px;
+  }
+
+  /* Status rows */
+  .status-row {
+    display: flex;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 14px;
+  }
+  .status-row:last-child { border-bottom: none; }
+  .status-label {
+    width: 140px;
+    color: #fff;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+  .status-badge {
+    width: 100px;
+    flex-shrink: 0;
+  }
+  .badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 12px;
+  }
+  .b-yes { background: var(--green-dim); color: var(--green); }
+  .b-wip { background: var(--yellow-dim); color: var(--yellow); }
+  .b-no { background: var(--red-dim); color: var(--red); }
+  .status-detail { color: var(--text-dim); }
+
+  /* Gaps */
+  .gaps {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    margin: 12px 0;
+  }
+  .gap {
+    font-size: 13px;
+    color: var(--text-dim);
+    padding: 10px 14px;
+    background: var(--red-dim);
+    border-radius: 8px;
+  }
+  .gap strong { color: var(--red); }
+
+  /* Quote */
+  .quote {
+    border-left: 3px solid var(--text-muted);
+    padding: 12px 16px;
+    margin: 12px 0;
+    font-size: 14px;
+    color: var(--text-dim);
+    font-style: italic;
+    background: var(--navy-light);
+    border-radius: 0 8px 8px 0;
+  }
+  .quote-by {
+    font-style: normal;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 6px;
+  }
+
+  /* Landing points */
+  .points {
+    list-style: none;
+    counter-reset: pts;
+    margin: 12px 0;
+  }
+  .points li {
+    counter-increment: pts;
+    padding: 8px 0;
+    font-size: 14px;
+    color: var(--text-dim);
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .points li::before {
+    content: counter(pts);
+    background: var(--gold-dim);
+    color: var(--gold);
+    font-weight: 700;
+    font-size: 12px;
+    min-width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+  .points li strong { color: #fff; }
+
+  /* Role rows */
+  .role-row {
+    display: flex;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 14px;
+    gap: 12px;
+  }
+  .role-row:last-child { border-bottom: none; }
+  .role-name {
+    width: 160px;
+    color: var(--gold);
+    font-weight: 600;
+    flex-shrink: 0;
+    font-size: 13px;
+  }
+  .role-who {
+    width: 180px;
+    color: #fff;
+    font-weight: 500;
+    flex-shrink: 0;
+    font-size: 13px;
+  }
+  .role-what {
+    color: var(--text-dim);
+    font-size: 13px;
+  }
+
+  /* Action items */
+  .action {
+    display: flex;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+    gap: 12px;
+    font-size: 14px;
+  }
+  .action:last-child { border-bottom: none; }
+  .check {
+    width: 20px;
+    height: 20px;
+    border: 2px solid var(--text-muted);
+    border-radius: 5px;
+    flex-shrink: 0;
+    cursor: pointer;
+    transition: all 0.15s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .check:hover { border-color: var(--gold); }
+  .check.on { background: var(--gold); border-color: var(--gold); }
+  .check.on::after { content: '\2713'; color: var(--navy); font-weight: 700; font-size: 12px; }
+  .action-text { color: var(--text-dim); flex: 1; }
+  .action-text.done { text-decoration: line-through; opacity: 0.4; }
+  .action-who {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--gold);
+    background: var(--gold-dim);
+    padding: 3px 10px;
+    border-radius: 12px;
+    white-space: nowrap;
+  }
+
+  /* Parking lot */
+  .parking {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 8px 0;
+  }
+  .parking span {
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--navy-light);
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+  }
+
+  /* Divider */
+  hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 0;
+  }
+
+  /* Prep section */
+  .prep {
+    margin-top: 48px;
+    padding-top: 24px;
+    border-top: 2px dashed rgba(245,166,35,0.2);
+  }
+  .prep h2 {
+    font-size: 16px;
+    color: var(--text-muted);
+    font-weight: 600;
+    margin-bottom: 16px;
+  }
+  .prep-item {
+    margin-bottom: 12px;
+    padding: 12px 16px;
+    background: var(--navy-light);
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }
+  .prep-item h4 {
+    font-size: 12px;
+    color: var(--gold);
+    font-weight: 600;
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .prep-item p {
+    font-size: 13px;
+    color: var(--text-dim);
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <h1>ZAO Stock sync</h1>
+  <p>April 10, 2026 &middot; Zaal + FailOften &middot; ~30 min</p>
+</div>
+
+<!-- 1. Structure -->
+<div class="section">
+  <div class="section-head">
+    <h2>1. The structure</h2>
+    <span class="time">~5 min</span>
+  </div>
+
+  <div class="diagram">
+    <div class="entity e-zao">
+      <h3>ZAO</h3>
+      <div class="sub">talent + programming</div>
+      <ul>
+        <li>Artists</li>
+        <li>Community</li>
+        <li>Events</li>
+        <li>Sponsorship relationships</li>
+      </ul>
+    </div>
+    <div class="connector">&times;</div>
+    <div class="entity e-nmc">
+      <h3>New Media Commons</h3>
+      <div class="sub">funding structure</div>
+      <ul>
+        <li>Grant pathway</li>
+        <li>Tax-deductible layer</li>
+        <li>Institutional money</li>
+        <li>Legitimacy</li>
+      </ul>
+    </div>
+    <div class="connector">&times;</div>
+    <div class="entity e-ent">
+      <h3>ENTERACT</h3>
+      <div class="sub">technical build</div>
+      <ul>
+        <li>Installations</li>
+        <li>Systems</li>
+        <li>Production tech</li>
+        <li>Delivery</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="oneliner">
+    ZAO brings the project. New Media Commons makes it fundable. ENTERACT handles the technical side. One project budget pays everyone.
+  </div>
+
+  <div class="lanes">
+    <div class="lane lane-1"><strong>Paid</strong><p>Client has budget, direct contract</p></div>
+    <div class="lane lane-2"><strong>Sponsored</strong><p>No budget yet, ZAO brings sponsors</p></div>
+    <div class="lane lane-3"><strong>Funded</strong><p>Grants, tax-deductible, institutional</p></div>
+  </div>
+
+  <ul class="questions">
+    <li>Are we aligned on this 3-entity model?</li>
+    <li>Where does BCZ Strategies fit - Zaal's lane within ZAO, or separate?</li>
+    <li>What exactly is New Media Commons - FailOften's org? Fiscal sponsor?</li>
+  </ul>
+</div>
+
+<hr>
+
+<!-- 2. Where things stand -->
+<div class="section">
+  <div class="section-head">
+    <h2>2. Where things stand</h2>
+    <span class="time">~5 min</span>
+  </div>
+
+  <div style="margin-bottom: 16px;">
+    <div class="status-row">
+      <div class="status-label">Date</div>
+      <div class="status-badge"><span class="badge b-yes">LOCKED</span></div>
+      <div class="status-detail">October 3, 2026</div>
+    </div>
+    <div class="status-row">
+      <div class="status-label">Venue</div>
+      <div class="status-badge"><span class="badge b-wip">WIP</span></div>
+      <div class="status-detail">Franklin St Parklet, via Heart of Ellsworth</div>
+    </div>
+    <div class="status-row">
+      <div class="status-label">Official status</div>
+      <div class="status-badge"><span class="badge b-yes">LOCKED</span></div>
+      <div class="status-detail">Part of Art of Ellsworth: Maine Craft Weekend (9th year)</div>
+    </div>
+    <div class="status-row">
+      <div class="status-label">Weather backup</div>
+      <div class="status-badge"><span class="badge b-no">TBD</span></div>
+      <div class="status-detail">Wallace Events tent rental - not yet contacted</div>
+    </div>
+    <div class="status-row">
+      <div class="status-label">Artists</div>
+      <div class="status-badge"><span class="badge b-wip">4 IN</span></div>
+      <div class="status-detail">AttaBotty, Jango, Hurric4n3Ike, DCoop</div>
+    </div>
+    <div class="status-row">
+      <div class="status-label">Steve Peer</div>
+      <div class="status-badge"><span class="badge b-no">TBD</span></div>
+      <div class="status-detail">Local music anchor, not yet pitched</div>
+    </div>
+  </div>
+
+  <div class="gaps">
+    <div class="gap"><strong>Funding:</strong> nothing in place yet</div>
+    <div class="gap"><strong>Budget:</strong> $5K min / $25K goal, no money committed</div>
+    <div class="gap"><strong>Compensation:</strong> no real currency plan</div>
+    <div class="gap"><strong>Sound/staging:</strong> need local vendor, no quotes</div>
+    <div class="gap"><strong>Contracts:</strong> none exist</div>
+  </div>
+</div>
+
+<hr>
+
+<!-- 3. Compensation -->
+<div class="section">
+  <div class="section-head">
+    <h2>3. Compensation</h2>
+    <span class="time">~10 min</span>
+  </div>
+
+  <div class="quote">
+    "For this to be viable and to actually respect the artists involved, people need to be paid in real currency. Systems like that can sit alongside it, but they can't replace it."
+    <div class="quote-by">- FailOften, 4/7</div>
+  </div>
+
+  <p style="font-size: 14px; color: var(--text-dim); margin: 12px 0;">We agree. The fractal/respect system is for <strong style="color:#fff">tracking</strong>, not replacing pay. Here's where we want to land:</p>
+
+  <ol class="points">
+    <li><strong>Respect tracks contribution</strong> - who did what, transparent ledger</li>
+    <li><strong>Real money pays people</strong> - from sponsors, grants, ticket sales</li>
+    <li><strong>Respect informs allocation</strong> - when money comes in, scores help determine fair splits</li>
+    <li><strong>No one works for tokens</strong> - respect is recognition, not compensation</li>
+  </ol>
+
+  <ul class="questions">
+    <li>How does the NMC / ENTERACT structure actually bring money into ZAO Stock?</li>
+    <li>What's the realistic funding path + timeline?</li>
+  </ul>
+</div>
+
+<hr>
+
+<!-- 4. Roles -->
+<div class="section">
+  <div class="section-head">
+    <h2>4. Roles</h2>
+    <span class="time">~5 min</span>
+  </div>
+
+  <div>
+    <div class="role-row">
+      <div class="role-name">Curation</div>
+      <div class="role-who">Zaal + Steve Peer (TBD)</div>
+      <div class="role-what">Lineup, set times, event shape</div>
+    </div>
+    <div class="role-row">
+      <div class="role-name">Community</div>
+      <div class="role-who">Zaal + ZAO members</div>
+      <div class="role-what">Promo, virtual ramp-up Apr-Sept</div>
+    </div>
+    <div class="role-row">
+      <div class="role-name">Technical build</div>
+      <div class="role-who">FailOften / ENTERACT</div>
+      <div class="role-what">Installations, visuals, production tech</div>
+    </div>
+    <div class="role-row">
+      <div class="role-name">Production</div>
+      <div class="role-who">AttaBotty</div>
+      <div class="role-what">On-site staging, sound coordination</div>
+    </div>
+    <div class="role-row">
+      <div class="role-name">Funding</div>
+      <div class="role-who">FailOften + Zaal</div>
+      <div class="role-what">Grants, sponsors, budget</div>
+    </div>
+    <div class="role-row">
+      <div class="role-name">Local logistics</div>
+      <div class="role-who">Zaal</div>
+      <div class="role-what">Venue, permits, vendors, HoE relationship</div>
+    </div>
+  </div>
+
+  <ul class="questions">
+    <li>Does FailOften want to own the funding lane or advise on it?</li>
+    <li>Is ENTERACT involved as an org, or is it just him for this?</li>
+    <li>Capacity - he's in KC, how much on-site time?</li>
+  </ul>
+</div>
+
+<hr>
+
+<!-- 5. Next steps -->
+<div class="section">
+  <div class="section-head">
+    <h2>5. Next steps</h2>
+    <span class="time">~5 min</span>
+  </div>
+
+  <div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Draft simple budget (min viable + stretch)</div>
+      <div class="action-who">Both</div>
+    </div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Identify 2-3 grant / funding paths</div>
+      <div class="action-who">FailOften</div>
+    </div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Pitch Steve Peer on co-curating</div>
+      <div class="action-who">Zaal</div>
+    </div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Wallace Events tent quote</div>
+      <div class="action-who">Zaal</div>
+    </div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Define what contracts look like for team</div>
+      <div class="action-who">FailOften</div>
+    </div>
+    <div class="action">
+      <div class="check" onclick="this.classList.toggle('on'); this.nextElementSibling.classList.toggle('done');"></div>
+      <div class="action-text">Sound / PA vendor research (Ellsworth area)</div>
+      <div class="action-who">Zaal</div>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px;">
+    <p style="font-size: 12px; color: var(--text-muted); margin-bottom: 8px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;">Parking lot</p>
+    <div class="parking">
+      <span>ZAOVille / DCoop coordination</span>
+      <span>Thursday summer concerts</span>
+      <span>ZAO OS event page</span>
+      <span>Livestream strategy</span>
+    </div>
+  </div>
+</div>
+
+<!-- Prep notes - scroll past the fold -->
+<div class="prep">
+  <h2>Notes for Zaal (don't scroll here on screen share)</h2>
+  <div class="prep-item">
+    <h4>On funding</h4>
+    <p>"We have no funding in place yet. Goal is $25K, min viable $5K. I want your help figuring out how to get there - that's where the NMC structure you laid out could be the answer."</p>
+  </div>
+  <div class="prep-item">
+    <h4>On compensation</h4>
+    <p>"The fractal system is for tracking, not replacing pay. I agree people need real money. The question is where it comes from, and that's what we need to figure out together."</p>
+  </div>
+  <div class="prep-item">
+    <h4>On roles</h4>
+    <p>"I see you as both the tech/installations lead AND the person who understands how to structure funding. That's why this conversation matters."</p>
+  </div>
+  <div class="prep-item">
+    <h4>General</h4>
+    <p>Be transparent about what's not figured out. He respects that. "Just getting the fundamentals down will be key."</p>
+  </div>
+</div>
+
+</body>
+</html>

--- a/tmp/zaostock-failoften-agenda-0410.md
+++ b/tmp/zaostock-failoften-agenda-0410.md
@@ -1,0 +1,122 @@
+# ZAO Stock - FailOften Sync Agenda
+**Date:** April 10, 2026 | **Duration:** 30 min | **Attendees:** Zaal, FailOften
+
+**Context:** FailOften sent the ZAO x ENTERACT x New Media Commons framework doc. Discord exchange on 4/7-4/8 covered basics. This call is to go deeper on the specifics.
+
+---
+
+## 1. Align on the Structure (5 min)
+*FailOften's framework is solid - confirm Zaal agrees with the 3-entity model*
+
+FailOften's framework:
+```
+ZAO                    New Media Commons         ENTERACT
+(talent/programming)   (funding structure)        (technical build)
+- Artists              - Grant pathway            - Installations
+- Community            - Tax-deductible layer     - Systems
+- Events               - Institutional money      - Production tech
+- Sponsorship rels     - Legitimacy               - Delivery
+```
+
+**The 3 lanes** (from FailOften's doc):
+1. **Paid** - client already has budget, direct contract
+2. **Sponsored** - no budget yet, ZAO helps bring sponsors
+3. **Funded** - grants, tax-deductible sponsorship, institutional/philanthropic money
+
+**Where BCZ Strategies fits:** BCZ is Zaal's LLC - the entity that contracts, invoices, and gets paid. It sits alongside this structure as the business vehicle for Zaal's work specifically.
+
+**Discuss:**
+- Does Zaal agree with ZAO / New Media Commons / ENTERACT as the 3 pillars?
+- How does BCZ Strategies relate to this - is it Zaal's personal lane within ZAO, or separate?
+- What is New Media Commons exactly? Is it FailOften's org? A fiscal sponsor? A nonprofit?
+
+---
+
+## 2. ZAO Stock Status Update (5 min)
+*Answering FailOften's questions from Discord more fully*
+
+### What's confirmed
+| Item | Status | Details |
+|------|--------|---------|
+| Date | **CONFIRMED** | October 3, 2026 |
+| Venue | **In progress** | Franklin Street Parklet, rented from Heart of Ellsworth |
+| Official status | **CONFIRMED** | Part of Art of Ellsworth: Maine Craft Weekend (9th annual, statewide promo) |
+| Weather backup | **Not yet onboarded** | Wallace Events tent rental |
+| Artists confirmed | **4 confirmed** | AttaBotty, Jango, Hurric4n3Ike, DCoop |
+| Steve Peer | **Not yet pitched** | Local music anchor, 37 years in Ellsworth, 430 house concerts |
+
+### What's NOT figured out yet (be honest)
+- **Funding:** Nothing in place. No sponsors, no grants, no crowdfunding yet
+- **Budget:** Goal $25K, minimum viable $5K - but no money committed
+- **Compensation:** Zaal mentioned fractal/respect tracking, but no real currency plan yet
+- **Sound/staging:** Need local Ellsworth/Bangor vendor, no quotes yet
+- **Contracts:** None exist
+
+**FailOften will want to hear:** A clear acknowledgment that the funding/compensation piece is the gap, and that this call is about figuring that out together.
+
+---
+
+## 3. The Compensation Question (10 min)
+*This is the key tension FailOften flagged - address it directly*
+
+**FailOften's position (from Discord 4/7):**
+> "For this to be viable and to actually respect the artists involved, people need to be paid in real currency. Systems like that can sit alongside it, but they can't replace it."
+
+**Zaal's position:**
+- Fractal/respect system for **tracking contribution** (not replacing pay)
+- All volunteer currently - goal is to cover flights + lodging for traveling team
+- Would like to pay people but needs funding first
+
+**Where to land:**
+1. **Respect tracks contribution** - who did what, how much, transparent ledger
+2. **Real money pays people** - from actual funding (sponsors, grants, ticket sales)
+3. **Respect informs allocation** - when money comes in, respect scores help determine fair splits
+4. **No one works for tokens** - respect is recognition, not compensation
+
+**Question for FailOften:** How does the New Media Commons / ENTERACT structure actually bring money into ZAO Stock? What's the realistic path?
+
+---
+
+## 4. Roles + Lanes for ZAO Stock (5 min)
+*Using FailOften's "who does what" framework applied to ZAO Stock specifically*
+
+| Lane | Owner | ZAO Stock scope |
+|------|-------|-----------------|
+| **Programming / Curation** | Zaal + Steve Peer (TBD) | Artist lineup, set times, overall event shape |
+| **Community / Outreach** | Zaal + ZAO members | Promo, virtual ramp-up (Apr-Sept), member attendance |
+| **Technical Build** | FailOften / ENTERACT | Installations, visuals, production tech |
+| **Production** | AttaBotty | On-site production, staging, sound coordination |
+| **Funding / Sponsorship** | FailOften + Zaal | Grant applications, sponsor outreach, budget |
+| **Local logistics** | Zaal | Venue, permits, vendors, Heart of Ellsworth relationship |
+
+**Discuss:**
+- Does FailOften want to own the funding/sponsorship lane, or advise on it?
+- What does ENTERACT's involvement actually look like? Is FailOften bringing ENTERACT to this, or is it just him?
+- What's FailOften's capacity? He's in Kansas City - how much on-site time?
+
+---
+
+## 5. Concrete Next Steps (5 min)
+*Lock in 3-5 things that happen before the next sync*
+
+| Action Item | Owner | By When |
+|-------------|-------|---------|
+| Draft a simple budget (minimum viable + stretch) | Zaal + FailOften | ? |
+| Identify 2-3 grant/funding paths for ZAO Stock | FailOften | ? |
+| Pitch Steve Peer on co-curating | Zaal | ? |
+| Get Wallace Events tent quote | Zaal | ? |
+| Define what "contract" looks like for team members | FailOften | ? |
+| Sound/PA vendor research (Ellsworth/Bangor area) | Zaal | ? |
+
+---
+
+## Zaal's Prep Notes
+*Things to be ready to say on the call*
+
+**On funding:** "Right now we have no funding in place. The goal is $25K, minimum viable is $5K. I want your help figuring out how to get there - that's where the New Media Commons structure you laid out could be the answer."
+
+**On compensation:** "The fractal system is for tracking contribution, not replacing pay. I agree - people need to be paid real money. The question is where that money comes from, and I think that's what you and I need to figure out together."
+
+**On roles:** "I see you as both the technical/installations lead AND the person who understands how to structure funding. That's why this conversation matters."
+
+**On what's real vs aspirational:** Be transparent. FailOften respects honesty about what's not figured out yet. He said it himself - "just getting the fundamentals down will be key."


### PR DESCRIPTION
## Summary
- **Team dashboard at `/stock/team`** - password-gated dashboard where ZAO Stock team (Zaal, FailOften, AttaBotty, DaNici, Hurric4n3Ike, DCoop) can track goals, todos, and roles
- **Public `/stock` page cleanup** - removed placeholder artist grid, simplified lineup section
- **Meeting agenda** - structured HTML agenda for FailOften sync on 4/10

## What's in the dashboard
- Password login (separate iron-session cookie, doesn't interfere with main auth)
- Status board with 11 seeded goals grouped by category (venue, funding, artists, production, logistics, marketing)
- Todo list with create/update/filter by owner, inline notes
- Team roles display
- All backed by 3 new Supabase tables + 5 API routes

## Setup after merge
1. Run migration: apply `supabase/migrations/20260410_stock_team_dashboard.sql` via Supabase SQL editor
2. Seed team: `npx tsx scripts/seed-stock-team.ts` (prints passwords to share via DM)
3. Visit `/stock/team` and login

## Test plan
- [ ] `/stock` page renders without artist placeholder grid
- [ ] `/stock/team` shows login form when not authenticated
- [ ] Login with seeded credentials works
- [ ] Goals board displays, status can be changed, details can be edited
- [ ] Todos can be created, status cycled, notes added, filtered by owner
- [ ] Team roles display correctly
- [ ] Logout works and returns to login form

🤖 Generated with [Claude Code](https://claude.com/claude-code)