### PR TITLE
feat(infra): audit-log triggers + DIY Supabase backup (OSS, $0)

### DIFF
--- a/bot/scripts/backup-supabase.sh
+++ b/bot/scripts/backup-supabase.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Daily Supabase backup -> age-encrypted -> Cloudflare R2 (free 10GB tier)
+# ============================================================================
+# Belt-and-suspenders backup. Native Supabase backups + this = 2 parachutes.
+# OSS-only stack: pg_dump (Postgres native) + age (modern OSS encryption) +
+# rclone (OSS S3 client, talks to R2).
+#
+# Run via cron on VPS 1:  0 2 * * *  /home/zaal/bin/backup-supabase.sh
+#
+# Setup once on VPS 1:
+#   1. apt install postgresql-client age rclone
+#   2. age-keygen -o ~/.config/age/zao-backup.key  # save pubkey + privkey
+#      (commit pubkey to repo, KEEP privkey offline + somewhere safe)
+#   3. rclone config  # add 'r2' remote with Cloudflare R2 access key + secret
+#      (Cloudflare dashboard -> R2 -> Manage R2 API tokens)
+#   4. mkdir -p ~/zao-backups
+#   5. cp .env.backup.example ~/zao-backups/.env  # see template at bottom
+#   6. chmod 600 ~/zao-backups/.env
+#   7. crontab -e -> add: 0 2 * * * /home/zaal/zaostock-bot/scripts/backup-supabase.sh
+#
+# Restore drill (quarterly):
+#   bash bot/scripts/restore-supabase-drill.sh <YYYY-MM-DD>
+# ============================================================================
+
+set -euo pipefail
+
+# ---- config ----------------------------------------------------------------
+ENV_FILE="${HOME}/zao-backups/.env"
+BACKUP_DIR="${HOME}/zao-backups"
+LOG_FILE="${BACKUP_DIR}/backup.log"
+KEEP_LOCAL_DAYS=3      # keep 3 days of local copies
+RCLONE_REMOTE="r2:zao-supabase-backups"
+AGE_RECIPIENT_FILE="${HOME}/.config/age/zao-backup.pub"
+
+mkdir -p "${BACKUP_DIR}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "${LOG_FILE}"; }
+
+# ---- preflight -------------------------------------------------------------
+if [ ! -f "${ENV_FILE}" ]; then
+  log "ERROR: ${ENV_FILE} missing. See setup notes at top of script."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a; . "${ENV_FILE}"; set +a
+
+: "${SUPABASE_DB_URL:?SUPABASE_DB_URL required in ${ENV_FILE}}"
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF required in ${ENV_FILE}}"
+
+if [ ! -f "${AGE_RECIPIENT_FILE}" ]; then
+  log "ERROR: age public key missing at ${AGE_RECIPIENT_FILE}. Run age-keygen first."
+  exit 1
+fi
+
+for cmd in pg_dump age rclone gzip; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    log "ERROR: ${cmd} not installed. apt install postgresql-client age rclone"
+    exit 1
+  fi
+done
+
+# ---- dump ------------------------------------------------------------------
+DATE_TAG="$(date -u +%Y-%m-%d)"
+TIME_TAG="$(date -u +%H%M%SZ)"
+DUMP_NAME="${SUPABASE_PROJECT_REF}-${DATE_TAG}-${TIME_TAG}.sql.gz"
+DUMP_PATH="${BACKUP_DIR}/${DUMP_NAME}"
+ENC_PATH="${DUMP_PATH}.age"
+
+log "Starting pg_dump for ${SUPABASE_PROJECT_REF}"
+
+# Use custom format would be smaller but plain SQL is portable + diff-friendly.
+# --no-owner / --no-privileges so dump is restorable on a fresh project.
+# --schema=public + --schema=auth covers app data + Supabase auth metadata.
+pg_dump \
+  --dbname="${SUPABASE_DB_URL}" \
+  --no-owner \
+  --no-privileges \
+  --no-comments \
+  --quote-all-identifiers \
+  --schema=public \
+  --schema=auth \
+  --schema=storage \
+  --exclude-table-data='auth.refresh_tokens' \
+  --exclude-table-data='auth.sessions' \
+  --exclude-table-data='auth.flow_state' \
+  --exclude-table-data='audit_log' \
+  --format=plain \
+  | gzip -9 > "${DUMP_PATH}"
+
+DUMP_SIZE="$(du -h "${DUMP_PATH}" | cut -f1)"
+log "Dump complete: ${DUMP_NAME} (${DUMP_SIZE})"
+
+# ---- encrypt ---------------------------------------------------------------
+age -R "${AGE_RECIPIENT_FILE}" -o "${ENC_PATH}" "${DUMP_PATH}"
+ENC_SIZE="$(du -h "${ENC_PATH}" | cut -f1)"
+log "Encrypted: ${ENC_PATH##*/} (${ENC_SIZE})"
+rm -f "${DUMP_PATH}"  # remove plaintext
+
+# ---- upload to R2 ----------------------------------------------------------
+log "Uploading to ${RCLONE_REMOTE}/${ENC_PATH##*/}"
+rclone copy "${ENC_PATH}" "${RCLONE_REMOTE}/" --no-traverse --quiet
+
+# verify upload landed
+if rclone lsf "${RCLONE_REMOTE}/" --include="${ENC_PATH##*/}" | grep -q .; then
+  log "Upload verified."
+else
+  log "ERROR: upload verification failed."
+  exit 1
+fi
+
+# ---- prune local + remote --------------------------------------------------
+log "Pruning local files older than ${KEEP_LOCAL_DAYS} days"
+find "${BACKUP_DIR}" -name "${SUPABASE_PROJECT_REF}-*.sql.gz.age" -mtime +${KEEP_LOCAL_DAYS} -delete
+
+# Remote retention: keep 30 days. R2 lifecycle rules handle this best - configure
+# in Cloudflare R2 dashboard: Bucket -> Settings -> Object lifecycle -> Delete after 30 days.
+# Manual prune fallback (commented):
+# rclone delete "${RCLONE_REMOTE}/" --min-age 30d --include="${SUPABASE_PROJECT_REF}-*.sql.gz.age"
+
+log "Backup complete: ${ENC_PATH##*/}"
+echo "OK: ${ENC_PATH##*/} (${ENC_SIZE})"
+
+# ============================================================================
+# Template for ${HOME}/zao-backups/.env (chmod 600):
+#
+# SUPABASE_PROJECT_REF=abcdefghijklmnop
+# SUPABASE_DB_URL=postgresql://postgres.<project-ref>:<password>@aws-0-<region>.pooler.supabase.com:5432/postgres
+#
+# Get DB URL from: Supabase Dashboard -> Project Settings -> Database -> Connection string -> URI
+# Use the "Session Pooler" or "Direct connection" string - NOT transaction pooler (it doesn't support pg_dump).
+# ============================================================================

--- a/bot/scripts/restore-supabase-drill.sh
+++ b/bot/scripts/restore-supabase-drill.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Restore drill - quarterly test that backups actually work
+# ============================================================================
+# Pulls a backup from R2, decrypts, restores to a *temporary* Supabase project
+# OR a local Postgres, verifies row counts. NEVER restores over production.
+#
+# Usage:
+#   bash bot/scripts/restore-supabase-drill.sh 2026-04-25
+#   bash bot/scripts/restore-supabase-drill.sh latest
+# ============================================================================
+
+set -euo pipefail
+
+DATE_OR_LATEST="${1:-latest}"
+ENV_FILE="${HOME}/zao-backups/.env"
+BACKUP_DIR="${HOME}/zao-backups"
+DRILL_DIR="${BACKUP_DIR}/drill-$(date -u +%Y%m%d-%H%M%S)"
+RCLONE_REMOTE="r2:zao-supabase-backups"
+AGE_KEY_FILE="${HOME}/.config/age/zao-backup.key"
+
+mkdir -p "${DRILL_DIR}"
+
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "ERROR: ${ENV_FILE} missing. Run backup-supabase.sh first to set up."
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a; . "${ENV_FILE}"; set +a
+
+: "${SUPABASE_PROJECT_REF:?SUPABASE_PROJECT_REF required}"
+: "${RESTORE_TARGET_DB_URL:?RESTORE_TARGET_DB_URL required for drill - see notes below}"
+
+if [ ! -f "${AGE_KEY_FILE}" ]; then
+  echo "ERROR: age private key missing at ${AGE_KEY_FILE}"
+  exit 1
+fi
+
+# ---- pick the backup file --------------------------------------------------
+if [ "${DATE_OR_LATEST}" = "latest" ]; then
+  BACKUP_FILE="$(rclone lsf "${RCLONE_REMOTE}/" --include="${SUPABASE_PROJECT_REF}-*.sql.gz.age" | sort | tail -1)"
+else
+  BACKUP_FILE="$(rclone lsf "${RCLONE_REMOTE}/" --include="${SUPABASE_PROJECT_REF}-${DATE_OR_LATEST}-*.sql.gz.age" | sort | tail -1)"
+fi
+
+if [ -z "${BACKUP_FILE}" ]; then
+  echo "ERROR: no backup found for ${DATE_OR_LATEST}"
+  echo "Available:"
+  rclone lsf "${RCLONE_REMOTE}/" | tail -10
+  exit 1
+fi
+
+echo "[drill] Using backup: ${BACKUP_FILE}"
+echo "[drill] Target DB: ${RESTORE_TARGET_DB_URL%%@*}@***"
+echo "[drill] Drill dir: ${DRILL_DIR}"
+echo
+
+# ---- safety guard - never restore to production ----------------------------
+if echo "${RESTORE_TARGET_DB_URL}" | grep -q "${SUPABASE_PROJECT_REF}"; then
+  echo "REFUSING: RESTORE_TARGET_DB_URL points at the same project as the backup."
+  echo "Create a separate Supabase project (free) for drills, or use a local Postgres."
+  exit 1
+fi
+
+# ---- download + decrypt ----------------------------------------------------
+rclone copy "${RCLONE_REMOTE}/${BACKUP_FILE}" "${DRILL_DIR}/"
+ENC_PATH="${DRILL_DIR}/${BACKUP_FILE}"
+SQL_GZ_PATH="${ENC_PATH%.age}"
+
+age -d -i "${AGE_KEY_FILE}" -o "${SQL_GZ_PATH}" "${ENC_PATH}"
+echo "[drill] Decrypted to ${SQL_GZ_PATH##*/}"
+
+# ---- restore ---------------------------------------------------------------
+echo "[drill] Restoring..."
+gunzip -c "${SQL_GZ_PATH}" | psql "${RESTORE_TARGET_DB_URL}" --quiet --single-transaction --set ON_ERROR_STOP=on
+
+# ---- verify ----------------------------------------------------------------
+echo "[drill] Verifying row counts on critical tables..."
+for table in stock_team_members stock_circles stock_sponsors stock_artists stock_onepagers; do
+  count=$(psql "${RESTORE_TARGET_DB_URL}" -tAc "SELECT count(*) FROM ${table}" 2>/dev/null || echo "missing")
+  echo "  ${table}: ${count}"
+done
+
+echo
+echo "[drill] DONE. Backup ${BACKUP_FILE} restored + verified at $(date -u)."
+echo "[drill] Remember to wipe the drill DB if not needed: drop tables or delete project."
+
+# ============================================================================
+# Add to ${HOME}/zao-backups/.env:
+#
+# RESTORE_TARGET_DB_URL=postgresql://postgres:<password>@<host>:5432/postgres
+#
+# Best target: a separate free Supabase project named "zao-drill". Free tier OK
+# since drill DB is wiped after each test.
+# Alternative: local Postgres via Docker - `docker run -d -p 5432:5432
+#   -e POSTGRES_PASSWORD=drill postgres:15` and use postgres://postgres:drill@localhost:5432/postgres
+# ============================================================================

--- a/scripts/stock-audit-log-migration.sql
+++ b/scripts/stock-audit-log-migration.sql
@@ -1,0 +1,159 @@
+-- ============================================================================
+-- audit_log + triggers - "git for the database" lite
+-- ============================================================================
+-- Captures every INSERT/UPDATE/DELETE on critical ZAOstock tables.
+-- Stores old + new row state as JSONB. Native Postgres, no external infra.
+-- Idempotent. Paste into Supabase SQL Editor.
+--
+-- Read history of one row:
+--   SELECT changed_at, op, changed_fields, actor_id
+--   FROM audit_log
+--   WHERE table_name = 'stock_sponsors' AND row_id = '<uuid>'
+--   ORDER BY changed_at DESC;
+-- ============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  table_name TEXT NOT NULL,
+  row_id TEXT NOT NULL,
+  op TEXT NOT NULL CHECK (op IN ('INSERT', 'UPDATE', 'DELETE')),
+  old_data JSONB,
+  new_data JSONB,
+  changed_fields TEXT[],
+  actor_id UUID,
+  actor_role TEXT,
+  app_context JSONB DEFAULT '{}',
+  changed_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_log_table_row_idx ON audit_log(table_name, row_id, changed_at DESC);
+CREATE INDEX IF NOT EXISTS audit_log_actor_idx ON audit_log(actor_id, changed_at DESC) WHERE actor_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS audit_log_changed_at_idx ON audit_log(changed_at DESC);
+
+ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Service role full access" ON audit_log;
+CREATE POLICY "Service role full access" ON audit_log FOR ALL USING (true) WITH CHECK (true);
+
+-- ============================================================================
+-- Trigger function - one fn, runs for any audited table
+-- ============================================================================
+-- Reads optional session vars set by application code:
+--   SET LOCAL app.actor_id = '<uuid>';     -- the team member id
+--   SET LOCAL app.actor_role = 'bot';       -- 'bot' | 'dashboard' | 'admin'
+--   SET LOCAL app.context = '{...}'::jsonb; -- any extra metadata
+
+CREATE OR REPLACE FUNCTION audit_log_capture()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_actor_id UUID;
+  v_actor_role TEXT;
+  v_context JSONB;
+  v_changed_fields TEXT[];
+  v_row_id TEXT;
+BEGIN
+  -- best-effort actor capture from session vars (silent on failure)
+  BEGIN v_actor_id := nullif(current_setting('app.actor_id', true), '')::uuid; EXCEPTION WHEN others THEN v_actor_id := NULL; END;
+  BEGIN v_actor_role := nullif(current_setting('app.actor_role', true), ''); EXCEPTION WHEN others THEN v_actor_role := NULL; END;
+  BEGIN v_context := nullif(current_setting('app.context', true), '')::jsonb; EXCEPTION WHEN others THEN v_context := '{}'::jsonb; END;
+
+  -- pick the row id - assumes 'id' column on audited tables
+  IF TG_OP = 'DELETE' THEN
+    v_row_id := (to_jsonb(OLD)->>'id');
+  ELSE
+    v_row_id := (to_jsonb(NEW)->>'id');
+  END IF;
+
+  -- compute changed fields on UPDATE only
+  IF TG_OP = 'UPDATE' THEN
+    SELECT array_agg(key) INTO v_changed_fields
+    FROM jsonb_each(to_jsonb(NEW))
+    WHERE to_jsonb(NEW)->key IS DISTINCT FROM to_jsonb(OLD)->key;
+  END IF;
+
+  INSERT INTO audit_log (
+    table_name, row_id, op, old_data, new_data,
+    changed_fields, actor_id, actor_role, app_context
+  ) VALUES (
+    TG_TABLE_NAME,
+    v_row_id,
+    TG_OP,
+    CASE WHEN TG_OP IN ('UPDATE','DELETE') THEN to_jsonb(OLD) ELSE NULL END,
+    CASE WHEN TG_OP IN ('INSERT','UPDATE') THEN to_jsonb(NEW) ELSE NULL END,
+    v_changed_fields,
+    v_actor_id,
+    v_actor_role,
+    coalesce(v_context, '{}'::jsonb)
+  );
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- Attach triggers to critical ZAOstock tables
+-- ============================================================================
+-- Order tables by criticality (lose-this-and-it-hurts).
+
+DO $$
+DECLARE
+  t TEXT;
+  audited TEXT[] := ARRAY[
+    'stock_team_members',
+    'stock_sponsors',
+    'stock_artists',
+    'stock_onepagers',
+    'stock_circles',
+    'stock_circle_members',
+    'stock_milestones',
+    'stock_budget',
+    'stock_volunteers',
+    'stock_proposals'
+  ];
+BEGIN
+  FOREACH t IN ARRAY audited LOOP
+    -- only attach if the table exists (handles fresh DBs where some tables not yet migrated)
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = t) THEN
+      EXECUTE format('DROP TRIGGER IF EXISTS audit_capture_%I ON %I', t, t);
+      EXECUTE format('CREATE TRIGGER audit_capture_%I AFTER INSERT OR UPDATE OR DELETE ON %I FOR EACH ROW EXECUTE FUNCTION audit_log_capture()', t, t);
+      RAISE NOTICE 'Attached audit trigger to %', t;
+    ELSE
+      RAISE NOTICE 'Skipping % - table does not exist yet', t;
+    END IF;
+  END LOOP;
+END $$;
+
+-- ============================================================================
+-- Retention: keep 365 days of audit history. Cleanup runs as a scheduled job.
+-- ============================================================================
+-- To run weekly (via Supabase pg_cron or manual call), add:
+--   SELECT cron.schedule('audit-log-cleanup', '0 3 * * 0',
+--     $$DELETE FROM audit_log WHERE changed_at < now() - interval '365 days'$$);
+-- pg_cron requires Supabase Database extensions panel - enable if needed.
+
+CREATE OR REPLACE FUNCTION audit_log_cleanup(retention_days INT DEFAULT 365)
+RETURNS INT AS $$
+DECLARE
+  deleted_count INT;
+BEGIN
+  DELETE FROM audit_log WHERE changed_at < now() - (retention_days || ' days')::interval;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- ============================================================================
+-- Verify
+-- ============================================================================
+SELECT
+  'TRIGGERS ATTACHED' AS check,
+  event_object_table AS table_name,
+  trigger_name
+FROM information_schema.triggers
+WHERE trigger_name LIKE 'audit_capture_%'
+ORDER BY event_object_table;
+
+SELECT 'AUDIT TABLE READY' AS check, COUNT(*) AS existing_rows FROM audit_log;


### PR DESCRIPTION
## Summary
Two infra-grade pieces, both OSS, both ~free:

1. **audit_log + triggers** - Postgres-native "git for the database" lite. Captures every INSERT/UPDATE/DELETE on 10 critical ZAOstock tables with old_data/new_data/changed_fields/actor_id.
2. **DIY backup pipeline** - pg_dump → age encrypt → rclone to Cloudflare R2 (free 10GB tier). Daily cron on VPS 1. Restore-drill script for quarterly verification.

Aligns with the OSS-first rule (no Supabase Pro $61/mo, no SaaS).

## Files
- `scripts/stock-audit-log-migration.sql` - paste in Supabase SQL Editor
- `bot/scripts/backup-supabase.sh` - cron-friendly daily backup (setup notes inline)
- `bot/scripts/restore-supabase-drill.sh` - quarterly drill, refuses to overwrite prod

## Cost
- Recurring: $0 (Cloudflare R2 10GB free, age + rclone + pg_dump are OSS)
- One-time setup time: ~1 hour on VPS 1

## Test plan
- [ ] Paste audit-log SQL in Supabase, verify triggers attached
- [ ] Make a test edit in /stock/team, query `audit_log` to confirm row appears
- [ ] SSH to VPS 1, install postgresql-client + age + rclone, configure R2 remote
- [ ] Run `backup-supabase.sh` manually, verify file lands in R2
- [ ] Run `restore-supabase-drill.sh latest` against a separate Supabase project, verify row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)