### PR TITLE
feat(stock): Sponsors CRM - Wave 1 of Notion replacement

### DIFF
--- a/research/dev-workflows/414-ai-native-documentation-patterns/README.md
+++ b/research/dev-workflows/414-ai-native-documentation-patterns/README.md
@@ -1,0 +1,258 @@
+# 414 - AI-Native Documentation Patterns for Monorepos (2026)
+
+> **Status:** Research complete
+> **Date:** April 15, 2026
+> **Goal:** Best practices for documenting codebases where AI agents (Claude Code, Cursor, Copilot) are primary collaborators, and human collaborators need to onboard into AI-built code
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Primary agent config** | USE CLAUDE.md (root + per-package). Already have this. Anthropic's hierarchy walks up directory tree - subdirectory files load on demand. Under 500 words per file for density |
+| **Universal agent standard** | ADD AGENTS.md at root as universal standard (60K+ projects). Symlink CLAUDE.md content or vice versa. Supported by Sourcegraph, OpenAI, Google, GitHub |
+| **llms.txt** | ADD `/public/llms.txt` for web-facing docs. 60K+ projects adopted. Structured markdown with H1/H2 sections + links. Good for external AI tools accessing our docs |
+| **ETH Zurich warning** | HEED - research shows AGENTS.md can hurt agent performance when it contains LLM-generated context. Only include non-inferable details (env setup, gotchas, security rules). Skip architecture AI can read from code |
+| **Per-package CLAUDE.md** | USE for monorepo. Each package gets its own CLAUDE.md with build/test/lint commands + domain-specific rules. Root CLAUDE.md = map of what each app/package does |
+| **Onboarding doc strategy** | USE CLAUDE.md as dual-purpose: onboards AI agents AND human collaborators. Answer "what would you tell a senior dev joining in 5 minutes?" |
+| **Three-tier boundaries** | USE "Always do" / "Ask first" / "Never do" pattern from doc 366. More actionable than prose |
+| **.cursorrules** | SKIP - Cursor-specific, doesn't benefit Claude Code or Copilot. AGENTS.md is universal |
+| **CONTEXT.md** | SKIP - not adopted as standard. AGENTS.md superseded it |
+| **Architecture docs for AI** | USE inline code comments + CLAUDE.md map over separate ARCHITECTURE.md. AI reads code better than prose descriptions of code |
+
+---
+
+## Comparison: AI Documentation Standards (2026)
+
+| Standard | Adoption | Audience | Where | Format | ZAO Action |
+|----------|----------|----------|-------|--------|------------|
+| **CLAUDE.md** | Claude Code users | Claude agents | Root + subdirs | Markdown, <500 words | KEEP + improve |
+| **AGENTS.md** | 60K+ projects | All AI agents | Root | Markdown, 6 sections | ADD (symlink from CLAUDE.md) |
+| **llms.txt** | 60K+ projects | External AI tools | /llms.txt or /public/ | Structured MD, H1/H2 + links | ADD for web docs |
+| **.cursorrules** | Cursor users | Cursor AI | Root | JSON/text | SKIP |
+| **.github/copilot-instructions.md** | GitHub Copilot | Copilot | .github/ | Markdown | SKIP (AGENTS.md covers this) |
+| **GEMINI.md** | Gemini CLI users | Gemini | Root | Markdown | SKIP for now |
+| **CONTEXT.md** | Minimal | Mixed | Root | Markdown | SKIP (not standard) |
+
+## The Documentation Stack (Recommended)
+
+```
+zaoos/
+  CLAUDE.md              # Root - project map, security rules, conventions
+  AGENTS.md              # Universal agent standard (can symlink to CLAUDE.md)
+  public/llms.txt        # AI-readable project overview for web
+  apps/
+    web/
+      CLAUDE.md          # Next.js app specifics: routes, components, build
+    zabal-snap/
+      CLAUDE.md          # Snap-specific: Farcaster Mini App patterns
+  packages/
+    agents/
+      CLAUDE.md          # Agent module: Privy wallets, 0x API, trading logic
+    publish/
+      CLAUDE.md          # Cross-posting: platforms, normalization, rate limits
+    config/
+      CLAUDE.md          # Community config: what each field controls
+    db/
+      CLAUDE.md          # Supabase: RLS rules, service role usage, migrations
+```
+
+## What Goes Where
+
+### Root CLAUDE.md (already exists, refine)
+
+```markdown
+# Project Map
+- apps/web/ - Main Next.js 16 app (social client, music, governance)
+- apps/zabal-snap/ - Farcaster Mini App for ZABAL staking
+- packages/agents/ - VAULT/BANKER/DEALER autonomous trading agents
+- packages/publish/ - Cross-platform publishing (Farcaster, X, Bluesky)
+- packages/config/ - Community branding, channels, contracts
+- packages/db/ - Supabase client + helpers
+
+# Quick Start
+npm install && npm run dev
+
+# Security (Non-Negotiable)
+- NEVER expose SUPABASE_SERVICE_ROLE_KEY, NEYNAR_API_KEY, SESSION_SECRET
+- NEVER use dangerouslySetInnerHTML
+- All user input validated with Zod
+
+# Conventions
+[existing conventions - already good]
+```
+
+### Per-Package CLAUDE.md (new)
+
+```markdown
+# @zaoos/agents
+
+Trading agents (VAULT/BANKER/DEALER) that autonomously buy ZABAL on Base.
+
+## Build/Test
+npm run test          # vitest
+npm run typecheck     # tsc --noEmit
+
+## Key Files
+- runner.ts     - Shared agent logic (buy, burn, stake, post)
+- wallet.ts     - Privy TEE signing
+- swap.ts       - 0x Swap API integration
+- types.ts      - AgentName, TOKENS, contracts
+
+## Boundaries
+ALWAYS: validate swap quotes before executing
+ASK FIRST: changing trade amounts or burn percentages
+NEVER: expose Privy wallet IDs or signing keys in responses
+```
+
+### AGENTS.md (new, universal)
+
+```markdown
+# AGENTS.md - ZAO OS
+
+## Commands
+- Build: `npm run build`
+- Test: `npm run test` (vitest)
+- Lint: `npm run lint:biome`
+- Typecheck: `npm run typecheck`
+- Dev: `npm run dev`
+
+## Testing
+- Framework: Vitest
+- Mock pattern: `vi.mock()` + `vi.hoisted()`
+- Co-locate: `src/app/api/foo/__tests__/route.test.ts`
+- Helpers: `src/test-utils/api-helpers.ts`
+
+## Project Structure
+[point to CLAUDE.md project map]
+
+## Code Style
+- Imports: `@/` alias (maps to src/)
+- Components: PascalCase .tsx with "use client" for interactive
+- API routes: /api/[feature]/[action]/route.ts
+- Styling: Tailwind CSS v4, dark navy #0a1628 + gold #f5a623
+
+## Git Workflow
+- Branch: ws/<description>-MMDD-HHMM from main
+- PRs: always to main, never push directly
+- Commits: conventional commits
+
+## Boundaries
+ALWAYS: validate with Zod, check session, return NextResponse.json
+ASK FIRST: database migrations, new dependencies, env var changes
+NEVER: expose service keys, use dangerouslySetInnerHTML, skip auth checks
+```
+
+### llms.txt (new)
+
+```markdown
+# ZAO OS
+
+> Gated Farcaster social client for The ZAO - a decentralized music community. Built with Next.js 16, Supabase, Neynar, XMTP.
+
+## Docs
+- [README](https://github.com/ZAO-OS/zaoos/blob/main/README.md): Project overview
+- [CLAUDE.md](https://github.com/ZAO-OS/zaoos/blob/main/CLAUDE.md): Full codebase guide
+- [AGENTS.md](https://github.com/ZAO-OS/zaoos/blob/main/AGENTS.md): AI agent instructions
+
+## API
+- [Auth](https://github.com/ZAO-OS/zaoos/tree/main/src/app/api/auth): Session management
+- [Agents](https://github.com/ZAO-OS/zaoos/tree/main/src/app/api/agents): Trading agent endpoints
+- [Music](https://github.com/ZAO-OS/zaoos/tree/main/src/app/api/music): Player + queue API
+
+## Stack
+- Next.js 16 + React 19 (App Router)
+- Supabase (PostgreSQL + RLS)
+- Neynar (Farcaster API)
+- XMTP (encrypted messaging)
+- Stream.io (live audio/video)
+- Wagmi + Viem (blockchain)
+```
+
+---
+
+## Onboarding Pattern: AI-Built Codebases
+
+When code was primarily written with AI assistance, human collaborators face specific challenges:
+
+### Problem: Tribal Knowledge Lives in Chat History
+
+| Challenge | Solution |
+|-----------|----------|
+| "Why was this built this way?" | Research docs (240+ in `research/`) capture decision rationale |
+| "What's the architecture?" | CLAUDE.md project map + per-package CLAUDE.md |
+| "How do I run things?" | AGENTS.md commands section (universal, not Claude-specific) |
+| "What are the gotchas?" | Three-tier boundaries in AGENTS.md |
+| "What's in progress?" | GitHub Issues + PR descriptions |
+
+### The 5-Minute Onboarding Test
+
+Good documentation passes this test: A senior developer with the right stack experience can go from `git clone` to making a meaningful PR in under 30 minutes by reading only:
+
+1. Root CLAUDE.md (2 min) - what is this, how to run it
+2. AGENTS.md (1 min) - commands, style, boundaries
+3. Relevant package CLAUDE.md (2 min) - domain-specific context
+
+### ETH Zurich Finding (Critical)
+
+Research from ETH Zurich (2026) found AGENTS.md files can **hurt** agent performance when they contain information the agent can infer from code. Rules:
+
+- **DO include:** env setup, security rules, non-obvious gotchas, test commands, deployment steps
+- **DO NOT include:** architecture descriptions AI can read from imports, type definitions AI can read from code, file listings AI can glob for
+
+This aligns with Stack Overflow's finding: guidelines should be **explicit** (not tacit), **demonstrate patterns** (not describe them), **explain WHY** (not just what), and be **tested adversarially** (try to break them).
+
+---
+
+## ZAO OS Implementation Plan
+
+### Phase 1: Improve Existing (30 min)
+
+1. Trim root CLAUDE.md - remove architecture AI can read, keep security rules + conventions + project map
+2. Add three-tier boundaries section
+3. Add per-file test/lint commands
+
+### Phase 2: Add Universal Standards (1 hour)
+
+1. Create `AGENTS.md` at root (symlink relationship with CLAUDE.md)
+2. Create `public/llms.txt` for web-facing docs
+3. Create per-package `CLAUDE.md` files after monorepo migration completes
+
+### Phase 3: Onboarding (Post-Migration)
+
+1. Create `CONTRIBUTING.md` with the 5-minute onboarding flow
+2. Add `research/README.md` pointer in root docs
+3. Test with a fresh Claude Code session - can it make a PR without asking questions?
+
+---
+
+## Codebase Files Affected
+
+| File | Action |
+|------|--------|
+| `CLAUDE.md` | REFINE - trim to <500 words, add project map, add boundaries |
+| `AGENTS.md` | CREATE - universal agent standard |
+| `public/llms.txt` | CREATE - web-facing AI docs |
+| `apps/web/CLAUDE.md` | CREATE after monorepo Phase 3 |
+| `packages/agents/CLAUDE.md` | CREATE after monorepo Phase 3 |
+| `packages/publish/CLAUDE.md` | CREATE after monorepo Phase 3 |
+| `packages/config/CLAUDE.md` | CREATE after monorepo Phase 3 |
+| `packages/db/CLAUDE.md` | CREATE after monorepo Phase 3 |
+| `CONTRIBUTING.md` | CREATE - human onboarding flow |
+| `.claude/rules/` | KEEP - already contains per-domain rules (api-routes, components, tests) |
+
+---
+
+## Sources
+
+- [llms.txt Standard](https://llmstxt.org/) - 60K+ projects, structured MD for AI
+- [AGENTS.md Standard](https://agents.md/) - Universal agent config, Linux Foundation
+- [How to Build AGENTS.md](https://www.augmentcode.com/guides/how-to-build-agents-md) - Augment Code, 2026
+- [Writing a Good CLAUDE.md](https://www.humanlayer.dev/blog/writing-a-good-claude-md) - HumanLayer, dual-purpose onboarding
+- [Using CLAUDE.md Files](https://claude.com/blog/using-claude-md-files) - Official Anthropic guidance
+- [AI File Format Reference](https://p0stman.com/the-complete-reference-guide-to-ai-file-formats-for-coding-agents/) - p0stman.com, full comparison
+- [Stack Overflow: Coding Guidelines for AI + Humans](https://stackoverflow.blog/2025/01/23/coding-guidelines-for-ai-agents-and-humans/) - Explicit > tacit, demonstrate > describe
+- [ETH Zurich AGENTS.md Research](https://arxiv.org/abs/2506.03276) - Warning: LLM-generated context in AGENTS.md can hurt performance
+- [Doc 366: AGENTS.md Monorepo Best Practices](../366-agents-md-monorepo-best-practices-2026/) - Prior ZAO research on structure
+- [Doc 405: Monorepo Migration Plan](../405-monorepo-migration/) - Turborepo + pnpm migration

--- a/research/dev-workflows/README.md
+++ b/research/dev-workflows/README.md
@@ -54,3 +54,4 @@
 | 409 | [Claude Skills: Anthropic Engineers Guide](./409-claude-skills-anthropic-engineers-guide/) | STANDALONE | Barry & Mahesh explain skills = folders with markdown. ZAO already follows this pattern with 11+ skills. |
 | 411 | [AI-Native Engineering Team: CREAO 99% AI Code](./411-ai-native-eng-team-creao-99pct-ai-code/) | STANDALONE | 25 people = 100+ output, 3-8 daily deploys, harness engineering, junior > senior for AI adoption, validates ZAO lean model |
 | 412 | [AI Dev Tools: Conductor, Replicas, AO Agents](./412-ai-dev-tools-roundup-conductor-replicas-aoagents/) | STANDALONE | Conductor (parallel Claude Code, YC S24, $2.8M), Replicas (background agents from GitHub/Slack), AO Agents (Arweave compute) |
+| 414 | [AI-Native Documentation Patterns](./414-ai-native-documentation-patterns/) | CANONICAL | llms.txt (60K+), AGENTS.md (60K+), per-package CLAUDE.md, ETH Zurich warning, dual-purpose onboarding, 3-phase implementation |

--- a/scripts/stock-team-sponsors.sql
+++ b/scripts/stock-team-sponsors.sql
@@ -1,0 +1,48 @@
+-- ZAOstock Sponsors CRM - Wave 1 of Dashboard Expansion
+-- Run in Supabase SQL Editor after stock-team-setup.sql
+
+-- Sponsors table
+CREATE TABLE IF NOT EXISTS stock_sponsors (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT NOT NULL,
+  track TEXT NOT NULL CHECK (track IN ('local', 'virtual', 'ecosystem')),
+  status TEXT NOT NULL DEFAULT 'lead' CHECK (status IN ('lead', 'contacted', 'in_talks', 'committed', 'paid', 'declined')),
+  contact_name TEXT DEFAULT '',
+  contact_email TEXT DEFAULT '',
+  contact_phone TEXT DEFAULT '',
+  amount_committed NUMERIC(10,2) DEFAULT 0,
+  amount_paid NUMERIC(10,2) DEFAULT 0,
+  why_them TEXT DEFAULT '',
+  notes TEXT DEFAULT '',
+  owner_id UUID REFERENCES stock_team_members(id),
+  last_contacted_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE stock_sponsors ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access" ON stock_sponsors FOR ALL USING (true) WITH CHECK (true);
+
+-- Seed from outreach.md
+INSERT INTO stock_sponsors (name, track, status, contact_name, contact_phone, why_them) VALUES
+  -- Local
+  ('Fogtown Brewing', 'local', 'lead', 'Jon Stein', '', 'Beer partner, 25 Pine St, existing music venue'),
+  ('Precipice Coffee', 'local', 'lead', '', '', 'Coffee partner, saw 25% MCW boost'),
+  ('Atlantic Art Glass', 'local', 'lead', 'Linda Perrin', '', 'Art partner, saw 300% MCW boost'),
+  ('Franklin Savings Bank', 'local', 'lead', '', '', 'Already funds Heart of Ellsworth'),
+  ('Bangor Savings Bank', 'local', 'lead', '', '', '$1,000 corporate giving, monthly review cycle - FIRST TARGET'),
+  ('Maine Community Foundation', 'local', 'lead', '', '', 'Funded HoE Asset Mapping study'),
+  ('Wallace Events', 'local', 'lead', '', '(207) 667-6000', 'Tent partner, in-kind sponsor potential'),
+  ('Share Studios', 'local', 'lead', 'Stephanie Hare', '', 'Art/craft partner'),
+  ('Vinyl Vogue', 'local', 'lead', 'Matt Manry', '', 'Record shop at Newberry Exchange, literally next to Parklet'),
+  -- Virtual (Web3)
+  ('Coinbase / Base', 'virtual', 'lead', '', '', 'AttaBotty on Base Onchain Registry, Onchain Summer grants ($2M)'),
+  ('Audius', 'virtual', 'lead', '', '', 'Decentralized music streaming, ZAO already integrates'),
+  ('Impact3', 'virtual', 'lead', 'Kyle Reidhead', '', 'Candy former employer, crypto marketing agency'),
+  ('OnChain Records', 'virtual', 'lead', '', '', 'AttaBotty collaborator, 90% artist revenue'),
+  ('One Love Art DAO', 'virtual', 'lead', 'Jenifer Pepen (SirenAi)', '', 'FailOften connection, 600+ artists globally'),
+  ('Whop', 'virtual', 'lead', 'Craig Gonzalez', '', '$1.6B creator platform, Craig on advisory board'),
+  ('Songjam', 'virtual', 'lead', 'Adam Place', '', 'Advisory board member, ZABAL leaderboard powers ZAO engagement'),
+  -- Ecosystem
+  ('Fractured Atlas', 'ecosystem', 'committed', '', '', 'Already our 501(c)(3) fiscal sponsor - covers all ZAO Festivals'),
+  ('Heart of Ellsworth', 'ecosystem', 'committed', 'Cara Romano', '(207) 812-4164', 'Venue + MCW statewide promo - CONFIRMED');

--- a/src/app/api/stock/team/sponsors/route.ts
+++ b/src/app/api/stock/team/sponsors/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_sponsors')
+    .select('*, owner:stock_team_members!owner_id(id, name)')
+    .order('track')
+    .order('status')
+    .order('created_at', { ascending: false });
+
+  if (error) return NextResponse.json({ error: 'Failed to load sponsors' }, { status: 500 });
+  return NextResponse.json({ sponsors: data });
+}
+
+const createSchema = z.object({
+  name: z.string().min(1).max(200),
+  track: z.enum(['local', 'virtual', 'ecosystem']),
+  status: z.enum(['lead', 'contacted', 'in_talks', 'committed', 'paid', 'declined']).optional(),
+  contact_name: z.string().max(200).optional(),
+  contact_email: z.string().max(200).optional(),
+  contact_phone: z.string().max(50).optional(),
+  why_them: z.string().max(1000).optional(),
+  owner_id: z.string().uuid().nullable().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_sponsors')
+    .insert(parsed.data)
+    .select('*, owner:stock_team_members!owner_id(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create sponsor' }, { status: 500 });
+  return NextResponse.json({ sponsor: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(200).optional(),
+  track: z.enum(['local', 'virtual', 'ecosystem']).optional(),
+  status: z.enum(['lead', 'contacted', 'in_talks', 'committed', 'paid', 'declined']).optional(),
+  contact_name: z.string().max(200).optional(),
+  contact_email: z.string().max(200).optional(),
+  contact_phone: z.string().max(50).optional(),
+  amount_committed: z.number().min(0).optional(),
+  amount_paid: z.number().min(0).optional(),
+  why_them: z.string().max(1000).optional(),
+  notes: z.string().max(2000).optional(),
+  owner_id: z.string().uuid().nullable().optional(),
+  last_contacted_at: z.string().datetime().nullable().optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_sponsors')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update sponsor' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_sponsors').delete().eq('id', parsed.data.id);
+
+  if (error) return NextResponse.json({ error: 'Failed to delete sponsor' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -1,9 +1,30 @@
 'use client';
 
+import { useState } from 'react';
 import { GoalsBoard } from './GoalsBoard';
 import { TodoList } from './TodoList';
 import { TeamRoles } from './TeamRoles';
+import { SponsorCRM } from './SponsorCRM';
 import { useRouter } from 'next/navigation';
+
+type Tab = 'overview' | 'sponsors' | 'team';
+
+interface Sponsor {
+  id: string;
+  name: string;
+  track: 'local' | 'virtual' | 'ecosystem';
+  status: 'lead' | 'contacted' | 'in_talks' | 'committed' | 'paid' | 'declined';
+  contact_name: string;
+  contact_email: string;
+  contact_phone: string;
+  amount_committed: number;
+  amount_paid: number;
+  why_them: string;
+  notes: string;
+  owner: { id: string; name: string } | null;
+  last_contacted_at: string | null;
+  created_at: string;
+}
 
 interface Props {
   memberName: string;
@@ -11,10 +32,12 @@ interface Props {
   goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
   todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
   members: Array<{ id: string; name: string; role: string; scope: string }>;
+  sponsors: Sponsor[];
 }
 
-export function Dashboard({ memberName, memberId, goals, todos, members }: Props) {
+export function Dashboard({ memberName, memberId, goals, todos, members, sponsors }: Props) {
   const router = useRouter();
+  const [tab, setTab] = useState<Tab>('overview');
 
   async function handleLogout() {
     await fetch('/api/stock/team/logout', { method: 'POST' });
@@ -36,15 +59,52 @@ export function Dashboard({ memberName, memberId, goals, todos, members }: Props
             </button>
           </div>
         </div>
+        <div className="max-w-2xl mx-auto px-4 pb-2 flex gap-1 overflow-x-auto">
+          <TabButton active={tab === 'overview'} onClick={() => setTab('overview')}>
+            Overview
+          </TabButton>
+          <TabButton active={tab === 'sponsors'} onClick={() => setTab('sponsors')}>
+            Sponsors
+            <span className="ml-1 text-[10px] text-gray-500">{sponsors.length}</span>
+          </TabButton>
+          <TabButton active={tab === 'team'} onClick={() => setTab('team')}>
+            Team
+          </TabButton>
+        </div>
       </header>
 
       <div className="max-w-2xl mx-auto px-4 py-6 space-y-8 pb-16">
-        <GoalsBoard goals={goals} />
-        <hr className="border-white/[0.06]" />
-        <TodoList todos={todos} members={members.map((m) => ({ id: m.id, name: m.name }))} currentMemberId={memberId} />
-        <hr className="border-white/[0.06]" />
-        <TeamRoles members={members} />
+        {tab === 'overview' && (
+          <>
+            <GoalsBoard goals={goals} />
+            <hr className="border-white/[0.06]" />
+            <TodoList
+              todos={todos}
+              members={members.map((m) => ({ id: m.id, name: m.name }))}
+              currentMemberId={memberId}
+            />
+          </>
+        )}
+        {tab === 'sponsors' && (
+          <SponsorCRM sponsors={sponsors} members={members.map((m) => ({ id: m.id, name: m.name }))} />
+        )}
+        {tab === 'team' && <TeamRoles members={members} />}
       </div>
     </div>
+  );
+}
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors whitespace-nowrap ${
+        active
+          ? 'bg-[#f5a623]/15 text-[#f5a623] border border-[#f5a623]/30'
+          : 'text-gray-400 border border-transparent hover:text-white hover:bg-white/[0.04]'
+      }`}
+    >
+      {children}
+    </button>
   );
 }

--- a/src/app/stock/team/SponsorCRM.tsx
+++ b/src/app/stock/team/SponsorCRM.tsx
@@ -1,0 +1,309 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Member { id: string; name: string; }
+
+interface Sponsor {
+  id: string;
+  name: string;
+  track: 'local' | 'virtual' | 'ecosystem';
+  status: 'lead' | 'contacted' | 'in_talks' | 'committed' | 'paid' | 'declined';
+  contact_name: string;
+  contact_email: string;
+  contact_phone: string;
+  amount_committed: number;
+  amount_paid: number;
+  why_them: string;
+  notes: string;
+  owner: Member | null;
+  last_contacted_at: string | null;
+  created_at: string;
+}
+
+const STATUS_ORDER: Record<Sponsor['status'], number> = {
+  lead: 0,
+  contacted: 1,
+  in_talks: 2,
+  committed: 3,
+  paid: 4,
+  declined: 5,
+};
+
+const STATUS_LABEL: Record<Sponsor['status'], string> = {
+  lead: 'Lead',
+  contacted: 'Contacted',
+  in_talks: 'In Talks',
+  committed: 'Committed',
+  paid: 'Paid',
+  declined: 'Declined',
+};
+
+const STATUS_COLOR: Record<Sponsor['status'], string> = {
+  lead: 'border-gray-600 text-gray-400',
+  contacted: 'border-blue-500/40 bg-blue-500/10 text-blue-400',
+  in_talks: 'border-amber-500/40 bg-amber-500/10 text-amber-400',
+  committed: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400',
+  paid: 'border-emerald-500 bg-emerald-500/20 text-emerald-300',
+  declined: 'border-red-500/40 bg-red-500/10 text-red-400',
+};
+
+const TRACK_COLOR: Record<Sponsor['track'], string> = {
+  local: 'text-green-400 bg-green-500/10',
+  virtual: 'text-indigo-400 bg-indigo-500/10',
+  ecosystem: 'text-[#f5a623] bg-[#f5a623]/10',
+};
+
+const TRACK_LABEL: Record<Sponsor['track'], string> = {
+  local: 'Local',
+  virtual: 'Virtual',
+  ecosystem: 'Ecosystem',
+};
+
+export function SponsorCRM({ sponsors: initial, members }: { sponsors: Sponsor[]; members: Member[] }) {
+  const [sponsors, setSponsors] = useState(initial);
+  const [track, setTrack] = useState<'all' | Sponsor['track']>('all');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newTrack, setNewTrack] = useState<Sponsor['track']>('local');
+
+  const filtered = sponsors
+    .filter((s) => track === 'all' || s.track === track)
+    .sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+
+  const totalCommitted = sponsors.reduce((sum, s) => sum + Number(s.amount_committed || 0), 0);
+  const totalPaid = sponsors.reduce((sum, s) => sum + Number(s.amount_paid || 0), 0);
+  const committedCount = sponsors.filter((s) => s.status === 'committed' || s.status === 'paid').length;
+
+  async function createSponsor(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    const res = await fetch('/api/stock/team/sponsors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName.trim(), track: newTrack }),
+    });
+    if (res.ok) {
+      const { sponsor } = await res.json();
+      setSponsors((prev) => [sponsor, ...prev]);
+      setNewName('');
+    }
+  }
+
+  async function updateSponsor(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/sponsors', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setSponsors((prev) => prev.map((s) => (s.id === id ? { ...s, ...updates } : s)));
+    }
+  }
+
+  function cycleStatus(s: Sponsor) {
+    const order: Sponsor['status'][] = ['lead', 'contacted', 'in_talks', 'committed', 'paid'];
+    const idx = order.indexOf(s.status);
+    const next = idx >= 0 && idx < order.length - 1 ? order[idx + 1] : 'lead';
+    const update: Record<string, unknown> = { status: next };
+    if (next !== 'lead' && !s.last_contacted_at) {
+      update.last_contacted_at = new Date().toISOString();
+    }
+    updateSponsor(s.id, update);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-white">Sponsors</h2>
+        <select
+          value={track}
+          onChange={(e) => setTrack(e.target.value as 'all' | Sponsor['track'])}
+          className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+        >
+          <option value="all">All Tracks</option>
+          <option value="local">Local</option>
+          <option value="virtual">Virtual</option>
+          <option value="ecosystem">Ecosystem</option>
+        </select>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-emerald-400">${totalPaid.toLocaleString()}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Paid</p>
+        </div>
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-amber-400">${totalCommitted.toLocaleString()}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Committed</p>
+        </div>
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-white">{committedCount}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Secured</p>
+        </div>
+      </div>
+
+      <form onSubmit={createSponsor} className="flex gap-2">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Add a sponsor..."
+          className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <select
+          value={newTrack}
+          onChange={(e) => setNewTrack(e.target.value as Sponsor['track'])}
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-2 py-2 text-xs text-gray-400 focus:outline-none"
+        >
+          <option value="local">Local</option>
+          <option value="virtual">Virtual</option>
+          <option value="ecosystem">Ecosystem</option>
+        </select>
+        <button
+          type="submit"
+          className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2 text-sm transition-colors"
+        >
+          Add
+        </button>
+      </form>
+
+      <div className="space-y-2">
+        {filtered.map((sponsor) => (
+          <div key={sponsor.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] overflow-hidden">
+            <div className="p-3 flex items-start gap-3">
+              <button
+                onClick={() => cycleStatus(sponsor)}
+                className={`text-[10px] font-bold px-2 py-0.5 rounded-full border flex-shrink-0 mt-0.5 ${STATUS_COLOR[sponsor.status]}`}
+                title="Click to advance status"
+              >
+                {STATUS_LABEL[sponsor.status]}
+              </button>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="text-sm font-medium text-white">{sponsor.name}</p>
+                  <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded uppercase ${TRACK_COLOR[sponsor.track]}`}>
+                    {TRACK_LABEL[sponsor.track]}
+                  </span>
+                  {Number(sponsor.amount_committed) > 0 && (
+                    <span className="text-[10px] text-amber-400">${Number(sponsor.amount_committed).toLocaleString()}</span>
+                  )}
+                </div>
+                {sponsor.why_them && <p className="text-xs text-gray-500 mt-1 line-clamp-1">{sponsor.why_them}</p>}
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  {sponsor.contact_name && (
+                    <span className="text-[10px] text-gray-400">{sponsor.contact_name}</span>
+                  )}
+                  {sponsor.owner && (
+                    <span className="text-[10px] text-[#f5a623] bg-[#f5a623]/10 px-1.5 py-0.5 rounded-full">
+                      {sponsor.owner.name}
+                    </span>
+                  )}
+                  <button
+                    onClick={() => setExpandedId(expandedId === sponsor.id ? null : sponsor.id)}
+                    className="text-[10px] text-gray-500 hover:text-gray-400"
+                  >
+                    {expandedId === sponsor.id ? 'collapse' : 'edit'}
+                  </button>
+                </div>
+              </div>
+            </div>
+            {expandedId === sponsor.id && (
+              <div className="border-t border-white/[0.06] p-3 space-y-2 bg-[#0a1628]">
+                <EditRow sponsor={sponsor} members={members} onUpdate={updateSponsor} />
+              </div>
+            )}
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-gray-500 text-center py-4">No sponsors in this track yet</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EditRow({
+  sponsor,
+  members,
+  onUpdate,
+}: {
+  sponsor: Sponsor;
+  members: Member[];
+  onUpdate: (id: string, updates: Record<string, unknown>) => void;
+}) {
+  const [committed, setCommitted] = useState(String(sponsor.amount_committed || ''));
+  const [paid, setPaid] = useState(String(sponsor.amount_paid || ''));
+  const [notes, setNotes] = useState(sponsor.notes || '');
+  const [contactName, setContactName] = useState(sponsor.contact_name || '');
+  const [contactEmail, setContactEmail] = useState(sponsor.contact_email || '');
+
+  function save() {
+    onUpdate(sponsor.id, {
+      amount_committed: Number(committed) || 0,
+      amount_paid: Number(paid) || 0,
+      notes,
+      contact_name: contactName,
+      contact_email: contactEmail,
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-2">
+        <input
+          value={contactName}
+          onChange={(e) => setContactName(e.target.value)}
+          placeholder="Contact name"
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <input
+          value={contactEmail}
+          onChange={(e) => setContactEmail(e.target.value)}
+          placeholder="Contact email"
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <input
+          type="number"
+          value={committed}
+          onChange={(e) => setCommitted(e.target.value)}
+          placeholder="Committed $"
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <input
+          type="number"
+          value={paid}
+          onChange={(e) => setPaid(e.target.value)}
+          placeholder="Paid $"
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+      <textarea
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        placeholder="Notes"
+        rows={2}
+        className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+      />
+      <div className="flex items-center gap-2">
+        <select
+          value={sponsor.owner?.id || ''}
+          onChange={(e) => onUpdate(sponsor.id, { owner_id: e.target.value || null })}
+          className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-gray-400 focus:outline-none"
+        >
+          <option value="">Unassigned</option>
+          {members.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <button
+          onClick={save}
+          className="ml-auto bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded px-3 py-1.5 text-xs transition-colors"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -20,7 +20,7 @@ export default async function StockTeamPage() {
 
   const supabase = getSupabaseAdmin();
 
-  const [goalsRes, todosRes, membersRes] = await Promise.allSettled([
+  const [goalsRes, todosRes, membersRes, sponsorsRes] = await Promise.allSettled([
     supabase.from('stock_goals').select('*').order('sort_order'),
     supabase
       .from('stock_todos')
@@ -28,11 +28,18 @@ export default async function StockTeamPage() {
       .order('status')
       .order('created_at', { ascending: false }),
     supabase.from('stock_team_members').select('id, name, role, scope').order('created_at'),
+    supabase
+      .from('stock_sponsors')
+      .select('*, owner:stock_team_members!owner_id(id, name)')
+      .order('track')
+      .order('status')
+      .order('created_at', { ascending: false }),
   ]);
 
   const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
   const todos = todosRes.status === 'fulfilled' ? todosRes.value.data || [] : [];
   const members = membersRes.status === 'fulfilled' ? membersRes.value.data || [] : [];
+  const sponsors = sponsorsRes.status === 'fulfilled' ? sponsorsRes.value.data || [] : [];
 
   return (
     <Dashboard
@@ -41,6 +48,7 @@ export default async function StockTeamPage() {
       goals={goals}
       todos={todos}
       members={members}
+      sponsors={sponsors}
     />
   );
 }


### PR DESCRIPTION
## Summary
Wave 1 of the dashboard expansion to kill the Notion plan ($840/yr saved). Sponsor CRM tab lets team track the sponsor pipeline directly inside the existing /stock/team dashboard.

## What shipped
- **SQL migration** at \`scripts/stock-team-sponsors.sql\`: new \`stock_sponsors\` table with 3 tracks (local/virtual/ecosystem) and 6 statuses (lead → contacted → in_talks → committed → paid). Seeds 18 targets from \`outreach.md\` + doc 364 (Bangor Savings, Fogtown, Whop, Songjam, Fractured Atlas, etc).
- **API route** at \`src/app/api/stock/team/sponsors/route.ts\`: GET/POST/PATCH/DELETE, Zod validated, uses existing \`stock-team-session\` auth.
- **SponsorCRM component**: live stats (paid $, committed $, secured count), click-to-cycle status pills, track filter, expandable edit row for contact + amounts + notes + owner.
- **Tabbed dashboard shell**: Overview (goals + todos) / Sponsors / Team.

## Setup
1. Merge PR
2. Run \`scripts/stock-team-sponsors.sql\` in Supabase SQL Editor
3. Visit zaoos.com/stock/team → Sponsors tab

## What's next (Wave 2)
Artists pipeline + Timeline milestones. Research doc: [413 - Dashboard as Notion Replacement](https://github.com/bettercallzaal/ZAOOS/blob/main/research/infrastructure/413-zaostock-dashboard-notion-replacement/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)