### PR TITLE
fix(bcz-yapz): backfill youtube_video_id so thumbnails render (14 transcripts)

### DIFF
--- a/content/transcripts/bcz-yapz/2025-08-22-deepa-grantorb.md
+++ b/content/transcripts/bcz-yapz/2025-08-22-deepa-grantorb.md
@@ -1,25 +1,30 @@
 ---
-title: "BCZ YapZ w/Deepa"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Deepa
+show: BCZ YapZ
 episode: 1
-guest: "Deepa"
-guest_org: "GrantOrb"
-host: "Zaal"
-date: 2025-08-22
-youtube_url: "https://youtu.be/3vUAFwXqdeo"
-youtube_title: "BCZ Yaps – Episode 1: Deepa from GrantOrb on AI Grants and the Future of Funding"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Deepa
+guest_org: GrantOrb
+host: Zaal
+date: 2025-08-22T00:00:00.000Z
+youtube_url: 'https://youtu.be/3vUAFwXqdeo'
+youtube_title: >-
+  BCZ Yaps – Episode 1: Deepa from GrantOrb on AI Grants and the Future of
+  Funding
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/BCZ Yaps #1 W_ Deepa from GrantOrb.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: >-
+    Movies/bcz stream/BCZyapz/transcripts/BCZ Yaps #1 W_ Deepa from
+    GrantOrb.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 3vUAFwXqdeo
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2025-10-14-rich-bartuc.md
+++ b/content/transcripts/bcz-yapz/2025-10-14-rich-bartuc.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ YapZ w/Rich Bartuc"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Rich Bartuc
+show: BCZ YapZ
 episode: 2
-guest: "Rich Bartuc"
-guest_org: "PowerPacks Diamondhands Club"
-host: "Zaal"
-date: 2025-10-14
-youtube_url: "https://youtu.be/AOcp8Jpyw3k"
-youtube_title: "BCZ Yaps – Episode 2: Rich Bartuc & the PowerPacks Diamondhands Club"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Rich Bartuc
+guest_org: PowerPacks Diamondhands Club
+host: Zaal
+date: 2025-10-14T00:00:00.000Z
+youtube_url: 'https://youtu.be/AOcp8Jpyw3k'
+youtube_title: 'BCZ Yaps – Episode 2: Rich Bartuc & the PowerPacks Diamondhands Club'
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapz2w_rich.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bczyapz2w_rich.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: AOcp8Jpyw3k
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2025-10-19-yoni-dubz.md
+++ b/content/transcripts/bcz-yapz/2025-10-19-yoni-dubz.md
@@ -1,24 +1,27 @@
 ---
-title: "BCZ YapZ w/Yoni Dubz"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Yoni Dubz
+show: BCZ YapZ
 episode: 3
-guest: "Yoni Dubz"
-host: "Zaal"
-date: 2025-10-19
-youtube_url: "https://youtu.be/HopaeW7POis"
-youtube_title: "BCZ Yaps – Episode 3: Yoni Dubz on Streaming Culture, Web3 Music, and Owning Your Voice Online"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Yoni Dubz
+host: Zaal
+date: 2025-10-19T00:00:00.000Z
+youtube_url: 'https://youtu.be/HopaeW7POis'
+youtube_title: >-
+  BCZ Yaps – Episode 3: Yoni Dubz on Streaming Culture, Web3 Music, and Owning
+  Your Voice Online
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/BCZ Yaps w_yoni.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/BCZ Yaps w_yoni.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: HopaeW7POis
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2025-11-30-rockopera.md
+++ b/content/transcripts/bcz-yapz/2025-11-30-rockopera.md
@@ -1,24 +1,27 @@
 ---
-title: "BCZ YapZ w/Rock Opera"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Rock Opera
+show: BCZ YapZ
 episode: 4
-guest: "Rock Opera"
-host: "Zaal"
-date: 2025-11-30
-youtube_url: "https://youtu.be/43GPWLE6W5Q"
-youtube_title: "BCZ Yaps – Episode 4: Rock Opera on On-Chain Art, Color Theory, and Building for Ownership"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Rock Opera
+host: Zaal
+date: 2025-11-30T00:00:00.000Z
+youtube_url: 'https://youtu.be/43GPWLE6W5Q'
+youtube_title: >-
+  BCZ Yaps – Episode 4: Rock Opera on On-Chain Art, Color Theory, and Building
+  for Ownership
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapz w_w rockopera.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bczyapz w_w rockopera.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 43GPWLE6W5Q
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2025-12-11-daya-flix-fun.md
+++ b/content/transcripts/bcz-yapz/2025-12-11-daya-flix-fun.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ Yaps w/Daya (Flix.Fun)"
-show: "BCZ YapZ"
+title: BCZ Yaps w/Daya (Flix.Fun)
+show: BCZ YapZ
 episode: 5
-guest: "Daya"
-guest_org: "Flix.Fun"
-host: "Zaal"
-date: 2025-12-11
-youtube_url: "https://youtu.be/9ePU4qEc67Y"
-youtube_title: "BCZ Yaps – Episode 5: Flix.Fun with Daya"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Daya
+guest_org: Flix.Fun
+host: Zaal
+date: 2025-12-11T00:00:00.000Z
+youtube_url: 'https://youtu.be/9ePU4qEc67Y'
+youtube_title: 'BCZ Yaps – Episode 5: Flix.Fun with Daya'
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/flixfunbczyaps.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/flixfunbczyaps.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 9ePU4qEc67Y
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2025-12-16-sven-incented.md
+++ b/content/transcripts/bcz-yapz/2025-12-16-sven-incented.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ Yaps w/Sven (Incented)"
-show: "BCZ YapZ"
+title: BCZ Yaps w/Sven (Incented)
+show: BCZ YapZ
 episode: 6
-guest: "Sven"
-guest_org: "Incented"
-host: "Zaal"
-date: 2025-12-16
-youtube_url: "https://youtu.be/O7-1weR0Qog"
-youtube_title: "BCZ Yaps – Episode 6: Incented with Sven"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Sven
+guest_org: Incented
+host: Zaal
+date: 2025-12-16T00:00:00.000Z
+youtube_url: 'https://youtu.be/O7-1weR0Qog'
+youtube_title: 'BCZ Yaps – Episode 6: Incented with Sven'
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapz w_sven.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bczyapz w_sven.docx
+summary: ''
 action_items: []
-status: "raw-undated"                # needs: date, topics, entities, summary
+status: raw-undated
+youtube_video_id: O7-1weR0Qog
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-01-05-yerbearserker.md
+++ b/content/transcripts/bcz-yapz/2026-01-05-yerbearserker.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ YapZ w/Yerbearserker"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Yerbearserker
+show: BCZ YapZ
 episode: 7
-guest: "Yerbearserker"
-guest_org: "Empire Builder"
-host: "Zaal"
-date: 2026-01-05
-youtube_url: "https://youtu.be/EH-FWD7ySKk"
-youtube_title: "BCZ YapZ – Episode 7: Empire Builder w/Yerbearserker"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Yerbearserker
+guest_org: Empire Builder
+host: Zaal
+date: 2026-01-05T00:00:00.000Z
+youtube_url: 'https://youtu.be/EH-FWD7ySKk'
+youtube_title: 'BCZ YapZ – Episode 7: Empire Builder w/Yerbearserker'
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/BCZYapZ ep7 w_yerb.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/BCZYapZ ep7 w_yerb.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: EH-FWD7ySKk
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-02-11-diviflyy-empire-builder.md
+++ b/content/transcripts/bcz-yapz/2026-02-11-diviflyy-empire-builder.md
@@ -1,25 +1,28 @@
 ---
-title: "BCZ YapZ w/Diviflyy"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Diviflyy
+show: BCZ YapZ
 episode: 8
-guest: "Diviflyy"
-guest_org: "Empire Builder"
-host: "Zaal"
-date: 2026-02-11
-youtube_url: "https://youtu.be/0tyVpLGVxkA"
-youtube_title: "BCZ YapZ – Episode 8: Empire Builder w/diviflyy"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Diviflyy
+guest_org: Empire Builder
+host: Zaal
+date: 2026-02-11T00:00:00.000Z
+youtube_url: 'https://youtu.be/0tyVpLGVxkA'
+youtube_title: 'BCZ YapZ – Episode 8: Empire Builder w/diviflyy'
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/BCZ YapZ ep. 7 w_Diviflyy from Empire Builder.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: >-
+    Movies/bcz stream/BCZyapz/transcripts/BCZ YapZ ep. 7 w_Diviflyy from Empire
+    Builder.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 0tyVpLGVxkA
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-02-23-giu-pinetree.md
+++ b/content/transcripts/bcz-yapz/2026-02-23-giu-pinetree.md
@@ -1,18 +1,18 @@
 ---
-title: "BCZ YapZ w/GIU (Pinetree)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/GIU (Pinetree)
+show: BCZ YapZ
 episode: 10
-guest: "Juliano"
-guest_alias: "GIU"
-guest_origin: "Brazil"
-guest_org: "Pinetree"
-host: "Zaal"
-date: 2026-02-23
-youtube_url: "https://youtu.be/loSOniPcJx0"
-youtube_title: "BCZ YapZ – Episode 10 w/GIU from Pinetree"
+guest: Juliano
+guest_alias: GIU
+guest_origin: Brazil
+guest_org: Pinetree
+host: Zaal
+date: 2026-02-23T00:00:00.000Z
+youtube_url: 'https://youtu.be/loSOniPcJx0'
+youtube_title: BCZ YapZ – Episode 10 w/GIU from Pinetree
 duration_min: 25
-format: "video-podcast"
-language: "en"
+format: video-podcast
+language: en
 topics:
   - ai
   - crypto
@@ -33,29 +33,34 @@ keywords:
   - paul-graham-founders
 entities:
   orgs:
-    - "Pinetree"
-    - "MIT"
-    - "Transcend"
-    - "Anthropic"
-    - "OpenAI"
-    - "DeepMind"
-    - "Coinbase"
+    - Pinetree
+    - MIT
+    - Transcend
+    - Anthropic
+    - OpenAI
+    - DeepMind
+    - Coinbase
   people:
-    - "Juliano (GIU)"
-    - "Marvin Minsky"
-    - "Patrick Winston"
-    - "Android16 (co-founder)"
+    - Juliano (GIU)
+    - Marvin Minsky
+    - Patrick Winston
+    - Android16 (co-founder)
   projects:
-    - "Pinetree"
-    - "Making Things Think (book)"
+    - Pinetree
+    - Making Things Think (book)
 source:
-  video: "Movies/bcz stream/BCZyapz/transcripts/bcz yapz w_giu.mp4"
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bcz yapz w_giu.docx"
-summary: "Juliano (GIU) from Pinetree on his path from Brazilian Math Olympiads to MIT AI Lab (Minsky, Winston), writing a viral GPT-2 explainer, Transcend director of engineering, and building Pinetree - an on-chain platform for video creators with creator-owned monetization and distribution."
+  video: Movies/bcz stream/BCZyapz/transcripts/bcz yapz w_giu.mp4
+  docx: Movies/bcz stream/BCZyapz/transcripts/bcz yapz w_giu.docx
+summary: >-
+  Juliano (GIU) from Pinetree on his path from Brazilian Math Olympiads to MIT
+  AI Lab (Minsky, Winston), writing a viral GPT-2 explainer, Transcend director
+  of engineering, and building Pinetree - an on-chain platform for video
+  creators with creator-owned monetization and distribution.
 action_items:
-  - "Check out Pinetree for on-chain video creator tooling"
-  - "Read Juliano's book: Making Things Think"
-status: "raw"
+  - Check out Pinetree for on-chain video creator tooling
+  - 'Read Juliano''s book: Making Things Think'
+status: raw
+youtube_video_id: loSOniPcJx0
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-02-23-snax-pizza-dao.md
+++ b/content/transcripts/bcz-yapz/2026-02-23-snax-pizza-dao.md
@@ -1,26 +1,27 @@
 ---
-title: "BCZ YapZ w/SNAX (Pizza DAO)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/SNAX (Pizza DAO)
+show: BCZ YapZ
 episode: 9
-guest: "SNAX"
-guest_handle: "snax.eth"
-guest_org: "Pizza DAO"
-host: "Zaal"
-date: 2026-02-23
-youtube_url: "https://youtu.be/4CpblYpIO8Q"
-youtube_title: "BCZ YapZ – Episode 9 w/SNAX from PIZZA DAO"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: SNAX
+guest_handle: snax.eth
+guest_org: Pizza DAO
+host: Zaal
+date: 2026-02-23T00:00:00.000Z
+youtube_url: 'https://youtu.be/4CpblYpIO8Q'
+youtube_title: BCZ YapZ – Episode 9 w/SNAX from PIZZA DAO
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapzw_snax.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bczyapzw_snax.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 4CpblYpIO8Q
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-03-18-roaring-sensei.md
+++ b/content/transcripts/bcz-yapz/2026-03-18-roaring-sensei.md
@@ -1,24 +1,25 @@
 ---
-title: "BCZ YapZ w/Roaring Sensei"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Roaring Sensei
+show: BCZ YapZ
 episode: 11
-guest: "Roaring Sensei"
-host: "Zaal"
-date: 2026-03-18
-youtube_url: "https://youtu.be/DIeav3o8t9M"
-youtube_title: "BCZ YapZ – Episode 11 w/Roaring Sensei"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Roaring Sensei
+host: Zaal
+date: 2026-03-18T00:00:00.000Z
+youtube_url: 'https://youtu.be/DIeav3o8t9M'
+youtube_title: BCZ YapZ – Episode 11 w/Roaring Sensei
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapz w_roaring sensai.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bczyapz w_roaring sensai.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: DIeav3o8t9M
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-03-18-saltorious-among-traitors.md
+++ b/content/transcripts/bcz-yapz/2026-03-18-saltorious-among-traitors.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ YapZ w/Saltorious.eth (Among Traitors)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Saltorious.eth (Among Traitors)
+show: BCZ YapZ
 episode: 12
-guest: "Saltorious.eth"
-guest_org: "Among Traitors"
-host: "Zaal"
-date: 2026-03-18
-youtube_url: "https://youtu.be/0Tevgpr5TUQ"
-youtube_title: "BCZ YapZ – Episode 12 w/Saltorious.eth from Among Traitors"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Saltorious.eth
+guest_org: Among Traitors
+host: Zaal
+date: 2026-03-18T00:00:00.000Z
+youtube_url: 'https://youtu.be/0Tevgpr5TUQ'
+youtube_title: BCZ YapZ – Episode 12 w/Saltorious.eth from Among Traitors
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bcz yapz with saltorius.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/bcz yapz with saltorius.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: 0Tevgpr5TUQ
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-03-25-ali-inflynce.md
+++ b/content/transcripts/bcz-yapz/2026-03-25-ali-inflynce.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ YapZ w/Ali (Inflynce)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Ali (Inflynce)
+show: BCZ YapZ
 episode: 13
-guest: "Ali"
-guest_org: "Inflynce"
-host: "Zaal"
-date: 2026-03-25
-youtube_url: "https://youtu.be/WTyafqHKQqM"
-youtube_title: "BCZ YapZ – Episode 13 w/Ali from Inflynce"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Ali
+guest_org: Inflynce
+host: Zaal
+date: 2026-03-25T00:00:00.000Z
+youtube_url: 'https://youtu.be/WTyafqHKQqM'
+youtube_title: BCZ YapZ – Episode 13 w/Ali from Inflynce
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/bczyapz w:ali.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: 'Movies/bcz stream/BCZyapz/transcripts/bczyapz w:ali.docx'
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: WTyafqHKQqM
 ---
 
 ## Transcript

--- a/content/transcripts/bcz-yapz/2026-04-01-jordan-ryft.md
+++ b/content/transcripts/bcz-yapz/2026-04-01-jordan-ryft.md
@@ -1,25 +1,26 @@
 ---
-title: "BCZ YapZ w/Jordan (Ryft)"
-show: "BCZ YapZ"
+title: BCZ YapZ w/Jordan (Ryft)
+show: BCZ YapZ
 episode: 14
-guest: "Jordan"
-guest_org: "Ryft"
-host: "Zaal"
-date: 2026-04-01
-youtube_url: "https://youtu.be/IbhHxFR4yxE"
-youtube_title: "BCZ YapZ – Episode 14 w/Jordan from Ryft"
-format: "video-podcast"
-language: "en"
-topics: []                            # TODO: extract 3-8 tags
+guest: Jordan
+guest_org: Ryft
+host: Zaal
+date: 2026-04-01T00:00:00.000Z
+youtube_url: 'https://youtu.be/IbhHxFR4yxE'
+youtube_title: BCZ YapZ – Episode 14 w/Jordan from Ryft
+format: video-podcast
+language: en
+topics: []
 entities:
   orgs: []
   people: []
   projects: []
 source:
-  docx: "Movies/bcz stream/BCZyapz/transcripts/BCZ YapZ w_ Jordan.docx"
-summary: ""                           # TODO: one-sentence summary"
+  docx: Movies/bcz stream/BCZyapz/transcripts/BCZ YapZ w_ Jordan.docx
+summary: ''
 action_items: []
-status: "raw"
+status: raw
+youtube_video_id: IbhHxFR4yxE
 ---
 
 ## Transcript

--- a/scripts/backfill-youtube-video-ids.ts
+++ b/scripts/backfill-youtube-video-ids.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import matter from 'gray-matter'
+
+const TRANSCRIPTS_DIR = path.join(
+  process.cwd(),
+  'content/transcripts/bcz-yapz'
+)
+
+function extractVideoId(url: string): string | null {
+  const watchMatch = /[?&]v=([A-Za-z0-9_-]{11})/.exec(url)
+  if (watchMatch) return watchMatch[1]
+  const shortMatch = /youtu\.be\/([A-Za-z0-9_-]{11})/.exec(url)
+  if (shortMatch) return shortMatch[1]
+  const embedMatch = /youtube\.com\/embed\/([A-Za-z0-9_-]{11})/.exec(url)
+  if (embedMatch) return embedMatch[1]
+  return null
+}
+
+function main() {
+  const filenames = fs
+    .readdirSync(TRANSCRIPTS_DIR)
+    .filter((f) => f.endsWith('.md'))
+
+  let backfilled = 0
+  let alreadyHad = 0
+  let noUrl = 0
+  let parseFailed = 0
+
+  for (const filename of filenames) {
+    const filepath = path.join(TRANSCRIPTS_DIR, filename)
+    const raw = fs.readFileSync(filepath, 'utf-8')
+    const parsed = matter(raw)
+    const data = parsed.data as Record<string, unknown>
+
+    const url = typeof data.youtube_url === 'string' ? data.youtube_url : null
+    if (!url) {
+      noUrl++
+      continue
+    }
+
+    if (typeof data.youtube_video_id === 'string' && data.youtube_video_id.length > 0) {
+      alreadyHad++
+      continue
+    }
+
+    const id = extractVideoId(url)
+    if (!id) {
+      console.warn(`[skip] ${filename}: could not extract video id from ${url}`)
+      parseFailed++
+      continue
+    }
+
+    data.youtube_video_id = id
+    fs.writeFileSync(
+      filepath,
+      matter.stringify(parsed.content, data),
+      'utf-8'
+    )
+    console.log(`[backfill] ${filename} -> ${id}`)
+    backfilled++
+  }
+
+  console.log(
+    `[summary] backfilled=${backfilled} alreadyHad=${alreadyHad} noUrl=${noUrl} parseFailed=${parseFailed}`
+  )
+}
+
+main()


### PR DESCRIPTION
## Summary

Thumbnails weren't rendering on /bcz-yapz because 14 of 17 transcripts had `youtube_url` but no `youtube_video_id`. The page derives the thumbnail URL from `youtube_video_id`, so those cards all fell through to the 'No thumbnail' placeholder in grid view.

The 14 files were populated by earlier parallel-session yt-dlp work that only wrote the URL. My 3 (Nikoline/Dish/Hannah) from PR #287 already had both fields via the set-youtube-url.ts script.

## Fix

New idempotent script `scripts/backfill-youtube-video-ids.ts` extracts the 11-char video id from any existing `youtube_url` (handles watch, youtu.be, and embed URL forms) and writes `youtube_video_id`. Ran it - 14 files updated, 3 already had the field, 0 parse failures.

## Test plan
- [ ] Merge, wait for Vercel build
- [ ] Visit https://www.zaoos.com/bcz-yapz, toggle to Thumbnails view
- [ ] All 17 cards show YouTube thumbnails (not the 'No thumbnail' dark placeholder)
- [ ] Clicking any thumbnail opens that YouTube video