### PR TITLE
docs: WaveWarZ Sunday battle recap socials (doc 442)

### DIFF
--- a/research/events/442-wavewarz-sunday-battle-recap-socials/README.md
+++ b/research/events/442-wavewarz-sunday-battle-recap-socials/README.md
@@ -1,0 +1,135 @@
+# 442 — WaveWarZ Sunday Battle Recap Socials — Apr 20 2026
+
+> **Status:** Ready to post
+> **Date:** 2026-04-20
+> **Goal:** Draft cross-platform social recaps for the WaveWarZ Sunday featured battle — Scary vs Stormy, HadeZ Throne.
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| Post timing | **Post Sunday evening after battle concludes** — update with winner once known |
+| Cross-post strategy | **Firefly for FC+X combined cast**, Telegram GC manual, LinkedIn manual |
+| Tone | **Build-in-public, receipts over vibes** — lead with data (0.9049 SOL Thursday), close with CTA |
+| Hashtags | `#WaveWarZ` `#TheZAO` `#MusicTrading` — keep consistent across platforms |
+
+---
+
+## 1. Farcaster + X Combined Cast (Firefly — 280 char max)
+
+```
+Sunday main card. Scary vs Stormy for the HadeZ Throne.
+
+Thursday's Quick BattleZ did 0.9049 SOL in live music trades. Tonight we find out who rules.
+
+@r3plic4nt206 vs @Stormbourne_76
+
+Live music trading on SOL. Not memes — receipts.
+
+#WaveWarZ #TheZAO
+```
+
+**Char count:** 262
+
+---
+
+## 2. Telegram GC Message
+
+```
+SUNDAY MAIN CARD
+
+Scary vs Stormy — HadeZ Throne
+
+Quick BattleZ on Thursday pulled 0.9049 SOL in real-time music trades from ~10 traders. That's live, on-chain, songs-not-memes trading.
+
+Tonight the featured battle goes live. @r3plic4nt206 (Scary) vs @Stormbourne_76 (Stormy). Winner claims the HadeZ Throne and gets a minted asset through ZAO ZOUNZ distribution.
+
+This is what music as a live asset class looks like at day zero.
+
+Pull up.
+```
+
+---
+
+## 3. LinkedIn Professional Angle
+
+```
+Music as a live-traded asset class — it's happening.
+
+Last Thursday, WaveWarZ ran a Quick BattleZ session where ~10 participants traded songs in real time on Solana. Total volume: 0.9049 SOL (~$120 USD). Small numbers, massive signal.
+
+Tonight, we're running a featured Sunday battle: two artists competing head-to-head for the "HadeZ Throne." The winner earns a minted digital asset distributed through our ZOUNZ pipeline.
+
+Why this matters for music + crypto:
+- Real trades, not speculation on memecoins
+- Artists earn live during the session
+- Retail-friendly entry (~$12-30/trader)
+- Community-driven curation, not algorithmic
+
+We're building WaveWarZ as part of The ZAO — a decentralized music community on Base. Thursday nights are Quick BattleZ. Sundays are featured main cards. Every trade is a receipt.
+
+0.9049 SOL traded in one night. Music, not memes.
+
+#MusicTech #Web3Music #WaveWarZ #TheZAO #BuildInPublic
+```
+
+---
+
+## 4. Newsletter Blurb (Year of the ZABAL)
+
+```
+SUNDAY MAIN CARD: SCARY vs STORMY — HADEZ THRONE
+
+Thursday's Connect Sesh proved something: people will trade music live, on-chain, for real money.
+
+0.9049 SOL moved in a single Quick BattleZ night. That's ~$120 in real-time music trades from about 10 people in a room. Not hypothetical. Not a pitch deck. Receipts.
+
+Tonight we escalate. @r3plic4nt206 (Scary) goes head-to-head with @Stormbourne_76 (Stormy) in the first featured Sunday battle for the HadeZ Throne. The winner gets a minted asset via ZAO ZOUNZ distribution — because when you win a battle, you should own something for it.
+
+What we're seeing:
+- Product-market fit for live music trading (small volume, real engagement)
+- Per-trader average of $12-30 — this is retail-native, not whale games
+- A ritual forming: Thursday Quick BattleZ → Sunday main card → weekly recap
+
+The goal: 10 Quick BattleZ sessions/week × 5 SOL = meaningful weekly volume. We're at day zero. The curve starts here.
+
+Join the next WaveWarZ session. Bring your ears and your wallet.
+```
+
+---
+
+## Battle Context
+
+| Field | Detail |
+|-------|--------|
+| Event | WaveWarZ Sunday Featured Battle |
+| Date | 2026-04-20 (Sunday) |
+| Matchup | Scary (@r3plic4nt206) vs Stormy (@Stormbourne_76) |
+| Theme | HadeZ Throne |
+| Prize | Minted NFT-equivalent via ZAO ZOUNZ distribution |
+| Prior signal | 0.9049 SOL traded in Thursday Quick BattleZ (Apr 17) |
+| Hosts | WaveWarZ, co-hosts Candy, Hurric4n3 |
+
+---
+
+## Platform Distribution Checklist
+
+- [ ] Farcaster + X via Firefly (combined cast)
+- [ ] Telegram GC (ZAO main + WaveWarZ)
+- [ ] LinkedIn (Zaal personal)
+- [ ] Newsletter (Year of the ZABAL edition)
+- [ ] Update with winner post-battle
+- [ ] Clip top battle moment via Livepeer (doc 420)
+- [ ] Screenshot graphic via HyperFrames (doc 420)
+
+---
+
+## Sources
+
+- [Doc 423 — Music x Crypto Connect Sesh Apr 17](../423-music-x-crypto-connect-sesh-apr17/README.md)
+- [Doc 101 — WaveWarZ whitepaper](../../wavewarz/101-wavewarz-zao-whitepaper/README.md)
+- [Doc 144 — ZOUNZ music NFT distribution](../../music/144-zounz-music-nft-unified-distribution/README.md)
+- [Doc 420 — HyperFrames video agents](../../agents/420-hyperframes-html-video-agents/README.md)
+- [Doc 422 — Claude Routines automation](../../dev-workflows/422-claude-routines-zao-automation-stack/README.md)


### PR DESCRIPTION
## Summary
- Draft cross-platform social posts for Scary (@r3plic4nt206) vs Stormy (@Stormbourne_76) HadeZ Throne Sunday battle
- 4 formats: Farcaster+X combined cast (280 char), Telegram GC, LinkedIn professional angle, newsletter blurb
- Builds on Thursday Connect Sesh data — 0.9049 SOL in live music trades (doc 423)
- Includes distribution checklist and post-battle follow-up items

## Test plan
- [ ] Review each post for accuracy and tone
- [ ] Verify Farcaster+X cast is under 280 chars
- [ ] Update with battle winner after Sunday event
- [ ] Cross-post via Firefly, Telegram, LinkedIn

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)