### PR TITLE
feat: OS default home + Sentry + error boundary + live widgets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ See [FORK.md](./FORK.md) for full setup instructions including database and app 
 2. **Make your changes** following the conventions below
 3. **Run checks** before submitting:
    ```bash
-   npm run lint         # ESLint
+   npx biome check .    # Lint (Biome)
    npm run typecheck    # TypeScript
    npm run test         # Vitest
    npm run build        # Next.js build

--- a/scripts/add-room-slug-unique.sql
+++ b/scripts/add-room-slug-unique.sql
@@ -1,0 +1,5 @@
+-- Add UNIQUE constraint to rooms.slug
+-- Nullable columns allow multiple NULLs per Postgres spec, so rooms without slugs are fine.
+-- Prevents two rooms from having the same slug, which causes routing conflicts.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rooms_slug_unique ON rooms (slug) WHERE slug IS NOT NULL;

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,24 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+
+  // Performance monitoring - sample 10% of transactions in prod
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+
+  // Session replay - capture 1% of sessions, 100% of error sessions
+  replaysSessionSampleRate: 0.01,
+  replaysOnErrorSampleRate: 1.0,
+
+  // Don't send PII
+  sendDefaultPii: false,
+
+  // Filter noisy errors
+  ignoreErrors: [
+    'ResizeObserver loop',
+    'AbortError',
+    'NotAllowedError', // autoplay blocked
+    'ChunkLoadError',
+  ],
+});

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+});

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
+  sendDefaultPii: false,
+});

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -8,13 +8,20 @@ import { PersistentPlayerWithRadio } from '@/components/music/PersistentPlayerWi
 import { LazyGlobalSearch } from '@/components/search/LazyGlobalSearch';
 import { CommandPaletteProvider } from '@/components/navigation/CommandPaletteProvider';
 import PWAInstallPrompt from '@/components/navigation/PWAInstallPrompt';
+import { OSBackButton } from '@/components/os/OSBackButton';
 
 export default async function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const session = await getSessionData();
+  let session;
+  try {
+    session = await getSessionData();
+  } catch {
+    // Supabase or session service down - redirect to landing with error hint
+    redirect('/?error=unavailable');
+  }
   if (!session) {
     redirect('/');
   }
@@ -36,6 +43,7 @@ export default async function AuthLayout({
         <CommandPaletteProvider />
         <PersistentPlayerWithRadio />
         <BottomNav />
+        <OSBackButton />
         <PWAInstallPrompt />
       </div>
     </AuthAudioProviders>

--- a/src/app/api/auth/siwe/route.ts
+++ b/src/app/api/auth/siwe/route.ts
@@ -160,7 +160,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      redirect: '/home',
+      redirect: '/os',
       hasFarcaster: !!fid,
     });
   } catch (error) {

--- a/src/app/api/auth/verify/route.ts
+++ b/src/app/api/auth/verify/route.ts
@@ -241,7 +241,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      redirect: '/home',
+      redirect: '/os',
     });
   } catch (error) {
     logger.error('Auth verify error:', error);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
 export default async function LandingPage() {
   const session = await getSessionData();
   if (session) {
-    redirect('/home');
+    redirect('/os');
   }
 
   return (

--- a/src/components/gate/LoginButton.tsx
+++ b/src/components/gate/LoginButton.tsx
@@ -33,7 +33,7 @@ export function LoginButton() {
           if (res.ok) {
             const data = await res.json();
             if (data.fid) {
-              router.push('/home');
+              router.push('/os');
             }
           }
         } catch {

--- a/src/components/os/widgets/NowPlayingWidget.tsx
+++ b/src/components/os/widgets/NowPlayingWidget.tsx
@@ -1,28 +1,32 @@
 'use client';
 
+import { usePlayerContext } from '@/providers/audio/PlayerProvider';
 import type { WidgetProps } from '@/lib/os/types';
 
 export default function NowPlayingWidget({ size, onExpand }: WidgetProps) {
+  const { state } = usePlayerContext();
+  const { status, metadata } = state;
+  const isPlaying = status === 'playing';
+  const hasTrack = !!metadata?.trackName;
+
   return (
     <button
       type="button"
       onClick={onExpand}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06]"
+      aria-label={hasTrack ? `Now playing: ${metadata.trackName}` : 'Open music'}
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06] focus-visible:ring-2 focus-visible:ring-[#f5a623]"
     >
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#f5a623]/10 text-xl">
-        🎵
+        {isPlaying ? '🎵' : '⏸'}
       </div>
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-white">Now Playing</div>
-        <div className="truncate text-xs text-white/50">Open music to start listening</div>
-      </div>
-      {size !== 'small' && (
-        <div className="flex gap-2">
-          <div className="h-8 w-8 rounded-full bg-white/5 text-center leading-8 text-xs">⏮</div>
-          <div className="h-8 w-8 rounded-full bg-[#f5a623]/20 text-center leading-8 text-xs">▶</div>
-          <div className="h-8 w-8 rounded-full bg-white/5 text-center leading-8 text-xs">⏭</div>
+        <div className="truncate text-sm font-medium text-white">
+          {hasTrack ? metadata.trackName : 'Now Playing'}
         </div>
-      )}
+        <div className="truncate text-xs text-white/50">
+          {hasTrack ? (metadata.artistName || 'Unknown artist') : 'Open music to start listening'}
+        </div>
+      </div>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

### /os is now the default
- Login redirects to /os (not /home)
- Landing page redirects authenticated users to /os
- Mobile sign-in visibility check points to /os
- OSBackButton appears on all authenticated pages (floating "OS" link)

### Error resilience
- Protected layout catches getSessionData() failures (Supabase down)
- Redirects to /?error=unavailable instead of 500 page

### Sentry configured
- sentry.client.config.ts, sentry.server.config.ts, sentry.edge.config.ts
- Needs NEXT_PUBLIC_SENTRY_DSN env var in Vercel to activate
- 10% transaction sampling, 1% session replay, 100% error replay

### Live widget data
- NowPlayingWidget reads real player state (trackName, artistName, isPlaying)

### DB migrations (run in Supabase)
- scripts/create-user-app-config.sql (OS preferences)
- scripts/add-room-slug-unique.sql (Spaces slug uniqueness)

### Docs
- CONTRIBUTING.md updated with biome lint command

## Test plan
- [x] Typecheck: 0 errors
- [x] Tests: 378/378 pass
- [ ] Login -> lands on /os (not /home)
- [ ] Navigate to /chat -> see floating "OS" button top-left
- [ ] Play a track -> NowPlayingWidget shows real track name

🤖 Generated with [Claude Code](https://claude.com/claude-code)