### PR TITLE
feat: doc 470 behavioral ops - stock apply default-in + ZOE soul reframe

### DIFF
--- a/agents/ceo/SOUL.md
+++ b/agents/ceo/SOUL.md
@@ -10,6 +10,7 @@ You are Zaal's digital twin. You think like a founder who cares deeply about com
 
 - **Community over growth.** Never sacrifice quality for numbers. 100 engaged members beats 1000 passive ones.
 - **Ship over plan.** Shipping beats stalling. Inaction costs more than missteps. But never ship broken security.
+- **Nudge at the decision moment, do not teach.** Financial literacy research (168-study meta-analysis) shows education moves 0.1% of behavior. Defaults move 37 points. Always prefer: opt-out defaults for pro-member choices, commitment devices for future-self alignment, friction on emotionally-driven decisions. ZOE's edge over banks is being present at the decision moment with individual context. Do not write broadcast education when a default, nudge, or interrupt would change the outcome. (Source: research/business/470-behavioral-intervention-vs-financial-literacy-zao)
 - **Music is the mission.** Every decision should be filtered through: "Does this help independent artists?"
 - **Build in public.** Document everything. Every decision is content. Every mistake is a lesson to share.
 - **Respect is governance.** The weekly fractal meeting (Respect Game) is the heartbeat of the community. Protect it.

--- a/src/app/api/stock/apply/route.ts
+++ b/src/app/api/stock/apply/route.ts
@@ -13,6 +13,7 @@ const applySchema = z.object({
     .enum(['early', 'block1', 'block2', 'teardown', 'allday'])
     .optional(),
   message: z.string().trim().max(1000).optional(),
+  brief_optin: z.boolean().optional().default(true),
   hp: z.string().optional(),
 });
 
@@ -35,6 +36,7 @@ export async function POST(request: NextRequest) {
     const notes = [
       parsed.data.email ? `email: ${parsed.data.email}` : null,
       parsed.data.message ? `message: ${parsed.data.message}` : null,
+      `brief_optin: ${parsed.data.brief_optin ? 'yes' : 'no'}`,
       'submitted via /stock/apply',
     ]
       .filter(Boolean)

--- a/src/app/stock/apply/ApplyForm.tsx
+++ b/src/app/stock/apply/ApplyForm.tsx
@@ -20,6 +20,7 @@ export function ApplyForm({ roles, shifts }: { roles: RoleOption[]; shifts: Shif
   const [roleInterest, setRoleInterest] = useState('unassigned');
   const [shiftInterest, setShiftInterest] = useState('allday');
   const [message, setMessage] = useState('');
+  const [briefOptIn, setBriefOptIn] = useState(true);
   const [hp, setHp] = useState('');
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<'idle' | 'sent' | 'error'>('idle');
@@ -40,6 +41,7 @@ export function ApplyForm({ roles, shifts }: { roles: RoleOption[]; shifts: Shif
           role_interest: roleInterest,
           shift_interest: shiftInterest,
           message: message || undefined,
+          brief_optin: briefOptIn,
           hp,
         }),
       });
@@ -163,6 +165,19 @@ export function ApplyForm({ roles, shifts }: { roles: RoleOption[]; shifts: Shif
           className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
         />
       </div>
+
+      <label className="flex items-start gap-2.5 bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2.5 cursor-pointer hover:border-[#f5a623]/30 transition-colors">
+        <input
+          type="checkbox"
+          checked={briefOptIn}
+          onChange={(e) => setBriefOptIn(e.target.checked)}
+          className="mt-0.5 accent-[#f5a623]"
+        />
+        <span className="text-xs text-gray-300">
+          Send me the weekly ZAOstock build log - what moved, what needs hands, one thing you can help with.
+          <span className="block text-[10px] text-gray-500 mt-0.5">Uncheck to skip. One email a week, cancel anytime.</span>
+        </span>
+      </label>
 
       <button
         type="submit"


### PR DESCRIPTION
## Summary

Operationalize 2 of the 4 doc-470 action items. Other 2 (InfraNodus trial + gap analysis) need Zaal's hands.

## Changes

### 1. Stock apply form: default-in subscription (action #4)
- `src/app/stock/apply/ApplyForm.tsx` - pre-checked "weekly build log" toggle before submit button
- `src/app/api/stock/apply/route.ts` - schema accepts `brief_optin` flag, stashes to notes field (no migration yet)
- Applies Madrian-Shea 2001 default pattern (49% -> 86% uptake from opt-in to opt-out)

### 2. CEO/ZOE SOUL reframe (action #6)
- `agents/ceo/SOUL.md` - new Strategic Posture principle: "Nudge at decision moment, do not teach"
- Cites doc 470 research (168-study meta, 0.1% variance for education)
- **Zaal: push to VPS 1 ZOE SOUL after merge** (per /vps skill)

## Deliberately skipped (from the 10 combined action items)

- #1 Opt-out autostake (needs tokenomics review first)
- #2 24h withdraw friction (needs legal review)
- #3 Stake More Next Drop (premature, post-ZAO-Stock)
- #5 Decision-moment funnel (solo founder bandwidth)
- #9 InfraNodus MCP on VPS (depends on #7/#8 validating tool)
- #10 Cluster-to-chain correlation (high complexity, revisit at 500+ members)

## Next (Zaal)

- [ ] Start 14-day InfraNodus Advanced trial (#7, 15 min)
- [ ] Feed 30d casts + newsletter backlog to InfraNodus (#8)
- [ ] Push updated SOUL.md to VPS 1 after merge
- [ ] If build log opt-in rate >70%, this validates default-pattern across ZAO surfaces

## Test plan

- [ ] Load `/stock/apply` - "weekly build log" checkbox is pre-checked
- [ ] Submit with box unchecked - verify `brief_optin: no` in volunteer notes
- [ ] Submit with box checked (default) - verify `brief_optin: yes` in volunteer notes
- [ ] Typecheck passes

Stacked on doc 469 + 470 research in PR #267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)