### PR TITLE
ZAO Stock standup kickoff: dashboard + /stock teams

### DIFF
--- a/ZAO-STOCK/standups/dashboard.md
+++ b/ZAO-STOCK/standups/dashboard.md
@@ -28,6 +28,8 @@
 | **2nd** | Candy | Milk Road/Impact3 sponsorship pipeline ($10-25K/send), grant knowledge |
 | Member | Tyler Stambaugh | JPMorgan + Accenture finance, Magnetiq COO, grant writing |
 | Member | Ohnahji B | Community fundraising, 5K NFTs minted, education-track funding |
+| Member | DFresh | |
+| Member | Craig G | |
 
 ### Design
 | Role | Person | Strengths |
@@ -86,6 +88,8 @@
 | Ohnahji B | | |
 | Swarthy Hatter | | |
 | DCoop | | |
+| DFresh | | |
+| Craig G | | |
 
 ---
 

--- a/ZAO-STOCK/standups/dashboard.md
+++ b/ZAO-STOCK/standups/dashboard.md
@@ -73,26 +73,6 @@
 
 ---
 
-## Attendance Log
-
-### April 14, 2026 - Kickoff
-| Name | Present | Notes |
-|------|---------|-------|
-| Zaal | | |
-| AttaBotty | | |
-| DaNici | | |
-| FailOften | | |
-| Hurric4n3Ike | | |
-| Candy | | |
-| Tyler Stambaugh | | |
-| Ohnahji B | | |
-| Swarthy Hatter | | |
-| DCoop | | |
-| DFresh | | |
-| Craig G | | |
-
----
-
 ## Weekly Notes
 
 ### April 14, 2026 - Kickoff Meeting


### PR DESCRIPTION
## Summary
- Created living standup dashboard at `ZAO-STOCK/standups/dashboard.md` with team rosters (Operations/Finance/Design), resources landscape, and kickoff agenda
- Added "The Team" and "Partners" sections to `/stock` page with lead/2nd/member pills and confirmed partner badges
- Teams: Operations (Zaal lead), Finance (Zaal lead, DFresh + Craig G added), Design (DaNici lead)

## Test plan
- [ ] Visit /stock and verify Team + Partners sections appear after Lineup, before RSVP
- [ ] Verify mobile layout stacks correctly
- [ ] Review `ZAO-STOCK/standups/dashboard.md` for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)