### PR TITLE
fix(hermes): drop --json-schema flag (was blocking tool-use)

### DIFF
--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -60,9 +60,13 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
     if (opts.permissionMode) {
       args.push('--permission-mode', opts.permissionMode);
     }
-    if (opts.jsonSchema) {
-      args.push('--json-schema', JSON.stringify(opts.jsonSchema));
-    }
+    // NOTE: intentionally NOT forwarding `opts.jsonSchema` to the CLI.
+    // `--json-schema` enforces strict structured output, which prevents the
+    // model from running tool calls (Read/Edit/Write/etc) before producing
+    // the final JSON. We need both. The system prompt asks for JSON in the
+    // final assistant message; the orchestrator parses it. Schema is kept on
+    // the type only as a contract reference.
+    void opts.jsonSchema; // eslint-disable-line @typescript-eslint/no-unused-vars
     if (opts.maxBudgetUsd !== undefined) {
       args.push('--max-budget-usd', String(opts.maxBudgetUsd));
     }
@@ -97,6 +101,13 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
         return;
       }
 
+      // Empty stdout means Claude exited silently - log everything we have.
+      if (!stdout.trim()) {
+        console.error('[hermes/claude-cli] empty stdout. exit_code=', code, 'stderr=', stderr.slice(0, 800), 'args=', JSON.stringify(args).slice(0, 800));
+        reject(new Error(`claude CLI returned empty stdout. exit=${code}. stderr: ${stderr.slice(0, 400) || '(empty)'}`));
+        return;
+      }
+
       try {
         if (outputFormat === 'json') {
           const parsed = JSON.parse(stdout) as {
@@ -111,6 +122,16 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
             usage?: { input_tokens?: number; output_tokens?: number };
             modelUsage?: Record<string, { inputTokens: number; outputTokens: number; costUSD: number }>;
           };
+          if (parsed.is_error) {
+            console.error('[hermes/claude-cli] is_error=true full payload:', JSON.stringify(parsed).slice(0, 1200));
+            reject(new Error(`claude CLI reported is_error=true: ${(parsed.result ?? '').slice(0, 400) || '(no result body)'}`));
+            return;
+          }
+          if (!parsed.result || !parsed.result.trim()) {
+            console.error('[hermes/claude-cli] empty result. full payload:', JSON.stringify(parsed).slice(0, 1200));
+            reject(new Error(`claude CLI returned empty result. duration=${parsed.duration_ms}ms turns=${parsed.num_turns}. session=${parsed.session_id}`));
+            return;
+          }
           const usage = parsed.usage ?? { input_tokens: 0, output_tokens: 0 };
           resolve({
             text: parsed.result ?? '',


### PR DESCRIPTION
## Summary
First end-to-end /fix test crashed in 32s with `Stock-Coder returned non-JSON. First 200 chars: . Parse error: Unexpected end of JSON input`. Total tokens 0/0 in DB row = Claude exited fast without doing any work.

## Root cause
`bot/src/hermes/claude-cli.ts` forwarded our `FIXER_OUTPUT_SCHEMA` via the `--json-schema` CLI flag. Claude Code enforces strict structured output when that flag is set, which blocks tool calls. Coder can't Read/Edit/Write AND emit schema-constrained JSON in one shot - the model exited early with empty result.

## Verification
Reproduced manually on VPS: bare `claude -p "..." --output-format json --allowedTools Read Glob Bash` works perfectly (7s, $0.09, 4/124 tokens). Same call with `--json-schema` enforced returns nothing.

## Fix
- Drop `--json-schema` from the CLI args (schema kept on TS type as a contract reference)
- System prompt asks for JSON in final assistant message
- Orchestrator parses with `parseJsonStrict`

## Bonus: better error logging
- Empty stdout: log exit code, stderr, args
- Empty result: log full parsed payload (duration, turns, session_id)
- is_error=true: log full payload
- Next failure will tell us EXACTLY what Claude returned

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>