### PR TITLE
fix(hermes): handle spawn ENOENT + augment PATH for systemd context

### DIFF
--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -75,9 +75,17 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
     }
     args.push('--add-dir', opts.cwd);
 
-    const child = spawn('claude', args, {
+    // Augment PATH so claude resolves under systemd (strips user PATH).
+    const augmentedEnv: NodeJS.ProcessEnv = { ...process.env };
+    const home = augmentedEnv.HOME ?? '/home/zaal';
+    const localBin = `${home}/.local/bin`;
+    if (!augmentedEnv.PATH || !augmentedEnv.PATH.split(':').includes(localBin)) {
+      augmentedEnv.PATH = `${localBin}:${augmentedEnv.PATH ?? '/usr/local/bin:/usr/bin:/bin'}`;
+    }
+
+    const child = spawn(process.env.HERMES_CLAUDE_BIN || 'claude', args, {
       cwd: opts.cwd,
-      env: process.env,
+      env: augmentedEnv,
     });
 
     let stdout = '';
@@ -87,6 +95,13 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
       setTimeout(() => child.kill('SIGKILL'), 2000);
       reject(new Error(`claude CLI timed out after ${opts.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`));
     }, opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[hermes/claude-cli] spawn error:', msg);
+      reject(new Error(`Failed to spawn claude CLI: ${msg}. Is 'claude' in PATH? args=${JSON.stringify(args).slice(0, 200)}`));
+    });
 
     child.stdout.on('data', (d) => {
       stdout += d.toString();
@@ -164,10 +179,6 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
           ),
         );
       }
-    });
-    child.on('error', (err) => {
-      clearTimeout(timeout);
-      reject(new Error(`Failed to spawn claude CLI: ${err.message}. Is 'claude' in PATH?`));
     });
   });
 }

--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -10,8 +10,18 @@ export interface GitRunResult {
 }
 
 export function runCmd(cmd: string, args: string[], cwd?: string, env?: NodeJS.ProcessEnv): Promise<GitRunResult> {
+  // Augment PATH so binaries installed under ~/.local/bin (gh, claude, uv,
+  // serena, etc.) resolve when this process runs under systemd which strips
+  // user-specific shell PATH augmentations.
+  const augmentedEnv: NodeJS.ProcessEnv = { ...(env ?? process.env) };
+  const home = augmentedEnv.HOME ?? process.env.HOME ?? '/home/zaal';
+  const localBin = `${home}/.local/bin`;
+  if (!augmentedEnv.PATH || !augmentedEnv.PATH.split(':').includes(localBin)) {
+    augmentedEnv.PATH = `${localBin}:${augmentedEnv.PATH ?? '/usr/local/bin:/usr/bin:/bin'}`;
+  }
+
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { cwd, env: env ?? process.env });
+    const child = spawn(cmd, args, { cwd, env: augmentedEnv });
     let stdout = '';
     let stderr = '';
     child.stdout.on('data', (d) => {
@@ -19,6 +29,14 @@ export function runCmd(cmd: string, args: string[], cwd?: string, env?: NodeJS.P
     });
     child.stderr.on('data', (d) => {
       stderr += d.toString();
+    });
+    // Critical: spawn emits 'error' on ENOENT (binary not found). Without a
+    // handler the event throws and crashes the parent process - we saw this
+    // happen on the first /fix run (gh missing from systemd PATH took the
+    // whole zao-devz-stack process down).
+    child.on('error', (err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      resolve({ stdout, stderr: stderr + `\n[spawn-error] ${msg}`, exitCode: -1 });
     });
     child.on('close', (code) => {
       resolve({ stdout, stderr, exitCode: code ?? -1 });


### PR DESCRIPTION
## Summary
First /fix end-to-end run got 99% there: Coder ran in 1 min, Critic scored 95/100 PASS, then process crashed with `Error: spawn gh ENOENT` while opening the PR. Also leaves run stuck in `critiquing` state in DB.

## Root causes
1. `gh` CLI is at `/home/zaal/.local/bin/gh` - in zaal's interactive PATH but NOT in systemd's minimal default PATH
2. `runCmd()` in `git.ts` had no `error` event handler. spawn() emits 'error' on ENOENT, Node throws it unhandled, the whole bot process dies. Same bug existed in `claude-cli.ts` (handler was after close handler, never fired).

## Fix
**git.ts:**
- Augment `env.PATH` with `$HOME/.local/bin` if not already there
- Add `child.on('error')` that resolves with `{exitCode: -1, stderr: '[spawn-error] ...'}` - callers see a normal failure result instead of process crash

**claude-cli.ts:**
- Same PATH augmentation
- Early `child.on('error')` (was placed AFTER close handler, ineffective)
- Respect `HERMES_CLAUDE_BIN` env var if set

## After merge
Pull on VPS, restart `zao-devz-stack`, retry `@ZAODevZBot add a /healthcheck command...`. Should complete: Coder writes → Critic grades → Coder pushes → gh creates PR → Telegram posts URL.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>