### PR TITLE
fix(hermes): pass --head to gh pr create + redundant push (final unblock)

### DIFF
--- a/bot/src/hermes/pr.ts
+++ b/bot/src/hermes/pr.ts
@@ -8,21 +8,42 @@ export interface OpenedPR {
 /**
  * Open a PR via gh CLI from the current workdir checkout.
  * Returns the PR number + URL.
+ *
+ * IMPORTANT: pass --head explicitly. gh's auto-detection of the current
+ * branch's pushed-to-remote state has been flaky in production - even when
+ * the branch is on origin (verified via gh api repos/.../branches), gh may
+ * still report "you must first push the current branch to a remote".
+ * Passing --head bypasses that check.
  */
 export async function openPullRequest(opts: {
   workdir: string;
+  branchName: string;
   title: string;
   body: string;
   base?: string;
 }): Promise<OpenedPR> {
   const base = opts.base ?? 'main';
+
+  // Belt-and-suspenders: re-push to make sure remote is in sync before gh runs.
+  // If the branch tip already matches, this is a no-op.
+  await runCmd('git', ['push', '-u', 'origin', opts.branchName], opts.workdir);
+
   const r = await runCmd(
     'gh',
-    ['pr', 'create', '--base', base, '--title', opts.title, '--body', opts.body],
+    [
+      'pr',
+      'create',
+      '--base', base,
+      '--head', opts.branchName,
+      '--title', opts.title,
+      '--body', opts.body,
+    ],
     opts.workdir,
   );
   if (r.exitCode !== 0) {
-    throw new Error(`gh pr create failed: ${r.stderr.slice(0, 400) || r.stdout.slice(0, 400)}`);
+    throw new Error(
+      `gh pr create failed (exit ${r.exitCode}). stderr: ${r.stderr.slice(0, 600) || '(empty)'} stdout: ${r.stdout.slice(0, 200)}`,
+    );
   }
   // gh prints the PR URL on the last line.
   const url = r.stdout.trim().split('\n').pop() ?? '';

--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -152,6 +152,7 @@ export async function dispatchHermesRun(
         await commitAndPush(workdir, branchName, fixerOut.commitMessage);
         const pr = await openPullRequest({
           workdir,
+          branchName,
           title: fixerOut.prTitle,
           body: `${fixerOut.prBody}\n\n**Critic score:** ${critique.score}/100\n**Critic feedback:** ${critique.feedback}`,
         });


### PR DESCRIPTION
Third regression on the same /fix run. Coder + Critic both PASSED (Score 95/100), Coder pushed branch to remote (verified). gh pr create still failed: 'must push first'.

Fix: pass --head explicitly + redundant push before gh runs. gh skips its detection entirely.

After merge, /fix should complete the full Coder->Critic->PR sequence.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>