### PR TITLE
feat(bot): cohesion Tier 1 - voice + /mytodos_all + /press + new /start

### DIFF
--- a/bot/src/capture.ts
+++ b/bot/src/capture.ts
@@ -38,7 +38,7 @@ export async function addIdea(member: TeamMember, text: string): Promise<string>
     action: 'suggestion_add',
     newValue: text.trim().slice(0, 200),
   });
-  return `Saved your idea (id ${data.id.slice(0, 8)}). Zaal will see it in the suggestion box.`;
+  return `Idea logged. Zaal sees this daily. You're in the pool.`;
 }
 
 export async function addNote(member: TeamMember, text: string): Promise<string> {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -8,7 +8,7 @@ import {
   unlinkUsername,
   type TeamMember,
 } from './auth';
-import { buildStatus, buildMyTodos, buildMyContributions } from './status';
+import { buildStatus, buildMyTodos, buildMyContributions, buildAllOpenTodos } from './status';
 import { addGemba, addIdea, addNote } from './capture';
 import { executeFromText } from './actions';
 import { ask } from './llm';
@@ -68,10 +68,8 @@ async function currentMember(ctx: Context): Promise<TeamMember | null> {
 async function requireMember(ctx: Context): Promise<TeamMember | null> {
   const member = await currentMember(ctx);
   if (member) return member;
-  const u = ctx.from?.username ? `@${ctx.from.username}` : 'your Telegram account';
-  await ctx.reply(
-    `You're not on the ZAOstock team roster yet.\nAsk Zaal to link ${u} to your name, then try again.`,
-  );
+  const u = ctx.from?.username ? `@${ctx.from.username}` : 'your account';
+  await ctx.reply(`Not on the roster yet. Ping Zaal to link ${u}.`);
   return null;
 }
 
@@ -86,12 +84,32 @@ function isAdmin(ctx: Context): boolean {
 bot.command('start', async (ctx) => {
   const member = await currentMember(ctx);
   if (member) {
-    await ctx.reply(`Hey ${member.name}. Type /help to see what I can do.`);
+    await ctx.reply(
+      [
+        `Hey ${member.name}. Dashboard is your hub: https://zaoos.com/stock/team`,
+        '',
+        'Bot is backup. Useful for:',
+        '  /mytodos - what you are owning',
+        '  /do <text> - tell me what happened, I update the board',
+        '  /circles - the 8 circles, /join <slug> to grab one',
+        '  /op - 1-pagers (sponsor / partner / venue briefings)',
+        '  /digest morning - daily brief',
+        '  /ask - ask me anything',
+        '  /help - full list',
+      ].join('\n'),
+    );
     return;
   }
-  const u = ctx.from?.username ? `@${ctx.from.username}` : 'your Telegram account';
+  const u = ctx.from?.username ? `@${ctx.from.username}` : 'your account';
   await ctx.reply(
-    `Hey! I'm the ZAOstock Team Bot.\n\nI don't recognize ${u} on the roster yet. Ping Zaal to link you. Once linked you'll get:\n  /mytodos - your open tasks\n  /do <text> - natural-language actions\n  /digest - festival snapshots\n\nPublic commands work for anyone: /status /help /ask`,
+    [
+      `Hey - I'm the ZAOstock Team Bot. ZAO Festivals presents ZAOstock, Oct 3 in Ellsworth.`,
+      '',
+      `Don't recognize ${u} on the roster yet. Ping Zaal to link you.`,
+      '',
+      'Open to anyone: /status /help /ask /press',
+      'Dashboard: https://zaoos.com/stock/team',
+    ].join('\n'),
   );
 });
 
@@ -99,43 +117,48 @@ bot.command('help', async (ctx) => {
   const isGroup = ctx.chat?.type !== 'private';
   await ctx.reply(
     [
-      'ZAOstock Team Bot - v1.6',
+      'ZAOstock Team Bot - I save you typing. Dashboard has the context.',
       '',
       'Read:',
-      '  /status - festival snapshot',
-      '  /mytodos - your open todos',
+      '  /status - festival snapshot, top blockers',
+      '  /mytodos - what you are owning',
+      '  /mytodos_all - everything open across the team (claimable)',
       '  /mycontributions - your last 7 days',
+      '  /digest morning|evening|week|retro - the brief I post automatically',
       '',
-      'Act (LLM parses to DB writes):',
-      '  /do <text> - natural language -> action',
-      '  /ask <text> - ask me anything (no DB write)',
-      '',
-      'Capture:',
+      'Tell me what happened:',
+      '  /do <text> - I parse + update the board',
+      '  /idea <text> - drop into the pool, Zaal sees daily',
+      '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
-      '  /idea <text> - drop a suggestion',
-      '  /note <text> - meeting note',
       '',
-      'One-pagers:',
-      '  /op - list briefings (sponsor / partner / venue)',
-      '  /op <slug> - read one',
-      '  /op <slug> status <draft|review|final|sent|archived> - flip status',
-      '  /op <slug> note <text> - log activity note',
-      '  /op <slug> share <recipient> - log a share',
-      '  /op <slug> append <text> - append to body',
+      'Ask me anything:',
+      '  /ask <question> - LLM reply, no DB write',
+      '  /whoami - confirm who I think you are',
       '',
       'Circles:',
-      '  /circles - list all circles + who coordinates',
-      '  /join <circle> - jump into a circle (e.g. /join music)',
-      '  /leave <circle> - step out',
+      '  /circles - all 8 + who coordinates',
+      '  /join <slug> - grab one (music, ops, partners, finance, merch, marketing, media, host)',
+      '  /leave <slug> - step out',
       '  /mycircles - what you are in',
+      '',
+      '1-pagers (sponsor / partner / venue briefings):',
+      '  /op - list',
+      '  /op <slug> - read one',
+      '  /op <slug> status <draft|review|final|sent|archived>',
+      '  /op <slug> note <text> - log activity',
+      '  /op <slug> share <recipient> - log a send',
+      '  /op <slug> append <text> - extend the body',
+      '',
+      'External (anyone, no link needed):',
+      '  /press - press kit + contact info',
       '',
       'Ops:',
       '  /chatinfo - chat + topic ids',
-      '  /digest morning|evening|week|retro - preview on demand',
       isGroup
         ? '\n@mention me in a group to act. I respond only when tagged.'
-        : '\nIn DM I auto-parse plain text as an action.',
-      'Dashboard: https://zaoos.com/stock/team',
+        : '\nIn DM I auto-parse plain text. Just type what happened.',
+      'Dashboard is your hub: https://zaoos.com/stock/team',
     ].join('\n'),
   );
 });
@@ -150,10 +173,33 @@ bot.command('mytodos', async (ctx) => {
   await ctx.reply(await buildMyTodos(member));
 });
 
+bot.command('mytodos_all', async (ctx) => {
+  await ctx.reply(await buildAllOpenTodos());
+});
+
 bot.command('mycontributions', async (ctx) => {
   const member = await requireMember(ctx);
   if (!member) return;
   await ctx.reply(await buildMyContributions(member));
+});
+
+bot.command('press', async (ctx) => {
+  await ctx.reply(
+    [
+      'ZAO Festivals presents ZAOstock - Year 1, Oct 3 2026, Ellsworth Maine.',
+      '',
+      'Press kit + 1-pagers: https://zaoos.com/stock/onepagers',
+      'Public overview: https://zaoos.com/stock/onepagers/overview',
+      'Landing page: https://zaoos.com/stock',
+      '',
+      'Run by The ZAO (ZTalent Artist Organization). Music first.',
+      '',
+      'For interviews, photo passes, sponsor inquiries, partnership:',
+      '  zaal@thezao.com',
+      '',
+      'Newsletter: https://paragraph.com/@thezao',
+    ].join('\n'),
+  );
 });
 
 bot.command('gemba', async (ctx) => {

--- a/bot/src/status.ts
+++ b/bot/src/status.ts
@@ -107,6 +107,53 @@ export async function buildMyTodos(member: TeamMember): Promise<string> {
   return lines.join('\n');
 }
 
+export async function buildAllOpenTodos(): Promise<string> {
+  const { data } = await db()
+    .from('stock_todos')
+    .select('title, status, owner_id, created_at')
+    .neq('status', 'done')
+    .order('created_at', { ascending: false })
+    .limit(40);
+
+  const todos = (data ?? []) as Array<{ title: string; status: string; owner_id: string | null; created_at: string }>;
+  if (todos.length === 0) return 'No open todos. Nice.';
+
+  const ownerIds = Array.from(new Set(todos.map((t) => t.owner_id).filter((v): v is string => Boolean(v))));
+  const nameById = new Map<string, string>();
+  if (ownerIds.length > 0) {
+    const { data: owners } = await db()
+      .from('stock_team_members')
+      .select('id, name')
+      .in('id', ownerIds);
+    for (const o of (owners as Array<{ id: string; name: string }> | null) ?? []) {
+      nameById.set(o.id, o.name);
+    }
+  }
+
+  const unclaimed = todos.filter((t) => !t.owner_id);
+  const claimed = todos.filter((t) => t.owner_id);
+
+  const lines: string[] = [`${todos.length} open todo${todos.length === 1 ? '' : 's'}:`];
+  if (unclaimed.length > 0) {
+    lines.push('', `Unclaimed (${unclaimed.length}) - grab via /do "I am taking <title>":`);
+    for (const t of unclaimed.slice(0, 15)) {
+      const mark = t.status === 'in_progress' ? '▶' : '·';
+      lines.push(`${mark} ${t.title}`);
+    }
+    if (unclaimed.length > 15) lines.push(`  ... and ${unclaimed.length - 15} more.`);
+  }
+  if (claimed.length > 0) {
+    lines.push('', `Claimed (${claimed.length}):`);
+    for (const t of claimed.slice(0, 15)) {
+      const mark = t.status === 'in_progress' ? '▶' : '·';
+      const owner = t.owner_id ? nameById.get(t.owner_id) ?? '?' : '?';
+      lines.push(`${mark} ${t.title} - ${owner}`);
+    }
+    if (claimed.length > 15) lines.push(`  ... and ${claimed.length - 15} more.`);
+  }
+  return lines.join('\n');
+}
+
 export async function buildMyContributions(member: TeamMember): Promise<string> {
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const { data } = await db()


### PR DESCRIPTION
## Summary
Cohesion Tier 1 from 518/519/520/521/522 synthesis. ~3 hours of work, 5 user-facing changes.

## Changes
- `/start` framing → dashboard-first. Linked = hub URL + "I'm backup". Unlinked = ZAO Festivals positioning + public commands.
- `/help` → verb-led groups, specific examples, drops corporate framing.
- Roster gate → "Not on the roster yet. Ping Zaal to link @user." (warmer)
- `/idea` reply → "Idea logged. Zaal sees this daily. You're in the pool."
- `/mytodos_all` NEW → everything open across team, partitioned Unclaimed + Claimed.
- `/press` NEW → closes external-DM gate, returns press kit + zaal@thezao.com.

## Telegram menu
Refreshed: `/press`, `/mytodos_all`, `/whoami` now visible to all users.

## Deployed
Live on VPS as of this commit. Bot restarted.

## Test plan
- [ ] DM bot `/start` - see dashboard-first reply
- [ ] DM `/help` - new structure
- [ ] DM `/mytodos_all` - all open todos with Unclaimed/Claimed split
- [ ] DM `/press` - press kit response
- [ ] DM `/idea something something` - new affirming reply
- [ ] (As an unlinked TG user) `/mytodos` - see "Not on the roster yet" warmer message

🤖 Generated with [Claude Code](https://claude.com/claude-code)