### PR TITLE
fix(caddy): AO terminal render (real WS path to :14801/mux)

### DIFF
--- a/infra/portal/caddy/Caddyfile
+++ b/infra/portal/caddy/Caddyfile
@@ -22,10 +22,11 @@
     max_size 5MB
   }
 
-  # Terminal mux WebSocket - Next.js server on :3000 handles /ao-terminal-mux upgrade
+  # Terminal mux WebSocket - direct-terminal-ws.js listens on :14801 at path /mux
   @aoWebsocket path /ao-terminal-mux /ao-terminal-mux/*
   handle @aoWebsocket {
-    reverse_proxy localhost:3000
+    rewrite * /mux
+    reverse_proxy localhost:14801
   }
 
   # AO internal paths (Next.js uses absolute URLs for its own assets)


### PR DESCRIPTION
## Summary
- Caddy /ao-terminal-mux now rewrites to /mux and proxies to :14801 (direct-terminal-ws.js)
- Prior fix (PR #226) targeted :3000 which does not handle the upgrade

## Evidence
- curl WS upgrade vs :14801/mux returns HTTP 101 Switching Protocols
- Same curl vs :3000/ao-terminal-mux hangs with no response
- After Caddy update: curl through :3002 with Host ao.zaoos.com + valid cookie returns 101 + Sec-WebSocket-Accept

## Also
- Killed a legacy orphan direct-terminal-ws.js process (Apr 17 boot survivor)
- Memory file project_ao_two_spawn_paths.md corrected

## Test plan
- [ ] Zaal refreshes ao.zaoos.com, clicks a session
- [ ] Live terminal shows scrolling Claude Code output (was 'Terminal session has ended')

🤖 Generated with [Claude Code](https://claude.com/claude-code)