### PR TITLE
feat(stock): suggestion box + random codes + team post guide + 2 research docs

### DIFF
--- a/research/events/472-zaostock-artist-lockin-timeline/README.md
+++ b/research/events/472-zaostock-artist-lockin-timeline/README.md
@@ -1,0 +1,95 @@
+# 472 - ZAOstock Artist Lockin Timeline (Internal Proposal)
+
+> **Status:** Internal proposal, not for public comms yet
+> **Date:** 2026-04-21
+> **Goal:** Propose a full lockin timeline for the Oct 3 artist lineup. Came from the Apr 21 meeting where Zaal committed to the "1 month before or your spot goes" policy.
+
+---
+
+## The Policy (proposed)
+
+If an artist is not fully locked in (contract + tech rider + travel confirmed + bio submitted) by **September 3, 2026** (exactly one month before Oct 3), their slot goes to someone else.
+
+No exceptions - not even for friends. This is the biggest festival-killer: flaky artist bookings. We eliminate the pattern by making the rule clear up front.
+
+---
+
+## Full Timeline (artist milestones)
+
+| Milestone | Target date | Who owns | Trigger |
+|-----------|------------|----------|---------|
+| First-contact window closes | May 15 | DCoop + Zaal | Every wishlist artist must have been pitched at least once |
+| Interested-confirmation window | June 1 | DCoop | Every "contacted" artist replied yes or no |
+| Confirmed list v1 published | June 30 | Zaal | Half-lineup reveal on @ZAOfestivals |
+| Contracts issued | July 1-15 | Tyler + Zaal | Simple partner agreement + Fractured Atlas W-9 process |
+| Contracts signed | August 1 | Artists | No signed contract = no set |
+| Tech riders submitted | August 15 | Artists | Gear, audio, any specific asks |
+| Travel locked (for travel-booked artists) | August 31 | Zaal + artist | Flights / hotels booked |
+| Logos + promo assets delivered | September 1 | Artists | Brand pack for poster + stage + broadcast |
+| **LOCKIN DEADLINE** | **September 3** | Artist | All above items done or slot reopens |
+| Final run-of-show locked | September 10 | Zaal + DCoop + Hurric4n3 | Time slots assigned in dashboard |
+| Attendee-facing lineup reveal | September 15 | Zaal + DaNici | Full poster + program live |
+| Final tech + stage plan | September 20 | Zaal + vendor | Wallace Events tent, audio, power |
+| Artist day-of comms | September 30 | Zaal | Load-in times, parking, contact |
+| Festival | October 3 | Everyone | Execute |
+| Recap + pay artists | October 10-17 | Tyler | Post-event payout |
+
+---
+
+## Soft deadlines (not fireable offenses)
+
+- Submitting a bio: within 2 weeks of first yes
+- Social handle share: within 2 weeks of first yes
+- Bio edits requested: up to September 15
+
+---
+
+## Firing offenses (hard deadlines)
+
+- **August 1:** No signed contract -> slot reopens
+- **August 15:** No tech rider -> slot reopens (unless vendor intervention)
+- **September 3 (master deadline):** Any missing item from the lockin list -> slot reopens
+
+Why this works: artists who show up on August 1 with a signed contract are the ones who show up on October 3. Flakes filter themselves out naturally when you set the expectation clearly.
+
+---
+
+## Replacement Queue
+
+Track a wishlist of "backup artists" in the dashboard with status=wishlist. If a slot reopens, pull from the wishlist in order of pipeline priority. Dashboard filter: `status=wishlist AND cypher_interested=true` is a good first-pull heuristic.
+
+---
+
+## What to communicate publicly
+
+Nothing about the policy directly. Instead:
+- "We have a 10-artist lineup for Oct 3"
+- "Full lineup dropping September 15"
+- "Tickets drop once lineup is public"
+
+The internal deadlines keep us sane. The public just sees clarity and execution.
+
+---
+
+## Dashboard integration
+
+- Add timeline milestones to the `stock_timeline` table keyed to these dates
+- Dashboard Artists tab: add a "Lockin risk" column (red/yellow/green based on which milestones they've hit)
+- Automatic Pareto "Top 3" for artists: sorted by how many lockin milestones they've missed
+
+---
+
+## Next steps
+
+1. Tuesday Apr 28 meeting: present this to the team for feedback
+2. DCoop + Zaal: review together before the meeting
+3. Seed milestones into `stock_timeline` with dates above
+4. Add "Lockin risk" visual to dashboard Artists tab as a follow-up build
+
+---
+
+## Sources
+
+- Apr 21 meeting transcript: Zaal said "if a month before you are not locked in and signed up, like we're moving your spot to someone else, even if you're a friend."
+- Industry standard: most touring artists lock 60-90 days out; we're giving 30 because we're small
+- Precedent: ZAOCHELLA and PALOOZA lineup formation timelines

--- a/research/events/473-road-to-zaostock-magnetic-portal/README.md
+++ b/research/events/473-road-to-zaostock-magnetic-portal/README.md
@@ -1,0 +1,148 @@
+# 473 - Road to ZAOstock: Magnetic Portal Spec
+
+> **Status:** Proposal, Tyler to iterate
+> **Date:** 2026-04-21
+> **Goal:** Blueprint for a single Magnetic-powered portal that drips pre-event content weekly, turns into the day-of scavenger hunt, and persists as a post-event artifact. Came from Tyler Stambaugh joining the Apr 21 meeting and proposing the frame.
+
+---
+
+## The insight (Tyler's framing)
+
+"The difference between an email campaign and a portal is that emails die in your inbox, a portal accumulates into something you can return to."
+
+A 12-week drip campaign via email = 12 forgotten messages. The same campaign via Magnetic = one growing portal of value that attendees can revisit, screenshot, share, and that builds brand surface every week.
+
+---
+
+## Three-phase arc
+
+### Phase 1: Pre-event (June through September)
+
+**Mechanics:**
+- One Magnetic portal at /stock/road-to or similar
+- Weekly "drop" adds a new tile to the portal
+- Portal grid grows over 14 weeks (mid-June through Oct 3)
+- Each drop has something immediate: a sneak peek, a sponsor reveal, an artist spotlight, a behind-the-scenes update
+- Users who collected an early drop see their count on the portal
+
+**Content calendar (sketch):**
+| Week | Drop type | Hook |
+|------|-----------|------|
+| June 15 | ZAOstock 2026 announcement magnet | Foundation post, event overview |
+| June 22 | Partner 1 reveal | First confirmed partner + why they matter |
+| June 29 | Artist 1 spotlight | First confirmed artist, link to their music |
+| July 6 | Ville tie-in | DCoop's DC event plus how the two connect |
+| July 13 | Partner 2 reveal | |
+| July 20 | Artist 2 spotlight | |
+| July 25 | Ville event magnet | Live attendance magnet at Ville |
+| July 27 | Ville recap | Photos, quotes, next-event tease |
+| August 3 | Artist 3 spotlight | |
+| August 10 | The Cypher teaser | ZAOCHELLA Miami Cipher snippet |
+| August 17 | Full lineup poster reveal | All 10 artists public |
+| August 24 | Ticket drop | Tickets go live |
+| August 31 | Sponsor deck final | All partners named |
+| September 7 | Countdown starts | Under 30 days |
+| September 14 | ZAOCHELLA Miami Cipher full release | Drives traffic to /stock |
+| September 21 | Travel + logistics | Parking, food trucks, afterparty info |
+| September 28 | Final schedule | Run-of-show public |
+| October 3 | LIVE | Day-of scavenger hunt begins |
+
+### Phase 2: Day-of (October 3)
+
+- Portal transforms into day-of mode
+- QR codes posted at venue entry, main stage, bar, each artist set
+- Each scan drops a collectible into the user's portal
+- Collect 5+ collectibles during the day = post-event merch drop unlocks
+- Artist-specific drops: each artist has a unique collectible that hides an unreleased song snippet, photo, or backstage clip
+
+### Phase 3: Post-event (October 4 onwards)
+
+- Portal preserves the full 14-week timeline + day-of collection
+- New "recap" tile drops showing photos, stats, cypher release
+- Attendees get a final artifact they can return to later in the year
+- Leaderboard: who collected the most across the full journey
+- Tyler's insight: audience intelligence. We now know who showed up, what they engaged with, how active they were
+
+---
+
+## Tech stack (Tyler's existing Magnetic platform)
+
+- One portal per campaign (Magnetic handles)
+- Signed URL uploads (audio, video, image) hosted in their R2 infrastructure
+- Onchain NFT layer underneath for traceability, but UX is email-based (web2 friendly)
+- Public QR code generator for day-of
+- Admin dashboard for Zaal + team to see engagement
+
+---
+
+## Integration with existing ZAOstock systems
+
+- /stock landing links to the portal in the CTA section
+- /stock/program references the day-of scavenger hunt mechanic
+- Dashboard Volunteers tab can be extended to show Magnetic collectors who opted in (overlap with volunteer pool)
+- Media capture pipeline (research/events/433) drops go into the post-event portal recap tile
+
+---
+
+## Who owns what
+
+- **Tyler Stambaugh:** portal architecture, QR generator, Magnetic admin, technical integration
+- **Zaal:** content calendar, weekly drop copy, approval of each drop
+- **DaNici:** visual design of each drop tile (template system so weekly drops are fast to produce)
+- **DCoop:** artist spotlight coordination, artist-specific day-of drops
+- **Shawn:** Web3 music label tie-in (cipher drops routed through the portal)
+
+---
+
+## Budget ask
+
+- Magnetic platform: in-kind via Tyler joining advisory
+- Portal branding / creative: DaNici existing scope
+- Content production: Zaal + team existing scope
+- QR code printing for day-of: ~$100 (signage budget)
+
+**Total new budget ask: ~$100 for print**
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Low early engagement | Front-load value - first 3 drops include tangible things (partner discounts, artist music, etc) |
+| Content production exhaustion | Lock content calendar by June 15, batch produce in 2-week sprints |
+| Day-of QR failures (wifi, scanning issues) | Multiple QR locations + fallback paper signup; Tyler's platform handles offline queuing |
+| Attendees don't know the portal exists | Promote via every channel: email signature, onepager, stage MC, sponsor booth, ticket email |
+
+---
+
+## Success metrics
+
+- Pre-event: 200+ unique portal visitors by August 1, 500+ by Oct 1
+- Day-of: 30% of attendees collect at least one day-of drop
+- Post-event: 100+ users check the portal in the 2 weeks after the event
+- Soft metric: sponsors see engagement data and ask to return for 2027
+
+---
+
+## Next steps
+
+1. Tuesday Apr 28 meeting: Tyler presents this framework live to team
+2. DaNici + Tyler: kickoff call on the visual template system
+3. Zaal: draft first 4 weeks of content calendar (June 15 through July 6)
+4. Prototype portal launches June 15
+
+---
+
+## Sources
+
+- Apr 21 meeting transcript: Tyler's 15-minute pitch on road-to-event + day-of + post-event arc
+- Running Man / Ironman endurance event pre-drip models (Tyler's co-founder is a marathoner)
+- Existing Magnetic platform: https://magnetiq.xyz (Tyler's product)
+- Outer Edge LA scavenger hunt precedent (Shawn's reference)
+
+## Related ZAO research
+
+- [432 - ZAO master context](../../community/432-zao-master-context-tricky-buddha/)
+- [433 - Media capture pipeline spec](../433-zao-media-capture-pipeline-spec/)
+- [428 - ZAOstock run-of-show](../428-zaostock-run-of-show-program/)

--- a/scripts/set-stock-team-random-codes.ts
+++ b/scripts/set-stock-team-random-codes.ts
@@ -1,0 +1,80 @@
+// Generates RANDOMIZED 4-character codes (letters + digits, no 0/O/1/I to
+// avoid confusion) for every ZAOstock team member. Unlike the name-based
+// script, these are unguessable by knowing someone's name.
+//
+// Output: SQL upsert block for Supabase + a plaintext list of codes
+// grouped per-person so Zaal can DM each teammate their code privately.
+//
+// Usage:
+//   npx tsx scripts/set-stock-team-random-codes.ts
+//
+// Copy the printed SQL block into Supabase SQL Editor and run.
+// Then DM each teammate their code from the plaintext list at the top.
+
+import { scryptSync, randomBytes } from 'crypto';
+
+const TEAM: Array<{ name: string; role: string; scope: string }> = [
+  { name: 'Zaal', role: 'lead', scope: 'ops' },
+  { name: 'Candy', role: '2nd', scope: 'ops' },
+  { name: 'FailOften', role: 'member', scope: 'ops' },
+  { name: 'Hurric4n3Ike', role: 'member', scope: 'ops' },
+  { name: 'Swarthy Hatter', role: 'member', scope: 'ops' },
+  { name: 'DaNici', role: 'lead', scope: 'design' },
+  { name: 'Shawn', role: 'member', scope: 'design' },
+  { name: 'DCoop', role: '2nd', scope: 'music' },
+  { name: 'AttaBotty', role: 'member', scope: 'music' },
+  { name: 'Tyler Stambaugh', role: 'advisory', scope: 'finance' },
+  { name: 'Ohnahji B', role: 'member', scope: 'finance' },
+  { name: 'DFresh', role: 'member', scope: 'finance' },
+  { name: 'Craig G', role: 'member', scope: 'finance' },
+  { name: 'Maceo', role: 'member', scope: 'finance' },
+  { name: 'Jango', role: 'member', scope: 'ops' },
+];
+
+// Unambiguous alphabet - no 0, O, 1, I, L
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+function generateCode(): string {
+  let code = '';
+  for (let i = 0; i < 4; i++) {
+    code += ALPHABET[randomBytes(1)[0] % ALPHABET.length];
+  }
+  return code;
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+// Ensure uniqueness across the roster
+const used = new Set<string>();
+const entries = TEAM.map((m) => {
+  let code = generateCode();
+  while (used.has(code)) code = generateCode();
+  used.add(code);
+  return { ...m, code };
+});
+
+console.log('-- ZAOstock Team: randomized 4-char codes');
+console.log('-- Paste into Supabase SQL Editor and run.');
+console.log('-- Then DM each teammate their code from the plaintext list below.\n');
+
+console.log('-- Plaintext codes (share privately - do NOT paste these anywhere public):');
+for (const { name, code } of entries) {
+  console.log(`--   ${name.padEnd(20)} -> ${code}`);
+}
+console.log('');
+
+console.log('BEGIN;');
+for (const { name, code, role, scope } of entries) {
+  const hash = hashPassword(code);
+  const safeName = name.replace(/'/g, "''");
+  console.log(
+    `INSERT INTO stock_team_members (name, role, scope, password_hash) ` +
+    `VALUES ('${safeName}', '${role}', '${scope}', '${hash}') ` +
+    `ON CONFLICT (name) DO UPDATE SET password_hash = EXCLUDED.password_hash, role = EXCLUDED.role;`,
+  );
+}
+console.log('COMMIT;');

--- a/scripts/stock-team-suggestions.sql
+++ b/scripts/stock-team-suggestions.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- ZAOstock Suggestion Box
+-- ============================================================================
+-- Public suggestion submission. Zaal moderates (can delete any row).
+-- Everyone can read; team can action and credit the contributor.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS stock_suggestions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  name TEXT DEFAULT '',
+  contact TEXT DEFAULT '',
+  suggestion TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'new' CHECK (status IN ('new','reviewing','actioned','wontfix','archived')),
+  notes TEXT DEFAULT '',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE stock_suggestions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role full access" ON stock_suggestions;
+CREATE POLICY "Service role full access" ON stock_suggestions FOR ALL USING (true) WITH CHECK (true);
+
+COMMENT ON TABLE stock_suggestions IS
+  'Public suggestion box. Anyone can submit via /stock/suggest. Zaal moderates via the dashboard Suggestions tab.';
+COMMENT ON COLUMN stock_suggestions.status IS
+  'Triage: new (fresh submit), reviewing (team looking at it), actioned (done), wontfix, archived.';

--- a/scripts/team-post-self-draft-guide.md
+++ b/scripts/team-post-self-draft-guide.md
@@ -1,0 +1,150 @@
+# ZAOstock Team Intro Post - Self-Draft Guide
+
+**Who:** Every contributor drafts their own @ZAOfestivals intro post(s).
+**Approval:** Post goes through team review before publishing.
+**Recast plan:** After publish, ZAO + your personal + every other team account recast.
+
+---
+
+## The goal
+
+An intro post that lands on @ZAOfestivals about you. Your words. Your vibe. We collectively share and amplify it.
+
+You can draft multiple angles if you want - a short punchy one and a longer thread. Team picks or combines.
+
+---
+
+## Required beats (hit most, not all)
+
+- Who you are (artist name, real name if you want, handle)
+- What you bring to ZAOstock (Music? Design? Ops? Finance? All of the above?)
+- One or two sentences on why you showed up for this
+- Your current thing: what you're working on right now (a song, a brand, a project)
+- Where people can follow you (one or two links max)
+
+## Tone
+
+- First person. Sound like you, not a press release.
+- Zero crypto jargon up front. Music first, community second, technology third.
+- Confident. This is a team worth being on.
+- Short sentences win.
+
+---
+
+## Template A: single short post (~400 char)
+
+```
+[HANDLE / ARTIST NAME] is on the ZAOstock team for Oct 3 in Ellsworth, ME.
+
+[ONE LINE ON WHAT YOU BRING]
+
+[ONE LINE ON CURRENT PROJECT OR VIBE]
+
+Catch me at [LINK].
+
+Joining @ZAO + Zaostock crew building this in public. 165 days to go.
+```
+
+## Template B: thread (~3 parts)
+
+Post 1:
+```
+[HANDLE] on the ZAOstock team.
+
+Oct 3 in Ellsworth, ME at the Franklin Street Parklet. Community-built, community-run.
+```
+
+Post 2 (reply):
+```
+What I bring: [ROLE / SKILL / ENERGY]
+
+What I'm working on right now: [CURRENT PROJECT - 2 sentences]
+```
+
+Post 3 (reply):
+```
+Why I'm here: [SHORT REASON - 1 or 2 sentences about the community, the artists, the mission]
+
+Follow me: [LINK]
+```
+
+---
+
+## Drafts to replace placeholders (reference examples only)
+
+### DCoop example
+
+```
+DCoop on the ZAOstock team.
+
+Running Ville July 25 in DC - third installment. Music 2nd on the ZAOstock crew. Focus: artist pipeline + the on-stage experience.
+
+Currently: helping shape the cypher format and locking the Oct 3 lineup.
+
+zaoos.com/stock
+```
+
+### Shawn example
+
+```
+Shawn on the ZAOstock team.
+
+Music + design. Coming off a wave wars battle. Building a Web3 music label alongside the festival.
+
+Currently: finalizing my brand and shaping what music contributions look like on Oct 3.
+
+zaoos.com/stock
+```
+
+### Candy example
+
+```
+Candy on the ZAOstock team.
+
+Ops 2nd. The behind-the-scenes one: permits, venue, timeline, making sure nothing falls through the cracks.
+
+Currently: locking the Franklin Street Parklet permits and coordinating with Heart of Ellsworth.
+
+zaoos.com/stock
+```
+
+---
+
+## Approval flow
+
+1. Draft in the dashboard Meeting Notes or DM Zaal
+2. Team reviews (Zaal + scope lead - DaNici for design, DCoop for music, etc)
+3. Edits if needed
+4. Publish on @ZAOfestivals
+5. ZAO account recasts
+6. Your personal account recasts
+7. Every other teammate recasts
+
+Steps 5-7 compound reach. One post. Many recasts. Big surface.
+
+---
+
+## After your intro goes up
+
+- Every week we add a quote-cast update on top of your original post
+- 8 weeks of updates = a public chronicle of your ZAOstock work that fans can trace back
+- All updates count as your weekly contribution mark
+
+---
+
+## FAQ
+
+**Do I have to post on my personal account?**
+Yes, that's how step 3 of the contributor path completes.
+
+**What if I have no personal following?**
+Doesn't matter. The team cross-recast + @ZAO + @ZAOfestivals amplify. Your post is the source of truth, not the reach.
+
+**Can I post more than one draft?**
+Yes. Multiple drafts made by you are welcome. Team picks the angle.
+
+**Can I include crypto / Web3 language?**
+Keep it subtle. Lead with music and community. Web3 is infrastructure, not the headline.
+
+**What if I don't know what to say?**
+DM Zaal. We'll pull from your bio and your current work to build a draft together.

--- a/src/app/api/stock/suggestions/route.ts
+++ b/src/app/api/stock/suggestions/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { getStockTeamMember } from '@/lib/auth/stock-team-session';
+
+const createSchema = z.object({
+  name: z.string().trim().max(200).optional(),
+  contact: z.string().trim().max(200).optional(),
+  suggestion: z.string().trim().min(1, 'Suggestion cannot be empty').max(2000),
+  hp: z.string().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const parsed = createSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+
+    if (parsed.data.hp && parsed.data.hp.trim().length > 0) {
+      return NextResponse.json({ success: true }, { status: 201 });
+    }
+
+    const supabase = getSupabaseAdmin();
+    const { error } = await supabase.from('stock_suggestions').insert({
+      name: parsed.data.name || '',
+      contact: parsed.data.contact || '',
+      suggestion: parsed.data.suggestion,
+    });
+
+    if (error) {
+      return NextResponse.json({ error: 'Could not submit' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true }, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: 'Submission failed' }, { status: 500 });
+  }
+}
+
+export async function GET() {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('stock_suggestions')
+    .select('id, name, contact, suggestion, status, created_at')
+    .neq('status', 'archived')
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (error) return NextResponse.json({ error: 'Load failed' }, { status: 500 });
+  return NextResponse.json({ suggestions: data });
+}
+
+const patchSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['new', 'reviewing', 'actioned', 'wontfix', 'archived']).optional(),
+  notes: z.string().max(2000).optional(),
+});
+
+export async function PATCH(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = patchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  }
+
+  const { id, ...updates } = parsed.data;
+  if (Object.keys(updates).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('stock_suggestions')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+
+  if (error) return NextResponse.json({ error: 'Update failed' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({ id: z.string().uuid() });
+
+export async function DELETE(request: NextRequest) {
+  const member = await getStockTeamMember();
+  if (!member) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const body = await request.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('stock_suggestions').delete().eq('id', parsed.data.id);
+  if (error) return NextResponse.json({ error: 'Delete failed' }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/stock/page.tsx
+++ b/src/app/stock/page.tsx
@@ -94,6 +94,12 @@ export default async function StockPage() {
               Cypher
             </Link>
             <Link
+              href="/stock/suggest"
+              className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
+            >
+              Suggest
+            </Link>
+            <Link
               href="/stock/apply"
               className="text-xs text-gray-400 hover:text-[#f5a623] transition-colors"
             >

--- a/src/app/stock/suggest/SuggestForm.tsx
+++ b/src/app/stock/suggest/SuggestForm.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function SuggestForm() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [contact, setContact] = useState('');
+  const [suggestion, setSuggestion] = useState('');
+  const [hp, setHp] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState<'idle' | 'sent' | 'error'>('idle');
+  const [errMsg, setErrMsg] = useState('');
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!suggestion.trim()) return;
+    setBusy(true);
+    setErrMsg('');
+    try {
+      const res = await fetch('/api/stock/suggestions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name || undefined,
+          contact: contact || undefined,
+          suggestion,
+          hp,
+        }),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        setStatus('error');
+        setErrMsg(d.error || 'Submission failed');
+      } else {
+        setStatus('sent');
+        setSuggestion('');
+        setName('');
+        setContact('');
+        setTimeout(() => {
+          router.refresh();
+          setStatus('idle');
+        }, 1500);
+      }
+    } catch {
+      setStatus('error');
+      setErrMsg('Network error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (status === 'sent') {
+    return (
+      <div className="bg-gradient-to-br from-emerald-500/15 via-emerald-500/5 to-transparent rounded-xl p-6 border border-emerald-500/30 text-center">
+        <p className="text-xs uppercase tracking-wider text-emerald-400 font-bold">Thanks</p>
+        <p className="text-sm text-gray-300 mt-2">
+          Suggestion submitted. The team sees it in the dashboard. Refreshing the list now.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={submit} className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] space-y-3">
+      <input
+        type="text"
+        tabIndex={-1}
+        autoComplete="off"
+        value={hp}
+        onChange={(e) => setHp(e.target.value)}
+        className="hidden"
+        aria-hidden="true"
+      />
+      <div className="grid grid-cols-2 gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your name (optional)"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+        <input
+          value={contact}
+          onChange={(e) => setContact(e.target.value)}
+          placeholder="Contact (optional)"
+          maxLength={200}
+          className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+        />
+      </div>
+      <textarea
+        value={suggestion}
+        onChange={(e) => setSuggestion(e.target.value)}
+        placeholder="Your suggestion..."
+        required
+        rows={4}
+        maxLength={2000}
+        className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30 resize-none"
+      />
+      <button
+        type="submit"
+        disabled={busy || !suggestion.trim()}
+        className="w-full bg-[#f5a623] hover:bg-[#ffd700] disabled:opacity-50 text-black font-bold rounded-lg px-4 py-2.5 text-sm transition-colors"
+      >
+        {busy ? 'Sending...' : 'Drop suggestion'}
+      </button>
+      {status === 'error' && <p className="text-xs text-red-400 text-center">{errMsg}</p>}
+    </form>
+  );
+}

--- a/src/app/stock/suggest/page.tsx
+++ b/src/app/stock/suggest/page.tsx
@@ -1,0 +1,96 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { SuggestForm } from './SuggestForm';
+
+export const metadata: Metadata = {
+  title: 'Suggestions | ZAOstock',
+  description: 'Drop a suggestion for ZAOstock. Anyone can submit. We credit the contributors.',
+};
+
+export const dynamic = 'force-dynamic';
+
+async function getPublic() {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('stock_suggestions')
+    .select('id, name, suggestion, status, created_at')
+    .neq('status', 'archived')
+    .order('created_at', { ascending: false })
+    .limit(80);
+  return data || [];
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  new: 'bg-gray-500/10 text-gray-400 border-gray-500/30',
+  reviewing: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
+  actioned: 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30',
+  wontfix: 'bg-red-500/10 text-red-400 border-red-500/30',
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export default async function SuggestPage() {
+  const suggestions = await getPublic();
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white pb-12">
+      <header className="sticky top-0 z-40 bg-[#0a1628]/95 backdrop-blur-md border-b border-white/[0.06]">
+        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
+          <Link href="/stock" className="text-xs text-gray-400 hover:text-[#f5a623]">
+            &larr; ZAOstock
+          </Link>
+          <span className="text-xs text-gray-500">Suggestion Box</span>
+        </div>
+      </header>
+
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+        <div className="text-center space-y-2">
+          <p className="inline-block rounded-full bg-[#f5a623]/10 px-3 py-1 text-xs text-[#f5a623] font-medium border border-[#f5a623]/30">
+            Drop an idea
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight">Suggestion Box</h1>
+          <p className="text-sm text-gray-400 max-w-lg mx-auto">
+            Anyone can submit. Great ideas get credited and actioned. The team reviews every entry.
+          </p>
+        </div>
+
+        <SuggestForm />
+
+        <section className="space-y-3">
+          <p className="text-xs text-gray-500 uppercase tracking-wider px-1">Recent submissions</p>
+          {suggestions.length === 0 ? (
+            <div className="bg-[#0d1b2a] rounded-xl p-6 border border-white/[0.08] text-center">
+              <p className="text-sm text-gray-500">No suggestions yet. Be the first.</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {suggestions.map((s) => (
+                <div key={s.id} className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-4 space-y-2">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border uppercase ${STATUS_COLOR[s.status] || STATUS_COLOR.new}`}>
+                      {s.status}
+                    </span>
+                    <span className="text-[10px] text-gray-500">{formatDate(s.created_at)}</span>
+                    {s.name && (
+                      <span className="text-[10px] text-[#f5a623]">by {s.name}</span>
+                    )}
+                  </div>
+                  <p className="text-sm text-gray-200 whitespace-pre-wrap">{s.suggestion}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <div className="text-center">
+          <Link href="/stock" className="text-sm text-[#f5a623] hover:text-[#ffd700]">
+            Back to ZAOstock
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Post-meeting buildout. Five deliverables so the recap broadcast tomorrow can say "done" not "coming."

## Shipped
1. **Suggestion box** at /stock/suggest (public submit, live feed, status pills). SQL creates stock_suggestions table. /stock header gets a "Suggest" link.
2. **Randomized 4-char codes** script. Unambiguous alphabet, unguessable. Run it, get plaintext codes + upsert SQL. Tyler bumped to advisory.
3. **Team post self-draft guide** (scripts/team-post-self-draft-guide.md). Two templates, 3 example drafts (DCoop / Shawn / Candy), approval flow, FAQ.
4. **Research doc 472: Artist lockin timeline** (internal). Full May-Oct milestones. Hard Sep 3 lockin. Dashboard integration plan.
5. **Research doc 473: Road to ZAOstock Magnetic portal**. Spec for Tyler. 3-phase arc (pre-event drip / day-of scavenger / post artifact). 14-week content calendar sketch.

## To apply after merge
1. Paste `scripts/stock-team-suggestions.sql` into Supabase
2. Run `npx tsx scripts/set-stock-team-random-codes.ts`, paste upsert SQL into Supabase
3. Save the plaintext code list - DM each teammate their code privately
4. Verify /stock/suggest renders + submits successfully

## Still needs Zaal manually
- Attendance magnet (build later via Magnetic/Tyler)
- Google Meet integration for next Tuesday (set up + post link)
- Suggestion box moderation: dashboard-side tab for team triage (quick follow-up PR if wanted)

No emojis, no em dashes.