### PR TITLE
feat(stock): public volunteer signup at /stock/apply

### DIFF
--- a/research/community/427-uvr-jadyn-violet-brand-intro-bot/02-jadyn-violet-deep-dive.md
+++ b/research/community/427-uvr-jadyn-violet-brand-intro-bot/02-jadyn-violet-deep-dive.md
@@ -1,0 +1,126 @@
+# 427.02 — Jadyn Violet Deep Dive
+
+> **Status:** Research complete
+> **Date:** 2026-04-17
+> **Supplements:** `427-uvr-jadyn-violet-brand-intro-bot/README.md`
+> **Goal:** Biographical, musical, and community-building detail on Jadyn Violet for the UVRintroBot `/about` command and any future UVR collaborations.
+
+---
+
+## Key Facts
+
+| Field | Value |
+|-------|-------|
+| **Real identity** | First-generation Indian American |
+| **From** | Manassas, Virginia |
+| **Age at early press** | 23 (per Archiv3 + Word To Your Mama Ep 167). Likely ~25–26 in April 2026. |
+| **Education (prior)** | Rutgers business school — nearly perfect SAT, dropped out 3rd semester |
+| **Years making music** | 6+ (per Medium bio) |
+| **Father** | Career singer (direct influence) |
+| **Early inspiration** | Michael Jackson |
+| **Genre** | Alternative hip-hop; blends pop, rap, electronic |
+| **Production** | OADEVOUR, brace, Jadyn Violet |
+| **Spotify artist** | `3EzhvtRgIkIPK0VYNv1ooV` |
+| **Apple Music** | `artist/jadyn-violet/1488149647` |
+| **Twitch account created** | May 8, 2020 (account age; NOT when daily streaming started) |
+| **Daily Twitch streaming since** | **January 2025** (per Jadyn — confirmed by user 2026-04-17) |
+| **Twitch rank** | Top 0.69% globally, top 0.69% English (#46,051 global, #21,518 English) |
+| **Weekly Twitch hours** | ~65 (TwitchTracker) |
+| **IG followers** | ~18K |
+| **Discord members** | ~2,401 |
+
+## UVR Timeline
+
+| Date | Event |
+|------|-------|
+| **2021** | Underground Violet Rave founded |
+| **April 5, 2022** | Violet Token mint — 0.04 ETH, 11-day window, via `jadynviolet.xyz`. Top tier (60 tokens) = Jadyn goes full-time. |
+| **Dec 2, 2022** | "Open Borders x UVR" at Purple Bodega, Miami (Eventbrite) |
+| **2023** | UVR Miami at Secret Warehouse (Resident Advisor) |
+| **Ongoing** | Daily UVR Twitter/X Spaces — 10+ months consecutive run (mid-2023 → present at time of research) |
+| **Pre-"Violet"** | First Sound.xyz drop "Good Always Turns Evil" — 1.75 ETH raised |
+| **Release: "The Stern Mystic"** | Sound.xyz track (`sound.xyz/jadynviolet/the-stern-mystic`). Mirror post by Invest in Music. |
+| **Genesis Collection** | "Violet" — see GitHub `NicoAcosta/violet` (NFT contract) |
+| **Raver Realm mint** | October 23 (year unclear in sources — likely 2024 or 2025). 1,800 supply. Tiered pricing: Free (Violet Token + top 10 UVR Orb + Jadyn 1/1s), 0.02 ETH (select prior holders), 0.025 ETH (UVR Orb + allowlist), 0.03 ETH (public). |
+| **Upcoming** | TwitchCon UVR meetup (per IG reel `instagram.com/reel/DPW-P2TgZvN`) |
+
+## Cities Toured (Confirmed)
+
+Brooklyn, NYC, Los Angeles, Miami, Denver, Cincinnati.
+Known venues: Purple Bodega (Miami), Town Hall Collaborative (Denver), Secret Warehouse (Miami).
+
+## The 9 Ravers (Track Names)
+
+Each Raver = one song = one Realm (genre):
+
+1. Comeback Kid
+2. Rockstar Shit
+3. Dancing Damsel
+4. Toxic Queen
+5. Only Fans
+6. Disha
+7. Lone Wolf
+8. Champagne Poet
+9. Miss Influence
+
+Rolls up to debut album *Violet*.
+
+## Jadyn's Own Words (Quote Bank)
+
+> "I want people to feel what I feel, I want people to see things through my eyes when they listen to my music."
+
+> "I could accomplish great things in whatever I fully set my mind to, and because that happens to not be school does not mean I had given up on life."
+
+> "Creating Art for me is the idea of being able to translate the emotions and feelings that you feel within your chest."
+
+> "Your only obstacle in life is often yourself." (Word To Your Mama Ep 167)
+
+Aspirational side-quest: **own a Taco Bell franchise** (podcast, half-joking but repeatedly mentioned).
+
+## Streaming Schedule Conflict (Resolved)
+
+Sources give conflicting times:
+- IG reel (DFKCquBu6oZ): "streaming every day @ 10PM"
+- X post 1945499024993185930: "every single day at 4pm est"
+- X post 1970889993766994375: "Live on Twitch at 7PM EST"
+
+Interpretation: time varies; the consistent fact is **daily**. For the `/about` embed, state "streams every single day" without a fixed hour — safer and accurate.
+
+## Ecosystem / Peers
+
+- **Jadyn Violet's community shape** — value-first daily Spaces, token-gated podcasts, live raves bridging web2 + web3. Closest analog in ZAO: Stilo (150+ weekly VR concerts since 2007) + Mr. Darius (Sound.xyz + web3 + Wave).
+- **ZAO classification** — UVR = "Associated Community" per ZAO whitepaper Draft 4.4.
+- **Raver Realm supply** — 1,800 (ZAO doc) vs. minted 679 (per ZAO Stock snapshot in whitepaper).
+
+## Brand Voice Cues (for UVR bot copy)
+
+- **Ethos:** counter culture, authenticity, emotional truth, "make music in my bedroom" honesty.
+- **Tone:** hustle + vulnerability. Founder-voice ("gunna happen one day" bedroom bio).
+- **Avoid:** corporate jargon, overhype, emoji clutter. Jadyn's own copy leans plain and direct.
+- **Use:** "Raver" (community member), "Realm" (genre/world), "Orb" (POAP), "Violet Token" (genesis), "UVR" (umbrella).
+
+## Implications for UVRintroBot
+
+1. **`/about`** — lead with founder story (Indian American, Manassas, Rutgers dropout, bedroom music) because that's the hook that differentiates Jadyn from generic web3 music acts.
+2. **Streaming plug** — always link Twitch; daily = the brand signal. Don't state an hour (changes).
+3. **Album/Track name-drops** — listing the 9 Raver names makes the embed feel like a fan knows them.
+4. **No emojis** — Jadyn's own copy is emoji-light. Match his voice.
+5. **Future commands to consider:**
+   - `/raver <1-9>` — look up a specific Raver character + song.
+   - `/spaces` — link to today's UVR X Space.
+   - `/live` — ping Twitch API, show if Jadyn is currently streaming.
+
+## Sources (New for this supplement)
+
+- [ARCHIV3 — Jadyn Violet profile](https://archiv3.xyz/articles/jadyn-violet-is-molding-the-framework-for-future-musicians-using-web3)
+- [Jadyn Violet Medium — About](https://medium.com/@Jadynviolet/about)
+- [Violet Token Launch Details (Medium, 2022)](https://medium.com/@Jadynviolet/violet-token-launch-details-e10b0634d30)
+- [Word To Your Mama — Ep 167: Jadyn Violet](https://www.wordtoyourmama.com/episodes/167)
+- [Raver Realm — About](https://raverrealm.xyz/about/)
+- [Raver Realm — Rewards](https://raverrealm.xyz/rewards/)
+- [TwitchTracker — jadynviolet](https://twitchtracker.com/jadynviolet)
+- [Jadyn Violet — Spotify](https://open.spotify.com/artist/3EzhvtRgIkIPK0VYNv1ooV)
+- [Jadyn Violet — Apple Music](https://music.apple.com/us/artist/jadyn-violet/1488149647)
+- [Jadyn Violet — SoundCloud](https://soundcloud.com/jadynviolet)
+- [Open Borders x UVR Miami (Eventbrite, 2022)](https://www.eventbrite.com/e/open-borders-x-underground-violet-rave-tickets-469955849597)
+- [UVR TwitchCon IG reel](https://www.instagram.com/reel/DPW-P2TgZvN/)

--- a/research/community/427-uvr-jadyn-violet-brand-intro-bot/README.md
+++ b/research/community/427-uvr-jadyn-violet-brand-intro-bot/README.md
@@ -1,0 +1,100 @@
+# 427 — UVR (Underground Violet Rave) & Jadyn Violet — Brand Brief for Discord Intro Bot
+
+> **Status:** Research complete
+> **Date:** 2026-04-17
+> **Goal:** Brand profile + asset inventory for forking the ZAO Fractal `/intro` bot into a UVR-branded Discord bot at `/Users/zaalpanthaki/Documents/UVRintroBot/`.
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| Primary brand color | USE deep violet `#7A3FBF` (UVR signature). Pair with near-black `#0B0014` for dark-mode embeds. Reason: brand is "Underground **Violet** Rave" — purple/violet is the entire identity per Raver Realm site (dark mode default). |
+| Embed accent (`discord.Embed` color) | USE `0x7A3FBF` (violet) instead of Fractal's `0x57F287` (green). One-line swap on `cogs/intro.py:224`. |
+| Community page URL pattern | USE `https://raverrealm.xyz/raver/<slug>` IF a member directory exists; otherwise SKIP the community-page field entirely (do not invent). Confirm with Jadyn before shipping. |
+| Member terminology | USE "Raver" not "member". Embed title: `"Raver Intro: <display_name>"`. Footer: `"Underground Violet Rave • raverrealm.xyz"`. Reason: community self-identifies as "Ravers" — see Raver Realm FAQ. |
+| Intros channel ID | NEW env var `UVR_INTROS_CHANNEL_ID` (do not reuse `INTROS_CHANNEL_ID` from Fractal). Get the snowflake from Jadyn / UVR Discord (2,401 members). |
+| Wallet field | KEEP the wallet abbreviation block (`cogs/intro.py:235-240`) — UVR is NFT-native (Raver Realm 1,800 supply, Violet Token, UVR Orbs/POAPs). High value for this audience. |
+| Supabase table name | RENAME `discord_intros` → `uvr_intros` to keep ZAO Fractal and UVR data isolated in the same Supabase project, OR use a separate Supabase project. |
+| Optional brand flair | ADD a violet orb emoji `🟣` or custom UVR Orb emoji to the embed title. Reason: "Orbs" are the community's POAP/utility token language. |
+| Bot persona/voice | USE counter-culture, music-first, terse. Avoid corporate. Reason: brand mission = "counter culture and expression". |
+
+## UVR Brand Profile
+
+### Founder
+- **Jadyn Violet** — artist, musician, NFT illustrator. Hand-draws every Raver in **Paint.NET + Wacom tablet**. Produces all music (with OADEVOUR, brace, others).
+- Twitch: `twitch.tv/jadynviolet` (365-day streaming challenge per ZAO docs).
+- Sound.xyz: released "The Stern Mystic" + first drop "Good Always Turns Evil" (1.75 ETH raised).
+- Linktree: `linktr.ee/jadynviolet`.
+
+### UVR (Underground Violet Rave)
+- **Founded:** 2021.
+- **Live events:** 7–8 raves across 6–7 US cities (Brooklyn, LA, Miami, Cincinnati, etc.). Listed as "Active" associated community in ZAO whitepaper.
+- **Discord:** ~2,401 members (per public listing). Token-gated UVR channel for podcasts/shows.
+- **Daily ritual:** UVR Twitter Spaces — Music NFTs + POAP discussion.
+- **Mission:** "Seductively introduces web3 to the local underground scene." Onboarding + education + exposure.
+- **Tagline (Raver Realm):** "The Music Collectors PFP."
+
+### Lore Glossary (use these terms in the bot)
+| Term | Meaning |
+|------|---------|
+| **Raver** | A community member / a hand-drawn PFP NFT. |
+| **Realm** | Counter-culture philosophy each Raver embodies. |
+| **RaverDex** | Character collection / directory system. |
+| **UVR** | Underground Violet Rave — the brand + the live event series. |
+| **Orb** | POAP collectible giving utility/access to UVR members. |
+| **Violet Token** | Top-tier access token (free-mint tier on Raver Realm). |
+| **Violet** | Jadyn's debut studio album — the 9 Raver songs roll up to it. |
+
+### Visual Aesthetic
+- **Mode:** Dark by default, light alternate exists (`raverrealm.xyz/home-light`).
+- **Palette:** Deep violet/purple primary, near-black background, hand-drawn character art with vibrant accents.
+- **Typography:** Web inspection needed (not extracted — site uses standard web stack). Safe default: bold sans for headings, mono for wallet snippets in embed.
+
+## Comparison: Brand Swap from Fractal → UVR
+
+| Element | Fractal (current) | UVR (target) | File:Line |
+|--------|-------------------|--------------|-----------|
+| Embed color | `0x57F287` (green) | `0x7A3FBF` (violet) | `cogs/intro.py:224` |
+| Embed title | `"Introduction: {name}"` | `"Raver Intro: {name}"` | `cogs/intro.py:223` |
+| Community URL | `thezao.com/community/<slug>` | `raverrealm.xyz/raver/<slug>` *(verify exists)* | `cogs/intro.py:220, 230` |
+| Footer | `"ZAO Fractal • zao.frapps.xyz"` | `"Underground Violet Rave • raverrealm.xyz"` | `cogs/intro.py:251` |
+| Channel ID const | `INTROS_CHANNEL_ID` | `UVR_INTROS_CHANNEL_ID` | `config/config.py` + `cogs/intro.py:22, 184, 244, 281` |
+| Supabase table | `discord_intros` | `uvr_intros` | `cogs/intro.py:94, 113, 125, 131` |
+| Admin role check | `is_supreme_admin` (ZAO role) | UVR-equivalent role — likely "Founder" or "UVR Admin" — confirm w/ Jadyn | `cogs/intro.py:274` |
+| Wallet lookup | `bot.wallet_registry` (ZAO) | KEEP same pattern; populate UVR wallet registry separately. | `cogs/intro.py:236-240` |
+
+## ZAO Ecosystem Integration
+
+UVR is an "Associated Community" in ZAO per:
+- `research/_archive/047-zao-community-ecosystem/README.md`
+- `research/_archive/048-zao-ecosystem-deep-dive/README.md`
+- `research/community/050-the-zao-complete-guide/README.md`
+- `research/community/051-zao-whitepaper-2026/drafts/draft-4.0–4.4.md`
+
+The intro bot lives at `/Users/zaalpanthaki/Documents/UVRintroBot/` (currently empty — only `.claude/`). Source to fork: `/Users/zaalpanthaki/Documents/fractalbotapril2026/cogs/intro.py` (319 lines). Strip Fractal-specific cogs (`hats.py`, `proposals.py`, `snapshot.py` etc.) unless UVR wants Hats/governance — likely SKIP for v1.
+
+## Open Questions for Jadyn (resolve before code)
+
+1. UVR Discord guild ID + #intros channel snowflake?
+2. Does `raverrealm.xyz/raver/<slug>` exist or should the community-page field be dropped?
+3. Admin role name in UVR Discord (replaces "Supreme Admin")?
+4. Reuse ZAO Supabase or new UVR Supabase project?
+5. Wallet registry — pull from Raver Realm holder list, or build fresh?
+
+## Sources
+
+- [Raver Realm — Home](https://raverrealm.xyz/)
+- [Raver Realm — FAQ](https://raverrealm.xyz/faq/)
+- [Underground Violet Rave on Twitter/X (@projectuvr)](https://www.sotwe.com/projectuvr)
+- [Jadyn Violet on X (@jadynviolet)](https://x.com/jadynviolet)
+- [Jadyn Violet — Sound.xyz "The Stern Mystic"](https://www.sound.xyz/jadynviolet/the-stern-mystic)
+- [Jadyn Violet on Twitch](https://www.twitch.tv/jadynviolet)
+- [Jadyn Violet Linktree](https://linktr.ee/jadynviolet)
+- [UVR — Luma event listing](https://lu.ma/hgenj6yc)
+- [Raver Realm GitHub (NicoAcosta/violet — Genesis Collection)](https://github.com/NicoAcosta/violet)
+- [Resident Advisor — UVR Miami 2023](https://ra.co/events/1805374)
+- [Invest in Music — The Stern Mystic deep dive](https://investinmusic.mirror.xyz/a6ANWRPo7y7lKfOAeAYh6sU3B-dF_2hSIkKAuif2Y0I)
+- ZAO whitepaper draft (local): `research/community/051-zao-whitepaper-2026/drafts/draft-4.4.md`
+- ZAO ecosystem deep dive (local): `research/_archive/048-zao-ecosystem-deep-dive/README.md`

--- a/src/app/api/stock/apply/route.ts
+++ b/src/app/api/stock/apply/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+const applySchema = z.object({
+  name: z.string().trim().min(1, 'Name required').max(200),
+  email: z.string().trim().email('Valid email required').max(200),
+  phone: z.string().trim().max(50).optional(),
+  role_interest: z
+    .enum(['setup', 'checkin', 'water', 'safety', 'teardown', 'floater', 'content', 'unassigned'])
+    .optional(),
+  shift_interest: z
+    .enum(['early', 'block1', 'block2', 'teardown', 'allday'])
+    .optional(),
+  message: z.string().trim().max(1000).optional(),
+  hp: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = applySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    // Honeypot - silently accept but do nothing if bots fill this field
+    if (parsed.data.hp && parsed.data.hp.trim().length > 0) {
+      return NextResponse.json({ success: true }, { status: 201 });
+    }
+
+    const notes = [
+      parsed.data.email ? `email: ${parsed.data.email}` : null,
+      parsed.data.message ? `message: ${parsed.data.message}` : null,
+      'submitted via /stock/apply',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const supabase = getSupabaseAdmin();
+    const { error } = await supabase.from('stock_volunteers').insert({
+      name: parsed.data.name,
+      email: parsed.data.email,
+      phone: parsed.data.phone || '',
+      role: parsed.data.role_interest || 'unassigned',
+      shift: parsed.data.shift_interest || 'allday',
+      confirmed: false,
+      notes,
+    });
+
+    if (error) {
+      return NextResponse.json({ error: 'Could not submit right now' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Submission failed' }, { status: 500 });
+  }
+}

--- a/src/app/stock/apply/ApplyForm.tsx
+++ b/src/app/stock/apply/ApplyForm.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState } from 'react';
+
+interface RoleOption {
+  value: string;
+  label: string;
+  hint: string;
+}
+
+interface ShiftOption {
+  value: string;
+  label: string;
+}
+
+export function ApplyForm({ roles, shifts }: { roles: RoleOption[]; shifts: ShiftOption[] }) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [roleInterest, setRoleInterest] = useState('unassigned');
+  const [shiftInterest, setShiftInterest] = useState('allday');
+  const [message, setMessage] = useState('');
+  const [hp, setHp] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'sent' | 'error'>('idle');
+  const [errMsg, setErrMsg] = useState<string>('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setErrMsg('');
+    try {
+      const res = await fetch('/api/stock/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email,
+          phone: phone || undefined,
+          role_interest: roleInterest,
+          shift_interest: shiftInterest,
+          message: message || undefined,
+          hp,
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setStatus('error');
+        setErrMsg(d.error || 'Submission failed');
+      } else {
+        setStatus('sent');
+      }
+    } catch {
+      setStatus('error');
+      setErrMsg('Network error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div className="bg-gradient-to-br from-emerald-500/15 via-emerald-500/5 to-transparent rounded-xl p-6 border border-emerald-500/30 space-y-3 text-center">
+        <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold">You are in</p>
+        <h2 className="text-xl font-bold text-white">Thanks, {name || 'friend'}.</h2>
+        <p className="text-sm text-gray-300">
+          We got your application. Someone from the ZAOstock crew will follow up in the next few days with shift details and a crew kickoff message.
+        </p>
+        <p className="text-xs text-gray-500">
+          Questions in the meantime? Reply to the confirmation email or DM on Farcaster.
+        </p>
+      </div>
+    );
+  }
+
+  const selectedRole = roles.find((r) => r.value === roleInterest);
+
+  return (
+    <form onSubmit={submit} className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-4">
+      <input
+        type="text"
+        tabIndex={-1}
+        autoComplete="off"
+        value={hp}
+        onChange={(e) => setHp(e.target.value)}
+        className="hidden"
+        aria-hidden="true"
+      />
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Your name</label>
+        <input
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="First Last or handle"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Email</label>
+        <input
+          required
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Phone (optional)</label>
+        <input
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          placeholder="Day-of only, so we can reach you fast"
+          maxLength={50}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Where do you want to plug in?</label>
+        <select
+          value={roleInterest}
+          onChange={(e) => setRoleInterest(e.target.value)}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white focus:outline-none focus:border-[#f5a623]/30"
+        >
+          {roles.map((r) => (
+            <option key={r.value} value={r.value}>{r.label}</option>
+          ))}
+        </select>
+        {selectedRole && (
+          <p className="text-[11px] text-gray-500 italic">{selectedRole.hint}</p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Shift preference</label>
+        <select
+          value={shiftInterest}
+          onChange={(e) => setShiftInterest(e.target.value)}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white focus:outline-none focus:border-[#f5a623]/30"
+        >
+          {shifts.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Anything else? (optional)</label>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Skills, availability caveats, who referred you, why you want to help"
+          rows={4}
+          maxLength={1000}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={busy || !name.trim() || !email.trim()}
+        className="w-full bg-[#f5a623] hover:bg-[#ffd700] disabled:opacity-50 text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors"
+      >
+        {busy ? 'Sending...' : 'Sign me up'}
+      </button>
+
+      {status === 'error' && (
+        <p className="text-xs text-red-400 text-center">{errMsg || 'Something went wrong. Try again.'}</p>
+      )}
+
+      <p className="text-[11px] text-gray-600 text-center">
+        We reach out within a few days. No commitment until you say yes to a specific shift.
+      </p>
+    </form>
+  );
+}

--- a/src/app/stock/apply/page.tsx
+++ b/src/app/stock/apply/page.tsx
@@ -1,0 +1,88 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { ApplyForm } from './ApplyForm';
+
+export const metadata: Metadata = {
+  title: 'Volunteer with ZAOstock | October 3, 2026',
+  description: 'Sign up to volunteer at ZAOstock, a community music festival in Ellsworth, Maine on October 3, 2026.',
+};
+
+const ROLES: Array<{ value: string; label: string; hint: string }> = [
+  { value: 'setup', label: 'Setup', hint: 'Morning load-in, stage rigging, tents, signage' },
+  { value: 'checkin', label: 'Check-in', hint: 'Attendee welcome, wristbands, info booth' },
+  { value: 'water', label: 'Water / Hydration', hint: 'Keep the crowd watered, work the bar line' },
+  { value: 'safety', label: 'Safety', hint: 'Crowd flow, first-aid point, keep eyes open' },
+  { value: 'teardown', label: 'Teardown', hint: 'Strike the stage, pack out, leave no trace' },
+  { value: 'floater', label: 'Floater', hint: 'Available where needed, fill gaps, problem solver' },
+  { value: 'content', label: 'Content / Media', hint: 'Photos, short video, social amplification during the day' },
+  { value: 'unassigned', label: 'Pick for me', hint: 'You decide where you need me' },
+];
+
+const SHIFTS: Array<{ value: string; label: string }> = [
+  { value: 'early', label: 'Early morning load-in (~8am-12pm)' },
+  { value: 'block1', label: 'Block 1 (12pm-3pm)' },
+  { value: 'block2', label: 'Block 2 (3pm-6pm)' },
+  { value: 'teardown', label: 'Teardown (6pm-9pm)' },
+  { value: 'allday', label: 'All day, I am in' },
+];
+
+export default function ApplyPage() {
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link href="/stock" className="text-xs text-gray-400 hover:text-[#f5a623]">
+            &larr; ZAOstock
+          </Link>
+          <span className="text-xs text-gray-500">Volunteer signup</span>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <div className="text-center space-y-2">
+          <p className="inline-block rounded-full bg-[#f5a623]/10 px-3 py-1 text-xs text-[#f5a623] font-medium border border-[#f5a623]/30">
+            Join the crew
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">Volunteer with ZAOstock</h1>
+          <p className="text-sm text-gray-400 max-w-lg mx-auto">
+            October 3, 2026. Franklin Street Parklet, Ellsworth Maine. Community-built, community-run.
+          </p>
+        </div>
+
+        <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-3">
+          <p className="text-xs text-[#f5a623] uppercase tracking-wider font-bold">What you get</p>
+          <ul className="text-sm text-gray-300 space-y-1.5">
+            <li>- Free entry to the festival for the day</li>
+            <li>- A ZAOstock crew shirt</li>
+            <li>- Food and water covered during your shift</li>
+            <li>- First look at next year and standing invite to future ZAO events</li>
+            <li>- The satisfaction of building something local from scratch</li>
+          </ul>
+        </div>
+
+        <ApplyForm roles={ROLES} shifts={SHIFTS} />
+
+        <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08]">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-bold mb-2">Not sure yet?</p>
+          <p className="text-sm text-gray-400">
+            Apply anyway. We will reach out, answer questions, and you can opt out any time before Oct 3. No commitment yet.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <Link
+              href="/stock"
+              className="text-xs bg-white/[0.06] hover:bg-white/[0.12] text-gray-200 rounded-lg px-3 py-2 transition-colors"
+            >
+              Back to ZAOstock
+            </Link>
+            <Link
+              href="/stock/program"
+              className="text-xs bg-white/[0.06] hover:bg-white/[0.12] text-gray-200 rounded-lg px-3 py-2 transition-colors"
+            >
+              See the program
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/page.tsx
+++ b/src/app/stock/page.tsx
@@ -84,6 +84,12 @@ export default async function StockPage() {
               Program
             </Link>
             <Link
+              href="/stock/apply"
+              className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
+            >
+              Volunteer
+            </Link>
+            <Link
               href="/stock/sponsor"
               className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
             >
@@ -191,6 +197,23 @@ export default async function StockPage() {
                 <p className="text-xs text-gray-400 mt-1">{partner.role}</p>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Volunteer CTA */}
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Join The Crew</p>
+          <div className="bg-gradient-to-br from-[#f5a623]/15 via-[#f5a623]/5 to-transparent rounded-xl p-5 border border-[#f5a623]/30">
+            <p className="text-lg font-bold text-white">Volunteer at ZAOstock</p>
+            <p className="text-sm text-gray-300 mt-1 mb-4">
+              Festival built by the community. If you want in on setup, check-in, stage crew, content, teardown, or anything in between, sign up below.
+            </p>
+            <Link
+              href="/stock/apply"
+              className="inline-block bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              Sign up to volunteer -&gt;
+            </Link>
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
Public volunteer signup flow. Roster is currently empty. Tonight's social announce push has no landing spot for "I want to help" traffic. This closes that.

## Routes
- **`/stock/apply`** (public) - form with name, email, phone, role interest (8 options: setup, checkin, water, safety, teardown, floater, content, unassigned), shift preference (5 blocks), optional message. Inline success card on submit, no redirect.
- **POST `/api/stock/apply`** (public, no session) - Zod-validated, honeypot field for bot filtering, inserts into `stock_volunteers` with `confirmed=false`. New rows show up in the internal Volunteers tab automatically.

## Changes to /stock landing
- "Volunteer" link in header nav between Program and Sponsors
- New "Join The Crew" CTA section above RSVP that links to `/stock/apply`

## Data model
Uses existing `stock_volunteers` table + RLS policy. No schema change needed.

## Test plan
- [ ] Merge and deploy
- [ ] Visit `/stock` header shows Volunteer link
- [ ] Visit `/stock/apply` renders form
- [ ] Submit a test entry
- [ ] Team member logs in to `/stock/team` Volunteers tab, sees the new row
- [ ] Honeypot field is hidden, normal users do not see it

No emojis, no em dashes.