### PR TITLE
fix: mobile Farcaster sign-in + API logger audit

### DIFF
--- a/src/app/api/admin/agents/status/route.ts
+++ b/src/app/api/admin/agents/status/route.ts
@@ -4,6 +4,7 @@ import { supabaseAdmin } from '@/lib/db/supabase';
 import { AGENTS } from '@/components/admin/agents/constants';
 import type { AgentEvent, AgentStatus } from '@/components/admin/agents/constants';
 import { deriveStatus } from '@/components/admin/agents/constants';
+import { logger } from '@/lib/logger';
 
 export async function GET(req: NextRequest) {
   const session = await getSessionData();
@@ -76,13 +77,13 @@ export async function GET(req: NextRequest) {
 
     const { data, error } = await query;
     if (error) {
-      console.error('Agent events query error:', error);
+      logger.error('Agent events query error:', error);
       return NextResponse.json({ error: 'Failed to fetch events' }, { status: 500 });
     }
 
     return NextResponse.json({ events: data || [] });
   } catch (err) {
-    console.error('Agent status error:', err);
+    logger.error('Agent status error:', err);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/src/app/api/admin/audit-log/route.ts
+++ b/src/app/api/admin/audit-log/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
 
 const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(500).default(100),
@@ -92,7 +93,7 @@ export async function GET(req: NextRequest) {
       actions,
     });
   } catch (err) {
-    console.error('[admin/audit-log] Error fetching audit log:', err);
+    logger.error('[admin/audit-log] Error fetching audit log:', err);
     return NextResponse.json(
       { error: 'Failed to fetch audit log' },
       { status: 500 },

--- a/src/app/api/admin/broadcast/route.ts
+++ b/src/app/api/admin/broadcast/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSessionData } from '@/lib/auth/session';
 import { logAuditEvent, getClientIp } from '@/lib/db/audit-log';
+import { logger } from '@/lib/logger';
 
 const broadcastSchema = z.object({
   text: z.string().min(1).max(1024),
@@ -52,7 +53,7 @@ export async function POST(req: NextRequest) {
 
     if (!res.ok) {
       const errorBody = await res.text();
-      console.error('[broadcast] Neynar error:', res.status, errorBody);
+      logger.error('[broadcast] Neynar error:', res.status, errorBody);
       return NextResponse.json(
         { error: 'Failed to broadcast cast' },
         { status: 500 }
@@ -72,7 +73,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true, hash: data.cast?.hash });
   } catch (error) {
-    console.error('[broadcast] Unexpected error:', error);
+    logger.error('[broadcast] Unexpected error:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/api/admin/dormant/route.ts
+++ b/src/app/api/admin/dormant/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
 
 const querySchema = z.object({
   days: z.coerce.number().int().min(7).max(365).default(30),
@@ -105,7 +106,7 @@ export async function GET(request: NextRequest) {
       cutoffDays: days,
     });
   } catch (err) {
-    console.error('[admin/dormant] error:', err);
+    logger.error('[admin/dormant] error:', err);
     return NextResponse.json({ error: 'Failed to fetch dormant members' }, { status: 500 });
   }
 }

--- a/src/app/api/admin/export/route.ts
+++ b/src/app/api/admin/export/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
 
 const querySchema = z.object({
   type: z.enum(['members', 'respect', 'sessions']),
@@ -111,7 +112,7 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (err) {
-    console.error('[admin/export] Error:', err);
+    logger.error('[admin/export] Error:', err);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/src/app/api/admin/onboarding-funnel/route.ts
+++ b/src/app/api/admin/onboarding-funnel/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
 
 export async function GET() {
   try {
@@ -90,7 +91,7 @@ export async function GET() {
 
     return NextResponse.json({ stages });
   } catch (error) {
-    console.error('[onboarding-funnel] Error:', error);
+    logger.error('[onboarding-funnel] Error:', error);
     return NextResponse.json(
       { error: 'Failed to load onboarding funnel data' },
       { status: 500 }

--- a/src/app/api/admin/quick-stats/route.ts
+++ b/src/app/api/admin/quick-stats/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
 
 /**
  * GET /api/admin/quick-stats — Pulse stats for admin dashboard home card
@@ -93,7 +94,7 @@ export async function GET() {
       dormantUsers: dormantUsers.count || 0,
     });
   } catch (err) {
-    console.error('[quick-stats] error:', err);
+    logger.error('[quick-stats] error:', err);
     return NextResponse.json({ error: 'Failed to fetch stats' }, { status: 500 });
   }
 }

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSessionData } from '@/lib/auth/session';
 import { z } from 'zod';
 import { Octokit } from '@octokit/rest';
+import { logger } from '@/lib/logger';
 
 const feedbackSchema = z.object({
   type: z.enum(['bug', 'feature', 'feedback']),
@@ -52,7 +53,7 @@ export async function POST(req: NextRequest) {
     const githubToken = process.env.GITHUB_TOKEN;
     const repo = process.env.GITHUB_FEEDBACK_REPO || 'zaalpanthaki/zao-os';
     if (!githubToken) {
-      console.error('GITHUB_TOKEN not configured');
+      logger.error('GITHUB_TOKEN not configured');
       return NextResponse.json({ error: 'Feedback system not configured' }, { status: 503 });
     }
 
@@ -91,7 +92,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ success: true, issueUrl: issue.html_url, issueNumber: issue.number });
   } catch (err) {
-    console.error('Feedback submission error:', err);
+    logger.error('Feedback submission error:', err);
     return NextResponse.json({ error: 'Failed to submit feedback' }, { status: 500 });
   }
 }

--- a/src/app/api/fishbowlz/recap/route.ts
+++ b/src/app/api/fishbowlz/recap/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { z } from 'zod';
+import { logger } from '@/lib/logger';
 
 const RecapSchema = z.object({
   roomId: z.string().uuid(),
@@ -44,7 +45,7 @@ export async function POST(req: NextRequest) {
       .order('started_at', { ascending: true });
 
     if (txError) {
-      console.error('Recap transcript fetch error:', txError);
+      logger.error('Recap transcript fetch error:', txError);
       return NextResponse.json({ error: 'Failed to fetch transcripts' }, { status: 500 });
     }
 
@@ -144,7 +145,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ recap, transcriptCount: transcripts.length });
   } catch (err) {
-    console.error('Recap error:', err);
+    logger.error('Recap error:', err);
     return NextResponse.json({ error: 'Failed to generate recap' }, { status: 500 });
   }
 }

--- a/src/app/api/fishbowlz/rooms/[id]/route.ts
+++ b/src/app/api/fishbowlz/rooms/[id]/route.ts
@@ -5,6 +5,7 @@ import { getSessionData } from '@/lib/auth/session';
 import { checkGatingEligibility } from '@/lib/fc-identity';
 import { castRoomEnded } from '@/lib/fishbowlz/castRoom';
 import { generateTranscriptSummary } from '@/lib/fishbowlz/summarize';
+import { logger } from '@/lib/logger';
 
 // --- Zod schemas for PATCH body validation ---
 
@@ -444,7 +445,7 @@ export async function PATCH(
             }
           }
         } catch (err) {
-          console.error('Failed to generate transcript summary:', err);
+          logger.error('Failed to generate transcript summary:', err);
         }
       })();
 

--- a/src/app/api/fishbowlz/webhook/privy/route.ts
+++ b/src/app/api/fishbowlz/webhook/privy/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import crypto from 'crypto';
+import { logger } from '@/lib/logger';
 
 const PRIVY_WEBHOOK_SECRET = process.env.PRIVY_WEBHOOK_SECRET || '';
 
@@ -57,7 +58,7 @@ export async function POST(req: NextRequest) {
     // Acknowledge other event types
     return NextResponse.json({ success: true, event: type, action: 'ignored' });
   } catch (err) {
-    console.error('Privy webhook error:', err);
+    logger.error('Privy webhook error:', err);
     return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
   }
 }

--- a/src/app/api/staking/leaderboard/route.ts
+++ b/src/app/api/staking/leaderboard/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { getConvictionBatch } from '@/lib/staking/conviction';
+import { logger } from '@/lib/logger';
 
 /**
  * GET /api/staking/leaderboard
@@ -54,7 +55,7 @@ export async function GET() {
 
     return NextResponse.json(result);
   } catch (err) {
-    console.error('Staking leaderboard error:', err);
+    logger.error('Staking leaderboard error:', err);
     return NextResponse.json([], { status: 500 });
   }
 }

--- a/src/components/gate/LoginButton.tsx
+++ b/src/components/gate/LoginButton.tsx
@@ -21,6 +21,30 @@ export function LoginButton() {
     return () => clearInterval(interval);
   }, []);
 
+  // Mobile fix: when returning from Farcaster app, the page may have been killed.
+  // On visibility change (user returns to browser), check if session was created.
+  useEffect(() => {
+    function handleVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      // Small delay to let any in-flight auth complete
+      setTimeout(async () => {
+        try {
+          const res = await fetch('/api/auth/session');
+          if (res.ok) {
+            const data = await res.json();
+            if (data.fid) {
+              router.push('/home');
+            }
+          }
+        } catch {
+          // ignore - not authenticated yet
+        }
+      }, 500);
+    }
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [router]);
+
   const handleSuccess = useCallback(async (res: StatusAPIResponse) => {
     setError(null);
     setLoading(true);
@@ -84,7 +108,7 @@ export function LoginButton() {
         router.push(data.redirect);
       }
     } catch (err) {
-      console.error('Login failed:', err);
+      // Login error - don't use logger here (client component)
       setError('Connection error — check your internet and try again. If this persists, contact an admin.');
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- **Mobile sign-in fix**: When user signs in Farcaster app and returns to browser, the page may have been killed by the OS. Added `visibilitychange` listener that checks `/api/auth/session` when user returns - redirects to /home if session exists.
- **Logger audit**: Replaced `console.error` with `logger.error` in 12 API routes for consistent structured logging.

## Files changed
- `src/components/gate/LoginButton.tsx` - visibilitychange session check
- 12 API routes in admin/, feedback/, fishbowlz/, staking/ - logger swap

## Test plan
- [ ] Sign in on mobile: tap Sign In, approve in Farcaster app, return to browser - should redirect to /home
- [ ] Sign in on desktop: should still work as before (QR code flow)
- [ ] Check Vercel logs: should see logger.error format, no raw console.error

🤖 Generated with [Claude Code](https://claude.com/claude-code)