### PR TITLE
feat(portal): minimalistic top-sticky nav + Agents page

### DIFF
--- a/infra/portal/caddy/Caddyfile
+++ b/infra/portal/caddy/Caddyfile
@@ -57,6 +57,13 @@
     file_server
   }
 
+  @agentsPage path /agents
+  handle @agentsPage {
+    rewrite * /agents.html
+    root * /home/zaal/caddy/portal
+    file_server
+  }
+
   root * /home/zaal/caddy/portal
   file_server
 }

--- a/infra/portal/caddy/dock/dock.js
+++ b/infra/portal/caddy/dock/dock.js
@@ -1,6 +1,6 @@
 // Universal ZAO nav dock. Injected into every *.zaoos.com subdomain via wrapper pages.
-// Renders a floating bottom pill bar with Portal / Todos / AO / Claude / Tests.
-// Highlights the current surface based on hostname + path.
+// Minimalistic top-sticky thin bar: Portal / Todos / AO / Claude / ZOE / Agents.
+// Active surface = gold text + 2px gold underline. No pill fill. Subtle.
 (function () {
   if (window.__zaoDockLoaded) return;
   window.__zaoDockLoaded = true;
@@ -9,38 +9,55 @@
   const path = (window.location.pathname || "").toLowerCase();
 
   const tiles = [
-    { name: "Portal",  host: "portal.zaoos.com", url: "https://portal.zaoos.com/",               match: (h, p) => h === "portal.zaoos.com" && p === "/" },
-    { name: "Todos",   host: "portal.zaoos.com", url: "https://portal.zaoos.com/todos",          match: (h, p) => h === "portal.zaoos.com" && p.startsWith("/todos") },
-    { name: "AO",      host: "ao.zaoos.com",     url: "https://ao.zaoos.com/",                   match: (h) => h === "ao.zaoos.com" },
-    { name: "Claude",  host: "claude.zaoos.com", url: "https://claude.zaoos.com/",               match: (h) => h === "claude.zaoos.com" },
-    { name: "Tests",   host: "portal.zaoos.com", url: "https://portal.zaoos.com/test-checklist", match: (h, p) => h === "portal.zaoos.com" && p.includes("test-checklist") },
+    { name: "Portal",  url: "https://portal.zaoos.com/",                     match: (h, p) => h === "portal.zaoos.com" && (p === "/" || p === "") },
+    { name: "Todos",   url: "https://portal.zaoos.com/todos",                match: (h, p) => h === "portal.zaoos.com" && p.startsWith("/todos") },
+    { name: "AO",      url: "https://ao.zaoos.com/",                         match: (h) => h === "ao.zaoos.com" },
+    { name: "Claude",  url: "https://claude.zaoos.com/",                    match: (h) => h === "claude.zaoos.com" },
+    // ZOE lives in Telegram. Tap = open conversation with @zaoclaw_bot.
+    { name: "ZOE",     url: "https://t.me/zaoclaw_bot",                      match: () => false, external: true },
+    { name: "Agents",  url: "https://portal.zaoos.com/agents",               match: (h, p) => h === "portal.zaoos.com" && p.startsWith("/agents") },
   ];
 
-  const dock = document.createElement("div");
+  const dock = document.createElement("nav");
   dock.id = "zao-dock";
-  dock.setAttribute("role", "navigation");
   dock.setAttribute("aria-label", "ZAO surfaces");
 
   const style = document.createElement("style");
   style.textContent = [
-    "#zao-dock{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom,0px) + 6px);transform:translateX(-50%);display:flex;gap:4px;padding:4px;background:rgba(10,22,40,.92);backdrop-filter:saturate(140%) blur(10px);-webkit-backdrop-filter:saturate(140%) blur(10px);border:1px solid rgba(245,166,35,.22);border-radius:999px;box-shadow:0 6px 20px rgba(0,0,0,.35);z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,system-ui,\"Segoe UI\",sans-serif;pointer-events:auto}",
-    "#zao-dock a{display:block;padding:8px 14px;font-size:12px;font-weight:600;color:#f5f4ed;text-decoration:none;border-radius:999px;line-height:1;transition:background .15s,color .15s;-webkit-tap-highlight-color:transparent}",
-    "#zao-dock a:active{background:rgba(245,166,35,.15)}",
-    "#zao-dock a.active{background:#f5a623;color:#0a1628}",
-    "@media (max-width: 380px){#zao-dock a{padding:8px 10px;font-size:11px}}"
+    // Top-sticky thin bar across the full viewport width.
+    "#zao-dock{position:sticky;top:0;left:0;right:0;width:100%;display:flex;align-items:center;justify-content:center;gap:2px;padding:6px 10px;padding-top:calc(env(safe-area-inset-top,0px) + 6px);background:rgba(10,22,40,.75);backdrop-filter:saturate(140%) blur(12px);-webkit-backdrop-filter:saturate(140%) blur(12px);border-bottom:1px solid rgba(255,255,255,.06);z-index:2147483647;font-family:-apple-system,BlinkMacSystemFont,system-ui,\"Segoe UI\",sans-serif;pointer-events:auto}",
+    // Inactive tab: quiet gray, no weight, no pill.
+    "#zao-dock a{display:inline-block;padding:6px 10px;font-size:11px;font-weight:500;color:#a0a9b8;text-decoration:none;line-height:1;letter-spacing:.3px;border-bottom:2px solid transparent;transition:color .15s,border-color .15s,background .15s;-webkit-tap-highlight-color:transparent}",
+    "#zao-dock a:hover{color:#e8edf5;background:rgba(255,255,255,.04)}",
+    // Active tab: gold text + thin gold underline. No fill.
+    "#zao-dock a.active{color:#f5a623;border-bottom-color:#f5a623}",
+    "#zao-dock a:active{background:rgba(245,166,35,.08)}",
+    // External tab (ZOE in Telegram): subtle \u2197 indicator.
+    '#zao-dock a[data-external="1"]::after{content:"\\u2197";margin-left:3px;opacity:.5;font-size:9px}',
+    "@media (max-width: 420px){#zao-dock a{padding:6px 8px;font-size:10.5px}}"
   ].join("");
 
   for (const t of tiles) {
     const a = document.createElement("a");
     a.href = t.url;
     a.textContent = t.name;
+    if (t.external) {
+      a.setAttribute("data-external", "1");
+      a.setAttribute("target", "_blank");
+      a.setAttribute("rel", "noopener");
+    }
     if (t.match(here, path)) a.className = "active";
     dock.appendChild(a);
   }
 
   const attach = () => {
     document.head.appendChild(style);
-    document.body.appendChild(dock);
+    // Insert at the TOP of the body so the sticky bar floats above everything.
+    if (document.body.firstChild) {
+      document.body.insertBefore(dock, document.body.firstChild);
+    } else {
+      document.body.appendChild(dock);
+    }
   };
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", attach);

--- a/infra/portal/caddy/portal/agents.html
+++ b/infra/portal/caddy/portal/agents.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="apple-mobile-web-app-title" content="Agents" />
+<meta name="theme-color" content="#0a1628" />
+<link rel="manifest" href="/manifest.json" />
+<link rel="icon" href="/icon.svg" type="image/svg+xml" />
+<title>Agents - ZAO</title>
+<style>
+  :root{--navy:#0a1628;--ink:#f5f4ed;--gold:#f5a623;--dim:#a0a9b8;--panel:rgba(255,255,255,.03);--line:rgba(255,255,255,.06)}
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--navy);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,system-ui,"Segoe UI",sans-serif;min-height:100vh}
+  main{max-width:720px;margin:0 auto;padding:16px 14px 80px}
+  h1{font-size:20px;font-weight:600;letter-spacing:.2px;margin:6px 0 2px}
+  .subtitle{color:var(--dim);font-size:12px;margin:0 0 18px}
+  .layer{margin:18px 0 10px;font-size:10.5px;letter-spacing:1.2px;color:var(--dim);text-transform:uppercase;font-weight:600}
+  .grid{display:flex;flex-direction:column;gap:6px}
+  .row{display:grid;grid-template-columns:1fr auto;gap:6px 14px;padding:10px 12px;background:var(--panel);border:1px solid var(--line);border-radius:8px;align-items:center}
+  .row .name{font-size:13px;font-weight:600;color:var(--ink)}
+  .row .where{font-size:11px;color:var(--dim);grid-column:1/-1;margin-top:2px}
+  .row .status{font-size:10px;padding:3px 7px;border-radius:999px;border:1px solid var(--line);color:var(--dim);justify-self:end;white-space:nowrap}
+  .status.live{color:var(--gold);border-color:rgba(245,166,35,.35)}
+  .status.dormant{color:var(--dim)}
+  .note{color:var(--dim);font-size:11px;margin-top:18px;padding:10px 12px;background:var(--panel);border:1px solid var(--line);border-radius:8px;line-height:1.5}
+  .note a{color:var(--gold);text-decoration:none}
+</style>
+</head>
+<body>
+<main>
+  <h1>Agents</h1>
+  <p class="subtitle">Who runs where. 4 layers, 8 agents. Tap a layer to see details.</p>
+
+  <div class="layer">Edge — code authoring</div>
+  <div class="grid">
+    <div class="row">
+      <div class="name">Claude Code</div>
+      <div class="status live">live</div>
+      <div class="where">Mac work rig + Windows home rig. Per-session git worktrees via <code>zsesh</code>.</div>
+    </div>
+  </div>
+
+  <div class="layer">Concierge — dispatcher</div>
+  <div class="grid">
+    <div class="row">
+      <div class="name">ZOE</div>
+      <div class="status live">live</div>
+      <div class="where">VPS 1 (Hostinger) • Docker: openclaw-openclaw-gateway-1 • Telegram <a href="https://t.me/zaoclaw_bot">@zaoclaw_bot</a></div>
+    </div>
+  </div>
+
+  <div class="layer">Specialists — VPS 1</div>
+  <div class="grid">
+    <div class="row">
+      <div class="name">ZOEY</div>
+      <div class="status live">live</div>
+      <div class="where">openclaw-workspace/zoey/ • action agent, dispatched by ZOE</div>
+    </div>
+    <div class="row">
+      <div class="name">WALLET</div>
+      <div class="status live">live</div>
+      <div class="where">openclaw-workspace/zao-wallet/ • on-chain ops</div>
+    </div>
+    <div class="row">
+      <div class="name">ROLO</div>
+      <div class="status live">live</div>
+      <div class="where">openclaw-workspace/ • CRM / rolodex, relationship manager</div>
+    </div>
+  </div>
+
+  <div class="layer">In-app — Vercel cron</div>
+  <div class="grid">
+    <div class="row">
+      <div class="name">VAULT</div>
+      <div class="status live">live</div>
+      <div class="where">src/lib/agents/vault.ts • safe-hold strategy</div>
+    </div>
+    <div class="row">
+      <div class="name">BANKER</div>
+      <div class="status live">live</div>
+      <div class="where">src/lib/agents/banker.ts • PnL + trade execution</div>
+    </div>
+    <div class="row">
+      <div class="name">DEALER</div>
+      <div class="status live">live</div>
+      <div class="where">src/lib/agents/dealer.ts • market-making, liquidity</div>
+    </div>
+  </div>
+
+  <div class="layer">Cron — VPS 1 host</div>
+  <div class="grid">
+    <div class="row">
+      <div class="name">ZOE learning pings</div>
+      <div class="status dormant">staged</div>
+      <div class="where">/home/zaal/zoe-learning-pings/ • every 30 min during 9am-9pm ET (awaits activation)</div>
+    </div>
+  </div>
+
+  <div class="note">
+    Full stack design: <a href="https://github.com/bettercallzaal/ZAOOS/blob/main/research/agents/460-zao-agentic-stack-end-to-end-design/README.md">doc 460</a>.<br>
+    Company context (BRAIN synthesis): <a href="https://github.com/bettercallzaal/ZAOOS/blob/main/BRAIN/README.md">BRAIN/</a>.<br>
+    Tap <b>ZOE</b> in the nav to message her on Telegram.
+  </div>
+</main>
+<script src="/dock/dock.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
Per 2026-04-20 UX review: "the whole functionality isnt clean, make it easy to use and minimalistic."

### dock.js rewrite (50 lines)
- Top-sticky thin bar (was floating bottom pill)
- Active state = gold text + 2px gold underline (was solid yellow pill, too loud)
- Inactive: subtle gray #a0a9b8, regular weight
- Tighter: 6px padding, 2px gap, 11px font
- Lighter bg: rgba(10,22,40,.75) with blur
- External links get small up-right glyph

### Tabs changed
- DROPPED: Tests (dev-only, low daily value)
- ADDED: ZOE -> opens Telegram DM to @zaoclaw_bot
- ADDED: Agents -> new portal.zaoos.com/agents status page

Final lineup: Portal / Todos / AO / Claude / ZOE / Agents

### agents.html (new)
Minimalist 4-layer stack view per doc 460. 8 agents with name + status + location on one line each. Matches portal dark theme. Links to doc 460 + BRAIN/ for depth.

### Caddyfile
Added @agentsPage /agents route mirroring @todosPage.

### Deploy after merge
I will scp dock.js + agents.html to /home/zaal/caddy/portal/ and reload Caddy via the /vps skill.

### Test plan
- [ ] portal.zaoos.com renders top-sticky bar with no yellow pill
- [ ] /agents shows 8-agent stack view
- [ ] ZOE tab opens Telegram
- [ ] Works on iOS safe-area
- [ ] Merge

Refs: doc 460, BRAIN/