### PR TITLE
docs(stock): sponsor outreach + Apr 18 build-in-public drafts

### DIFF
--- a/scripts/social-posts-apr18-build-in-public.md
+++ b/scripts/social-posts-apr18-build-in-public.md
@@ -1,0 +1,192 @@
+# Build-in-Public Posts — Apr 18 Launch Push
+
+**Date:** 2026-04-18 (Saturday)
+**Theme:** Announce ZAOstock prep is live, drive traffic to zaoos.com/stock, invite sponsors and artists to reach out.
+
+Rule of thumb: one platform version of each message. Copy, post, move on. Reply to comments within the hour.
+
+---
+
+## Farcaster cast (primary)
+
+**Channel:** /zao (plus cross-post to /music and /events if you run those)
+
+```
+ZAOstock is locked for Oct 3, 2026.
+
+10 artists, one stage, full day at the Franklin Street Parklet in
+Ellsworth Maine. Part of Art of Ellsworth during Maine Craft Weekend.
+Co-presented with Heart of Ellsworth and the Town of Ellsworth.
+
+Dashboard live, team assembled, 168 days of prep starts now.
+
+zaoos.com/stock
+
+If you're an artist who wants a spot, DM. If you're a brand that wants
+to partner, same. Community-built, break-even, fair artist pay. No
+margin, no extraction.
+
+Let's build it in public.
+```
+
+**Longer variant if you want a thread:**
+
+Reply 1:
+```
+The team: 15 of us across Ops, Design, Music, Finance. Meet everyone at
+zaoos.com/stock - each has their own public profile page you can share.
+```
+
+Reply 2:
+```
+Sponsor tracks: Main Stage Partner (local Ellsworth), Broadcast Partner
+(web3 / onchain), Year-Round Partner (strategic). All contributions tax-
+deductible via Fractured Atlas 501(c)(3).
+```
+
+Reply 3:
+```
+We're also testing WaveWarZ live - a 4-artist bracket during the
+festival, audience votes via QR on our onchain prediction market.
+Winner gets the closing set. First time onchain music + IRL festival
+in one show.
+```
+
+---
+
+## X (Twitter) post
+
+**Character limit: 280**
+
+Version A (short, hook-heavy):
+```
+ZAOstock is locked.
+
+Oct 3, 2026. Franklin Street Parklet, Ellsworth ME.
+10 artists. One stage. All day.
+
+The ZAO community is building its first IRL festival in public.
+168 days to go.
+
+Join the list: zaoos.com/stock
+```
+
+Version B (focus on sponsors + artists):
+```
+Building ZAOstock in public.
+
+Oct 3 in Ellsworth, Maine. 10 artists + WaveWarZ live bracket.
+
+Looking for partners (Main Stage, Broadcast, Year-Round) and open
+to artist booking now.
+
+Community-built, break-even, fair pay. Tax-deductible.
+
+zaoos.com/stock
+```
+
+---
+
+## Bluesky post
+
+**Character limit: 300. Reasonable community for indie music.**
+
+```
+We're building ZAOstock in public.
+
+Outdoor music festival in Ellsworth, Maine. Oct 3, 2026. 10 artists,
+one stage, all day. Part of Art of Ellsworth.
+
+Run by The ZAO, a decentralized music community.
+Community-built, break-even, fair artist pay.
+
+Dashboard + team + public lineup coming: zaoos.com/stock
+```
+
+---
+
+## LinkedIn post
+
+**Audience:** Maine professional / arts circles, potential corporate sponsors.
+
+```
+Announcing ZAOstock - a community-built outdoor music festival in
+downtown Ellsworth, Maine on October 3, 2026.
+
+We are part of the 9th Annual Art of Ellsworth during Maine Craft
+Weekend, pulling foot traffic from the steady stream of visitors
+heading to Acadia National Park.
+
+10 independent artists perform equal sets across the day at the
+Franklin Street Parklet. Our afterparty is at Black Moon Public House,
+30 seconds from the stage.
+
+We are running the festival transparently - at break-even, with
+fair artist pay and no margin or extraction. Every dollar raised goes
+directly to artists and production.
+
+All contributions are tax-deductible through our 501(c)(3) fiscal
+sponsor, Fractured Atlas.
+
+We are actively looking for:
+- Local Ellsworth / Maine businesses as Main Stage Partners
+- Broadcast Partners across digital + streaming
+- Year-Round strategic partners
+
+Full festival details and partner packages at zaoos.com/stock.
+
+Co-presented with Heart of Ellsworth and the Town of Ellsworth.
+
+Drop a DM if your business wants to be part of what we are building.
+
+#MaineCraftWeekend #Ellsworth #LiveMusic #MaineEvents
+```
+
+---
+
+## Reply templates for interest that comes in
+
+**For artists:**
+```
+Hey [NAME] - so stoked you reached out. Sending you the full pitch via
+DM (genre, slot options, fee structure, travel policy). Let me know
+what questions you have.
+```
+
+**For sponsors/partners:**
+```
+[NAME] - thank you. Sending the partner deck + package options via
+[email/DM]. Would love a 15-min call this week if you have time - let
+me know what works.
+```
+
+**For attendees asking how to RSVP:**
+```
+RSVP list live now at zaoos.com/stock (scroll to RSVP). Tickets drop
+summer. We'll email the list first.
+```
+
+---
+
+## Posting schedule for today (Apr 18)
+
+1. **Farcaster** first - primary channel, our audience lives there
+2. **X** ~20 min later - cross-reach to the builder crowd
+3. **Bluesky** ~20 min after that - indie music fans
+4. **LinkedIn** last - the formal ask, no rush
+
+Check replies every 30-60 min today. Tomorrow: quote-replies / amplification from teammates who have big accounts (DCoop, Hurric4n3, DaNici).
+
+---
+
+## Weekly build-in-public cadence
+
+Going forward, one post per week minimum across all platforms. Topics that work:
+- Week's sponsor/artist wins
+- Behind-the-scenes of the dashboard build
+- Team member spotlights (pull from the public profile pages we just built)
+- Program / schedule teasers
+- Venue + permit progress
+- Weather-backup plans (humor)
+
+Target: 24 posts between now and Oct 3. One per week. Compound reach.

--- a/scripts/sponsor-outreach-templates.md
+++ b/scripts/sponsor-outreach-templates.md
@@ -1,0 +1,308 @@
+# Sponsor Outreach Templates — ZAOstock
+
+**Owner:** Zaal (lead outreach), Tyler (finance terms), Candy (follow-ups)
+**Festival:** ZAOstock, Oct 3 2026, Franklin Street Parklet, Ellsworth ME
+**Purpose:** Templates + ready-to-send specific drafts for 3 wave-1 targets.
+
+Three partner tracks:
+- **Main Stage Partner** — Local Ellsworth / Maine businesses
+- **Broadcast Partner** — Web3 / Farcaster / tools ecosystem (Whop, Songjam, Paragraph, etc)
+- **Year-Round Partner** — Strategic / grants / fiscal sponsorship
+
+Packages flexible. All contributions tax-deductible via Fractured Atlas 501(c)(3).
+
+Replace everything in `[SQUARE BRACKETS]` before sending.
+
+---
+
+## A. Short cold DM — Farcaster / X / LinkedIn / email
+
+Under 500 characters. Hook plus soft ask.
+
+```
+Hey [NAME] - I'm organizing ZAOstock, an outdoor music festival in Ellsworth, Maine on Oct 3, 2026. Part of Art of Ellsworth, run by The ZAO community. We're filling our Partner list and would love [COMPANY] involved. Named credit on stage and broadcast, tax-deductible via our 501(c)(3). Interested in a quick call? Here's the overview: zaoos.com/stock
+```
+
+**Shorter Farcaster cast variant:**
+```
+Partner ask: ZAOstock in Ellsworth, Maine on Oct 3. Outdoor music festival, run by The ZAO. Looking for Main Stage and Broadcast partners. Tax-deductible, community-built, break-even. zaoos.com/stock - DM if [COMPANY] wants in.
+```
+
+---
+
+## B. Full email — formal local business outreach
+
+**Subject lines:**
+- `Partnership opportunity: ZAOstock festival Oct 3 in Ellsworth`
+- `ZAOstock partner ask - local businesses on the main stage`
+- `[COMPANY] partner role on our Oct 3 festival?`
+
+**Body:**
+
+```
+Hi [CONTACT NAME],
+
+I'm reaching out about ZAOstock, a community-built outdoor music festival we
+are organizing on October 3, 2026 at the Franklin Street Parklet in downtown
+Ellsworth. We're part of the 9th Annual Art of Ellsworth during Maine Craft
+Weekend - so we will have every car heading to Acadia National Park rolling
+through downtown that day.
+
+Quick pitch for [COMPANY]:
+- 10 artists, one stage, full day (12pm-6pm, afterparty at Black Moon across
+  the street)
+- Looking to name [COMPANY] as a Main Stage Partner - your brand on the
+  stage banner, shout-outs during the day, booth space on-site, and a piece
+  of all our broadcast + social reach
+- Partner contribution of $[SUGGESTED AMOUNT] would be meaningful at our
+  scale (we're a small community-run festival, targeting $15K total to
+  cover artist pay and production)
+- 100% tax-deductible via Fractured Atlas, our 501(c)(3) fiscal sponsor
+- We operate at break-even. Every dollar goes to artists and production.
+
+Who we are: The ZAO is a decentralized music community that has run virtual
+festivals (PALOOZA, ZAO-CHELLA) for the last two years. ZAOstock 2026 is
+our first IRL festival, co-presented with Heart of Ellsworth and the Town
+of Ellsworth.
+
+Would you be open to a 15-minute call to walk through what partnership
+would look like? I can send the full deck and talk through package options.
+
+Thanks for considering,
+[YOUR NAME]
+ZAOstock team
+zaoos.com/stock
+```
+
+---
+
+## C. Full email — web3 / ecosystem brands
+
+**Subject lines:**
+- `ZAOstock festival partner ask: [COMPANY] on the broadcast`
+- `Onchain music IRL: ZAOstock Oct 3 partner opportunity`
+
+**Body:**
+
+```
+Hi [CONTACT NAME],
+
+ZAOstock is an outdoor festival The ZAO is running October 3, 2026 in
+Ellsworth, Maine. First IRL festival from a Farcaster-based music
+community that has been running virtual events (PALOOZA, ZAO-CHELLA) for
+two years.
+
+Ten artists. One stage. All day. Plus we are testing WaveWarZ live - a
+4-artist bracket tournament where the audience votes via QR onchain
+prediction market tech, winner gets the closing set. Showcase of what
+happens when onchain music meets IRL.
+
+Partner fit for [COMPANY]:
+- Broadcast Partner: your logo on livestream overlay, sponsored segment,
+  featured interview, announcement across Farcaster + X + LinkedIn +
+  Bluesky
+- Named credit as "[COMPANY]" presented partner across all our media
+- Priority placement in 2027 and future ZAO events
+- Tax-deductible contribution via Fractured Atlas 501(c)(3)
+
+Budget for partners like you is flexible - our typical range is $1K to
+$5K based on the level of integration. Happy to tailor.
+
+If this is something [COMPANY] could fit, I'd love 15 minutes to walk
+through the full pitch and the WaveWarZ integration angle. The ZAO is
+the kind of community you probably already have some overlap with.
+
+Thanks,
+[YOUR NAME]
+zaoos.com/stock
+```
+
+---
+
+## D. Follow-up (7-10 days later)
+
+```
+Hi [NAME],
+
+Quick nudge on the ZAOstock partnership below. We are locking our
+partner list by [TARGET DATE - e.g. June 15] so I wanted to give you
+one more shot.
+
+If it is a no for 2026, happy to keep you on the list for 2027. A
+short reply either way is very helpful.
+
+Thanks,
+[YOUR NAME]
+```
+
+---
+
+## E. Decline response (gracious close)
+
+```
+[NAME], totally understood. Appreciate the reply. I'll keep [COMPANY] on
+the radar for 2027 - feel free to reach out if anything changes. Thanks
+for considering.
+```
+
+---
+
+## F. Close response (accepted)
+
+```
+[NAME] - that is amazing, thank you.
+
+Next steps:
+1. I'll send the partner agreement and W-9 from Fractured Atlas this week
+2. Amount: $[AMOUNT] payable by [DATE] via [METHOD - check / wire / crypto]
+3. Your partner credit on stage banner, broadcast overlay, and website
+4. Logo file needed by [DATE - typically 60 days before event] for all
+   printed materials
+
+I will also add [COMPANY] to the partner section on zaoos.com/stock as a
+confirmed partner right now. Please let me know if you want a different
+display name or logo version.
+
+Welcome to ZAOstock.
+
+[YOUR NAME]
+```
+
+---
+
+## Ready-to-Send Drafts for Wave 1 (Tonight)
+
+Three real targets. Copy, edit bracketed pieces, send.
+
+---
+
+### Draft 1: Bangor Savings Bank
+
+**To:** [lookup - probably branch manager at Ellsworth branch or their community giving inbox]
+**Subject:** `Partnership opportunity: ZAOstock festival Oct 3 in Ellsworth`
+
+```
+Hi [CONTACT NAME],
+
+I'm reaching out about ZAOstock, a community-built outdoor music festival
+on October 3, 2026 at the Franklin Street Parklet in downtown Ellsworth.
+We are part of the 9th Annual Art of Ellsworth during Maine Craft Weekend,
+which pulls steady foot traffic from everyone heading to Acadia National
+Park.
+
+We would love Bangor Savings Bank as a Main Stage Partner at the $1,000
+level. In return:
+- Your name on the stage banner and signage
+- Shout-outs during the event
+- Booth space on-site to engage with the crowd
+- Named credit on our website, livestream overlay, and social campaign
+  across Farcaster + X + LinkedIn + Bluesky
+- Community goodwill from the Ellsworth locals who already bank with you
+- 100% tax-deductible through Fractured Atlas, our 501(c)(3) fiscal sponsor
+
+Bangor Savings has a strong track record supporting Maine arts. We think
+ZAOstock is a natural fit - we operate at break-even, every dollar goes
+to artists and production, and we are building something long-term here.
+
+Would you be open to a 15-minute call? I can send the full deck and walk
+through what partnership looks like at your end.
+
+Thanks,
+Zaal Panthaki
+ZAOstock
+zaoos.com/stock
+zaalp99@gmail.com
+```
+
+---
+
+### Draft 2: Fogtown Brewing (Ellsworth)
+
+**To:** [probably Jon or whoever runs partnerships at Fogtown]
+**Subject:** `Fogtown + ZAOstock partner fit? Oct 3, Franklin St Parklet`
+
+```
+Hey [NAME],
+
+I'm Zaal, organizing ZAOstock - a community-built music festival at the
+Franklin Street Parklet on October 3, 2026. Part of Art of Ellsworth, so
+the downtown traffic will be high that day.
+
+Fogtown feels like a perfect partner fit. Thinking:
+
+Main Stage Partner role at $500-1000 level, which could look like:
+- Fogtown serving at the festival (you bring the crew + product, we hold
+  the space - or we work out whatever logistics makes sense)
+- Named credit on stage banner, website, broadcast, and all social
+- Beer sales at the festival go to you directly
+- Bonus: afterparty at Black Moon is 30 seconds from the stage - easy
+  handoff
+
+All contributions are tax-deductible via our 501(c)(3) fiscal sponsor
+Fractured Atlas. We operate at break-even.
+
+Want to grab a coffee or a beer to talk through? I can come by the
+taproom whenever works.
+
+Thanks,
+Zaal
+zaoos.com/stock
+```
+
+---
+
+### Draft 3: Heart of Ellsworth (venue + permit lock)
+
+This is not technically a sponsor - it's the venue partner. Use to lock the Oct 3 date and permit.
+
+**To:** Cara Romano (or whoever coordinates MCW)
+**Subject:** `ZAOstock Oct 3 - confirming Franklin St Parklet dates + permit`
+
+```
+Hi Cara,
+
+Wanted to formally lock in the Franklin Street Parklet for ZAOstock on
+Oct 3, 2026. We're targeting 12pm-6pm with load-in starting at 10am.
+
+Quick confirm on a few things:
+- Parklet is ours for the day - no conflicts?
+- City permit - who on your end handles, or should I go directly to
+  Ellsworth?
+- MCW is Oct 3-5 I believe - is our Saturday slot aligned with the
+  overall schedule you are promoting?
+- Any paperwork or sign-offs we need to handle from our side?
+
+We have Wallace Events lined up for the tent in case of weather. Black
+Moon Public House is confirmed as the afterparty venue.
+
+Let me know what else you need from me. Happy to stop by if easier.
+
+Thanks,
+Zaal
+ZAOstock
+```
+
+---
+
+## Tracking
+
+Every sponsor email sent this week should get logged in the dashboard:
+1. Open the Sponsors tab on zaoos.com/stock/team
+2. Find the row (or create one via Add)
+3. Move the status to Contacted
+4. The system auto-stamps last_contacted_at
+5. Log notes in the expanded card (what you pitched, amount, follow-up date)
+
+If you log everything, the Pareto "Top 3 Need Attention" card on Home will
+flag stale contacts after 14 days so nothing falls through.
+
+---
+
+## Notes for Zaal
+
+- **First wave target: 3 sends tonight**. Bangor Savings + Fogtown + Heart of Ellsworth (venue lock).
+- **Wave 2 next week**: Songjam, Whop, Paragraph, Fractured Atlas, Base.
+- **Fee range**: $500-$1,000 for Main Stage Partners, $1,000-$5,000 for Broadcast Partners. Ecosystem partners may go higher if there is a real product integration.
+- **Don't over-ask**: community-built means we stay honest. If someone wants in at $250, take it and name them as a Community Supporter (not a top-tier partner).
+- **Follow-ups**: 7-10 days after first send. Track in Sponsors tab.
+- **Tyler gets pinged** when any sponsor commits, so he can kick off the Fractured Atlas paperwork.


### PR DESCRIPTION
## Summary
Two copy-ready docs for tonight's outreach push.

### `scripts/sponsor-outreach-templates.md`
- Short cold DM (Farcaster / X / LinkedIn)
- Full email for local businesses (Main Stage Partner framing, tax-deductible hook)
- Full email for web3 brands (Broadcast Partner framing, WaveWarZ angle)
- Follow-up nudge, decline response, close-commit response
- **Three ready-to-send drafts for Wave 1 tonight:** Bangor Savings Bank, Fogtown Brewing, Heart of Ellsworth (venue lock)
- Tracking workflow (log everything in Sponsors tab so Pareto flags stale)

### `scripts/social-posts-apr18-build-in-public.md`
- Farcaster primary cast + optional 3-reply thread
- X post (280 char), two variants
- Bluesky post (300 char)
- LinkedIn post (formal corporate ask)
- Reply templates for artist inbound, sponsor inbound, RSVP questions
- Posting schedule for today
- Weekly build-in-public cadence plan: 24 posts between now and Oct 3

## What to do with this
1. Open the files
2. Copy the Bangor Savings draft, fill in contact, send
3. Same for Fogtown + Heart of Ellsworth
4. Post the Farcaster cast first, then X, Bluesky, LinkedIn
5. Log every sponsor send in the dashboard Sponsors tab

No emojis, no em dashes.