### PR TITLE
fix(agents+admin): tests for silent-failure fixes + medium findings (doc 457)

### DIFF
--- a/src/app/api/admin/agents/route.ts
+++ b/src/app/api/admin/agents/route.ts
@@ -36,10 +36,29 @@ export async function GET() {
       .limit(50),
   ]);
 
-  const configs = configResult.status === 'fulfilled' ? (configResult.value.data ?? []) : [];
-  const events = eventsResult.status === 'fulfilled' ? (eventsResult.value.data ?? []) : [];
+  // Don't silently hide DB failures as empty arrays — admin can't distinguish
+  // "no agents configured" from "DB down" otherwise. Surface the error.
+  if (configResult.status === 'rejected') {
+    logger.error('GET /api/admin/agents: agent_config query failed:', configResult.reason);
+    return NextResponse.json({ error: 'Failed to fetch agent configs' }, { status: 500 });
+  }
+  if (eventsResult.status === 'rejected') {
+    logger.error('GET /api/admin/agents: agent_events query failed:', eventsResult.reason);
+    return NextResponse.json({ error: 'Failed to fetch agent events' }, { status: 500 });
+  }
+  if (configResult.value.error) {
+    logger.error('GET /api/admin/agents: agent_config returned error:', configResult.value.error);
+    return NextResponse.json({ error: 'Failed to fetch agent configs' }, { status: 500 });
+  }
+  if (eventsResult.value.error) {
+    logger.error('GET /api/admin/agents: agent_events returned error:', eventsResult.value.error);
+    return NextResponse.json({ error: 'Failed to fetch agent events' }, { status: 500 });
+  }
 
-  return NextResponse.json({ agents: configs, recentEvents: events });
+  return NextResponse.json({
+    agents: configResult.value.data ?? [],
+    recentEvents: eventsResult.value.data ?? [],
+  });
 }
 
 /**

--- a/src/app/api/admin/broadcast/route.ts
+++ b/src/app/api/admin/broadcast/route.ts
@@ -62,13 +62,21 @@ export async function POST(req: NextRequest) {
 
     const data = await res.json();
 
-    await logAuditEvent({
+    // Fire-and-forget audit log: a logAuditEvent rejection must never surface
+    // as a failed response when the cast already shipped. Log the drop instead
+    // so external scrapers can alert on missing audit rows.
+    logAuditEvent({
       actorFid: session.fid,
       action: 'broadcast',
       targetType: 'channel',
       targetId: channel,
       details: { text: text.slice(0, 100), castHash: data.cast?.hash },
       ipAddress: getClientIp(req),
+    }).catch((err) => {
+      logger.error(
+        `[broadcast] CRITICAL audit-trail drop: cast shipped but audit event failed. ` +
+          `castHash=${data.cast?.hash ?? '<none>'} actor_fid=${session.fid} error=${err instanceof Error ? err.message : String(err)}`,
+      );
     });
 
     return NextResponse.json({ success: true, hash: data.cast?.hash });

--- a/src/lib/agents/__tests__/autostake.test.ts
+++ b/src/lib/agents/__tests__/autostake.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExecuteSwap = vi.hoisted(() => vi.fn());
+const mockLogAgentEvent = vi.hoisted(() => vi.fn());
+const mockSelect = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() => vi.fn());
+const mockOrder = vi.hoisted(() => vi.fn());
+const mockLimit = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/agents/wallet', () => ({ executeSwap: mockExecuteSwap }));
+vi.mock('@/lib/agents/events', () => ({ logAgentEvent: mockLogAgentEvent }));
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+vi.mock('@/lib/agents/types', () => ({
+  TOKENS: { ZABAL: '0xZABAL', WETH: '0xWETH' },
+  ZABAL_STAKING_CONTRACT: '0xStake',
+  BURN_ADDRESS: '0xDead',
+  BURN_PCT: 0.01,
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { maybeAutoStake } from '@/lib/agents/autostake';
+
+describe('maybeAutoStake', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Supabase select chain: .from('agent_events').select('created_at').eq('agent_name', ...).eq(...).eq(...).order(...).limit(...)
+    // Chain returns { data: [] } meaning no prior stake → should attempt stake
+    const chain = {
+      select: mockSelect,
+      eq: mockEq,
+      order: mockOrder,
+      limit: mockLimit,
+    };
+    mockFrom.mockReturnValue(chain);
+    mockSelect.mockReturnValue(chain);
+    mockEq.mockReturnValue(chain);
+    mockOrder.mockReturnValue(chain);
+    mockLimit.mockResolvedValue({ data: [] });
+  });
+
+  it('success path: logs add_lp success after approve + stake', async () => {
+    mockExecuteSwap
+      .mockResolvedValueOnce('0xapprovehash')
+      .mockResolvedValueOnce('0xstakehash');
+
+    await maybeAutoStake('VAULT');
+
+    expect(mockExecuteSwap).toHaveBeenCalledTimes(2);
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    const logged = mockLogAgentEvent.mock.calls[0][0];
+    expect(logged.agent_name).toBe('VAULT');
+    expect(logged.action).toBe('add_lp');
+    expect(logged.status).toBe('success');
+    expect(logged.tx_hash).toBe('0xstakehash');
+  });
+
+  it('failure path: logs add_lp failed when approve throws', async () => {
+    mockExecuteSwap.mockRejectedValueOnce(new Error('privy rejected'));
+
+    await maybeAutoStake('BANKER');
+
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    const logged = mockLogAgentEvent.mock.calls[0][0];
+    expect(logged.agent_name).toBe('BANKER');
+    expect(logged.action).toBe('add_lp');
+    expect(logged.status).toBe('failed');
+    expect(logged.error_message).toBe('privy rejected');
+    expect(logged.token_in).toBe('ZABAL');
+    expect(logged.token_out).toBe('CONVICTION');
+  });
+
+  it('failure path: logs add_lp failed when stake call throws after approve succeeds', async () => {
+    mockExecuteSwap
+      .mockResolvedValueOnce('0xapprovehash')
+      .mockRejectedValueOnce(new Error('stake contract reverted'));
+
+    await maybeAutoStake('DEALER');
+
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogAgentEvent.mock.calls[0][0].status).toBe('failed');
+    expect(mockLogAgentEvent.mock.calls[0][0].error_message).toBe('stake contract reverted');
+  });
+
+  it('failure path handles non-Error throws', async () => {
+    mockExecuteSwap.mockRejectedValueOnce('string error');
+
+    await maybeAutoStake('VAULT');
+
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogAgentEvent.mock.calls[0][0].error_message).toBe('string error');
+  });
+});

--- a/src/lib/agents/__tests__/burn.test.ts
+++ b/src/lib/agents/__tests__/burn.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSendToken = vi.hoisted(() => vi.fn());
+const mockLogAgentEvent = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/agents/wallet', () => ({ sendToken: mockSendToken }));
+vi.mock('@/lib/agents/events', () => ({ logAgentEvent: mockLogAgentEvent }));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { burnZabal } from '@/lib/agents/burn';
+
+describe('burnZabal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null without logging when totalAmount <= 0', async () => {
+    const result = await burnZabal('VAULT', BigInt(0));
+    expect(result).toBeNull();
+    expect(mockSendToken).not.toHaveBeenCalled();
+    expect(mockLogAgentEvent).not.toHaveBeenCalled();
+  });
+
+  it('success path: logs success event with token_out=BURN', async () => {
+    mockSendToken.mockResolvedValue('0xburnhash');
+    // 10,000 ZABAL in wei (1% = 100 ZABAL burned)
+    const result = await burnZabal('VAULT', BigInt('10000000000000000000000'));
+    expect(result).toBe('0xburnhash');
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    const logged = mockLogAgentEvent.mock.calls[0][0];
+    expect(logged.agent_name).toBe('VAULT');
+    expect(logged.action).toBe('buy_zabal');
+    expect(logged.token_in).toBe('ZABAL');
+    expect(logged.token_out).toBe('BURN');
+    expect(logged.status).toBe('success');
+    expect(logged.tx_hash).toBe('0xburnhash');
+  });
+
+  it('failure path: logs failed event with error_message, still returns null', async () => {
+    mockSendToken.mockRejectedValue(new Error('gas too low'));
+    const result = await burnZabal('BANKER', BigInt('10000000000000000000000'));
+    expect(result).toBeNull();
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    const logged = mockLogAgentEvent.mock.calls[0][0];
+    expect(logged.agent_name).toBe('BANKER');
+    expect(logged.status).toBe('failed');
+    expect(logged.token_out).toBe('BURN');
+    expect(logged.error_message).toBe('gas too low');
+  });
+
+  it('failure path handles non-Error throws as String(err)', async () => {
+    mockSendToken.mockRejectedValue('plain string error');
+    const result = await burnZabal('DEALER', BigInt('10000000000000000000000'));
+    expect(result).toBeNull();
+    expect(mockLogAgentEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogAgentEvent.mock.calls[0][0].error_message).toBe('plain string error');
+  });
+});

--- a/src/lib/agents/__tests__/events.test.ts
+++ b/src/lib/agents/__tests__/events.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockInsert = vi.hoisted(() => vi.fn());
+const mockFrom = vi.hoisted(() => vi.fn());
+const mockLoggerError = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: mockLoggerError, info: vi.fn(), warn: vi.fn() },
+}));
+
+import { logAgentEvent } from '@/lib/agents/events';
+
+describe('logAgentEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({ insert: mockInsert });
+  });
+
+  it('silent success path: no logger.error when DB insert succeeds', async () => {
+    mockInsert.mockResolvedValue({ error: null });
+    await logAgentEvent({
+      agent_name: 'VAULT',
+      action: 'buy_zabal',
+      status: 'success',
+      tx_hash: '0xabc',
+    });
+    expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+
+  it('CRITICAL log path: logger.error fires with structured payload when DB insert fails', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'rls denied' } });
+    await logAgentEvent({
+      agent_name: 'BANKER',
+      action: 'add_lp',
+      status: 'failed',
+      tx_hash: '0xdeadbeef',
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const loggedMsg = mockLoggerError.mock.calls[0][0] as string;
+    expect(loggedMsg).toContain('CRITICAL audit-trail drop');
+    expect(loggedMsg).toContain('BANKER');
+    expect(loggedMsg).toContain('action=add_lp');
+    expect(loggedMsg).toContain('status=failed');
+    expect(loggedMsg).toContain('tx_hash=0xdeadbeef');
+    expect(loggedMsg).toContain('db_error="rls denied"');
+  });
+
+  it('CRITICAL log still uses <none> when tx_hash absent', async () => {
+    mockInsert.mockResolvedValue({ error: { message: 'conn refused' } });
+    await logAgentEvent({
+      agent_name: 'DEALER',
+      action: 'report',
+      status: 'failed',
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const loggedMsg = mockLoggerError.mock.calls[0][0] as string;
+    expect(loggedMsg).toContain('tx_hash=<none>');
+  });
+});


### PR DESCRIPTION
## Summary
Part 2 of doc 457 cleanup. Adds tests confirming PR #232 fixes behave as intended + ships remaining medium findings.

## Tests added (11 passing)

### `src/lib/agents/__tests__/events.test.ts` (3)
- silent success path: no `logger.error` when DB insert succeeds
- CRITICAL audit-trail drop: logs structured payload when DB insert fails (action, status, tx_hash, db_error)
- `<none>` tx_hash formatting when absent

### `src/lib/agents/__tests__/burn.test.ts` (4)
- returns null without logging when `totalAmount <= 0`
- success path: logs `buy_zabal success` with `token_out=BURN`
- failure path: logs `buy_zabal failed` with `error_message`, still returns null
- non-`Error` throws handled as `String(err)`

### `src/lib/agents/__tests__/autostake.test.ts` (4)
- success 2-tx path: logs `add_lp success` after approve + stake
- approve throws: logs `add_lp failed` with `error_message`
- stake throws after approve succeeds: logs `add_lp failed`
- non-`Error` throws handled

## Medium findings fixed

### `src/app/api/admin/broadcast/route.ts` (medium 3)
`logAuditEvent` was awaited AFTER the cast response committed. Any rejection would throw but the client already had success. Swapped to fire-and-forget with `.catch(err => logger.error(CRITICAL audit-trail drop...))` consistent with the `events.ts` pattern.

### `src/app/api/admin/agents/route.ts` (medium 4)
`Promise.allSettled` was silently collapsing rejected queries into empty arrays, hiding DB failures as "no agents configured". Now returns 500 with logged details on:
- promise rejection (connection/network)
- Supabase `.error` (RLS, constraint)

## Medium NOT fixed
- `runner.ts:143` (Farcaster post failure doesn't fail trade) — accepted per review. Trades should not fail if Farcaster is down. Log-only is correct.

## Verification
- [x] `npm run typecheck` passes
- [x] 15 tests pass (11 new + 4 existing admin tests regression-checked)
- [x] Manual read of diffs matches doc 457 recommended fixes

## Refs
- Doc 457: `research/agents/457-silent-failure-hunt-ecc/README.md`
- Parent PR #232 (CRITICAL + HIGH fixes) — already merged