### PR TITLE
docs(458): Contribution Circles recruitment copy draft

### DIFF
--- a/research/community/458-zao-contribution-circles/recruitment.md
+++ b/research/community/458-zao-contribution-circles/recruitment.md
@@ -1,0 +1,213 @@
+# ZAO Contribution Circles - Recruitment Copy
+
+> **Status:** Draft 1 for Zaal to review + send to Eric for input before publishing
+> **Date:** 2026-04-20
+> **For use with:** doc 458 parent
+> **Voice:** Zaal (short sentences, build-in-public, no corporate polish)
+> **Core framing:** low commitment + time comes after + dual support for ZAO Fractals AND Impactful Giving
+
+---
+
+## Master Message Points (thread all channels through these)
+
+1. Sign up now, commit later - **you don't have to do all 8 weeks**. Every week you show up counts.
+2. **Time comes after you sign up** - we'll run a time poll and find what works for the crew.
+3. **Double impact:** your hour a week supports the ZAO Fractal rhythm AND contributes to Impactful Giving's research helping nonprofits keep volunteers engaged.
+4. **4-6 people per circle.** Small enough that everyone gets heard. Big enough to keep the energy.
+5. **8 weeks, 1 hour a week, online.** That's it.
+6. Designed for people who want to show up but have real lives.
+
+---
+
+## Long-Form (Discord announcement / Newsletter blurb / Paragraph post)
+
+**Subject / Title:** ZAO Contribution Circles - join a small group of 4-6 for 8 weeks
+
+We are running a pilot of ZAO Contribution Circles starting late May.
+
+Here is the deal. Most people in our community want to show up more. Life gets in the way. Monday Fractal is great but it is a big room. Discord is always on but it is noisy. There is a middle cadence missing - a small group of 4-6 people who know what you are working on, check in with you once a week, and celebrate what ships.
+
+That is a Contribution Circle.
+
+8 weeks. 1 hour a week. Online. Small groups of 4-6 people.
+
+You share what you are working on. Others share theirs. Everyone leaves with more energy than they came with.
+
+**You do not have to commit to all 8 weeks.** Sign up now, come when you can. Every session you show up to counts.
+
+**You do not have to pick a time yet.** Sign up now, we will run a time poll across everyone who signed up and find what fits.
+
+This pilot is a partnership with Impactful Giving - they have been researching what actually keeps volunteers engaged for years. Your participation supports their research AND deepens the ZAO Fractal rhythm. Two-for-one.
+
+Projects on the table for circles to work on:
+- WaveWarZ battle prep and artist shipping
+- ZAOstock October 3 production
+- UK folks coordinating with Impact Concerts
+- Music on-chain builders shipping ZAO OS features
+
+After 8 weeks it is yours. Keep it running, swap the platform, mold it to your crew. We will not gatekeep.
+
+Sign up here: [LINK TO FORM]
+
+If you have been meaning to show up more and just needed the right format, this is it.
+
+---
+
+## Farcaster + X Combined Cast (Firefly, under 280 chars each)
+
+### Option A (270 chars)
+ZAO Contribution Circles pilot starts late May.
+
+Small groups of 4-6. 1 hour a week. 8 weeks online.
+
+You do not have to do all 8. Every session counts.
+Time comes after you sign up - we will poll the crew.
+
+Supports ZAO Fractals and Impactful Giving research.
+
+Sign up: [LINK]
+
+### Option B (245 chars)
+Launching ZAO Contribution Circles late May.
+
+4-6 people per circle. 1hr/week. 8 weeks.
+
+Miss a week? Still in.
+Time? Poll happens after signup.
+
+Double impact: deepens ZAO Fractals + helps Impactful Giving research keep volunteers engaged.
+
+[LINK]
+
+### Pick one with Eric's feedback. Both under 280.
+
+---
+
+## Telegram GC Message (short, punchy)
+
+Running a pilot of ZAO Contribution Circles starting late May.
+
+4-6 people. 1 hour a week. 8 weeks online.
+
+**You do not have to commit to all 8.** Every week you show up counts.
+**Do not worry about the time yet.** Time poll happens after signup.
+
+This supports both ZAO Fractals AND Impactful Giving's research on keeping volunteers engaged. Two birds.
+
+Sign up: [LINK]
+
+Tag anyone you want in your circle.
+
+---
+
+## Discord Announcement (role-pingable)
+
+@everyone
+
+**New: ZAO Contribution Circles pilot**
+
+Starts late May 2026. 8 weeks. 1 hour a week. 4-6 people per circle. Online.
+
+**What it is:** the middle-cadence missing piece between Monday Fractal and the always-on chat. Small enough to get heard, structured enough to keep you coming back.
+
+**What you commit to:** nothing yet. Sign up, we will match you to a circle, we will poll for the time that works, you show up when you can.
+
+**Why this helps ZAO AND Impactful Giving:** we partnered with Eric (Impactful Giving, impactfulgiving.org) who has been researching what keeps volunteers engaged. Your participation counts as Fractal contribution AND supports his research. Double impact.
+
+**Projects circles can work on:**
+- Artists shipping (WaveWarZ, albums, live sets)
+- ZAOstock October 3 crew
+- UK + Impact Concerts coordination
+- Music on-chain builders
+
+Sign up: [LINK]
+
+Reply in this thread if you want to be in a specific circle with specific people.
+
+---
+
+## ZAO Spaces Talking Points (11am pitch)
+
+Use this as the outline for announcing on the daily Spaces. Aim for 2-3 minutes.
+
+**Hook (30 sec):**
+"Going to drop something new we are trying. You know how Monday Fractal is great but it is a big room? And you know how Discord is always on but it is noisy? There is a middle piece missing. Small groups of 4-6 people. 1 hour a week. 8 weeks."
+
+**The deal (60 sec):**
+"We are running a pilot of Contribution Circles. You sign up, we match you with 4-6 people, we run a time poll so the time fits you, then you show up once a week for 8 weeks. Share what you are working on. Get supported. Keep moving."
+
+**The hook for people who have been quiet (30 sec):**
+"If you have been meaning to show up more and the format has not worked for you, this is designed for you. You do not have to do all 8 weeks. Every week you show up counts. Miss one, still in. No guilt."
+
+**The double-win (30 sec):**
+"This is a partnership with Impactful Giving. Eric has been researching what actually keeps volunteers engaged. Your participation counts for ZAO Fractals AND supports his research. It is a two-for-one."
+
+**CTA (15 sec):**
+"Link is in the chat now. Sign up takes 2 minutes. I will write back to you to confirm your circle and the time poll."
+
+---
+
+## Signup Form Spec
+
+Simple form. 5 fields + consent. Should take 2 minutes.
+
+1. **Name / preferred handle** (for introductions within circle) - text, required
+2. **Email** - required (for Eric's app to deliver appreciation points + session reminders, not shared publicly)
+3. **Time zone** - dropdown, required (ET / PT / CET / GMT / other)
+4. **Times you could make an hour-a-week commitment** - checkbox grid, select any that work:
+   - Tuesday morning (9am-12pm ET)
+   - Tuesday afternoon (1pm-5pm ET)
+   - Tuesday evening (6pm-9pm ET)
+   - Wednesday morning / afternoon / evening (same slots)
+   - Thursday same
+   - Other (text field)
+5. **What do you want to work on during the 8 weeks?** - textarea, optional
+   - Prompt: "An album, a project, a shipping streak, a personal challenge - what would the weekly check-in help you move forward?"
+6. **Which circle theme feels right?** - multi-select, optional:
+   - Artists shipping (ZABAL / WaveWarZ / albums)
+   - ZAOstock crew
+   - UK + Impact Concerts
+   - Music on-chain builders
+   - Other / no preference
+7. **Informed consent** - required checkbox + link to Eric's IRB consent form
+   - "I understand this is part of Impactful Giving's research program. Participation is voluntary. I can stop at any time. My name will not be attached to research data."
+
+**Submit button copy:** "Save my spot"
+
+**After submit page:** "You are in. Watch your email for: (1) informed consent confirmation from Impactful Giving, (2) the time poll once we have enough people signed up, (3) your volunteer ID and session link."
+
+---
+
+## What to Send Eric BEFORE Publishing
+
+Pack for Eric's review:
+1. This file (recruitment.md) in full
+2. A one-liner: "Here's what I'm planning to send. Want your review before it ships. Especially on: (a) whether the low-commitment framing conflicts with your research needs, (b) whether 'double impact' framing for Impactful Giving is OK to use, (c) any consent form language you want me to match."
+3. Eric's informed consent URL so we can link to it in the form
+4. Timing: when can we start? Proposed: signup opens this week, time poll closes one week later, first session late May.
+
+---
+
+## Order of Operations (distribution sequence)
+
+Once Eric approves:
+
+1. **Day 0:** Post signup form link in Discord announcement channel + Telegram GC + Farcaster cast. Talk about it on 11am Spaces.
+2. **Day 0 end of day:** DM past Fractal attendees directly (copy from the Telegram short version, personalized opener).
+3. **Day 1-3:** Remind across same channels, thank early signups publicly.
+4. **Day 4:** Close signups or extend another week based on count.
+5. **Day 5:** Send time poll to all signups (Rallly or Tally).
+6. **Day 7:** Announce final time(s), circle assignments, first session date.
+7. **Week 1 (late May):** First session. Zaal hosts. Eric observes / runs data collection.
+
+---
+
+## Voice Reference
+
+- Zaal tone: short sentences, builder energy, no corporate polish
+- Say "Farcaster" not "Warpcast"
+- No em dashes - hyphens only
+- No emojis or decorative Unicode
+- Never use "amazing" / "incredible" / "exciting" fluff words - use concrete language
+- Build-in-public frame: document, do not hype
+- Mobile-first: every version above should read fine on an iPhone screen without wrapping awkwardly


### PR DESCRIPTION
## Summary
- Adds `recruitment.md` alongside the doc 458 README
- Recruitment pack for Contribution Circles pilot: long-form, 2x Farcaster/X casts, Telegram GC, Discord @everyone, ZAO Spaces talking points, signup form spec, 7-day distribution sequence

## Why
Follow-up to PR #246 (merged). Captures Zaal's framing: low-commitment ("you do not have to do all 8"), time-after-signup poll, double-impact (ZAO Fractals AND Impactful Giving research). Needs Eric's review before publishing to the community.

## Test plan
- [ ] Send `recruitment.md` to Eric for research-compatibility review
- [ ] Get Eric's informed consent URL for the signup form
- [ ] Pick start date (late May, working back from Week 1)
- [ ] Build actual signup form (Tally/Google Form) once copy approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)