### PR TITLE
fix(agents): surface silent failures in burn + autostake + events (doc 457)

### DIFF
--- a/src/lib/agents/autostake.ts
+++ b/src/lib/agents/autostake.ts
@@ -71,6 +71,16 @@ export async function maybeAutoStake(agentName: AgentName): Promise<void> {
     logger.info(`[${agentName}] Auto-staked 100M ZABAL for conviction. TX: ${hash}`);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    await logAgentEvent({
+      agent_name: agentName,
+      action: 'add_lp',
+      token_in: 'ZABAL',
+      token_out: 'CONVICTION',
+      amount_in: 100_000_000,
+      usd_value: 0,
+      status: 'failed',
+      error_message: msg,
+    });
     logger.error(`[${agentName}] Auto-stake failed: ${msg}`);
   }
 }

--- a/src/lib/agents/burn.ts
+++ b/src/lib/agents/burn.ts
@@ -30,6 +30,16 @@ export async function burnZabal(
     return hash;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    await logAgentEvent({
+      agent_name: agentName,
+      action: 'buy_zabal',
+      token_in: 'ZABAL',
+      token_out: 'BURN',
+      amount_in: Number(burnAmount) / 1e18,
+      usd_value: 0,
+      status: 'failed',
+      error_message: msg,
+    });
     logger.error(`[${agentName}] Burn failed: ${msg}`);
     return null;
   }

--- a/src/lib/agents/events.ts
+++ b/src/lib/agents/events.ts
@@ -18,6 +18,15 @@ export async function logAgentEvent(params: {
   const db = getSupabaseAdmin();
   const { error } = await db.from('agent_events').insert(params);
   if (error) {
-    logger.error(`[${params.agent_name}] Failed to log event: ${error.message}`);
+    // Escalated visibility: CRITICAL prefix + structured payload so log scrapers can alert on
+    // audit-trail drops. Still swallowing here because many callers live inside outer
+    // catch blocks (runner.ts:149) — throwing would cascade into unhandled rejection.
+    // TODO(doc-457): wire a dead-letter queue (Redis list or filesystem fallback) so we
+    // don't permanently lose audit events when Supabase is down or RLS rejects an insert.
+    logger.error(
+      `[${params.agent_name}] CRITICAL audit-trail drop: failed to persist agent_events row. ` +
+        `action=${params.action} status=${params.status} ` +
+        `tx_hash=${params.tx_hash ?? '<none>'} db_error="${error.message}"`,
+    );
   }
 }


### PR DESCRIPTION
## Summary
Fixes 4 of 8 silent-failure findings from doc 457. Criticals + highs addressed.

## Changes

### `src/lib/agents/autostake.ts` (HIGH 1 — audit trail gap)
Catch block now logs `add_lp failed` event before the warning. Previously the catch just logged to stderr with no DB record, so admin dashboard saw nothing — the 14-day cycle would appear to simply not have fired. Now stake failures show up as `status: failed` in `agent_events`.

### `src/lib/agents/burn.ts` (CRITICAL 1 / MEDIUM)
Catch block logs `buy_zabal failed` event with `token_out=BURN` before returning null. Paired with the success event from the swap, we now get an accurate 2-event record:
- `buy_zabal success` (WETH → ZABAL swap)
- `buy_zabal failed, token_out=BURN` (burn attempt)

Runner keeps returning success for the overall trade (can't undo the on-chain swap), but audit trail is honest.

### `src/lib/agents/events.ts` (HIGH 2 — visibility)
`logAgentEvent` still swallows DB insert errors, because many callers live inside outer catch blocks (e.g. `runner.ts:149`) and throwing from here would cascade into unhandled rejections.

Instead, escalated visibility:
- Log prefix: `CRITICAL audit-trail drop:`
- Structured fields: action, status, tx_hash, db_error
- External log scrapers / alert rules can now fire on this signal

TODO in comments: wire a dead-letter queue (Redis list or filesystem fallback) for full durability. Tracked as follow-up in doc 457.

## What's NOT changed
- `runner.ts:93` (CRITICAL 2 — autostake unguarded) — addressed indirectly. With autostake.ts now logging failures, the previously "silent" case is visible. Runner's outer try/catch still handles non-autostake failures for the trade path.
- `runner.ts:128` (CRITICAL 1 — burn ignored) — addressed indirectly. With burn.ts logging failures, the previously "silent" case is visible. Trade isn't halted on burn failure because the swap is on-chain (can't undo).
- Medium findings 6-8 from doc 457 (Farcaster post, broadcast audit, agents/route allSettled) — separate PR.

## Verification
- [x] `npm run typecheck` passes
- [ ] No existing unit tests on these files (coverage gap tracked for evals/ scaffold)
- [ ] Manual verification after merge: trigger staking on a test agent with misconfigured Privy, confirm `add_lp failed` event lands in `agent_events`

## Refs
- Doc 457: `research/agents/457-silent-failure-hunt-ecc/README.md`
- Doc 441: ECC integration plan