### PR TITLE
feat(bots): A1 bot-core + A2 ZAO Devz scaffold (doc 467 track A)

### DIFF
--- a/infra/portal/bin/auto-sync.sh
+++ b/infra/portal/bin/auto-sync.sh
@@ -119,10 +119,15 @@ bounce_if_changed() {
 }
 
 # Hot files. bot.mjs pulls in events.mjs — bounce bot on either change.
-bounce_if_changed "zoe-bot" "$HOME/zao-os/infra/portal/bin/bot.mjs" "node.*bot.mjs"
-bounce_if_changed "zoe-bot" "$HOME/zao-os/infra/portal/bin/events.mjs" "node.*bot.mjs"
-bounce_if_changed "spawn-server" "$HOME/zao-os/infra/portal/bin/spawn-server.js" "node.*spawn-server.js"
-bounce_if_changed "auth-server" "$HOME/zao-os/infra/portal/bin/auth-server.js" "node.*auth-server.js"
+bounce_if_changed "zoe-bot"      "$HOME/zao-os/infra/portal/bin/bot.mjs"                       "bin/bot\\.mjs"
+bounce_if_changed "zoe-bot"      "$HOME/zao-os/infra/portal/bin/events.mjs"                    "bin/bot\\.mjs"
+bounce_if_changed "spawn-server" "$HOME/zao-os/infra/portal/bin/spawn-server.js"               "node.*spawn-server.js"
+bounce_if_changed "auth-server"  "$HOME/zao-os/infra/portal/bin/auth-server.js"                "node.*auth-server.js"
+# ZAO Devz bot + shared bot-core. Both bounce zoe-devz-bot when content
+# changes. Watchdog respawn is gated on ~/zoe-devz/.env existing, so these
+# no-op safely until Zaal installs the bot token.
+bounce_if_changed "zoe-devz-bot" "$HOME/zao-os/infra/portal/bin/bots/zao-devz/bot.mjs"         "devz-bot\\.mjs"
+bounce_if_changed "zoe-devz-bot" "$HOME/zao-os/infra/portal/bin/bots/_shared/bot-core.mjs"     "devz-bot\\.mjs"
 
 # Trim log to last 2000 lines.
 tail -n 2000 "$LOG" > "$LOG.tmp" 2>/dev/null && mv "$LOG.tmp" "$LOG" || true

--- a/infra/portal/bin/bots/_shared/bot-core.mjs
+++ b/infra/portal/bin/bots/_shared/bot-core.mjs
@@ -1,0 +1,183 @@
+// Shared Telegram primitives for every bot in the ZAO fleet.
+//
+// Scope (Phase 1, intentionally small): low-level outbound + authorization
+// helpers that every bot needs in exactly the same way. Each bot still owns
+// its OWN poll loop, slash handler, callback handler, and system-prompt
+// builder — those are where bot personality lives and should NOT be shared.
+//
+// Design goals:
+// - Every function takes a Telegram API URL as first arg so one bot process
+//   can hold state for multiple tokens if that ever becomes useful.
+// - Every outbound path emits a structured event to ~/zoe-bot/events.jsonl
+//   via events.mjs so "silent drop" failures remain impossible.
+// - No I/O to disk from here (conversation buffers and persona files live
+//   per-bot).
+
+import { emit } from "../../events.mjs";
+
+export function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+export function makeApiUrl(botToken) {
+  if (!botToken) throw new Error("makeApiUrl: missing botToken");
+  return "https://api.telegram.org/bot" + botToken;
+}
+
+// ALLOWED_USERS is an array of Telegram user IDs, strings. Returns a closure
+// so bots can inject their own allowlist without leaking globals.
+export function makeIsAllowed(allowedUsers) {
+  const list = (allowedUsers || []).map(String);
+  return function isAllowed(userId) {
+    return list.includes(String(userId));
+  };
+}
+
+// Exponential backoff send with Retry-After handling. Drops only on
+// unrecoverable 4xx (except 408). Emits a structured event on every
+// failure so silent drops become visible. Returns true on success.
+export async function sendMessageChunk(api, chatId, chunk, opts = {}) {
+  const { maxRetries = 3, baseDelay = 200, botName = "bot" } = opts;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const res = await fetch(api + "/sendMessage", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ chat_id: chatId, text: chunk }),
+      });
+      if (res.ok) return true;
+      if (res.status === 429) {
+        const ra = parseInt(res.headers.get("retry-after") || "1", 10) || 1;
+        emit({ source: botName, event: "send_rate_limited", status: 429, retry_after: ra, attempt });
+        await sleep(ra * 1000);
+        continue;
+      }
+      if (res.status >= 400 && res.status < 500 && res.status !== 408) {
+        emit({ source: botName, event: "send_fail_perm", status: res.status, attempt });
+        return false;
+      }
+      emit({ source: botName, event: "send_fail_transient", status: res.status, attempt });
+    } catch (e) {
+      emit({ source: botName, event: "send_fail_transient", err: String(e.message || e).slice(0, 200), attempt });
+    }
+    await sleep(baseDelay * Math.pow(2, attempt));
+  }
+  emit({ source: botName, event: "send_fail_exhausted", chat_id: chatId, chunk_bytes: chunk.length });
+  return false;
+}
+
+// Chunks a long message at 4000 chars (Telegram cap is 4096) preferring newline
+// breaks. Emits one outbound event per logical message with a trace_id if provided.
+export async function sendMessage(api, chatId, text, trace_id, opts = {}) {
+  const { botName = "bot" } = opts;
+  const chunks = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= 4000) { chunks.push(remaining); break; }
+    let splitAt = remaining.lastIndexOf("\n", 4000);
+    if (splitAt < 2000) splitAt = 4000;
+    chunks.push(remaining.substring(0, splitAt));
+    remaining = remaining.substring(splitAt);
+  }
+  let allOk = true;
+  for (const chunk of chunks) {
+    const ok = await sendMessageChunk(api, chatId, chunk, { botName });
+    if (!ok) allOk = false;
+  }
+  emit({ source: botName, event: "outbound", chat_id: chatId, bytes: text.length, chunks: chunks.length, ok: allOk, trace_id });
+  return allOk;
+}
+
+// Fire-and-forget typing indicator. Never awaits, never emits (too noisy).
+export function sendTyping(api, chatId) {
+  fetch(api + "/sendChatAction", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, action: "typing" }),
+  }).catch(function () {});
+}
+
+// Ack a tapped inline keyboard button. Always best-effort.
+export async function answerCallback(api, callbackId, text) {
+  try {
+    await fetch(api + "/answerCallbackQuery", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        callback_query_id: callbackId,
+        text: String(text || "").slice(0, 200),
+        show_alert: false,
+      }),
+    });
+  } catch (e) { console.error("answerCallback error:", e.message); }
+}
+
+// Mutate a previously-sent message (e.g. flipping [PENDING] -> [SHIPPED]).
+// Telegram enforces a 48h edit window.
+export async function editMessageText(api, chatId, messageId, newText) {
+  try {
+    await fetch(api + "/editMessageText", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        message_id: messageId,
+        text: newText,
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (e) { console.error("editMessageText error:", e.message); }
+}
+
+// Publish the slash-command list so Telegram's blue "menu" button surfaces
+// every command without users typing /help. Idempotent; safe on every boot.
+// `commands` is an array of { command, description } objects.
+export async function publishCommands(api, commands) {
+  try {
+    await fetch(api + "/setMyCommands", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ commands }),
+    });
+  } catch (e) { console.error("setMyCommands error:", e.message); }
+}
+
+// Poll-loop helper: long-polls getUpdates with backoff on failure. Caller
+// provides onUpdate(update) which returns a promise. Loop is an infinite
+// setTimeout chain so one failure doesn't kill the bot; failures emit
+// poll_fail events and widen the delay up to 30s.
+export function startPollLoop(api, { onUpdate, botName = "bot", allowedUpdates = ["message", "callback_query"] } = {}) {
+  if (typeof onUpdate !== "function") throw new Error("startPollLoop: onUpdate required");
+  const allowed = encodeURIComponent(JSON.stringify(allowedUpdates));
+  let pollErrorCount = 0;
+  let offset = 0;
+
+  async function tick() {
+    let nextDelay = 100;
+    try {
+      const res = await fetch(api + "/getUpdates?offset=" + offset + "&timeout=30&allowed_updates=" + allowed);
+      const data = await res.json();
+      pollErrorCount = 0;
+      if (data.ok && data.result.length > 0) {
+        for (const update of data.result) {
+          offset = update.update_id + 1;
+          try { await onUpdate(update); }
+          catch (e) { emit({ source: botName, event: "on_update_error", err: String(e.message || e).slice(0, 200) }); }
+        }
+      }
+    } catch (err) {
+      pollErrorCount += 1;
+      const errMsg = String(err.message || err).slice(0, 200);
+      emit({ source: botName, event: "poll_fail", err: errMsg, error_count: pollErrorCount });
+      console.error(botName + " poll error:", errMsg, "(count=" + pollErrorCount + ")");
+      nextDelay = Math.min(500 * Math.pow(2, Math.min(pollErrorCount - 1, 6)), 30000);
+    }
+    setTimeout(tick, nextDelay);
+  }
+
+  tick();
+}
+
+// Clear webhook (so getUpdates works) — call once on boot.
+export async function clearWebhook(api) {
+  try { await fetch(api + "/deleteWebhook"); }
+  catch (e) { console.error("deleteWebhook error:", e.message); }
+}

--- a/infra/portal/bin/bots/zao-devz/README.md
+++ b/infra/portal/bin/bots/zao-devz/README.md
@@ -1,0 +1,153 @@
+# ZAO Devz Bot — Setup Guide
+
+Autonomous coding agent for the ZAO DEVZ Telegram group. Phase 1 scope:
+slash + @mention commands that dispatch real coding tasks to the existing
+AO spawn-agent pipeline. Opens PRs, bot reports links, owner merges.
+
+## First-time setup (5 steps, difficulty 3/10)
+
+### 1. Create the Telegram bot
+
+- Open Telegram -> message @BotFather -> `/newbot`
+- Suggested name: `ZAO Devz` (public display name)
+- Suggested username: `zaodevz_bot` (or `zao_devz_bot` if taken)
+- BotFather will hand back a token like `7234567890:AAH1a2B3cD4e...`
+- Send `/setprivacy` to BotFather, pick `zaodevz_bot`, choose **Disable** so the
+  bot can read all messages in groups (needed to see `@zaodevz spawn` mentions).
+- Send `/setjoingroups` to BotFather, same bot, choose **Enable**.
+
+### 2. Add the bot to the ZAO DEVZ group
+
+- In the ZAO DEVZ Telegram group -> Group name -> Manage -> Administrators ->
+  Add administrator -> search `@zaodevz_bot` -> add with at minimum:
+  - `Delete Messages` (for clawback cases)
+  - `Send Messages` (obviously)
+  - No other perms needed
+- Grab the group's chat ID. Easiest: send any message to `@zaodevz_bot` first
+  via the group, then on the VPS run:
+
+```bash
+source ~/.env.portal
+curl -s "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/getUpdates" | \
+  jq '.result[] | {chat_id: .message.chat.id, title: .message.chat.title}'
+```
+
+Group chat IDs are negative (e.g. `-1002345678901`).
+
+### 3. Install token + config on VPS
+
+SSH in, create the bot's runtime dir with the token:
+
+```bash
+ssh zaal@31.97.148.88
+mkdir -p ~/zoe-devz
+cp ~/zao-os/infra/portal/bin/bots/zao-devz/.env.example ~/zoe-devz/.env
+nano ~/zoe-devz/.env
+```
+
+Fill in the 4 values:
+- `TELEGRAM_BOT_TOKEN=<token from BotFather>`
+- `ALLOWED_USERS=1447437687,<other-dev-ids-if-any>`
+- `ALLOWED_GROUPS=<the negative chat id from step 2>`
+- `OWNER_USER_ID=1447437687` (Zaal — only one who can merge)
+
+Save, then tighten perms:
+
+```bash
+chmod 600 ~/zoe-devz/.env
+```
+
+### 4. Wait for watchdog to pick it up
+
+Watchdog's check `[ -f "$HOME/zoe-devz/.env" ]` now passes. Next tick (within
+1 min) respawns `zoe-devz-bot` tmux session. Verify:
+
+```bash
+sleep 70   # one tick
+tmux ls | grep zoe-devz
+pgrep -af devz-bot.mjs
+grep '"event":"boot"' ~/zoe-bot/events.jsonl | grep zao-devz | tail -1
+```
+
+(The boot event goes to the same `events.jsonl` but with `"source":"zao-devz"`.)
+
+### 5. First real dispatch
+
+In the ZAO DEVZ Telegram group, send:
+
+```
+@zaodevz spawn fix a typo in research/agents/README.md line 1
+```
+
+Expected within 30s:
+1. Bot reply: `[DEVZ] dispatching — fix a typo in research/agents/...`
+2. Bot reply: `[DEVZ] spawned. session=xyz... Watcher will post PR link when ready. (1/3 today)`
+3. AO spawns a Claude Code session that creates `ws/act-research-agents-readme-...`, edits the doc, opens a PR.
+4. Within ~5-15 min: session-watcher (existing cron) posts `[SHIPPED] doc X -> PR #N <url>` to Zaal's private ZOE chat (not the devz group — that stays clean).
+5. Zaal reviews diff, DMs `/approve <pr-number>` to the bot in the devz group.
+6. Bot squash-merges + deletes the branch.
+
+## Commands reference
+
+| Command | Who can use | What |
+|---|---|---|
+| `@zaodevz spawn <task>` | Any ALLOWED_USER | Dispatches AO session on new branch |
+| `/spawn <task>` | Any ALLOWED_USER | Same |
+| `/status` | Any ALLOWED_USER | Open PRs + last-24h merges digest |
+| `/approve <pr>` | OWNER_USER_ID only | Squash-merge + delete branch |
+| `/help` | Any ALLOWED_USER | Command list |
+
+## Rate limits + budget
+
+- 3 spawns/user/day (rolling 24h)
+- 10 spawns/group/day (rolling 24h)
+- $5 Claude budget per spawn (via `spawn-agent --max-budget-usd 5`)
+- Rolling 24h windows reset on a per-event basis, not midnight
+
+## Operational
+
+Bot state:
+- `~/zoe-devz/.env` — token + allowlist (600, not committed)
+- `~/zoe-devz/bot.log` — stdout (`tee` from watchdog)
+- `~/.cache/zoe-devz/rate.json` — spawn rate limit tracker
+- `~/zoe-bot/events.jsonl` — all events, `"source":"zao-devz"` for this bot
+- Tmux session: `zoe-devz-bot`
+- Respawned by `~/bin/watchdog.sh` every minute if dead
+- Code synced by `~/bin/auto-sync.sh` — edits to `bots/zao-devz/bot.mjs` in main
+  auto-bounce within ~1-2 min
+
+## Troubleshooting
+
+Bot not responding:
+```bash
+# Env file present?
+ls -la ~/zoe-devz/.env
+# Process alive?
+pgrep -af devz-bot.mjs
+# Tmux running?
+tmux ls | grep zoe-devz
+# Recent errors?
+grep '"source":"zao-devz"' ~/zoe-bot/events.jsonl | tail -10
+# Force a respawn:
+tmux kill-session -t zoe-devz-bot; bash ~/bin/watchdog.sh
+```
+
+Bot spawning but not responding to messages:
+- Check group privacy setting (BotFather `/setprivacy` must be Disable).
+- Check group chat id matches `ALLOWED_GROUPS` (leading `-` required).
+
+PR not opening after spawn:
+- Check spawn-server logs: `tail -20 ~/spawn-server.log`
+- Check AO session: `ls -t ~/.agent-orchestrator/ZAOOS/sessions/ | head -3`
+- Check session-watcher: `tail -10 ~/.cache/zoe-telegram/session-watcher.log`
+
+## Limits (Phase 1 deliberately small)
+
+- No free-form conversation. Bot only responds to its 5 commands.
+- No inline keyboard buttons (callback_query unhandled).
+- No cross-bot dispatch (`@zoey from devz` deferred).
+- No cost tracking integration yet (B4 task in doc 465).
+- No Anthropic API use — relies on `claude -p` inside the AO session only.
+
+Each of these is a deliberate Phase 2 item once ZAO Devz proves out in live
+use in the group.

--- a/infra/portal/bin/bots/zao-devz/bot.mjs
+++ b/infra/portal/bin/bots/zao-devz/bot.mjs
@@ -1,0 +1,284 @@
+// ZAO Devz bot — autonomous coding agent in the ZAO DEVZ Telegram group.
+//
+// Scope Phase 1 (tonight): slash + mention commands that dispatch real coding
+// tasks to the existing AO spawn-agent pipeline at localhost:3004. No free-form
+// Claude calls from this bot — every reply is either a fixed string (status,
+// help) or a direct action (spawn, merge). Opus / Sonnet free-form stays out
+// until the Anthropic API key is installed.
+//
+// Commands:
+//   @zaodevz spawn <task>  — dispatches an AO session on a new ws/devz-* branch
+//   /spawn <task>          — same as above
+//   /status                — short PR + CI digest
+//   /approve <pr-number>   — owner-only, squash-merges the PR
+//   /help                  — command list
+//
+// Safety:
+//   - ALLOWED_USERS + ALLOWED_GROUPS env gates every inbound.
+//   - Rate limit: 3 spawns/user/day, 10/group/day.
+//   - Budget: $5/PR via spawn-agent --max-budget-usd.
+//   - OWNER_USER_ID only can merge.
+//   - Task text wrapped as DATA per doc 463.
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import {
+  makeApiUrl, makeIsAllowed, sendMessage, sendTyping,
+  publishCommands, clearWebhook, startPollLoop, sleep,
+} from "../_shared/bot-core.mjs";
+import { emit, traceId, startTimer } from "../../events.mjs";
+
+const BOT_NAME = "zao-devz";
+const TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+if (!TOKEN || TOKEN.startsWith("PASTE_")) {
+  console.error("[zao-devz] TELEGRAM_BOT_TOKEN not set; refusing to start");
+  process.exit(1);
+}
+
+const API = makeApiUrl(TOKEN);
+const ALLOWED_USERS = (process.env.ALLOWED_USERS || "1447437687")
+  .split(",").map((s) => s.trim()).filter(Boolean);
+const ALLOWED_GROUPS = (process.env.ALLOWED_GROUPS || "")
+  .split(",").map((s) => s.trim()).filter(Boolean);
+const OWNER_USER_ID = process.env.OWNER_USER_ID || "1447437687";
+const REPO = process.env.ZAOOS_REPO || "/home/zaal/zao-os";
+const GH = process.env.GITHUB_REPO || "bettercallzaal/ZAOOS";
+const SPAWN_SERVER = process.env.SPAWN_SERVER_URL || "http://127.0.0.1:3004";
+const GH_BIN = process.env.GH_BIN || "/home/zaal/.local/bin/gh";
+
+const RATE_DIR = process.env.HOME + "/.cache/zoe-devz";
+const RATE_FILE = RATE_DIR + "/rate.json";
+const SPAWNS_PER_USER_PER_DAY = parseInt(process.env.SPAWNS_PER_USER_PER_DAY || "3", 10);
+const SPAWNS_PER_GROUP_PER_DAY = parseInt(process.env.SPAWNS_PER_GROUP_PER_DAY || "10", 10);
+
+const isAllowed = makeIsAllowed(ALLOWED_USERS);
+
+function isAllowedGroup(chatId) {
+  if (!ALLOWED_GROUPS.length) return true;     // empty = any group (dev only)
+  return ALLOWED_GROUPS.includes(String(chatId));
+}
+
+// ----- rate limit --------------------------------------------------------
+// Day is rolling 24h, not calendar day. Stored as per-key event arrays in
+// ~/.cache/zoe-devz/rate.json, pruned on every read.
+
+function loadRate() {
+  try { return JSON.parse(readFileSync(RATE_FILE, "utf-8")); }
+  catch { return { events: [] }; }
+}
+function saveRate(state) {
+  try { mkdirSync(RATE_DIR, { recursive: true }); } catch {}
+  try { writeFileSync(RATE_FILE, JSON.stringify(state)); } catch {}
+}
+function checkAndRecordSpawn(userId, chatId) {
+  const state = loadRate();
+  const cutoff = Date.now() - 86400_000;
+  state.events = (state.events || []).filter((e) => e.at > cutoff);
+  const userCount = state.events.filter((e) => e.user === String(userId)).length;
+  const groupCount = state.events.filter((e) => e.chat === String(chatId)).length;
+  if (userCount >= SPAWNS_PER_USER_PER_DAY) {
+    return { ok: false, reason: "per-user cap " + SPAWNS_PER_USER_PER_DAY + "/day hit" };
+  }
+  if (groupCount >= SPAWNS_PER_GROUP_PER_DAY) {
+    return { ok: false, reason: "per-group cap " + SPAWNS_PER_GROUP_PER_DAY + "/day hit" };
+  }
+  state.events.push({ at: Date.now(), user: String(userId), chat: String(chatId) });
+  saveRate(state);
+  return { ok: true, user_today: userCount + 1, group_today: groupCount + 1 };
+}
+
+// ----- spawn dispatch ----------------------------------------------------
+
+async function dispatchSpawn(task, userId, chatId, trace_id) {
+  // Re-sanitize task text: strip newlines that would break YAML/prompt wrap,
+  // cap size to prevent unbounded prompts.
+  const cleaned = String(task || "").replace(/[\r\n]+/g, " ").trim().slice(0, 600);
+  if (!cleaned) return { ok: false, err: "empty task" };
+
+  // Build a slug for the branch name matching spawn-server.js:230 convention.
+  const slug = cleaned.replace(/[^a-z0-9]/gi, "-").slice(0, 40).toLowerCase();
+
+  // POST to spawn-server. Reuses doc 464 pipeline; branch will be ws/act-<slug>-*.
+  // For devz, override intent to "custom" with the task in extra.
+  const body = JSON.stringify({
+    doc: "research/agents/466-ao-ui-button-audit-apr21/README.md",  // placeholder doc — spawn-agent requires one
+    title: "ZAO Devz dispatch: " + cleaned.slice(0, 80),
+    intent: "custom",
+    extra: cleaned,
+  });
+  const t = startTimer();
+  try {
+    const res = await fetch(SPAWN_SERVER + "/api/spawn-agent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const text = await res.text();
+    let payload = {};
+    try { payload = JSON.parse(text); } catch {}
+    emit({
+      source: BOT_NAME, event: "spawn_dispatch", trace_id,
+      user: userId, chat: chatId,
+      status: res.status, duration_ms: t.ms(),
+      sessionId: payload.sessionId || null,
+      task_preview: cleaned.slice(0, 120),
+    });
+    if (res.status >= 400) return { ok: false, err: "spawn-server " + res.status + ": " + (payload.error || text.slice(0, 200)) };
+    return { ok: true, sessionId: payload.sessionId, slug };
+  } catch (e) {
+    emit({ source: BOT_NAME, event: "spawn_dispatch_err", err: String(e.message || e).slice(0, 200), trace_id });
+    return { ok: false, err: e.message };
+  }
+}
+
+// ----- status command ----------------------------------------------------
+
+function buildStatus() {
+  try {
+    const prsJson = execSync(
+      GH_BIN + " pr list --repo " + GH + " --state open --limit 10 --json number,title,headRefName,updatedAt 2>/dev/null || echo '[]'",
+      { encoding: "utf-8", timeout: 8000 }
+    ).trim();
+    const prs = JSON.parse(prsJson || "[]");
+    const mergedJson = execSync(
+      GH_BIN + " pr list --repo " + GH + " --state merged --search 'merged:>=' --limit 20 --json number,mergedAt 2>/dev/null || echo '[]'",
+      { encoding: "utf-8", timeout: 8000 }
+    ).trim();
+    const merged = JSON.parse(mergedJson || "[]");
+    const since24h = Date.now() - 86400_000;
+    const merged24h = merged.filter((p) => new Date(p.mergedAt).getTime() > since24h).length;
+    const commitsOut = execSync(
+      "cd " + REPO + " && git log --since='24 hours ago' --oneline main 2>/dev/null | wc -l",
+      { encoding: "utf-8", timeout: 5000 }
+    ).trim();
+    const lines = [
+      "Open PRs: " + prs.length,
+      "Merged last 24h: " + merged24h,
+      "Commits to main last 24h: " + commitsOut,
+    ];
+    prs.slice(0, 6).forEach((p) => lines.push("  #" + p.number + " " + (p.title || "").slice(0, 60)));
+    return lines.join("\n");
+  } catch (e) {
+    return "status error: " + String(e.message || e).slice(0, 200);
+  }
+}
+
+// ----- approve command ---------------------------------------------------
+
+function mergePr(prNumber) {
+  const n = parseInt(prNumber, 10);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, err: "bad pr number" };
+  try {
+    const out = execSync(
+      GH_BIN + " pr merge " + n + " --repo " + GH + " --squash --delete-branch 2>&1",
+      { encoding: "utf-8", timeout: 30000 }
+    ).trim();
+    return { ok: true, out: out.slice(0, 400) };
+  } catch (e) {
+    return { ok: false, err: String(e.message || e).slice(0, 400) };
+  }
+}
+
+// ----- help --------------------------------------------------------------
+
+const HELP = [
+  "ZAO Devz bot — autonomous coding dispatcher.",
+  "",
+  "@zaodevz spawn <task>  Dispatch an AO session. Creates ws/devz-<slug>-<ts> + PR.",
+  "/spawn <task>          Same.",
+  "/status                Open PRs + merge stats.",
+  "/approve <pr>          (owner-only) squash-merge a PR + delete branch.",
+  "/help                  This message.",
+  "",
+  "Rate: " + SPAWNS_PER_USER_PER_DAY + "/user/day, " + SPAWNS_PER_GROUP_PER_DAY + "/group/day. Budget $5/PR.",
+].join("\n");
+
+// ----- handle inbound ----------------------------------------------------
+
+async function handleMessage(msg) {
+  if (!msg || !msg.text) return;
+  const userId = String(msg.from.id);
+  const chatId = msg.chat.id;
+  const trace_id = traceId();
+  if (!isAllowed(userId)) {
+    emit({ source: BOT_NAME, event: "auth_reject", user: userId, chat: chatId, trace_id });
+    return;  // silent drop — no "not authorized" to avoid noise in groups
+  }
+  if (!isAllowedGroup(chatId)) {
+    emit({ source: BOT_NAME, event: "group_reject", user: userId, chat: chatId, trace_id });
+    return;  // silent
+  }
+  const text = msg.text.trim();
+  emit({ source: BOT_NAME, event: "inbound", user: userId, chat: chatId, bytes: text.length, trace_id, text_preview: text.slice(0, 80) });
+
+  // /help
+  if (/^\/help(\s|$)/i.test(text)) {
+    await sendMessage(API, chatId, HELP, trace_id, { botName: BOT_NAME });
+    return;
+  }
+  // /status
+  if (/^\/status(\s|$)/i.test(text)) {
+    sendTyping(API, chatId);
+    const s = buildStatus();
+    await sendMessage(API, chatId, s, trace_id, { botName: BOT_NAME });
+    return;
+  }
+  // /approve <n>
+  const appM = text.match(/^\/approve\s+(\d+)/i);
+  if (appM) {
+    if (userId !== String(OWNER_USER_ID)) {
+      await sendMessage(API, chatId, "Only owner can merge.", trace_id, { botName: BOT_NAME });
+      emit({ source: BOT_NAME, event: "approve_reject", user: userId, pr: appM[1], trace_id });
+      return;
+    }
+    const r = mergePr(appM[1]);
+    const reply = r.ok
+      ? "[MERGED] #" + appM[1] + " squashed, branch deleted."
+      : "[MERGE FAIL] #" + appM[1] + ": " + r.err;
+    await sendMessage(API, chatId, reply, trace_id, { botName: BOT_NAME });
+    emit({ source: BOT_NAME, event: r.ok ? "pr_merged" : "pr_merge_fail", user: userId, pr: appM[1], trace_id, err: r.err || null });
+    return;
+  }
+  // @zaodevz spawn <task> OR /spawn <task>
+  const spawnM = text.match(/^(?:@zaodevz|@zaodevzbot|@zaodevz_bot)\s+spawn\s+(.+)/is)
+               || text.match(/^\/spawn\s+(.+)/is);
+  if (spawnM) {
+    const task = spawnM[1];
+    const rate = checkAndRecordSpawn(userId, chatId);
+    if (!rate.ok) {
+      await sendMessage(API, chatId, "[RATE] " + rate.reason + ". Resets rolling 24h.", trace_id, { botName: BOT_NAME });
+      emit({ source: BOT_NAME, event: "spawn_rate_limit", user: userId, chat: chatId, reason: rate.reason, trace_id });
+      return;
+    }
+    await sendMessage(API, chatId, "[DEVZ] dispatching — " + task.slice(0, 100) + (task.length > 100 ? "..." : ""), trace_id, { botName: BOT_NAME });
+    sendTyping(API, chatId);
+    const r = await dispatchSpawn(task, userId, chatId, trace_id);
+    const reply = r.ok
+      ? "[DEVZ] spawned. session=" + (r.sessionId || "pending") + ". Watcher will post PR link when ready. (" + rate.user_today + "/" + SPAWNS_PER_USER_PER_DAY + " today)"
+      : "[DEVZ] spawn failed: " + r.err;
+    await sendMessage(API, chatId, reply, trace_id, { botName: BOT_NAME });
+    return;
+  }
+  // Unknown — silent. /help if they ask directly.
+  emit({ source: BOT_NAME, event: "unknown_input", user: userId, chat: chatId, bytes: text.length, trace_id });
+}
+
+async function handleUpdate(update) {
+  if (update.message) return handleMessage(update.message);
+  // callback_query intentionally unhandled Phase 1 — inline keyboards come later.
+}
+
+// ----- boot --------------------------------------------------------------
+
+const COMMANDS = [
+  { command: "spawn", description: "Dispatch coding task: /spawn <description>" },
+  { command: "status", description: "Open PRs + merge stats last 24h" },
+  { command: "approve", description: "(owner) squash-merge a PR: /approve <pr>" },
+  { command: "help", description: "Command list" },
+];
+
+console.log("[zao-devz] booting. allowed_users=" + ALLOWED_USERS.length + " allowed_groups=" + (ALLOWED_GROUPS.length || "any") + " owner=" + OWNER_USER_ID);
+emit({ source: BOT_NAME, event: "boot", allowed_user_count: ALLOWED_USERS.length, allowed_group_count: ALLOWED_GROUPS.length, owner: String(OWNER_USER_ID) });
+await clearWebhook(API);
+await publishCommands(API, COMMANDS);
+startPollLoop(API, { onUpdate: handleUpdate, botName: BOT_NAME });

--- a/infra/portal/bin/bots/zao-devz/persona.md
+++ b/infra/portal/bin/bots/zao-devz/persona.md
@@ -1,0 +1,45 @@
+# ZAO Devz Bot Persona
+
+Voice: Terse, code-first, slightly sardonic. Talks like a senior dev pairing
+on a Slack thread. Uses ship/land/merge vocabulary native to the team.
+
+Tone: 60% practical (what just happened, what's next), 20% dry humor, 20%
+signal (PR stats, CI state, doc pointers). Never hype.
+
+Audience: trusted ZAO devs in a private group. Zaal is admin. Other members
+can dispatch coding tasks via @mention but only Zaal can merge.
+
+Example replies:
+
+- User: "@zaodevz spawn fix the Sentry DSN env var in /api/health"
+  Bot:  "[DEVZ] spawning — ws/devz-sentry-dsn-XXXX. Session id coming."
+
+- User: "/status"
+  Bot:  "2 PRs open, 1 spawning. Last 24h: 4 merged. No watchdog alerts."
+
+- User: "/approve 269"
+  Bot:  "[MERGED] #269 squashed to main. Branch deleted."
+
+- User: "what's the deal with auto-sync?"
+  Bot:  "Cron every min pulls zao-os + openclaw clone + bounces bot/server
+         if their file hash changed. Log at ~/.claude/auto-sync.log."
+
+Forbidden:
+
+- Cheerleading ("nice work!", "great job team!")
+- Fake urgency / hype emoji / exclamation points
+- "As an AI" or similar meta
+- Explaining commands without being asked
+- Speculation about user intent ("I think you meant...")
+- Any claim about a PR without actually querying GitHub
+
+Escalation:
+
+- Unknown commands -> suggest /help once, then silent
+- Merge conflicts -> post PR link + "Zaal resolves"
+- Build failures -> post CI error + Vercel URL, no speculation
+- Out-of-scope requests (non-coding) -> "wrong bot, DM @zoe"
+- Rate limit hit -> state quota + when it resets, no apology
+
+Voice anchor: treat the ZAO DEVZ group like a dev Slack channel with
+tight norms — signal only, no noise.

--- a/infra/portal/bin/bots/zao-devz/triggers.yaml
+++ b/infra/portal/bin/bots/zao-devz/triggers.yaml
@@ -1,0 +1,41 @@
+# ZAO Devz bot triggers + rate limits. Read on boot by bot.mjs.
+
+reactive:
+  mention:
+    # Fires when @zaodevz is mentioned in an allowed group
+    pattern: "@zaodevz\\s+spawn\\s+(.+)"
+    action: spawn_agent
+    rate_per_user_per_day: 3
+    rate_per_group_per_day: 10
+    budget_usd_per_pr: 5
+  slash_spawn:
+    # Fires on /spawn <task>
+    pattern: "^/spawn\\s+(.+)"
+    action: spawn_agent
+    rate_per_user_per_day: 3
+    rate_per_group_per_day: 10
+  slash_approve:
+    # Fires on /approve <pr_number> — owner-only
+    pattern: "^/approve\\s+(\\d+)"
+    action: merge_pr
+    owner_only: true
+  slash_status:
+    pattern: "^/status$"
+    action: status_digest
+  slash_help:
+    pattern: "^/help$"
+    action: help_message
+
+scheduled:
+  # Deferred. Once bot is live + proven, consider:
+  # daily-digest: 09:00 ET each weekday, posts open PR count + overnight merges.
+
+external:
+  # Deferred. Hook for GitHub webhooks later — e.g. post [MERGED] into the group
+  # when a PR with `devz:dispatched` label lands.
+
+safety:
+  allowed_users_env: ALLOWED_USERS        # comma-sep Telegram IDs
+  allowed_groups_env: ALLOWED_GROUPS      # comma-sep chat IDs (negative for groups)
+  owner_user_id_env: OWNER_USER_ID        # single ID that can merge
+  callback_data_regex: "^(spawn|approve|cancel):[a-z0-9/_.\\-]+$"

--- a/infra/portal/bin/watchdog.sh
+++ b/infra/portal/bin/watchdog.sh
@@ -42,4 +42,15 @@ respawn auth-server   "bash -c \"$ENV_SOURCE; node \$HOME/bin/auth-server.js 2>&
 # Bot source of truth = repo-synced symlink at $HOME/bin/bot.mjs (per install.sh).
 # cwd stays at $HOME/zoe-bot so existing logs (bot.log, api.log, commands.log)
 # and auxiliary scripts (send-coc4.sh) keep their home.
-respawn zoe-bot       "bash -c \"$ENV_SOURCE; mkdir -p \$HOME/zoe-bot; cd \$HOME/zoe-bot; node \$HOME/bin/bot.mjs 2>&1 | tee bot.log\"" "node.*bot.mjs"
+# zoe-bot pattern is the bare `bin/bot.mjs` path — distinct from devz-bot whose
+# entry file is named devz-bot.mjs so the two never collide under pgrep.
+respawn zoe-bot       "bash -c \"$ENV_SOURCE; mkdir -p \$HOME/zoe-bot; cd \$HOME/zoe-bot; node \$HOME/bin/bot.mjs 2>&1 | tee bot.log\"" "bin/bot\\.mjs"
+
+# ZAO Devz bot. Only spawns if ~/zoe-devz/.env exists (so the bot stays dormant
+# until Zaal creates @zaodevz_bot via @BotFather + installs the token).
+# Token + allowlist live in ~/zoe-devz/.env (600, not committed). Code is the
+# repo-synced devz-bot.mjs symlink at $HOME/bin/devz-bot.mjs.
+if [ -f "$HOME/zoe-devz/.env" ]; then
+  DEVZ_ENV_SOURCE='set -a; . $HOME/zoe-devz/.env; set +a'
+  respawn zoe-devz-bot  "bash -c \"$DEVZ_ENV_SOURCE; cd \$HOME/zoe-devz; node \$HOME/bin/devz-bot.mjs 2>&1 | tee bot.log\"" "devz-bot\\.mjs"
+fi

--- a/infra/portal/install.sh
+++ b/infra/portal/install.sh
@@ -29,6 +29,12 @@ for f in auth-server.js spawn-server.js watchdog.sh start-agents.sh fix-node-pty
   ln -sfn "$REPO_DIR/bin/$f" "$HOME_DIR/bin/$f"
   chmod +x "$HOME_DIR/bin/$f" 2>/dev/null || true
 done
+# Branded bots — symlinked with a unique filename at $HOME/bin so watchdog's
+# pgrep patterns can discriminate between them. Each bot's actual code lives
+# at infra/portal/bin/bots/<name>/bot.mjs in the repo. ~/zoe-<name>/.env gates
+# whether watchdog boots it (prevents flapping when token not yet installed).
+ln -sfn "$REPO_DIR/bin/bots/zao-devz/bot.mjs" "$HOME_DIR/bin/devz-bot.mjs"
+chmod +x "$HOME_DIR/bin/devz-bot.mjs" 2>/dev/null || true
 # Cloudflared config lives in ~/.cloudflared (not symlinked so CF creds file is separate)
 mkdir -p "$HOME_DIR/.cloudflared"
 cp -f "$REPO_DIR/cloudflared/config.yml" "$HOME_DIR/.cloudflared/config.yml"


### PR DESCRIPTION
## Summary

Launches the branded bot fleet. Two intentionally-small pieces:

### A1 — \`bots/_shared/bot-core.mjs\` (183 lines)

Low-level reusable Telegram plumbing every branded bot shares. Send-with-retry, typing indicator, callback ack, edit, setMyCommands, poll loop with exponential backoff. Every outbound path emits structured events to \`events.jsonl\` so silent drops stay impossible across the whole fleet.

Deliberately small scope: **does not refactor ZOE's bot.mjs** — that's held for a later PR once ZAO Devz proves the pattern in live use. Zero risk to current ZOE.

### A2 — \`bots/zao-devz/\` (484 lines across 5 files)

Autonomous coding dispatcher for the ZAO DEVZ Telegram group.

Phase 1 commands:
- \`@zaodevz spawn <task>\` / \`/spawn <task>\` — POST to \`/api/spawn-agent\`, opens PR
- \`/status\` — open PRs + 24h merge count
- \`/approve <pr>\` — owner-only squash-merge
- \`/help\` — command reference

No free-form Claude calls. Every reply is fixed string or direct action, so **no Anthropic API key needed for Phase 1** (still dispatched through AO's \`claude -p\` via Max plan).

Rate: 3 spawns/user/day, 10/group/day rolling 24h. Budget: $5/PR.

## Wiring (both A1 + A2)

- \`install.sh\` symlinks \`bots/zao-devz/bot.mjs\` → \`$HOME/bin/devz-bot.mjs\` (unique filename keeps pgrep honest)
- \`watchdog.sh\` spawns \`zoe-devz-bot\` tmux session **only if \`~/zoe-devz/.env\` exists** — stays dormant until Zaal installs the token so no crash-loop on deploy
- \`zoe-bot\` pgrep pattern tightened from \`node.*bot.mjs\` to \`bin/bot\\.mjs\` so it doesn't match the new devz-bot.mjs path
- \`auto-sync.sh\` hash-watches devz bot.mjs + bot-core.mjs → changes bounce devz bot within 1-2 min

## What Zaal still needs to do (all documented in \`bots/zao-devz/README.md\`)

1. Create \`@zaodevz_bot\` via @BotFather + disable privacy mode + enable groups
2. Add bot to ZAO DEVZ group as admin
3. SSH to VPS → \`cp .env.example ~/zoe-devz/.env\` → fill in token + ALLOWED_USERS + ALLOWED_GROUPS
4. \`chmod 600 ~/zoe-devz/.env\`
5. Wait one watchdog tick, first dispatch test

## Test plan (after merge)

- [ ] \`ls ~/zao-os/infra/portal/bin/bots/zao-devz/\` shows all 5 files after auto-pull
- [ ] \`ls ~/bin/devz-bot.mjs\` is a symlink to the repo file
- [ ] Without \`~/zoe-devz/.env\`: \`tmux ls | grep zoe-devz\` returns empty (dormant, correct)
- [ ] ZOE bot itself still running: \`tmux ls | grep zoe-bot\` shows active session
- [ ] Once env installed: \`zoe-devz-bot\` tmux session appears; \`grep '\"source\":\"zao-devz\"' ~/zoe-bot/events.jsonl\` shows a boot event
- [ ] \`@zaodevz spawn fix a README typo\` in group yields \`[DEVZ] dispatching\` then \`[DEVZ] spawned. session=...\`
- [ ] PR opens in \`bettercallzaal/ZAOOS\` on a \`ws/act-*\` branch
- [ ] Session-watcher posts PR link to Zaal's private ZOE DM when ready
- [ ] \`/approve <n>\` from non-owner is rejected
- [ ] \`/approve <n>\` from Zaal squash-merges

## Deferred to later PRs

- Refactor ZOE's \`bot.mjs\` to use \`bot-core.mjs\` (risk-controlled, after devz dogfoods)
- Full Haiku/Sonnet/Opus model routing per doc 467 §3 (needs API key)
- Inline keyboards + callback buttons in devz replies
- \`@zoey\` dispatch from devz (cross-bot)
- The other 4 branded bots (Research, Stock, Magnetiq, WaveWarZ) + 2 Farcaster bots