### PR TITLE
fix(auto-sync): per-file hash key, not per-tmux session

### DIFF
--- a/infra/portal/bin/auto-sync.sh
+++ b/infra/portal/bin/auto-sync.sh
@@ -85,7 +85,12 @@ bounce_if_changed() {
   local new old
   new=$(file_hash "$file")
   [ -z "$new" ] && return 0
-  local hf="$HASH_DIR/${tmux_name}.hash"
+  # Hash key is per-FILE (basename), not per-tmux session. Prior version used
+  # ${tmux_name}.hash which caused every watched file that shared a tmux name
+  # (bot.mjs + events.mjs both bounce zoe-bot) to overwrite the same hash
+  # file on each pass, producing a bounce-every-tick loop observed at
+  # 2026-04-21T11:35:03 in ~/.claude/auto-sync.log.
+  local hf="$HASH_DIR/$(basename "$file").hash"
   old=""
   [ -f "$hf" ] && old=$(cat "$hf")
   if [ "$new" != "$old" ]; then
@@ -96,7 +101,7 @@ bounce_if_changed() {
       [ -n "$procpat" ] && pkill -f "$procpat" 2>/dev/null || true
       log "bounced $tmux_name (file=$file)"
     else
-      log "seeded $tmux_name hash (no bounce)"
+      log "seeded $(basename "$file") hash (no bounce)"
     fi
   fi
 }


### PR DESCRIPTION
Tight bugfix for the deploy loop seen in production right after PR #262 merged.

## Symptom

\`~/.claude/auto-sync.log\` showed zoe-bot being bounced TWICE per minute:
\`\`\`
11:36:02 bounced zoe-bot (file=bot.mjs)
11:36:02 bounced zoe-bot (file=events.mjs)
\`\`\`

Each minute kills the bot, watchdog respawns it, then kills it again, respawns it again. Two boot events per minute in events.jsonl.

## Root cause

\`bounce_if_changed()\` stored hash files as \`\${tmux_name}.hash\`. Two watched files (\`bot.mjs\` + \`events.mjs\`) both target the same tmux session \`zoe-bot\`, so they share one hash file and ping-pong overwrite each other. Each pass sees the OTHER file's hash as \"old\" and triggers a bounce.

## Fix

Hash file is now keyed on \`basename(file)\` — each watched file has its own hash. Bounce fires only when its own content changes.

## Test plan

- [ ] After merge + auto-sync picks up: next cron tick writes \`bot.mjs.hash\`, \`events.mjs.hash\`, etc. as separate files
- [ ] No more \"bounced zoe-bot\" lines in auto-sync.log after initial seed (unless there's an actual deploy)
- [ ] Single boot event per deploy, not two per minute

## Stranded state

Existing \`zoe-bot.hash\` etc. from the buggy version are leftover but harmless. Next tick writes the new per-file hashes alongside. They can be cleaned up manually: \`rm ~/.cache/auto-sync/{zoe-bot,spawn-server,auth-server}.hash\` — not required.