### PR TITLE
fix(hermes): install deps in fresh clone so pre-flight tsc/biome can run

### DIFF
--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -76,6 +76,29 @@ export async function cloneAndBranch(
   if (checkout.exitCode !== 0) {
     throw new Error(`git checkout -b failed: ${checkout.stderr.slice(0, 400)}`);
   }
+
+  // Install deps so pre-flight typecheck + lint can run (tsc/biome live in
+  // node_modules/.bin). --ignore-scripts blocks postinstall supply-chain
+  // attacks (Shai-Hulud/Axios pattern). Use npm ci if package-lock exists,
+  // npm install otherwise. ~30-60s but only once per /fix run.
+  const lockExists = await fs
+    .access(`${workdir}/package-lock.json`)
+    .then(() => true)
+    .catch(() => false);
+  const installCmd = lockExists ? 'ci' : 'install';
+  const install = await runCmd(
+    'npm',
+    [installCmd, '--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'],
+    workdir,
+  );
+  if (install.exitCode !== 0) {
+    // Don't hard-fail; pre-flight will surface specific errors. Some hermes runs
+    // might not need typecheck (e.g. doc-only changes). Log + continue.
+    console.error(
+      `[hermes/git] npm ${installCmd} returned exit ${install.exitCode}. Pre-flight may fail. stderr: ${install.stderr.slice(0, 300)}`,
+    );
+  }
+
   // Install pre-commit hook to reject any commit that contains conflict markers.
   // Standard practice (AWS samples, AutoGPT #12469). Fresh /tmp clone has no
   // hooks by default; we bake one in.


### PR DESCRIPTION
## Summary
Re-do of #326 (closed due to merge conflict with main; rebase logic was already in main from #325, so #326 had a duplicate region that conflicted).

This PR adds ONLY the npm install step to `cloneAndBranch`. Rebase + pre-commit hook stay as they are on main.

## Why
First pre-flight test (run 4190e16c, /uptime task) failed with:
```
Pre-flight gate failed: TypeScript errors block the merge.
sh: 1: tsc: not found
```
`tsc` lives in `node_modules/.bin`. Fresh `/tmp/hermes-{id}/` clone has none.

## Fix
After clone+branch, run `npm ci --ignore-scripts --no-audit --no-fund --prefer-offline` (or `npm install` if no lockfile). `--ignore-scripts` blocks Shai-Hulud-style supply-chain attacks. Logs warning on failure but doesn't hard-fail (doc-only fixes don't need typecheck).

## Cost
+30-60s per /fix run, only once. Worth it for CI-green-by-construction guarantee.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>