### PR TITLE
feat(stock): cypher signup + partner deck + llms.txt + Tuesday agenda v2 + media pipeline spec

### DIFF
--- a/research/events/433-zao-media-capture-pipeline-spec/README.md
+++ b/research/events/433-zao-media-capture-pipeline-spec/README.md
@@ -1,0 +1,244 @@
+# 433 - ZAO Media Capture Pipeline Spec
+
+> **Status:** Research + spec, no code yet
+> **Date:** 2026-04-18
+> **Goal:** Design a structured media capture pipeline for ZAOstock and every future The ZAO event. Addresses one of the top gaps from doc 432 (Tricky Buddha master context): "Media loss - valuable content not captured, no structured ingestion pipeline."
+
+---
+
+## Problem Statement
+
+Every ZAO event produces immense raw cultural value: live performances, cyphers, backstage moments, crowd energy, artist interactions. ZAOCHELLA lost most of this to the ether. Phone footage on 53 different devices that never gets uploaded. A few highlight reels emerge weeks later but 95% of the material sits in camera rolls.
+
+For ZAOstock and every event after, we need a **structured pipeline** so media:
+1. Gets uploaded quickly (ideally day-of)
+2. Lands in a shared place
+3. Gets tagged and searchable
+4. Becomes raw material for promotion, artist marketing, and onchain artifacts
+
+Tokenized incentives (ZABAL) reward contributors so uploading stops being friction.
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Choice |
+|----------|--------|
+| Storage backend | Arweave (permanent) via ArDrive for the official archive, plus R2/S3 warm cache for speed |
+| Upload interface | Simple public `/stock/media` page + QR code posted around venue. Drag-drop or phone-camera picker. No login required for small files. |
+| Auth for larger uploads | Rate-limited by IP + honeypot. Token-reward path requires a wallet or email. |
+| Tagging | Auto-capture (upload time, device, IP region) + optional user tags (artist name, moment type) |
+| Review flow | Content team (DaNici + Shawn + FailOften) flags public-ready vs private-only |
+| Token reward | Flat ZABAL per approved upload (example: 10 ZABAL for a clip, 50 ZABAL for a cypher-quality clip) |
+| Distribution | Weekly content drop to Farcaster channel + dedicated /stock/gallery page built from approved items |
+| Storage cost | Arweave one-time ~$5/GB at current rates. Budget: $50-100 for ZAOstock (10-20GB total) |
+
+## Comparison of Storage Options
+
+| Option | Cost | Permanence | Ease of use | Web3 fit | Fit for ZAOstock |
+|--------|------|-----------|-------------|----------|------------------|
+| Arweave (via ArDrive) | $5-7/GB one-time | Permanent | Moderate (need wallet, turbo topup) | Native | USE (archive layer) |
+| Cloudflare R2 | $0.015/GB/mo, no egress | Rented | Simple | No | USE (warm cache) |
+| AWS S3 | $0.023/GB/mo + egress fees | Rented | Simple | No | SKIP (egress kills us) |
+| IPFS + Pinata | $0.15/GB/mo | Dependent on pins | Moderate | Native | SKIP (IPFS content addressing less useful for our flow) |
+| YouTube + Instagram | Free | Platform risk | Easy for users | No | USE (distribution layer, not archive) |
+| Supabase Storage | Included in plan | Rented | Simple | No | SKIP for archive, OK for previews |
+
+**Recommendation stack:** Arweave (archive) + R2 (warm cache + signed URLs for upload) + social platforms (distribution). Do not build our own CDN.
+
+---
+
+## Capture Points Throughout an Event
+
+For ZAOstock specifically, these are the 8 moments that MUST be captured:
+
+1. **Opening set** (Artist 1, 12:15-12:45) - full performance
+2. **Each individual artist set** (Artists 2-4, mid-day) - 15-20 min each
+3. **The Cypher** (~14:35, 30 min) - the day's signature artifact. Multi-cam preferred.
+4. **WaveWarZ Round 1** (~15:10) - all 4 artists
+5. **WaveWarZ Semi-Final** (~15:55) - top 2
+6. **WaveWarZ Final + voting announcement** (~16:55-17:25)
+7. **Closing set** (~17:30, 30 min) - winner plays the day out
+8. **Partner / sponsor activations** - booth interactions, verbal credits, attendee reactions at sponsor booths
+
+Plus continuous capture:
+- Crowd wide shots every 15 min
+- Attendee candid interactions
+- Artist backstage prep
+- The parklet itself filling up and emptying out across the day
+
+---
+
+## Three Contributor Tiers
+
+**Tier 1: Official Production (owned, paid)**
+- 1 videographer + 1 photographer hired or barterd
+- Shoots main stage, cypher, WaveWarZ rounds in good quality
+- Uploads raw to R2 end-of-day, transfers to Arweave post-event
+- Content team has exclusive first-window access
+
+**Tier 2: Volunteer Media Crew (earned rewards)**
+- 3-5 volunteers with the content role (already a field in stock_volunteers)
+- Shoot crowd, candid, sponsor booths, artist backstage
+- Upload via /stock/media on their phones throughout the day
+- Rewarded in ZABAL per approved upload
+
+**Tier 3: Crowd / Public (discretionary rewards)**
+- Anyone at the event can upload via /stock/media (or a QR code posted at the entrance)
+- Content team reviews + keeps the good stuff
+- Rewarded in ZABAL for each accepted upload
+- Crowd-sourced angles that official team cannot cover
+
+---
+
+## Token Reward Model (ZABAL)
+
+Simple payout tiers, paid post-event after review:
+
+| Upload type | ZABAL reward |
+|-------------|-------------|
+| Approved photo | 5 |
+| Approved short clip (<30s) | 10 |
+| Approved full artist set clip (>1 min) | 50 |
+| Approved cypher participant contribution | 100 |
+| Approved content team work (video edit, highlight reel) | 500-2000 |
+
+**Why tokens:**
+- Turns a chore into a game
+- Creates ongoing value to ZABAL holders
+- Documents contribution for future ZAO roles
+- Reusable for every future event
+
+**Mechanics:**
+- Upload form captures wallet address (or email to claim later)
+- Content team approval triggers batch payout via a single transaction at end of month
+- Public leaderboard shows top contributors per event (drives competition)
+
+---
+
+## Data Model
+
+Suggested schema if we build this on Supabase:
+
+```sql
+CREATE TABLE IF NOT EXISTS event_media_uploads (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  event_slug TEXT NOT NULL,
+  uploader_name TEXT DEFAULT '',
+  uploader_wallet TEXT DEFAULT '',
+  uploader_email TEXT DEFAULT '',
+  tier TEXT CHECK (tier IN ('official','volunteer','crowd')) DEFAULT 'crowd',
+  media_type TEXT CHECK (media_type IN ('photo','video','audio')) NOT NULL,
+  -- Storage URLs
+  r2_url TEXT,
+  arweave_tx TEXT,
+  thumbnail_url TEXT,
+  -- Metadata
+  captured_at TIMESTAMPTZ,
+  captured_location TEXT DEFAULT '',
+  tags TEXT[] DEFAULT '{}',
+  description TEXT DEFAULT '',
+  -- Review
+  status TEXT CHECK (status IN ('pending','approved','rejected','public')) DEFAULT 'pending',
+  reviewed_by UUID REFERENCES stock_team_members(id),
+  reviewed_at TIMESTAMPTZ,
+  zabal_paid INT DEFAULT 0,
+  zabal_paid_tx TEXT DEFAULT '',
+  -- Housekeeping
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+One table, one event slug, scales to every future event.
+
+---
+
+## Build Phases
+
+**Phase 1 (pre-event, by Aug 1):**
+- Create the `event_media_uploads` table
+- Build `/stock/media` upload form (public, optional wallet)
+- Simple upload path to R2 via signed URL (no Arweave yet - batch later)
+- Review queue in dashboard: new "Media" tab that shows pending uploads with approve/reject buttons
+- Document the QR code for venue signage
+
+**Phase 2 (day-of and post-event):**
+- Content team posts QR codes around venue
+- Volunteers and attendees upload throughout the day
+- Review queue fills up; Zaal, DaNici, Shawn review over the following week
+- Batch approved uploads to Arweave via ArDrive
+- Compute ZABAL payouts, execute batch transaction
+
+**Phase 3 (future events, by 2027):**
+- Public gallery page per event at `/stock/gallery` or `/concertz/gallery` etc
+- Farcaster channel auto-posts weekly highlights
+- Leaderboard page ranking contributors across events
+- API so agents (ZOE) can pull approved media for use in content
+- Generalize to multi-event (COC Concertz, FISHBOWLZ, future)
+
+---
+
+## ZAO Ecosystem Integration
+
+**Code files that would exist:**
+- `scripts/event-media-uploads.sql` - schema
+- `src/app/stock/media/page.tsx` + form - public upload
+- `src/app/api/stock/media/route.ts` - signed URL issuer + save row
+- `src/app/api/stock/media/review/route.ts` - team approval endpoint
+- `src/app/stock/team/MediaReview.tsx` - dashboard tab for content team
+- `src/lib/storage/r2.ts` + `src/lib/storage/arweave.ts` - storage helpers
+
+**Who owns what:**
+- FailOften: technical build of upload path + R2 + Arweave integration
+- DaNici + Shawn: content review rubric + approve/reject decisions
+- Zaal: ZABAL payout logic + content strategy direction
+- DCoop: cypher-specific capture plan (multi-cam, audio feed from the board)
+
+**Reward budget:**
+If we hit ~100 approved uploads for ZAOstock (reasonable for a first event):
+- 50 photos at 5 ZABAL = 250
+- 30 short clips at 10 = 300
+- 15 full clips at 50 = 750
+- 5 cypher clips at 100 = 500
+- 2 content-team edits at 1000 = 2000
+- **Total: ~3,800 ZABAL per event, budgeted in advance**
+
+This is cheap fuel compared to what it unlocks.
+
+---
+
+## Next Actions (before ZAOstock Oct 3)
+
+1. **Tuesday Apr 21 meeting** - bring this doc. Decide if we build Phase 1 before event.
+2. **April-May**: FailOften scopes the upload form + R2 integration (2-week estimate)
+3. **May 15**: Phase 1 shipped; volunteer content crew trained on the flow
+4. **June**: QR code signage designed by DaNici + Shawn for venue
+5. **August**: First test upload + approval flow dry run
+6. **Oct 3**: live capture. Content team runs review queue through the following week
+7. **Oct 15**: ZABAL payout batch, public highlights drop
+
+## Risks + Decisions to Make
+
+| Risk | Mitigation |
+|------|-----------|
+| Too few uploads day-of | QR code signage + volunteer content crew pre-briefed with upload mission |
+| Too many uploads, review backlog | Clear review rubric, approval can be fast (yes/no) |
+| Low quality uploads | Filter at review stage, reject aggressively |
+| Artist rights issues | Upload form has a checkbox: "I took this or am in it, I agree to share for ZAO use" |
+| Arweave costs spike | R2-only for Phase 1, Arweave transfer as a post-event batch |
+| Wallet UX kills uploads | Email-claim fallback; they give email, get ZABAL later |
+
+## Sources
+
+- Internal: doc 432 (Tricky Buddha Space master context) - identifies media loss as a top gap
+- [ArDrive pricing](https://ardrive.io/pricing)
+- [Cloudflare R2 pricing](https://developers.cloudflare.com/r2/pricing/)
+- Prior art: Paragraph's media pipeline, Paragraph article uploads
+- ZAO existing: `stock_volunteers` table has `role='content'` category already
+
+## Related Research
+
+- [432 - ZAO Master Context (Tricky Buddha)](../../community/432-zao-master-context-tricky-buddha/)
+- [418 - Birding Man Festival Analysis](../418-birding-man-festival-analysis/)
+- [428 - ZAOstock Run-of-Show Program](../428-zaostock-run-of-show-program/)

--- a/scripts/stock-team-cypher-signup.sql
+++ b/scripts/stock-team-cypher-signup.sql
@@ -1,0 +1,20 @@
+-- ============================================================================
+-- ZAOstock Cypher: artist signup fields
+-- ============================================================================
+-- Cyphers are ZAO's signature product (see research/community/432). A cypher
+-- is a multi-artist collaborative track created live during the event. This
+-- SQL adds fields so any artist (from pipeline OR public signup) can indicate
+-- interest in the Oct 3 cypher session.
+--
+-- Public signup form at /stock/cypher POSTs into stock_artists with
+-- cypher_interested=true.
+-- ============================================================================
+
+ALTER TABLE stock_artists
+  ADD COLUMN IF NOT EXISTS cypher_interested BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS cypher_role TEXT DEFAULT '';
+
+COMMENT ON COLUMN stock_artists.cypher_interested IS
+  'True if this artist wants to be in the Oct 3 cypher session. Can be set by music team or by the artist via the public /stock/cypher signup form.';
+COMMENT ON COLUMN stock_artists.cypher_role IS
+  'What the artist brings to the cypher: vocals, production, instrument, etc. Free-form text.';

--- a/scripts/stock-team-tuesday-agenda-v2.sql
+++ b/scripts/stock-team-tuesday-agenda-v2.sql
@@ -1,0 +1,16 @@
+-- ============================================================================
+-- ZAOstock Tuesday Apr 21 Meeting Agenda v2
+-- ============================================================================
+-- Updates the Apr 21 meeting note to reflect:
+-- - Master context from Tricky Buddha Space (music first, community second, tech third)
+-- - Cypher session now part of the run-of-show
+-- - Media capture pipeline as a new gap to discuss
+-- - Sponsor deck (/stock/sponsor/deck) + llms.txt live
+-- - Pre-reads: team member reports via /stock/team Meeting Notes
+-- ============================================================================
+
+UPDATE stock_meeting_notes
+SET
+  title = 'ZAOstock Team Meeting - April 21, 10:00am EST',
+  notes = E'# Agenda (v2)\n\n**Time:** Tuesday April 21, 10:00am EST\n**Location:** TBD - confirm in team channel Monday\n\n**Core principle (Tricky Buddha Space):** Music first, Community second, Technology third.\n\n---\n\n**10:00-10:15 (15 min) - Zaal + team lead updates**\n- Zaal: overall status, timeline, distribution push summary\n- DaNici: design team update\n- DCoop: music team update (including WaveWarZ + Cypher feasibility)\n- Tyler: finance team update\n- Candy: ops + permits update\n\n**10:15-10:30 (15 min) - Team reports, round-robin**\n- Each member drops: moved-forward / blockers / top ask\n- Pre-logged in dashboard Meeting Notes\n- Team Reports Collector in-app\n\n**10:30-10:45 (15 min) - Decisions needed from the group**\n- Run-of-show format vote (doc 428): traditional vs hybrid with WaveWarZ + Cypher\n- Sponsor deck final approval (live at /stock/sponsor/deck)\n- Artist outreach wave 1 sign-off (templates at scripts/artist-outreach-templates.md)\n- Media capture pipeline - who owns this\n\n**10:45-11:00 (15 min) - Live demo + next 2 weeks**\n- Quick dashboard tour (Zaal)\n- New: /stock/cypher signup, /stock/sponsor/deck, /stock/llms.txt\n- Each team confirms what they own through May 5\n- Q&A, close\n\n---\n\n## Pre-reads (before the meeting)\n\n- Master strategic context: [research/community/432-zao-master-context-tricky-buddha](https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/432-zao-master-context-tricky-buddha)\n- Run-of-show draft: [research/events/428](https://github.com/bettercallzaal/ZAOOS/tree/main/research/events/428-zaostock-run-of-show-program)\n- Birding Man lessons: [research/events/418](https://github.com/bettercallzaal/ZAOOS/tree/main/research/events/418-birding-man-festival-analysis)\n- Dashboard UI plan: [research/events/425](https://github.com/bettercallzaal/ZAOOS/tree/main/research/events/425-zaostock-dashboard-ui-lean-kanban-patterns)\n\n## Post-meeting deliverables\n\n- Action items captured here in this note (use Action Items field)\n- Each team commits to 1 deliverable through May 5\n- Next meeting scheduled before closing'
+WHERE meeting_date = '2026-04-21';

--- a/src/app/api/stock/cypher/route.ts
+++ b/src/app/api/stock/cypher/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+const cypherSchema = z.object({
+  name: z.string().trim().min(1, 'Name required').max(200),
+  email: z.string().trim().email('Valid email required').max(200).optional(),
+  socials: z.string().trim().max(500).optional(),
+  cypher_role: z.string().trim().min(1, 'Tell us what you bring').max(300),
+  notes: z.string().trim().max(1000).optional(),
+  hp: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = cypherSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    if (parsed.data.hp && parsed.data.hp.trim().length > 0) {
+      return NextResponse.json({ success: true }, { status: 201 });
+    }
+
+    const notes = [
+      parsed.data.email ? `email: ${parsed.data.email}` : null,
+      parsed.data.notes ? `notes: ${parsed.data.notes}` : null,
+      'cypher signup via /stock/cypher',
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const supabase = getSupabaseAdmin();
+
+    const { data: existing } = await supabase
+      .from('stock_artists')
+      .select('id')
+      .ilike('name', parsed.data.name)
+      .maybeSingle();
+
+    if (existing) {
+      const { error: updateError } = await supabase
+        .from('stock_artists')
+        .update({
+          cypher_interested: true,
+          cypher_role: parsed.data.cypher_role,
+          socials: parsed.data.socials || undefined,
+          notes: notes,
+        })
+        .eq('id', existing.id);
+      if (updateError) {
+        return NextResponse.json({ error: 'Could not update signup' }, { status: 500 });
+      }
+    } else {
+      const { error: insertError } = await supabase.from('stock_artists').insert({
+        name: parsed.data.name,
+        status: 'wishlist',
+        socials: parsed.data.socials || '',
+        cypher_interested: true,
+        cypher_role: parsed.data.cypher_role,
+        notes,
+      });
+      if (insertError) {
+        return NextResponse.json({ error: 'Could not save signup' }, { status: 500 });
+      }
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Submission failed' }, { status: 500 });
+  }
+}

--- a/src/app/stock/cypher/CypherForm.tsx
+++ b/src/app/stock/cypher/CypherForm.tsx
@@ -1,0 +1,179 @@
+'use client';
+
+import { useState } from 'react';
+
+const ROLE_OPTIONS = [
+  { value: 'Vocalist / Rapper', label: 'Vocalist / Rapper' },
+  { value: 'Producer', label: 'Producer (laptop + beats)' },
+  { value: 'Instrumentalist - guitar', label: 'Guitar' },
+  { value: 'Instrumentalist - bass', label: 'Bass' },
+  { value: 'Instrumentalist - keys', label: 'Keys / Piano' },
+  { value: 'Instrumentalist - horns', label: 'Horns' },
+  { value: 'Instrumentalist - drums', label: 'Drums / Percussion' },
+  { value: 'DJ', label: 'DJ' },
+  { value: 'Spoken word / poet', label: 'Spoken word / poet' },
+  { value: 'Other', label: 'Other (tell us below)' },
+];
+
+export function CypherForm() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [socials, setSocials] = useState('');
+  const [roleSelect, setRoleSelect] = useState(ROLE_OPTIONS[0].value);
+  const [roleCustom, setRoleCustom] = useState('');
+  const [notes, setNotes] = useState('');
+  const [hp, setHp] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'sent' | 'error'>('idle');
+  const [errMsg, setErrMsg] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setErrMsg('');
+    const cypherRole = roleSelect === 'Other' ? roleCustom.trim() : roleSelect;
+    try {
+      const res = await fetch('/api/stock/cypher', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email: email || undefined,
+          socials: socials || undefined,
+          cypher_role: cypherRole,
+          notes: notes || undefined,
+          hp,
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setStatus('error');
+        setErrMsg(d.error || 'Submission failed');
+      } else {
+        setStatus('sent');
+      }
+    } catch {
+      setStatus('error');
+      setErrMsg('Network error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div className="bg-gradient-to-br from-emerald-500/15 via-emerald-500/5 to-transparent rounded-xl p-6 border border-emerald-500/30 space-y-3 text-center">
+        <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold">You are in</p>
+        <h2 className="text-xl font-bold text-white">Thanks, {name || 'friend'}.</h2>
+        <p className="text-sm text-gray-300">
+          Your cypher signup landed in the ZAOstock music team dashboard. DCoop or someone from the music crew will reach out with logistics and the pre-event coordination thread.
+        </p>
+        <p className="text-xs text-gray-500">
+          Questions in the meantime? DM Zaal on Farcaster.
+        </p>
+      </div>
+    );
+  }
+
+  const needsCustomRole = roleSelect === 'Other';
+
+  return (
+    <form onSubmit={submit} className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-4">
+      <input
+        type="text"
+        tabIndex={-1}
+        autoComplete="off"
+        value={hp}
+        onChange={(e) => setHp(e.target.value)}
+        className="hidden"
+        aria-hidden="true"
+      />
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Name or artist handle</label>
+        <input
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="How the cypher track will credit you"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Email (optional)</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="We follow up here"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Socials or music links</label>
+        <input
+          value={socials}
+          onChange={(e) => setSocials(e.target.value)}
+          placeholder="X, Farcaster, Spotify, Soundcloud, website"
+          maxLength={500}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">What do you bring to the cypher?</label>
+        <select
+          value={roleSelect}
+          onChange={(e) => setRoleSelect(e.target.value)}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white focus:outline-none focus:border-[#f5a623]/30"
+        >
+          {ROLE_OPTIONS.map((r) => (
+            <option key={r.value} value={r.value}>{r.label}</option>
+          ))}
+        </select>
+        {needsCustomRole && (
+          <input
+            value={roleCustom}
+            onChange={(e) => setRoleCustom(e.target.value)}
+            placeholder="Tell us exactly what you bring"
+            maxLength={200}
+            className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+            required
+          />
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs text-gray-400 uppercase tracking-wider font-bold">Anything else? (optional)</label>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Genre, references, other artists you want to work with, equipment you bring, anything else"
+          rows={4}
+          maxLength={1000}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={busy || !name.trim() || (needsCustomRole && !roleCustom.trim())}
+        className="w-full bg-[#f5a623] hover:bg-[#ffd700] disabled:opacity-50 text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors"
+      >
+        {busy ? 'Sending...' : 'I want in on the cypher'}
+      </button>
+
+      {status === 'error' && (
+        <p className="text-xs text-red-400 text-center">{errMsg || 'Something went wrong. Try again.'}</p>
+      )}
+
+      <p className="text-[11px] text-gray-600 text-center">
+        The music team reaches out within a few days with the pre-event coordination thread.
+      </p>
+    </form>
+  );
+}

--- a/src/app/stock/cypher/page.tsx
+++ b/src/app/stock/cypher/page.tsx
@@ -1,0 +1,82 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { CypherForm } from './CypherForm';
+
+export const metadata: Metadata = {
+  title: 'ZAOstock Cypher | Live multi-artist session Oct 3',
+  description: 'Sign up to be part of the ZAOstock cypher - a live multi-artist collaborative track created at the festival on October 3, 2026.',
+};
+
+export default function CypherPage() {
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link href="/stock" className="text-xs text-gray-400 hover:text-[#f5a623]">
+            &larr; ZAOstock
+          </Link>
+          <span className="text-xs text-gray-500">The Cypher</span>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <div className="text-center space-y-2">
+          <p className="inline-block rounded-full bg-[#f5a623]/10 px-3 py-1 text-xs text-[#f5a623] font-medium border border-[#f5a623]/30">
+            ZAO Signature Product
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">The ZAOstock Cypher</h1>
+          <p className="text-sm text-gray-400 max-w-lg mx-auto">
+            Live multi-artist collaborative track. Created on-site at ZAOstock, Oct 3, 2026. If you bring verses, beats, or an instrument, this is your signup.
+          </p>
+        </div>
+
+        <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-3">
+          <p className="text-xs text-[#f5a623] uppercase tracking-wider font-bold">What is a cypher?</p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            A cypher is a multi-artist collaborative track built live. Vocalists trade verses, producers cook the beat on the spot, instrumentalists add texture. One track, many voices. It becomes the cultural artifact of the day.
+          </p>
+          <p className="text-sm text-gray-300 leading-relaxed">
+            The ZAOstock Cypher will be recorded, mixed, and released as onchain music after the festival. Every contributor gets credit and share.
+          </p>
+        </div>
+
+        <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-3">
+          <p className="text-xs text-[#f5a623] uppercase tracking-wider font-bold">Who should sign up</p>
+          <ul className="text-sm text-gray-300 space-y-1.5">
+            <li>- Rappers, vocalists, singers</li>
+            <li>- Producers (bring your laptop + a beat or two)</li>
+            <li>- Instrumentalists (guitar, bass, horns, keys, etc)</li>
+            <li>- Spoken word / poets</li>
+            <li>- Anyone who wants to add a voice to the day</li>
+          </ul>
+          <p className="text-xs text-gray-500">
+            You do not need to be on the main lineup to join the cypher. Cypher is open.
+          </p>
+        </div>
+
+        <CypherForm />
+
+        <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08]">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-bold mb-2">What happens next</p>
+          <p className="text-sm text-gray-400">
+            The music team reviews every signup and reaches out with logistics, timing, and the pre-event coordination thread. Expect a follow-up within a few days.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <Link
+              href="/stock/program"
+              className="text-xs bg-white/[0.06] hover:bg-white/[0.12] text-gray-200 rounded-lg px-3 py-2 transition-colors"
+            >
+              See the program
+            </Link>
+            <Link
+              href="/stock"
+              className="text-xs bg-white/[0.06] hover:bg-white/[0.12] text-gray-200 rounded-lg px-3 py-2 transition-colors"
+            >
+              Back to ZAOstock
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/stock/llms.txt/route.ts
+++ b/src/app/stock/llms.txt/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 3600;
+
+const CONTENT = `# ZAOstock
+
+> A community-built outdoor music festival on October 3, 2026 at the Franklin Street Parklet in downtown Ellsworth, Maine. Part of the 9th Annual Art of Ellsworth during Maine Craft Weekend. Run by The ZAO, a decentralized music community. Co-presented with Heart of Ellsworth and the Town of Ellsworth.
+
+ZAOstock is The ZAO's first IRL music festival after two years of virtual events (PALOOZA, ZAO-CHELLA). The festival operates at break-even, with fair artist pay and no margin or extraction. All partner contributions are tax-deductible via Fractured Atlas, a 501(c)(3) fiscal sponsor.
+
+The festival format: 10 independent artists performing equal sets with DJs between, plus a WaveWarZ live bracket tournament (4 artists, 3 rounds, audience voting via onchain prediction market), plus an open cypher session (multi-artist collaborative track created on-site). Afterparty at Black Moon Public House, 30 seconds from the stage.
+
+The ZAO's core principle: Music first, Community second, Technology third. The festival leads with experience, not crypto. Web3 is invisible infrastructure.
+
+## Key dates
+
+- October 3, 2026: Festival day, 12pm to 6pm, afterparty follows
+- June 30, 2026: Partner commitments due for printed materials
+- August 1, 2026: Final lineup public
+- September 15, 2026: Run-of-show locked, attendee schedule cards printed
+
+## Pages
+
+- [ZAOstock overview](https://zaoos.com/stock): Festival info, countdown, team, partners, past events, RSVP
+- [Day-of program](https://zaoos.com/stock/program): Draft schedule with music, talks, WaveWarZ rounds, and cypher session
+- [Partner deck](https://zaoos.com/stock/sponsor/deck): Three partner tracks, FAQ, how to commit
+- [Volunteer signup](https://zaoos.com/stock/apply): Sign up to volunteer in setup, check-in, stage crew, content, teardown, and other roles
+- [Cypher signup](https://zaoos.com/stock/cypher): Artists who want to be part of the live multi-artist cypher track on Oct 3
+- [Team dashboard login](https://zaoos.com/stock/team): 4-letter code access for the organizing team (15 members across Ops, Design, Music, Finance)
+
+## Partner tracks
+
+- Main Stage Partner ($500-$2,500): Local Ellsworth and Maine businesses. Named credit on stage, booth space, co-presented in printed materials.
+- Broadcast Partner ($1,000-$5,000): Web3 brands and ecosystem partners. Livestream overlay, sponsored segment, social campaign across Farcaster + X + Bluesky + LinkedIn.
+- Year-Round Partner ($5,000+): Strategic long-term partners. All Broadcast credits plus Year 2 advisory seat and priority 2027 placement.
+
+## Team
+
+15 members across four scopes:
+- Operations: Zaal (lead), Candy (2nd), FailOften, Hurric4n3Ike, Swarthy Hatter, Jango
+- Design: DaNici (lead), Shawn
+- Music: DCoop (2nd), AttaBotty
+- Finance: Tyler Stambaugh, Ohnahji B, DFresh, Craig G, Maceo
+
+Every team member has a public profile at https://zaoos.com/stock/team/m/[slug] with photo, bio, and links.
+
+## Public form submissions
+
+- Volunteer applications from /stock/apply flow into the team dashboard Volunteers tab
+- RSVPs from /stock flow into the team dashboard RSVPs tab
+- Cypher signups from /stock/cypher flow into the team dashboard Artists tab with cypher_interested=true
+
+## How to pitch ZAOstock to others
+
+- Lead with the experience, not the tech. "Outdoor festival in Ellsworth Maine on Oct 3, part of Art of Ellsworth."
+- Mention the community layer second. "Run by The ZAO, a music community we have built over the past two years."
+- Web3 is the infrastructure, not the headline. Most attendees do not need to know or care.
+- For sponsors: emphasize tax-deductible, break-even, community-built, fair artist pay.
+- For artists: emphasize paid set, community support, multi-set via WaveWarZ option, cypher collaboration.
+- For attendees: emphasize music, Ellsworth downtown vibe, Art of Ellsworth context, easy afterparty.
+
+## Contact
+
+Zaal - zaalp99@gmail.com - lead organizer, ZAO founder, partner and artist outreach
+
+## About The ZAO
+
+The ZAO (ZTalent Artist Organization) is a decentralized music community on Farcaster and Base. It functions as a coordination layer for independent musicians: providing infrastructure, events, and collaborative IP production (cyphers). The ZAO has run virtual festivals (PALOOZA, ZAO-CHELLA, 53+ communities, 26 sponsors) and is expanding to IRL events starting with ZAOstock 2026. Future flagship event: The ZAO Cruise (2027+), a multi-community sea-based festival.
+
+More on The ZAO: https://zaoos.com
+`;
+
+export async function GET() {
+  return new NextResponse(CONTENT, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/src/app/stock/page.tsx
+++ b/src/app/stock/page.tsx
@@ -88,16 +88,22 @@ export default async function StockPage() {
               Program
             </Link>
             <Link
+              href="/stock/cypher"
+              className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
+            >
+              Cypher
+            </Link>
+            <Link
               href="/stock/apply"
               className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
             >
               Volunteer
             </Link>
             <Link
-              href="/stock/sponsor"
+              href="/stock/sponsor/deck"
               className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
             >
-              Sponsors
+              Partner
             </Link>
             <Link
               href="/stock#team"
@@ -201,6 +207,23 @@ export default async function StockPage() {
                 <p className="text-xs text-gray-400 mt-1">{partner.role}</p>
               </div>
             ))}
+          </div>
+        </section>
+
+        {/* Cypher CTA */}
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">The Cypher</p>
+          <div className="bg-gradient-to-br from-rose-500/10 via-purple-500/5 to-transparent rounded-xl p-5 border border-rose-500/30">
+            <p className="text-lg font-bold text-white">The ZAOstock Cypher</p>
+            <p className="text-sm text-gray-300 mt-1">
+              Multi-artist collaborative track, created live on-site. Vocalists trade verses, producers cook beats, instrumentalists add texture. Released as onchain music after the festival with full credits and share.
+            </p>
+            <Link
+              href="/stock/cypher"
+              className="inline-block mt-3 bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              Sign up to be in the cypher -&gt;
+            </Link>
           </div>
         </section>
 

--- a/src/app/stock/program/page.tsx
+++ b/src/app/stock/program/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 interface Block {
   target: string;
   label: string;
-  type: 'MUSIC' | 'TALK' | 'BATTLE' | 'DJ' | 'BREAK';
+  type: 'MUSIC' | 'TALK' | 'BATTLE' | 'DJ' | 'BREAK' | 'CYPHER';
   detail: string;
 }
 
@@ -21,16 +21,16 @@ const PROGRAM: Block[] = [
   { target: '~13:35', type: 'TALK', label: 'Web3 music 101', detail: '5-10 minutes. Why onchain music matters, pitched for IRL audience.' },
   { target: '~13:50', type: 'MUSIC', label: 'Artist 3', detail: '15-20 minute set.' },
   { target: '~14:20', type: 'BREAK', label: 'Mid-day break', detail: '15 minutes. Food trucks, bathrooms, mingle.' },
-  { target: '~14:35', type: 'TALK', label: 'An artist\'s perspective', detail: '5-10 minutes from a WaveWarZ contestant.' },
-  { target: '~14:50', type: 'BATTLE', label: 'WaveWarZ Round 1', detail: 'Four artists, five minutes each. Audience votes live via QR code.' },
-  { target: '~15:25', type: 'DJ', label: 'Vote break', detail: 'Votes tally, DJ bridges.' },
-  { target: '~15:35', type: 'BATTLE', label: 'WaveWarZ Semi-Final', detail: 'Top two from Round 1, 7-8 minutes each.' },
-  { target: '~16:00', type: 'TALK', label: 'The ZAO community', detail: '5-10 minutes. How to join, what ZAO is.' },
-  { target: '~16:15', type: 'MUSIC', label: 'Artist 4', detail: '15 minute set.' },
-  { target: '~16:35', type: 'TALK', label: 'Partners and Year 2', detail: '5-10 minutes. Thank-you and preview of 2027.' },
-  { target: '~16:50', type: 'BATTLE', label: 'WaveWarZ Final', detail: 'Two finalists, 10 minutes each.' },
-  { target: '~17:20', type: 'DJ', label: 'Final voting', detail: 'Winner announced.' },
-  { target: '~17:25', type: 'MUSIC', label: 'Closing set', detail: 'WaveWarZ winner (or special guest), 25-30 minutes.' },
+  { target: '~14:35', type: 'CYPHER', label: 'The ZAOstock Cypher', detail: '30 minutes. Multi-artist collaborative track built live on stage. Vocalists, producers, instrumentalists all contribute. Recorded and released as onchain music after the festival. Sign up at zaoos.com/stock/cypher to be in it.' },
+  { target: '~15:10', type: 'BATTLE', label: 'WaveWarZ Round 1', detail: 'Four artists, five minutes each. Audience votes live via QR code.' },
+  { target: '~15:45', type: 'DJ', label: 'Vote break', detail: 'Votes tally, DJ bridges.' },
+  { target: '~15:55', type: 'BATTLE', label: 'WaveWarZ Semi-Final', detail: 'Top two from Round 1, 7-8 minutes each.' },
+  { target: '~16:15', type: 'TALK', label: 'The ZAO community', detail: '5-10 minutes. How to join, what ZAO is.' },
+  { target: '~16:25', type: 'MUSIC', label: 'Artist 4', detail: '15 minute set.' },
+  { target: '~16:45', type: 'TALK', label: 'Partners and Year 2', detail: '5-10 minutes. Thank-you and preview of 2027.' },
+  { target: '~16:55', type: 'BATTLE', label: 'WaveWarZ Final', detail: 'Two finalists, 10 minutes each.' },
+  { target: '~17:25', type: 'DJ', label: 'Final voting', detail: 'Winner announced.' },
+  { target: '~17:30', type: 'MUSIC', label: 'Closing set', detail: 'WaveWarZ winner (or special guest), 25-30 minutes.' },
   { target: '~17:55', type: 'DJ', label: 'Afterparty call', detail: 'Wind down. Head to Black Moon Public House next door.' },
 ];
 
@@ -38,6 +38,7 @@ const TYPE_COLOR: Record<Block['type'], string> = {
   MUSIC: 'border-purple-500/40 bg-purple-500/10 text-purple-400',
   TALK: 'border-blue-500/40 bg-blue-500/10 text-blue-400',
   BATTLE: 'border-rose-500/40 bg-rose-500/10 text-rose-400',
+  CYPHER: 'border-amber-500/40 bg-amber-500/10 text-amber-400',
   DJ: 'border-gray-500/40 bg-gray-500/10 text-gray-400',
   BREAK: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400',
 };
@@ -65,8 +66,8 @@ export default function ProgramPage() {
           </p>
         </div>
 
-        <div className="grid grid-cols-5 gap-1.5 text-[10px]">
-          {(['MUSIC', 'TALK', 'BATTLE', 'DJ', 'BREAK'] as const).map((t) => (
+        <div className="grid grid-cols-3 sm:grid-cols-6 gap-1.5 text-[10px]">
+          {(['MUSIC', 'CYPHER', 'BATTLE', 'TALK', 'DJ', 'BREAK'] as const).map((t) => (
             <div key={t} className={`text-center font-bold px-2 py-1 rounded border ${TYPE_COLOR[t]}`}>
               {t}
             </div>

--- a/src/app/stock/sponsor/deck/page.tsx
+++ b/src/app/stock/sponsor/deck/page.tsx
@@ -1,0 +1,204 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getStockCounts } from '@/lib/stock/members';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'ZAOstock Partner Deck | Oct 3, 2026',
+  description: 'Partner packages for ZAOstock, a community-built outdoor music festival in Ellsworth, Maine on October 3, 2026. Tax-deductible via Fractured Atlas 501(c)(3).',
+  openGraph: {
+    title: 'ZAOstock Partner Deck',
+    description: 'Become a Main Stage, Broadcast, or Year-Round Partner for ZAOstock on Oct 3, 2026.',
+  },
+};
+
+const TRACKS = [
+  {
+    name: 'Main Stage Partner',
+    range: '$500 - $2,500',
+    fit: 'Local Ellsworth and Maine businesses who want to be credited at the stage and on-site.',
+    credits: [
+      'Named credit on stage banner and signage',
+      'Booth or table space on-site',
+      'Welcome bag inclusion',
+      'Live verbal credit during the event',
+      'Co-presented in all printed materials',
+    ],
+  },
+  {
+    name: 'Broadcast Partner',
+    range: '$1,000 - $5,000',
+    fit: 'Web3 brands, tools, and ecosystem partners who want reach across Farcaster + streaming.',
+    credits: [
+      'Named credit on festival website with backlink',
+      'Livestream overlay credit',
+      'Sponsored segment plus interview feature',
+      'Social campaign across Farcaster, X, Bluesky, LinkedIn',
+      'Newsletter credit (400+ editions)',
+    ],
+  },
+  {
+    name: 'Year-Round Partner',
+    range: '$5,000+',
+    fit: 'Strategic partners who want a long-term relationship with The ZAO.',
+    credits: [
+      'All Broadcast Partner credits',
+      'Advisory seat for Year 2 planning',
+      'Priority placement in 2027',
+      'Quarterly collaboration across The ZAO calendar',
+      'Tax-deductible via Fractured Atlas 501(c)(3)',
+    ],
+  },
+];
+
+const FAQ = [
+  {
+    q: 'Is this tax-deductible?',
+    a: 'Yes. All partnerships flow through Fractured Atlas, our 501(c)(3) fiscal sponsor. You will receive proper documentation.',
+  },
+  {
+    q: 'What do you do with the funds?',
+    a: 'Every dollar goes to artist pay, production, and keeping the festival accessible. ZAOstock operates at break-even. No margin, no extraction.',
+  },
+  {
+    q: 'Who is The ZAO?',
+    a: 'A decentralized music community on Farcaster and Base, active since 2023. We have run virtual festivals (PALOOZA, ZAO-CHELLA) for two years. ZAOstock 2026 is our first IRL festival. Co-presented with Heart of Ellsworth and the Town of Ellsworth.',
+  },
+  {
+    q: 'How many people show up?',
+    a: 'ZAOstock runs during Maine Craft Weekend, pulling steady foot traffic from visitors heading to Acadia National Park. We are also marketing to our 188-member community and partner networks. Target: several hundred attendees plus digital livestream reach.',
+  },
+  {
+    q: 'Can we customize the package?',
+    a: 'Yes. Everything is modular. If you have a specific ask (booth placement, product integration, named stage, etc), let us talk.',
+  },
+  {
+    q: 'What is the deadline?',
+    a: 'We are locking partners by June 15, 2026 to hit print and digital deadlines. Earlier is better.',
+  },
+  {
+    q: 'Can we pay in crypto?',
+    a: 'Yes. USDC on Base preferred. Check, wire, or card also fine via Fractured Atlas.',
+  },
+];
+
+export default async function DeckPage() {
+  const counts = await getStockCounts();
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link href="/stock" className="text-xs text-gray-400 hover:text-[#f5a623]">
+            &larr; ZAOstock
+          </Link>
+          <span className="text-xs text-gray-500">Partner Deck</span>
+        </div>
+      </header>
+
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-8">
+        <div className="text-center space-y-3">
+          <p className="inline-block rounded-full bg-[#f5a623]/10 px-3 py-1 text-xs text-[#f5a623] font-medium border border-[#f5a623]/30">
+            Partner Opportunity
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-bold tracking-tight">ZAOstock Partners</h1>
+          <p className="text-sm text-gray-400 max-w-xl mx-auto">
+            October 3, 2026. Franklin Street Parklet, Ellsworth Maine. 10 artists, one stage, all day. Part of the 9th Annual Art of Ellsworth. Run by The ZAO, a decentralized music community.
+          </p>
+        </div>
+
+        <section className="grid grid-cols-3 gap-2">
+          <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+            <p className="text-2xl font-bold text-[#f5a623]">10</p>
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">Artists</p>
+          </div>
+          <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+            <p className="text-2xl font-bold text-[#f5a623]">{counts.rsvps || '-'}</p>
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">RSVPs so far</p>
+          </div>
+          <div className="bg-[#0d1b2a] rounded-lg p-3 border border-white/[0.06] text-center">
+            <p className="text-2xl font-bold text-[#f5a623]">Oct 3</p>
+            <p className="text-[10px] text-gray-500 uppercase tracking-wider">2026</p>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Three Partner Tracks</p>
+          {TRACKS.map((t) => (
+            <div key={t.name} className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] overflow-hidden">
+              <div className="bg-gradient-to-r from-[#f5a623]/20 to-transparent px-4 py-3 flex items-baseline justify-between flex-wrap gap-2">
+                <span className="font-bold text-base text-[#f5a623]">{t.name}</span>
+                <span className="text-sm text-gray-300 font-medium">{t.range}</span>
+              </div>
+              <div className="px-4 py-3 space-y-3">
+                <p className="text-sm text-gray-300 italic">{t.fit}</p>
+                <ul className="text-sm text-gray-300 space-y-1.5">
+                  {t.credits.map((c) => (
+                    <li key={c} className="flex items-start gap-2">
+                      <span className="text-[#f5a623] mt-1 text-xs">-</span>
+                      <span>{c}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        <section className="bg-gradient-to-br from-[#f5a623]/15 via-[#f5a623]/5 to-transparent rounded-xl p-5 border border-[#f5a623]/30 space-y-3">
+          <p className="text-xs text-[#f5a623] uppercase tracking-wider font-bold">How to commit</p>
+          <ol className="text-sm text-gray-300 space-y-2">
+            <li><strong className="text-white">1.</strong> Email Zaal with the track you want (Main Stage / Broadcast / Year-Round) and any custom asks.</li>
+            <li><strong className="text-white">2.</strong> We send a simple partner agreement + Fractured Atlas W-9 for tax docs.</li>
+            <li><strong className="text-white">3.</strong> Partner contribution due by June 30 to lock printed materials.</li>
+            <li><strong className="text-white">4.</strong> You ship your logo file by August 1 for all merch, stage, and broadcast use.</li>
+            <li><strong className="text-white">5.</strong> Oct 3 - you are named on the stage, the broadcast, the website, and the day.</li>
+          </ol>
+          <div className="pt-2">
+            <a
+              href="mailto:zaalp99@gmail.com?subject=ZAOstock%20Partner%20Interest"
+              className="inline-block bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-2.5 text-sm transition-colors"
+            >
+              Email Zaal
+            </a>
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">FAQ</p>
+          <div className="space-y-2">
+            {FAQ.map((f) => (
+              <details key={f.q} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 group">
+                <summary className="text-sm font-medium text-white cursor-pointer list-none flex justify-between items-center">
+                  <span>{f.q}</span>
+                  <span className="text-gray-500 text-xs group-open:rotate-180 transition-transform">v</span>
+                </summary>
+                <p className="text-sm text-gray-400 mt-2 leading-relaxed">{f.a}</p>
+              </details>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-2">
+          <p className="text-xs text-gray-500 uppercase tracking-wider font-bold">Confirmed so far</p>
+          <ul className="text-sm text-gray-300 space-y-1">
+            <li>- Heart of Ellsworth - Venue + Maine Craft Weekend promotion</li>
+            <li>- Town of Ellsworth - Parklet venue</li>
+            <li>- Fractured Atlas - 501(c)(3) fiscal sponsor</li>
+            <li>- Black Moon Public House - Afterparty venue (30 seconds from the stage)</li>
+          </ul>
+          <p className="text-[11px] text-gray-500 italic pt-2">
+            Reach out to be the first named partner in 2026.
+          </p>
+        </section>
+
+        <div className="text-center">
+          <Link href="/stock" className="text-sm text-[#f5a623] hover:text-[#ffd700]">
+            Back to ZAOstock
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Atomic ship: 5 public-facing + 2 internal items aligned with the Tricky Buddha master context (doc 432). Core principle: music first, community second, technology third. Cyphers as the signature product.

## 1. Cypher signup at /stock/cypher (public)
- Public page invites artists to join the live multi-artist cypher on Oct 3 (30 min block in the run-of-show, recorded and released onchain post-event)
- Role picker: vocalist, producer, instrumentalist, DJ, spoken word
- POST /api/stock/cypher writes to stock_artists with cypher_interested=true and cypher_role
- Dedupes by name (upsert)
- SQL: new cypher_interested BOOLEAN + cypher_role TEXT columns on stock_artists

## 2. Partner deck at /stock/sponsor/deck (public)
- Single-page linkable HTML pitch for sponsor outreach emails
- 3 tracks priced: Main Stage $500-2500, Broadcast $1K-5K, Year-Round $5K+
- Live RSVP + artist + date tiles
- Inline FAQ (collapsed by default)
- Mailto Zaal CTA

## 3. /stock/llms.txt (AI documentation)
- AI-readable site summary at /stock/llms.txt
- Describes festival, dates, team, partner tracks, form submissions, how-to-pitch guidance
- text/plain + 1hr cache
- Makes ZAOstock discoverable by AI agents

## 4. Program update (/stock/program)
- Cypher block added at 14:35 (30 min)
- WaveWarZ shifted 20 min later
- New amber CYPHER type + 6-column legend

## 5. /stock landing page
- Header nav: Program | Cypher | Volunteer | Partner | Team
- Cypher CTA section above Volunteer CTA
- Partner link goes to /stock/sponsor/deck

## 6. Tuesday agenda v2 (scripts/stock-team-tuesday-agenda-v2.sql)
- Refreshes the Apr 21 meeting note
- Core principle from master context
- Adds WaveWarZ + Cypher feasibility discussion
- Adds media capture pipeline as agenda item
- Lists pre-reads: docs 432, 428, 418, 425

## 7. Research doc 433: Media capture pipeline spec
- Storage stack: Arweave + R2 + social distribution
- 3 contributor tiers (official, volunteer, crowd-sourced)
- ZABAL token reward schedule
- Data model spec for event_media_uploads table
- 3-phase build plan

## To apply after merge
1. Paste scripts/stock-team-cypher-signup.sql into Supabase (idempotent)
2. Paste scripts/stock-team-tuesday-agenda-v2.sql into Supabase (updates Tuesday meeting note)
3. Verify /stock/llms.txt returns plain text
4. Verify /stock/cypher form submits (test incognito)
5. Verify /stock/sponsor/deck renders with counts

No emojis, no em dashes.