### PR TITLE
content(bcz-yapz): wire 3 YouTube URLs (Nikoline / Dish / Hannah)

### DIFF
--- a/content/transcripts/bcz-yapz/2026-04-14-nikoline-hubs-network.md
+++ b/content/transcripts/bcz-yapz/2026-04-14-nikoline-hubs-network.md
@@ -1,29 +1,29 @@
 ---
-title: "BCZ YapZ w/Nikoline (Hubs Network)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Nikoline (Hubs Network)
+show: BCZ YapZ
 episode: 15
-guest: "Nikoline Arns"
-guest_alias: "Nikoline"
-guest_org: "Hubs Network"
+guest: Nikoline Arns
+guest_alias: Nikoline
+guest_org: Hubs Network
 guest_links:
-  - "x: https://x.com/nikoline_nik"
-  - "linkedin: https://linkedin.com/in/nikoline-nik"
-  - "paragraph: https://paragraph.xyz/@nikoline"
-  - "telegram: https://t.me/nikoline_nik"
-  - "personal: https://nikoline.github.io/arns/"
-  - "web: https://hubsnetwork.org"
-  - "substack: https://hubsnetwork.substack.com"
-  - "farcaster-channel: /hubs-network"
-  - "partners: Akasha Hub, Radical Exchange, Web3 Privacy Now, Logos"
-host: "Zaal"
+  - 'x: https://x.com/nikoline_nik'
+  - 'linkedin: https://linkedin.com/in/nikoline-nik'
+  - 'paragraph: https://paragraph.xyz/@nikoline'
+  - 'telegram: https://t.me/nikoline_nik'
+  - 'personal: https://nikoline.github.io/arns/'
+  - 'web: https://hubsnetwork.org'
+  - 'substack: https://hubsnetwork.substack.com'
+  - 'farcaster-channel: /hubs-network'
+  - 'partners: Akasha Hub, Radical Exchange, Web3 Privacy Now, Logos'
+host: Zaal
 host_handles:
-  - "farcaster: @zaal"
-  - "x: @bettercallzaal"
-  - "youtube: @bettercallzaal"
-date: 2026-04-14
+  - 'farcaster: @zaal'
+  - 'x: @bettercallzaal'
+  - 'youtube: @bettercallzaal'
+date: 2026-04-14T00:00:00.000Z
 duration_min: 27
-format: "video-podcast"
-language: "en"
+format: video-podcast
+language: en
 topics:
   - governance
   - sociocracy
@@ -45,36 +45,43 @@ keywords:
   - networked-hubs
 entities:
   orgs:
-    - "Hubs Network"
-    - "Akasha Foundation"
-    - "Akasha Hub"
-    - "Nasha Hub"
-    - "Radical Exchange"
-    - "Web3 Privacy Now"
-    - "Logos"
-    - "Liminal Village"
-    - "Commons Hub"
+    - Hubs Network
+    - Akasha Foundation
+    - Akasha Hub
+    - Nasha Hub
+    - Radical Exchange
+    - Web3 Privacy Now
+    - Logos
+    - Liminal Village
+    - Commons Hub
   people:
-    - "Lorenzo (Nasha Hub)"
-    - "Roberto (Liminal Village)"
-    - "Charles (Radical Exchange Zurich)"
-    - "Malik (Radical Exchange Foundation)"
-    - "Audrey Tang"
+    - Lorenzo (Nasha Hub)
+    - Roberto (Liminal Village)
+    - Charles (Radical Exchange Zurich)
+    - Malik (Radical Exchange Foundation)
+    - Audrey Tang
   projects:
-    - "Plural Events"
-    - "Agora Citizen"
-    - "Polis"
-    - "Context Engine"
+    - Plural Events
+    - Agora Citizen
+    - Polis
+    - Context Engine
 source:
-  video: "Movies/bcz stream/BCZyapz/nik/bcz yapz w_nikoline.mp4"
-  docx: "Movies/bcz stream/BCZyapz/nik/bcz yapz w_nikoline.docx"
-summary: "Nikoline of Hubs Network on connecting physical web3/coordination hubs worldwide, sociocracy as a fractal governance tool, and the Plural Events format that runs the same conversation simultaneously across 12+ cities."
+  video: Movies/bcz stream/BCZyapz/nik/bcz yapz w_nikoline.mp4
+  docx: Movies/bcz stream/BCZyapz/nik/bcz yapz w_nikoline.docx
+summary: >-
+  Nikoline of Hubs Network on connecting physical web3/coordination hubs
+  worldwide, sociocracy as a fractal governance tool, and the Plural Events
+  format that runs the same conversation simultaneously across 12+ cities.
 action_items:
-  - "Plural Event on 2026-05-14 - local hosts wanted (even 15 people in a bar counts)"
-  - "Visit hubsnetwork.org + subscribe to substack newsletter"
-  - "Web3 Privacy Now summit in Berlin mid-June - Hubs Network on panel"
-  - "Zaal to explore starting a Maine hub"
-status: "raw"
+  - >-
+    Plural Event on 2026-05-14 - local hosts wanted (even 15 people in a bar
+    counts)
+  - Visit hubsnetwork.org + subscribe to substack newsletter
+  - Web3 Privacy Now summit in Berlin mid-June - Hubs Network on panel
+  - Zaal to explore starting a Maine hub
+status: raw
+youtube_url: 'https://youtu.be/RuYxRBfLGCc'
+youtube_video_id: RuYxRBfLGCc
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-04-21-dish-clanker.md
+++ b/content/transcripts/bcz-yapz/2026-04-21-dish-clanker.md
@@ -1,19 +1,19 @@
 ---
-title: "BCZ YapZ w/Dish (Clanker)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Dish (Clanker)
+show: BCZ YapZ
 episode: 16
-guest: "Jack Dishman"
-guest_alias: "Dish"
-guest_org: "Clanker"
+guest: Jack Dishman
+guest_alias: Dish
+guest_org: Clanker
 guest_links:
-  - "farcaster: @dish"
-  - "x: @jackdishman"
-  - "project: clanker.world"
-host: "Zaal"
-date: 2026-04-21
+  - 'farcaster: @dish'
+  - 'x: @jackdishman'
+  - 'project: clanker.world'
+host: Zaal
+date: 2026-04-21T00:00:00.000Z
 duration_min: 29
-format: "video-podcast"
-language: "en"
+format: video-podcast
+language: en
 topics:
   - farcaster
   - clanker
@@ -36,29 +36,34 @@ keywords:
   - dev-shop
 entities:
   orgs:
-    - "Clanker"
-    - "Farcaster"
-    - "Coinbase / Base"
-    - "GameStop NFT"
-    - "Wizards of the Coast / D&D Beyond"
-    - "Empire Builder"
+    - Clanker
+    - Farcaster
+    - Coinbase / Base
+    - GameStop NFT
+    - Wizards of the Coast / D&D Beyond
+    - Empire Builder
   people:
-    - "Jack Dishman (Dish)"
-    - "Proxy Studio (Clanker team)"
+    - Jack Dishman (Dish)
+    - Proxy Studio (Clanker team)
   projects:
-    - "Clanker"
-    - "Empire Builder"
-    - "CrustyKeno"
-    - "Eliza (AI agent framework)"
+    - Clanker
+    - Empire Builder
+    - CrustyKeno
+    - Eliza (AI agent framework)
 source:
-  video: "Movies/bcz stream/BCZyapz/jack/bcz yapz w_dish.mp4"
-  docx: "Movies/bcz stream/BCZyapz/jack/bcz yapz w_dish.docx"
-summary: "Jack Dishman (Dish) on building Clanker - the Farcaster-native ERC20 token launcher - how an in-feed AI agent became a launchpad, the evolution from chat-bot to flagship + alt-clients, and why in-feed experiences win."
+  video: Movies/bcz stream/BCZyapz/jack/bcz yapz w_dish.mp4
+  docx: Movies/bcz stream/BCZyapz/jack/bcz yapz w_dish.docx
+summary: >-
+  Jack Dishman (Dish) on building Clanker - the Farcaster-native ERC20 token
+  launcher - how an in-feed AI agent became a launchpad, the evolution from
+  chat-bot to flagship + alt-clients, and why in-feed experiences win.
 action_items:
-  - "Follow Dish on Farcaster (@dish) and X (@jackdishman)"
-  - "Try Clanker in-feed on Farcaster to launch a token"
-  - "Dish to visit Maine for ZAO Stock October event"
-status: "raw"
+  - Follow Dish on Farcaster (@dish) and X (@jackdishman)
+  - Try Clanker in-feed on Farcaster to launch a token
+  - Dish to visit Maine for ZAO Stock October event
+status: raw
+youtube_url: 'https://youtu.be/gHbktZC6HbA'
+youtube_video_id: gHbktZC6HbA
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-04-21-hannah-farmdrop.md
+++ b/content/transcripts/bcz-yapz/2026-04-21-hannah-farmdrop.md
@@ -1,16 +1,16 @@
 ---
-title: "BCZ YapZ w/Hannah (Farm Drop)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Hannah (Farm Drop)
+show: BCZ YapZ
 episode: 17
-guest: "Hannah"
-guest_org: "Farm Drop"
+guest: Hannah
+guest_org: Farm Drop
 guest_links:
-  - "web: farmdrop.us"
-host: "Zaal"
-date: 2026-04-21
+  - 'web: farmdrop.us'
+host: Zaal
+date: 2026-04-21T00:00:00.000Z
 duration_min: 30
-format: "video-podcast"
-language: "en"
+format: video-podcast
+language: en
 topics:
   - food-systems
   - csa
@@ -32,31 +32,38 @@ keywords:
   - food-pantry
 entities:
   orgs:
-    - "Farm Drop"
-    - "College of the Atlantic"
-    - "Acadia Action"
-    - "Reversing Falls Sanctuary"
-    - "Down East Food Systems Partnership"
-    - "Sassafras Cafe"
-    - "Soul Vendors (band)"
+    - Farm Drop
+    - College of the Atlantic
+    - Acadia Action
+    - Reversing Falls Sanctuary
+    - Down East Food Systems Partnership
+    - Sassafras Cafe
+    - Soul Vendors (band)
   people:
-    - "Hannah (Farm Drop lead)"
+    - Hannah (Farm Drop lead)
   projects:
-    - "Food for Health"
-    - "Reaccion (event series)"
-    - "Grocery List documentary"
+    - Food for Health
+    - Reaccion (event series)
+    - Grocery List documentary
 source:
-  video: "Movies/bcz stream/BCZyapz/hannah/bcz yapz w_hannah.mp4"
-  docx: "Movies/bcz stream/BCZyapz/hannah/bcz yapz w_hannah.docx"
-summary: "Hannah of Farm Drop on building a volunteer-driven local food network across Downeast Maine since 2011, the Food for Health mutual-aid program, and an upcoming slate of community solution events."
+  video: Movies/bcz stream/BCZyapz/hannah/bcz yapz w_hannah.mp4
+  docx: Movies/bcz stream/BCZyapz/hannah/bcz yapz w_hannah.docx
+summary: >-
+  Hannah of Farm Drop on building a volunteer-driven local food network across
+  Downeast Maine since 2011, the Food for Health mutual-aid program, and an
+  upcoming slate of community solution events.
 action_items:
-  - "Visit farmdrop.us"
-  - "2026-05-09 - community solutions conversation at Reversing Falls Sanctuary, Brooksville"
-  - "2026-05-20 - Grocery List documentary screening at Ellsworth Library"
-  - "2026-05-24 - Soul Vendors fundraiser for Food for Health"
-  - "2026-08-06 - Farm Drop supporter event at Sassafras Cafe"
-  - "Explore Farm Drop x ZAO Stock alignment (Ellsworth local food presence)"
-status: "raw"
+  - Visit farmdrop.us
+  - >-
+    2026-05-09 - community solutions conversation at Reversing Falls Sanctuary,
+    Brooksville
+  - 2026-05-20 - Grocery List documentary screening at Ellsworth Library
+  - 2026-05-24 - Soul Vendors fundraiser for Food for Health
+  - 2026-08-06 - Farm Drop supporter event at Sassafras Cafe
+  - Explore Farm Drop x ZAO Stock alignment (Ellsworth local food presence)
+status: raw
+youtube_url: 'https://youtu.be/hw-6IHaziV0'
+youtube_video_id: hw-6IHaziV0
 ---
 
 ## Transcript


### PR DESCRIPTION
Populates youtube_url + youtube_video_id for the 3 most recently posted BCZ YapZ episodes so the /bcz-yapz page renders Watch buttons instead of 'Not yet posted'.

- Nikoline ep 15: https://youtu.be/RuYxRBfLGCc
- Dish ep 16: https://youtu.be/gHbktZC6HbA
- Hannah ep 17: https://youtu.be/hw-6IHaziV0

Ran via scripts/set-youtube-url.ts (shipped in PR #285).

## Test plan
- [ ] Merge, wait for Vercel build
- [ ] Visit www.zaoos.com/bcz-yapz - top 3 cards have gold Watch on YouTube buttons (not the disabled 'Not yet posted' state)
- [ ] Thumbnail view shows YouTube thumbnails for the 3 cards