### PR TITLE
feat(zoe): ship-fix inline-keyboard -> AO -> PR loop (doc 464 parts 3+5)

### DIFF
--- a/infra/portal/bin/bot.mjs
+++ b/infra/portal/bin/bot.mjs
@@ -13,8 +13,13 @@ const CHECKLIST_FILE = "/home/zaal/test-checklist/state.json";
 // doc doesn't exist. Root cause of the 2026-04-20 bug logged in doc 464.
 const SENT_TIPS_FILE = process.env.HOME + "/.cache/zoe-learning-pings/sent.json";
 const CONV_DIR = process.env.HOME + "/.cache/zoe-telegram";
+const SHIP_RATE_FILE = CONV_DIR + "/ship-rate.json";
+const MUTE_FILE = CONV_DIR + "/muted-docs.json";
+const WATCH_FILE = CONV_DIR + "/watched-sessions.json";
 const CONV_TURN_LIMIT = 20;
 const TIP_CONTEXT_DAYS = 7;
+const SHIP_RATE_LIMIT_PER_HOUR = 3;
+const SPAWN_SERVER_URL = process.env.SPAWN_SERVER_URL || "http://127.0.0.1:3004";
 
 function readTodos() {
   try { return JSON.parse(readFileSync(TODOS_FILE, "utf-8")); }
@@ -53,6 +58,115 @@ function appendConversation(chatId, userMsg, botReply) {
   }]).slice(-CONV_TURN_LIMIT);
   try { writeFileSync(f, JSON.stringify({ turns }, null, 2)); }
   catch (e) { console.error("Conv write error:", e.message); }
+}
+
+function checkShipRateLimit() {
+  try {
+    const s = JSON.parse(readFileSync(SHIP_RATE_FILE, "utf-8"));
+    const cutoff = Date.now() - 3600_000;
+    const recent = (s.events || []).filter((e) => e.at > cutoff);
+    return { allowed: recent.length < SHIP_RATE_LIMIT_PER_HOUR, used: recent.length };
+  } catch { return { allowed: true, used: 0 }; }
+}
+
+function recordShipAttempt() {
+  try { mkdirSync(CONV_DIR, { recursive: true }); } catch {}
+  let s = { events: [] };
+  try { s = JSON.parse(readFileSync(SHIP_RATE_FILE, "utf-8")); } catch {}
+  const cutoff = Date.now() - 3600_000;
+  s.events = (s.events || []).filter((e) => e.at > cutoff);
+  s.events.push({ at: Date.now() });
+  try { writeFileSync(SHIP_RATE_FILE, JSON.stringify(s)); } catch {}
+}
+
+function loadMutedDocs() {
+  try { return JSON.parse(readFileSync(MUTE_FILE, "utf-8")); }
+  catch { return { muted: {} }; }
+}
+
+function muteDoc(docNum, days) {
+  try { mkdirSync(CONV_DIR, { recursive: true }); } catch {}
+  const s = loadMutedDocs();
+  s.muted = s.muted || {};
+  s.muted[String(docNum)] = { until: Date.now() + days * 86400000 };
+  try { writeFileSync(MUTE_FILE, JSON.stringify(s, null, 2)); } catch {}
+}
+
+function recordWatchedSession(sessionId, meta) {
+  if (!sessionId) return;
+  try { mkdirSync(CONV_DIR, { recursive: true }); } catch {}
+  let s = { sessions: {} };
+  try { s = JSON.parse(readFileSync(WATCH_FILE, "utf-8")); } catch {}
+  s.sessions = s.sessions || {};
+  s.sessions[sessionId] = { ...meta, started_at: Date.now(), notified: false };
+  try { writeFileSync(WATCH_FILE, JSON.stringify(s, null, 2)); } catch {}
+}
+
+async function postSpawnAgent({ doc, title, intent = "review", extra = "" }) {
+  const body = JSON.stringify({ doc, title, intent, extra });
+  const res = await fetch(SPAWN_SERVER_URL + "/api/spawn-agent", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  });
+  const text = await res.text();
+  let payload = {};
+  try { payload = JSON.parse(text); } catch {}
+  return { status: res.status, payload, rawText: text.slice(0, 500) };
+}
+
+async function editMessageText(chatId, messageId, newText) {
+  try {
+    await fetch(API + "/editMessageText", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        message_id: messageId,
+        text: newText,
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (e) { console.error("editMessageText error:", e.message); }
+}
+
+async function answerCallback(callbackId, text) {
+  try {
+    await fetch(API + "/answerCallbackQuery", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        callback_query_id: callbackId,
+        text: String(text || "").slice(0, 200),
+        show_alert: false,
+      }),
+    });
+  } catch (e) { console.error("answerCallback error:", e.message); }
+}
+
+// Publish the slash-command list so Telegram's blue "menu" button surfaces
+// every command without Zaal typing /help. Idempotent — safe to call on boot.
+async function publishCommands() {
+  const commands = [
+    { command: "todo", description: "Add todo: /todo <text> [P0-P3] [+Project] [#tag]" },
+    { command: "done", description: "Mark todo done: /done <id-prefix|text>" },
+    { command: "list", description: "Top 12 open todos by priority" },
+    { command: "p0", description: "Show only P0 open todos" },
+    { command: "p1", description: "Show P0 + P1 open todos" },
+    { command: "note", description: "Append note to todo: /note <id> <text>" },
+    { command: "recap", description: "Recap last 14 days of shipped work" },
+    { command: "summarize", description: "Project status: /summarize <project>" },
+    { command: "focus", description: "Mute nudges for N min: /focus 60" },
+    { command: "tip", description: "Resolve a ZOE tip: /tip 157" },
+    { command: "help", description: "Command reference" },
+  ];
+  try {
+    await fetch(API + "/setMyCommands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ commands }),
+    });
+  } catch (e) { console.error("setMyCommands error:", e.message); }
 }
 
 // Local fallback when sent.json hasn't caught this tip yet (e.g. Zaal asks
@@ -413,14 +527,115 @@ function logConversation(userMsg, botReply) {
   try { appendFileSync(logFile, entry); } catch (e) { console.error("Log error:", e.message); }
 }
 
+async function handleCallback(update) {
+  const cq = update.callback_query;
+  if (!cq || !cq.data) return;
+  const userId = String(cq.from.id);
+  if (userId !== ALLOWED_USER) {
+    await answerCallback(cq.id, "Not authorized.");
+    return;
+  }
+  const chatId = cq.message && cq.message.chat && cq.message.chat.id;
+  const messageId = cq.message && cq.message.message_id;
+  const originalText = (cq.message && cq.message.text) || "";
+  // callback_data is `ship:<num>` | `snooze:<num>` | `mute:<num>`. <num> is the
+  // research doc's leading integer id. Cheap to validate.
+  const m = cq.data.match(/^(ship|snooze|mute):(\d+)$/);
+  if (!m) { await answerCallback(cq.id, "Unknown action"); return; }
+  const action = m[1];
+  const docNum = m[2];
+
+  if (action === "snooze") {
+    await answerCallback(cq.id, "Noted. Will re-surface soon.");
+    if (chatId && messageId) {
+      await editMessageText(chatId, messageId, originalText + "\n\n[SNOOZED]");
+    }
+    return;
+  }
+
+  if (action === "mute") {
+    muteDoc(docNum, 7);
+    await answerCallback(cq.id, "Muted for 7 days.");
+    if (chatId && messageId) {
+      await editMessageText(chatId, messageId, originalText + "\n\n[MUTED 7d]");
+    }
+    return;
+  }
+
+  // action === "ship": locate doc + spawn AO agent via spawn-server.
+  const rate = checkShipRateLimit();
+  if (!rate.allowed) {
+    await answerCallback(cq.id, "Rate limit: " + SHIP_RATE_LIMIT_PER_HOUR + "/hour");
+    if (chatId) {
+      await sendMessage(chatId, "[SHIP FIX] rate-limited (" + rate.used + "/" + SHIP_RATE_LIMIT_PER_HOUR + " this hour). Try again in 1hr.");
+    }
+    return;
+  }
+
+  const docPath = findDocByNumber(docNum);
+  if (!docPath) {
+    await answerCallback(cq.id, "Doc " + docNum + " not found in research/");
+    return;
+  }
+  // Re-validate against handleSpawnAgent's allowlist to fail fast if we
+  // somehow built a bad path. Mirrors spawn-server.js:213.
+  if (!/^[a-z0-9][a-z0-9/_.-]*\.md$/i.test(docPath)) {
+    await answerCallback(cq.id, "Invalid doc path");
+    return;
+  }
+
+  // Try to pull the tip's title from sent.json so the PR title reads nicely.
+  const tips = loadRecentTips(30);
+  const hit = tips.find((t) => (t.path || "").includes("/" + docNum + "-"));
+  const title = (hit && hit.title) || ("Doc " + docNum);
+
+  await answerCallback(cq.id, "Spawning fix agent...");
+  if (chatId && messageId) {
+    await editMessageText(chatId, messageId, originalText + "\n\n[SHIPPING] spawning Claude Code...");
+  }
+
+  recordShipAttempt();
+  let result;
+  try {
+    result = await postSpawnAgent({ doc: docPath, title, intent: "review" });
+  } catch (e) {
+    if (chatId) await sendMessage(chatId, "[SHIP FIX] spawn error: " + e.message.slice(0, 200));
+    return;
+  }
+
+  if (result.status >= 400) {
+    if (chatId) await sendMessage(chatId, "[SHIP FIX] spawn-server " + result.status + ": " + (result.payload.error || result.rawText));
+    return;
+  }
+
+  const sessionId = result.payload && result.payload.sessionId;
+  recordWatchedSession(sessionId, { docNum, docPath, title, chatId, messageId });
+
+  if (chatId) {
+    const lines = ["[SHIPPING] doc " + docNum + " -> " + docPath];
+    if (sessionId) {
+      lines.push("Session: " + sessionId);
+    } else {
+      lines.push("Session: spawning in background (status " + result.status + ")");
+    }
+    lines.push("Watcher will reply with PR link when ready.");
+    await sendMessage(chatId, lines.join("\n"));
+  }
+}
+
 async function poll(offset) {
   offset = offset || 0;
   try {
-    const res = await fetch(API + "/getUpdates?offset=" + offset + "&timeout=30");
+    const res = await fetch(API + "/getUpdates?offset=" + offset + "&timeout=30&allowed_updates=%5B%22message%22%2C%22callback_query%22%5D");
     const data = await res.json();
     if (data.ok && data.result.length > 0) {
       for (const update of data.result) {
         offset = update.update_id + 1;
+        if (update.callback_query) {
+          try { await handleCallback(update); }
+          catch (e) { console.error("Callback handler error:", e.message); }
+          continue;
+        }
         const msg = update.message;
         if (!msg || !msg.text) continue;
         const userId = String(msg.from.id);
@@ -453,5 +668,7 @@ console.log("ZOE v2 Telegram Bot (Opus via Max plan)");
 console.log("Workspace: " + WORKSPACE);
 console.log("Repo: " + REPO);
 await fetch(API + "/deleteWebhook");
-console.log("Webhook cleared. Polling...");
+console.log("Webhook cleared. Publishing commands menu...");
+await publishCommands();
+console.log("Polling...");
 poll();

--- a/infra/portal/bin/session-watcher.mjs
+++ b/infra/portal/bin/session-watcher.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// ZOE ship-fix session watcher.
+//
+// bot.mjs records every Ship-Fix spawn in ~/.cache/zoe-telegram/watched-sessions.json.
+// Each entry: { sessionId, docNum, docPath, title, chatId, messageId, started_at, notified }.
+// This watcher runs on a cron (every 2 min is plenty) and for each unnotified
+// session either:
+//   - finds a PR matching branch pattern ws/act-<doc-slug>-* and posts its URL to Telegram
+//   - if >20 min elapsed and no PR, posts a timeout message
+// then marks notified=true so we don't double-post.
+//
+// Kept intentionally simple — no dependencies, no daemon. Re-runs idempotently.
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const API = "https://api.telegram.org/bot" + BOT_TOKEN;
+const WATCH_FILE = process.env.HOME + "/.cache/zoe-telegram/watched-sessions.json";
+const REPO = "bettercallzaal/ZAOOS";
+const MAX_WAIT_MS = 20 * 60_000;
+const GH_BIN = process.env.GH_BIN || "/home/zaal/.local/bin/gh";
+
+function log(msg) {
+  console.log("[" + new Date().toISOString() + "] " + msg);
+}
+
+function loadWatch() {
+  try { return JSON.parse(readFileSync(WATCH_FILE, "utf-8")); }
+  catch { return { sessions: {} }; }
+}
+
+function saveWatch(state) {
+  try { mkdirSync(process.env.HOME + "/.cache/zoe-telegram", { recursive: true }); } catch {}
+  writeFileSync(WATCH_FILE, JSON.stringify(state, null, 2));
+}
+
+async function sendTelegram(chatId, text) {
+  if (!BOT_TOKEN) { log("TELEGRAM_BOT_TOKEN missing; printing"); console.log(text); return; }
+  if (!chatId) { log("no chat_id; printing"); console.log(text); return; }
+  try {
+    await fetch(API + "/sendMessage", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+    });
+  } catch (e) { log("send error: " + e.message); }
+}
+
+// Given a doc path like research/dev-workflows/157-cross-project-asset-audit/README.md,
+// rebuild the branch slug bot.mjs/spawn-server.js uses:
+//   slug = doc.replace(/[^a-z0-9]/gi, "-").slice(0, 40).toLowerCase()
+//   branch = "ws/act-" + slug + "-MMDD-HHMM"
+// We don't know the timestamp suffix, so we search gh for matching prefix.
+function docSlug(docPath) {
+  return String(docPath).replace(/[^a-z0-9]/gi, "-").slice(0, 40).toLowerCase();
+}
+
+function findPrForDoc(docPath) {
+  const slug = docSlug(docPath);
+  const prefix = "ws/act-" + slug;
+  try {
+    const out = execSync(
+      GH_BIN + " pr list --repo " + REPO + " --state open --limit 20 " +
+      "--json number,title,headRefName,url --search \"head:" + prefix + "\" 2>/dev/null || echo '[]'",
+      { encoding: "utf-8", timeout: 10000 }
+    ).trim();
+    const prs = JSON.parse(out || "[]");
+    return prs.find((p) => (p.headRefName || "").startsWith(prefix)) || null;
+  } catch (e) {
+    log("gh pr list failed: " + e.message.slice(0, 160));
+    return null;
+  }
+}
+
+async function processSession(sessionId, meta) {
+  const { docNum, docPath, title, chatId, started_at } = meta;
+  const age = Date.now() - (started_at || 0);
+  const pr = findPrForDoc(docPath);
+  if (pr) {
+    const msg = [
+      "[SHIPPED] doc " + docNum + " -> PR #" + pr.number,
+      title || "",
+      pr.url || "",
+    ].filter(Boolean).join("\n");
+    await sendTelegram(chatId, msg);
+    return { notified: true, result: "pr", pr: pr.number };
+  }
+  if (age > MAX_WAIT_MS) {
+    await sendTelegram(
+      chatId,
+      "[SHIP FIX TIMEOUT] doc " + docNum + " (session " + sessionId + ") no PR after 20 min. " +
+      "Check ~/.agent-orchestrator/ZAOOS/sessions/ on VPS."
+    );
+    return { notified: true, result: "timeout" };
+  }
+  return { notified: false };
+}
+
+async function main() {
+  const state = loadWatch();
+  const sessions = state.sessions || {};
+  const sids = Object.keys(sessions);
+  if (!sids.length) { log("no watched sessions"); return; }
+
+  let changed = false;
+  for (const sid of sids) {
+    const meta = sessions[sid];
+    if (meta.notified) continue;
+    try {
+      const res = await processSession(sid, meta);
+      if (res.notified) {
+        meta.notified = true;
+        meta.result = res.result;
+        if (res.pr) meta.pr = res.pr;
+        changed = true;
+      }
+    } catch (e) { log("session " + sid + " error: " + e.message); }
+  }
+
+  // Prune notified sessions older than 24h.
+  const cutoff = Date.now() - 86_400_000;
+  for (const sid of sids) {
+    const meta = sessions[sid];
+    if (meta.notified && (meta.started_at || 0) < cutoff) {
+      delete sessions[sid];
+      changed = true;
+    }
+  }
+
+  if (changed) saveWatch(state);
+}
+
+main().catch((e) => { log("fatal: " + e.message); process.exit(1); });

--- a/infra/portal/bin/watchdog.sh
+++ b/infra/portal/bin/watchdog.sh
@@ -36,4 +36,7 @@ respawn ttyd          "$HOME/.local/bin/ttyd -i lo -p 7681 -W -t fontSize=15 -t 
 respawn cloudflared   "cloudflared tunnel run zao-agents" "cloudflared tunnel run"
 respawn spawn-server  "bash -c \"$ENV_SOURCE; node \$HOME/bin/spawn-server.js 2>&1 | tee \$HOME/spawn-server.log\"" "node.*spawn-server.js"
 respawn auth-server   "bash -c \"$ENV_SOURCE; node \$HOME/bin/auth-server.js 2>&1 | tee \$HOME/auth-server.log\"" "node.*auth-server.js"
-respawn zoe-bot       "bash -c \"$ENV_SOURCE; cd \$HOME/zoe-bot; node bot.mjs 2>&1 | tee bot.log\"" "node bot.mjs"
+# Bot source of truth = repo-synced symlink at $HOME/bin/bot.mjs (per install.sh).
+# cwd stays at $HOME/zoe-bot so existing logs (bot.log, api.log, commands.log)
+# and auxiliary scripts (send-coc4.sh) keep their home.
+respawn zoe-bot       "bash -c \"$ENV_SOURCE; mkdir -p \$HOME/zoe-bot; cd \$HOME/zoe-bot; node \$HOME/bin/bot.mjs 2>&1 | tee bot.log\"" "node.*bot.mjs"

--- a/infra/portal/install.sh
+++ b/infra/portal/install.sh
@@ -25,7 +25,7 @@ ln -sfn "$REPO_DIR/caddy/portal"            "$HOME_DIR/caddy/portal"
 ln -sfn "$REPO_DIR/caddy/dock"              "$HOME_DIR/caddy/dock"
 ln -sfn "$REPO_DIR/caddy/claude"            "$HOME_DIR/caddy/claude"
 ln -sfn "$REPO_DIR/caddy/ao"                "$HOME_DIR/caddy/ao"
-for f in auth-server.js spawn-server.js watchdog.sh start-agents.sh fix-node-pty.sh test-checklist-ping.sh; do
+for f in auth-server.js spawn-server.js watchdog.sh start-agents.sh fix-node-pty.sh test-checklist-ping.sh bot.mjs session-watcher.mjs; do
   ln -sfn "$REPO_DIR/bin/$f" "$HOME_DIR/bin/$f"
   chmod +x "$HOME_DIR/bin/$f" 2>/dev/null || true
 done
@@ -62,12 +62,15 @@ echo "== ensure todos state =="
 [ -f "$HOME_DIR/portal-state/todos.json" ] || echo '{"todos":[]}' > "$HOME_DIR/portal-state/todos.json"
 
 echo "== install crontab entries =="
-CRON=$(crontab -l 2>/dev/null | grep -v -E "start-agents\.sh|watchdog\.sh|test-checklist-ping\.sh" || true)
+CRON=$(crontab -l 2>/dev/null | grep -v -E "start-agents\.sh|watchdog\.sh|test-checklist-ping\.sh|session-watcher\.mjs" || true)
 {
   echo "$CRON"
   echo "@reboot $HOME_DIR/bin/start-agents.sh"
   echo "* * * * * $HOME_DIR/bin/watchdog.sh"
   echo "*/15 * * * * $HOME_DIR/bin/test-checklist-ping.sh >> $HOME_DIR/test-checklist/cron.log 2>&1"
+  # ZOE ship-fix session watcher: polls watched-sessions.json for matured AO
+  # sessions and posts PR links back to Telegram. See doc 464 Part 3 / Patch 6.
+  echo "*/2 * * * * . \$HOME/.env.portal 2>/dev/null; $HOME_DIR/bin/session-watcher.mjs >> $HOME_DIR/.cache/zoe-telegram/session-watcher.log 2>&1"
 } | crontab -
 
 echo "== fix node-pty (use homebridge prebuilt multiarch) =="

--- a/infra/portal/sync.sh
+++ b/infra/portal/sync.sh
@@ -9,11 +9,13 @@ git pull --ff-only origin main || echo "git pull skipped"
 # Re-run install to refresh symlinks + copy dock.js
 "$REPO_DIR/install.sh"
 
-# Bounce caddy + spawn-server + auth-server so new config + code takes effect.
+# Bounce caddy + spawn-server + auth-server + zoe-bot so new config + code takes effect.
 # ao / claude-zaoos / cloudflared left alone (sessions are precious).
-for s in caddy spawn-server auth-server ttyd; do
+for s in caddy spawn-server auth-server ttyd zoe-bot; do
   tmux kill-session -t "$s" 2>/dev/null || true
 done
+# Best-effort: kill any stray node bot.mjs processes that slipped tmux.
+pkill -f "node.*bot.mjs" 2>/dev/null || true
 sleep 2
 # watchdog runs every minute; fire it now for speed
 "$REPO_DIR/bin/watchdog.sh"

--- a/scripts/zoe-learning-pings/random_tip.py
+++ b/scripts/zoe-learning-pings/random_tip.py
@@ -225,7 +225,18 @@ def extract_tip_via_claude(doc_text: str, doc_title: str) -> str | None:
     return tip[:MAX_TIP_CHARS]
 
 
-def send_telegram(text: str) -> bool:
+def extract_doc_number(rel_path: str) -> str | None:
+    """
+    Pull the leading numeric id from a research doc path like
+    'research/dev-workflows/157-cross-project-asset-audit/README.md'
+    -> '157'. Returns None if no number found (e.g. ADRs, BRAIN entries).
+    Kept short so Telegram callback_data (64-byte cap) has room.
+    """
+    m = re.search(r"/(\d+)-[^/]+/README\.md$", rel_path)
+    return m.group(1) if m else None
+
+
+def send_telegram(text: str, reply_markup: dict | None = None) -> bool:
     if not TELEGRAM_BOT_TOKEN or not TELEGRAM_CHAT_ID:
         print("TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set; printing instead",
               file=sys.stderr)
@@ -237,11 +248,14 @@ def send_telegram(text: str) -> bool:
         print(text)
         return False
 
-    body = json.dumps({
+    payload: dict = {
         "chat_id": TELEGRAM_CHAT_ID,
         "text": text,
         "disable_web_page_preview": True,
-    }).encode("utf-8")
+    }
+    if reply_markup is not None:
+        payload["reply_markup"] = reply_markup
+    body = json.dumps(payload).encode("utf-8")
 
     req = urllib_request.Request(
         f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendMessage",
@@ -312,7 +326,27 @@ def main() -> int:
     ]
     msg = "\n".join(msg_parts)
 
-    if send_telegram(msg):
+    # Inline keyboard: SHIP FIX triggers the Telegram -> bot.mjs -> spawn-server
+    # -> AO -> Claude Code -> PR loop. MUTE parks this doc number in a snooze
+    # file so it skips future random picks for N days. Callback data is capped
+    # at 64 bytes, so we identify the doc by its numeric id.
+    doc_num = extract_doc_number(str(rel))
+    reply_markup: dict | None = None
+    if doc_num:
+        reply_markup = {
+            "inline_keyboard": [
+                [
+                    {"text": "SHIP FIX", "callback_data": f"ship:{doc_num}"},
+                    {"text": "Read", "url": github_url},
+                ],
+                [
+                    {"text": "Not now", "callback_data": f"snooze:{doc_num}"},
+                    {"text": "Mute 7d", "callback_data": f"mute:{doc_num}"},
+                ],
+            ]
+        }
+
+    if send_telegram(msg, reply_markup=reply_markup):
         state["sent"].append({
             "path": str(rel),
             "title": title,


### PR DESCRIPTION
## Summary

Implements the tip-to-PR shipping loop designed in doc 464:

1. Every ZOE tip in Telegram now has a 2-row inline keyboard: `[SHIP FIX] [Read]` / `[Not now] [Mute 7d]`.
2. Tap `SHIP FIX` -> `bot.mjs` validates + POSTs to `spawn-server.js` `/api/spawn-agent` -> AO spawns Claude Code in a worktree -> agent opens `ws/act-<slug>-<ts>` branch + PR.
3. A new `session-watcher.mjs` cron (every 2 min) polls `~/.cache/zoe-telegram/watched-sessions.json`, finds the created PR via `gh pr list --search head:<prefix>`, and posts `[SHIPPED] doc <n> -> PR #<num>` back to Telegram.

Also publishes `setMyCommands` on bot boot so Telegram's blue menu button surfaces every slash command without typing `/help`.

## Changes

- `scripts/zoe-learning-pings/random_tip.py` — `extract_doc_number()`, `send_telegram(reply_markup=...)`, inline keyboard on every tip.
- `infra/portal/bin/bot.mjs` — `handleCallback()` with allowlist re-validation, 3/hour rate limit, `editMessageText` to `[SHIPPING]`; `publishCommands()` on boot; `poll()` subscribes to `callback_query` updates.
- `infra/portal/bin/session-watcher.mjs` — new cron-driven watcher (~130 lines, zero deps).
- `infra/portal/bin/watchdog.sh` — zoe-bot now runs repo-synced `$HOME/bin/bot.mjs` with cwd stay at `$HOME/zoe-bot` for existing logs.
- `infra/portal/install.sh` — symlinks bot + watcher into `$HOME/bin/`, adds watcher crontab entry.
- `infra/portal/sync.sh` — bounces zoe-bot + pkills strays on deploy.

## Security

Per doc 463 findings:
- `callback_data` re-validated against `/^(ship|snooze|mute):(\d+)$/` before any action.
- `ALLOWED_USER` re-checked inside `handleCallback` (defense in depth, can't be set via callback).
- Doc path re-validated against `^[a-z0-9][a-z0-9/_.-]*\.md$` (same allowlist `spawn-server.js:213` enforces).
- 3 Ship-Fix spawns per hour cap in `~/.cache/zoe-telegram/ship-rate.json`.
- `handleSpawnAgent` still wraps `extra` context as DATA, not instruction override.

## Test plan

- [ ] VPS auto-pull picks up change within 15 min
- [ ] `sync.sh` bounces zoe-bot, new bot.mjs runs from `$HOME/bin/bot.mjs`
- [ ] Next tip arrives with inline keyboard (4 buttons in 2 rows)
- [ ] Tap `Not now` -> message appended with `[SNOOZED]`, no spawn
- [ ] Tap `Mute 7d` -> message appended with `[MUTED 7d]`, file written to `muted-docs.json`
- [ ] Tap `SHIP FIX` -> message shows `[SHIPPING] spawning Claude Code...`, follow-up `[SHIPPING] doc N -> path` arrives
- [ ] Within ~5-15 min: `[SHIPPED] doc N -> PR #M` follow-up arrives
- [ ] Rate limit: 4th tap within 1 hour responds `[SHIP FIX] rate-limited`
- [ ] `/tip 157` still works from bug-fix PR #253
- [ ] Telegram blue menu button shows 11 commands
- [ ] `node --check` passes on bot.mjs + session-watcher.mjs (verified locally)

## Deferred (next PR)

- `parse_mode: "HTML"` for bold tip titles + clickable URLs (easy, non-urgent)
- Mem0 memory layer per doc 245 (wait until flat JSON conv buffer proves insufficient for 2+ weeks)
- Neynar webhook -> Telegram relay (Track B in doc 464)