### PR TITLE
docs: ZAO master context from Tricky Buddha Space (doc 432)

### DIFF
--- a/research/community/432-zao-master-context-tricky-buddha/README.md
+++ b/research/community/432-zao-master-context-tricky-buddha/README.md
@@ -1,0 +1,199 @@
+# 432 - ZAO Master Context: Tricky Buddha Space Recap
+
+> **Status:** Canonical strategy context
+> **Date:** 2026-04-18
+> **Source:** X Space with Tricky Buddha (DeFi Space Donkeys partner, ZAO events + promotion team)
+> **Goal:** Preserve the master positioning, event strategy, and gaps doc dropped in chat as a permanent reference. Use for future strategic decisions, sponsor pitches, and event planning.
+
+---
+
+## Core Identity
+
+The ZAO (ZTalent Artist Organization) is a decentralized creator network focused on:
+- Empowering independent musicians
+- Enabling collaboration at scale
+- Providing infrastructure, not ownership, for artists
+
+**Core principle:** Music first, Community second, Technology third.
+
+The ZAO does not lead with crypto. It leads with experience, culture, and creation, with Web3 as invisible infrastructure.
+
+## Event Strategy - Primary Growth Engine
+
+Events serve 5 purposes:
+1. Artist exposure
+2. Content generation
+3. Community bonding
+4. Onboarding new users (non-Web3)
+5. Creation of collaborative IP (music, media)
+
+## ZAO-CHELLA Reference Model
+
+**Stats:**
+- 53 communities
+- 26 sponsors
+- 16 performing artists
+- Mansion (Zao House) plus club activation
+- ~12-hour runtime
+
+**Key insight:** The ZAO successfully coordinated more Web3 communities than major ecosystem events.
+
+**What worked:**
+1. **Multi-community aggregation** - each community contributed people, compounding into large-scale attendance
+2. **Artist density** - high concentration of creators creates spontaneous collaboration
+3. **Creation over consumption** - artists didn't just perform, they created cyphers, music, content
+4. **Culture over structure** - loose, high-energy environment enabled organic moments
+
+**What broke:**
+1. **Housing** - shared housing required rebooking multiple times, attendee drop-off created instability
+2. **Logistics** - too many manual processes, not enough systemization
+3. **Media loss** - valuable content not captured, no structured ingestion pipeline
+
+## Required Fixes (Event System V2)
+
+| Area | Direction |
+|------|-----------|
+| Housing | Choose ONE: fully centralized (single location) OR fully decentralized (no shared booking). Never hybrid. |
+| Media | Incentivize uploads via token rewards, build structured submission pipeline |
+| Logistics | Pre-plan 6-12 months ahead, modularize roles and responsibilities |
+
+## Music Strategy - Cyphers as Signature Product
+
+**Definition:** Multi-artist collaborative track created live during events.
+
+**Example:** 10 artists on one cypher including producers, vocalists, instrumentalists.
+
+**Properties:** Repeatable, scalable, high cultural value, strong marketing asset.
+
+**Use cases:**
+- Event promotion
+- Artist onboarding
+- Content distribution
+- Community identity
+
+**Strategic insight:** The ZAO is not just hosting events - it is producing collaborative music IP at scale.
+
+## Next Event - ZAOstock (Maine)
+
+**Objectives:**
+- Bring artists together physically
+- Showcase Web3 musicians to non-Web3 audiences
+- Focus on experience over explanation
+
+**Strategic direction:**
+- Year 1: music and community focus
+- Future: add tech activations gradually
+
+**Key positioning:** "Show, don't explain" Web3.
+
+## Internal Infrastructure
+
+1. **Team Dashboard** - password-protected access, task management system, direct contribution input (currently live at `/stock/team`)
+2. **Brand Kit System** - messaging, FAQs, key talking points so any team member can represent The ZAO
+3. **Communication Flow** - layered structure: basic, intermediate, escalation
+4. **Contribution System** - community submits media, ideas, tasks; rewards via ZAO token
+
+## Sponsorship Model - Dual Approach
+
+**Web3 Sponsors:**
+- Digital activations
+- Streaming integrations
+- Online exposure
+
+**Local Sponsors:**
+- Physical presence
+- Booths
+- Installations
+
+**Key insight:** Sponsorship must be modular based on sponsor type.
+
+## Experience Design Upgrades (All Events)
+
+- **Food system** - food trucks, vendor partnerships
+- **Lodging deals** - group hotel rates OR centralized housing
+- **Structured programming** - flexible but anchored with performance blocks, cypher sessions, meetups
+
+## Future Flagship - ZAO Cruise
+
+**Concept:** Large-scale multi-community cruise event.
+
+**Features:**
+- Housing, food, transport included
+- Music, panels, networking
+- Beach stops
+- Continuous programming
+
+**Scale model:**
+- Each community brings 3-20 people
+- Target: 1000+ attendees
+
+**Benefits:**
+- Eliminates logistics complexity
+- Forces high-density interaction
+- Creates immersive environment
+
+**Branding:** "W3 Cruise" (Web3 Cruise) or "We Cruise" (normie-friendly).
+
+## Core Strategic Insights
+
+1. **The ZAO is a coordination layer.** Not a label. Not a platform. A system that organizes communities and creators into shared experiences.
+2. **Events are the content engine.** Every event produces music, media, social content, relationships.
+3. **Cyphers are productized culture.** Repeatable format, ownable IP, scalable across events.
+4. **Community aggregation is the growth mechanism.** Growth comes from communities bringing communities.
+5. **Simplicity first.** Lead with music and experience. Add tech later.
+
+## Current Gaps
+
+1. No standardized event playbook
+2. Weak media capture system
+3. Housing and logistics instability
+4. Sponsor packaging not fully systemized
+5. Limited onboarding structure for contributors
+
+## High-Priority Opportunities
+
+1. **Productize cyphers** - turn into a recurring series, distribute across platforms
+2. **Build The ZAO event playbook** - repeatable framework for planning, execution, scaling
+3. **Tokenize contributions** - reward media, promotion, participation
+4. **Expand community network** - focus on onboarding communities, not just individuals
+5. **Launch flagship event (Cruise)** - high-visibility, high-density, scalable
+
+## Final Meta Positioning
+
+The ZAO is evolving into: a decentralized coordination engine for music culture, powered by community aggregation, expressed through live experiences, and captured as collaborative IP.
+
+---
+
+## ZAOstock (Oct 3, 2026) Alignment
+
+This context locks in:
+- ZAOstock is Year 1 of the Maine event. Music and community focus. Tech activations minimal.
+- "Show, don't explain" - do not lead with Web3 in sponsor pitches, attendee marketing, or public copy. Let the experience carry.
+- WaveWarZ bracket at ZAOstock IS the tech activation. Keep it backgrounded, not centered.
+- Cyphers - consider producing a ZAOstock cypher on-site as the signature cultural artifact from the day.
+- Housing - ZAOstock is one-day, so no overnight. But log the principle for 2027: if we go multi-day, lock single housing location (don't split).
+- Media - need a capture pipeline by June so every set, cypher, and sponsor activation is archived. Token reward for uploads fits here.
+- Sponsor tracks already match the dual model: Main Stage Partner (local physical) vs Broadcast Partner (web3 digital).
+
+## Action Items This Context Surfaces for ZAOstock
+
+| Item | Priority | Owner |
+|------|----------|-------|
+| Add a cypher session to the run-of-show (doc 428) | Medium | DCoop |
+| Build media capture pipeline (token-rewarded uploads) | Medium | FailOften + Zaal |
+| Document the Event Playbook v1 using ZAOstock as the template | Medium (post-event) | Candy |
+| Update public ZAOstock copy to "show don't explain" Web3 | Low (already mostly aligned) | Zaal |
+| Map ZAOstock as case study in the 2027 Cruise pitch | Future (post-event) | Zaal |
+
+## Sources
+
+- X Space with Tricky Buddha (DeFi Space Donkeys) - Apr 17, 2026
+- Transcript / notes provided by Zaal on Apr 18, 2026
+- ZAO Stock team dashboard + planning docs (270, 274, 418, 425, 428)
+
+## Related Research
+
+- [270 - ZAOstock Planning](../../events/270-zao-stock-planning/)
+- [418 - Birding Man Festival Analysis](../../events/418-birding-man-festival-analysis/)
+- [428 - ZAOstock Run-of-Show Program](../../events/428-zaostock-run-of-show-program/)
+- [423 - Music x Crypto Connect Sesh](../../events/423-music-x-crypto-connect-sesh-apr17/)


### PR DESCRIPTION
## Summary
Canonical strategy doc capturing The ZAO's master positioning from the Apr 17 X Space with Tricky Buddha (DeFi Space Donkeys, ZAO events + promotion team).

## Core principle
Music first, Community second, Technology third. Do not lead with crypto.

## What the doc covers
- Core identity + positioning
- 5-purpose event strategy (exposure, content, community, onboarding, IP)
- ZAOCHELLA reference model stats (53 communities, 26 sponsors, 16 artists)
- What worked + what broke at prior events
- Event System V2 fixes (housing, media, logistics)
- Cyphers as the signature product line
- ZAOstock Year 1 alignment (music + community focus, tech minimal)
- Dual sponsorship model (Web3 digital + local physical)
- Experience design upgrades (food, lodging, programming)
- ZAO Cruise 2027+ flagship vision
- Current gaps + high-priority opportunities

## ZAOstock-specific action items surfaced
- Add cypher session to the run-of-show (DCoop)
- Build media capture pipeline with token-rewarded uploads (FailOften + Zaal)
- Document Event Playbook v1 using ZAOstock as template (Candy, post-event)
- Review public copy for "show don't explain" Web3 alignment
- Map ZAOstock into 2027 Cruise pitch (post-event)

## Also saved
Memory pointer at `~/.claude/projects/.../memory/project_zao_master_context.md` so every future session loads this strategic frame.

No emojis, no em dashes.