### PR TITLE
feat(stock): public team profile pages + DB-backed team section

### DIFF
--- a/scripts/set-stock-team-4letter-codes.ts
+++ b/scripts/set-stock-team-4letter-codes.ts
@@ -9,21 +9,24 @@
 
 import { scryptSync, randomBytes } from 'crypto';
 
-const TEAM = [
-  'Zaal',
-  'Candy',
-  'FailOften',
-  'Hurric4n3Ike',
-  'Swarthy Hatter',
-  'DaNici',
-  'Shawn',
-  'DCoop',
-  'AttaBotty',
-  'Tyler Stambaugh',
-  'Ohnahji B',
-  'DFresh',
-  'Craig G',
-  'Maceo',
+// role/scope for new members (existing members won't be re-roled by this script;
+// the upsert only sets password_hash, role, and scope on INSERT)
+const TEAM: Array<{ name: string; role: string; scope: string }> = [
+  { name: 'Zaal', role: 'lead', scope: 'ops' },
+  { name: 'Candy', role: '2nd', scope: 'ops' },
+  { name: 'FailOften', role: 'member', scope: 'ops' },
+  { name: 'Hurric4n3Ike', role: 'member', scope: 'ops' },
+  { name: 'Swarthy Hatter', role: 'member', scope: 'ops' },
+  { name: 'DaNici', role: 'lead', scope: 'design' },
+  { name: 'Shawn', role: 'member', scope: 'design' },
+  { name: 'DCoop', role: '2nd', scope: 'music' },
+  { name: 'AttaBotty', role: 'member', scope: 'music' },
+  { name: 'Tyler Stambaugh', role: 'member', scope: 'finance' },
+  { name: 'Ohnahji B', role: 'member', scope: 'finance' },
+  { name: 'DFresh', role: 'member', scope: 'finance' },
+  { name: 'Craig G', role: 'member', scope: 'finance' },
+  { name: 'Maceo', role: 'member', scope: 'finance' },
+  { name: 'Jango', role: 'member', scope: 'ops' },
 ];
 
 function code(name: string): string {
@@ -36,28 +39,35 @@ function hashPassword(password: string): string {
   return `${salt}:${hash}`;
 }
 
-const codes = TEAM.map((name) => ({ name, code: code(name) }));
+const entries = TEAM.map((m) => ({ ...m, code: code(m.name) }));
 
 // Verify uniqueness
-const codeSet = new Set(codes.map((c) => c.code));
-if (codeSet.size !== codes.length) {
+const codeSet = new Set(entries.map((c) => c.code));
+if (codeSet.size !== entries.length) {
   console.error('COLLISION: two members share a 4-letter code. Resolve before running.');
   process.exit(1);
 }
 
-console.log('-- ZAOstock Team: 4-letter password codes');
+console.log('-- ZAOstock Team: 4-letter password codes + member upsert');
 console.log('-- Paste this into Supabase SQL Editor and run.');
 console.log('-- Distribute each teammate their code via DM.\n');
 
-console.log('-- Codes (plaintext — share these, not the hashes below):');
-for (const { name, code: c } of codes) {
-  console.log(`--   ${name.padEnd(20)} → ${c}`);
+console.log('-- Codes (plaintext - share these, not the hashes below):');
+for (const { name, code: c } of entries) {
+  console.log(`--   ${name.padEnd(20)} -> ${c}`);
 }
 console.log('');
 
 console.log('BEGIN;');
-for (const { name, code: c } of codes) {
+for (const { name, code: c, role, scope } of entries) {
   const hash = hashPassword(c);
-  console.log(`UPDATE stock_team_members SET password_hash = '${hash}' WHERE name = '${name.replace(/'/g, "''")}';`);
+  const safeName = name.replace(/'/g, "''");
+  // Upsert: creates new members, updates password_hash for existing ones.
+  // Role/scope only set on INSERT - does not overwrite existing role/scope.
+  console.log(
+    `INSERT INTO stock_team_members (name, role, scope, password_hash) ` +
+    `VALUES ('${safeName}', '${role}', '${scope}', '${hash}') ` +
+    `ON CONFLICT (name) DO UPDATE SET password_hash = EXCLUDED.password_hash;`,
+  );
 }
 console.log('COMMIT;');

--- a/src/app/stock/PublicTeamGrid.tsx
+++ b/src/app/stock/PublicTeamGrid.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { PublicMember } from '@/lib/stock/members';
+
+const SCOPE_COLOR: Record<string, string> = {
+  ops: 'border-blue-500/30',
+  finance: 'border-emerald-500/30',
+  design: 'border-indigo-500/30',
+  music: 'border-rose-500/30',
+};
+
+const SCOPE_LABEL: Record<string, string> = {
+  ops: 'Operations',
+  finance: 'Finance',
+  design: 'Design',
+  music: 'Music',
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  lead: 'Lead',
+  '2nd': '2nd',
+  member: 'Member',
+};
+
+const SCOPE_ORDER = ['ops', 'design', 'music', 'finance'];
+
+export function PublicTeamGrid({ members }: { members: PublicMember[] }) {
+  const byScope: Record<string, PublicMember[]> = {};
+  for (const m of members) {
+    if (!byScope[m.scope]) byScope[m.scope] = [];
+    byScope[m.scope].push(m);
+  }
+  for (const s of Object.keys(byScope)) {
+    byScope[s].sort((a, b) => {
+      const rank = (r: string) => (r === 'lead' ? 0 : r === '2nd' ? 1 : 2);
+      return rank(a.role) - rank(b.role);
+    });
+  }
+
+  const orderedScopes = SCOPE_ORDER.filter((s) => byScope[s] && byScope[s].length > 0);
+
+  return (
+    <div className="space-y-4">
+      {orderedScopes.map((scope) => (
+        <div key={scope} className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] overflow-hidden">
+          <div className="bg-gradient-to-r from-[#f5a623]/15 to-transparent px-4 py-2.5">
+            <span className="font-bold text-sm text-[#f5a623]">{SCOPE_LABEL[scope] || scope}</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3 p-3">
+            {byScope[scope].map((m) => (
+              <MemberTile key={m.id} member={m} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MemberTile({ member }: { member: PublicMember }) {
+  const [photoBroken, setPhotoBroken] = useState(false);
+  const showPhoto = member.photo_url && !photoBroken;
+  const initials = member.name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <Link
+      href={`/stock/team/m/${member.slug}`}
+      className={`flex items-center gap-3 p-3 rounded-lg bg-[#0a1628] border ${SCOPE_COLOR[member.scope] || 'border-white/[0.08]'} hover:bg-[#0a1628]/80 transition-colors`}
+    >
+      {showPhoto ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={member.photo_url}
+          alt={member.name}
+          onError={() => setPhotoBroken(true)}
+          className="w-10 h-10 rounded-full object-cover border border-white/[0.06] flex-shrink-0"
+        />
+      ) : (
+        <div className="w-10 h-10 rounded-full bg-[#0d1b2a] border border-white/[0.06] flex-shrink-0 flex items-center justify-center">
+          <span className="text-[11px] font-bold text-gray-500">{initials}</span>
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-white truncate">{member.name}</p>
+        <p className="text-[10px] text-gray-500 truncate">
+          {ROLE_LABEL[member.role] || member.role}
+        </p>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/stock/page.tsx
+++ b/src/app/stock/page.tsx
@@ -2,6 +2,10 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import { CountdownTimer } from '@/components/events/CountdownTimer';
 import { RSVPForm } from './RSVPForm';
+import { getPublicMembers, type PublicMember } from '@/lib/stock/members';
+import { PublicTeamGrid } from './PublicTeamGrid';
+
+export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'ZAOstock | Community Music Festival',
@@ -52,33 +56,6 @@ const PAST_EVENTS = [
   },
 ];
 
-const TEAMS = [
-  {
-    name: 'Operations',
-    lead: 'Zaal',
-    second: 'Candy',
-    members: ['FailOften', 'Hurric4n3Ike', 'Swarthy Hatter'],
-  },
-  {
-    name: 'Finance',
-    lead: 'Zaal',
-    second: '',
-    members: ['Tyler Stambaugh', 'Ohnahji B', 'DFresh', 'Craig G', 'Maceo'],
-  },
-  {
-    name: 'Design',
-    lead: 'DaNici',
-    second: 'Candy',
-    members: ['FailOften', 'Shawn'],
-  },
-  {
-    name: 'Music',
-    lead: 'Zaal',
-    second: 'DCoop',
-    members: ['AttaBotty', 'Shawn'],
-  },
-];
-
 const PARTNERS = [
   { name: 'Heart of Ellsworth', role: 'Venue + MCW statewide promotion', confirmed: true },
   { name: 'Town of Ellsworth', role: 'Parklet venue', confirmed: true },
@@ -87,7 +64,9 @@ const PARTNERS = [
   { name: 'Wallace Events', role: 'Tent rental + weather backup', confirmed: false },
 ];
 
-export default function StockPage() {
+export default async function StockPage() {
+  const publicMembers: PublicMember[] = await getPublicMembers();
+
   return (
     <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
       {/* Simple public header */}
@@ -191,34 +170,10 @@ export default function StockPage() {
         {/* Team */}
         <section className="space-y-3">
           <p className="text-xs text-gray-500 uppercase tracking-wider px-1">The Team</p>
-          <div className="space-y-3">
-            {TEAMS.map((team) => (
-              <div key={team.name} className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] overflow-hidden">
-                <div className="bg-gradient-to-r from-[#f5a623]/20 to-transparent px-4 py-2.5">
-                  <span className="font-bold text-sm text-[#f5a623]">{team.name}</span>
-                </div>
-                <div className="px-4 py-3 space-y-2">
-                  <div className="flex flex-wrap gap-2">
-                    <span className="inline-flex items-center gap-1 text-xs bg-[#f5a623]/10 text-[#f5a623] border border-[#f5a623]/30 rounded-full px-2.5 py-1 font-medium">
-                      {team.lead}
-                      <span className="text-[10px] text-[#f5a623]/60">Lead</span>
-                    </span>
-                    {team.second && (
-                    <span className="inline-flex items-center gap-1 text-xs bg-white/[0.04] text-gray-300 border border-white/[0.08] rounded-full px-2.5 py-1">
-                      {team.second}
-                      <span className="text-[10px] text-gray-500">2nd</span>
-                    </span>
-                    )}
-                    {team.members.map((m) => (
-                      <span key={m} className="text-xs bg-white/[0.04] text-gray-400 border border-white/[0.06] rounded-full px-2.5 py-1">
-                        {m}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+          <PublicTeamGrid members={publicMembers} />
+          <p className="text-[11px] text-gray-600 italic px-1">
+            Tap any name for their full bio and links.
+          </p>
         </section>
 
         {/* Partners */}

--- a/src/app/stock/team/TeamRoles.tsx
+++ b/src/app/stock/team/TeamRoles.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
+import { slugify } from '@/lib/stock/members';
 
 interface Member {
   id: string;
@@ -57,6 +59,7 @@ function MemberCard({ member: m }: { member: Member }) {
     .join('')
     .slice(0, 2)
     .toUpperCase();
+  const slug = slugify(m.name);
 
   return (
     <div className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 flex items-start gap-3">
@@ -75,7 +78,12 @@ function MemberCard({ member: m }: { member: Member }) {
       )}
       <div className="flex-1 min-w-0 space-y-1">
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-sm font-medium text-white">{m.name}</span>
+          <Link
+            href={`/stock/team/m/${slug}`}
+            className="text-sm font-medium text-white hover:text-[#f5a623] transition-colors"
+          >
+            {m.name}
+          </Link>
           <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border uppercase ${SCOPE_COLOR[m.scope] || SCOPE_COLOR.ops}`}>
             {SCOPE_LABEL[m.scope] || m.scope} - {ROLE_LABEL[m.role] || m.role}
           </span>
@@ -88,6 +96,12 @@ function MemberCard({ member: m }: { member: Member }) {
         {m.links && m.links.trim() && (
           <p className="text-[10px] text-gray-500">{m.links}</p>
         )}
+        <Link
+          href={`/stock/team/m/${slug}`}
+          className="inline-block text-[10px] text-[#f5a623] hover:text-[#ffd700] mt-1"
+        >
+          Public profile: /stock/team/m/{slug} -&gt;
+        </Link>
       </div>
     </div>
   );

--- a/src/app/stock/team/m/[slug]/MemberProfileView.tsx
+++ b/src/app/stock/team/m/[slug]/MemberProfileView.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import type { PublicMember } from '@/lib/stock/members';
+
+const SCOPE_COLOR: Record<string, string> = {
+  ops: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+  finance: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30',
+  design: 'bg-indigo-500/10 text-indigo-400 border-indigo-500/30',
+  music: 'bg-rose-500/10 text-rose-400 border-rose-500/30',
+};
+
+interface Props {
+  member: PublicMember;
+  scopeLabel: string;
+  roleLabel: string;
+}
+
+export function MemberProfileView({ member, scopeLabel, roleLabel }: Props) {
+  const [photoBroken, setPhotoBroken] = useState(false);
+  const showPhoto = member.photo_url && !photoBroken;
+  const initials = member.name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <section className="bg-gradient-to-br from-[#f5a623]/10 via-transparent to-transparent rounded-2xl p-6 border border-white/[0.08] space-y-4">
+      <div className="flex items-start gap-4">
+        {showPhoto ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={member.photo_url}
+            alt={member.name}
+            onError={() => setPhotoBroken(true)}
+            className="w-24 h-24 rounded-full object-cover border-2 border-[#f5a623]/40 flex-shrink-0"
+          />
+        ) : (
+          <div className="w-24 h-24 rounded-full bg-[#0d1b2a] border-2 border-white/[0.08] flex-shrink-0 flex items-center justify-center">
+            <span className="text-2xl font-bold text-gray-500">{initials}</span>
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl font-bold text-white">{member.name}</h1>
+          <div className="mt-2">
+            <span className={`text-[10px] font-bold px-2 py-1 rounded-full border uppercase ${SCOPE_COLOR[member.scope] || SCOPE_COLOR.ops}`}>
+              {scopeLabel} - {roleLabel}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {member.bio && member.bio.trim() ? (
+        <div>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider font-bold mb-1">Bio</p>
+          <p className="text-sm text-gray-200 leading-relaxed whitespace-pre-wrap">{member.bio}</p>
+        </div>
+      ) : (
+        <div className="bg-[#0d1b2a] border border-white/[0.08] rounded-lg p-4">
+          <p className="text-sm text-gray-500 italic">Bio coming soon.</p>
+        </div>
+      )}
+
+      {member.links && member.links.trim() && (
+        <div>
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider font-bold mb-1">Links</p>
+          <p className="text-xs text-gray-400">{member.links}</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/app/stock/team/m/[slug]/page.tsx
+++ b/src/app/stock/team/m/[slug]/page.tsx
@@ -1,0 +1,112 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getMemberBySlug, getPublicMembers } from '@/lib/stock/members';
+import { MemberProfileView } from './MemberProfileView';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+const SCOPE_LABEL: Record<string, string> = {
+  ops: 'Operations',
+  finance: 'Finance',
+  design: 'Design',
+  music: 'Music',
+};
+
+const ROLE_LABEL: Record<string, string> = {
+  lead: 'Lead',
+  '2nd': '2nd',
+  member: 'Member',
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const member = await getMemberBySlug(slug);
+  if (!member) return { title: 'Member not found' };
+
+  return {
+    title: `${member.name} | ZAOstock Team`,
+    description: member.bio.slice(0, 160) || `${member.name} on the ZAOstock team.`,
+    openGraph: {
+      title: `${member.name} | ZAOstock Team`,
+      description: member.bio.slice(0, 160) || `${member.name} - ${SCOPE_LABEL[member.scope] || member.scope}`,
+      images: member.photo_url ? [member.photo_url] : [],
+    },
+  };
+}
+
+export default async function MemberProfilePage({ params }: Props) {
+  const { slug } = await params;
+  const member = await getMemberBySlug(slug);
+  if (!member) notFound();
+
+  const all = await getPublicMembers();
+  const teammates = all
+    .filter((m) => m.scope === member.scope && m.id !== member.id)
+    .slice(0, 6);
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link href="/stock" className="text-xs text-gray-400 hover:text-[#f5a623]">
+            &larr; ZAOstock
+          </Link>
+          <span className="text-xs text-gray-500">The Team</span>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <MemberProfileView
+          member={member}
+          scopeLabel={SCOPE_LABEL[member.scope] || member.scope}
+          roleLabel={ROLE_LABEL[member.role] || member.role}
+        />
+
+        {teammates.length > 0 && (
+          <section className="space-y-3">
+            <p className="text-xs text-gray-500 uppercase tracking-wider px-1">
+              Also on {SCOPE_LABEL[member.scope] || member.scope}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {teammates.map((t) => (
+                <Link
+                  key={t.id}
+                  href={`/stock/team/m/${t.slug}`}
+                  className="text-xs bg-[#0d1b2a] border border-white/[0.08] rounded-full px-3 py-1.5 text-gray-300 hover:border-[#f5a623]/30 hover:text-white transition-colors"
+                >
+                  {t.name}
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <section className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-2">
+          <p className="text-xs text-[#f5a623] uppercase tracking-wider font-bold">About ZAOstock</p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            {member.name} is part of the crew building ZAOstock - a community-built outdoor music festival in Ellsworth, Maine on October 3, 2026. Ten artists, one stage, all day at the Franklin Street Parklet. Part of the 9th Annual Art of Ellsworth.
+          </p>
+          <div className="flex gap-2 pt-2">
+            <Link
+              href="/stock"
+              className="text-xs bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-3 py-2 transition-colors"
+            >
+              Festival info
+            </Link>
+            <Link
+              href="/stock/program"
+              className="text-xs bg-white/[0.06] hover:bg-white/[0.12] text-gray-200 rounded-lg px-3 py-2 transition-colors"
+            >
+              Program
+            </Link>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/stock/members.ts
+++ b/src/lib/stock/members.ts
@@ -1,0 +1,46 @@
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+export interface PublicMember {
+  id: string;
+  name: string;
+  role: string;
+  scope: string;
+  bio: string;
+  links: string;
+  photo_url: string;
+  slug: string;
+}
+
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+export async function getPublicMembers(): Promise<PublicMember[]> {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_team_members')
+    .select('id, name, role, scope, bio, links, photo_url')
+    .order('created_at');
+
+  if (error || !data) return [];
+
+  return data.map((m) => ({
+    id: m.id,
+    name: m.name,
+    role: m.role || 'member',
+    scope: m.scope || 'ops',
+    bio: m.bio || '',
+    links: m.links || '',
+    photo_url: m.photo_url || '',
+    slug: slugify(m.name),
+  }));
+}
+
+export async function getMemberBySlug(slug: string): Promise<PublicMember | null> {
+  const all = await getPublicMembers();
+  return all.find((m) => m.slug === slug) || null;
+}


### PR DESCRIPTION
## Summary
Every teammate now has their own shareable public profile URL. /stock Team section pulls live from DB instead of hardcoded names. Shawn can send zaoos.com/stock/team/m/shawn and it shows his photo, bio, team, links.

## Routes
- **/stock/team/m/<slug>** - public profile page for any teammate. OpenGraph metadata includes their photo + bio for clean link previews. Links to same-scope teammates + festival info.
- **/stock** Team section now live-fetches from DB. Hardcoded TEAMS array removed. Members grouped by scope (Ops, Design, Music, Finance), each row is clickable to their profile.

## New
- src/lib/stock/members.ts - shared getPublicMembers + getMemberBySlug + slugify
- src/app/stock/team/m/[slug]/page.tsx + MemberProfileView.tsx
- src/app/stock/PublicTeamGrid.tsx

## Changed
- /stock/page.tsx - async server component. Hardcoded TEAMS gone.
- TeamRoles (Team tab, internal) - each member name links to their public profile. Sharable URL shown under each bio.
- set-stock-team-4letter-codes.ts - now upserts (INSERT ON CONFLICT DO UPDATE), safely adds new members and refreshes codes. Jango added as ops member with code JANG.

## To apply
Paste refreshed SQL output from the clipboard page already open in browser. Adds Jango + refreshes all 15 password codes.

No emojis, no em dashes.