### PR TITLE
ops(portal): durable AO fixes (spawn path + archive cron)

### DIFF
--- a/infra/portal/bin/archive-ao-sessions.sh
+++ b/infra/portal/bin/archive-ao-sessions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Archive terminal AO sessions (killed / merged / exited) so the dashboard
+# sidebar badge only counts active work. Moves session dirs from
+# ~/.agent-orchestrator/<project>/sessions/<id> -> .../sessions/archive/<id>.
+#
+# Run weekly via cron. Safe to run ad-hoc.
+
+set -euo pipefail
+
+AO_ROOT="${AO_ROOT:-$HOME/.agent-orchestrator}"
+LOG="${HOME}/portal-logs/archive-ao-sessions.log"
+mkdir -p "$(dirname "$LOG")"
+
+exec >>"$LOG" 2>&1
+echo "=== $(date -Iseconds) archive-ao-sessions ==="
+
+if [ ! -d "$AO_ROOT" ]; then
+  echo "AO_ROOT missing: $AO_ROOT"
+  exit 0
+fi
+
+AUTH_TOKEN_FILE="${HOME}/.auth-token"
+if [ ! -f "$AUTH_TOKEN_FILE" ]; then
+  echo "auth-token missing; skipping api probe"
+fi
+
+archived_count=0
+for project_dir in "$AO_ROOT"/*/sessions; do
+  [ -d "$project_dir" ] || continue
+  mkdir -p "$project_dir/archive"
+  for session in "$project_dir"/*; do
+    [ -d "$session" ] || continue
+    name=$(basename "$session")
+    case "$name" in
+      archive) continue ;;
+    esac
+
+    # Skip sessions that still have a live tmux window (active work).
+    tmux_name="$(cat "$session/.tmux-session" 2>/dev/null || true)"
+    if [ -n "$tmux_name" ] && tmux has-session -t "$tmux_name" 2>/dev/null; then
+      echo "skip live: $name ($tmux_name)"
+      continue
+    fi
+
+    mv "$session" "$project_dir/archive/"
+    echo "archived: $name"
+    archived_count=$((archived_count + 1))
+  done
+done
+
+echo "total archived: $archived_count"

--- a/infra/portal/bin/patch-ao-plugin.sh
+++ b/infra/portal/bin/patch-ao-plugin.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Apply durable patches to the installed @aoagents/ao plugin so they survive
+# npm install / update. Idempotent - safe to re-run.
+#
+# Patch 1 (doc 441/428): use --permission-mode acceptEdits instead of
+#   --dangerously-skip-permissions (which always shows a blocking dialog).
+# Patch 2 (doc 451): inject CLAUDE_AUTOUPDATER_DISABLE=1 so Claude Code
+#   skips the auto-updater check that blocks headless sessions.
+#
+# Run after every `npm install -g @aoagents/ao` or `npm update`.
+
+set -euo pipefail
+
+PLUGIN="${AO_PLUGIN:-$HOME/.local/lib/node_modules/@aoagents/ao/node_modules/@aoagents/ao-plugin-agent-claude-code/dist/index.js}"
+LOG="${HOME}/portal-logs/patch-ao-plugin.log"
+mkdir -p "$(dirname "$LOG")"
+
+exec >>"$LOG" 2>&1
+echo "=== $(date -Iseconds) patch-ao-plugin ==="
+
+if [ ! -f "$PLUGIN" ]; then
+  echo "plugin missing: $PLUGIN"
+  exit 1
+fi
+
+cp "$PLUGIN" "$PLUGIN.bak-$(date +%s)"
+
+# Patch 1: --dangerously-skip-permissions -> --permission-mode acceptEdits
+if grep -q 'dangerously-skip-permissions' "$PLUGIN"; then
+  sed -i 's|parts.push("--dangerously-skip-permissions")|parts.push("--permission-mode", "acceptEdits")|g' "$PLUGIN"
+  echo "patch1 applied (permission-mode)"
+else
+  echo "patch1 already applied"
+fi
+
+# Patch 1b: ao-web Next.js compiled server chunks also embed the flag. Replace
+# the exact literal string so spawns via the web API (not the plugin path) also
+# use acceptEdits. Targets any chunk containing the flag under .next/server.
+AO_WEB_SERVER="${AO_WEB_SERVER:-$HOME/.local/lib/node_modules/@aoagents/ao/node_modules/@aoagents/ao-web/.next/server}"
+if [ -d "$AO_WEB_SERVER" ]; then
+  while IFS= read -r chunk; do
+    cp "$chunk" "$chunk.bak-$(date +%s)"
+    sed -i 's|"--dangerously-skip-permissions"|"--permission-mode","acceptEdits"|g' "$chunk"
+    echo "patch1b applied: $chunk"
+  done < <(grep -rl '"--dangerously-skip-permissions"' "$AO_WEB_SERVER" 2>/dev/null)
+fi
+
+# Patch 2: inject CLAUDE_AUTOUPDATER_DISABLE
+if grep -q 'CLAUDE_AUTOUPDATER_DISABLE' "$PLUGIN"; then
+  echo "patch2 already applied"
+else
+  sed -i 's|env\["CLAUDECODE"\] = "";|env["CLAUDE_AUTOUPDATER_DISABLE"] = "1"; env["CLAUDECODE"] = "";|' "$PLUGIN"
+  echo "patch2 applied (auto-updater disable)"
+fi
+
+echo "done"


### PR DESCRIPTION
## Summary
- archive-ao-sessions.sh runs weekly, keeps sidebar badge in sync with actual active sessions
- patch-ao-plugin.sh re-applies on @reboot, covers both the plugin and the ao-web Next.js compiled chunks (the real spawn-path source of --dangerously-skip-permissions)

## Why
Today spawn tests via ao.zaoos.com hit the Bypass Permissions dialog even with the plugin patched. Root cause: ao-web Next.js has its own compiled chunk at .next/server/chunks/886.js embedding the flag separate from the plugin. Patch both.

Verified after restart: /api/spawn replied OK, no dialog block.

## Test plan
- [ ] Zaal clicks Spawn in ao.zaoos.com, session runs to completion
- [ ] @reboot cron re-applies both patches (verified idempotent)
- [ ] Weekly 0 7 * * 0 archive cron fires, archives dead sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)