### PR TITLE
docs: ZAOstock sponsor pitch drafts — 3 tiers

### DIFF
--- a/research/events/443-zao-stock-sponsor-pitch-drafts/README.md
+++ b/research/events/443-zao-stock-sponsor-pitch-drafts/README.md
@@ -1,0 +1,141 @@
+# 443 — ZAOstock Sponsor Pitch Drafts (Oct 3, 2026)
+
+> **Status:** Draft — ready for team review
+> **Date:** 2026-04-20
+> **Goal:** Three-tier sponsor pitch emails for ZAOstock Year 1, tailored by budget and audience
+> **Builds on:** Docs 274 (team profiles), 363 (people + brands), 270 (planning), 428 (run-of-show)
+
+---
+
+## Key Decisions
+
+| Decision | Choice |
+|----------|--------|
+| **Tier structure** | Small (under $1K), Medium ($1-5K), Large ($5K+) |
+| **Tone** | Warm, community-first, music-forward. Lead with the event, not the tech. |
+| **Proof points** | Use credibility stats from Doc 363: 90+ governance sessions, 795 WaveWarZ battles, 400+ newsletter editions, ZAO-Chella/ZAO-Palooza track record |
+| **Venue details** | Franklin Street Parklet, Ellsworth ME. Part of 9th Annual Art of Ellsworth / Maine Craft Weekend. 12pm-6pm. After-party at Black Moon Public House. |
+| **Customization notes** | Replace [BUSINESS NAME], [YOUR NAME], and specific benefit lines per prospect |
+
+---
+
+## Tier 1: Small Sponsor — Under $1K (Local Businesses)
+
+**Target:** Ellsworth/MDI local businesses, restaurants, shops, breweries, studios
+
+**Subject:** ZAOstock Music Festival — Oct 3 in Ellsworth — local sponsor opportunity
+
+---
+
+Hi [BUSINESS NAME],
+
+I'm Zaal, one of the organizers of ZAOstock — a new outdoor music festival happening October 3rd, 2026 at the Franklin Street Parklet in Ellsworth, 12pm to 6pm. We're part of the 9th Annual Art of Ellsworth and Maine Craft Weekend, so we'll be drawing from the statewide crowd that weekend brings, plus our own community.
+
+ZAOstock features 10 artists performing live sets, a live music battle bracket (WaveWarZ) where the audience votes for the winner, short talks between sets, and an after-party at Black Moon Public House. It's a full afternoon of music, food, and community — free to attend, family-friendly, and designed to bring energy to downtown Ellsworth on one of the busiest weekends of the year.
+
+We're looking for local sponsors at the **$250–$750 level** to help cover sound equipment rental, artist travel, and day-of logistics. Here's what you'd get:
+
+- **Logo on the printed program and event signage** (handed to every attendee)
+- **Social media shoutout** to our community of 188+ members across Farcaster, X, and our 400+ edition daily newsletter
+- **Table or banner space** at the parklet during the event
+- **Mention from stage** during the welcome and closing remarks
+- **Livestream visibility** — the full event is livestreamed to our online community
+
+This is Year 1. We're building something that grows with Ellsworth. Your early support means you're part of the founding story.
+
+Would you be open to a 15-minute conversation this week? I'm happy to stop by in person — I'm local.
+
+Best,
+Zaal
+ZAOstock Organizer
+zaoos.com/stock
+
+---
+
+## Tier 2: Medium Sponsor — $1K–$5K (Maine & Regional Brands)
+
+**Target:** Maine breweries/distilleries, outdoor brands, music gear companies, arts organizations, regional media
+
+**Subject:** Sponsor ZAOstock — Maine's first community-built music festival (Oct 3, Ellsworth)
+
+---
+
+Hi [YOUR NAME],
+
+I'm reaching out because [BUSINESS NAME] aligns perfectly with what we're building. ZAOstock is a new outdoor music festival on October 3rd, 2026 in Ellsworth, Maine — 10 live artists, a live audience-voted music battle, short talks, and an after-party. We're part of the 9th Annual Art of Ellsworth and Maine Craft Weekend, tapping into the statewide traffic that weekend already generates.
+
+What makes ZAOstock different: we're community-built. Our organizing team of 14 active members and 4 advisors has been meeting weekly for over 90 consecutive weeks — that's nearly two years of consistent governance. We've produced events at NFT NYC (12 artists), Art Basel Miami (10 artists), and ETH Denver. Our community publishes a daily newsletter with 400+ editions. This isn't a pop-up — it's a movement putting down roots in Maine.
+
+**At the $1,000–$5,000 level, sponsors receive:**
+
+- **Logo placement** on all event signage, printed programs, and the zaoos.com/stock event page
+- **Dedicated social media feature** (not just a mention — a full post about your brand) across our channels
+- **On-stage recognition** during 2 of our 5 talk segments
+- **Product placement or activation space** at the parklet — sample table, demo area, or branded tent section
+- **Livestream integration** — your logo on the stream overlay seen by our online audience
+- **Inclusion in post-event recap** content shared with our 188+ member community and newsletter subscribers
+
+The total event budget is $5K–$25K. A $2,500 sponsorship meaningfully shapes this festival and puts your brand in front of hundreds of attendees plus our engaged online community of musicians, artists, and creators.
+
+We have a 6-hour run-of-show designed, a venue secured, and a team with real event production experience. Happy to share the full deck.
+
+Can we set up a 20-minute call this week?
+
+Best,
+Zaal
+ZAOstock Organizer | The ZAO
+zaoos.com/stock
+
+---
+
+## Tier 3: Large Sponsor — $5K+ (Regional / National Brands)
+
+**Target:** Music streaming platforms, crypto/web3 companies, national beverage brands, music equipment manufacturers, arts foundations
+
+**Subject:** ZAOstock 2026 — presenting sponsor opportunity for Maine's first onchain music festival
+
+---
+
+Hi [YOUR NAME],
+
+ZAOstock is a first-of-its-kind outdoor music festival launching October 3, 2026 in Ellsworth, Maine. We're inviting [BUSINESS NAME] to be a presenting sponsor — the brand most visibly associated with Year 1 of what we're building into a multi-year, multi-city festival series.
+
+**The event:** 10 live artists, a WaveWarZ live music battle bracket (audience votes via QR code — real stakes, real payouts to artists on-chain), 5 short talks, and an after-party at Black Moon Public House. Six hours of programming at the Franklin Street Parklet during Maine Craft Weekend, one of the state's largest statewide arts weekends. Free admission. Fully livestreamed.
+
+**The organization behind it:** The ZAO (ZTalent Artist Organization) is a 188-member decentralized music community that has run 90+ consecutive weekly governance sessions, published 400+ daily newsletter editions, produced events at NFT NYC (12 artists), Art Basel Miami (10 artists, AR installations), and ETH Denver. Our WaveWarZ music battle platform has hosted 795 battles with 435 SOL ($37K+) in real trading volume and direct artist payouts. We have a 14-person organizing team with advisors from Whop ($1.6B creator platform), JPMorgan/Accenture alumni, and NEA/Warhol-funded artists.
+
+**At the $5,000+ presenting sponsor level:**
+
+- **"Presented by [BRAND]"** on all materials — signage, programs, website, social, livestream, and press
+- **Dedicated 5-10 minute brand moment** on stage (talk slot, demo, or artist introduction)
+- **Premium activation space** — branded tent section with full setup
+- **Co-branded content series** — pre-event features, day-of coverage, post-event recap across all ZAO channels
+- **Logo on the WaveWarZ voting interface** — every attendee scanning the QR code sees your brand
+- **VIP access** to the after-party and artist meet-and-greet
+- **First right of refusal** for ZAOstock Year 2 and ZAOVille (our planned DMV-area satellite festival)
+- **Direct association with transparent artist payments** — your brand funds artists who get paid on-chain, publicly and fairly
+
+This is Year 1 — the ground floor. Early presenting sponsors don't just get visibility, they get credit for helping launch something new. We're building in public: every decision, every budget line, every planning session is documented and shared with our community.
+
+I'd love to set up a 30-minute call to walk through the full sponsorship deck and discuss how we can tailor the partnership to [BUSINESS NAME]'s goals.
+
+Best,
+Zaal
+ZAOstock Organizer | The ZAO
+zaoos.com/stock | cocconcertz.com
+
+---
+
+## Usage Notes
+
+- **Personalize every email.** Replace bracketed fields. Add a sentence about why that specific business fits.
+- **Attach or link:** Event one-pager (to be created), zaoos.com/stock page, @zaofestivals Instagram for ZAO-Chella photos.
+- **Follow up:** 5 business days after send. Reference a specific thing about their business.
+- **Track:** Use a shared spreadsheet (Finance team — DFresh, Ohnahji B, Maceo) to log every outreach, response, and status.
+
+## Sources
+
+- [Doc 274 — Team Deep Profiles](../274-zao-stock-team-deep-profiles/)
+- [Doc 363 — People + Brands 2026](../../community/363-zao-stock-people-brands-2026/)
+- [Doc 270 — ZAOstock Planning](../270-zao-stock-planning/)
+- [Doc 428 — Run-of-Show Program](../428-zaostock-run-of-show-program/)


### PR DESCRIPTION
## Summary
- Three-tier sponsor pitch email templates for ZAOstock Oct 3, 2026
- **Tier 1** (under $1K): Local Ellsworth businesses — logo, table space, stage mention
- **Tier 2** ($1-5K): Maine/regional brands — dedicated social features, activation space, livestream integration
- **Tier 3** ($5K+): Presenting sponsor — "Presented by" branding, stage time, WaveWarZ QR integration, Year 2 first refusal
- Each pitch has subject line, ~250-word body, clear ask, and specific benefits
- Built from docs 274, 363, 270, 428

## Test plan
- [ ] Review pitch tone and accuracy with Finance team (DFresh, Ohnahji B, Maceo)
- [ ] Verify all stats match latest data
- [ ] Customize and send first batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)