### PR TITLE
feat(bot): ZAO Devz dual-bot stack - ZAODevzBot + HermesBot in one process

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
+    "dev:devz": "tsx watch src/devz/index.ts",
+    "start:devz": "tsx src/devz/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/bot/src/devz/README.md
+++ b/bot/src/devz/README.md
@@ -1,0 +1,171 @@
+# ZAO Devz Dual-Bot Stack
+
+Two Telegram bots, one Node process, one chat. They narrate the Hermes Coder + Critic loop as separate identities so the conversation reads like two agents reviewing each other's work.
+
+## Architecture
+
+```
+Zaal in ZAO Devz Telegram chat
+            |
+            | /fix <issue>
+            v
++-------------------+
+| @ZAODevzBot       |  <- Coder (this bot dispatches the loop)
+| posts:            |
+|   "Coder starting"|
+|   "Coder done.    |
+|    3 files."      |
++-------------------+
+            |
+            v
+   bot/src/hermes/runner.ts (in-process)
+   spawns Claude Code CLI in /tmp/hermes-{id}/
+   Coder pass (opus) -> Critic pass (sonnet)
+            |
+            v
++-------------------+
+| @HermesBot        |  <- Critic (same process, different token)
+| posts:            |
+|   "Reviewing..."  |
+|   "Score 85.      |
+|    PR #N opened." |
++-------------------+
+            |
+            v
+[Zaal pushes after review] -> safe-git-push.sh -> branch protection
+```
+
+## Required Telegram Setup (one-time)
+
+1. Talk to @BotFather, create two bots:
+   - `@ZAODevzBot` (or whatever name you choose) - the Coder
+   - `@HermesZAOBot` (or similar) - the Critic
+2. Save both tokens
+3. Create a private Telegram group called "ZAO Devz" (or similar)
+4. Add @ZAODevzBot to the group, make it admin
+5. Add @HermesBot to the group, make it admin
+6. Get the group's chat id: send `/whoami` in the group after the bots run, or use `@RawDataBot` first
+
+## Required Env Vars
+
+In `~/zaostock-bot/.env` or wherever the stack runs:
+
+```
+ZAO_DEVZ_BOT_TOKEN=<from BotFather>
+HERMES_BOT_TOKEN=<from BotFather>
+ZAO_DEVZ_CHAT_ID=<-100xxxxxxxx, the Telegram group id>
+BOT_ADMIN_TELEGRAM_IDS=<your tg user id, comma-separated for multiple>
+ZAAL_TELEGRAM_ID=<your tg user id, used for cc tag>
+
+# Already required by the rest of the bot:
+SUPABASE_URL=...
+SUPABASE_SERVICE_ROLE_KEY=...
+
+# Optional Hermes overrides:
+HERMES_FIXER_MODEL=opus
+HERMES_CRITIC_MODEL=sonnet
+HERMES_FIXER_BUDGET_USD=5
+HERMES_CRITIC_BUDGET_USD=1
+HERMES_REPO_URL=https://github.com/bettercallzaal/ZAOOS.git
+HERMES_GIT_USER_NAME=Hermes Bot
+HERMES_GIT_USER_EMAIL=hermes@thezao.com
+HERMES_CLAUDE_BIN=/path/to/claude  # only if not on PATH
+```
+
+No `ANTHROPIC_API_KEY` needed - Hermes uses Claude Code CLI which reads Max-plan auth from `~/.claude/auth.json`.
+
+## VPS Deployment
+
+```bash
+ssh zaal@31.97.148.88
+cd ~/zaostock-bot
+git pull
+npm install
+
+# Add the env vars above to ~/zaostock-bot/.env
+chmod 600 ~/zaostock-bot/.env
+
+# Apply hermes_runs migration in Supabase SQL editor (one-time)
+# - paste contents of bot/migrations/hermes_runs.sql
+
+# Confirm Claude Code CLI on PATH for zaal user
+which claude
+ls -la ~/.claude/auth.json
+
+# Test run (manual, not via systemd):
+npm run start:devz
+# Should print: ZAODevzBot=@... HermesBot=@... chat=<id>
+# In the Telegram group, try /whoami in DM or /fix Add a healthcheck
+
+# Once happy, install systemd unit:
+cat <<'UNIT' > ~/.config/systemd/user/zao-devz-stack.service
+[Unit]
+Description=ZAO Devz dual-bot (Coder + Critic)
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/zaostock-bot
+ExecStart=%h/zaostock-bot/node_modules/.bin/tsx %h/zaostock-bot/src/devz/index.ts
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+UNIT
+
+systemctl --user daemon-reload
+systemctl --user enable --now zao-devz-stack
+journalctl --user -u zao-devz-stack -f  # watch boot
+```
+
+## First Test
+
+In the ZAO Devz group, as an admin user:
+
+```
+/fix Add a /healthcheck command to the bot that returns "OK - hermes alive"
+```
+
+Expected message sequence:
+
+```
+ZAODevzBot: Got it. Spinning up the loop. Updates incoming from me + HermesBot.
+ZAODevzBot: Coder starting (attempt 1/3) on run abc12345
+            Issue: Add a /healthcheck command...
+            Model: opus | Tools: Read/Edit/Write/Glob/Grep
+[~3-5 min later]
+ZAODevzBot: Coder done on run abc12345 (attempt 1). Changed 1 files:
+              - bot/src/index.ts
+            Handing to @HermesBot.
+HermesBot:  Reviewing run abc12345. Reading diff + source. Model: sonnet.
+[~30s later]
+HermesBot:  Score 85/100 (PASS) on run abc12345
+            Feedback: clean addition, follows existing command pattern
+HermesBot:  READY. Score 85/100. PR #N: https://github.com/.../pull/N
+            Run: abc12345
+            cc Zaal - push when good
+```
+
+If score drops below 70:
+
+```
+HermesBot:  Score 55/100 (NEEDS REVISION) on run abc12345
+            Feedback: missing Zod validation on input
+ZAODevzBot: Retrying run abc12345 (attempt 2). Critic said: missing Zod validation on input
+ZAODevzBot: Coder starting (attempt 2/3)...
+[loops up to 3 attempts, then escalates]
+```
+
+## Safety Recap
+
+Same as before:
+- Admin-only `/fix` (BOT_ADMIN_TELEGRAM_IDS gate)
+- Bot only accepts `/fix` from the configured ZAO_DEVZ_CHAT_ID
+- HERMES_FORBIDDEN_PATHS refuses `bot/src/hermes/` and `.env*`
+- No git commit/push tools allowed in Coder Claude Code session
+- Coder runs in isolated `/tmp/hermes-{id}/` workdir, cleaned up on exit
+- All actual `git push` goes through `~/bin/safe-git-push.sh` + GitHub branch protection
+- Override: `ALLOW_UNSAFE_PUSH=1` for true emergencies only

--- a/bot/src/devz/index.ts
+++ b/bot/src/devz/index.ts
@@ -1,0 +1,342 @@
+/**
+ * ZAO Devz dual-bot runner.
+ *
+ * Boots TWO grammy bots in one Node process:
+ *   - ZAODevzBot  (ZAO_DEVZ_BOT_TOKEN): handles `/fix`, runs Coder
+ *   - HermesBot   (HERMES_BOT_TOKEN):   posts review/critique narration
+ *
+ * Both bots live in the ZAO Devz Telegram chat and narrate Hermes phases
+ * as distinct identities so the conversation reads like two agents
+ * checking each other's work.
+ *
+ * Telegram setup:
+ *   1. Create two bots via @BotFather, get tokens
+ *   2. Add both bots to the ZAO Devz private group (admin permission)
+ *   3. Set ZAO_DEVZ_CHAT_ID to that group's chat id
+ *   4. systemctl --user start zao-devz-stack
+ */
+import { config as loadEnv } from 'dotenv';
+loadEnv();
+
+import { Bot, Context } from 'grammy';
+import { dispatchHermesRun, type HermesNarrator } from '../hermes/runner';
+import { listOpenRuns, getRun } from '../hermes/db';
+import { existsSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+
+const devzToken = process.env.ZAO_DEVZ_BOT_TOKEN;
+const hermesToken = process.env.HERMES_BOT_TOKEN;
+const devzChatRaw = process.env.ZAO_DEVZ_CHAT_ID;
+
+if (!devzToken) {
+  console.error('Missing ZAO_DEVZ_BOT_TOKEN');
+  process.exit(1);
+}
+if (!hermesToken) {
+  console.error('Missing HERMES_BOT_TOKEN');
+  process.exit(1);
+}
+if (!devzChatRaw) {
+  console.error('Missing ZAO_DEVZ_CHAT_ID (the Telegram group id where both bots live)');
+  process.exit(1);
+}
+const devzChatId = Number(devzChatRaw);
+if (!Number.isFinite(devzChatId)) {
+  console.error(`ZAO_DEVZ_CHAT_ID is not a number: ${devzChatRaw}`);
+  process.exit(1);
+}
+
+const ADMIN_IDS = (process.env.BOT_ADMIN_TELEGRAM_IDS ?? '')
+  .split(',')
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isFinite(n) && n > 0);
+
+const ZAAL_TG_ID = Number(process.env.ZAAL_TELEGRAM_ID ?? '0') || null;
+
+const devz = new Bot<Context>(devzToken);
+const hermes = new Bot<Context>(hermesToken);
+
+function isAdmin(ctx: Context): boolean {
+  const id = ctx.from?.id;
+  if (!id) return false;
+  return ADMIN_IDS.includes(id);
+}
+
+async function checkClaudeOnPath(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn('which', ['claude']);
+    child.on('close', (code) => resolve(code === 0));
+    child.on('error', () => resolve(false));
+  });
+}
+
+// ---- Narrator: ZAODevzBot speaks as Coder, HermesBot speaks as Critic ------
+
+function buildNarrator(): HermesNarrator {
+  return {
+    async onCoderStart(runId, attempt, max, issue) {
+      const truncated = issue.length > 120 ? `${issue.slice(0, 120)}...` : issue;
+      await devz.api.sendMessage(
+        devzChatId,
+        `Coder starting (attempt ${attempt}/${max}) on run ${runId.slice(0, 8)}\nIssue: ${truncated}\nModel: opus | Tools: Read/Edit/Write/Glob/Grep`,
+      );
+    },
+    async onCoderDone(runId, attempt, files) {
+      const list = files.slice(0, 8).map((f) => `  - ${f}`).join('\n');
+      const more = files.length > 8 ? `\n  ...+${files.length - 8} more` : '';
+      await devz.api.sendMessage(
+        devzChatId,
+        `Coder done on run ${runId.slice(0, 8)} (attempt ${attempt}). Changed ${files.length} files:\n${list}${more}\nHanding to @${hermesUsername()}.`,
+      );
+    },
+    async onCriticStart(runId) {
+      await hermes.api.sendMessage(
+        devzChatId,
+        `Reviewing run ${runId.slice(0, 8)}. Reading diff + source. Model: sonnet.`,
+      );
+    },
+    async onCriticDone(runId, score, feedback) {
+      const verdict = score >= 70 ? 'PASS' : score >= 50 ? 'NEEDS REVISION' : 'REJECT';
+      await hermes.api.sendMessage(
+        devzChatId,
+        `Score ${score}/100 (${verdict}) on run ${runId.slice(0, 8)}\nFeedback: ${feedback}`,
+      );
+    },
+    async onPrOpened(runId, prNumber, prUrl, score) {
+      const cc = ZAAL_TG_ID ? `\ncc <a href="tg://user?id=${ZAAL_TG_ID}">Zaal</a> - push when good` : '';
+      await hermes.api.sendMessage(
+        devzChatId,
+        `READY. Score ${score}/100. PR #${prNumber}: ${prUrl}\nRun: ${runId.slice(0, 8)}${cc}`,
+        { parse_mode: 'HTML' },
+      );
+    },
+    async onRetry(runId, nextAttempt, feedback) {
+      await devz.api.sendMessage(
+        devzChatId,
+        `Retrying run ${runId.slice(0, 8)} (attempt ${nextAttempt}). Critic said: ${feedback}`,
+      );
+    },
+    async onEscalated(runId, reason) {
+      await hermes.api.sendMessage(
+        devzChatId,
+        `ESCALATED. Hit max attempts on run ${runId.slice(0, 8)}.\nLast critic feedback: ${reason}\nNeeds human.`,
+      );
+    },
+    async onFailed(runId, reason) {
+      await hermes.api.sendMessage(
+        devzChatId,
+        `FAILED. Run ${runId.slice(0, 8)} crashed.\nReason: ${reason}`,
+      );
+    },
+  };
+}
+
+let _hermesUsername: string | null = null;
+function hermesUsername(): string {
+  return _hermesUsername ?? 'HermesBot';
+}
+
+// ---- ZAODevzBot commands ----------------------------------------------------
+
+devz.command('start', async (ctx) => {
+  await ctx.reply(
+    [
+      'ZAO Devz channel bot. I am the Coder half of the Hermes pair.',
+      '',
+      '/fix <issue> - I write a diff, HermesBot grades it, you get a PR if score >=70',
+      '/help - command list',
+      '/whoami - confirm chat id + your tg id',
+    ].join('\n'),
+  );
+});
+
+devz.command('help', async (ctx) => {
+  await ctx.reply(
+    [
+      'ZAO Devz - Coder half',
+      '',
+      'Admin only:',
+      '  /fix <issue> - dispatch Hermes loop',
+      '  /fix_status [run_id_8chars] - check open runs',
+      '',
+      'Open:',
+      '  /whoami - confirm chat + sender ids',
+      '',
+      'Pair: HermesBot reviews everything I write.',
+    ].join('\n'),
+  );
+});
+
+devz.command('whoami', async (ctx) => {
+  await ctx.reply(`chat_id=${ctx.chat?.id}\nfrom_id=${ctx.from?.id}\nusername=${ctx.from?.username ?? 'none'}`);
+});
+
+devz.command('fix', async (ctx) => {
+  if (!isAdmin(ctx)) {
+    await ctx.reply('Hermes /fix is admin-only. Add yourself to BOT_ADMIN_TELEGRAM_IDS.');
+    return;
+  }
+  if (ctx.chat?.id !== devzChatId) {
+    await ctx.reply(`This bot only runs /fix from the ZAO Devz chat (id ${devzChatId}). You're in ${ctx.chat?.id}.`);
+    return;
+  }
+  if (!existsSync(process.env.HERMES_CLAUDE_BIN ?? '/dev/null') && !(await checkClaudeOnPath())) {
+    await ctx.reply("Can't find 'claude' CLI on PATH. Install Claude Code on the bot host (Max plan).");
+    return;
+  }
+  const text = (ctx.message?.text ?? '').replace(/^\/fix(@\w+)?\s*/, '').trim();
+  if (!text || text.length < 10) {
+    await ctx.reply('Usage: /fix <issue> - describe the bug or feature in 1-3 sentences (10+ chars).');
+    return;
+  }
+  const fromId = ctx.from?.id;
+  if (!fromId) {
+    await ctx.reply('Cannot identify sender.');
+    return;
+  }
+
+  await ctx.reply('Got it. Spinning up the loop. Updates incoming from me + HermesBot.');
+
+  // Fire-and-forget. Narrator surfaces progress.
+  void runWithGuard({
+    triggered_by_telegram_id: fromId,
+    triggered_in_chat_id: devzChatId,
+    issue_text: text,
+  });
+});
+
+devz.command('fix_status', async (ctx) => {
+  const arg = (ctx.message?.text ?? '').replace(/^\/fix_status(@\w+)?\s*/, '').trim();
+  if (arg) {
+    const matches = await findRunByPrefix(arg);
+    if (!matches) {
+      await ctx.reply(`No run matching ${arg}`);
+      return;
+    }
+    await ctx.reply(formatRun(matches));
+    return;
+  }
+  const open = await listOpenRuns(10);
+  if (open.length === 0) {
+    await ctx.reply('No open Hermes runs.');
+    return;
+  }
+  await ctx.reply(open.map(formatRun).join('\n\n'));
+});
+
+// ---- HermesBot is mostly observer; expose a status command for visibility -----
+
+hermes.command('start', async (ctx) => {
+  await ctx.reply(
+    [
+      'HermesBot - the Critic half of the Hermes pair.',
+      '',
+      'I review everything ZAODevzBot writes. I grade 0-100. >=70 = ship, <70 = retry, max 3 attempts.',
+      '',
+      '/fix_status [run_id_8chars] - inspect a run',
+      '/whoami - confirm chat + sender',
+    ].join('\n'),
+  );
+});
+
+hermes.command('whoami', async (ctx) => {
+  await ctx.reply(`chat_id=${ctx.chat?.id}\nfrom_id=${ctx.from?.id}\nusername=${ctx.from?.username ?? 'none'}`);
+});
+
+hermes.command('fix_status', async (ctx) => {
+  const arg = (ctx.message?.text ?? '').replace(/^\/fix_status(@\w+)?\s*/, '').trim();
+  if (arg) {
+    const r = await findRunByPrefix(arg);
+    if (!r) {
+      await ctx.reply(`No run matching ${arg}`);
+      return;
+    }
+    await ctx.reply(formatRun(r));
+    return;
+  }
+  const open = await listOpenRuns(10);
+  if (open.length === 0) {
+    await ctx.reply('No open Hermes runs to review.');
+    return;
+  }
+  await ctx.reply(open.map(formatRun).join('\n\n'));
+});
+
+// ---- Helpers ---------------------------------------------------------------
+
+interface MinimalRun {
+  id: string;
+  status: string;
+  fixer_attempts: number;
+  critic_score: number | null;
+  pr_url: string | null;
+  issue_text: string;
+}
+
+async function findRunByPrefix(prefix: string): Promise<MinimalRun | null> {
+  if (prefix.length >= 36) {
+    const r = await getRun(prefix);
+    return r as MinimalRun | null;
+  }
+  const open = await listOpenRuns(50);
+  return (open.find((r) => r.id.startsWith(prefix)) as MinimalRun | undefined) ?? null;
+}
+
+function formatRun(r: MinimalRun): string {
+  const issue = r.issue_text.length > 80 ? `${r.issue_text.slice(0, 80)}...` : r.issue_text;
+  return [
+    `${r.id.slice(0, 8)} | ${r.status} | attempts=${r.fixer_attempts} | score=${r.critic_score ?? '-'}`,
+    `issue: ${issue}`,
+    r.pr_url ? `pr: ${r.pr_url}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function runWithGuard(input: {
+  triggered_by_telegram_id: number;
+  triggered_in_chat_id: number;
+  issue_text: string;
+}): Promise<void> {
+  try {
+    await dispatchHermesRun(input, buildNarrator());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    try {
+      await hermes.api.sendMessage(devzChatId, `Hermes crashed outside the loop: ${msg}`);
+    } catch {
+      console.error('[devz] failed to post crash notification', msg);
+    }
+  }
+}
+
+// ---- Boot ------------------------------------------------------------------
+
+async function boot(): Promise<void> {
+  const devzInfo = await devz.api.getMe();
+  const hermesInfo = await hermes.api.getMe();
+  _hermesUsername = hermesInfo.username ?? 'HermesBot';
+  console.log(`[devz] ZAODevzBot=@${devzInfo.username} HermesBot=@${hermesInfo.username} chat=${devzChatId}`);
+
+  await Promise.all([
+    devz.start({ drop_pending_updates: true, onStart: () => console.log('[devz] ZAODevzBot polling') }),
+    hermes.start({ drop_pending_updates: true, onStart: () => console.log('[devz] HermesBot polling') }),
+  ]);
+}
+
+boot().catch((err) => {
+  console.error('[devz] boot failed', err);
+  process.exit(1);
+});
+
+// graceful shutdown
+process.on('SIGTERM', async () => {
+  console.log('[devz] SIGTERM - stopping bots');
+  await Promise.allSettled([devz.stop(), hermes.stop()]);
+  process.exit(0);
+});
+process.on('SIGINT', async () => {
+  console.log('[devz] SIGINT - stopping bots');
+  await Promise.allSettled([devz.stop(), hermes.stop()]);
+  process.exit(0);
+});

--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -30,6 +30,22 @@ export interface DispatchInput {
   issue_text: string;
 }
 
+/**
+ * Narrator hooks let two Telegram bots (ZAO Devz + Hermes) post phase
+ * updates as distinct identities into the same chat. All hooks are optional;
+ * if absent, the runner is silent and the caller surfaces the final result.
+ */
+export interface HermesNarrator {
+  onCoderStart?: (runId: string, attempt: number, max: number, issue: string) => Promise<void>;
+  onCoderDone?: (runId: string, attempt: number, filesChanged: string[]) => Promise<void>;
+  onCriticStart?: (runId: string) => Promise<void>;
+  onCriticDone?: (runId: string, score: number, feedback: string) => Promise<void>;
+  onPrOpened?: (runId: string, prNumber: number, prUrl: string, score: number) => Promise<void>;
+  onRetry?: (runId: string, nextAttempt: number, feedback: string) => Promise<void>;
+  onEscalated?: (runId: string, reason: string) => Promise<void>;
+  onFailed?: (runId: string, reason: string) => Promise<void>;
+}
+
 export type DispatchResult =
   | { kind: 'ready'; run: HermesRun }
   | { kind: 'failed'; run: HermesRun; reason: string }
@@ -39,7 +55,10 @@ export type DispatchResult =
  * Run the full Coder -> Critic loop. Returns a result describing the outcome.
  * Caller (Telegram handler) decides how to surface it.
  */
-export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchResult> {
+export async function dispatchHermesRun(
+  input: DispatchInput,
+  narrator?: HermesNarrator,
+): Promise<DispatchResult> {
   const created = await createRun(input);
   await updateRun(created.id, { status: 'fixing', started_at: new Date().toISOString() });
 
@@ -57,6 +76,7 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
     while (attempt < HERMES_DEFAULT_MAX_ATTEMPTS) {
       attempt += 1;
       await updateRun(created.id, { fixer_attempts: attempt, status: 'fixing' });
+      await narrator?.onCoderStart?.(created.id, attempt, HERMES_DEFAULT_MAX_ATTEMPTS, input.issue_text);
 
       const fixerOut = await runFixer({
         issueText: input.issue_text,
@@ -70,10 +90,15 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
 
       if (fixerOut.filesChanged.length === 0) {
         lastFeedback = 'fixer produced no file changes; revise and try again';
+        await narrator?.onRetry?.(created.id, attempt + 1, lastFeedback);
         continue;
       }
 
+      await narrator?.onCoderDone?.(created.id, attempt, fixerOut.filesChanged);
+
       await updateRun(created.id, { status: 'critiquing' });
+      await narrator?.onCriticStart?.(created.id);
+
       const critique = await runCritic({
         workTreePath: workdir,
         branchName,
@@ -83,6 +108,8 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
       totalIn += critique.inputTokens;
       totalOut += critique.outputTokens;
 
+      await narrator?.onCriticDone?.(created.id, critique.score, critique.feedback);
+
       if (critique.score >= HERMES_PASS_THRESHOLD) {
         await commitAndPush(workdir, branchName, fixerOut.commitMessage);
         const pr = await openPullRequest({
@@ -90,6 +117,7 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
           title: fixerOut.prTitle,
           body: `${fixerOut.prBody}\n\n**Critic score:** ${critique.score}/100\n**Critic feedback:** ${critique.feedback}`,
         });
+        await narrator?.onPrOpened?.(created.id, pr.number, pr.url, critique.score);
         await updateRun(created.id, {
           status: 'ready',
           branch: branchName,
@@ -120,6 +148,9 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
         critic_score: critique.score,
         critic_feedback: critique.feedback,
       });
+      if (attempt < HERMES_DEFAULT_MAX_ATTEMPTS) {
+        await narrator?.onRetry?.(created.id, attempt + 1, critique.feedback);
+      }
 
       // reset workdir for next attempt (drop in-flight changes, keep branch)
       await resetToMain(workdir);
@@ -133,6 +164,7 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
       error_message: `exceeded ${HERMES_DEFAULT_MAX_ATTEMPTS} attempts; last critic feedback: ${lastFeedback ?? 'n/a'}`,
     });
     const final = (await reloadRun(created.id)) ?? created;
+    await narrator?.onEscalated?.(created.id, lastFeedback ?? 'no feedback recorded');
     return { kind: 'escalated', run: final, reason: lastFeedback ?? 'no feedback recorded' };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -144,6 +176,7 @@ export async function dispatchHermesRun(input: DispatchInput): Promise<DispatchR
       completed_at: new Date().toISOString(),
     });
     const final = (await reloadRun(created.id)) ?? created;
+    await narrator?.onFailed?.(created.id, message);
     return { kind: 'failed', run: final, reason: message };
   } finally {
     await cleanupWorkdir(workdir);


### PR DESCRIPTION
## Summary
Per Zaal's design: TWO Telegram bots (ZAODevzBot + HermesBot) in the ZAO Devz chat that narrate the Hermes Coder + Critic loop as separate identities. Reads like two agents reviewing each other's work.

Builds on PR #310 (Claude Code CLI / Max plan).

## What changes
- **NEW** `bot/src/devz/index.ts` - dual-bot entry point. Two grammy `Bot()` instances in one Node process, each with its own token + identity. ZAODevzBot handles `/fix`; HermesBot is observer + status. Both post into the same chat as distinct Telegram users.
- **NEW** `bot/src/devz/README.md` - end-to-end deployment guide (BotFather steps, env vars, group setup, systemd unit, first-run expected message sequence).
- **MODIFIED** `bot/src/hermes/runner.ts` - adds optional `HermesNarrator` interface to `dispatchHermesRun()`. Backward compat preserved (no narrator = silent runner).
- **MODIFIED** `bot/package.json` - adds `start:devz` + `dev:devz` scripts.

## Architecture decision
- **One Node process, two grammy bots** (cleaner deploy than two services). Each bot has its own token + identity but shares the in-process loop.
- `/fix` only accepted from configured `ZAO_DEVZ_CHAT_ID` to prevent leakage.
- HermesBot is currently passive (commands: `/start`, `/whoami`, `/fix_status`). Future: take a `/reroute` command, suggest fixes, or graduate to its own subprocess.

## How the chat reads after `/fix`
```
ZAODevzBot: Got it. Spinning up the loop.
ZAODevzBot: Coder starting (attempt 1/3) on run abc12345
            Issue: Add a /healthcheck...
            Model: opus | Tools: Read/Edit/Write/Glob/Grep
[3-5 min]
ZAODevzBot: Coder done. Changed 1 file:
              - bot/src/index.ts
            Handing to @HermesBot.
HermesBot:  Reviewing run abc12345. Reading diff + source. Model: sonnet.
HermesBot:  Score 85/100 (PASS). Feedback: clean addition, follows pattern.
HermesBot:  READY. Score 85/100. PR #N: https://...
            cc Zaal - push when good
```

If score < 70:
```
HermesBot:  Score 55/100 (NEEDS REVISION). Feedback: missing Zod validation
ZAODevzBot: Retrying run abc12345 (attempt 2). Critic said: missing Zod validation
ZAODevzBot: Coder starting (attempt 2/3)...
```

## New env vars
```
ZAO_DEVZ_BOT_TOKEN=<from @BotFather>
HERMES_BOT_TOKEN=<from @BotFather>
ZAO_DEVZ_CHAT_ID=<-100xxx, the Telegram group id>
```

Still uses Claude Code CLI (Max plan auth). No `ANTHROPIC_API_KEY` needed.

## Pre-deploy checklist
See `bot/src/devz/README.md` for the full sequence:
1. Create both bots via @BotFather, save tokens
2. Create ZAO Devz Telegram group, add both bots as admins
3. Get group chat id
4. Add 3 env vars to `~/zaostock-bot/.env`
5. `npm install` on VPS
6. Test: `npm run start:devz`
7. Once green, install systemd user unit `zao-devz-stack.service`

## Tests
- typecheck: clean (already passing in PR #310 base)
- runtime: requires both bot tokens + chat id; first run validates end-to-end

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>