### PR TITLE
docs: ECC Path B — full plugin install (doc 441)

### DIFF
--- a/research/agents/451-ao-claude-code-dialog-block-forensics/README.md
+++ b/research/agents/451-ao-claude-code-dialog-block-forensics/README.md
@@ -1,0 +1,147 @@
+# AO Claude Code Dialog Block Forensics - Doc 451
+
+**Date:** 2026-04-20  
+**Status:** RESEARCH - Do Not Apply Yet  
+**Affected Sessions:** zaoos-39, zaoos-40, zaoos-41  
+**Root Cause:** Claude Code auto-updater dialog blocking stdin — sessions spawn correctly but hang waiting for dialog dismissal
+
+---
+
+## Key Findings
+
+| Finding | Detail |
+|---------|--------|
+| Dialog Text | `Auto-update failed · Try claude doctor or npm …` |
+| Blocker Type | User-facing dialog (not permission dialog) |
+| Current Patch Applied | Yes — `--permission-mode acceptEdits` already in plugin |
+| Env Var Name | `CLAUDE_AUTOUPDATER_DISABLE=1` (Anthropic default for CI) |
+| Plugin File | `~/.local/lib/node_modules/@aoagents/ao/node_modules/@aoagents/ao-plugin-agent-claude-code/dist/index.js` |
+| Plugin Version | @aoagents/ao-plugin-agent-claude-code v0.2.5 |
+| Claude Code Version | 2.1.86 |
+
+---
+
+## Problem Statement
+
+Sessions zaoos-40 and zaoos-41 are still alive (created Mon Apr 20 00:19:29-38 2026), but the Claude Code prompt is frozen. Tmux capture shows:
+
+```
+⏵⏵ accept edits on (shift ✗ Auto-update failed · Try claude doctor or npm …
+```
+
+The prompt is displayed but Claude Code never processes it. The dialog message appears to be from Claude's auto-updater check failing, not a permission issue. This is distinct from the earlier permission-dialog blocker fixed by the `--permission-mode acceptEdits` patch.
+
+Cause: Claude Code spawns and shows the task context, but when it tries to present the next prompt, the auto-updater dialog appears. Since we can't interact with tmux dialogs in headless mode, the session hangs indefinitely.
+
+---
+
+## Exact Dialog Output
+
+From `tmux capture-pane -t 2883535895a7-zaoos-40 -p -S -200`:
+
+```
+⏵⏵ accept edits on (shift ✗ Auto-update failed · Try claude doctor or npm …
+```
+
+This indicates:
+- Claude Code CLI is running (`⏵⏵ accept edits on`)
+- A dialog is blocking (shift key symbol)
+- Auto-update check failed or was skipped
+- User interaction required to dismiss
+
+---
+
+## Solution: Environment Variable Injection
+
+**Env Var:** `CLAUDE_AUTOUPDATER_DISABLE=1`
+
+Claude Code respects `CLAUDE_AUTOUPDATER_DISABLE` to skip the updater check entirely. This is the standard Anthropic pattern for CI/automation environments.
+
+---
+
+## Proposed Patch
+
+File: `~/.local/lib/node_modules/@aoagents/ao/node_modules/@aoagents/ao-plugin-agent-claude-code/dist/index.js`
+
+Location: `getEnvironment()` function around line 612.
+
+```diff
+         getEnvironment(config) {
+             const env = {};
++            // Disable Claude Code auto-updater in orchestrator context (headless)
++            env["CLAUDE_AUTOUPDATER_DISABLE"] = "1";
+             // Unset CLAUDECODE to avoid nested agent conflicts
+             env["CLAUDECODE"] = "";
+             // Set session info for introspection
+             env["AO_SESSION_ID"] = config.sessionId;
+```
+
+This adds one line to the environment object returned by `getEnvironment()`, ensuring every spawned Claude Code session runs with the auto-updater disabled.
+
+---
+
+## Verification Steps
+
+Once patched:
+
+1. Kill current hung sessions (or let them timeout)
+2. Run a new AO session spawn
+3. Monitor tmux pane: `tmux capture-pane -t <name> -p -S -50`
+4. Verify Claude Code processes prompt immediately (no "Auto-update failed" dialog)
+5. Check session logs for successful tool invocation
+
+Respawn command:
+```bash
+# On VPS, once patched:
+curl -X POST http://localhost:3000/spawn-session \
+  -H "Content-Type: application/json" \
+  -d '{"agentName":"claude-code","task":"Your test prompt here"}'
+```
+
+---
+
+## Why This Happens
+
+- Claude Code v2.1.86 checks for updates on startup (networking call)
+- In VPS headless environment, no TTY → dialog can't be dismissed
+- Prompt is already rendered, waiting for user to hit a key → deadlock
+- `--permission-mode acceptEdits` bypasses permission dialogs but NOT updater dialogs (separate system)
+
+---
+
+## Alternative: Source-Level Patch
+
+If the above env var patch doesn't work, the AO plugin could also inject the env var at Claude spawn time using `execFileAsync()` options:
+
+```typescript
+// In getLaunchCommand or spawn logic
+const env = { ...process.env, ...config.environment };
+env["CLAUDE_AUTOUPDATER_DISABLE"] = "1";
+execFileAsync("claude", [...args], { env });
+```
+
+But `getEnvironment()` is cleaner and follows the plugin's existing pattern.
+
+---
+
+## Files Involved
+
+- Plugin source: `~/.local/lib/node_modules/@aoagents/ao/node_modules/@aoagents/ao-plugin-agent-claude-code/dist/index.js`
+- Sessions: `~/.agent-orchestrator/2883535895a7-ZAOOS/`
+- Tmux windows: `2883535895a7-zaoos-40`, `2883535895a7-zaoos-41`
+- Lifecycle log: `~/.agent-orchestrator/2883535895a7-ZAOOS/lifecycle-worker.log`
+
+---
+
+## Timeline
+
+- zaoos-40 created: 2026-04-20T00:19:29Z
+- zaoos-41 created: 2026-04-20T00:19:38Z
+- Hung state detected: ~00:20Z (right after spawn, before prompt processing)
+- Status at forensics: Still alive, frozen on dialog (2026-04-20T09:15Z)
+
+---
+
+## Do Not Apply
+
+This is research only. Wait for explicit instruction before patching the plugin file on the VPS. The hung sessions are safe to leave running and can be killed manually if needed.

--- a/research/dev-workflows/441-everything-claude-code-integration/MANIFEST.md
+++ b/research/dev-workflows/441-everything-claude-code-integration/MANIFEST.md
@@ -1,0 +1,226 @@
+### MANIFEST — ECC-origin Artifacts Installed
+
+> Source: `affaan-m/everything-claude-code`
+> Pinned SHA: `8bdf88e5ad8877bcd00a4aba7ccbfb50f235f10f` (audit reference)
+> Pinned date: 2026-04-19
+> Last updated: 2026-04-20 (Path B — full plugin install)
+
+---
+
+## Current Strategy: PATH B (Full Plugin Install + Selective Disable)
+
+Previous Path A cherry-picks REMOVED. Plugin now provides all ECC artifacts natively, selectively filtered via `skillOverrides`.
+
+### Why Path B?
+- Unlocks `continuous-learning-v2` (instinct system) — the biggest ECC feature.
+- Unlocks `/checkpoint`, `/verify`, `/learn`, `/harness-audit`, `/evolve`, `/prune`, `/instinct-*` commands.
+- Unlocks all ECC hooks (coupled to plugin bootstrap).
+- Cherry-pick overhead eliminated — upstream ECC updates flow through.
+
+### Trade-off
+- 48 agents + 79 commands load (no filter mechanism).
+- 183 skills, but 163 disabled via `skillOverrides`.
+- Active skill count from ECC plugin: **20**.
+
+---
+
+## Plugin Config (~/.claude/settings.json)
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "everything-claude-code": {
+      "source": { "source": "github", "repo": "affaan-m/everything-claude-code" }
+    }
+  },
+  "enabledPlugins": {
+    "everything-claude-code@everything-claude-code": true
+  },
+  "skillOverrides": {
+    "everything-claude-code:<skill-name>": "off"  // 163 entries
+  }
+}
+```
+
+Backup: `~/.claude/settings.json.pre-path-b-2026-04-20`
+Previous (Path A) backup still at: `~/.claude/settings.json.pre-ecc-2026-04-19`
+
+---
+
+## Active ECC Skills (20, plugin-scoped as `everything-claude-code:<name>`)
+
+### Top 10 (daily-use, from doc 442)
+| Skill | Why |
+|-------|-----|
+| `continuous-learning-v2` | Instinct store — captures patterns session-to-session |
+| `continuous-learning` | Legacy compat for CL-v2 hooks |
+| `verification-loop` | Post-edit build/test/lint/typecheck cycle |
+| `security-review` | OWASP + cloud infra checklist |
+| `eval-harness` | Eval-driven dev for VAULT/BANKER/DEALER |
+| `nextjs-turbopack` | Next.js 16 + Turbopack perf knobs |
+| `postgres-patterns` | Supabase query/index/RLS patterns |
+| `database-migrations` | Safe schema change playbook |
+| `hookify-rules` | Author hookify rules from natural language |
+| `agent-introspection-debugging` | Debug ZAO agents when they loop |
+| `skill-stocktake` | Audit 80+ skill quality |
+
+### Honorable mentions (kept, situational)
+| Skill | When |
+|-------|------|
+| `gateguard` | Fact-forcing gate before edits (+2.25 quality) |
+| `rules-distill` | Auto-promote cross-cutting principles to `.claude/rules/` |
+| `architecture-decision-records` | ADRs for major new modules |
+| `prompt-optimizer` | Tune agent/skill prompts |
+| `canary-watch` | Pre-deploy regression radar |
+| `deployment-patterns` | Vercel + rollout patterns |
+| `mcp-server-patterns` | Maintain ZAO's existing MCP server |
+| `content-hash-cache-pattern` | SHA-256 file processing cache |
+| `strategic-compact` | Context compaction suggestions |
+
+---
+
+## Disabled (163 of 183 ECC skills — see `/tmp/ecc-overrides.json` or settings.json)
+
+Dropped reasons:
+- Framework not in ZAO stack (Django, Spring, Laravel, NestJS, Nuxt, Rails, Flutter, Android, etc.)
+- Language not TS/Python (Go, Rust, C++, Perl, Java, C#, PHP, Ruby)
+- Industry-specific (healthcare, logistics, customs, carrier)
+- Direct duplicates of existing ZAO skills (tdd-workflow, code-reviewer, planner, etc.)
+- Niche / unclear value (ralphinho-rfc, santa-method, ck, etc.)
+
+Full list lives in `~/.claude/settings.json` `skillOverrides` block.
+
+---
+
+## Agents (48 — all load, no filter mechanism)
+
+Most daily-relevant:
+- `silent-failure-hunter` — hunt swallowed errors (pre-ship)
+- `pr-test-analyzer` — behavioral coverage check on PR diffs
+- `harness-optimizer` — audit Claude Code setup
+- `planner` / `architect` — reference only (prefer `/plan-eng-review` + `/plan-ceo-review`)
+- Language reviewers (`typescript-reviewer`, `python-reviewer`, etc.) — ignore unless targeting language
+
+---
+
+## Commands (79 — all load as slash commands)
+
+Key additions from Path B (previously absent):
+- `/checkpoint` — save verification state
+- `/verify` — run verification loop
+- `/learn` — extract patterns from session
+- `/learn-eval` — extract + evaluate before saving
+- `/harness-audit` — audit repository harness
+- `/evolve` — evolve captured instincts
+- `/prune` — remove stale instincts
+- `/instinct-status` / `/instinct-import` / `/instinct-export`
+- `/skill-create` — generate skills from git history
+- `/skill-health` — check skill quality
+- `/model-route` — task routing by complexity
+- `/pm2` — service lifecycle
+- `/multi-plan` / `/multi-execute` / `/orchestrate`
+
+Collisions to watch (if they happen, rename in doc 442 follow-up):
+- `/plan` — we have `/plan-eng-review`, `/plan-ceo-review`, `/plan-design-review`
+- `/tdd` — we have superpowers:test-driven-development
+- `/e2e` — we have `/qa`, `gstack`
+- `/build-fix`, `/refactor-clean` — unclear, likely fine
+
+---
+
+## Hooks (active via plugin)
+
+ECC `hooks.json` wires many PreToolUse/PostToolUse/SessionStart hooks. Plugin bootstrap handles execution:
+- `pre:bash:dispatcher` — bash preflight checks
+- `pre:write:doc-file-warning` — warn on non-standard docs
+- `pre:edit-write:suggest-compact` — auto-compact suggestion
+- `pre:observe:continuous-learning` — capture tool use for CL-v2
+- `pre:governance-capture` — policy/secret events
+- `pre:config-protection` — block linter/formatter config edits
+- `pre:mcp-health-check` — MCP server health gate
+- `pre:edit-write:gateguard-fact-force` — gateguard fact-forcing
+- `PreCompact` hooks
+- Plus SessionStart hooks
+
+Strictness controlled via env var `ECC_HOOK_PROFILE=minimal|standard|strict` (default: standard after plugin install).
+
+---
+
+## MCPs (still manual, separate from plugin)
+
+Installed via `claude mcp add`:
+- `context7` — `npx -y @upstash/context7-mcp@2.1.4`
+- `playwright` — `npx -y @playwright/mcp@0.0.69 --extension`
+
+Stored in `~/.claude.json` (not settings.json).
+
+---
+
+## Rules (still manual, plugin can't auto-distribute)
+
+- `.claude/rules/typescript-hygiene.md` — merged additive from ECC `rules/typescript/`
+
+---
+
+## Env Vars
+
+`~/.claude/settings.json` env:
+- `MAX_THINKING_TOKENS=10000`
+- `CLAUDE_CODE_SUBAGENT_MODEL=haiku`
+
+Plugin may add `ECC_HOOK_PROFILE`, `ECC_DISABLED_HOOKS`, `ECC_GOVERNANCE_CAPTURE`, etc. Check after first load.
+
+---
+
+## Rollback (to Pre-ECC State)
+
+```bash
+cp ~/.claude/settings.json.pre-ecc-2026-04-19 ~/.claude/settings.json
+```
+
+## Partial Rollback (from Path B to Path A)
+
+```bash
+cp ~/.claude/settings.json.pre-path-b-2026-04-20 ~/.claude/settings.json
+# Then re-install the 10 ecc-* cherry-picks per previous MANIFEST entry
+```
+
+## Rollback (remove just plugin, keep everything else)
+
+Remove from settings.json:
+- `enabledPlugins["everything-claude-code@everything-claude-code"]`
+- `extraKnownMarketplaces["everything-claude-code"]`
+- All `skillOverrides` keys starting with `everything-claude-code:`
+
+---
+
+## Verification (after Claude Code restart)
+
+Run these to confirm plugin loaded:
+
+```bash
+# Plugin listing
+claude /plugin list
+
+# Should see everything-claude-code@everything-claude-code
+
+# Skill listing should include everything-claude-code:continuous-learning-v2, :verification-loop, etc.
+# Disabled skills should NOT appear.
+
+# Commands — test
+claude /learn
+claude /checkpoint
+claude /verify
+claude /harness-audit
+```
+
+---
+
+## Next Steps
+
+1. Restart Claude Code to trigger plugin install from marketplace.
+2. Verify 20 ECC skills visible, ~163 hidden.
+3. Test `/learn` + `/checkpoint` + `/verify` + `/harness-audit` commands.
+4. Run `/harness-audit` on current setup — save report.
+5. 7-day window: use `/learn` at end of each session to populate instinct store.
+6. 2026-04-27: evaluate continuous-learning-v2 value via `/instinct-status`.

--- a/research/dev-workflows/441-everything-claude-code-integration/PLAN.md
+++ b/research/dev-workflows/441-everything-claude-code-integration/PLAN.md
@@ -263,6 +263,34 @@ Phases 2, 3, 4, 5 can run in parallel after Phase 1. Sequence 6 → 7 → 8.
 
 ---
 
-## Next Action
+## Execution Log
 
-Confirm scope + open questions with Zaal, then kick Phase 1 in a fresh `ws/` worktree branch.
+**2026-04-19** — Audit + Path A cherry-pick start (see AUDIT.md). 5 skills + 2 cmds + haiku env installed.
+
+**2026-04-20 AM** — Doc 442 top-picks ranking. Extended Path A to 10 skills + 1 agent + 6 cmds. Dropped `ecc-strategic-compact`. Added Context7 + Playwright MCPs via `claude mcp add`. AgentShield baselines captured (project B/83, global D/55 with 1 critical `Bash(*)`). TS hygiene rule merged.
+
+**2026-04-20 PM — SWITCHED TO PATH B (full plugin install).**
+
+All Path A cherry-picks REMOVED. ECC plugin installed via settings.json:
+- `extraKnownMarketplaces["everything-claude-code"]` → github source
+- `enabledPlugins["everything-claude-code@everything-claude-code"]: true`
+- `skillOverrides` — 163 skills set to `"off"`, 20 kept enabled
+
+**Why Path B:** Unlocks `continuous-learning-v2` (instinct system), `/checkpoint`, `/verify`, `/learn`, `/harness-audit`, `/evolve`, `/prune`, `/instinct-*` commands, full hook suite (coupled to plugin bootstrap). Cherry-pick overhead eliminated.
+
+**Cost:** 48 agents + 79 commands load without filter (no agent/command override mechanism). Accepted.
+
+Backup: `~/.claude/settings.json.pre-path-b-2026-04-20`.
+
+See `MANIFEST.md` for active-20 skill list + rollback. See `AUDIT.md` for discovery findings. See doc 442 for ranking methodology. See doc 448 for per-artifact teaching guide.
+
+---
+
+## Next Action (post-restart)
+
+1. Restart Claude Code → plugin install from marketplace.
+2. Verify 20 ECC skills visible as `everything-claude-code:<name>`.
+3. Test `/learn` + `/checkpoint` + `/verify` + `/harness-audit` commands.
+4. Run `/harness-audit` once — save report under `441-.../harness-audit-report.md`.
+5. 7-day window (thru 2026-04-27): invoke `/learn` at end of each work session.
+6. 2026-04-27: `/instinct-status` check + decide keep/drop per skill.


### PR DESCRIPTION
## Summary
Switched from cherry-pick (Path A) to full ECC plugin install (Path B) via settings.json.

## Why
Unlocks the features Path A couldn't reach — all coupled to ECC plugin bootstrap:
- `continuous-learning-v2` (instinct system — captures session-to-session patterns)
- `/checkpoint`, `/verify`, `/learn`, `/harness-audit`, `/evolve`, `/prune`, `/instinct-*`
- Full ECC hook suite: gateguard fact-forcing, governance-capture, config-protection, mcp-health-check

## Changes to ~/.claude/settings.json

```json
{
  "extraKnownMarketplaces": {
    "everything-claude-code": {
      "source": { "source": "github", "repo": "affaan-m/everything-claude-code" }
    }
  },
  "enabledPlugins": {
    "everything-claude-code@everything-claude-code": true
  },
  "skillOverrides": {
    // 163 entries set to "off" — everything outside the 20-skill keep list
  }
}
```

Backup: `~/.claude/settings.json.pre-path-b-2026-04-20`

## Active (20 ECC skills, kept enabled)
**Daily-use (Tier 1):** continuous-learning-v2, verification-loop, security-review, eval-harness, nextjs-turbopack, postgres-patterns, database-migrations, hookify-rules, agent-introspection-debugging, skill-stocktake

**Situational (Tier 2):** gateguard, rules-distill, architecture-decision-records, prompt-optimizer, canary-watch, deployment-patterns, mcp-server-patterns, content-hash-cache-pattern, strategic-compact, continuous-learning

## Disabled (163 ECC skills)
Framework-specific (Django/Spring/Laravel/etc), non-TS languages, industry-niche, duplicates of existing ZAO skills.

## Removed (all Path A cherry-picks)
- 10 ecc-* skill copies in `~/.claude/skills/`
- 1 ecc-* agent in `~/.claude/agents/`
- 6 ecc-* commands in `~/.claude/commands/`
- Kept: `.claude/rules/typescript-hygiene.md` (plugin can't auto-distribute rules)
- Kept: Context7 + Playwright MCPs (stored in `~/.claude.json`)

## Trade-off Accepted
48 agents + 79 commands load without filter (no override mechanism). Manageable.

## Test plan
- [ ] Restart Claude Code — plugin auto-installs from marketplace
- [ ] `claude /plugin list` shows `everything-claude-code@everything-claude-code`
- [ ] Skill listing shows ~20 `everything-claude-code:*` skills (not 183)
- [ ] `/learn`, `/checkpoint`, `/verify`, `/harness-audit` commands work
- [ ] Caveman + superpowers + oh-my-mermaid still loaded