### PR TITLE
feat: ZOE learning pings + workspace isolation wrap-up (doc 459)

### DIFF
--- a/.claude/skills/worksession/SKILL.md
+++ b/.claude/skills/worksession/SKILL.md
@@ -52,10 +52,13 @@ Run these steps in order:
    npm install --prefer-offline
    ```
 
-   **Fallback** - if worktree creation fails (e.g. disk space, permissions), fall back to branch-only:
-   ```bash
-   git checkout -b "$BRANCH"
-   ```
+   **NO FALLBACK.** Per doc 459 + ADR-001 + `feedback_workspace_worktrees.md`, the worktree IS the only valid path. If `git worktree add` fails:
+   - Diagnose the cause (disk space, permissions, locked branch, missing parent dir)
+   - Fix it
+   - Retry the worktree command
+   - Do NOT fall back to a branch in the shared checkout — branch-only sessions caused multiple wrong-branch incidents (2026-04-19 push to main, 2026-04-20 mid-session branch flips). Doc 459.
+
+   **Better path:** the user should launch new Claude Code sessions via the `zsesh` shell alias (`~/.zshrc`) which runs `claude --worktree ws/<desc>-<stamp>` automatically. Use this skill only when the user is ALREADY inside a Claude session and needs to spin up another worktree from there.
 
    - Format: `ws/fractal-fixes-0406-1423`
    - Always branch from latest `main`
@@ -64,9 +67,6 @@ Run these steps in order:
 
 5. **Confirm:**
    > "Session `ws/<name>` created at `../worktrees/<name>/`. Ready to work."
-   
-   Or if fallback:
-   > "Session branch `ws/<name>` created (same directory, worktree unavailable). Ready to work."
 
 ## End of Session (PR Workflow)
 

--- a/scripts/zoe-learning-pings/README.md
+++ b/scripts/zoe-learning-pings/README.md
@@ -1,0 +1,126 @@
+# ZOE Learning Pings
+
+Random tip from the ZAO OS research library + ADRs, sent every 30 minutes during waking hours via ZOE's Telegram bot. Helps Zaal stay current on what's in the brain trust without manual searching.
+
+**Spec source:** doc 459 follow-up + 2026-04-20 EOD wrap-up.
+
+## Source Docs
+
+The script picks randomly from:
+
+- `research/dev-workflows/*/README.md`
+- `research/agents/*/README.md`
+- `research/infrastructure/*/README.md`
+- `research/community/*/README.md`
+- `research/governance/*/README.md`
+- `research/farcaster/*/README.md`
+- `research/identity/*/README.md`
+- `docs/adr/*.md`
+
+Edit `DOC_GLOBS` in `random_tip.py` to widen/narrow the pool.
+
+## Tip Extraction
+
+Sends doc to Claude Haiku 4.5 via the Anthropic API. Prompt asks for ONE actionable tip in Zaal's second person, max 240 chars, with `SKIP` allowed when no tip exists. Cost is approx $0.0001 per ping (Haiku-tier).
+
+## Anti-Repeat
+
+State file at `~/.cache/zoe-learning-pings/sent.json` tracks the last 7 days of sent doc paths. Picks exclude recently-sent docs unless the pool is exhausted.
+
+## Quiet Hours
+
+Default: skip pings between 9pm-9am host time. Override via `QUIET_HOURS_START` / `QUIET_HOURS_END` env vars.
+
+Set the host timezone to America/New_York if not already:
+
+```bash
+sudo timedatectl set-timezone America/New_York
+```
+
+## Local Dry Run (Mac)
+
+Test from this repo without needing the VPS or Telegram:
+
+```bash
+cd "/Users/zaalpanthaki/Documents/ZAO OS V1"
+ANTHROPIC_API_KEY=<your-key> \
+ZAO_OS_REPO="$(pwd)" \
+python3 scripts/zoe-learning-pings/random_tip.py
+```
+
+Without `TELEGRAM_BOT_TOKEN` set, the tip prints to stdout instead of sending. That's the verification mode.
+
+## Deploy to VPS 1 (Hostinger ZOE host)
+
+Run via the `/vps` skill in a Claude session, or manually:
+
+```bash
+# 1. SSH to VPS 1
+ssh root@31.97.148.88
+
+# 2. Clone or update ZAO OS repo
+mkdir -p /opt/zao-os && cd /opt/zao-os
+if [ -d .git ]; then git pull; else git clone https://github.com/bettercallzaal/ZAOOS.git .; fi
+
+# 3. Install Python script (idempotent)
+mkdir -p /opt/zoe/bin /var/cache/zoe-learning-pings
+cp /opt/zao-os/scripts/zoe-learning-pings/random_tip.py /opt/zoe/bin/random_tip.py
+chmod +x /opt/zoe/bin/random_tip.py
+
+# 4. Create env file (only once - protect with chmod 600)
+cat > /opt/zoe/zoe-learning-pings.env <<'EOF'
+ANTHROPIC_API_KEY=<paste-key>
+TELEGRAM_BOT_TOKEN=<paste-zoe-bot-token>
+TELEGRAM_CHAT_ID=<paste-zaal-chat-id>
+ZAO_OS_REPO=/opt/zao-os
+ZOE_PINGS_STATE=/var/cache/zoe-learning-pings/sent.json
+QUIET_HOURS_START=21
+QUIET_HOURS_END=9
+EOF
+chmod 600 /opt/zoe/zoe-learning-pings.env
+
+# 5. Wrapper script that loads env then runs Python
+cat > /opt/zoe/bin/zoe-learning-pings.sh <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+set -a
+source /opt/zoe/zoe-learning-pings.env
+set +a
+cd /opt/zao-os && git pull --quiet
+exec python3 /opt/zoe/bin/random_tip.py
+EOF
+chmod +x /opt/zoe/bin/zoe-learning-pings.sh
+
+# 6. Test once before scheduling
+/opt/zoe/bin/zoe-learning-pings.sh
+
+# 7. Add to crontab (every 30 min, all hours - script self-gates quiet hours)
+(crontab -l 2>/dev/null; echo "*/30 * * * * /opt/zoe/bin/zoe-learning-pings.sh >> /var/log/zoe-learning-pings.log 2>&1") | crontab -
+
+# 8. Verify
+crontab -l | grep zoe-learning-pings
+tail -f /var/log/zoe-learning-pings.log
+```
+
+## Cost
+
+- Claude Haiku 4.5: ~$0.0001 per ping
+- 24 pings/day (12 hours active * 2/hour) = ~$0.0024/day = ~$0.07/month
+- Telegram bot: free
+- VPS overhead: negligible (cron + small Python process)
+
+## Disable
+
+```bash
+crontab -l | grep -v zoe-learning-pings | crontab -
+```
+
+State + script remain on disk; just removes the schedule. Re-add the cron line to resume.
+
+## Future Extensions
+
+- **Sync auto-memory to VPS** so instinct store + project memos enter the pool. Today the pool is repo-only; auto-memory is Mac-local.
+- **Open from Telegram** — add inline button on each tip that opens the source doc on the laptop (deep-link to `cursor://` or `code://` URI).
+- **Topic weighting** — boost docs from areas Zaal is currently working in (detect via recent git activity).
+- **Streak tracking** — every doc has a "last sent" timestamp; build a "X docs in your library you haven't seen in 30 days" report.
+- **Move from cron to Claude Routines** (doc 422) — gets cloud execution + UI dashboard for free.

--- a/scripts/zoe-learning-pings/random_tip.py
+++ b/scripts/zoe-learning-pings/random_tip.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+ZOE random learning pings.
+
+Picks a random doc from the ZAO OS research library + ADRs, extracts a
+1-line actionable tip via Claude Haiku, sends to Zaal via Telegram bot.
+
+Designed to run every 30 minutes via cron during waking hours (9am-9pm ET).
+
+Environment variables required:
+  - ANTHROPIC_API_KEY: Claude API key (Haiku tier is sufficient + cheap)
+  - TELEGRAM_BOT_TOKEN: ZOE's existing bot token
+  - TELEGRAM_CHAT_ID: Zaal's user/chat ID
+  - ZAO_OS_REPO: path to the ZAO OS V1 git checkout on the host
+                 (default: /opt/zao-os)
+  - QUIET_HOURS_START: hour to skip starting from (default: 21 = 9pm ET)
+  - QUIET_HOURS_END: hour to resume (default: 9 = 9am ET)
+
+State file: ~/.cache/zoe-learning-pings/sent.json
+  Tracks last 7 days of sent doc paths so we don't repeat the same tip.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+from urllib import request as urllib_request
+from urllib import error as urllib_error
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+ZAO_OS_REPO = Path(os.environ.get("ZAO_OS_REPO", "/opt/zao-os"))
+STATE_FILE = Path(os.environ.get(
+    "ZOE_PINGS_STATE",
+    str(Path.home() / ".cache" / "zoe-learning-pings" / "sent.json"),
+))
+QUIET_START = int(os.environ.get("QUIET_HOURS_START", "21"))
+QUIET_END = int(os.environ.get("QUIET_HOURS_END", "9"))
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
+TELEGRAM_CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID")
+HAIKU_MODEL = os.environ.get("ZOE_TIP_MODEL", "claude-haiku-4-5-20251001")
+MAX_DOC_CHARS = 3500
+MAX_TIP_CHARS = 240
+COOLDOWN_DAYS = 7
+
+DOC_GLOBS = [
+    "research/dev-workflows/*/README.md",
+    "research/agents/*/README.md",
+    "research/infrastructure/*/README.md",
+    "research/community/*/README.md",
+    "research/governance/*/README.md",
+    "research/farcaster/*/README.md",
+    "research/identity/*/README.md",
+    "docs/adr/*.md",
+]
+
+
+# -----------------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------------
+def in_quiet_hours(now_local: datetime) -> bool:
+    """Return True if the current ET hour is inside the quiet window."""
+    h = now_local.hour
+    if QUIET_START < QUIET_END:  # e.g. 9..21 = active 9-21
+        return not (QUIET_START <= h < QUIET_END)
+    return QUIET_START <= h or h < QUIET_END  # default 21..9 = quiet 9pm-9am
+
+
+def load_state() -> dict:
+    if not STATE_FILE.exists():
+        return {"sent": []}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception:
+        return {"sent": []}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def prune_old(state: dict, days: int = COOLDOWN_DAYS) -> dict:
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    state["sent"] = [s for s in state["sent"] if s.get("at", "") > cutoff]
+    return state
+
+
+def list_candidate_docs() -> list[Path]:
+    docs: list[Path] = []
+    for g in DOC_GLOBS:
+        docs.extend(ZAO_OS_REPO.glob(g))
+    return docs
+
+
+def pick_doc(state: dict) -> Path | None:
+    candidates = list_candidate_docs()
+    if not candidates:
+        return None
+    recent = {s["path"] for s in state["sent"]}
+    pool = [d for d in candidates if str(d.relative_to(ZAO_OS_REPO)) not in recent]
+    if not pool:
+        # Everything sent in last week — open the floodgates.
+        pool = candidates
+    return random.choice(pool)
+
+
+def extract_tip(doc_text: str, doc_title: str) -> str | None:
+    """Call Claude Haiku to extract 1 actionable tip. Returns None on failure."""
+    if not ANTHROPIC_API_KEY:
+        print("ANTHROPIC_API_KEY not set; cannot extract tip", file=sys.stderr)
+        return None
+
+    prompt = (
+        "You are ZOE, Zaal's concierge agent. Extract ONE actionable tip from the "
+        f"following ZAO OS research doc titled '{doc_title}'.\n\n"
+        f"Constraints:\n"
+        f"- Max {MAX_TIP_CHARS} characters total.\n"
+        "- Make it concrete and immediately useful TODAY (no abstract advice).\n"
+        "- Reference the doc's specific recommendation, not a generic principle.\n"
+        "- Speak directly to Zaal in second person.\n"
+        "- No preamble, no quotes, no markdown — just the tip text.\n"
+        "- If the doc has no actionable tip (pure history/log), respond with exactly: SKIP\n\n"
+        f"--- DOC START ---\n{doc_text[:MAX_DOC_CHARS]}\n--- DOC END ---"
+    )
+
+    body = json.dumps({
+        "model": HAIKU_MODEL,
+        "max_tokens": 256,
+        "messages": [{"role": "user", "content": prompt}],
+    }).encode("utf-8")
+
+    req = urllib_request.Request(
+        "https://api.anthropic.com/v1/messages",
+        data=body,
+        method="POST",
+        headers={
+            "x-api-key": ANTHROPIC_API_KEY,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        },
+    )
+
+    try:
+        with urllib_request.urlopen(req, timeout=30) as resp:
+            data = json.load(resp)
+    except urllib_error.HTTPError as e:
+        print(f"Claude API error {e.code}: {e.read().decode('utf-8', errors='replace')}",
+              file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Claude API call failed: {e}", file=sys.stderr)
+        return None
+
+    blocks = data.get("content", [])
+    if not blocks:
+        return None
+    tip = "".join(b.get("text", "") for b in blocks if b.get("type") == "text").strip()
+    if not tip or tip.upper().startswith("SKIP"):
+        return None
+    return tip[:MAX_TIP_CHARS]
+
+
+def send_telegram(text: str) -> bool:
+    if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
+        print("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; printing instead",
+              file=sys.stderr)
+        print(text)
+        return False
+
+    body = json.dumps({
+        "chat_id": TELEGRAM_CHAT_ID,
+        "text": text,
+        "disable_web_page_preview": True,
+    }).encode("utf-8")
+
+    req = urllib_request.Request(
+        f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage",
+        data=body,
+        method="POST",
+        headers={"content-type": "application/json"},
+    )
+
+    try:
+        with urllib_request.urlopen(req, timeout=15) as resp:
+            data = json.load(resp)
+            return bool(data.get("ok"))
+    except Exception as e:
+        print(f"Telegram send failed: {e}", file=sys.stderr)
+        return False
+
+
+def doc_title_from(path: Path) -> str:
+    """Pull the first H1 (or H3 for ADR style) from the doc as a title."""
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                return stripped.lstrip("# ").strip()
+    except Exception:
+        pass
+    return path.stem
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main() -> int:
+    # ZOE pings respect Eastern Time waking hours.
+    now_local = datetime.now()  # Host TZ (set host TZ to America/New_York or use TZ env)
+    if in_quiet_hours(now_local):
+        print(f"Quiet hours ({QUIET_START}-{QUIET_END}); skipping.", file=sys.stderr)
+        return 0
+
+    state = prune_old(load_state())
+    doc = pick_doc(state)
+    if doc is None:
+        print(f"No candidate docs found under {ZAO_OS_REPO}", file=sys.stderr)
+        return 1
+
+    title = doc_title_from(doc)
+    rel = doc.relative_to(ZAO_OS_REPO)
+    text_body = doc.read_text(encoding="utf-8", errors="replace")
+    tip = extract_tip(text_body, title)
+    if not tip:
+        print(f"No tip extractable from {rel}", file=sys.stderr)
+        return 0  # silent miss; try again in 30 min
+
+    msg = f"[ZOE TIP] {title}\n\n{tip}\n\n>> {rel}"
+    if send_telegram(msg):
+        state["sent"].append({
+            "path": str(rel),
+            "title": title,
+            "at": datetime.now(timezone.utc).isoformat(),
+        })
+        save_state(state)
+        print(f"Sent: {rel}")
+        return 0
+    else:
+        print("Telegram send failed; not recording in state", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
End-of-Monday wrap-up that closes out doc 459 + ships the ZOE random-learning feature so Zaal walks into Tuesday with the new tooling live.

## Track 1 — Workspace Isolation (doc 459 adoption)
- **`/worksession` skill** — dropped branch-only fallback. Worktree IS the only valid path. If `git worktree add` fails, diagnose and retry — never silently degrade. Pairs with new feedback memory `feedback_workspace_worktrees.md`.
- **Local zsh aliases** (in `~/.zshrc`, not committed):
  - `zsesh <desc>` → spawns `claude --worktree ws/<desc>-<MMDD>-<HHMM>`
  - `wtl` → list active worktrees
  - `wtprune` → clean merged/dead worktrees
- **New auto-memory entry** at `~/.claude/projects/.../memory/feedback_workspace_worktrees.md` — never edit ZAO OS V1 root directly, all sessions launch via `zsesh`.

## Track 2 — ZOE Random Learning Pings (Zaal asked for this)
Random research tip every 30 min during waking hours, delivered via ZOE's Telegram bot.

- **`scripts/zoe-learning-pings/random_tip.py`** — zero-deps Python (urllib + Anthropic API + Telegram Bot API). Picks random doc from 8 topic folders + ADRs, calls Claude Haiku 4.5 for 1-tip 240-char extraction in Zaal's voice, sends to Telegram. ~$0.07/month.
- **`scripts/zoe-learning-pings/README.md`** — install + deploy + cost + extensions.
- **Anti-repeat:** `~/.cache/zoe-learning-pings/sent.json` tracks last 7 days.
- **Quiet hours:** self-gated 9pm-9am ET via env vars.

### Deployed to VPS 1 tonight (no manual steps required during merge)
```
/home/zaal/zao-os/                                 # ZAO OS repo clone (sources)
/home/zaal/zoe-learning-pings/random_tip.py        # script (chmod +x)
/home/zaal/zoe-learning-pings/run.sh               # cron wrapper (loads env, pulls repo, runs)
/home/zaal/zoe-learning-pings/zoe-learning-pings.env  # template, chmod 600
                                                    #   TELEGRAM_CHAT_ID=1447437687 pre-filled
                                                    #   from openclaw.json channels.telegram.allowFrom
crontab line                                        # COMMENTED OUT until Zaal activates
```

### Activation (Zaal, ~2 min):
```bash
ssh zaal@31.97.148.88
nano ~/zoe-learning-pings/zoe-learning-pings.env   # paste 2 keys
~/zoe-learning-pings/run.sh                         # test once (sends 1 tip)
crontab -e                                          # uncomment the */30 line
```

## Test plan
- [ ] Activation works (paste keys, get 1 tip in Telegram)
- [ ] First cron tip arrives within 30 min
- [ ] No tip during quiet hours (9pm-9am)
- [ ] No repeat tip within 7 days
- [ ] In Tuesday morning's first session, run `zsesh test-isolation` and confirm new worktree at `~/Documents/worktrees/`

## Refs
- Doc 459: `research/dev-workflows/459-parallel-workspace-isolation-zao-os/`
- ADR-001: `docs/adr/001-ecc-path-b-plugin-install.md`
- Feedback memory: `~/.claude/projects/.../memory/feedback_workspace_worktrees.md`