### PR TITLE
feat(stock): collapsible detail tabs + day-of time + cypher fields

### DIFF
--- a/src/app/stock/team/ArtistPipeline.tsx
+++ b/src/app/stock/team/ArtistPipeline.tsx
@@ -27,6 +27,10 @@ interface Artist {
   notes: string;
   outreach: Member | null;
   created_at: string;
+  cypher_interested?: boolean;
+  cypher_role?: string;
+  day_of_start_time?: string | null;
+  day_of_duration_min?: number | null;
 }
 
 const STATUS_ORDER: Record<Artist['status'], number> = {
@@ -321,6 +325,10 @@ function ArtistEditRow({
   const [fee, setFee] = useState(String(artist.fee || ''));
   const [setOrder, setSetOrder] = useState(artist.set_order !== null ? String(artist.set_order) : '');
   const [needsTravel, setNeedsTravel] = useState(artist.needs_travel);
+  const [dayOfStart, setDayOfStart] = useState((artist.day_of_start_time || '').slice(0, 5));
+  const [dayOfDuration, setDayOfDuration] = useState(artist.day_of_duration_min ? String(artist.day_of_duration_min) : '');
+  const [cypherInterested, setCypherInterested] = useState(Boolean(artist.cypher_interested));
+  const [cypherRole, setCypherRole] = useState(artist.cypher_role || '');
 
   function save() {
     onUpdate(artist.id, {
@@ -330,6 +338,10 @@ function ArtistEditRow({
       fee: Number(fee) || 0,
       set_order: setOrder === '' ? null : Number(setOrder),
       needs_travel: needsTravel,
+      day_of_start_time: dayOfStart ? `${dayOfStart}:00` : null,
+      day_of_duration_min: dayOfDuration === '' ? null : Number(dayOfDuration),
+      cypher_interested: cypherInterested,
+      cypher_role: cypherRole,
     });
   }
 
@@ -365,6 +377,50 @@ function ArtistEditRow({
           className="bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
         />
       </div>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <label className="text-[10px] text-gray-500 uppercase tracking-wider">Day-of start time</label>
+          <input
+            type="time"
+            value={dayOfStart}
+            onChange={(e) => setDayOfStart(e.target.value)}
+            className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white focus:outline-none focus:border-[#f5a623]/30"
+          />
+        </div>
+        <div className="space-y-1">
+          <label className="text-[10px] text-gray-500 uppercase tracking-wider">Duration (min)</label>
+          <input
+            type="number"
+            min="0"
+            max="180"
+            value={dayOfDuration}
+            onChange={(e) => setDayOfDuration(e.target.value)}
+            placeholder="15"
+            className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+          />
+        </div>
+      </div>
+
+      <div className="bg-rose-500/5 border border-rose-500/20 rounded-lg p-2 space-y-1.5">
+        <label className="flex items-center gap-1.5 text-xs text-rose-400">
+          <input
+            type="checkbox"
+            checked={cypherInterested}
+            onChange={(e) => setCypherInterested(e.target.checked)}
+            className="accent-rose-400"
+          />
+          In the Oct 3 Cypher
+        </label>
+        {cypherInterested && (
+          <input
+            value={cypherRole}
+            onChange={(e) => setCypherRole(e.target.value)}
+            placeholder="What they bring (vocals, production, guitar, etc)"
+            className="w-full bg-[#0d1b2a] border border-white/[0.06] rounded px-2 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-rose-500/30"
+          />
+        )}
+      </div>
+
       <textarea
         value={notes}
         onChange={(e) => setNotes(e.target.value)}

--- a/src/app/stock/team/CollapsibleDetail.tsx
+++ b/src/app/stock/team/CollapsibleDetail.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState, ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  summary: ReactNode;
+  children: ReactNode;
+  expandedByDefault?: boolean;
+}
+
+export function CollapsibleDetail({ title, summary, children, expandedByDefault = false }: Props) {
+  const [open, setOpen] = useState(expandedByDefault);
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-[#0d1b2a] rounded-xl border border-white/[0.08] p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-bold text-white">{title}</h2>
+          <span className="text-[10px] text-gray-500 uppercase tracking-wider">At a glance</span>
+        </div>
+        {summary}
+        <button
+          onClick={() => setOpen(!open)}
+          className="w-full bg-[#f5a623]/10 hover:bg-[#f5a623]/20 text-[#f5a623] font-bold rounded-lg px-3 py-2 text-sm transition-colors border border-[#f5a623]/30"
+        >
+          {open ? 'Hide full view' : 'Show everything (full tools, lists, board view)'}
+        </button>
+      </div>
+
+      {open && <div className="pt-2">{children}</div>}
+    </div>
+  );
+}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -14,6 +14,8 @@ import { PersonalHome } from './PersonalHome';
 import { OnboardingModal } from './OnboardingModal';
 import { SnapshotButton } from './SnapshotButton';
 import { RsvpList } from './RsvpList';
+import { CollapsibleDetail } from './CollapsibleDetail';
+import { SponsorSummary, ArtistSummary, TimelineSummary } from './TabSummaries';
 import { useRouter } from 'next/navigation';
 
 type Tab = 'home' | 'overview' | 'sponsors' | 'artists' | 'timeline' | 'volunteers' | 'rsvps' | 'budget' | 'notes' | 'team';
@@ -51,6 +53,10 @@ interface Artist {
   notes: string;
   outreach: { id: string; name: string } | null;
   created_at: string;
+  cypher_interested?: boolean;
+  cypher_role?: string;
+  day_of_start_time?: string | null;
+  day_of_duration_min?: number | null;
 }
 
 interface Milestone {
@@ -241,9 +247,30 @@ export function Dashboard({
             <TodoList todos={todos} members={memberList} currentMemberId={memberId} />
           </>
         )}
-        {tab === 'sponsors' && <SponsorCRM sponsors={sponsors} members={memberList} />}
-        {tab === 'artists' && <ArtistPipeline artists={artists} members={memberList} />}
-        {tab === 'timeline' && <Timeline milestones={milestones} members={memberList} />}
+        {tab === 'sponsors' && (
+          <CollapsibleDetail
+            title="Sponsors"
+            summary={<SponsorSummary sponsors={sponsors} />}
+          >
+            <SponsorCRM sponsors={sponsors} members={memberList} />
+          </CollapsibleDetail>
+        )}
+        {tab === 'artists' && (
+          <CollapsibleDetail
+            title="Artists"
+            summary={<ArtistSummary artists={artists} />}
+          >
+            <ArtistPipeline artists={artists} members={memberList} />
+          </CollapsibleDetail>
+        )}
+        {tab === 'timeline' && (
+          <CollapsibleDetail
+            title="Timeline"
+            summary={<TimelineSummary milestones={milestones} />}
+          >
+            <Timeline milestones={milestones} members={memberList} />
+          </CollapsibleDetail>
+        )}
         {tab === 'volunteers' && (
           <>
             <CalloutBanner

--- a/src/app/stock/team/TabSummaries.tsx
+++ b/src/app/stock/team/TabSummaries.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+interface Sponsor {
+  status: 'lead' | 'contacted' | 'in_talks' | 'committed' | 'paid' | 'declined';
+  amount_committed: number;
+}
+
+interface Artist {
+  status: 'wishlist' | 'contacted' | 'interested' | 'confirmed' | 'declined' | 'travel_booked';
+  needs_travel: boolean;
+  travel_from: string;
+  cypher_interested?: boolean;
+}
+
+interface Milestone {
+  due_date: string;
+  status: 'pending' | 'in_progress' | 'done' | 'blocked';
+}
+
+function daysToDue(date: string): number {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return Math.ceil((new Date(date + 'T00:00:00').getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function SponsorSummary({ sponsors }: { sponsors: Sponsor[] }) {
+  const committed = sponsors.filter((s) => s.status === 'committed' || s.status === 'paid').length;
+  const inPipeline = sponsors.filter((s) => s.status === 'in_talks' || s.status === 'contacted').length;
+  const totalDollars = sponsors
+    .filter((s) => s.status === 'committed' || s.status === 'paid')
+    .reduce((sum, s) => sum + Number(s.amount_committed || 0), 0);
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      <Tile label="Committed" value={String(committed)} color="text-emerald-400" />
+      <Tile label="In pipeline" value={String(inPipeline)} color="text-amber-400" />
+      <Tile label="Raised" value={`$${totalDollars.toLocaleString()}`} color="text-[#f5a623]" />
+    </div>
+  );
+}
+
+export function ArtistSummary({ artists }: { artists: Artist[] }) {
+  const confirmed = artists.filter((a) => a.status === 'confirmed' || a.status === 'travel_booked').length;
+  const contacted = artists.filter((a) => a.status === 'contacted' || a.status === 'interested').length;
+  const cypher = artists.filter((a) => a.cypher_interested).length;
+  const needsTravel = artists.filter((a) => a.status === 'confirmed' && a.needs_travel && !a.travel_from).length;
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-3 gap-2">
+        <Tile label="Confirmed" value={`${confirmed} / 10`} color="text-emerald-400" />
+        <Tile label="In pipeline" value={String(contacted)} color="text-amber-400" />
+        <Tile label="Cypher signups" value={String(cypher)} color="text-rose-400" />
+      </div>
+      {needsTravel > 0 && (
+        <p className="text-[11px] text-amber-400 px-1">
+          {needsTravel} confirmed artist{needsTravel === 1 ? '' : 's'} still need{needsTravel === 1 ? 's' : ''} travel origin set.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function TimelineSummary({ milestones }: { milestones: Milestone[] }) {
+  const overdue = milestones.filter((m) => m.status !== 'done' && daysToDue(m.due_date) < 0).length;
+  const upcoming7 = milestones.filter((m) => {
+    if (m.status === 'done') return false;
+    const d = daysToDue(m.due_date);
+    return d >= 0 && d <= 7;
+  }).length;
+  const done = milestones.filter((m) => m.status === 'done').length;
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      <Tile label="Overdue" value={String(overdue)} color={overdue > 0 ? 'text-red-400' : 'text-gray-500'} />
+      <Tile label="Due in 7 days" value={String(upcoming7)} color="text-amber-400" />
+      <Tile label="Done" value={String(done)} color="text-emerald-400" />
+    </div>
+  );
+}
+
+function Tile({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <div className="bg-[#0a1628] rounded-lg p-3 border border-white/[0.06] text-center">
+      <p className={`text-lg font-bold ${color}`}>{value}</p>
+      <p className="text-[10px] text-gray-500 uppercase tracking-wider">{label}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Addresses the "dashboard too confusing" feedback and uses the day_of columns we shipped.

## Collapsible detail tabs
- New `CollapsibleDetail` wrapper: summary card on top, single "Show everything" button to expand the full tool
- New `TabSummaries` with SponsorSummary, ArtistSummary, TimelineSummary (3 stat tiles each + contextual warnings)
- Applied to Sponsors, Artists, Timeline tabs
- **Default state:** collapsed. User sees stats + one button, nothing else
- **Expanded state:** full existing tool (Kanban, list, forms, Pareto, etc)

## Day-of time on Artists
- `ArtistEditRow` now has day-of start time (HTML time input) + duration (minutes) fields
- Uses the `day_of_start_time` + `day_of_duration_min` columns already live in DB
- Music team can assign specific start times as the run-of-show firms up

## Cypher fields on Artists
- Checkbox "In the Oct 3 Cypher" in the edit row
- Text input for cypher_role (what they bring) reveals when checkbox is on
- Rose accent color matches the /stock/cypher public page
- Artist summary tile now shows "Cypher signups" count

## Artist summary also surfaces
- "N confirmed artists still need travel origin set" warning when applicable
- Confirmed count vs the 10-slot target

## Test plan
- Login, click More details -> Sponsors - see only stat tiles + "Show everything" button
- Click button - full CRM appears
- Same for Artists + Timeline tabs
- Edit an artist - new Day-of start + Duration + Cypher fields visible
- Cypher signups count on summary reflects public /stock/cypher submissions

No emojis, no em dashes.