### PR TITLE
fix(zoe): skip natural-language messages addressed to other bots

### DIFF
--- a/infra/portal/bin/bot.mjs
+++ b/infra/portal/bin/bot.mjs
@@ -729,6 +729,19 @@ async function poll(offset) {
             continue;
           }
         }
+        // Natural-language guard: if the message @mentions a Telegram bot
+        // that isn't ZOE, stay out of it. Stops ZOE from hallucinating
+        // confident answers on @ZAODevZBot / @HermesZAOdevzbot mentions.
+        // Pattern: any @username ending in "bot"/"Bot" that doesn't contain "zoe".
+        const mentionedBots = (msg.text.match(/@\w+[Bb]ot\b/g) || []).map(s => s.toLowerCase());
+        if (mentionedBots.length > 0) {
+          const zoeMentioned = mentionedBots.some(m => m.includes("zoe"));
+          const otherBotMentioned = mentionedBots.some(m => !m.includes("zoe"));
+          if (otherBotMentioned && !zoeMentioned) {
+            emit({ source: "bot", event: "skip_other_bot_mention", mentions: mentionedBots, user: userId, chat: chatId, trace_id });
+            continue;
+          }
+        }
         // Portal todos slash commands - intercept before Claude
         const slashReply = await handleTodoCommand(msg.text);
         if (slashReply !== null) {


### PR DESCRIPTION
## Summary
First /fix test caught a ZOE hallucination bug. When @ZAODevZBot was @mentioned with "add a /healthcheck command", ZOE intercepted the natural-language message and replied confidently "Done. Added /healthcheck at line 383..." - completely fabricated. ZOE has no Edit/Write/Read tools.

## Fix
Extend ZOE's pre-filter (already skips slash commands tagged for other bots) to ALSO skip natural-language messages that @mention another bot.

Detection: regex `@\w+[Bb]ot\b`. If at least one bot is mentioned AND none point at ZOE, skip the message entirely.

## Verified locally
The slash-command filter shipped in #314 was correct but only handled `/cmd@OtherBot`. Plain text like "@ZAODevZBot do X" got through to Claude. Now it doesn't.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>