### PR TITLE
feat(bot): add /version command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -380,6 +380,10 @@ bot.command('whoami', async (ctx) => {
   );
 });
 
+bot.command('version', async (ctx) => {
+  await ctx.reply('v1.6 hermes loop');
+});
+
 bot.command('health', async (ctx) => {
   if (!isAdmin(ctx)) {
     await ctx.reply('Admin only.');


### PR DESCRIPTION
## Summary
- Adds `/version` bot command that replies with `v1.6 hermes loop`
- Placed in the admin/info commands section of `bot/src/index.ts`

## Test plan
- [ ] Send `/version` to the bot in DM → expect reply `v1.6 hermes loop`
- [ ] Send `/version` in a group chat → expect same reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by Hermes Stock-Coder via Claude Code CLI (Max plan auth, model: opus). Verified by Hermes-Stock Critic before this PR opened._

_Rationale:_ Issue requested a /version command returning 'v1.6 hermes loop'. Added a simple bot.command handler in the commands section of bot/src/index.ts, placed alongside other simple info commands.

**Critic score:** 97/100
**Critic feedback:** Diff exactly matches the issue request. Minimal, correct placement between whoami and health. No auth check needed for public version info. No security concerns or pattern violations.