### PR TITLE
feat(stock): member profile photos via paste-URL

### DIFF
--- a/scripts/stock-team-bios.sql
+++ b/scripts/stock-team-bios.sql
@@ -7,9 +7,12 @@
 
 ALTER TABLE stock_team_members
   ADD COLUMN IF NOT EXISTS bio TEXT DEFAULT '',
-  ADD COLUMN IF NOT EXISTS links TEXT DEFAULT '';
+  ADD COLUMN IF NOT EXISTS links TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS photo_url TEXT DEFAULT '';
 
 COMMENT ON COLUMN stock_team_members.bio IS
   'Self-authored bio. Teammate edits this from the dashboard Profile card. Plain text or simple markdown.';
 COMMENT ON COLUMN stock_team_members.links IS
   'Comma-separated list of socials or websites. Free-form. Example: x.com/zaal, farcaster.xyz/zaal';
+COMMENT ON COLUMN stock_team_members.photo_url IS
+  'Full URL to a hosted profile image. Teammate pastes their existing pfp URL (X, Farcaster, Imgur, etc). Validated as https on save.';

--- a/src/app/api/stock/team/profile/route.ts
+++ b/src/app/api/stock/team/profile/route.ts
@@ -6,6 +6,14 @@ import { getSupabaseAdmin } from '@/lib/db/supabase';
 const patchSchema = z.object({
   bio: z.string().max(2000).optional(),
   links: z.string().max(500).optional(),
+  photo_url: z
+    .string()
+    .max(500)
+    .optional()
+    .refine(
+      (v) => !v || v === '' || /^https:\/\//i.test(v),
+      { message: 'Photo URL must start with https://' },
+    ),
 });
 
 export async function PATCH(request: NextRequest) {
@@ -24,6 +32,7 @@ export async function PATCH(request: NextRequest) {
     const updates: Record<string, string> = {};
     if (parsed.data.bio !== undefined) updates.bio = parsed.data.bio;
     if (parsed.data.links !== undefined) updates.links = parsed.data.links;
+    if (parsed.data.photo_url !== undefined) updates.photo_url = parsed.data.photo_url;
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
@@ -34,7 +43,7 @@ export async function PATCH(request: NextRequest) {
       .from('stock_team_members')
       .update(updates)
       .eq('id', session.memberId)
-      .select('id, name, bio, links')
+      .select('id, name, bio, links, photo_url')
       .single();
 
     if (error || !data) {

--- a/src/app/stock/team/BioEditor.tsx
+++ b/src/app/stock/team/BioEditor.tsx
@@ -6,14 +6,17 @@ interface Props {
   memberName: string;
   initialBio: string;
   initialLinks: string;
+  initialPhotoUrl: string;
 }
 
-export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
+export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUrl }: Props) {
   const [bio, setBio] = useState(initialBio);
   const [links, setLinks] = useState(initialLinks);
+  const [photoUrl, setPhotoUrl] = useState(initialPhotoUrl);
   const [editing, setEditing] = useState(initialBio.trim().length === 0);
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
+  const [photoBroken, setPhotoBroken] = useState(false);
 
   async function save() {
     setBusy(true);
@@ -22,13 +25,14 @@ export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
       const res = await fetch('/api/stock/team/profile', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bio, links }),
+        body: JSON.stringify({ bio, links, photo_url: photoUrl }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         setMsg(data.error || 'Save failed');
       } else {
         setEditing(false);
+        setPhotoBroken(false);
         setMsg('Saved');
         setTimeout(() => setMsg(null), 1500);
       }
@@ -40,6 +44,7 @@ export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
   }
 
   const hasBio = bio.trim().length > 0;
+  const showPhoto = photoUrl.trim() && !photoBroken;
 
   return (
     <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08] space-y-3">
@@ -56,11 +61,22 @@ export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
       </div>
 
       {!editing && hasBio && (
-        <div className="space-y-2">
-          <p className="text-sm text-gray-200 whitespace-pre-wrap leading-relaxed">{bio}</p>
-          {links.trim() && (
-            <p className="text-[11px] text-gray-500">{links}</p>
+        <div className="flex items-start gap-3">
+          {showPhoto && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photoUrl}
+              alt={`${memberName} profile`}
+              onError={() => setPhotoBroken(true)}
+              className="w-16 h-16 rounded-full object-cover border border-white/[0.08] flex-shrink-0"
+            />
           )}
+          <div className="flex-1 min-w-0 space-y-1">
+            <p className="text-sm text-gray-200 whitespace-pre-wrap leading-relaxed">{bio}</p>
+            {links.trim() && (
+              <p className="text-[11px] text-gray-500">{links}</p>
+            )}
+          </div>
         </div>
       )}
 
@@ -68,13 +84,35 @@ export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
         <div className="space-y-2">
           <p className="text-xs text-gray-400">
             {hasBio
-              ? `Editing ${memberName}'s bio.`
+              ? `Editing ${memberName}'s profile.`
               : `Hey ${memberName}, drop a quick bio so the team knows who you are.`}
           </p>
+
+          {showPhoto && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={photoUrl}
+              alt="Preview"
+              onError={() => setPhotoBroken(true)}
+              className="w-20 h-20 rounded-full object-cover border border-[#f5a623]/30"
+            />
+          )}
+
+          <input
+            value={photoUrl}
+            onChange={(e) => { setPhotoUrl(e.target.value); setPhotoBroken(false); }}
+            placeholder="Photo URL (https://...) - paste your X/Farcaster/Imgur pfp link"
+            maxLength={500}
+            className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+          />
+          {photoBroken && photoUrl.trim() && (
+            <p className="text-[10px] text-amber-400">That image URL did not load. Try another link.</p>
+          )}
+
           <textarea
             value={bio}
             onChange={(e) => setBio(e.target.value)}
-            placeholder="Who you are, what you bring to ZAOstock, what you're working on, anything you want the team and public to know..."
+            placeholder="Who you are, what you bring to ZAOstock, what you're working on, anything you want the team to know..."
             rows={5}
             maxLength={2000}
             className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
@@ -105,6 +143,9 @@ export function BioEditor({ memberName, initialBio, initialLinks }: Props) {
             )}
             {msg && <p className="text-[10px] text-emerald-400 ml-auto">{msg}</p>}
           </div>
+          <p className="text-[10px] text-gray-600 italic">
+            For the photo: right-click your X or Farcaster profile pic, Copy Image Address, paste above. Or use any image URL that starts with https://.
+          </p>
         </div>
       )}
     </div>

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -106,7 +106,7 @@ interface Props {
   memberId: string;
   goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
   todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
-  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string }>;
+  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string }>;
   sponsors: Sponsor[];
   artists: Artist[];
   milestones: Milestone[];

--- a/src/app/stock/team/PersonalHome.tsx
+++ b/src/app/stock/team/PersonalHome.tsx
@@ -8,7 +8,7 @@ import { BioEditor } from './BioEditor';
 
 const FESTIVAL_DATE = new Date('2026-10-03T12:00:00-04:00');
 
-interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; }
+interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; }
 
 interface Todo {
   id: string;
@@ -138,7 +138,12 @@ export function PersonalHome({ member, allMembers, todos, sponsors, artists, mil
       <QuickAdd currentMemberId={member.id} />
 
       {/* Bio editor */}
-      <BioEditor memberName={member.name} initialBio={member.bio || ''} initialLinks={member.links || ''} />
+      <BioEditor
+        memberName={member.name}
+        initialBio={member.bio || ''}
+        initialLinks={member.links || ''}
+        initialPhotoUrl={member.photo_url || ''}
+      />
 
       {/* Welcome banner */}
       <div className="bg-gradient-to-br from-[#f5a623]/20 via-[#f5a623]/5 to-transparent rounded-xl p-5 border border-[#f5a623]/30">

--- a/src/app/stock/team/TeamRoles.tsx
+++ b/src/app/stock/team/TeamRoles.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 interface Member {
   id: string;
   name: string;
@@ -7,6 +9,7 @@ interface Member {
   scope: string;
   bio?: string;
   links?: string;
+  photo_url?: string;
 }
 
 const SCOPE_LABEL: Record<string, string> = {
@@ -34,27 +37,57 @@ export function TeamRoles({ members }: { members: Member[] }) {
     <div className="space-y-3">
       <h2 className="text-lg font-bold text-white">Team</h2>
       <p className="text-xs text-gray-500">
-        Each teammate edits their own profile from the Home tab. If yours is blank, login and add a bio.
+        Each teammate edits their own profile from the Home tab. If yours is blank, login and add a bio + photo.
       </p>
       <div className="space-y-2">
         {members.map((m) => (
-          <div key={m.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 space-y-2">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-sm font-medium text-white">{m.name}</span>
-              <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border uppercase ${SCOPE_COLOR[m.scope] || SCOPE_COLOR.ops}`}>
-                {SCOPE_LABEL[m.scope] || m.scope} - {ROLE_LABEL[m.role] || m.role}
-              </span>
-            </div>
-            {m.bio && m.bio.trim() ? (
-              <p className="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed">{m.bio}</p>
-            ) : (
-              <p className="text-[11px] text-gray-600 italic">No bio yet.</p>
-            )}
-            {m.links && m.links.trim() && (
-              <p className="text-[10px] text-gray-500">{m.links}</p>
-            )}
-          </div>
+          <MemberCard key={m.id} member={m} />
         ))}
+      </div>
+    </div>
+  );
+}
+
+function MemberCard({ member: m }: { member: Member }) {
+  const [photoBroken, setPhotoBroken] = useState(false);
+  const showPhoto = m.photo_url && m.photo_url.trim() && !photoBroken;
+  const initials = m.name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 flex items-start gap-3">
+      {showPhoto ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={m.photo_url}
+          alt={m.name}
+          onError={() => setPhotoBroken(true)}
+          className="w-12 h-12 rounded-full object-cover border border-white/[0.08] flex-shrink-0"
+        />
+      ) : (
+        <div className="w-12 h-12 rounded-full bg-[#0a1628] border border-white/[0.08] flex-shrink-0 flex items-center justify-center">
+          <span className="text-xs font-bold text-gray-500">{initials}</span>
+        </div>
+      )}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-sm font-medium text-white">{m.name}</span>
+          <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border uppercase ${SCOPE_COLOR[m.scope] || SCOPE_COLOR.ops}`}>
+            {SCOPE_LABEL[m.scope] || m.scope} - {ROLE_LABEL[m.role] || m.role}
+          </span>
+        </div>
+        {m.bio && m.bio.trim() ? (
+          <p className="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed">{m.bio}</p>
+        ) : (
+          <p className="text-[11px] text-gray-600 italic">No bio yet.</p>
+        )}
+        {m.links && m.links.trim() && (
+          <p className="text-[10px] text-gray-500">{m.links}</p>
+        )}
       </div>
     </div>
   );

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -37,7 +37,7 @@ export default async function StockTeamPage() {
       .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
       .order('status')
       .order('created_at', { ascending: false }),
-    supabase.from('stock_team_members').select('id, name, role, scope, bio, links').order('created_at'),
+    supabase.from('stock_team_members').select('id, name, role, scope, bio, links, photo_url').order('created_at'),
     supabase
       .from('stock_sponsors')
       .select('*, owner:stock_team_members!owner_id(id, name)')


### PR DESCRIPTION
## Summary
Adds profile photos to ZAOstock team members. No storage infra, no uploads - teammates paste an existing image URL (X pfp, Farcaster pfp, Imgur, etc). Fastest path to visual bios.

## Changes
- `scripts/stock-team-bios.sql` updated to also add `photo_url TEXT DEFAULT ''`. Paste the full file into Supabase again (idempotent - IF NOT EXISTS guards).
- `/api/stock/team/profile` PATCH now accepts `photo_url` with `https://` prefix validation
- `BioEditor` (Home tab Profile card) gets a Photo URL input with live preview and broken-image fallback
- `TeamRoles` (Team tab) shows round avatars next to each bio, or clean initials fallback

## UX
On Home tab Profile card:
- Photo URL field at top (preview appears live below as you type)
- Bio textarea
- Links field
- Save button

On Team tab:
- Every member row now has an avatar circle
- If photo is set and loads: shows image
- If not: shows initials on dark circle

## How teammates add a photo
1. Right-click their X or Farcaster profile pic
2. Copy Image Address
3. Paste into Photo URL field on Home tab
4. Save

## To apply after merge
Paste `scripts/stock-team-bios.sql` into Supabase SQL Editor and run. Idempotent - safe to re-run even though earlier version was applied.

## Test plan
- [ ] Merge and deploy
- [ ] Paste updated SQL
- [ ] Login as Zaal, paste a photo URL, save - photo appears on Home and Team tab
- [ ] Invalid URL (no https) gets rejected
- [ ] Broken URL shows initials fallback
- [ ] Team tab renders all 14 members with avatar-or-initials

No emojis, no em dashes.