### PR TITLE
feat(portal): observability polish — live sessions widget + Caddy body caps

### DIFF
--- a/infra/portal/caddy/Caddyfile
+++ b/infra/portal/caddy/Caddyfile
@@ -17,6 +17,10 @@
 # ao.zaoos.com -> :3002 -> wrapper at /, /app/* proxies to AO :3001
 :3002 {
   import protected
+  # Body-size cap: AO app proxies uploads; keep generous but bounded (doc 463 finding 5).
+  request_body {
+    max_size 5MB
+  }
 
   # Terminal mux WebSocket - Next.js server on :3000 handles /ao-terminal-mux upgrade
   @aoWebsocket path /ao-terminal-mux /ao-terminal-mux/*
@@ -46,8 +50,12 @@
 # portal.zaoos.com -> :3003 -> static portal, /todos UI, backend API
 :3003 {
   import protected
+  # Body-size cap: portal APIs are small JSON (todos, spawn-agent) — tight cap (doc 463 finding 5).
+  request_body {
+    max_size 256KB
+  }
 
-  @backend path /spawn-action /api/spawn /api/spawn-agent /test-checklist /test-done /api/todos /api/todos/*
+  @backend path /spawn-action /api/spawn /api/spawn-agent /api/sessions /test-checklist /test-done /api/todos /api/todos/*
   reverse_proxy @backend localhost:3004
 
   @todosPage path /todos

--- a/infra/portal/caddy/portal/agents.html
+++ b/infra/portal/caddy/portal/agents.html
@@ -94,8 +94,17 @@
   <div class="grid">
     <div class="row">
       <div class="name">ZOE learning pings</div>
-      <div class="status dormant">staged</div>
-      <div class="where">/home/zaal/zoe-learning-pings/ • every 30 min during 9am-9pm ET (awaits activation)</div>
+      <div class="status live">live</div>
+      <div class="where">/home/zaal/zoe-learning-pings/ • every 30 min during 9am-9pm ET</div>
+    </div>
+  </div>
+
+  <div class="layer">Live AO sessions</div>
+  <div class="grid" id="sessions-grid">
+    <div class="row">
+      <div class="name" id="sessions-status">loading...</div>
+      <div class="status dormant" id="sessions-count">-</div>
+      <div class="where" id="sessions-hint">polling /api/sessions every 15s</div>
     </div>
   </div>
 
@@ -106,5 +115,44 @@
   </div>
 </main>
 <script src="/dock/dock.js" defer></script>
+<script>
+(function(){
+  const grid = document.getElementById('sessions-grid');
+  function fmtAge(secs){
+    if (secs < 60) return secs + 's ago';
+    if (secs < 3600) return Math.floor(secs/60) + 'm ago';
+    if (secs < 86400) return Math.floor(secs/3600) + 'h ago';
+    return Math.floor(secs/86400) + 'd ago';
+  }
+  function render(sessions){
+    if (!sessions || sessions.length === 0){
+      grid.innerHTML = '<div class="row"><div class="name">no sessions</div><div class="status dormant">0</div><div class="where">nothing running in ~/.agent-orchestrator/ZAOOS/sessions/</div></div>';
+      return;
+    }
+    const live = sessions.slice(0, 5);
+    grid.innerHTML = live.map(s => {
+      const isRecent = s.ageSecs < 900; // <15 min = considered running
+      const statusClass = isRecent ? 'live' : 'dormant';
+      const statusText = isRecent ? 'running' : 'idle';
+      return '<div class="row"><div class="name">' + escapeHTML(s.id.slice(0, 40)) + '</div><div class="status ' + statusClass + '">' + statusText + '</div><div class="where">' + fmtAge(s.ageSecs) + '</div></div>';
+    }).join('');
+  }
+  function escapeHTML(s){
+    return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+  async function poll(){
+    try {
+      const r = await fetch('/api/sessions', {credentials:'same-origin'});
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const data = await r.json();
+      render(data.sessions || []);
+    } catch (e) {
+      grid.innerHTML = '<div class="row"><div class="name">error</div><div class="status dormant">-</div><div class="where">' + escapeHTML(e.message) + '</div></div>';
+    }
+  }
+  poll();
+  setInterval(poll, 15000);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds live AO sessions widget to `portal.zaoos.com/agents` — polls `/api/sessions` every 15s, marks sessions <15 min old as "running".
- Flips "ZOE learning pings" row from "staged" to "live" (cron has been running).
- Caddy body-size caps: `:3002` (ao) 5MB, `:3003` (portal) 256KB. Registers `/api/sessions` on the portal backend matcher.
- Follows up doc 463 finding 5 (unbounded body DoS) with a Caddy-layer defense in addition to the app-layer cap shipped in PR #249.

## Validation

- `caddy validate` on VPS returned "Valid configuration".
- No new dependencies, no new state.

## Deploy after merge

```bash
git show origin/main:infra/portal/caddy/Caddyfile | ssh zaal@31.97.148.88 'cat > ~/caddy/Caddyfile'
git show origin/main:infra/portal/caddy/portal/agents.html | ssh zaal@31.97.148.88 'cat > ~/caddy/portal/agents.html'
ssh zaal@31.97.148.88 '~/.local/bin/caddy reload --config ~/caddy/Caddyfile --adapter caddyfile'
```

## Test plan

- [ ] After deploy: open `portal.zaoos.com/agents` — "Live AO sessions" section renders
- [ ] Widget shows existing session dirs if any exist under `~/.agent-orchestrator/ZAOOS/sessions/`
- [ ] Widget auto-refreshes without a page reload
- [ ] `curl -X POST --data-binary @huge.bin portal.zaoos.com/api/spawn-agent` → 413 from Caddy
- [ ] Existing Act button flow still works (small payload = no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)