### PR TITLE
fix(bot): 3 user-facing bugs - LLM JSON parse, circles slug list, FK embedding

### DIFF
--- a/bot/src/actions.ts
+++ b/bot/src/actions.ts
@@ -59,6 +59,17 @@ const ActionSchema = z.discriminatedUnion('kind', [
     direction: z.enum(['outbound', 'inbound']).default('outbound'),
   }),
   z.object({
+    kind: z.literal('add_idea'),
+    title: z.string().min(1).max(300),
+    body: z.string().max(4000).optional(),
+    category: z.string().max(100).optional(),
+  }),
+  z.object({
+    kind: z.literal('add_note'),
+    title: z.string().min(1).max(300),
+    body: z.string().min(1).max(8000),
+  }),
+  z.object({
     kind: z.literal('unknown'),
     reason: z.string(),
   }),
@@ -80,6 +91,8 @@ Allowed actions:
 - { "kind": "update_artist_status", "name_query": "substring match", "status": "wishlist|contacted|interested|confirmed|declined|travel_booked" }
 - { "kind": "add_milestone", "title": "...", "due_date": "YYYY-MM-DD", "category": "sponsors|artists|ops|marketing|event|logistics|post|...?" }
 - { "kind": "log_contact", "entity_type": "sponsor|artist", "name_query": "substring match", "summary": "brief what was said", "channel": "email|call|sms|dm_farcaster|dm_x|dm_tg|in_person|other?", "direction": "outbound|inbound?" }
+- { "kind": "add_idea", "title": "...", "body": "...?", "category": "music|ops|merch|marketing|...?" }
+- { "kind": "add_note", "title": "...", "body": "..." }
 - { "kind": "unknown", "reason": "what's missing or ambiguous" }
 
 Rules:
@@ -91,7 +104,16 @@ Rules:
 
 function stripCodeFences(text: string): string {
   let s = text.trim();
+  // Minimax M2.7 + other reasoning models wrap output in <think>...</think>.
+  // Strip every think block so JSON parsing can find the actual payload.
+  s = s.replace(/<think>[\s\S]*?<\/think>/gi, '').trim();
   if (s.startsWith('```')) s = s.replace(/^```(?:json)?\s*/, '').replace(/```$/, '').trim();
+  // If model still emitted prose around JSON, slice to the first/last brace.
+  const firstBrace = s.indexOf('{');
+  const lastBrace = s.lastIndexOf('}');
+  if (firstBrace > 0 && lastBrace > firstBrace) {
+    s = s.slice(firstBrace, lastBrace + 1);
+  }
   return s;
 }
 
@@ -319,6 +341,69 @@ export async function executeFromText(
         if (error) return { ok: false, reply: `Couldn't log contact: ${error.message}` };
         await logDelegation({ requester, action, originalText: userText, persona: usedPersona, entityType: action.entity_type, entityId: match.id, actionName: 'bot_log_contact' });
         return { ok: true, reply: `Logged ${action.direction} ${action.channel} with ${match.name}: "${action.summary.slice(0, 80)}${action.summary.length > 80 ? '...' : ''}". via bot @ ${usedPersona}` };
+      }
+      case 'add_idea': {
+        const ideaBody = [action.body, action.category ? `(category: ${action.category})` : null]
+          .filter(Boolean)
+          .join('\n\n') || action.title;
+        const { data, error } = await db()
+          .from('stock_activity_log')
+          .insert({
+            actor_id: requester.id,
+            entity_type: 'idea',
+            entity_id: null,
+            action: 'bot_add_idea',
+            new_value: JSON.stringify({
+              via: 'bot',
+              persona: usedPersona,
+              requested_by: requester.name,
+              requested_by_id: requester.id,
+              kind: 'add_idea',
+              title: action.title,
+              body: ideaBody,
+              category: action.category ?? null,
+              original_text: userText.slice(0, 1000),
+            }),
+          })
+          .select('id')
+          .single();
+        if (error || !data) return { ok: false, reply: `Couldn't log idea: ${error?.message ?? 'unknown'}` };
+        return { ok: true, reply: `Idea logged: "${action.title}". via bot @ ${usedPersona}` };
+      }
+      case 'add_note': {
+        const { data, error } = await db()
+          .from('stock_meeting_notes')
+          .insert({
+            title: action.title,
+            notes: action.body,
+            meeting_date: new Date().toISOString().slice(0, 10),
+            attendees: [requester.name],
+            action_items: '',
+            creator_id: requester.id,
+          })
+          .select('id, title')
+          .single();
+        if (error || !data) {
+          // Fallback to activity log if meeting_notes shape doesn't match
+          await db().from('stock_activity_log').insert({
+            actor_id: requester.id,
+            entity_type: 'note',
+            entity_id: null,
+            action: 'bot_add_note',
+            new_value: JSON.stringify({
+              via: 'bot',
+              persona: usedPersona,
+              requested_by: requester.name,
+              kind: 'add_note',
+              title: action.title,
+              body: action.body,
+              original_text: userText.slice(0, 1000),
+            }),
+          });
+          return { ok: true, reply: `Note logged (fallback): "${action.title}". via bot @ ${usedPersona}` };
+        }
+        await logDelegation({ requester, action, originalText: userText, persona: usedPersona, entityType: 'note', entityId: data.id, actionName: 'bot_add_note' });
+        return { ok: true, reply: `Note added: "${data.title}". via bot @ ${usedPersona}` };
       }
     }
   } catch (err) {

--- a/bot/src/circles.ts
+++ b/bot/src/circles.ts
@@ -6,7 +6,7 @@ import type { TeamMember } from './auth';
 import { db } from './supabase';
 import { alertDevops } from './ops';
 
-const CIRCLE_SLUGS = ['music', 'ops', 'partners', 'merch', 'marketing', 'host'] as const;
+const CIRCLE_SLUGS = ['music', 'ops', 'partners', 'finance', 'merch', 'marketing', 'media', 'host'] as const;
 type CircleSlug = (typeof CIRCLE_SLUGS)[number];
 
 interface Circle {
@@ -39,45 +39,56 @@ function validateCircleSlug(slug: string): slug is CircleSlug {
 async function getCircle(slug: CircleSlug): Promise<Circle | null> {
   const { data, error } = await db()
     .from('stock_circles')
-    .select(`
-      id,
-      slug,
-      name,
-      coordinator_member_id,
-      coordinator:stock_team_members(name)
-    `)
+    .select('id, slug, name, coordinator_member_id')
     .eq('slug', slug)
     .maybeSingle();
 
   if (error || !data) return null;
 
-  const { data: countData } = await db()
-    .from('stock_circle_members')
-    .select('id')
-    .eq('circle_id', (data as unknown as { id: string }).id);
+  const row = data as { id: string; slug: CircleSlug; name: string; coordinator_member_id: string | null };
 
-  const coordinator = ((data as unknown as { coordinator: { name: string } | null }).coordinator);
+  const { data: members } = await db()
+    .from('stock_circle_members')
+    .select('member_id')
+    .eq('circle_id', row.id);
+
+  let coordinator_name: string | null = null;
+  if (row.coordinator_member_id) {
+    const { data: coord } = await db()
+      .from('stock_team_members')
+      .select('name')
+      .eq('id', row.coordinator_member_id)
+      .maybeSingle();
+    coordinator_name = (coord as { name: string } | null)?.name ?? null;
+  }
 
   return {
-    id: (data as unknown as { id: string }).id,
-    slug: (data as unknown as { slug: CircleSlug }).slug,
-    name: (data as unknown as { name: string }).name,
-    member_count: countData?.length ?? 0,
-    coordinator_id: (data as unknown as { coordinator_member_id: string | null }).coordinator_member_id,
-    coordinator_name: coordinator?.name ?? null,
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    member_count: members?.length ?? 0,
+    coordinator_id: row.coordinator_member_id,
+    coordinator_name,
   };
 }
 
 async function getMemberCircles(memberId: string): Promise<CircleSlug[]> {
-  const { data } = await db()
+  const { data: rows } = await db()
     .from('stock_circle_members')
-    .select('circle:stock_circles(slug)')
+    .select('circle_id')
     .eq('member_id', memberId);
 
-  if (!data) return [];
-  return (data as unknown as Array<{ circle: { slug: CircleSlug } | null }>)
-    .map((row) => row.circle?.slug)
-    .filter((slug): slug is CircleSlug => Boolean(slug));
+  if (!rows || rows.length === 0) return [];
+  const circleIds = (rows as Array<{ circle_id: string }>).map((r) => r.circle_id);
+
+  const { data: circles } = await db()
+    .from('stock_circles')
+    .select('slug')
+    .in('id', circleIds);
+
+  return ((circles as Array<{ slug: string }> | null) ?? [])
+    .map((c) => c.slug.toLowerCase())
+    .filter((slug): slug is CircleSlug => CIRCLE_SLUGS.includes(slug as CircleSlug));
 }
 
 // ---- Commands ----
@@ -86,30 +97,49 @@ export async function cmdCircles(ctx: Context): Promise<void> {
   try {
     const { data: circles, error } = await db()
       .from('stock_circles')
-      .select(`
-        id,
-        slug,
-        name,
-        coordinator_member_id,
-        coordinator:stock_team_members(name)
-      `)
+      .select('id, slug, name, coordinator_member_id')
       .order('slug');
 
     if (error || !circles) {
-      await ctx.reply('Could not fetch circles.');
+      await ctx.reply(`Could not fetch circles${error ? `: ${error.message}` : ''}`);
       return;
     }
 
-    const lines = (circles as unknown as Array<{ name: string; slug: CircleSlug; coordinator: { name: string } | null }>).map(
-      (c) => {
-        const coord = c.coordinator?.name ?? '(unassigned)';
-        return `• **${c.name}** (\`${c.slug}\`) - coordinator: ${coord}`;
-      },
-    );
+    type CircleRow = { id: string; slug: string; name: string; coordinator_member_id: string | null };
+    const rows = (circles as CircleRow[]) ?? [];
 
-    await ctx.reply(['**Circles**', '', ...lines].join('\n'));
+    // Batch lookup coordinator names
+    const coordIds = rows.map((c) => c.coordinator_member_id).filter((v): v is string => Boolean(v));
+    const coordMap = new Map<string, string>();
+    if (coordIds.length > 0) {
+      const { data: coords } = await db()
+        .from('stock_team_members')
+        .select('id, name')
+        .in('id', coordIds);
+      for (const c of (coords as Array<{ id: string; name: string }> | null) ?? []) {
+        coordMap.set(c.id, c.name);
+      }
+    }
+
+    // Batch member counts
+    const { data: allMembers } = await db()
+      .from('stock_circle_members')
+      .select('circle_id');
+    const counts = new Map<string, number>();
+    for (const m of (allMembers as Array<{ circle_id: string }> | null) ?? []) {
+      counts.set(m.circle_id, (counts.get(m.circle_id) ?? 0) + 1);
+    }
+
+    const lines = rows.map((c) => {
+      const coord = c.coordinator_member_id ? coordMap.get(c.coordinator_member_id) ?? '(unknown)' : '(unassigned)';
+      const count = counts.get(c.id) ?? 0;
+      return `• ${c.name} (/${c.slug}) - ${count} member${count === 1 ? '' : 's'} - coordinator: ${coord}`;
+    });
+
+    const out = ['Circles:', '', ...lines, '', 'Join: /join <slug> · Leave: /leave <slug> · Mine: /mycircles'].join('\n');
+    await ctx.reply(out);
   } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
+    await ctx.reply(`Could not fetch circles: ${err instanceof Error ? err.message : 'unknown'}`);
   }
 }
 

--- a/bot/src/circles.ts
+++ b/bot/src/circles.ts
@@ -244,26 +244,37 @@ export async function cmdCoordinators(ctx: Context): Promise<void> {
   try {
     const { data: circles, error } = await db()
       .from('stock_circles')
-      .select(`
-        slug,
-        name,
-        coordinator:stock_team_members(name)
-      `)
+      .select('slug, name, coordinator_member_id')
       .order('slug');
 
     if (error || !circles) {
-      await ctx.reply('Could not fetch coordinators.');
+      await ctx.reply(`Could not fetch coordinators${error ? `: ${error.message}` : ''}`);
       return;
     }
 
-    const lines = (circles as unknown as Array<{ name: string; coordinator: { name: string } | null }>).map((c) => {
-      const coord = c.coordinator?.name ?? '(unassigned)';
-      return `• ${c.name}: **${coord}**`;
+    type Row = { slug: string; name: string; coordinator_member_id: string | null };
+    const rows = (circles as Row[]) ?? [];
+
+    const ids = rows.map((c) => c.coordinator_member_id).filter((v): v is string => Boolean(v));
+    const nameById = new Map<string, string>();
+    if (ids.length > 0) {
+      const { data: members } = await db()
+        .from('stock_team_members')
+        .select('id, name')
+        .in('id', ids);
+      for (const m of (members as Array<{ id: string; name: string }> | null) ?? []) {
+        nameById.set(m.id, m.name);
+      }
+    }
+
+    const lines = rows.map((c) => {
+      const coord = c.coordinator_member_id ? nameById.get(c.coordinator_member_id) ?? '(unknown)' : '(unassigned)';
+      return `• ${c.name} (/${c.slug}): ${coord}`;
     });
 
-    await ctx.reply(['**Circle coordinators**', '', ...lines].join('\n'));
+    await ctx.reply(['Circle coordinators:', '', ...lines].join('\n'));
   } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
+    await ctx.reply(`Could not fetch coordinators: ${err instanceof Error ? err.message : 'unknown'}`);
   }
 }
 
@@ -350,14 +361,7 @@ export async function cmdProposals(ctx: Context, member: TeamMember): Promise<vo
 
     const { data: proposals } = await db()
       .from('stock_proposals')
-      .select(`
-        id,
-        circle:stock_circles(slug, name),
-        proposer:stock_team_members(name),
-        title,
-        status,
-        created_at
-      `)
+      .select('id, circle_id, proposer_member_id, title, status, created_at')
       .in('circle_id', circleIds)
       .eq('status', 'open')
       .order('created_at', { ascending: false });
@@ -367,16 +371,38 @@ export async function cmdProposals(ctx: Context, member: TeamMember): Promise<vo
       return;
     }
 
-    const lines = proposals.map((p: any) => {
-      const circle = p.circle as { slug: CircleSlug; name: string } | null;
-      return `• [${circle?.slug}] **${p.title}** by ${p.proposer?.name} - \`${p.id}\``;
+    type ProposalRow = { id: string; circle_id: string; proposer_member_id: string; title: string; status: string };
+    const rows = (proposals as ProposalRow[]) ?? [];
+
+    // Batch lookups
+    const cIds = Array.from(new Set(rows.map((p) => p.circle_id)));
+    const pIds = Array.from(new Set(rows.map((p) => p.proposer_member_id)));
+
+    const [{ data: circleRows }, { data: memberRows }] = await Promise.all([
+      db().from('stock_circles').select('id, slug, name').in('id', cIds),
+      db().from('stock_team_members').select('id, name').in('id', pIds),
+    ]);
+
+    const circleById = new Map<string, { slug: string; name: string }>();
+    for (const c of (circleRows as Array<{ id: string; slug: string; name: string }> | null) ?? []) {
+      circleById.set(c.id, { slug: c.slug, name: c.name });
+    }
+    const memberById = new Map<string, string>();
+    for (const m of (memberRows as Array<{ id: string; name: string }> | null) ?? []) {
+      memberById.set(m.id, m.name);
+    }
+
+    const lines = rows.map((p) => {
+      const circle = circleById.get(p.circle_id);
+      const proposer = memberById.get(p.proposer_member_id) ?? '(unknown)';
+      return `• [${circle?.slug ?? '?'}] ${p.title} by ${proposer} - id:${p.id.slice(0, 8)}`;
     });
 
     await ctx.reply(
-      ['**Open proposals**', '', ...lines.slice(0, 10), lines.length > 10 ? `... and ${lines.length - 10} more.` : ''].filter(Boolean).join('\n'),
+      ['Open proposals:', '', ...lines.slice(0, 10), lines.length > 10 ? `... and ${lines.length - 10} more.` : ''].filter(Boolean).join('\n'),
     );
   } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
+    await ctx.reply(`Could not fetch proposals: ${err instanceof Error ? err.message : 'unknown'}`);
   }
 }
 
@@ -497,67 +523,72 @@ export async function cmdBuddy(ctx: Context, member: TeamMember): Promise<void> 
   try {
     const { data: existing } = await db()
       .from('stock_buddy_pairings')
-      .select('buddy:stock_team_members(name, telegram_username)')
+      .select('buddy_member_id')
       .eq('new_member_id', member.id)
       .is('ended_at', null)
       .maybeSingle();
 
-    if (existing) {
-      const buddy = existing as unknown as { buddy: { name: string; telegram_username: string | null } | null };
-      if (buddy.buddy) {
-        const tgHandle = buddy.buddy.telegram_username ? `@${buddy.buddy.telegram_username}` : buddy.buddy.name;
-        await ctx.reply(`Your buddy: **${buddy.buddy.name}** (${tgHandle})`);
+    if (existing && (existing as { buddy_member_id: string }).buddy_member_id) {
+      const buddyId = (existing as { buddy_member_id: string }).buddy_member_id;
+      const { data: buddy } = await db()
+        .from('stock_team_members')
+        .select('name, telegram_username')
+        .eq('id', buddyId)
+        .maybeSingle();
+      if (buddy) {
+        const b = buddy as { name: string; telegram_username: string | null };
+        const tgHandle = b.telegram_username ? `@${b.telegram_username}` : b.name;
+        await ctx.reply(`Your buddy: ${b.name} (${tgHandle})`);
         return;
       }
     }
 
-    // Get member's circles
     const circles = await getMemberCircles(member.id);
     if (circles.length === 0) {
       await ctx.reply('You must be in at least one circle first. Use /join <circle>.');
       return;
     }
 
-    // Find active members in their circles
-    const { data: circleIds } = await db()
+    const { data: circleRows } = await db()
       .from('stock_circles')
       .select('id')
       .in('slug', circles);
 
-    if (!circleIds || circleIds.length === 0) {
+    if (!circleRows || circleRows.length === 0) {
       await ctx.reply('No active circles found.');
       return;
     }
+    const circleIds = (circleRows as Array<{ id: string }>).map((c) => c.id);
 
-    const { data: potentialBuddies } = await db()
+    const { data: peerRows } = await db()
       .from('stock_circle_members')
-      .select('member:stock_team_members(id, name, telegram_username)')
-      .in('circle_id', circleIds.map((c: { id: string }) => c.id))
+      .select('member_id')
+      .in('circle_id', circleIds)
       .neq('member_id', member.id);
 
-    if (!potentialBuddies || potentialBuddies.length === 0) {
+    if (!peerRows || peerRows.length === 0) {
       await ctx.reply('No other members in your circles yet.');
       return;
     }
+    const peerIds = Array.from(new Set((peerRows as Array<{ member_id: string }>).map((p) => p.member_id)));
 
-    // Pick random
-    const typed = potentialBuddies as unknown as Array<{
-      member: { id: string; name: string; telegram_username: string | null } | null;
-    }>;
-    const buddyData = typed[Math.floor(Math.random() * typed.length)];
-    const buddy = buddyData.member;
+    const { data: peers } = await db()
+      .from('stock_team_members')
+      .select('id, name, telegram_username, active')
+      .in('id', peerIds)
+      .neq('active', false);
 
-    if (!buddy) {
-      await ctx.reply('Could not find buddy.');
+    const candidates = (peers as Array<{ id: string; name: string; telegram_username: string | null }> | null) ?? [];
+    if (candidates.length === 0) {
+      await ctx.reply('No active peers in your circles.');
       return;
     }
 
+    const buddy = candidates[Math.floor(Math.random() * candidates.length)];
+
     const { error } = await db()
       .from('stock_buddy_pairings')
-      .insert({
-        new_member_id: member.id,
-        buddy_member_id: buddy.id,
-      });
+      .insert({ new_member_id: member.id, buddy_member_id: buddy.id });
 
     if (error) {
       await ctx.reply(`Could not pair buddy: ${error.message}`);
@@ -565,9 +596,9 @@ export async function cmdBuddy(ctx: Context, member: TeamMember): Promise<void> 
     }
 
     const tgHandle = buddy.telegram_username ? `@${buddy.telegram_username}` : buddy.name;
-    await ctx.reply(`Buddy paired: **${buddy.name}** (${tgHandle}). Reach out and introduce yourself!`);
+    await ctx.reply(`Buddy paired: ${buddy.name} (${tgHandle}). Reach out and introduce yourself.`);
   } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
+    await ctx.reply(`Could not pair buddy: ${err instanceof Error ? err.message : 'unknown'}`);
   }
 }
 


### PR DESCRIPTION
1. /do failed on natural-language idea/note requests
   - Minimax M2.7 wraps JSON in <think>...</think> blocks. stripCodeFences
     now strips them before JSON.parse. Also slices to first/last brace
     as fallback if model emits prose around the JSON.
   - Added add_idea + add_note to the Zod action union + system prompt
     so /do can route to ideas (logged in stock_activity_log) and notes
     (stock_meeting_notes with activity_log fallback).

2. /circles returned 'Could not fetch circles'
   - The coordinator:stock_team_members(name) FK embedding wasn't
     resolving (FK probably not declared in Supabase). Replaced with
     two batched queries: list circles, then resolve coordinator names
     via .in('id', ids). Same pattern used in onepagers.ts.
   - cmdCircles output also now shows member counts + slug + join hints.

3. /join finance / /join media returned 'Circle not found'
   - CIRCLE_SLUGS hardcoded array missed 'finance' + 'media' (DB has 8
     circles, code only listed 6). Added both to the const tuple type.
   - Same fix unblocks /leave + /mycircles for those two circles.

Deployed to VPS via rsync. Bot restarted.