### PR TITLE
feat: safe-git-push hooks (doc 461) + Hyperspell company-brain research (doc 462)

### DIFF
--- a/scripts/safe-git-push/README.md
+++ b/scripts/safe-git-push/README.md
@@ -1,0 +1,96 @@
+# safe-git-push
+
+Defense-in-depth push safety per doc 461. Stops:
+
+- Direct push to `main` / `master`
+- Push to a branch whose PR was already merged (orphan commit risk)
+
+## Files
+
+- `safe-git-push.sh` — the checker. Single source of truth, called from all enforcement layers.
+- `install.sh` — idempotent installer for the script + git pre-push hook in the current checkout.
+
+## Quick install (per-checkout)
+
+```bash
+bash scripts/safe-git-push/install.sh
+```
+
+This:
+1. Symlinks `~/bin/safe-git-push.sh` to the repo copy so updates flow via `git pull`.
+2. Writes `.git/hooks/pre-push` that calls the checker.
+
+Repeat for every worktree (or wire into `/worksession` skill).
+
+## Claude Code PreToolUse hook (per-user)
+
+Add to `~/.claude/settings.json` inside the existing `"hooks"` block:
+
+```json
+"PreToolUse": [
+  {
+    "matcher": "Bash",
+    "hooks": [
+      {
+        "type": "command",
+        "command": "SAFE_PUSH_ARGS=\"$CLAUDE_TOOL_INPUT_command\" REPO_DIR=\"$(pwd)\" \"$HOME/bin/safe-git-push.sh\"",
+        "if": "Bash(git push *)",
+        "timeout": 12
+      }
+    ]
+  }
+]
+```
+
+This blocks Claude-initiated pushes that violate the rules.
+
+## Optional zsh wrapper
+
+Append to `~/.zshrc`:
+
+```bash
+git() {
+  if [[ "$1" == "push" ]]; then
+    SAFE_PUSH_ARGS="$*" REPO_DIR="$(command git rev-parse --show-toplevel 2>/dev/null || pwd)" ~/bin/safe-git-push.sh || return 2
+  fi
+  command git "$@"
+}
+```
+
+Catches manually-typed `git push` commands. Bypass: `command git push ...`.
+
+## GitHub branch protection (server-side)
+
+```bash
+gh api repos/bettercallzaal/ZAOOS/branches/main/protection \
+  -X PUT \
+  -F enforce_admins=true \
+  -F allow_force_pushes=false \
+  -F allow_deletions=false \
+  -F required_status_checks=null \
+  -f required_pull_request_reviews[required_approving_review_count]=0 \
+  -F restrictions=null
+```
+
+Server-side authoritative — even if every client hook fails, GitHub refuses direct pushes to main.
+
+## Test
+
+```bash
+~/bin/safe-git-push.sh                       # OK on a ws/ branch
+git checkout main; git push --dry-run        # BLOCKED (push to main)
+ALLOW_UNSAFE_PUSH=1 git push --dry-run       # bypass (emergency only)
+```
+
+## Disable
+
+```bash
+rm .git/hooks/pre-push                       # remove pre-push hook
+# Edit ~/.claude/settings.json to remove the PreToolUse Bash entry
+# Edit ~/.zshrc to remove the git() function
+```
+
+## Refs
+
+- Doc 461: `research/dev-workflows/461-push-to-merged-pr-failure-fix/README.md`
+- Existing feedback memos covering same intent (now downgraded to "intent docs"): `feedback_no_push_merged_pr.md`, `feedback_branch_discipline.md`, `feedback_always_pr.md`, `feedback_workspace_worktrees.md`

--- a/scripts/safe-git-push/install.sh
+++ b/scripts/safe-git-push/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install the safe-git-push checker + git pre-push hook in this checkout.
+# Per doc 461. Idempotent — safe to re-run on every worktree.
+#
+# Usage:
+#   bash scripts/safe-git-push/install.sh
+#
+# Installs:
+#   - ~/bin/safe-git-push.sh (symlink to repo copy, so updates flow via git pull)
+#   - .git/hooks/pre-push in the current worktree
+#
+# Does NOT install the Claude Code PreToolUse hook — that's a per-user setting.
+# See scripts/safe-git-push/README.md for the settings.json snippet.
+
+set -euo pipefail
+
+REPO_DIR="$(git rev-parse --show-toplevel)"
+SCRIPT_SRC="$REPO_DIR/scripts/safe-git-push/safe-git-push.sh"
+
+if [[ ! -f "$SCRIPT_SRC" ]]; then
+  echo "Cannot find $SCRIPT_SRC" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/bin"
+ln -sf "$SCRIPT_SRC" "$HOME/bin/safe-git-push.sh"
+echo "Installed: $HOME/bin/safe-git-push.sh -> $SCRIPT_SRC"
+
+if [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
+  echo "WARNING: $HOME/bin is not on PATH. Add the following to ~/.zshrc or ~/.bashrc:"
+  echo '  export PATH="$HOME/bin:$PATH"'
+fi
+
+HOOK_DIR="$(git rev-parse --git-dir)/hooks"
+mkdir -p "$HOOK_DIR"
+cat > "$HOOK_DIR/pre-push" <<'EOF'
+#!/usr/bin/env bash
+# Doc 461: block push to main/master OR to a branch with a merged PR.
+SAFE_PUSH_ARGS="$*" REPO_DIR="$(git rev-parse --show-toplevel)" "$HOME/bin/safe-git-push.sh"
+EOF
+chmod +x "$HOOK_DIR/pre-push"
+echo "Installed: $HOOK_DIR/pre-push"
+
+echo ""
+echo "Done. Test:"
+echo "  $HOME/bin/safe-git-push.sh    # should print OK with current branch"
+echo ""
+echo "For Claude Code PreToolUse hook, see scripts/safe-git-push/README.md."

--- a/scripts/safe-git-push/safe-git-push.sh
+++ b/scripts/safe-git-push/safe-git-push.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Block git pushes that would land on main/master or on a branch whose PR is already merged.
+# Called from: Claude PreToolUse hook, .git/hooks/pre-push, optional zsh wrapper.
+#
+# Source of truth: research/dev-workflows/461-push-to-merged-pr-failure-fix/README.md
+#
+# Exit codes:
+#   0 = safe to push
+#   2 = BLOCKED (caller should refuse the push)
+#
+# Override: ALLOW_UNSAFE_PUSH=1 in env bypasses checks (rare emergency only).
+
+set -euo pipefail
+
+if [[ "${ALLOW_UNSAFE_PUSH:-0}" == "1" ]]; then
+  echo "[safe-git-push] ALLOW_UNSAFE_PUSH=1 — skipping checks." >&2
+  exit 0
+fi
+
+REPO_DIR="${REPO_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || echo "")}"
+if [[ -z "$REPO_DIR" ]]; then
+  echo "[safe-git-push] not inside a git repo — allowing." >&2
+  exit 0
+fi
+
+cd "$REPO_DIR"
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+if [[ -z "$BRANCH" ]]; then
+  echo "[safe-git-push] detached HEAD — refusing as a precaution." >&2
+  exit 2
+fi
+
+case "$BRANCH" in
+  main|master)
+    cat <<EOF >&2
+[safe-git-push] BLOCKED: pushing while on '$BRANCH'.
+
+Always create a PR. Recovery:
+  git checkout -b ws/<descriptive-slug>-\$(date +%m%d-%H%M)
+  git push -u origin HEAD
+  gh pr create --base $BRANCH
+
+If this is a TRUE emergency (admin recovery push), set ALLOW_UNSAFE_PUSH=1.
+EOF
+    exit 2
+    ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[safe-git-push] gh CLI not installed — skipping merged-PR check." >&2
+  exit 0
+fi
+
+MERGED_PR=$(timeout 8 gh pr list --state merged --head "$BRANCH" --json number,mergedAt --jq '.[0].number' 2>/dev/null || echo "")
+
+if [[ -n "$MERGED_PR" ]]; then
+  cat <<EOF >&2
+[safe-git-push] BLOCKED: branch '$BRANCH' has merged PR #$MERGED_PR.
+
+Pushing more commits to a merged-PR branch orphans them — they never
+reach main. Recover by cherry-picking onto a fresh branch and opening a new PR:
+
+  git fetch origin main
+  NEW_BRANCH="ws/$(echo "$BRANCH" | sed 's/^ws\///')-followup-\$(date +%m%d-%H%M)"
+  git checkout -b "\$NEW_BRANCH" origin/main
+  git cherry-pick <commit-sha>
+  git push -u origin HEAD
+  gh pr create --base main
+
+Override (rare emergency only): ALLOW_UNSAFE_PUSH=1.
+EOF
+  exit 2
+fi
+
+if [[ "${SAFE_PUSH_ARGS:-}" == *"--force"* ]] || [[ "${SAFE_PUSH_ARGS:-}" == *" -f "* ]] || [[ "${SAFE_PUSH_ARGS:-}" == *" -f"* ]]; then
+  echo "[safe-git-push] WARNING: force push detected on '$BRANCH' — allowed for non-main branches." >&2
+fi
+
+echo "[safe-git-push] OK: '$BRANCH' passes safety checks." >&2
+exit 0


### PR DESCRIPTION
## Summary
Two related shipments bundled (would normally be separate PRs but the second commit slipped in before the branch swap):

1. **Doc 461 install scripts** — repo-tracked half of the push-safety system
2. **Doc 462 research** — Hyperspell company-brain pattern + ZAO BRAIN/ adoption plan

## Doc 461 — safe-git-push install (commit 4b6c4a58)

Files:
- `scripts/safe-git-push/safe-git-push.sh` — checker (exits 2 on push to main/master or merged-PR branch; ALLOW_UNSAFE_PUSH=1 bypass)
- `scripts/safe-git-push/install.sh` — idempotent installer (symlinks `~/bin/safe-git-push.sh` + writes `.git/hooks/pre-push`)
- `scripts/safe-git-push/README.md` — Claude PreToolUse hook snippet, zsh wrapper, GitHub branch protection, test plan

Already installed on the work Mac:
- `~/bin/safe-git-push.sh`
- `~/.claude/settings.json` PreToolUse hook
- `/Users/zaalpanthaki/Documents/ZAO OS V1/.git/hooks/pre-push`
- `~/.zshrc` PATH update
- Backup: `~/.claude/settings.json.pre-doc-461-2026-04-20`

Self-test: pre-push hook fired on the push that created this PR and printed `[safe-git-push] OK`. The system protected its own first push.

## Doc 462 — Hyperspell company-brain research (commit 7732454a)

Conor Brennan-Burke (@contextconor, Hyperspell YC F25) thread Apr 19 2026 (312K views) frames the agent industry's gap: synthesis vs retrieval. ZAO is 50% there (research/, ADRs, .claude/memory.md, openclaw MEMORY.md exist as sources). Missing: synthesis pass that resolves conflicts + tracks source authority + builds identity + tracks freshness.

Verdict: **REJECT buying Hyperspell** (YC F25 too early, vendor lock-in, sensitive data). **ADOPT thesis** — build BRAIN/ in `zao-memory` private repo (per doc 460 Gap 1) + nightly Claude Routine (per doc 422). 4-tier source authority (TRUTH / ARCHITECTURAL / INTENT / SIGNAL). FID-based identity. ~$15/mo Haiku cost.

First prototype: `BRAIN/projects/zao-stock-2026-10-03.md` — real conflicts across 5+ sources, real ROI.

## Proper PR discipline note
The two commits should have been separate PRs. The deny rule on `git reset --hard` (added as part of doc 461's safety system) prevented me from splitting them after the fact, which is the safer behavior — honor the guardrail.

## Test plan
- [ ] Read doc 461 install scripts + try `bash scripts/safe-git-push/install.sh` on a worktree
- [ ] Read doc 462 + decide on the BRAIN/ pattern
- [ ] Approve GitHub branch protection on `main` (separate, needs `gh api` call)
- [ ] Merge

## Refs
- Doc 461: `research/dev-workflows/461-push-to-merged-pr-failure-fix/README.md`
- Doc 462: `research/agents/462-hyperspell-company-brain-context-graph/README.md`
- Companion: doc 460 (agentic stack) Gap 1 `zao-memory` repo is the substrate doc 462 builds on