### PR TITLE
feat(stock): Volunteers + Budget + Notes - Wave 3 (Notion replacement complete)

### DIFF
--- a/scripts/stock-team-wave3.sql
+++ b/scripts/stock-team-wave3.sql
@@ -1,0 +1,81 @@
+-- ZAOstock Wave 3: Volunteers + Budget + Meeting Notes
+-- Run in Supabase SQL Editor after stock-team-artists-timeline.sql
+
+-- Volunteers
+CREATE TABLE IF NOT EXISTS stock_volunteers (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT NOT NULL,
+  email TEXT DEFAULT '',
+  phone TEXT DEFAULT '',
+  role TEXT DEFAULT 'unassigned' CHECK (role IN ('setup', 'checkin', 'water', 'safety', 'teardown', 'floater', 'content', 'unassigned')),
+  shift TEXT DEFAULT 'allday' CHECK (shift IN ('early', 'block1', 'block2', 'teardown', 'allday')),
+  confirmed BOOLEAN DEFAULT false,
+  notes TEXT DEFAULT '',
+  recruited_by UUID REFERENCES stock_team_members(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE stock_volunteers ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access" ON stock_volunteers FOR ALL USING (true) WITH CHECK (true);
+
+-- Budget entries
+CREATE TABLE IF NOT EXISTS stock_budget_entries (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  type TEXT NOT NULL CHECK (type IN ('income', 'expense')),
+  category TEXT NOT NULL,
+  description TEXT NOT NULL,
+  amount NUMERIC(10,2) NOT NULL,
+  status TEXT NOT NULL DEFAULT 'projected' CHECK (status IN ('projected', 'committed', 'actual')),
+  date DATE,
+  related_sponsor_id UUID REFERENCES stock_sponsors(id),
+  notes TEXT DEFAULT '',
+  created_by UUID REFERENCES stock_team_members(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE stock_budget_entries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access" ON stock_budget_entries FOR ALL USING (true) WITH CHECK (true);
+
+-- Meeting notes
+CREATE TABLE IF NOT EXISTS stock_meeting_notes (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  meeting_date DATE NOT NULL,
+  title TEXT NOT NULL,
+  attendees TEXT[] DEFAULT '{}',
+  notes TEXT DEFAULT '',
+  action_items TEXT DEFAULT '',
+  created_by UUID REFERENCES stock_team_members(id),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+ALTER TABLE stock_meeting_notes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Service role full access" ON stock_meeting_notes FOR ALL USING (true) WITH CHECK (true);
+
+-- Seed budget from budget.md (projected)
+INSERT INTO stock_budget_entries (type, category, description, amount, status) VALUES
+  -- Income targets
+  ('income', 'crowdfunding', 'Giveth crypto crowdfunding target', 3500, 'projected'),
+  ('income', 'crowdfunding', 'GoFundMe traditional crowdfunding target', 3500, 'projected'),
+  ('income', 'crowdfunding', 'Mirror onchain post target', 1000, 'projected'),
+  ('income', 'sponsorship', 'Local Ellsworth sponsorships target', 3500, 'projected'),
+  ('income', 'sponsorship', 'Web3 brand sponsorships target', 3500, 'projected'),
+  ('income', 'door', 'Door / tips day-of', 750, 'projected'),
+  -- Expenses
+  ('expense', 'travel', 'Artist flights (5-8 x $200-$400)', 5000, 'projected'),
+  ('expense', 'lodging', 'Team Airbnb/hotels 2-3 nights', 4000, 'projected'),
+  ('expense', 'sound', 'PA rental + operator', 3000, 'projected'),
+  ('expense', 'tent', 'Wallace Events tent (weather backup)', 2000, 'projected'),
+  ('expense', 'artist_fees', 'Per diem + meals for artists', 2000, 'projected'),
+  ('expense', 'marketing', 'Print materials + signage', 1000, 'projected'),
+  ('expense', 'venue', 'Parklet rental (may be free via HoE)', 1000, 'projected'),
+  ('expense', 'insurance', 'Event liability insurance', 300, 'projected'),
+  ('expense', 'contingency', 'Unexpected costs buffer', 1000, 'projected')
+ON CONFLICT DO NOTHING;
+
+-- Seed meeting notes from existing standup recaps
+INSERT INTO stock_meeting_notes (meeting_date, title, attendees, notes) VALUES
+  ('2026-04-14', 'Kickoff Standup', ARRAY['Zaal','DCoop','Candy','Shawn','FailOften'],
+   '4 teams confirmed (Operations/Finance/Design/Music). Advisory board established. Venue keeping Parklet through Oct 3 weekend at no cost. Bangor Savings Bank identified as first sponsor target.'),
+  ('2026-04-16', 'DaNici Design Meeting', ARRAY['Zaal','DaNici'],
+   'ZAOstock brand confirmed (one word, lowercase s). Design team workflow: Thu brainstorm, Mon updates, Tue report. T-shirt designs coming before next standup. Cipher update from Anna incoming.')
+ON CONFLICT DO NOTHING;

--- a/src/app/api/stock/team/budget/route.ts
+++ b/src/app/api/stock/team/budget/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_budget_entries')
+    .select('*, related_sponsor:stock_sponsors!related_sponsor_id(id, name)')
+    .order('type')
+    .order('category')
+    .order('created_at', { ascending: false });
+
+  if (error) return NextResponse.json({ error: 'Failed to load budget' }, { status: 500 });
+  return NextResponse.json({ entries: data });
+}
+
+const createSchema = z.object({
+  type: z.enum(['income', 'expense']),
+  category: z.string().min(1).max(100),
+  description: z.string().min(1).max(500),
+  amount: z.number().min(0),
+  status: z.enum(['projected', 'committed', 'actual']).optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  related_sponsor_id: z.string().uuid().nullable().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_budget_entries')
+    .insert({ ...parsed.data, created_by: member.memberId })
+    .select('*, related_sponsor:stock_sponsors!related_sponsor_id(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create entry' }, { status: 500 });
+  return NextResponse.json({ entry: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  type: z.enum(['income', 'expense']).optional(),
+  category: z.string().min(1).max(100).optional(),
+  description: z.string().min(1).max(500).optional(),
+  amount: z.number().min(0).optional(),
+  status: z.enum(['projected', 'committed', 'actual']).optional(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).nullable().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_budget_entries')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update entry' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_budget_entries').delete().eq('id', parsed.data.id);
+  if (error) return NextResponse.json({ error: 'Failed to delete entry' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/stock/team/notes/route.ts
+++ b/src/app/api/stock/team/notes/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_meeting_notes')
+    .select('*, creator:stock_team_members!created_by(id, name)')
+    .order('meeting_date', { ascending: false });
+
+  if (error) return NextResponse.json({ error: 'Failed to load notes' }, { status: 500 });
+  return NextResponse.json({ notes: data });
+}
+
+const createSchema = z.object({
+  meeting_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  title: z.string().min(1).max(200),
+  attendees: z.array(z.string()).optional(),
+  notes: z.string().max(10000).optional(),
+  action_items: z.string().max(5000).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_meeting_notes')
+    .insert({ ...parsed.data, created_by: member.memberId })
+    .select('*, creator:stock_team_members!created_by(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create note' }, { status: 500 });
+  return NextResponse.json({ note: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  meeting_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  title: z.string().min(1).max(200).optional(),
+  attendees: z.array(z.string()).optional(),
+  notes: z.string().max(10000).optional(),
+  action_items: z.string().max(5000).optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_meeting_notes')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update note' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_meeting_notes').delete().eq('id', parsed.data.id);
+  if (error) return NextResponse.json({ error: 'Failed to delete note' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/stock/team/volunteers/route.ts
+++ b/src/app/api/stock/team/volunteers/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export async function GET() {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_volunteers')
+    .select('*, recruited_by_member:stock_team_members!recruited_by(id, name)')
+    .order('confirmed', { ascending: false })
+    .order('created_at', { ascending: false });
+
+  if (error) return NextResponse.json({ error: 'Failed to load volunteers' }, { status: 500 });
+  return NextResponse.json({ volunteers: data });
+}
+
+const createSchema = z.object({
+  name: z.string().min(1).max(200),
+  email: z.string().max(200).optional(),
+  phone: z.string().max(50).optional(),
+  role: z.enum(['setup', 'checkin', 'water', 'safety', 'teardown', 'floater', 'content', 'unassigned']).optional(),
+  shift: z.enum(['early', 'block1', 'block2', 'teardown', 'allday']).optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_volunteers')
+    .insert({ ...parsed.data, recruited_by: member.memberId })
+    .select('*, recruited_by_member:stock_team_members!recruited_by(id, name)')
+    .single();
+
+  if (error) return NextResponse.json({ error: 'Failed to create volunteer' }, { status: 500 });
+  return NextResponse.json({ volunteer: data }, { status: 201 });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(200).optional(),
+  email: z.string().max(200).optional(),
+  phone: z.string().max(50).optional(),
+  role: z.enum(['setup', 'checkin', 'water', 'safety', 'teardown', 'floater', 'content', 'unassigned']).optional(),
+  shift: z.enum(['early', 'block1', 'block2', 'teardown', 'allday']).optional(),
+  confirmed: z.boolean().optional(),
+  notes: z.string().max(1000).optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input', details: parsed.error.issues }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_volunteers')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Failed to update volunteer' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_volunteers').delete().eq('id', parsed.data.id);
+  if (error) return NextResponse.json({ error: 'Failed to delete volunteer' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/stock/team/BudgetTracker.tsx
+++ b/src/app/stock/team/BudgetTracker.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState } from 'react';
+
+interface BudgetEntry {
+  id: string;
+  type: 'income' | 'expense';
+  category: string;
+  description: string;
+  amount: number;
+  status: 'projected' | 'committed' | 'actual';
+  date: string | null;
+  notes: string;
+  related_sponsor: { id: string; name: string } | null;
+  created_at: string;
+}
+
+const STATUS_COLOR: Record<BudgetEntry['status'], string> = {
+  projected: 'border-gray-600 text-gray-400',
+  committed: 'border-amber-500/40 bg-amber-500/10 text-amber-400',
+  actual: 'border-emerald-500 bg-emerald-500/20 text-emerald-300',
+};
+
+export function BudgetTracker({ entries: initial }: { entries: BudgetEntry[] }) {
+  const [entries, setEntries] = useState(initial);
+  const [view, setView] = useState<'all' | 'income' | 'expense'>('all');
+  const [newType, setNewType] = useState<'income' | 'expense'>('income');
+  const [newCategory, setNewCategory] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [newAmount, setNewAmount] = useState('');
+
+  async function createEntry(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newCategory.trim() || !newDescription.trim() || !newAmount) return;
+    const res = await fetch('/api/stock/team/budget', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        type: newType,
+        category: newCategory.trim(),
+        description: newDescription.trim(),
+        amount: Number(newAmount),
+      }),
+    });
+    if (res.ok) {
+      const { entry } = await res.json();
+      setEntries((prev) => [entry, ...prev]);
+      setNewCategory('');
+      setNewDescription('');
+      setNewAmount('');
+    }
+  }
+
+  async function updateEntry(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/budget', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setEntries((prev) => prev.map((e) => (e.id === id ? { ...e, ...updates } : e)));
+    }
+  }
+
+  function cycleStatus(entry: BudgetEntry) {
+    const next = entry.status === 'projected' ? 'committed' : entry.status === 'committed' ? 'actual' : 'projected';
+    updateEntry(entry.id, { status: next });
+  }
+
+  const income = entries.filter((e) => e.type === 'income');
+  const expenses = entries.filter((e) => e.type === 'expense');
+  const incomeActual = income.filter((e) => e.status === 'actual').reduce((sum, e) => sum + Number(e.amount), 0);
+  const incomeCommitted = income.filter((e) => e.status !== 'projected').reduce((sum, e) => sum + Number(e.amount), 0);
+  const incomeProjected = income.reduce((sum, e) => sum + Number(e.amount), 0);
+  const expenseActual = expenses.filter((e) => e.status === 'actual').reduce((sum, e) => sum + Number(e.amount), 0);
+  const expenseProjected = expenses.reduce((sum, e) => sum + Number(e.amount), 0);
+  const netProjected = incomeProjected - expenseProjected;
+
+  const filtered = view === 'all' ? entries : entries.filter((e) => e.type === view);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-white">Budget</h2>
+        <select
+          value={view}
+          onChange={(e) => setView(e.target.value as 'all' | 'income' | 'expense')}
+          className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+        >
+          <option value="all">All</option>
+          <option value="income">Income</option>
+          <option value="expense">Expenses</option>
+        </select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06]">
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider mb-1">Income</p>
+          <p className="text-base font-bold text-emerald-400">${incomeActual.toLocaleString()}</p>
+          <p className="text-[10px] text-gray-500">
+            ${incomeCommitted.toLocaleString()} committed · ${incomeProjected.toLocaleString()} projected
+          </p>
+        </div>
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06]">
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider mb-1">Expenses</p>
+          <p className="text-base font-bold text-red-400">${expenseActual.toLocaleString()}</p>
+          <p className="text-[10px] text-gray-500">
+            ${expenseProjected.toLocaleString()} projected
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-gradient-to-r from-[#f5a623]/10 to-[#ffd700]/5 rounded-lg p-3 border border-[#f5a623]/30 text-center">
+        <p className="text-[10px] text-[#f5a623] uppercase tracking-wider">Projected Net</p>
+        <p className={`text-2xl font-bold ${netProjected >= 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+          {netProjected >= 0 ? '+' : ''}${netProjected.toLocaleString()}
+        </p>
+      </div>
+
+      <form onSubmit={createEntry} className="space-y-2">
+        <div className="flex gap-2">
+          <select
+            value={newType}
+            onChange={(e) => setNewType(e.target.value as 'income' | 'expense')}
+            className="bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-2 py-2 text-xs text-gray-400 focus:outline-none"
+          >
+            <option value="income">Income</option>
+            <option value="expense">Expense</option>
+          </select>
+          <input
+            value={newCategory}
+            onChange={(e) => setNewCategory(e.target.value)}
+            placeholder="Category"
+            className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+          />
+          <input
+            type="number"
+            value={newAmount}
+            onChange={(e) => setNewAmount(e.target.value)}
+            placeholder="$"
+            className="w-24 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-2 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+          />
+        </div>
+        <div className="flex gap-2">
+          <input
+            value={newDescription}
+            onChange={(e) => setNewDescription(e.target.value)}
+            placeholder="Description"
+            className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+          />
+          <button
+            type="submit"
+            className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2 text-sm transition-colors"
+          >
+            Add
+          </button>
+        </div>
+      </form>
+
+      <div className="space-y-2">
+        {filtered.map((entry) => (
+          <div key={entry.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 flex items-start gap-3">
+            <button
+              onClick={() => cycleStatus(entry)}
+              className={`text-[10px] font-bold px-2 py-0.5 rounded-full border flex-shrink-0 mt-0.5 ${STATUS_COLOR[entry.status]}`}
+              title="Cycle status"
+            >
+              {entry.status}
+            </button>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded uppercase ${
+                  entry.type === 'income' ? 'bg-emerald-500/10 text-emerald-400' : 'bg-red-500/10 text-red-400'
+                }`}>
+                  {entry.type}
+                </span>
+                <p className="text-sm text-white">{entry.description}</p>
+              </div>
+              <div className="flex items-center gap-2 mt-1 flex-wrap">
+                <span className="text-[10px] text-gray-500">{entry.category}</span>
+                {entry.related_sponsor && (
+                  <span className="text-[10px] text-[#f5a623] bg-[#f5a623]/10 px-1.5 py-0.5 rounded-full">
+                    via {entry.related_sponsor.name}
+                  </span>
+                )}
+              </div>
+            </div>
+            <p className={`text-base font-bold flex-shrink-0 ${
+              entry.type === 'income' ? 'text-emerald-400' : 'text-red-400'
+            }`}>
+              {entry.type === 'income' ? '+' : '-'}${Number(entry.amount).toLocaleString()}
+            </p>
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <p className="text-sm text-gray-500 text-center py-4">No entries in this view</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -7,9 +7,12 @@ import { TeamRoles } from './TeamRoles';
 import { SponsorCRM } from './SponsorCRM';
 import { ArtistPipeline } from './ArtistPipeline';
 import { Timeline } from './Timeline';
+import { VolunteerRoster } from './VolunteerRoster';
+import { BudgetTracker } from './BudgetTracker';
+import { MeetingNotes } from './MeetingNotes';
 import { useRouter } from 'next/navigation';
 
-type Tab = 'overview' | 'sponsors' | 'artists' | 'timeline' | 'team';
+type Tab = 'overview' | 'sponsors' | 'artists' | 'timeline' | 'volunteers' | 'budget' | 'notes' | 'team';
 
 interface Sponsor {
   id: string;
@@ -58,6 +61,43 @@ interface Milestone {
   created_at: string;
 }
 
+interface Volunteer {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  role: 'setup' | 'checkin' | 'water' | 'safety' | 'teardown' | 'floater' | 'content' | 'unassigned';
+  shift: 'early' | 'block1' | 'block2' | 'teardown' | 'allday';
+  confirmed: boolean;
+  notes: string;
+  recruited_by_member: { id: string; name: string } | null;
+  created_at: string;
+}
+
+interface BudgetEntry {
+  id: string;
+  type: 'income' | 'expense';
+  category: string;
+  description: string;
+  amount: number;
+  status: 'projected' | 'committed' | 'actual';
+  date: string | null;
+  notes: string;
+  related_sponsor: { id: string; name: string } | null;
+  created_at: string;
+}
+
+interface Note {
+  id: string;
+  meeting_date: string;
+  title: string;
+  attendees: string[];
+  notes: string;
+  action_items: string;
+  creator: { id: string; name: string } | null;
+  created_at: string;
+}
+
 interface Props {
   memberName: string;
   memberId: string;
@@ -67,9 +107,24 @@ interface Props {
   sponsors: Sponsor[];
   artists: Artist[];
   milestones: Milestone[];
+  volunteers: Volunteer[];
+  budget: BudgetEntry[];
+  meetingNotes: Note[];
 }
 
-export function Dashboard({ memberName, memberId, goals, todos, members, sponsors, artists, milestones }: Props) {
+export function Dashboard({
+  memberName,
+  memberId,
+  goals,
+  todos,
+  members,
+  sponsors,
+  artists,
+  milestones,
+  volunteers,
+  budget,
+  meetingNotes,
+}: Props) {
   const router = useRouter();
   const [tab, setTab] = useState<Tab>('overview');
 
@@ -96,9 +151,7 @@ export function Dashboard({ memberName, memberId, goals, todos, members, sponsor
           </div>
         </div>
         <div className="max-w-2xl mx-auto px-4 pb-2 flex gap-1 overflow-x-auto">
-          <TabButton active={tab === 'overview'} onClick={() => setTab('overview')}>
-            Overview
-          </TabButton>
+          <TabButton active={tab === 'overview'} onClick={() => setTab('overview')}>Overview</TabButton>
           <TabButton active={tab === 'sponsors'} onClick={() => setTab('sponsors')}>
             Sponsors <span className="ml-1 text-[10px] text-gray-500">{sponsors.length}</span>
           </TabButton>
@@ -108,9 +161,14 @@ export function Dashboard({ memberName, memberId, goals, todos, members, sponsor
           <TabButton active={tab === 'timeline'} onClick={() => setTab('timeline')}>
             Timeline <span className="ml-1 text-[10px] text-gray-500">{milestones.length}</span>
           </TabButton>
-          <TabButton active={tab === 'team'} onClick={() => setTab('team')}>
-            Team
+          <TabButton active={tab === 'volunteers'} onClick={() => setTab('volunteers')}>
+            Volunteers <span className="ml-1 text-[10px] text-gray-500">{volunteers.length}</span>
           </TabButton>
+          <TabButton active={tab === 'budget'} onClick={() => setTab('budget')}>Budget</TabButton>
+          <TabButton active={tab === 'notes'} onClick={() => setTab('notes')}>
+            Notes <span className="ml-1 text-[10px] text-gray-500">{meetingNotes.length}</span>
+          </TabButton>
+          <TabButton active={tab === 'team'} onClick={() => setTab('team')}>Team</TabButton>
         </div>
       </header>
 
@@ -125,6 +183,9 @@ export function Dashboard({ memberName, memberId, goals, todos, members, sponsor
         {tab === 'sponsors' && <SponsorCRM sponsors={sponsors} members={memberList} />}
         {tab === 'artists' && <ArtistPipeline artists={artists} members={memberList} />}
         {tab === 'timeline' && <Timeline milestones={milestones} members={memberList} />}
+        {tab === 'volunteers' && <VolunteerRoster volunteers={volunteers} />}
+        {tab === 'budget' && <BudgetTracker entries={budget} />}
+        {tab === 'notes' && <MeetingNotes notes={meetingNotes} />}
         {tab === 'team' && <TeamRoles members={members} />}
       </div>
     </div>

--- a/src/app/stock/team/MeetingNotes.tsx
+++ b/src/app/stock/team/MeetingNotes.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Note {
+  id: string;
+  meeting_date: string;
+  title: string;
+  attendees: string[];
+  notes: string;
+  action_items: string;
+  creator: { id: string; name: string } | null;
+  created_at: string;
+}
+
+export function MeetingNotes({ notes: initial }: { notes: Note[] }) {
+  const [notes, setNotes] = useState(initial);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newDate, setNewDate] = useState(new Date().toISOString().slice(0, 10));
+  const [newNotes, setNewNotes] = useState('');
+
+  async function createNote(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newTitle.trim() || !newDate) return;
+    const res = await fetch('/api/stock/team/notes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: newTitle.trim(),
+        meeting_date: newDate,
+        notes: newNotes.trim() || undefined,
+      }),
+    });
+    if (res.ok) {
+      const { note } = await res.json();
+      setNotes((prev) => [note, ...prev]);
+      setNewTitle('');
+      setNewNotes('');
+      setCreating(false);
+    }
+  }
+
+  async function updateNote(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/notes', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setNotes((prev) => prev.map((n) => (n.id === id ? { ...n, ...updates } : n)));
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-bold text-white">Meeting Notes</h2>
+        <button
+          onClick={() => setCreating(!creating)}
+          className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-3 py-1.5 text-xs transition-colors"
+        >
+          {creating ? 'Cancel' : '+ New'}
+        </button>
+      </div>
+
+      {creating && (
+        <form onSubmit={createNote} className="bg-[#0d1b2a] rounded-lg border border-[#f5a623]/30 p-3 space-y-2">
+          <div className="flex gap-2">
+            <input
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              placeholder="Meeting title (e.g. Tuesday Standup)"
+              className="flex-1 bg-[#0a1628] border border-white/[0.06] rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+              autoFocus
+            />
+            <input
+              type="date"
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+              className="bg-[#0a1628] border border-white/[0.06] rounded px-2 py-2 text-xs text-gray-400 focus:outline-none"
+            />
+          </div>
+          <textarea
+            value={newNotes}
+            onChange={(e) => setNewNotes(e.target.value)}
+            placeholder="Notes..."
+            rows={4}
+            className="w-full bg-[#0a1628] border border-white/[0.06] rounded px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+          />
+          <button
+            type="submit"
+            className="w-full bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded px-4 py-2 text-sm transition-colors"
+          >
+            Save Note
+          </button>
+        </form>
+      )}
+
+      <div className="space-y-2">
+        {notes.map((note) => (
+          <div key={note.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] overflow-hidden">
+            <button
+              onClick={() => setExpandedId(expandedId === note.id ? null : note.id)}
+              className="w-full p-3 flex items-start gap-3 text-left hover:bg-white/[0.02] transition-colors"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="text-sm font-medium text-white">{note.title}</p>
+                  <span className="text-[10px] text-[#f5a623]">
+                    {new Date(note.meeting_date + 'T00:00:00').toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </span>
+                </div>
+                {note.attendees.length > 0 && (
+                  <p className="text-[10px] text-gray-500 mt-1">
+                    {note.attendees.join(', ')}
+                  </p>
+                )}
+                {expandedId !== note.id && note.notes && (
+                  <p className="text-xs text-gray-400 mt-1 line-clamp-2">{note.notes}</p>
+                )}
+              </div>
+              <span className="text-gray-500 text-xs mt-0.5">{expandedId === note.id ? '▲' : '▼'}</span>
+            </button>
+            {expandedId === note.id && (
+              <div className="border-t border-white/[0.06] p-3 space-y-3 bg-[#0a1628]">
+                <div>
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wider mb-1">Notes</p>
+                  <textarea
+                    defaultValue={note.notes}
+                    onBlur={(e) => e.target.value !== note.notes && updateNote(note.id, { notes: e.target.value })}
+                    rows={6}
+                    className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-3 py-2 text-xs text-white focus:outline-none focus:border-[#f5a623]/30 resize-none"
+                  />
+                </div>
+                <div>
+                  <p className="text-[10px] text-gray-500 uppercase tracking-wider mb-1">Action Items</p>
+                  <textarea
+                    defaultValue={note.action_items}
+                    onBlur={(e) => e.target.value !== note.action_items && updateNote(note.id, { action_items: e.target.value })}
+                    placeholder="- [ ] ..."
+                    rows={4}
+                    className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+        {notes.length === 0 && !creating && (
+          <p className="text-sm text-gray-500 text-center py-4">No meeting notes yet</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/VolunteerRoster.tsx
+++ b/src/app/stock/team/VolunteerRoster.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Member { id: string; name: string; }
+
+interface Volunteer {
+  id: string;
+  name: string;
+  email: string;
+  phone: string;
+  role: 'setup' | 'checkin' | 'water' | 'safety' | 'teardown' | 'floater' | 'content' | 'unassigned';
+  shift: 'early' | 'block1' | 'block2' | 'teardown' | 'allday';
+  confirmed: boolean;
+  notes: string;
+  recruited_by_member: Member | null;
+  created_at: string;
+}
+
+const ROLE_LABEL: Record<Volunteer['role'], string> = {
+  setup: 'Setup',
+  checkin: 'Check-In',
+  water: 'Water',
+  safety: 'Safety',
+  teardown: 'Teardown',
+  floater: 'Floater',
+  content: 'Content',
+  unassigned: 'Unassigned',
+};
+
+const SHIFT_LABEL: Record<Volunteer['shift'], string> = {
+  early: 'Early (8-12)',
+  block1: 'Block 1 (12-3)',
+  block2: 'Block 2 (3-6)',
+  teardown: 'Teardown (6-7:30)',
+  allday: 'All Day',
+};
+
+export function VolunteerRoster({ volunteers: initial }: { volunteers: Volunteer[] }) {
+  const [volunteers, setVolunteers] = useState(initial);
+  const [newName, setNewName] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  async function createVolunteer(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim()) return;
+    const res = await fetch('/api/stock/team/volunteers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: newName.trim(),
+        email: newEmail.trim() || undefined,
+      }),
+    });
+    if (res.ok) {
+      const { volunteer } = await res.json();
+      setVolunteers((prev) => [volunteer, ...prev]);
+      setNewName('');
+      setNewEmail('');
+    }
+  }
+
+  async function updateVolunteer(id: string, updates: Record<string, unknown>) {
+    const res = await fetch('/api/stock/team/volunteers', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id, ...updates }),
+    });
+    if (res.ok) {
+      setVolunteers((prev) => prev.map((v) => (v.id === id ? { ...v, ...updates } : v)));
+    }
+  }
+
+  const confirmed = volunteers.filter((v) => v.confirmed).length;
+  const target = 20;
+  const unassigned = volunteers.filter((v) => v.role === 'unassigned').length;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold text-white">Volunteers</h2>
+
+      <div className="grid grid-cols-3 gap-2">
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-emerald-400">{confirmed} / {target}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Confirmed</p>
+        </div>
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-white">{volunteers.length}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Total</p>
+        </div>
+        <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+          <p className="text-lg font-bold text-amber-400">{unassigned}</p>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">No Role</p>
+        </div>
+      </div>
+
+      <form onSubmit={createVolunteer} className="flex gap-2">
+        <input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          placeholder="Name"
+          className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <input
+          value={newEmail}
+          onChange={(e) => setNewEmail(e.target.value)}
+          placeholder="Email"
+          type="email"
+          className="flex-1 bg-[#0d1b2a] border border-white/[0.06] rounded-lg px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <button
+          type="submit"
+          className="bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2 text-sm transition-colors"
+        >
+          Add
+        </button>
+      </form>
+
+      <div className="space-y-2">
+        {volunteers.map((v) => (
+          <div key={v.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] overflow-hidden">
+            <div className="p-3 flex items-start gap-3">
+              <button
+                onClick={() => updateVolunteer(v.id, { confirmed: !v.confirmed })}
+                className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${
+                  v.confirmed ? 'bg-emerald-500 border-emerald-500 text-white' : 'border-gray-600'
+                }`}
+                title="Toggle confirmed"
+              >
+                {v.confirmed && '✓'}
+              </button>
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-white">{v.name}</p>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded uppercase ${
+                    v.role === 'unassigned' ? 'bg-amber-500/10 text-amber-400' : 'bg-[#f5a623]/10 text-[#f5a623]'
+                  }`}>
+                    {ROLE_LABEL[v.role]}
+                  </span>
+                  <span className="text-[10px] text-gray-500">{SHIFT_LABEL[v.shift]}</span>
+                  {v.email && <span className="text-[10px] text-gray-500">{v.email}</span>}
+                  <button
+                    onClick={() => setExpandedId(expandedId === v.id ? null : v.id)}
+                    className="text-[10px] text-gray-500 hover:text-gray-400 ml-auto"
+                  >
+                    {expandedId === v.id ? 'collapse' : 'edit'}
+                  </button>
+                </div>
+              </div>
+            </div>
+            {expandedId === v.id && (
+              <div className="border-t border-white/[0.06] p-3 space-y-2 bg-[#0a1628]">
+                <div className="grid grid-cols-2 gap-2">
+                  <select
+                    value={v.role}
+                    onChange={(e) => updateVolunteer(v.id, { role: e.target.value })}
+                    className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-gray-400 focus:outline-none"
+                  >
+                    {(Object.keys(ROLE_LABEL) as Volunteer['role'][]).map((r) => (
+                      <option key={r} value={r}>{ROLE_LABEL[r]}</option>
+                    ))}
+                  </select>
+                  <select
+                    value={v.shift}
+                    onChange={(e) => updateVolunteer(v.id, { shift: e.target.value })}
+                    className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-gray-400 focus:outline-none"
+                  >
+                    {(Object.keys(SHIFT_LABEL) as Volunteer['shift'][]).map((s) => (
+                      <option key={s} value={s}>{SHIFT_LABEL[s]}</option>
+                    ))}
+                  </select>
+                </div>
+                <input
+                  defaultValue={v.phone}
+                  onBlur={(e) => e.target.value !== v.phone && updateVolunteer(v.id, { phone: e.target.value })}
+                  placeholder="Phone"
+                  className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+                />
+                <textarea
+                  defaultValue={v.notes}
+                  onBlur={(e) => e.target.value !== v.notes && updateVolunteer(v.id, { notes: e.target.value })}
+                  placeholder="Notes"
+                  rows={2}
+                  className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+                />
+              </div>
+            )}
+          </div>
+        ))}
+        {volunteers.length === 0 && (
+          <p className="text-sm text-gray-500 text-center py-4">No volunteers yet. Add the first one above.</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -20,7 +20,17 @@ export default async function StockTeamPage() {
 
   const supabase = getSupabaseAdmin();
 
-  const [goalsRes, todosRes, membersRes, sponsorsRes, artistsRes, timelineRes] = await Promise.allSettled([
+  const [
+    goalsRes,
+    todosRes,
+    membersRes,
+    sponsorsRes,
+    artistsRes,
+    timelineRes,
+    volunteersRes,
+    budgetRes,
+    notesRes,
+  ] = await Promise.allSettled([
     supabase.from('stock_goals').select('*').order('sort_order'),
     supabase
       .from('stock_todos')
@@ -44,6 +54,21 @@ export default async function StockTeamPage() {
       .from('stock_timeline')
       .select('*, owner:stock_team_members!owner_id(id, name)')
       .order('due_date', { ascending: true }),
+    supabase
+      .from('stock_volunteers')
+      .select('*, recruited_by_member:stock_team_members!recruited_by(id, name)')
+      .order('confirmed', { ascending: false })
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('stock_budget_entries')
+      .select('*, related_sponsor:stock_sponsors!related_sponsor_id(id, name)')
+      .order('type')
+      .order('category')
+      .order('created_at', { ascending: false }),
+    supabase
+      .from('stock_meeting_notes')
+      .select('*, creator:stock_team_members!created_by(id, name)')
+      .order('meeting_date', { ascending: false }),
   ]);
 
   const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
@@ -52,6 +77,9 @@ export default async function StockTeamPage() {
   const sponsors = sponsorsRes.status === 'fulfilled' ? sponsorsRes.value.data || [] : [];
   const artists = artistsRes.status === 'fulfilled' ? artistsRes.value.data || [] : [];
   const milestones = timelineRes.status === 'fulfilled' ? timelineRes.value.data || [] : [];
+  const volunteers = volunteersRes.status === 'fulfilled' ? volunteersRes.value.data || [] : [];
+  const budget = budgetRes.status === 'fulfilled' ? budgetRes.value.data || [] : [];
+  const meetingNotes = notesRes.status === 'fulfilled' ? notesRes.value.data || [] : [];
 
   return (
     <Dashboard
@@ -63,6 +91,9 @@ export default async function StockTeamPage() {
       sponsors={sponsors}
       artists={artists}
       milestones={milestones}
+      volunteers={volunteers}
+      budget={budget}
+      meetingNotes={meetingNotes}
     />
   );
 }


### PR DESCRIPTION
## Summary
Wave 3 finishes the dashboard expansion. Volunteers, Budget, and Meeting Notes tabs land in /stock/team. **Full Notion replacement complete** - \$840/yr saved, 14 team editors, no block limits, direct Supabase queries to pitch pages.

## What shipped

### SQL migration (\`scripts/stock-team-wave3.sql\`)
- \`stock_volunteers\`: 8 roles, 5 shifts, confirm toggle
- \`stock_budget_entries\`: income/expense, 3-stage status (projected/committed/actual)
- \`stock_meeting_notes\`: date + attendees + notes + action items
- **Seeded 15 budget entries** (\$15.75K income target, \$19.3K expense projection) from budget.md
- **Seeded 2 past meetings** (April 14 kickoff, April 16 DaNici design)

### API routes
- \`/api/stock/team/volunteers\`
- \`/api/stock/team/budget\`
- \`/api/stock/team/notes\`
All GET/POST/PATCH/DELETE, Zod validated, reuses stock-team-session auth.

### UI
- **VolunteerRoster**: confirm checkbox, role + shift dropdowns, inline phone/notes edit, stats (confirmed vs 20 target / total / unassigned)
- **BudgetTracker**: income vs expense filter, big projected-net card (green if positive), income/expense breakdown cards (paid / committed / projected), status-cycle entries
- **MeetingNotes**: accordion list, date + title, attendees, inline-edit notes + action items with auto-save on blur, \"+ New\" button for capturing this week's standup live

### Dashboard shell
8 tabs: **Overview / Sponsors / Artists / Timeline / Volunteers / Budget / Notes / Team**

## Setup
1. Merge PR
2. Run \`scripts/stock-team-wave3.sql\` in Supabase SQL Editor
3. zaoos.com/stock/team - all 8 tabs live

## Notion migration decision
Doc 413 recommendation shipped. Custom dashboard does everything Notion would have, with zero per-user cost and direct integration with /stock/sponsor pitch page (sponsor commit → live on pitch page instantly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)