### PR TITLE
feat(bot): add /healthcheck command (Hermes run d133dc2f)

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -380,6 +380,10 @@ bot.command('whoami', async (ctx) => {
   );
 });
 
+bot.command('healthcheck', async (ctx) => {
+  await ctx.reply('OK - hermes alive');
+});
+
 bot.command('health', async (ctx) => {
   if (!isAdmin(ctx)) {
     await ctx.reply('Admin only.');


### PR DESCRIPTION
## Summary
Manually-opened PR for Hermes run `d133dc2f`. Coder + Critic completed cleanly:
- Coder: Opus, 1 file changed (bot/src/index.ts)
- Critic: Sonnet, score 82/100 (PASS)
- Critic feedback: "Correct reply text, no security issues, within scope. Minor gap: issue says 'in ZAO Devz group' but no group filter added — command responds in any chat. Acceptable for a healthcheck; consider adding a group guard if restriction is intended."

## Why opened manually
Hermes runner.ts crashed at `gh pr create` step due to gh's stale upstream detection. PR #319 fixes this with `--head <branchName>` explicitly + redundant push. After PR #319 merge propagates to VPS, future runs auto-open PRs.

## What's in the diff
The `/healthcheck` command was added to `bot/src/index.ts` per the request. Returns `OK - hermes alive`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Co-Authored-By: Hermes Stock-Coder via Claude Code CLI (Max plan, model: opus)