### PR TITLE
chore(zoe): trace_id on outbound + auto-sync quiet + bots/ scaffold

### DIFF
--- a/infra/portal/bin/auto-sync.sh
+++ b/infra/portal/bin/auto-sync.sh
@@ -28,6 +28,18 @@ log() { echo "$(TS) $*" >> "$LOG"; }
 pull_clone() {
   local dir=$1
   [ -d "$dir/.git" ] || return 0
+  # Skip clones that aren't on `main` with a clean tree. Dev work copies
+  # (Zaal's ~/code/ZAOOS sits on a feature branch with uncommitted changes)
+  # always fail ff-only pull and were flooding the log every tick. Silent
+  # skip respects user workflow.
+  local branch
+  branch=$(git -C "$dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  if [ "$branch" != "main" ]; then
+    return 0
+  fi
+  if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null)" ]; then
+    return 0
+  fi
   local before after
   before=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo "")
   git -C "$dir" pull --ff-only origin main >/dev/null 2>&1 || {

--- a/infra/portal/bin/bot.mjs
+++ b/infra/portal/bin/bot.mjs
@@ -495,7 +495,9 @@ async function sendMessageChunk(chatId, chunk, { maxRetries = 3, baseDelay = 200
   return false;
 }
 
-async function sendMessage(chatId, text) {
+// trace_id is optional but strongly preferred — lets /activity digest + debugger
+// stitch the full inbound -> claude_call -> outbound chain into one request.
+async function sendMessage(chatId, text, trace_id) {
   const chunks = [];
   let remaining = text;
   while (remaining.length > 0) {
@@ -510,7 +512,7 @@ async function sendMessage(chatId, text) {
     const ok = await sendMessageChunk(chatId, chunk);
     if (!ok) allOk = false;
   }
-  emit({ source: "bot", event: "outbound", chat_id: chatId, bytes: text.length, chunks: chunks.length, ok: allOk });
+  emit({ source: "bot", event: "outbound", chat_id: chatId, bytes: text.length, chunks: chunks.length, ok: allOk, trace_id });
   return allOk;
 }
 
@@ -699,7 +701,7 @@ async function poll(offset) {
         const trace_id = traceId();
         if (!isAllowed(userId)) {
           emit({ source: "bot", event: "auth_reject", user: userId, chat: chatId, trace_id });
-          await sendMessage(chatId, "Not authorized.");
+          await sendMessage(chatId, "Not authorized.", trace_id);
           continue;
         }
         emit({ source: "bot", event: "inbound", user: userId, chat: chatId, bytes: msg.text.length, trace_id, text_preview: msg.text.slice(0, 80) });
@@ -708,7 +710,7 @@ async function poll(offset) {
         const slashReply = await handleTodoCommand(msg.text);
         if (slashReply !== null) {
           emit({ source: "bot", event: "slash_handled", user: userId, chat: chatId, trace_id, bytes: slashReply.length });
-          await sendMessage(chatId, slashReply);
+          await sendMessage(chatId, slashReply, trace_id);
           logConversation(msg.text, slashReply);
           appendConversation(chatId, msg.text, slashReply);
           console.log("[" + new Date().toISOString() + "] ZOE(todo): " + slashReply.substring(0, 80));
@@ -719,7 +721,7 @@ async function poll(offset) {
         const t = startTimer();
         const reply = callClaude(msg.text, systemPrompt);
         emit({ source: "bot", event: "claude_call", user: userId, chat: chatId, trace_id, duration_ms: t.ms(), reply_bytes: reply.length });
-        await sendMessage(chatId, reply);
+        await sendMessage(chatId, reply, trace_id);
         logConversation(msg.text, reply);
         appendConversation(chatId, msg.text, reply);
         console.log("[" + new Date().toISOString() + "] ZOE: " + reply.substring(0, 80) + "...");

--- a/infra/portal/bin/bots/README.md
+++ b/infra/portal/bin/bots/README.md
@@ -1,0 +1,62 @@
+# ZAO Branded Bot Fleet
+
+Home for all ZAO branded Telegram + Farcaster bots. Each bot runs as its own
+tmux session managed by `infra/portal/bin/watchdog.sh`. Shared plumbing lives
+in `_shared/`.
+
+Designed per research docs 464, 465, 467, 468.
+
+## Layout
+
+```
+bots/
+  _shared/                    shared modules, imported by every bot
+    bot-core.mjs              Telegram plumbing: poll, send+retry, callbacks
+    fc-bot-core.mjs           Farcaster plumbing: Neynar webhooks, publishCast
+    persona-loader.js         reads bots/<name>/persona.md
+    rate-limit.js             per-user + per-group caps
+    guardrail.js              Haiku post-reply tone check (placeholder)
+    circuit.js                N-rejections-in-24h -> read-only (placeholder)
+    model-router.js           Haiku/Sonnet/Opus routing per task
+    approval-queue.js         draft-to-Telegram pattern for FC casts
+  zao-devz/                   order 1 — autonomous coding in ZAO DEVZ group
+  research/                   order 2 — /zao-research skill wrapper
+  zao-stock/                  order 3 — conversational event assistant
+  magnetiq/                   order 4 — SAPS idea generator
+  wavewarz/                   order 5 — planning + hype
+  poidh/                      Farcaster order 1 — bounty ideas in /poidh
+  hypersub/                   Farcaster order 2 — TBD per Zaal
+```
+
+Each `bots/<name>/` contains:
+- `persona.md` — voice, tone, examples, forbidden phrases, escalation
+- `triggers.yaml` — scheduled + reactive + external trigger config with rate caps
+- `.env` — bot token, fid, ALLOWED_USERS/GROUPS/FIDS, model overrides
+- `bot.mjs` or `fc-bot.mjs` — thin wrapper that calls `runBot(config)`
+
+## Current status (2026-04-21)
+
+**Phase 1 — scaffolding only.** `_shared/` is empty. ZOE's existing bot at
+`infra/portal/bin/bot.mjs` is the template we'll extract from in the A1 task
+tomorrow. No branded bot is live yet.
+
+## Next action
+
+Per `project_tomorrow_first_tasks` memory: install Anthropic API key on VPS,
+then extract `_shared/bot-core.mjs`, then ship `bots/zao-devz/`.
+
+## Model routing default
+
+- Haiku 4.5 for classification + guardrails + rate checks (60-80% of calls)
+- Sonnet 4.6 for brand-voice reply generation (15-20%)
+- Opus 4.7 reserved for ZOE concierge + heavy code inside AO sessions (<=5%)
+
+Target: $5-8/day steady state across the full fleet per doc 467.
+
+## Safety floor (required, every bot)
+
+- `ALLOWED_USERS` + `ALLOWED_GROUPS` env vars
+- Rate limit 3 replies/user/5min per group
+- `callback_data` regex re-validation before any spawn
+- `extra` context always wrapped as DATA not instruction-override
+- Spawn-agent calls pass through existing allowlist at `spawn-server.js:213`


### PR DESCRIPTION
Three small, independent finishing touches that close out tonight's ZOE hardening batch.

## Changes

### 1. trace_id propagated to outbound event
\`sendMessage\` now takes an optional \`trace_id\` arg. Call sites in \`poll()\` pass the inbound request's trace_id through so \`inbound -> claude_call -> outbound\` events all share one id.

Before (observed 2026-04-21T12:10):
\`\`\`
12:09:38  inbound      trace=2fd310
12:10:08  claude_call  trace=2fd310
12:10:08  outbound     trace=------   <- missing
\`\`\`

After: all three tagged. Makes \`/activity\` digest + debugger one grep.

### 2. auto-sync quiet on dirty / non-main clones
\`pull_clone()\` now checks \`git symbolic-ref HEAD\` and \`git status --porcelain\`. Silently skips clones not on main with a clean tree.

Today's logs show \`pull-fail /home/zaal/code/ZAOOS\` every minute — that clone is Zaal's dev work, on a feature branch with uncommitted changes. Not a failure, just noise. Silent skip now.

### 3. \`bots/\` directory scaffold
Adds \`infra/portal/bin/bots/\` with a README documenting the per-bot layout + model routing defaults + safety floor. \`_shared/\` sits empty — tomorrow's A1 task extracts plumbing from \`bot.mjs\` into \`_shared/bot-core.mjs\`.

## Test plan

- [ ] After merge: auto-sync picks up, bot bounces once (normal for deploy), resume silence
- [ ] Send a message; confirm \`tail -5 ~/zoe-bot/events.jsonl | jq -c .trace_id\` shows all three events share one id
- [ ] \`tail -20 ~/.claude/auto-sync.log\` shows clean ticks (no more pull-fail lines)
- [ ] \`ls ~/zao-os/infra/portal/bin/bots/\` shows the new directory + README