### PR TITLE
docs: overhaul CLAUDE.md + AGENTS.md + add llms.txt + install biome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,135 +1,112 @@
-# AGENTS.md — ZAO OS
+# AGENTS.md - ZAO OS
 
-> **For AI coding agents:** This file gives you the context you need to work on this codebase.
-> Works with Claude Code, Cursor, Copilot, Windsurf, Gemini, or any LLM-powered coding tool.
-> For fork/setup instructions, read [FORK.md](./FORK.md) first.
+> Universal agent config for AI coding tools (Claude Code, Cursor, Copilot, Gemini, Codex).
+> For Claude Code specifics, see [CLAUDE.md](./CLAUDE.md).
 
-## What This Is
+## Commands
 
-ZAO OS is a **gated, music-first Farcaster social client** — a community hub where members chat on Farcaster channels, send encrypted DMs via XMTP, listen to music together, govern via on-chain proposals, and earn reputation. Built with Next.js 16 + React 19, Supabase, Neynar, and XMTP.
+```bash
+npm install          # postinstall: patch-package + XMTP WASM
+npm run dev          # next dev (Turbopack)
+npm run build        # next build
+npm run typecheck    # tsc --noEmit
+npm run test         # vitest run
+npm run test:watch   # vitest (watch mode)
+npm run lint:biome   # biome check .
+npm run lint:fix     # biome check --write .
+npm run format       # biome format --write .
+```
 
-**The single customization file is [`community.config.ts`](./community.config.ts)** — all branding, channels, contracts, admin access, and navigation live there.
+## Testing
 
-## Tech Stack
+- **Framework:** Vitest (`describe`, `it`, `expect` - not Jest globals)
+- **Mocking:** `vi.mock()` + `vi.hoisted()` - never MSW or raw `fetch` mocks
+- **Helpers:** `src/test-utils/api-helpers.ts` (session mocks, request builders, Supabase chain mocks)
+- **Location:** Co-located: `src/app/api/foo/__tests__/route.test.ts`
+- **Auth guards:** Table-driven tests with `describe.each` across routes
+- **Database:** Never connect to real databases in tests. Mocks only.
 
-| Layer | Technology |
-|-------|-----------|
-| Framework | Next.js 16 (App Router, Turbopack) |
-| UI | React 19, Tailwind CSS v4 |
-| Auth | iron-session (encrypted httpOnly cookies) |
-| Social | Neynar SDK (Farcaster) |
-| Messaging | XMTP Browser SDK (MLS, E2E encrypted) |
-| Database | Supabase PostgreSQL + RLS + Realtime |
-| Blockchain | Wagmi + Viem (Optimism, Base) |
-| State | React Query (@tanstack/react-query) |
-| Validation | Zod on every API route |
-| Music | 9 platform providers + Web Audio API |
-| Testing | Vitest |
-| Deployment | Vercel |
+### Per-file test commands
+
+```bash
+npx vitest run src/app/api/auth       # test specific API route
+npx vitest run src/components/chat    # test specific component
+npx vitest run src/lib/agents         # test specific lib module
+npm run typecheck                     # typecheck everything
+npx biome check src/lib/agents        # lint specific module
+```
 
 ## Project Structure
 
 ```
-src/
-├── app/                  # Next.js App Router
-│   ├── (auth)/           # Protected routes (chat, messages, governance, admin, etc.)
-│   ├── api/              # 121 route handlers: /api/[feature]/[action]/route.ts
-│   └── page.tsx          # Landing / login
-├── components/           # React components organized by feature
-├── hooks/                # Custom hooks: useAuth, useChat, useRadio, usePlayerQueue, etc.
-├── contexts/             # React contexts (XMTPContext, QueueContext)
-├── providers/            # Provider wrappers (9 audio providers, PostHog)
-├── lib/                  # Utilities by domain: auth, db, farcaster, gates, music, xmtp, etc.
-└── types/                # TypeScript type definitions
-community.config.ts       # All community branding, channels, contracts — THE fork point
-scripts/                  # Database setup, wallet generation, data import
-research/                 # 155+ research docs
+src/app/api/         # 301 route handlers: /api/[feature]/[action]/route.ts
+src/components/      # 279 components organized by feature
+src/hooks/           # 19 custom hooks (useAuth, useChat, useRadio, etc.)
+src/lib/             # Utilities by domain (auth, db, farcaster, music, publish, agents)
+src/providers/       # React providers (audio player, contexts)
+src/types/           # TypeScript type definitions
+community.config.ts  # Branding, channels, contracts, nav - THE fork point
+research/            # 240+ research docs
+scripts/             # SQL migrations, wallet generation, webhooks
+contracts/           # Solidity (staking, bounty board)
 ```
 
-## Code Conventions
+## Code Style
 
-### Components
-- PascalCase `.tsx` files with `"use client"` directive for interactive components
-- Mobile-first design using Tailwind responsive prefixes (`sm:`, `md:`, `lg:`)
-- Dark theme: navy `#0a1628` background, gold `#f5a623` primary
-- Use `next/dynamic` with `{ ssr: false }` for heavy components
+- **Imports:** `@/` path alias (maps to `src/`)
+- **Components:** PascalCase `.tsx`, `"use client"` for interactive
+- **API routes:** `/api/[feature]/[action]/route.ts` - Zod validation, session check, `NextResponse.json`
+- **Utilities:** camelCase `.ts` in `src/lib/[domain]/`
+- **Hooks:** `use*` prefix in `src/hooks/`
+- **Styling:** Tailwind CSS v4. Dark theme: navy `#0a1628`, gold `#f5a623`. Mobile-first.
+- **State:** React hooks + `@tanstack/react-query`. No Redux/Zustand.
+- **Code splitting:** `next/dynamic` with `{ ssr: false }` for heavy components
+- **Error handling:** try/catch with Zod `safeParse`. `Promise.allSettled` for parallel ops.
+
+## Git Workflow
+
+- **Branch:** `ws/<description>-MMDD-HHMM` from latest `main`
+- **PRs:** Always to `main`. Never push directly.
+- **Commits:** Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`)
+
+## Boundaries
+
+### Always Do
+
+- Validate ALL user input with Zod `safeParse` before processing
+- Check session with `getSession()` before authenticated operations
+- Return `NextResponse.json(...)` from API routes
+- Wrap API handler body in try/catch, log errors server-side
 - Use `@/` import alias for all project imports
+- Design mobile-first with Tailwind responsive prefixes
 
-### API Routes
-- Path: `/api/[feature]/[action]/route.ts`
-- Validate ALL input with Zod `safeParse` — return 400 on failure
-- Check session with `getSession()` — return 401 if missing
-- Always return `NextResponse.json(...)` — never plain Response
-- Wrap body in try/catch, log errors server-side, return sanitized 500
-- Use `Promise.allSettled` for parallel fault-tolerant operations
+### Ask First
 
-### Hooks & State
-- `use*` prefix, in `src/hooks/`
-- React Query for server state — no Redux/Zustand
-- Tailwind CSS v4 — no inline styles or CSS modules
+- Database migrations or schema changes
+- Adding new npm dependencies
+- Changing environment variables
+- Modifying `community.config.ts`
+- Changing agent trading parameters or wallet configs
 
-### Testing
-- Vitest: `describe`, `it`, `expect` — not Jest globals
-- Mock with `vi.mock()` + `vi.hoisted()` — not MSW or raw fetch mocks
-- Co-locate tests: `src/app/api/foo/__tests__/route.test.ts`
-- Cover success and error paths
+### Never Do
 
-## Security Rules (Non-Negotiable)
-
-- **NEVER** store, log, or access user wallet private keys
-- **NEVER** use `dangerouslySetInnerHTML`
-- **NEVER** expose server-only env vars to the browser:
-  - `SUPABASE_SERVICE_ROLE_KEY`, `NEYNAR_API_KEY`, `SESSION_SECRET`, `APP_SIGNER_PRIVATE_KEY`
-- All user input validated with Zod before processing
-- Supabase RLS enabled on all tables — use service role only server-side
-- XMTP keys are app-specific burner keys, never personal wallet keys
+- Expose server env vars: `SUPABASE_SERVICE_ROLE_KEY`, `NEYNAR_API_KEY`, `SESSION_SECRET`, `APP_SIGNER_PRIVATE_KEY`
+- Use `dangerouslySetInnerHTML`
+- Ask for, store, or access user wallet private keys
+- Commit `.env` files or secrets
+- Use CSS modules, inline styles, or non-Tailwind styling
+- Skip Zod validation on any API route
+- Connect to production/staging databases in tests
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `community.config.ts` | All branding, channels, contracts, admin FIDs, nav — **change this to fork** |
-| `src/middleware.ts` | Rate limiting + CORS headers |
+| `community.config.ts` | All branding, channels, contracts, nav - change this to fork |
+| `src/middleware.ts` | Rate limiting + CORS |
 | `src/lib/auth/session.ts` | iron-session config |
 | `src/lib/db/supabase.ts` | Supabase client (service role + anon) |
 | `src/lib/farcaster/neynar.ts` | Neynar SDK wrapper |
-| `src/lib/validation/schemas.ts` | All Zod schemas |
+| `src/lib/agents/runner.ts` | Shared agent trading logic (VAULT/BANKER/DEALER) |
 | `src/providers/audio/PlayerProvider.tsx` | Player state, MediaSession, Wake Lock |
-| `src/providers/audio/HTMLAudioProvider.tsx` | Dual audio element crossfade engine |
-
-## Common Tasks
-
-### Add a new API route
-```bash
-# Create: src/app/api/{feature}/{action}/route.ts
-# Pattern: Zod validate → getSession() → try/catch → NextResponse.json
-```
-
-### Add a new component
-```bash
-# Create: src/components/{feature}/{Name}.tsx
-# Add "use client" if interactive, use Tailwind dark theme classes
-```
-
-### Add a new Farcaster channel
-Edit `community.config.ts` → `farcaster.channels` array. It appears as a chat room automatically.
-
-### Run tests
-```bash
-npm run test           # vitest run
-npm run test:watch     # vitest watch mode
-npm run lint           # eslint
-npm run typecheck      # tsc --noEmit
-```
-
-### Database changes
-Write SQL migration → run in Supabase SQL Editor → save to `scripts/migrations/applied/`.
-
-## Architecture Decisions
-
-- **Auth:** Two methods — Sign In With Farcaster (Neynar managed signers) + Sign In With Ethereum (SIWE). Both create iron-session cookies.
-- **Database:** No ORM — direct `@supabase/supabase-js` queries with RLS.
-- **Messaging:** Public (Farcaster casts cached in Supabase) + Private (XMTP E2E encrypted).
-- **Music:** 9 platform providers, crossfade via dual `<audio>` elements, binaural beats via Web Audio API oscillators.
-- **Governance:** Three tiers: (1) On-chain Nouns Builder Governor, (2) Snapshot gasless polls, (3) Supabase community proposals with respect-weighted voting.
-- **Cross-posting:** Approved proposals auto-publish to Farcaster + Bluesky + X with per-platform content normalization.
+| `SECURITY.md` | Full security policy |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,174 +1,109 @@
-# CLAUDE.md — ZAO OS
+# CLAUDE.md - ZAO OS
 
-## Session Start (Do This First)
+## Session Start
 
-**Before any work, invoke `/worksession`** to create an isolated branch. Multiple Claude Code terminals may be open simultaneously — each must work on its own `ws/` branch to avoid conflicts. Do not skip this even if the user jumps straight into a task.
+**Invoke `/worksession`** before any work. Each terminal gets its own `ws/` branch.
 
 ## What This Is
 
-ZAO OS is a gated Farcaster social client for **The ZAO** (ZTalent Artist Organization) — a decentralized music community. Built with Next.js 16 + React 19, Supabase, Neynar, and XMTP.
+ZAO OS is a gated Farcaster social client for **The ZAO** (ZTalent Artist Organization) - a decentralized music community on Base chain. 301 API routes, 279 components, 19 hooks, 240+ research docs.
+
+**Stack:** Next.js 16, React 19, Supabase (RLS), Neynar, XMTP, Stream.io, Wagmi/Viem, Tailwind v4, iron-session.
+
+## Project Map
+
+| Directory | What | When to Read |
+|-----------|------|-------------|
+| `src/app/api/` | 301 route handlers across 54 domains | Working on backend |
+| `src/components/` | 279 components by feature | Working on UI |
+| `src/hooks/` | 19 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
+| `src/lib/` | Utils by domain: auth, db, farcaster, music, publish, agents | Working on business logic |
+| `src/lib/agents/` | VAULT/BANKER/DEALER autonomous trading bots | Working on agents |
+| `src/lib/publish/` | Cross-platform posting (Farcaster, X, Bluesky) | Working on distribution |
+| `src/providers/` | Audio player, contexts | Working on player |
+| `community.config.ts` | All branding, channels, admin FIDs, contracts, nav | Forking or configuring |
+| `research/` | 240+ research docs (see research/README.md) | Use grep, not bulk reads |
+| `scripts/` | SQL migrations, wallet generation, webhook setup | DB or infra work |
+| `contracts/` | Solidity (staking, bounty board) | Smart contract work |
 
 ## Quick Start
 
 ```bash
-npm install          # also runs postinstall (patch-package + copies XMTP WASM)
-npm run dev          # next dev (Turbopack)
-npm run build        # next build
-npm run lint         # eslint
+npm install          # postinstall: patch-package + XMTP WASM copy
+npm run dev          # Turbopack
+npm run build        # production build
+npm run typecheck    # tsc --noEmit
+npm run test         # vitest
+npm run lint:biome   # biome check
 ```
 
-Required env vars: see `.env.example`. Generate app wallet with `npx tsx scripts/generate-wallet.ts`.
+Env vars: see `.env.example`. App wallet: `npx tsx scripts/generate-wallet.ts`.
 
-## Project Structure
+## Security (Non-Negotiable)
 
-```
-src/
-├── app/                  # Next.js App Router
-│   ├── (auth)/           # Protected routes (chat, messages, governance, social, admin, etc.)
-│   ├── api/              # Route handlers: /api/[feature]/[action]/route.ts
-│   └── page.tsx          # Landing / login
-├── components/           # React components organized by feature (chat, messages, music, admin, social, etc.)
-│   └── music/            # 30+ components: player, queue, reactions, binaural beats, lyrics, etc.
-├── hooks/                # Custom hooks: useAuth, useChat, useRadio, usePlayerQueue, useNowPlaying, useListeningRoom, etc.
-├── contexts/             # React contexts (XMTPContext, QueueContext)
-├── providers/            # Provider wrappers (audio: PlayerProvider, HTMLAudioProvider)
-├── lib/                  # Utilities by domain: auth, db, farcaster, gates, music, xmtp, validation, publish, moderation
-└── types/                # TypeScript type definitions
-community.config.ts       # All community branding, channels, contracts, nav — fork-friendly
-research/                 # 155+ research docs (see research/README.md)
-scripts/                  # DB setup, wallet generation, webhook registration
-supabase/                 # Database config
-```
+- **NEVER** expose `SUPABASE_SERVICE_ROLE_KEY`, `NEYNAR_API_KEY`, `SESSION_SECRET`, `APP_SIGNER_PRIVATE_KEY` to browser
+- **NEVER** use `dangerouslySetInnerHTML`
+- **NEVER** ask for user wallet private keys
+- All user input: Zod `safeParse` before processing
+- Supabase RLS on all tables. Service role = server-side only
+- XMTP keys are app-specific burner keys, never personal wallet keys
 
-## Code Conventions
+## Boundaries
 
-- **Components:** PascalCase `.tsx` files. Use `"use client"` directive for interactive components.
-- **Utilities:** camelCase `.ts` files in `src/lib/[domain]/`.
-- **Hooks:** `use*` prefix, in `src/hooks/`.
-- **API routes:** `/api/[feature]/[action]/route.ts`. Always validate input with Zod, check session, return `NextResponse.json`.
-- **Imports:** Use `@/` path alias (maps to `src/`).
-- **State:** React hooks + `@tanstack/react-query`. No Redux/Zustand.
-- **Styling:** Tailwind CSS v4. Dark theme: navy `#0a1628` background, gold `#f5a623` primary.
-- **Code splitting:** Use `next/dynamic` for heavy components (SearchDialog, SongSubmit, ProfileDrawer).
-- **Error handling:** try/catch with Zod `safeParse` for inputs. Use `Promise.allSettled` for parallel fault-tolerant operations.
+**Always do:**
+- Validate inputs with Zod, check session, return `NextResponse.json`
+- Use `@/` import alias
+- Mobile-first, dark theme (navy `#0a1628`, gold `#f5a623`)
+- Use `Promise.allSettled` for parallel fault-tolerant operations
+- Create PRs to main (never push directly)
 
-## Security Rules (Non-Negotiable)
+**Ask first:**
+- Database migrations or schema changes
+- New dependencies
+- Env var changes
+- Changes to `community.config.ts`
+- Changes to agent trading parameters
 
-**Read `SECURITY.md` for full details.** Key rules:
+**Never do:**
+- Commit secrets or `.env` files
+- Skip Zod validation on API routes
+- Use Redux/Zustand (we use React hooks + react-query)
+- Use CSS modules or inline styles (Tailwind only)
+- Pre-read large directories (spaces/ music/ governance/ zounz/) unless task requires it
 
-- **NEVER ask for, store, or access user wallet private keys.** The `APP_SIGNER_PRIVATE_KEY` is an auto-generated app wallet — not a user's key.
-- **NEVER use `dangerouslySetInnerHTML`.**
-- **NEVER expose server-only env vars** (`SUPABASE_SERVICE_ROLE_KEY`, `NEYNAR_API_KEY`, `SESSION_SECRET`, `APP_SIGNER_PRIVATE_KEY`) to the browser.
-- All user input must be validated with Zod before processing.
-- Supabase RLS is enabled on all tables. Use service role only server-side.
-- XMTP keys are app-specific burner keys in localStorage — never personal wallet keys.
+## Per-File Commands
 
-## Key Architecture Decisions
+| File Pattern | Test | Lint |
+|-------------|------|------|
+| `src/app/api/**/*.ts` | `npx vitest run src/app/api/<feature>` | `npx biome check src/app/api/<feature>` |
+| `src/components/**/*.tsx` | `npx vitest run src/components/<feature>` | `npx biome check src/components/<feature>` |
+| `src/lib/**/*.ts` | `npx vitest run src/lib/<domain>` | `npx biome check src/lib/<domain>` |
+| Any file | `npm run typecheck` | `npm run lint:biome` |
 
-- **Auth:** iron-session (encrypted httpOnly cookies, 7-day TTL). Two auth methods: Sign In With Farcaster + wallet signature (SIWE).
-- **Database:** Supabase PostgreSQL with RLS. No ORM — direct `@supabase/supabase-js` queries.
-- **Messaging:** Farcaster casts (public, cached in Supabase) + XMTP (private, E2E encrypted via MLS).
-- **Blockchain:** Wagmi + Viem for wallet integration. Respect tokens on Optimism.
-- **Rate limiting:** Middleware-based per-IP limits on API routes (see `src/middleware.ts`).
-- **Cross-platform publishing:** Approved proposals (1000+ Respect) auto-publish to Farcaster + Bluesky + X. Content normalization per platform. Lens + Hive scaffolded but deferred.
-- **AI moderation:** Perspective API for content safety scoring (`src/lib/moderation/moderate.ts`).
-- **Music Player:** Multi-platform (9 providers), crossfade engine (dual audio elements), binaural beats (Web Audio API oscillators), MediaSession API (all 8 actions), Wake Lock, respect-weighted curation.
-- **Spaces (Live Audio/Video):** Stream.io Video SDK (`audio_room` call type) with backstage mode, RTMP multistream broadcast (Twitch/YouTube/Kick/Facebook), screen share, recording, transcription/closed captions, noise cancellation, hand raise queue, song requests, room chat, emoji reactions. Slug-based URLs. Admin can end/delete any room. Webhook for auto participant counts + recording URLs. Token auto-refresh (1-hour expiry). Alternative 100ms provider for fractal meetings.
-- **Governance:** Three-tier system: (1) ZOUNZ Nouns Builder on-chain proposals (NFT voting on Base), (2) Snapshot gasless weekly priority polls via `@snapshot-labs/snapshot.js`, (3) Community proposals (Supabase, Respect-weighted, auto-publishes to Farcaster/Bluesky/X after 7-day voting + 1000R threshold).
-- **Community config:** All branding, channels, admin FIDs, contracts in `community.config.ts`. Change this file to fork for a different community.
+## Key Files
 
-## Important Files
+- `community.config.ts` - branding, channels, contracts, nav
+- `src/middleware.ts` - rate limiting, CORS
+- `src/lib/auth/session.ts` - iron-session config
+- `src/lib/db/supabase.ts` - Supabase client
+- `src/lib/agents/runner.ts` - shared agent trading logic
+- `src/lib/agents/types.ts` - tokens, contracts, agent types
+- `SECURITY.md` - full security policy
 
-- `community.config.ts` — branding, channels, admin FIDs, contracts, nav pillars
-- `src/middleware.ts` — rate limiting, CORS headers
-- `src/lib/auth/session.ts` — iron-session config
-- `src/lib/db/supabase.ts` — Supabase client setup
-- `src/lib/farcaster/neynar.ts` — Neynar SDK client
-- `src/lib/publish/` — cross-platform publishing (Farcaster, X, normalize, Lens/Hive scaffolds)
-- `src/lib/moderation/moderate.ts` — AI content moderation (Perspective API)
-- `src/providers/audio/PlayerProvider.tsx` — player state, MediaSession, Wake Lock, haptics
-- `src/providers/audio/HTMLAudioProvider.tsx` — dual audio element engine with crossfade
-- `src/components/music/BinauralBeats.tsx` — binaural beats with ambient mixer
-- `src/lib/music/curationWeight.ts` — respect-weighted curation formula
-- `src/lib/zounz/contracts.ts` — ZOUNZ DAO contract addresses + ABIs (Token, Auction, Governor, Treasury)
-- `src/lib/snapshot/client.ts` — Snapshot GraphQL client for reading polls
-- `src/components/governance/CreateWeeklyPoll.tsx` — One-click Snapshot poll creator
-- `src/components/zounz/ZounzProposals.tsx` — On-chain proposals from ZOUNZ Governor
-- `src/app/api/stream/` — Stream.io token generation, room CRUD, webhook handler
-- `src/app/api/admin/spaces/` — Admin list/delete rooms endpoints
-- `src/components/spaces/` — 40+ components: RoomView, controls, participants, chat, reactions, broadcast
-- `src/lib/spaces/roomsDb.ts` — Room database CRUD with slug support
-- `src/lib/spaces/rtmpManager.ts` — RTMP multistream broadcast engine
-- `scripts/configure-stream-grants.ts` — Stream.io call type permission setup
-- `scripts/` — DB setup SQL, wallet generation, webhook registration, data import
+## Token Budget
 
-## Research Library
+- Use `/compact` every 15-20 messages
+- Use grep on `research/*/README.md`, not bulk reads
+- Don't pre-read `src/components/spaces/` (40+), `music/` (30+), `governance/`, `zounz/`
+- Batch related questions into single messages
 
-240+ research documents in `research/`. Start with:
-- `research/README.md` — full index organized by topic
-- `research/050-the-zao-complete-guide/` — canonical project reference
-- `research/051-zao-whitepaper-2026/` — whitepaper Draft 4.5
-- `research/154-skills-commands-master-reference/` — **CANONICAL** all commands/skills reference
+## Style
 
-Use the `/zao-research` skill for conducting new research.
+- Say "Farcaster" not "Warpcast"
+- Mobile-first, desktop as enhancement
+- Document build steps (build-in-public)
+- Never generate wallet keys interactively
 
-## Skills & Commands
+## Skills
 
-11 project skills in `.claude/skills/`, 8 autoresearch subcommands, 1 command (minimax), plus ~30 gstack/superpowers skills. See [Doc 154](research/154-skills-commands-master-reference/) for the complete reference.
-
-**Most-used commands:**
-
-| Command | When to Use |
-|---------|-------------|
-| `/catchup` | Start of session — restore context |
-| `/new-route feature/action` | Scaffold API route with ZAO conventions |
-| `/new-component feature/Name` | Scaffold component with dark theme, mobile-first |
-| `/fix-issue 42` | Fix a GitHub issue end-to-end |
-| `/check-env` | Validate env vars before deploy |
-| `/standup` | Generate build-in-public notes |
-| `/zao-research topic` | Research with 155+ doc library + web |
-| `/review` | Pre-landing PR review |
-| `/ship` | Ship workflow: tests → review → PR |
-| `/qa` | QA test the site, find and fix bugs |
-| `/investigate` | Root cause debugging |
-| `/autoresearch goal` | Autonomous iteration toward a measurable goal |
-| `/autoresearch:security` | STRIDE + OWASP security audit |
-| `/vps` | Generate prompts for VPS Claude Code to manage ZOE |
-| `/vps status` | Health check prompt for ZOE on VPS |
-| `/z` | Quick status dashboard — branch, commits, needs attention |
-
-**How to ask for new features:** Describe the outcome you want for users, not the implementation. Let the skill system figure out the workflow. See Doc 154, Part 13.
-
-## Context Budget (Token Optimization)
-
-To reduce token consumption, follow these rules:
-
-**DO NOT pre-read these directories** unless the task specifically involves them:
-- `src/components/spaces/` (40+ files) — only for Spaces/live audio work
-- `src/components/music/` (30+ files) — only for music player work
-- `src/components/governance/` — only for governance/voting work
-- `src/components/zounz/` — only for ZOUNZ DAO work
-- `research/` — use `/graphify` or targeted grep, not bulk file reads
-
-**Session hygiene:**
-- Use `/compact` every 15-20 messages to compress conversation history
-- Use `/model sonnet` for simple tasks (file reads, grep, formatting, simple edits)
-- Switch to Opus for architecture decisions, complex refactors, brainstorming, security reviews
-- Batch related questions into single messages instead of separate prompts
-- Edit prompts instead of sending corrections as follow-ups
-- Schedule Opus-heavy work outside peak hours (5:00-11:00 AM PT weekdays)
-
-**Compact instructions:**
-When compacting, preserve: modified file paths, test commands, architecture decisions, API contracts. Drop: exploration output, grep results, file contents already committed.
-
-**Research queries:**
-- If Graphify is installed, use `/graphify query "question"` instead of reading raw research files
-- For targeted lookups, use `grep` across `research/*/README.md` — don't read entire docs unless needed
-- Cross-reference at most 2-3 docs per query, not the entire library
-
-## Style Preferences
-
-- Mobile-first design, desktop as enhancement
-- Always say "Farcaster" not "Warpcast"
-- Never generate app wallet keys interactively — use `scripts/generate-wallet.ts`
-- Document build steps for content creation (build-in-public approach)
+See [Doc 154](research/154-skills-commands-master-reference/) for complete reference. Key commands: `/worksession`, `/z`, `/qa`, `/ship`, `/review`, `/zao-research`, `/autoresearch`, `/vps`.

--- a/community.config.ts
+++ b/community.config.ts
@@ -65,11 +65,31 @@ export const communityConfig = {
   // ── Spaces ─────────────────────────────────────────────────────
   /** Voice/video room definitions — appear in the Spaces section */
   voiceChannels: [
-    { id: 'general-hangout', name: 'General Hangout', emoji: '💬', description: 'Casual conversation' },
-    { id: 'fractal-call', name: 'Fractal Call', emoji: '📞', description: 'Monday 6pm EST weekly fractal' },
-    { id: 'music-lounge', name: 'Music Lounge', emoji: '🎵', description: 'Always-on listening room' },
+    {
+      id: 'general-hangout',
+      name: 'General Hangout',
+      emoji: '💬',
+      description: 'Casual conversation',
+    },
+    {
+      id: 'fractal-call',
+      name: 'Fractal Call',
+      emoji: '📞',
+      description: 'Monday 6pm EST weekly fractal',
+    },
+    {
+      id: 'music-lounge',
+      name: 'Music Lounge',
+      emoji: '🎵',
+      description: 'Always-on listening room',
+    },
     { id: 'tech-talk', name: 'Tech Talk', emoji: '💻', description: 'Technical discussions' },
-    { id: 'coworking', name: 'Coworking', emoji: '🏢', description: 'Silent cowork with ambient presence' },
+    {
+      id: 'coworking',
+      name: 'Coworking',
+      emoji: '🏢',
+      description: 'Silent cowork with ambient presence',
+    },
   ],
 
   // ── Audio Provider ───────────────────────────────────────────
@@ -272,7 +292,14 @@ export const communityConfig = {
     /** Max cover image size in bytes (default: 5MB) */
     maxCoverSize: 5 * 1024 * 1024,
     /** Allowed audio MIME types for upload */
-    allowedAudioTypes: ['audio/mpeg', 'audio/mp4', 'audio/wav', 'audio/flac', 'audio/ogg', 'audio/aac'],
+    allowedAudioTypes: [
+      'audio/mpeg',
+      'audio/mp4',
+      'audio/wav',
+      'audio/flac',
+      'audio/ogg',
+      'audio/aac',
+    ],
     /** Allowed image MIME types for upload */
     allowedImageTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.12",
         "@next/bundle-analyzer": "^16.2.0",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
@@ -1395,6 +1396,169 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
+      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.12",
+        "@biomejs/cli-darwin-x64": "2.4.12",
+        "@biomejs/cli-linux-arm64": "2.4.12",
+        "@biomejs/cli-linux-arm64-musl": "2.4.12",
+        "@biomejs/cli-linux-x64": "2.4.12",
+        "@biomejs/cli-linux-x64-musl": "2.4.12",
+        "@biomejs/cli-win32-arm64": "2.4.12",
+        "@biomejs/cli-win32-x64": "2.4.12"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
+      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
+      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
+      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
+      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
+      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
+      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
+      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
+      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.12",
     "@next/bundle-analyzer": "^16.2.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,45 @@
+# ZAO OS
+
+> Gated Farcaster social client for The ZAO - a decentralized music community on Base chain. Built with Next.js 16, React 19, Supabase, Neynar, XMTP, Stream.io.
+
+## Overview
+
+ZAO OS is a community hub where members chat on Farcaster channels, send encrypted DMs via XMTP, listen to music together, govern via on-chain proposals, earn reputation, and trade ZABAL tokens. Gated to ZAO NFT holders.
+
+## Stack
+
+- [Next.js 16](https://nextjs.org): App Router with Turbopack
+- [React 19](https://react.dev): UI framework
+- [Supabase](https://supabase.com): PostgreSQL with Row Level Security
+- [Neynar](https://neynar.com): Farcaster API integration
+- [XMTP](https://xmtp.org): End-to-end encrypted messaging (MLS protocol)
+- [Stream.io](https://getstream.io): Live audio/video rooms
+- [Wagmi](https://wagmi.sh) + [Viem](https://viem.sh): Wallet integration (Base, Optimism)
+- [Tailwind CSS v4](https://tailwindcss.com): Styling
+- [iron-session](https://github.com/vvo/iron-session): Encrypted cookie auth
+- [Vitest](https://vitest.dev): Testing framework
+
+## Features
+
+- [Chat](https://zaoos.com): Farcaster channel-based chat rooms
+- [Messaging](https://zaoos.com/messages): XMTP encrypted DMs and group chats
+- [Music](https://zaoos.com/radio): 9-provider music player with crossfade, binaural beats
+- [Spaces](https://zaoos.com/spaces): Live audio/video rooms with RTMP broadcast
+- [Governance](https://zaoos.com/governance): Three-tier voting (on-chain, Snapshot, community)
+- [Respect](https://zaoos.com/respect): Reputation system with fractal scoring
+- [Agents](https://zaoos.com/admin/agents): VAULT/BANKER/DEALER autonomous ZABAL traders
+
+## Docs
+
+- [AGENTS.md](https://github.com/bettercallzaal/ZAOOS/blob/main/AGENTS.md): AI agent instructions
+- [CLAUDE.md](https://github.com/bettercallzaal/ZAOOS/blob/main/CLAUDE.md): Claude Code configuration
+- [SECURITY.md](https://github.com/bettercallzaal/ZAOOS/blob/main/SECURITY.md): Security policy
+
+## API
+
+301 API route handlers across 54 domains including auth, agents, music, chat, governance, spaces, staking, and cross-platform publishing.
+
+## Community
+
+- [The ZAO](https://warpcast.com/~/channel/the-zao): Farcaster channel
+- [ZABAL Token](https://basescan.org/token/0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07): Base chain ERC-20

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: 1410 -> 634 words. Added project map table, three-tier boundaries (always/ask/never), per-file test commands. Removed architecture AI can infer from code (per ETH Zurich finding on AGENTS.md effectiveness)
- **AGENTS.md**: Updated counts (301 routes, 279 components, 240+ docs), added per-file test commands, three-tier boundaries, git workflow section
- **public/llms.txt**: New AI-readable project overview following llms.txt standard (60K+ projects adopted)
- **@biomejs/biome**: Added as devDep (was referenced in scripts but never installed). Fixed lint errors in vitest.config.ts, community.config.ts, biome.json
- Cleaned 2 stale agent worktrees

## Verification
- Typecheck: pass
- Tests: 378/378 pass
- Biome: 0 errors
- Research: doc 414 (AI-native documentation patterns)

## Test plan
- [ ] Verify CLAUDE.md loads correctly in new Claude Code sessions
- [ ] Verify AGENTS.md works with Cursor/Copilot
- [ ] Verify llms.txt accessible at zaoos.com/llms.txt after deploy
- [ ] Verify biome lint runs clean: `npx biome check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)