### PR TITLE
fix(bot): /join duplicate-key + did-you-mean fuzzy match + 4 new teammates

### DIFF
--- a/bot/src/circles.ts
+++ b/bot/src/circles.ts
@@ -36,6 +36,39 @@ function validateCircleSlug(slug: string): slug is CircleSlug {
   return CIRCLE_SLUGS.includes(slug.toLowerCase() as CircleSlug);
 }
 
+// Levenshtein for "did you mean" suggestions
+function distance(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0) return n;
+  if (n === 0) return m;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost);
+    }
+  }
+  return dp[m][n];
+}
+
+function suggestSlug(input: string): CircleSlug | null {
+  const lower = input.toLowerCase().trim();
+  if (!lower) return null;
+  // substring match first (e.g. "med" -> "media")
+  const sub = CIRCLE_SLUGS.find((s) => s.startsWith(lower) || lower.startsWith(s));
+  if (sub) return sub;
+  // edit distance <= 2
+  let best: { slug: CircleSlug; d: number } | null = null;
+  for (const s of CIRCLE_SLUGS) {
+    const d = distance(lower, s);
+    if (d <= 2 && (!best || d < best.d)) best = { slug: s, d };
+  }
+  return best?.slug ?? null;
+}
+
 async function getCircle(slug: CircleSlug): Promise<Circle | null> {
   const { data, error } = await db()
     .from('stock_circles')
@@ -144,22 +177,28 @@ export async function cmdCircles(ctx: Context): Promise<void> {
 }
 
 export async function cmdJoin(ctx: Context, member: TeamMember, slug: string): Promise<void> {
-  if (!validateCircleSlug(slug)) {
-    await ctx.reply(`Unknown circle: ${slug}. Valid: ${CIRCLE_SLUGS.join(', ')}.`);
+  const lower = slug.toLowerCase().trim();
+  if (!validateCircleSlug(lower)) {
+    const suggest = suggestSlug(lower);
+    if (suggest) {
+      await ctx.reply(`Unknown circle: ${slug}. Did you mean /${suggest}? Reply /join ${suggest} to confirm.`);
+    } else {
+      await ctx.reply(`Unknown circle: ${slug}. Valid: ${CIRCLE_SLUGS.join(', ')}.`);
+    }
     return;
   }
 
   try {
-    const circle = await getCircle(slug);
+    const circle = await getCircle(lower);
     if (!circle) {
-      await ctx.reply(`Circle not found: ${slug}.`);
+      await ctx.reply(`Circle not found: ${lower}.`);
       return;
     }
 
-    // Check if already member
+    // Pre-check (composite PK is (member_id, circle_id), so select an actual column)
     const { data: existing } = await db()
       .from('stock_circle_members')
-      .select('id')
+      .select('member_id')
       .eq('circle_id', circle.id)
       .eq('member_id', member.id)
       .maybeSingle();
@@ -178,24 +217,35 @@ export async function cmdJoin(ctx: Context, member: TeamMember, slug: string): P
       });
 
     if (error) {
+      // Belt-and-suspenders: race or pre-check miss -> friendly message
+      if (error.code === '23505' || /duplicate key/i.test(error.message)) {
+        await ctx.reply(`You're already in ${circle.name}.`);
+        return;
+      }
       await ctx.reply(`Could not join: ${error.message}`);
       return;
     }
 
-    await ctx.reply(`Joined **${circle.name}** (${slug}).`);
+    await ctx.reply(`Joined ${circle.name} (${lower}).`);
   } catch (err) {
     await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
   }
 }
 
 export async function cmdLeave(ctx: Context, member: TeamMember, slug: string): Promise<void> {
-  if (!validateCircleSlug(slug)) {
-    await ctx.reply(`Unknown circle: ${slug}.`);
+  const lower = slug.toLowerCase().trim();
+  if (!validateCircleSlug(lower)) {
+    const suggest = suggestSlug(lower);
+    if (suggest) {
+      await ctx.reply(`Unknown circle: ${slug}. Did you mean /leave ${suggest}?`);
+    } else {
+      await ctx.reply(`Unknown circle: ${slug}. Valid: ${CIRCLE_SLUGS.join(', ')}.`);
+    }
     return;
   }
 
   try {
-    const circle = await getCircle(slug);
+    const circle = await getCircle(lower);
     if (!circle) {
       await ctx.reply(`Circle not found: ${slug}.`);
       return;

--- a/scripts/stock-add-stilo-eve-bacon-eduard.ts
+++ b/scripts/stock-add-stilo-eve-bacon-eduard.ts
@@ -1,0 +1,63 @@
+// One-shot: add Stilo, Eve, Bacon, Eduard to stock_team_members with NEW
+// individual codes. Does NOT touch any existing teammate's code.
+//
+// Per memory feedback_no_regenerate_codes.md: never re-run the all-team
+// random-codes script after codes have been sent.
+//
+// Usage: npx tsx scripts/stock-add-stilo-eve-bacon-eduard.ts
+// Then paste the printed SQL into Supabase SQL Editor + DM each their code.
+
+import { scryptSync, randomBytes } from 'crypto';
+
+const NEW_TEAM: Array<{ name: string; role: string; scope: string }> = [
+  { name: 'Stilo', role: 'member', scope: 'ops' },
+  { name: 'Eve', role: 'member', scope: 'ops' },
+  { name: 'Bacon', role: 'member', scope: 'ops' },
+  { name: 'Eduard', role: 'member', scope: 'ops' },
+];
+
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+function generateCode(): string {
+  let code = '';
+  for (let i = 0; i < 4; i++) {
+    code += ALPHABET[randomBytes(1)[0] % ALPHABET.length];
+  }
+  return code;
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+const used = new Set<string>();
+const entries = NEW_TEAM.map((m) => {
+  let code = generateCode();
+  while (used.has(code)) code = generateCode();
+  used.add(code);
+  return { ...m, code };
+});
+
+console.log('-- ZAOstock: add Stilo, Eve, Bacon, Eduard with new codes');
+console.log('-- Idempotent on name (UPDATE if exists).');
+console.log('-- DOES NOT alter other teammates.\n');
+
+console.log('-- Plaintext (DM each privately, never paste publicly):');
+for (const { name, code } of entries) {
+  console.log(`--   ${name.padEnd(10)} -> ${code}`);
+}
+console.log('');
+
+console.log('BEGIN;');
+for (const { name, code, role, scope } of entries) {
+  const hash = hashPassword(code);
+  const safeName = name.replace(/'/g, "''");
+  console.log(
+    `INSERT INTO stock_team_members (name, role, scope, password_hash, active) ` +
+      `VALUES ('${safeName}', '${role}', '${scope}', '${hash}', true) ` +
+      `ON CONFLICT (name) DO UPDATE SET password_hash = EXCLUDED.password_hash, role = EXCLUDED.role, scope = EXCLUDED.scope, active = true;`,
+  );
+}
+console.log('COMMIT;');


### PR DESCRIPTION
## Summary
- Fix `/join media` duplicate-key error: composite PK on `stock_circle_members` (no `id` column) caused the pre-check to silently fail, falling through to insert that hit 23505.
- Add fuzzy "did you mean" on `/join` and `/leave` using Levenshtein <=2 plus substring match.
- New script `scripts/stock-add-stilo-eve-bacon-eduard.ts` to onboard 4 teammates without disturbing existing codes (per `feedback_no_regenerate_codes`).

## Codes (DM each privately, do NOT paste in groups)
- Stilo: 2BZ3
- Eve: 4FMD
- Bacon: 8RFV
- Eduard: AYNU

(Plaintext also lives in `/tmp/clipboard.html` from the local run.)

## Run order
1. Paste SQL from clipboard into Supabase
2. Merge this PR + redeploy bot to VPS
3. DM each of the 4 their code

## Test plan
- [ ] `/join media` (when already in) -> "You're already in Media."
- [ ] `/join meda` -> "Did you mean /media?"
- [ ] `/join hist` -> "Did you mean /host?"
- [ ] `/leave musci` -> suggestion path
- [ ] After 4 codes inserted, each `/login <code>` in DM links telegram_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)