### PR TITLE
feat(portal): Act button in ZOE tips — spawns AO agent + opens PR

### DIFF
--- a/infra/portal/bin/spawn-server.js
+++ b/infra/portal/bin/spawn-server.js
@@ -162,6 +162,69 @@ function handleTodoById(req, res, u, id) {
   return json(res, 405, { error: "method not allowed" });
 }
 
+// --------- spawn-agent (from ZOE tip Act button) ---------
+// Thin wrapper around /api/spawn. Builds an agent prompt from {doc, title,
+// intent, extra} and delegates to handleSpawn with project=ZAOOS.
+function handleSpawnAgent(req, res) {
+  let body = "";
+  req.on("data", c => body += c);
+  req.on("end", () => {
+    let payload;
+    try { payload = JSON.parse(body); } catch { return json(res, 400, { error: "invalid JSON" }); }
+    const doc = (payload.doc || "").trim();
+    const title = (payload.title || "").trim().slice(0, 120);
+    const intent = (payload.intent || "review").trim();
+    const extra = (payload.extra || "").trim().slice(0, 600);
+    if (!doc) return json(res, 400, { error: "doc path required" });
+    if (doc.includes("..") || doc.startsWith("/") || doc.startsWith("~")) {
+      return json(res, 400, { error: "invalid doc path" });
+    }
+    const validIntents = ["review", "expand", "update", "custom"];
+    if (!validIntents.includes(intent)) return json(res, 400, { error: "invalid intent" });
+
+    const intentPrompts = {
+      review: "Review the doc, find stale info / unclear sections / broken links / outdated recommendations. Make small targeted fixes.",
+      expand: "Deepen coverage of the weakest or most outdated section of the doc. Add concrete details, examples, or links.",
+      update: "Reconcile this doc against newer ADRs (docs/adr/), research docs, and BRAIN/ entries. Update stale claims.",
+      custom: "Follow the user's extra context exactly.",
+    };
+
+    const slug = doc.replace(/[^a-z0-9]/gi, "-").slice(0, 40).toLowerCase();
+    const agentPrompt = [
+      "You are a ZAO OS doc-improvement agent.",
+      "Doc: " + doc,
+      "Title: " + title,
+      "",
+      "Task: " + intentPrompts[intent],
+      extra ? "User extra context: " + extra : "",
+      "",
+      "Workflow:",
+      "1. Read the doc at the path above.",
+      "2. If relevant, also read: BRAIN/_meta/conflicts.md, docs/adr/, and obviously related research/ docs.",
+      "3. Create a fresh branch: ws/act-" + slug + "-$(date +%m%d-%H%M).",
+      "4. Make minimal targeted edits. Do not rewrite the whole doc.",
+      "5. Commit with a clear one-line message referring to this act session.",
+      "6. Push the branch.",
+      "7. Open a PR to main with a short summary of what changed and why.",
+      "8. Stop. Do not merge.",
+      "",
+      "Constraints:",
+      "- Never push to main directly (safe-git-push hook will block this anyway).",
+      "- Keep edits small and atomic. If the request is too big for a single PR, describe the split in the PR body and stop.",
+    ].filter(Boolean).join("\n");
+
+    // Delegate via a synthetic request that carries the built prompt.
+    const inner = JSON.stringify({ project: "ZAOOS", prompt: agentPrompt });
+    const fakeReq = Object.assign(Object.create(req), {
+      on(evt, cb) {
+        if (evt === "data") cb(inner);
+        else if (evt === "end") cb();
+      },
+    });
+    handleSpawn(fakeReq, res);
+  });
+}
+
 // --------- spawn ---------
 function handleSpawn(req, res) {
   let body = "";
@@ -215,6 +278,7 @@ function handleSpawn(req, res) {
 const server = http.createServer((req, res) => {
   const u = new URL(req.url, "http://localhost");
   if (req.method === "POST" && (u.pathname === "/spawn-action" || u.pathname === "/api/spawn")) return handleSpawn(req, res);
+  if (req.method === "POST" && u.pathname === "/api/spawn-agent") return handleSpawnAgent(req, res);
   if (req.method === "GET" && u.pathname === "/test-checklist") {
     const state = readJSON(CHECKLIST_FILE, null);
     if (!state) return html(res, 404, "<h1>no checklist</h1>");

--- a/infra/portal/caddy/Caddyfile
+++ b/infra/portal/caddy/Caddyfile
@@ -47,7 +47,7 @@
 :3003 {
   import protected
 
-  @backend path /spawn-action /api/spawn /test-checklist /test-done /api/todos /api/todos/*
+  @backend path /spawn-action /api/spawn /api/spawn-agent /test-checklist /test-done /api/todos /api/todos/*
   reverse_proxy @backend localhost:3004
 
   @todosPage path /todos
@@ -60,6 +60,13 @@
   @agentsPage path /agents
   handle @agentsPage {
     rewrite * /agents.html
+    root * /home/zaal/caddy/portal
+    file_server
+  }
+
+  @actPage path /act
+  handle @actPage {
+    rewrite * /act.html
     root * /home/zaal/caddy/portal
     file_server
   }

--- a/infra/portal/caddy/portal/act.html
+++ b/infra/portal/caddy/portal/act.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="apple-mobile-web-app-title" content="Act" />
+<meta name="theme-color" content="#0a1628" />
+<link rel="manifest" href="/manifest.json" />
+<link rel="icon" href="/icon.svg" type="image/svg+xml" />
+<title>Act on Tip - ZAO</title>
+<style>
+  :root{--navy:#0a1628;--ink:#f5f4ed;--gold:#f5a623;--dim:#a0a9b8;--panel:rgba(255,255,255,.03);--line:rgba(255,255,255,.08);--green:#4ade80;--red:#ef4444}
+  *{box-sizing:border-box}
+  html,body{margin:0;padding:0;background:var(--navy);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,system-ui,"Segoe UI",sans-serif;min-height:100vh}
+  main{max-width:620px;margin:0 auto;padding:16px 14px 80px}
+  h1{font-size:18px;font-weight:600;letter-spacing:.2px;margin:6px 0 4px}
+  .sub{color:var(--dim);font-size:12px;margin:0 0 16px}
+  .card{padding:12px 14px;background:var(--panel);border:1px solid var(--line);border-radius:8px;margin-bottom:12px}
+  .label{display:block;font-size:10.5px;color:var(--dim);letter-spacing:1.2px;text-transform:uppercase;font-weight:600;margin-bottom:6px}
+  .doc-title{font-size:14px;font-weight:600;margin:0 0 4px;line-height:1.35}
+  .doc-path{font-size:11px;color:var(--dim);font-family:ui-monospace,"SF Mono",Menlo,monospace;word-break:break-all}
+  .choices{display:flex;flex-direction:column;gap:6px;margin-top:4px}
+  .choice{display:flex;align-items:flex-start;gap:10px;padding:10px 12px;background:var(--panel);border:1px solid var(--line);border-radius:8px;cursor:pointer;transition:border-color .15s,background .15s;-webkit-tap-highlight-color:transparent}
+  .choice:hover{background:rgba(255,255,255,.05)}
+  .choice input{margin-top:2px;accent-color:var(--gold)}
+  .choice-label{font-size:13px;font-weight:500;line-height:1.3}
+  .choice-desc{font-size:11px;color:var(--dim);margin-top:2px;line-height:1.4}
+  .choice:has(input:checked){border-color:rgba(245,166,35,.5);background:rgba(245,166,35,.04)}
+  .choice:has(input:checked) .choice-label{color:var(--gold)}
+  textarea{width:100%;padding:10px 12px;background:var(--navy);color:var(--ink);border:1px solid var(--line);border-radius:8px;font-family:inherit;font-size:13px;line-height:1.5;resize:vertical;min-height:80px}
+  textarea:focus{outline:none;border-color:rgba(245,166,35,.5)}
+  button{display:block;width:100%;padding:12px;margin-top:16px;background:var(--gold);color:var(--navy);border:0;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;-webkit-tap-highlight-color:transparent;transition:opacity .15s}
+  button:hover{opacity:.92}
+  button:disabled{opacity:.5;cursor:not-allowed}
+  .status{margin-top:12px;padding:10px 12px;border-radius:8px;font-size:12px;line-height:1.5;display:none}
+  .status.show{display:block}
+  .status.ok{background:rgba(74,222,128,.08);border:1px solid rgba(74,222,128,.3);color:var(--green)}
+  .status.err{background:rgba(239,68,68,.08);border:1px solid rgba(239,68,68,.3);color:var(--red)}
+  .status.info{background:rgba(245,166,35,.08);border:1px solid rgba(245,166,35,.3);color:var(--gold)}
+  .back{display:inline-block;margin-top:16px;color:var(--dim);text-decoration:none;font-size:11px}
+  .back:hover{color:var(--gold)}
+</style>
+</head>
+<body>
+<main>
+  <h1>Act on this tip</h1>
+  <p class="sub">Spawn an AO agent in a fresh worktree. Agent reads the doc, makes edits, opens a PR.</p>
+
+  <div class="card">
+    <span class="label">Doc</span>
+    <p class="doc-title" id="doc-title">Loading...</p>
+    <p class="doc-path" id="doc-path"></p>
+  </div>
+
+  <form id="act-form">
+    <span class="label">What should the agent do?</span>
+    <div class="choices">
+      <label class="choice">
+        <input type="radio" name="intent" value="review" checked />
+        <div>
+          <div class="choice-label">Review and improve</div>
+          <div class="choice-desc">Find stale info, unclear sections, broken links. Make small targeted fixes.</div>
+        </div>
+      </label>
+      <label class="choice">
+        <input type="radio" name="intent" value="expand" />
+        <div>
+          <div class="choice-label">Expand a section</div>
+          <div class="choice-desc">Deepen coverage of the weakest or most outdated part.</div>
+        </div>
+      </label>
+      <label class="choice">
+        <input type="radio" name="intent" value="update" />
+        <div>
+          <div class="choice-label">Update with recent changes</div>
+          <div class="choice-desc">Reconcile this doc against newer ADRs, research docs, and BRAIN entries.</div>
+        </div>
+      </label>
+      <label class="choice">
+        <input type="radio" name="intent" value="custom" />
+        <div>
+          <div class="choice-label">Custom</div>
+          <div class="choice-desc">Describe below.</div>
+        </div>
+      </label>
+    </div>
+
+    <span class="label" style="margin-top:14px">Extra context for the agent (optional)</span>
+    <textarea id="extra" name="extra" placeholder="e.g. focus on the sponsor section, or align with doc 459..."></textarea>
+
+    <button type="submit" id="submit-btn">Spawn agent</button>
+    <div id="status" class="status"></div>
+  </form>
+
+  <a href="/" class="back">&larr; back to portal</a>
+</main>
+<script>
+  const params = new URLSearchParams(window.location.search);
+  const docPath = params.get('doc') || '';
+  const docTitle = params.get('title') || 'No title';
+  document.getElementById('doc-title').textContent = docTitle;
+  document.getElementById('doc-path').textContent = docPath || '(no doc specified)';
+
+  const form = document.getElementById('act-form');
+  const btn = document.getElementById('submit-btn');
+  const status = document.getElementById('status');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!docPath) {
+      status.className = 'status err show';
+      status.textContent = 'No doc specified in URL. Go back to the Telegram tip.';
+      return;
+    }
+    const intent = form.intent.value;
+    const extra = document.getElementById('extra').value.trim();
+    btn.disabled = true;
+    btn.textContent = 'Spawning...';
+    status.className = 'status info show';
+    status.textContent = 'Asking AO to spawn a Claude Code session...';
+    try {
+      const resp = await fetch('/api/spawn-agent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doc: docPath, title: docTitle, intent, extra }),
+      });
+      const data = await resp.json();
+      if (resp.ok) {
+        status.className = 'status ok show';
+        const sid = data.sessionId ? 'session ' + data.sessionId : 'background';
+        status.innerHTML = 'Spawned (' + sid + '). Agent reading the doc. Will push ws/ branch + open PR.<br>Watch: <a href="https://github.com/bettercallzaal/ZAOOS/pulls" style="color:inherit">github.com/bettercallzaal/ZAOOS/pulls</a>';
+        btn.textContent = 'Spawned';
+      } else {
+        status.className = 'status err show';
+        status.textContent = 'Error: ' + (data.error || 'unknown');
+        btn.disabled = false;
+        btn.textContent = 'Retry';
+      }
+    } catch (err) {
+      status.className = 'status err show';
+      status.textContent = 'Network error: ' + (err && err.message || err);
+      btn.disabled = false;
+      btn.textContent = 'Retry';
+    }
+  });
+</script>
+<script src="/dock/dock.js" defer></script>
+</body>
+</html>

--- a/scripts/zoe-learning-pings/random_tip.py
+++ b/scripts/zoe-learning-pings/random_tip.py
@@ -1,23 +1,27 @@
 #!/usr/bin/env python3
 """
-ZOE random learning pings.
+ZOE random learning pings (no-LLM mode).
 
-Picks a random doc from the ZAO OS research library + ADRs, extracts a
-1-line actionable tip via Claude Haiku, sends to Zaal via Telegram bot.
+Picks a random doc from the ZAO OS research library + ADRs + BRAIN/,
+extracts the title + opening summary, sends to Zaal via Telegram.
 
 Designed to run every 30 minutes via cron during waking hours (9am-9pm ET).
 
 Environment variables required:
-  - ANTHROPIC_API_KEY: Claude API key (Haiku tier is sufficient + cheap)
-  - TELEGRAM_BOT_TOKEN: ZOE's existing bot token
-  - TELEGRAM_CHAT_ID: Zaal's user/chat ID
+  - TELEGRAM_BOT_TOKEN: ZOE's Telegram bot token (auto-wired from ~/.env.portal)
+  - TELEGRAM_CHAT_ID: Zaal's user/chat ID (default: 1447437687)
   - ZAO_OS_REPO: path to the ZAO OS V1 git checkout on the host
-                 (default: /opt/zao-os)
-  - QUIET_HOURS_START: hour to skip starting from (default: 21 = 9pm ET)
-  - QUIET_HOURS_END: hour to resume (default: 9 = 9am ET)
+                 (default: /home/zaal/zao-os)
+
+Optional:
+  - ANTHROPIC_API_KEY: if set, uses Claude Haiku to synthesize a 1-line tip
+                       instead of the doc's opening summary. Costs ~$3-4/mo.
+                       Default off — shipped as no-LLM to start (doc 462 plan).
+  - QUIET_HOURS_START: hour to skip starting from (default: 21 = 9pm)
+  - QUIET_HOURS_END: hour to resume (default: 9 = 9am)
 
 State file: ~/.cache/zoe-learning-pings/sent.json
-  Tracks last 7 days of sent doc paths so we don't repeat the same tip.
+  Tracks last 7 days of sent doc paths so we don't repeat.
 """
 
 from __future__ import annotations
@@ -25,30 +29,30 @@ from __future__ import annotations
 import json
 import os
 import random
+import re
 import sys
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable
 from urllib import request as urllib_request
 from urllib import error as urllib_error
 
 # -----------------------------------------------------------------------------
 # Config
 # -----------------------------------------------------------------------------
-ZAO_OS_REPO = Path(os.environ.get("ZAO_OS_REPO", "/opt/zao-os"))
+ZAO_OS_REPO = Path(os.environ.get("ZAO_OS_REPO", "/home/zaal/zao-os"))
 STATE_FILE = Path(os.environ.get(
     "ZOE_PINGS_STATE",
     str(Path.home() / ".cache" / "zoe-learning-pings" / "sent.json"),
 ))
 QUIET_START = int(os.environ.get("QUIET_HOURS_START", "21"))
 QUIET_END = int(os.environ.get("QUIET_HOURS_END", "9"))
-ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "").strip()
 TELEGRAM_BOT_TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
 TELEGRAM_CHAT_ID = os.environ.get("TELEGRAM_CHAT_ID")
 HAIKU_MODEL = os.environ.get("ZOE_TIP_MODEL", "claude-haiku-4-5-20251001")
-MAX_DOC_CHARS = 3500
+MAX_DOC_CHARS_FOR_LLM = 3500
 MAX_TIP_CHARS = 240
+MAX_SUMMARY_CHARS = 420
 COOLDOWN_DAYS = 7
 
 DOC_GLOBS = [
@@ -60,18 +64,22 @@ DOC_GLOBS = [
     "research/farcaster/*/README.md",
     "research/identity/*/README.md",
     "docs/adr/*.md",
+    "BRAIN/projects/*.md",
+    "BRAIN/people/*.md",
 ]
+
+# Placeholders in env file that mean "not yet configured"
+PLACEHOLDER_PREFIXES = ("PASTE_", "YOUR_", "TBD", "REPLACE_")
 
 
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
 def in_quiet_hours(now_local: datetime) -> bool:
-    """Return True if the current ET hour is inside the quiet window."""
     h = now_local.hour
-    if QUIET_START < QUIET_END:  # e.g. 9..21 = active 9-21
+    if QUIET_START < QUIET_END:
         return not (QUIET_START <= h < QUIET_END)
-    return QUIET_START <= h or h < QUIET_END  # default 21..9 = quiet 9pm-9am
+    return QUIET_START <= h or h < QUIET_END
 
 
 def load_state() -> dict:
@@ -113,10 +121,58 @@ def pick_doc(state: dict) -> Path | None:
     return random.choice(pool)
 
 
-def extract_tip(doc_text: str, doc_title: str) -> str | None:
-    """Call Claude Haiku to extract 1 actionable tip. Returns None on failure."""
-    if not ANTHROPIC_API_KEY:
-        print("ANTHROPIC_API_KEY not set; cannot extract tip", file=sys.stderr)
+def doc_title_from(path: Path, text: str) -> str:
+    """Extract the first heading (# or ###) as the title."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            return stripped.lstrip("# ").strip().strip(">").strip()
+    return path.stem
+
+
+def doc_summary_from(text: str, max_chars: int = MAX_SUMMARY_CHARS) -> str:
+    """
+    Extract an opening summary. Strips frontmatter + title, then keeps
+    everything else up to max_chars, cleaning whitespace. Forgiving — if the
+    doc starts with tables or subheadings, those get included.
+    """
+    lines = text.splitlines()
+    # Strip YAML frontmatter block
+    if lines and lines[0].strip() == "---":
+        try:
+            end = next(i for i in range(1, len(lines)) if lines[i].strip() == "---")
+            lines = lines[end + 1 :]
+        except StopIteration:
+            pass
+
+    # Skip until we're past the title
+    past_title = False
+    content_lines: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not past_title:
+            if stripped.startswith("#"):
+                past_title = True
+            continue
+        # Skip horizontal rules; they contribute nothing
+        if stripped == "---":
+            continue
+        content_lines.append(stripped)
+
+    # Join, collapse whitespace, clip
+    summary = " ".join(ln for ln in content_lines if ln).strip()
+    summary = re.sub(r"\s+", " ", summary)
+    # Strip markdown artifacts that read weird in Telegram
+    summary = re.sub(r"\*\*([^*]+)\*\*", r"\1", summary)  # **bold** -> bold
+    summary = re.sub(r"`([^`]+)`", r"\1", summary)         # `code` -> code
+    if len(summary) > max_chars:
+        summary = summary[: max_chars - 1].rsplit(" ", 1)[0] + "…"
+    return summary
+
+
+def extract_tip_via_claude(doc_text: str, doc_title: str) -> str | None:
+    """Call Claude Haiku for a 1-line synthesis. Only runs if ANTHROPIC_API_KEY set."""
+    if not ANTHROPIC_API_KEY or ANTHROPIC_API_KEY.upper().startswith(PLACEHOLDER_PREFIXES):
         return None
 
     prompt = (
@@ -129,7 +185,7 @@ def extract_tip(doc_text: str, doc_title: str) -> str | None:
         "- Speak directly to Zaal in second person.\n"
         "- No preamble, no quotes, no markdown — just the tip text.\n"
         "- If the doc has no actionable tip (pure history/log), respond with exactly: SKIP\n\n"
-        f"--- DOC START ---\n{doc_text[:MAX_DOC_CHARS]}\n--- DOC END ---"
+        f"--- DOC START ---\n{doc_text[:MAX_DOC_CHARS_FOR_LLM]}\n--- DOC END ---"
     )
 
     body = json.dumps({
@@ -175,6 +231,11 @@ def send_telegram(text: str) -> bool:
               file=sys.stderr)
         print(text)
         return False
+    if TELEGRAM_BOT_TOKEN.upper().startswith(PLACEHOLDER_PREFIXES):
+        print("TELEGRAM_BOT_TOKEN is still a placeholder; printing instead",
+              file=sys.stderr)
+        print(text)
+        return False
 
     body = json.dumps({
         "chat_id": TELEGRAM_CHAT_ID,
@@ -198,24 +259,11 @@ def send_telegram(text: str) -> bool:
         return False
 
 
-def doc_title_from(path: Path) -> str:
-    """Pull the first H1 (or H3 for ADR style) from the doc as a title."""
-    try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            stripped = line.strip()
-            if stripped.startswith("#"):
-                return stripped.lstrip("# ").strip()
-    except Exception:
-        pass
-    return path.stem
-
-
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 def main() -> int:
-    # ZOE pings respect Eastern Time waking hours.
-    now_local = datetime.now()  # Host TZ (set host TZ to America/New_York or use TZ env)
+    now_local = datetime.now()
     if in_quiet_hours(now_local):
         print(f"Quiet hours ({QUIET_START}-{QUIET_END}); skipping.", file=sys.stderr)
         return 0
@@ -226,23 +274,36 @@ def main() -> int:
         print(f"No candidate docs found under {ZAO_OS_REPO}", file=sys.stderr)
         return 1
 
-    title = doc_title_from(doc)
     rel = doc.relative_to(ZAO_OS_REPO)
     text_body = doc.read_text(encoding="utf-8", errors="replace")
-    tip = extract_tip(text_body, title)
+    title = doc_title_from(doc, text_body)
+
+    # Prefer Claude Haiku synthesis IF a real key is configured, else fall back
+    # to a plain summary extracted from the doc itself (no-LLM mode, $0 cost).
+    tip = extract_tip_via_claude(text_body, title)
+    mode = "llm"
+    if not tip:
+        tip = doc_summary_from(text_body)
+        mode = "summary"
+
     if not tip:
         print(f"No tip extractable from {rel}", file=sys.stderr)
-        return 0  # silent miss; try again in 30 min
+        return 0
 
-    msg = f"[ZOE TIP] {title}\n\n{tip}\n\n>> {rel}"
+    # GitHub URL for tap-to-open (assumes public main branch of the ZAOOS repo).
+    github_url = f"https://github.com/bettercallzaal/ZAOOS/blob/main/{rel}"
+    msg_parts = [f"[ZOE TIP] {title}", "", tip, "", github_url]
+    msg = "\n".join(msg_parts)
+
     if send_telegram(msg):
         state["sent"].append({
             "path": str(rel),
             "title": title,
+            "mode": mode,
             "at": datetime.now(timezone.utc).isoformat(),
         })
         save_state(state)
-        print(f"Sent: {rel}")
+        print(f"Sent ({mode}): {rel}")
         return 0
     else:
         print("Telegram send failed; not recording in state", file=sys.stderr)

--- a/scripts/zoe-learning-pings/random_tip.py
+++ b/scripts/zoe-learning-pings/random_tip.py
@@ -290,9 +290,26 @@ def main() -> int:
         print(f"No tip extractable from {rel}", file=sys.stderr)
         return 0
 
-    # GitHub URL for tap-to-open (assumes public main branch of the ZAOOS repo).
+    # GitHub URL for tap-to-open.
     github_url = f"https://github.com/bettercallzaal/ZAOOS/blob/main/{rel}"
-    msg_parts = [f"[ZOE TIP] {title}", "", tip, "", github_url]
+
+    # Act URL: one-tap portal page that spawns an AO agent to work on THIS doc.
+    # Portal hosts act.html + POSTs to /api/spawn-agent (spawn-server.js).
+    from urllib.parse import quote
+    act_url = (
+        "https://portal.zaoos.com/act"
+        f"?doc={quote(str(rel), safe='/')}"
+        f"&title={quote(title[:80])}"
+    )
+
+    msg_parts = [
+        f"[ZOE TIP] {title}",
+        "",
+        tip,
+        "",
+        f"Read: {github_url}",
+        f"Act:  {act_url}",
+    ]
     msg = "\n".join(msg_parts)
 
     if send_telegram(msg):


### PR DESCRIPTION
One-tap from a ZOE Telegram tip to a portal page that spawns an agent to edit the doc and open a PR.

### Flow
1. ZOE tip message now includes TWO URLs:
   - Read: GitHub file link
   - Act: portal.zaoos.com/act?doc=...&title=...
2. Tap Act -> minimal form page (dark theme matches portal)
3. Pick intent (review / expand / update / custom) + optional extra context
4. Submit -> POST /api/spawn-agent -> backend builds agent prompt -> calls ao spawn in ~/code/ZAOOS
5. AO creates a worktree + Claude Code session
6. Agent reads doc, makes edits, creates ws/act-<slug>-<stamp> branch, pushes, opens PR
7. You get the PR notification via normal GitHub flow

### Files
- scripts/zoe-learning-pings/random_tip.py: add Act URL to tip message
- infra/portal/caddy/portal/act.html (new): form page
- infra/portal/bin/spawn-server.js: new /api/spawn-agent endpoint
- infra/portal/caddy/Caddyfile: /act route + /api/spawn-agent backend proxy

### Safety
- Path-traversal guards (no .., no absolute paths)
- Intent whitelist
- Title clipped 120 chars, extra context 600 chars
- Agent prompt explicitly says "Never push to main" (redundant with doc 461 pre-push hook)
- Cookie auth enforced at Caddy layer (existing 'protected' block)

### Deploy after merge
scp random_tip.py + act.html + spawn-server.js to VPS, reload Caddy + restart spawn-server. I can drive via /vps skill once merged.

### Test plan
- [ ] Open a ZOE tip in Telegram — see 'Act:' URL
- [ ] Tap Act — form loads with doc title + path populated
- [ ] Pick 'review & improve' + submit — status shows 'Spawned'
- [ ] GitHub shows new ws/act-* PR within ~60s

Refs: doc 459 (workspace isolation), doc 461 (push safety), doc 462 (BRAIN).