### PR TITLE
docs: Crown Vics artist outreach for ZAO Stock Oct 3 (doc 446)

### DIFF
--- a/research/music/446-crown-vics-artist-outreach/README.md
+++ b/research/music/446-crown-vics-artist-outreach/README.md
@@ -1,0 +1,231 @@
+# Doc 446: Crown Vics Artist Outreach - ZAO Stock Oct 3 Music Programming
+
+**Created:** 2026-04-20
+**Category:** Music / Artist Relations / ZAO Stock Programming
+**Use Case:** Artist outreach package for The Crown Vics (Steve Peer's rockabilly band) to anchor ZAO Stock Oct 3 local music programming, bridging 37 years of Ellsworth music community with onchain music innovation.
+**Related:** Doc 224 (ZAO Stock Multi-Year Vision), Doc 274 (ZAO Stock Team Deep Profiles), Doc 363 (ZAO Stock People & Brands), Doc 419 (Matteo Tambussi / Livepeer), Doc 270 (ZAO Stock Planning)
+
+---
+
+## Table of Contents
+
+1. [Artist Spotlight Post](#1-artist-spotlight-post)
+2. [Invitation DM - Crown Vics Oct 3 Performance](#2-invitation-dm---crown-vics-oct-3-performance)
+3. [Livepeer Broadcast Proposal](#3-livepeer-broadcast-proposal)
+4. [Content Ideas](#4-content-ideas)
+5. [Background & Context](#5-background--context)
+
+---
+
+## 1. Artist Spotlight Post
+
+**For:** ZAO OS community feed / Farcaster / newsletter
+
+---
+
+### The Crown Vics: Ellsworth's Rockabilly Heart
+
+Before there was ZAO Stock, before there was an onchain music scene in Downeast Maine, there was a living room on Bayside Road.
+
+Steve Peer moved to Ellsworth in 1989 — fresh from the late-'70s NYC punk scene where he'd roadied for Richard Hell and Television at CBGB. He brought something with him that no venue could contain: the belief that music belongs in the room with you, not behind a velvet rope.
+
+Since 2009, the **430 Bayside Concert Series** has packed 50 people into Steve's living room, kitchen, and loft for house concerts that split 80/20 in the musicians' favor. Three shows a month at peak. Sixteen years running. No ticket fees, no corporate sponsors — just community showing up for community.
+
+The Crown Vics — Steve on drums alongside Drew Myers, Jennifer Myers, Frank Schwartz, and Gordon Fellis — are the rockabilly anchor of that ecosystem. They've charted in Australia, recorded the album *Hell Yeah!* in a single weekend at 430 Bayside, and assembled 40 musicians worldwide for *It's a Global Rock Thing* (2022).
+
+Steve doesn't just play in five active bands (Crown Vics, The Shambles, The Tumblers, Spilled Milk, The Larks). He's spent his day job as Director of Special Education at School Union 93, holding a M.Ed from UMaine. He builds community by day and soundtracks it by night.
+
+**Why this matters for The ZAO:** ZAO Stock (October 3, Franklin Street Parklet, Ellsworth) isn't parachuting a festival into a town. It's growing from roots that Steve Peer planted 37 years ago. The Crown Vics represent everything we believe — artist-first economics, community over clout, music that lives in the room with you. Now we're putting that room onchain.
+
+**Fun fact:** The 430 Bayside motto is "America's favorite house concert where everyone is welcome." Sounds like a DAO to us.
+
+---
+
+## 2. Invitation DM - Crown Vics Oct 3 Performance
+
+**For:** Direct message to Steve Peer (Farcaster / text / email)
+
+---
+
+Hey Steve,
+
+Hope the spring thaw is treating 430 Bayside well. I wanted to reach out about something we're building for October 3rd and I think you're the perfect person to talk to.
+
+We're producing **ZAO Stock** — a one-day music event on Franklin Street Parklet as part of Art of Ellsworth / Maine Craft Weekend. 10 artists, equal sets, DJs between. Goal: 200-500 people hearing live music on a Saturday in downtown Ellsworth.
+
+Here's the thing — ZAO Stock wouldn't make sense without the Crown Vics. You've been the backbone of live music in this town for almost four decades. We don't want to build something new on top of Ellsworth. We want to build something new *with* Ellsworth, and that starts with you.
+
+**What we're offering:**
+- **Headline set** for the Crown Vics at ZAO Stock (Oct 3, afternoon/evening TBD)
+- **Fair pay** — we run an 80/20 artist-first split, same as 430 Bayside (we learned from the best)
+- **ZABAL integration** — every attendee gets a digital token that unlocks Crown Vics content, exclusive recordings, and future perks. Think of it as a backstage pass that never expires. Your fans become stakeholders in your music.
+- **Livepeer broadcast** — we're working with an Italian web3 streaming team to broadcast performances live on Farcaster. Crown Vics could reach 10x the 430 Bayside room capacity while keeping the intimate feel.
+- **Advisory role** — if you're interested, we'd love your input on the full music lineup. Nobody knows Ellsworth artists like you do. 37 years of relationships > any booking algorithm.
+
+**The ZABAL angle:** ZABAL is our community token. When Crown Vics fans mint a ZABAL at ZAO Stock, they're not just buying a ticket — they're joining an artist-support network. Revenue flows back to performers through onchain splits (0xSplits). No middlemen, no label cut, no Ticketmaster fees. It's the 80/20 house concert model, but it scales to 500 people and lives on the internet forever.
+
+No pressure, no rush. I'd love to grab coffee or swing by Bayside to talk through it. This only works if it feels right to you.
+
+Best,
+Zaal
+
+P.S. — After-party at Black Moon Public House, 30 seconds from the parklet. Crown Vics closing set into the after-party would be legendary.
+
+---
+
+## 3. Livepeer Broadcast Proposal
+
+**For:** Internal planning doc tying Crown Vics performance to Doc 419 (Matteo Tambussi / Livepeer thread)
+
+---
+
+### Crown Vics x Livepeer x Farcaster: Live from ZAO Stock
+
+**Context:** Doc 419 documents the connection with Matteo Alessio Tambussi — ex-musician, Ethereum Berlin 2018 veteran, co-organizer of ETHTurin/SpaghettETH, and builder of web3radio.it. Matteo's team has deep Livepeer integration experience and is exploring Farcaster streaming mini apps.
+
+**Proposal:** Partner with Matteo's team to produce a professional Livepeer-powered broadcast of ZAO Stock, with the Crown Vics set as the flagship stream.
+
+### Why Crown Vics + Livepeer
+
+| Element | Traditional Stream | Livepeer + Farcaster Stream |
+|---------|-------------------|----------------------------|
+| **Cost** | $500-2K for platform fees | Livepeer transcoding at fraction of centralized cost |
+| **Reach** | YouTube/Twitch (algorithm-gated) | Farcaster feed (community-native, composable) |
+| **Monetization** | Ads, donations | ZABAL-gated access tiers, onchain tipping, NFT moments |
+| **Archive** | Platform-owned VOD | IPFS/Arweave permanent archive, community-owned |
+| **Interactivity** | Chat sidebar | Farcaster frames for live reactions, song requests, merch drops |
+
+### Technical Integration
+
+1. **Capture:** Multi-camera setup at Franklin Street Parklet (2-3 cameras, board audio feed)
+2. **Encode:** Livepeer transcoding network for adaptive bitrate streaming
+3. **Distribute:** Farcaster mini app (per Doc 419 recommendations) embedded in ZAO OS feed
+4. **Monetize:** ZABAL-gated tiers:
+   - **Free tier:** Audio-only stream on Farcaster
+   - **ZABAL holder tier:** Full video + backstage cam + chat
+   - **Collector tier:** Mint individual songs as onchain moments (NFT clips of live performance)
+5. **Archive:** Post-show VOD minted as community-owned media on IPFS
+
+### Matteo Collaboration Points
+
+- **Technical advisory:** Livepeer node setup, transcoding pipeline, Farcaster frame architecture
+- **Cross-promotion:** web3radio.it audience discovers Crown Vics and ZAO Stock; Italian web3 music scene meets Downeast Maine
+- **Proof of concept:** ZAO Stock becomes a reference implementation for Livepeer + Farcaster live music — reusable by any community
+- **ETHTurin connection:** If successful, Crown Vics performance clip could be showcased at SpaghettETH/ETHTurin as a case study
+
+### Budget Estimate
+
+| Item | Cost | Notes |
+|------|------|-------|
+| Livepeer transcoding | ~$50-100 | Pay-per-use, fraction of traditional CDN |
+| Camera operator(s) | $300-500 | Local crew, 4-hour shoot |
+| Audio board split | $0 | Standard output from PA system |
+| Farcaster mini app dev | Internal | ZAO OS team builds this |
+| Matteo advisory | Partnership | Knowledge exchange, not cash |
+| **Total** | **~$350-600** | vs. $2-5K for traditional streaming production |
+
+---
+
+## 4. Content Ideas
+
+### 4.1 Playlist Takeover: "Steve Peer's Ellsworth Jukebox"
+
+**Format:** Curated playlist on ZAO OS radio featuring tracks hand-picked by Steve Peer — the songs that shaped Ellsworth's music scene over 37 years.
+
+**Execution:**
+- Steve selects 20-30 tracks: Crown Vics originals, 430 Bayside favorite performers, NYC punk influences (Richard Hell, Television, Ramones), and the northern soul / R&B that fuels The Tumblers
+- Each track gets a one-line Steve Peer annotation ("This is the song that made me move to Maine" / "Jennifer Myers sang this at the first 430 Bayside show")
+- Published as a ZAO OS Radio feature 2 weeks before ZAO Stock (Sept 19)
+- Promoted on Farcaster with daily track reveals leading up to Oct 3
+
+**Why it works:** Positions Steve as a tastemaker, gives the community a musical education in Ellsworth's roots, and creates anticipation content for ZAO Stock with zero production cost.
+
+### 4.2 HyperFrames Behind-the-Scenes Video: "430 Bayside to Franklin Street"
+
+**Format:** Short-form documentary (3-5 min) shot at 430 Bayside Road, following Steve through his living room concert setup, then cutting to the Franklin Street Parklet build-out for ZAO Stock.
+
+**Execution:**
+- **Scene 1:** Steve in his living room, setting up folding chairs for a house concert. Voiceover: "I've been doing this since 2009. Fifty people in a living room. 80/20 split. No contracts."
+- **Scene 2:** Crown Vics rehearsal — raw, unpolished, real. Show the band as they actually are.
+- **Scene 3:** Cut to Franklin Street Parklet. Same energy, bigger stage. Steve walks the space, talks about what it means to bring this downtown.
+- **Scene 4:** Split screen — 430 Bayside living room vs. Franklin Street Parklet. Same music, different scale. "From 50 to 500, but the deal stays the same."
+- **Distribution:** Minted as a HyperFrame on Farcaster (composable video NFT). Viewers can collect it, and proceeds flow to Crown Vics via 0xSplits.
+
+**Why it works:** Authentic storytelling that makes the ZAO Stock mission tangible. Not "we're disrupting the music industry" — it's "we're scaling what already works."
+
+### 4.3 Pre-Show Telegram Livestream: "Soundcheck with the Crown Vics"
+
+**Format:** 30-minute casual livestream on the ZAO Telegram channel the evening before or morning of ZAO Stock (Oct 2 evening or Oct 3 morning).
+
+**Execution:**
+- **Setting:** Crown Vics soundcheck at Franklin Street Parklet or backstage area
+- **Host:** Zaal (or ZOE agent relaying questions from Telegram chat)
+- **Content:**
+  - Steve tells the CBGB stories (Richard Hell, Television — the punk history is gold)
+  - Band plays 2-3 acoustic/stripped-down songs during soundcheck
+  - Live Q&A from Telegram members ("What was the wildest 430 Bayside show?")
+  - Announce the set time and any surprise guests
+  - ZABAL holders get a secret link to an extended soundcheck or unreleased track
+- **Archive:** Recording saved to ZAO OS media library, clippable for Farcaster posts
+
+**Why it works:** Builds day-of hype, gives remote ZAO members a reason to tune in, and creates intimate content that contrasts with the main event scale. The CBGB stories alone are worth the stream — Steve's history bridges NYC punk to Downeast Maine in a way that no marketing copy can.
+
+---
+
+## 5. Background & Context
+
+### Steve Peer Profile
+
+| Detail | Info |
+|--------|------|
+| **Location** | 430 Bayside Road, Ellsworth, Maine |
+| **In Ellsworth since** | 1989 (37 years) |
+| **Origin** | Dover, NJ; late-1970s NYC punk scene (CBGB, roadie for Richard Hell/Television) |
+| **Day job** | Director of Special Education, School Union 93; M.Ed, UMaine |
+| **Active bands** | Crown Vics (rockabilly), The Shambles (blues), The Tumblers (R&B/northern soul), Spilled Milk (alt-rock), The Larks (punk) |
+| **House concerts** | 430 Bayside Concert Series (est. 2009), 50-person capacity, 80/20 artist split |
+| **Notable albums** | *Hell Yeah!* (2022, recorded at 430 Bayside in one weekend), *It's a Global Rock Thing* (2022, 40 musicians worldwide) |
+| **Press** | BDN (2010), Central Maine (2019), Profiles Maine (2013: "The coolest guy we know") |
+| **ZAO Stock role** | Proposed: Local Music Director / Advisory Board (not yet pitched) |
+
+### Crown Vics Members
+
+| Name | Role |
+|------|------|
+| Steve Peer | Drums |
+| Drew Myers | Guitar/Vocals |
+| Jennifer Myers | Vocals |
+| Frank Schwartz | Bass |
+| Gordon Fellis | Guitar |
+
+### ZAO Stock Quick Reference
+
+- **Date:** October 3, 2026 (Saturday)
+- **Venue:** Franklin Street Parklet, Ellsworth, Maine
+- **Context:** 9th Annual Art of Ellsworth / Maine Craft Weekend
+- **Format:** 10 artists, equal sets, DJs between
+- **After-party:** Black Moon Public House (30 seconds from parklet)
+- **Budget:** $5K-$25K
+- **Target:** 200-500 attendees (Year 1)
+
+---
+
+## Sources
+
+- [430 Bayside Concert Series — BDN (2010)](https://bangordailynews.com)
+- [Steve Peer of The Crown Vics — Central Maine (2019)](https://centralmaine.com)
+- [Profiles Maine — "The coolest guy we know" (2013)](https://profilesmaine.com)
+- [The Crown Vics — Facebook](https://facebook.com/thecrownvicsband/)
+- [Livepeer Documentation](https://docs.livepeer.org/)
+- [Matteo Tambussi / web3radio.it — Doc 419](../community/419-maceo-call-matteo-tambussi-italy-web3-music/README.md)
+
+---
+
+## Cross-References
+
+- **Doc 224** — ZAO Stock Multi-Year Vision (Steve Peer profile, local music director role)
+- **Doc 270** — ZAO Stock Planning & Knowledge Base (festival logistics, NFT integration)
+- **Doc 274** — ZAO Stock Team Deep Profiles (Steve Peer section, full discography)
+- **Doc 363** — ZAO Stock People & Brands Index (advisory board status)
+- **Doc 419** — Matteo Tambussi / Livepeer / Italy Web3 Music (streaming infrastructure partner)
+- **Doc 433** — Agent Outbound Phone Calls (Steve Peer call task reference)


### PR DESCRIPTION
## Summary

- Artist outreach package for The Crown Vics (Steve Peer's rockabilly band) to anchor ZAO Stock Oct 3 local music programming in Ellsworth
- Includes community spotlight post, performance invitation DM with ZABAL token angle, Livepeer broadcast proposal (tying into doc 419 Matteo/web3radio.it thread), and 3 content ideas
- Content ideas: playlist takeover ("Steve Peer's Ellsworth Jukebox"), HyperFrames behind-the-scenes video ("430 Bayside to Franklin Street"), pre-show Telegram livestream ("Soundcheck with the Crown Vics")

## Deliverables

1. **Artist Spotlight Post** — community feed / Farcaster / newsletter ready
2. **Invitation DM** — direct outreach to Steve Peer with ZABAL integration pitch
3. **Livepeer Broadcast Proposal** — technical plan + budget ($350-600) linking Matteo's team
4. **3 Content Ideas** — playlist takeover, BTS video, pre-show livestream

## Test plan

- [ ] Review spotlight post tone matches BetterCallZaal brand voice (doc 358)
- [ ] Verify all cross-references to docs 224, 270, 274, 363, 419 are accurate
- [ ] Confirm ZAO Stock details (Oct 3, Franklin Street Parklet, budget range) match planning docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)