### PR TITLE
fix(os): mobile polish - safe area, touch targets, brand colors

### DIFF
--- a/src/components/os/AppDrawer.tsx
+++ b/src/components/os/AppDrawer.tsx
@@ -65,7 +65,7 @@ export function AppDrawer({ pinnedApps, onOpen, onPin, onUnpin, onClose }: AppDr
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search apps..."
-          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder-white/40 outline-none focus:border-[#f5a623]/50"
+          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 text-sm text-white placeholder-white/40 outline-none focus:border-[#f5a623]/50 focus-visible:ring-2 focus-visible:ring-[#f5a623]"
         />
       </div>
 
@@ -94,7 +94,7 @@ export function AppDrawer({ pinnedApps, onOpen, onPin, onUnpin, onClose }: AppDr
             <h3 className="pb-3 text-xs font-medium uppercase tracking-wider text-white/40">
               Apps
             </h3>
-            <div className="grid grid-cols-4 gap-4 sm:grid-cols-5 md:grid-cols-6">
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
               {fullApps.map((app) => (
                 <AppIcon
                   key={app.id}
@@ -114,7 +114,7 @@ export function AppDrawer({ pinnedApps, onOpen, onPin, onUnpin, onClose }: AppDr
             <h3 className="pb-3 text-xs font-medium uppercase tracking-wider text-white/40">
               Micro-Apps
             </h3>
-            <div className="grid grid-cols-4 gap-4 sm:grid-cols-5 md:grid-cols-6">
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6">
               {microApps.map((app) => (
                 <AppIcon
                   key={app.id}

--- a/src/components/os/Dock.tsx
+++ b/src/components/os/Dock.tsx
@@ -42,7 +42,7 @@ export function Dock({ onOpenDrawer }: DockProps) {
         </button>
       </div>
       {/* Home indicator */}
-      <div className="flex justify-center pb-1">
+      <div className="flex justify-center pb-[calc(0.25rem+env(safe-area-inset-bottom,0px))]">
         <div className="h-1 w-28 rounded-full bg-white/15" />
       </div>
     </div>

--- a/src/components/os/PhoneShell.tsx
+++ b/src/components/os/PhoneShell.tsx
@@ -53,7 +53,7 @@ export function PhoneShell({
   const dateStr = now.toLocaleDateString([], { weekday: 'long', month: 'long', day: 'numeric' });
 
   return (
-    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] pb-20">
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] pb-[calc(5rem+env(safe-area-inset-bottom,0px))]">
       {/* Status bar */}
       <div className="mx-auto w-full max-w-4xl">
         <div className="flex items-center justify-between px-4 pt-6 pb-1 sm:px-8">
@@ -61,7 +61,7 @@ export function PhoneShell({
             type="button"
             aria-label="Change shell layout"
             onClick={() => setShowShellPicker(true)}
-            className="rounded-lg p-2 text-xs text-white/60 transition-colors hover:bg-white/5 hover:text-white/80 focus-visible:ring-2 focus-visible:ring-[#f5a623]"
+            className="rounded-lg p-3 text-xs min-h-[44px] min-w-[44px] text-white/60 transition-colors hover:bg-white/5 hover:text-white/80 focus-visible:ring-2 focus-visible:ring-[#f5a623]"
           >
             📱 Shell
           </button>
@@ -73,7 +73,7 @@ export function PhoneShell({
             type="button"
             aria-label="Settings"
             onClick={() => router.push('/settings')}
-            className="rounded-lg p-2 text-xs text-white/60 transition-colors hover:bg-white/5 hover:text-white/80 focus-visible:ring-2 focus-visible:ring-[#f5a623]"
+            className="rounded-lg p-3 text-xs min-h-[44px] min-w-[44px] text-white/60 transition-colors hover:bg-white/5 hover:text-white/80 focus-visible:ring-2 focus-visible:ring-[#f5a623]"
           >
             ⚙️
           </button>
@@ -113,7 +113,7 @@ export function PhoneShell({
             </button>
           </div>
           {resolvedApps.length > 0 ? (
-            <div className="grid grid-cols-4 gap-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8">
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8">
               {resolvedApps.map((app) => (
                 <AppIcon
                   key={app.id}

--- a/src/components/os/widgets/AgentStatusWidget.tsx
+++ b/src/components/os/widgets/AgentStatusWidget.tsx
@@ -13,7 +13,8 @@ export default function AgentStatusWidget({ size, onExpand }: WidgetProps) {
     <button
       type="button"
       onClick={onExpand}
-      className="flex w-full flex-col gap-2 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06]"
+      aria-label="Open agent dashboard"
+      className="flex w-full flex-col gap-2 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06] focus-visible:ring-2 focus-visible:ring-[#f5a623]"
     >
       <div className="text-sm font-medium text-white">Agent Squad</div>
       <div className="flex gap-3">
@@ -21,7 +22,7 @@ export default function AgentStatusWidget({ size, onExpand }: WidgetProps) {
           <div key={agent.name} className="flex items-center gap-1.5">
             <span className="text-sm">{agent.icon}</span>
             <span className="text-xs text-white/50">{agent.name}</span>
-            <span className="h-1.5 w-1.5 rounded-full bg-green-400/60" />
+            <span className="h-1.5 w-1.5 rounded-full bg-[#f5a623]" />
           </div>
         ))}
       </div>

--- a/src/components/os/widgets/UnreadWidget.tsx
+++ b/src/components/os/widgets/UnreadWidget.tsx
@@ -7,9 +7,10 @@ export default function UnreadWidget({ size, onExpand }: WidgetProps) {
     <button
       type="button"
       onClick={onExpand}
-      className="flex w-full items-center gap-3 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06]"
+      aria-label="Open messages"
+      className="flex w-full items-center gap-3 rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-left transition-colors hover:bg-white/[0.06] focus-visible:ring-2 focus-visible:ring-[#f5a623]"
     >
-      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-500/10 text-xl">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-[#f5a623]/10 text-xl">
         ✉️
       </div>
       <div className="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
Fixes from visual + mobile responsiveness audit agents.

- Safe area padding for notched iPhones (Dock + PhoneShell)
- Touch targets bumped to 44x44px minimum (WCAG AA)
- Off-brand colors fixed: blue -> gold, green -> gold
- App grid: 3 cols on small screens (was 4, broke on 320px)
- AppDrawer search focus-visible ring added

## Test plan
- [ ] zaoos.com/os on iPhone - no content behind notch/home indicator
- [ ] Tap Shell/Settings buttons easily on mobile
- [ ] All colors navy + gold (no blue or green)
- [ ] 3 app icons per row on small phone, 4+ on larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)