### PR TITLE
fix + docs: watchdog stop managing cloudflared + ZOE observability (doc 465)

### DIFF
--- a/infra/portal/bin/watchdog.sh
+++ b/infra/portal/bin/watchdog.sh
@@ -33,7 +33,10 @@ respawn ao            "cd $HOME/code/ZAOOS && ao start 2>&1 | tee $HOME/ao.log" 
 respawn caddy         "$HOME/.local/bin/caddy run --config $HOME/caddy/Caddyfile --adapter caddyfile" "caddy run"
 respawn claude-zaoos  "cd $HOME/code/ZAOOS && claude"  ""
 respawn ttyd          "$HOME/.local/bin/ttyd -i lo -p 7681 -W -t fontSize=15 -t scrollback=10000 -t disableLeaveAlert=true -t cursorBlink=true tmux attach -t claude-zaoos" "ttyd -i lo -p 7681"
-respawn cloudflared   "cloudflared tunnel run zao-agents" "cloudflared tunnel run"
+# cloudflared is supervised by user-systemd (~/.config/systemd/user/cloudflared.service)
+# so watchdog no longer manages it. Running both systemd and tmux simultaneously
+# caused duplicate tunnel connections and ~19s TTFB on every request (2026-04-20).
+# respawn cloudflared   "cloudflared tunnel run zao-agents" "cloudflared tunnel run"
 respawn spawn-server  "bash -c \"$ENV_SOURCE; node \$HOME/bin/spawn-server.js 2>&1 | tee \$HOME/spawn-server.log\"" "node.*spawn-server.js"
 respawn auth-server   "bash -c \"$ENV_SOURCE; node \$HOME/bin/auth-server.js 2>&1 | tee \$HOME/auth-server.log\"" "node.*auth-server.js"
 # Bot source of truth = repo-synced symlink at $HOME/bin/bot.mjs (per install.sh).


### PR DESCRIPTION
## Summary
- Watchdog no longer respawns cloudflared. User-systemd owns it. Running both caused duplicate tunnel connections (same UUID) and ~19s TTFB.
- Companion commit: doc 465 ZOE observability + dispatch hardening (from parallel session)

## Evidence for the cloudflared fix
- 2 processes running same UUID: one under user-systemd cloudflared.service (active), one in tmux via watchdog (from Apr 18 boot)
- Cloudflare QUIC log showed timeouts alternating between them
- curl https://ao.zaoos.com/: 19.4s TTFB before, 48-131ms after single-process fix

## Test plan
- [ ] Zaal refreshes ao.zaoos.com + portal.zaoos.com — snappy load
- [ ] Reboot VPS — systemd alone handles cloudflared
- [ ] Watchdog runs as normal without respawning a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)