### PR TITLE
feat(stock): Kanban on Artists + Todos + Pareto attention cards

### DIFF
--- a/src/app/stock/team/ArtistPipeline.tsx
+++ b/src/app/stock/team/ArtistPipeline.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { KanbanBoard, KanbanColumn } from './KanbanBoard';
+import { AttentionCard } from './AttentionCard';
+
+function daysSince(iso: string | null): number {
+  if (!iso) return Infinity;
+  return Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
+}
 
 interface Member { id: string; name: string; }
 
@@ -49,8 +56,27 @@ const STATUS_COLOR: Record<Artist['status'], string> = {
   declined: 'border-red-500/40 bg-red-500/10 text-red-400',
 };
 
+const STATUS_STRIPE: Record<Artist['status'], string> = {
+  wishlist: 'bg-gray-600',
+  contacted: 'bg-blue-500',
+  interested: 'bg-amber-500',
+  confirmed: 'bg-emerald-500',
+  travel_booked: 'bg-emerald-400',
+  declined: 'bg-red-500',
+};
+
+const KANBAN_COLUMNS: KanbanColumn<Artist['status']>[] = [
+  { key: 'wishlist', label: 'Wishlist', accent: 'border-gray-600 text-gray-400' },
+  { key: 'contacted', label: 'Contacted', accent: 'border-blue-500/40 bg-blue-500/10 text-blue-400' },
+  { key: 'interested', label: 'Interested', accent: 'border-amber-500/40 bg-amber-500/10 text-amber-400' },
+  { key: 'confirmed', label: 'Confirmed', accent: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400', wipSoftCap: 10 },
+  { key: 'travel_booked', label: 'Booked', accent: 'border-emerald-500 bg-emerald-500/20 text-emerald-300' },
+  { key: 'declined', label: 'Declined', accent: 'border-red-500/40 bg-red-500/10 text-red-400', defaultCollapsed: true },
+];
+
 export function ArtistPipeline({ artists: initial, members }: { artists: Artist[]; members: Member[] }) {
   const [artists, setArtists] = useState(initial);
+  const [view, setView] = useState<'list' | 'board'>('list');
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [newName, setNewName] = useState('');
   const [newGenre, setNewGenre] = useState('');
@@ -62,6 +88,20 @@ export function ArtistPipeline({ artists: initial, members }: { artists: Artist[
     contacted: artists.filter((a) => a.status === 'contacted' || a.status === 'interested').length,
     confirmed: artists.filter((a) => a.status === 'confirmed' || a.status === 'travel_booked').length,
   };
+
+  const attention = useMemo(() => {
+    const flagged: Array<{ id: string; title: string; reason: string; score: number }> = [];
+    for (const a of artists) {
+      if (a.status === 'contacted' && daysSince(a.created_at) > 10) {
+        flagged.push({ id: a.id, title: a.name, reason: `Contacted ${daysSince(a.created_at)}d ago — nudge`, score: 3 });
+      } else if (a.status === 'interested' && !a.notes) {
+        flagged.push({ id: a.id, title: a.name, reason: 'Interested but no notes — log next step', score: 2 });
+      } else if (a.status === 'confirmed' && a.needs_travel && !a.travel_from) {
+        flagged.push({ id: a.id, title: a.name, reason: 'Confirmed, needs travel, no origin set', score: 1 });
+      }
+    }
+    return flagged.sort((a, b) => b.score - a.score).slice(0, 3);
+  }, [artists]);
 
   async function createArtist(e: React.FormEvent) {
     e.preventDefault();
@@ -104,7 +144,29 @@ export function ArtistPipeline({ artists: initial, members }: { artists: Artist[
 
   return (
     <div className="space-y-4">
-      <h2 className="text-lg font-bold text-white">Artists</h2>
+      <div className="flex items-center justify-between gap-2">
+        <h2 className="text-lg font-bold text-white">Artists</h2>
+        <div className="flex rounded border border-white/[0.08] overflow-hidden">
+          <button
+            onClick={() => setView('list')}
+            className={`text-[10px] font-bold px-2 py-1 transition-colors ${
+              view === 'list' ? 'bg-[#f5a623]/15 text-[#f5a623]' : 'text-gray-500 hover:text-gray-300'
+            }`}
+          >
+            List
+          </button>
+          <button
+            onClick={() => setView('board')}
+            className={`text-[10px] font-bold px-2 py-1 transition-colors border-l border-white/[0.08] ${
+              view === 'board' ? 'bg-[#f5a623]/15 text-[#f5a623]' : 'text-gray-500 hover:text-gray-300'
+            }`}
+          >
+            Board
+          </button>
+        </div>
+      </div>
+
+      <AttentionCard items={attention} />
 
       <div className="grid grid-cols-3 gap-2">
         <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
@@ -150,6 +212,34 @@ export function ArtistPipeline({ artists: initial, members }: { artists: Artist[
         </div>
       </form>
 
+      {view === 'board' ? (
+        <KanbanBoard
+          items={artists}
+          columns={KANBAN_COLUMNS}
+          onStatusChange={(id, status) => updateArtist(id, { status })}
+          getStripeColor={(a) => STATUS_STRIPE[a.status]}
+          renderCard={(artist) => (
+            <div className="p-3">
+              <p className="text-sm font-medium text-white">{artist.name}</p>
+              <div className="flex items-center gap-2 mt-1 flex-wrap">
+                {artist.genre && <span className="text-[10px] text-gray-500">{artist.genre}</span>}
+                {artist.city && <span className="text-[10px] text-gray-500">{artist.city}</span>}
+                {artist.needs_travel && artist.status !== 'declined' && (
+                  <span className="text-[9px] font-bold px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 uppercase">Travel</span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 mt-1 flex-wrap">
+                {artist.outreach && (
+                  <span className="text-[10px] text-[#f5a623] bg-[#f5a623]/10 px-1.5 py-0.5 rounded-full">{artist.outreach.name}</span>
+                )}
+                {artist.set_order !== null && (
+                  <span className="text-[10px] text-gray-400">Slot {artist.set_order}</span>
+                )}
+              </div>
+            </div>
+          )}
+        />
+      ) : (
       <div className="space-y-2">
         {sorted.map((artist) => (
           <div key={artist.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] overflow-hidden">
@@ -202,6 +292,7 @@ export function ArtistPipeline({ artists: initial, members }: { artists: Artist[
           <p className="text-sm text-gray-500 text-center py-4">No artists yet. Add one above.</p>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/src/app/stock/team/AttentionCard.tsx
+++ b/src/app/stock/team/AttentionCard.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+interface Item {
+  id: string;
+  title: string;
+  reason: string;
+}
+
+export function AttentionCard({ items }: { items: Item[] }) {
+  if (items.length === 0) return null;
+
+  return (
+    <div className="bg-gradient-to-br from-amber-500/10 via-amber-500/5 to-transparent rounded-lg border border-amber-500/30 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-[10px] font-bold text-amber-400 uppercase tracking-wider">⚠ Top {items.length} Need Attention</p>
+      </div>
+      {items.map((item) => (
+        <div key={item.id} className="flex items-start gap-2 text-xs">
+          <span className="text-amber-400 flex-shrink-0">→</span>
+          <div className="min-w-0">
+            <p className="text-white truncate">{item.title}</p>
+            <p className="text-[10px] text-amber-500/80">{item.reason}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stock/team/SponsorCRM.tsx
+++ b/src/app/stock/team/SponsorCRM.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { KanbanBoard, KanbanColumn } from './KanbanBoard';
+import { AttentionCard } from './AttentionCard';
+
+function daysSince(iso: string | null): number {
+  if (!iso) return Infinity;
+  return Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
+}
 
 interface Member { id: string; name: string; }
 
@@ -95,6 +101,20 @@ export function SponsorCRM({ sponsors: initial, members }: { sponsors: Sponsor[]
   const totalPaid = sponsors.reduce((sum, s) => sum + Number(s.amount_paid || 0), 0);
   const committedCount = sponsors.filter((s) => s.status === 'committed' || s.status === 'paid').length;
 
+  const attention = useMemo(() => {
+    const flagged: Array<{ id: string; title: string; reason: string; score: number }> = [];
+    for (const s of sponsors) {
+      if (s.status === 'contacted' && daysSince(s.last_contacted_at) > 14) {
+        flagged.push({ id: s.id, title: s.name, reason: `Contacted ${daysSince(s.last_contacted_at)}d ago — no reply`, score: 3 });
+      } else if (s.status === 'in_talks' && daysSince(s.last_contacted_at) > 7) {
+        flagged.push({ id: s.id, title: s.name, reason: `In talks, silent ${daysSince(s.last_contacted_at)}d — follow up`, score: 2 });
+      } else if (s.status === 'committed' && Number(s.amount_paid) < Number(s.amount_committed) && daysSince(s.created_at) > 30) {
+        flagged.push({ id: s.id, title: s.name, reason: `Committed $${Number(s.amount_committed).toLocaleString()} not paid yet`, score: 1 });
+      }
+    }
+    return flagged.sort((a, b) => b.score - a.score).slice(0, 3);
+  }, [sponsors]);
+
   async function createSponsor(e: React.FormEvent) {
     e.preventDefault();
     if (!newName.trim()) return;
@@ -167,6 +187,8 @@ export function SponsorCRM({ sponsors: initial, members }: { sponsors: Sponsor[]
           </select>
         </div>
       </div>
+
+      <AttentionCard items={attention} />
 
       <div className="grid grid-cols-3 gap-2">
         <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">

--- a/src/app/stock/team/TodoList.tsx
+++ b/src/app/stock/team/TodoList.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
+import { KanbanBoard, KanbanColumn } from './KanbanBoard';
+import { AttentionCard } from './AttentionCard';
+
+function daysSince(iso: string | null): number {
+  if (!iso) return Infinity;
+  return Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24));
+}
 
 interface Member { id: string; name: string; }
 interface Todo {
@@ -15,6 +22,18 @@ interface Todo {
 
 const STATUS_ORDER = { todo: 0, in_progress: 1, done: 2 };
 
+const KANBAN_COLUMNS: KanbanColumn<Todo['status']>[] = [
+  { key: 'todo', label: 'To Do', accent: 'border-gray-600 text-gray-400' },
+  { key: 'in_progress', label: 'In Progress', accent: 'border-amber-500/40 bg-amber-500/10 text-amber-400', wipSoftCap: 5 },
+  { key: 'done', label: 'Done', accent: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400', defaultCollapsed: true },
+];
+
+const STATUS_STRIPE: Record<Todo['status'], string> = {
+  todo: 'bg-gray-600',
+  in_progress: 'bg-amber-500',
+  done: 'bg-emerald-500',
+};
+
 export function TodoList({ todos: initialTodos, members, currentMemberId }: {
   todos: Todo[];
   members: Member[];
@@ -24,6 +43,7 @@ export function TodoList({ todos: initialTodos, members, currentMemberId }: {
     [...initialTodos].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status])
   );
   const [filter, setFilter] = useState<'all' | 'mine' | string>('all');
+  const [view, setView] = useState<'list' | 'board'>('list');
   const [newTitle, setNewTitle] = useState('');
   const [newOwner, setNewOwner] = useState<string>('');
   const [editNotesId, setEditNotesId] = useState<string | null>(null);
@@ -34,6 +54,21 @@ export function TodoList({ todos: initialTodos, members, currentMemberId }: {
     if (filter === 'mine') return t.owner?.id === currentMemberId;
     return t.owner?.id === filter;
   });
+
+  const attention = useMemo(() => {
+    const flagged: Array<{ id: string; title: string; reason: string; score: number }> = [];
+    for (const t of todos) {
+      if (t.status === 'done') continue;
+      if (t.status === 'in_progress' && daysSince(t.created_at) > 7) {
+        flagged.push({ id: t.id, title: t.title, reason: `In progress ${daysSince(t.created_at)}d — stalled?`, score: 3 });
+      } else if (t.status === 'todo' && !t.owner) {
+        flagged.push({ id: t.id, title: t.title, reason: 'Unassigned', score: 2 });
+      } else if (t.status === 'todo' && t.creator && t.owner && t.creator.id !== t.owner.id && daysSince(t.created_at) > 14) {
+        flagged.push({ id: t.id, title: t.title, reason: `Assigned ${daysSince(t.created_at)}d ago — forgotten?`, score: 1 });
+      }
+    }
+    return flagged.sort((a, b) => b.score - a.score).slice(0, 3);
+  }, [todos]);
 
   async function createTodo(e: React.FormEvent) {
     e.preventDefault();
@@ -79,20 +114,42 @@ export function TodoList({ todos: initialTodos, members, currentMemberId }: {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <h2 className="text-lg font-bold text-white">Todos</h2>
-        <select
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
-        >
-          <option value="all">All</option>
-          <option value="mine">Mine</option>
-          {members.map((m) => (
-            <option key={m.id} value={m.id}>{m.name}</option>
-          ))}
-        </select>
+        <div className="flex items-center gap-2">
+          <div className="flex rounded border border-white/[0.08] overflow-hidden">
+            <button
+              onClick={() => setView('list')}
+              className={`text-[10px] font-bold px-2 py-1 transition-colors ${
+                view === 'list' ? 'bg-[#f5a623]/15 text-[#f5a623]' : 'text-gray-500 hover:text-gray-300'
+              }`}
+            >
+              List
+            </button>
+            <button
+              onClick={() => setView('board')}
+              className={`text-[10px] font-bold px-2 py-1 transition-colors border-l border-white/[0.08] ${
+                view === 'board' ? 'bg-[#f5a623]/15 text-[#f5a623]' : 'text-gray-500 hover:text-gray-300'
+              }`}
+            >
+              Board
+            </button>
+          </div>
+          <select
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="bg-[#0a1628] border border-white/[0.08] rounded text-xs text-gray-400 px-2 py-1 focus:outline-none"
+          >
+            <option value="all">All</option>
+            <option value="mine">Mine</option>
+            {members.map((m) => (
+              <option key={m.id} value={m.id}>{m.name}</option>
+            ))}
+          </select>
+        </div>
       </div>
+
+      <AttentionCard items={attention} />
 
       <form onSubmit={createTodo} className="flex gap-2">
         <input
@@ -116,58 +173,82 @@ export function TodoList({ todos: initialTodos, members, currentMemberId }: {
         </button>
       </form>
 
-      <div className="space-y-2">
-        {filtered.map((todo) => (
-          <div key={todo.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
-            <div className="flex items-start gap-3">
-              <button
-                onClick={() => cycleStatus(todo)}
-                className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${statusColor[todo.status]}`}
-                title={`Status: ${todo.status}. Click to cycle.`}
-              >
-                {statusIcon[todo.status]}
-              </button>
-              <div className="flex-1 min-w-0">
-                <p className={`text-sm ${todo.status === 'done' ? 'text-gray-500 line-through' : 'text-white'}`}>
-                  {todo.title}
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  {todo.owner && (
-                    <span className="text-[10px] font-medium text-[#f5a623] bg-[#f5a623]/10 px-2 py-0.5 rounded-full">
-                      {todo.owner.name}
-                    </span>
-                  )}
-                  <button
-                    onClick={() => { setEditNotesId(editNotesId === todo.id ? null : todo.id); setEditNotesVal(todo.notes || ''); }}
-                    className="text-[10px] text-gray-500 hover:text-gray-400"
-                  >
-                    {todo.notes ? 'notes' : '+ note'}
-                  </button>
-                </div>
-                {editNotesId === todo.id && (
-                  <div className="mt-2 flex gap-2">
-                    <input
-                      value={editNotesVal}
-                      onChange={(e) => setEditNotesVal(e.target.value)}
-                      placeholder="Add a note..."
-                      className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
-                      onKeyDown={(e) => { if (e.key === 'Enter') { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); } }}
-                      autoFocus
-                    />
-                    <button onClick={() => { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); }} className="text-xs text-[#f5a623]">Save</button>
+      {view === 'list' ? (
+        <div className="space-y-2">
+          {filtered.map((todo) => (
+            <div key={todo.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3">
+              <div className="flex items-start gap-3">
+                <button
+                  onClick={() => cycleStatus(todo)}
+                  className={`mt-0.5 w-5 h-5 rounded border-2 flex items-center justify-center text-xs font-bold flex-shrink-0 ${statusColor[todo.status]}`}
+                  title={`Status: ${todo.status}. Click to cycle.`}
+                >
+                  {statusIcon[todo.status]}
+                </button>
+                <div className="flex-1 min-w-0">
+                  <p className={`text-sm ${todo.status === 'done' ? 'text-gray-500 line-through' : 'text-white'}`}>
+                    {todo.title}
+                  </p>
+                  <div className="flex items-center gap-2 mt-1">
+                    {todo.owner && (
+                      <span className="text-[10px] font-medium text-[#f5a623] bg-[#f5a623]/10 px-2 py-0.5 rounded-full">
+                        {todo.owner.name}
+                      </span>
+                    )}
+                    <button
+                      onClick={() => { setEditNotesId(editNotesId === todo.id ? null : todo.id); setEditNotesVal(todo.notes || ''); }}
+                      className="text-[10px] text-gray-500 hover:text-gray-400"
+                    >
+                      {todo.notes ? 'notes' : '+ note'}
+                    </button>
                   </div>
-                )}
-                {editNotesId !== todo.id && todo.notes && (
-                  <p className="text-xs text-gray-500 mt-1 italic">{todo.notes}</p>
-                )}
+                  {editNotesId === todo.id && (
+                    <div className="mt-2 flex gap-2">
+                      <input
+                        value={editNotesVal}
+                        onChange={(e) => setEditNotesVal(e.target.value)}
+                        placeholder="Add a note..."
+                        className="flex-1 bg-[#0a1628] border border-white/[0.1] rounded px-2 py-1 text-xs text-gray-300 focus:outline-none focus:border-[#f5a623]/50"
+                        onKeyDown={(e) => { if (e.key === 'Enter') { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); } }}
+                        autoFocus
+                      />
+                      <button onClick={() => { updateTodo(todo.id, { notes: editNotesVal }); setEditNotesId(null); }} className="text-xs text-[#f5a623]">Save</button>
+                    </div>
+                  )}
+                  {editNotesId !== todo.id && todo.notes && (
+                    <p className="text-xs text-gray-500 mt-1 italic">{todo.notes}</p>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        ))}
-        {filtered.length === 0 && (
-          <p className="text-sm text-gray-500 text-center py-4">No todos yet</p>
-        )}
-      </div>
+          ))}
+          {filtered.length === 0 && (
+            <p className="text-sm text-gray-500 text-center py-4">No todos yet</p>
+          )}
+        </div>
+      ) : (
+        <KanbanBoard
+          items={filtered}
+          columns={KANBAN_COLUMNS}
+          onStatusChange={(id, status) => updateTodo(id, { status })}
+          getStripeColor={(t) => STATUS_STRIPE[t.status]}
+          renderCard={(todo) => (
+            <div className="p-3">
+              <p className={`text-sm ${todo.status === 'done' ? 'text-gray-500 line-through' : 'text-white'}`}>
+                {todo.title}
+              </p>
+              <div className="flex items-center gap-2 mt-2 flex-wrap">
+                {todo.owner && (
+                  <span className="text-[10px] font-medium text-[#f5a623] bg-[#f5a623]/10 px-2 py-0.5 rounded-full">
+                    {todo.owner.name}
+                  </span>
+                )}
+                {todo.notes && <span className="text-[10px] text-gray-500 italic line-clamp-1">{todo.notes}</span>}
+              </div>
+            </div>
+          )}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Extends the Kanban pattern from Sponsors (PR #189, merged) to the remaining two tabs + adds Pareto "Top 3 Need Attention" cards to all three.

Orphaned commit from the already-merged PR #189 branch — re-opening cleanly on a fresh branch.

## Kanban everywhere
- **Artists**: 6 columns (Wishlist → Contacted → Interested → Confirmed (cap 10) → Booked → Declined collapsed)
- **Todos**: 3 columns (To Do → In Progress (cap 5) → Done collapsed)
- **Sponsors**: already live from PR #189
- All tabs have List ↔ Board toggle top-right

## Pareto "Top 3 Need Attention" cards
Shared `<AttentionCard>` primitive. Each tab computes its own flag rules:

**Sponsors**
- status=contacted AND last_contacted_at > 14d (silent after contact)
- status=in_talks AND last_contacted_at > 7d (stalled in-talks)
- status=committed AND amount_paid < amount_committed AND created_at > 30d (unpaid)

**Artists**
- status=contacted AND created_at > 10d (stale)
- status=interested AND no notes (no logged next step)
- status=confirmed AND needs_travel AND !travel_from (travel gap)

**Todos**
- status=in_progress AND created_at > 7d (stalled)
- status=todo AND no owner (unassigned)
- status=todo AND creator != owner AND created_at > 14d (forgotten)

## Files
- `src/app/stock/team/AttentionCard.tsx` (new)
- `src/app/stock/team/ArtistPipeline.tsx` (+kanban view +attention)
- `src/app/stock/team/TodoList.tsx` (+kanban view +attention)
- `src/app/stock/team/SponsorCRM.tsx` (+attention card only — kanban already live)

## Test plan
- [ ] Merge + deploy
- [ ] Artists tab — List/Board toggle, drag to change status
- [ ] Todos tab — 3 columns, drag Todo → In Progress → Done
- [ ] Artists Confirmed column shows 7/10 counter
- [ ] Todos In Progress > 5 shows ⚠ warning
- [ ] Attention cards render when there's stale data (may be empty on fresh seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)