### PR TITLE
fix(hermes): bot/ deps install + prose-wrapped JSON tolerance + Coder soft-fail

### DIFF
--- a/bot/src/hermes/coder.ts
+++ b/bot/src/hermes/coder.ts
@@ -144,15 +144,27 @@ export async function runFixer(input: FixerInput): Promise<FixerOutput> {
 }
 
 function parseJsonStrict<T>(text: string): T {
-  const cleaned = text
+  // Strip code fences if present
+  let cleaned = text
     .replace(/^\s*```(?:json)?\s*/i, '')
     .replace(/\s*```\s*$/i, '')
     .trim();
+
+  // Coder occasionally writes prose before/after the JSON object.
+  // Extract the largest balanced { ... } block and try parsing that.
+  if (!cleaned.startsWith('{')) {
+    const firstBrace = cleaned.indexOf('{');
+    const lastBrace = cleaned.lastIndexOf('}');
+    if (firstBrace !== -1 && lastBrace > firstBrace) {
+      cleaned = cleaned.slice(firstBrace, lastBrace + 1);
+    }
+  }
+
   try {
     return JSON.parse(cleaned) as T;
   } catch (err) {
     throw new Error(
-      `Stock-Coder returned non-JSON. First 200 chars: ${cleaned.slice(0, 200)}. Parse error: ${err instanceof Error ? err.message : String(err)}`,
+      `Stock-Coder returned non-JSON. First 300 chars: ${text.slice(0, 300)}. Parse error: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -92,11 +92,35 @@ export async function cloneAndBranch(
     workdir,
   );
   if (install.exitCode !== 0) {
-    // Don't hard-fail; pre-flight will surface specific errors. Some hermes runs
-    // might not need typecheck (e.g. doc-only changes). Log + continue.
     console.error(
       `[hermes/git] npm ${installCmd} returned exit ${install.exitCode}. Pre-flight may fail. stderr: ${install.stderr.slice(0, 300)}`,
     );
+  }
+
+  // ALSO install bot/ deps. ZAO is not a real workspace (no pnpm-workspace
+  // entry for bot, has own package-lock.json) so root install doesn't pull
+  // grammy/supabase-js into bot/node_modules. Without this the bot-side
+  // typecheck fails with "Cannot find module 'grammy'".
+  const botLockExists = await fs
+    .access(`${workdir}/bot/package-lock.json`)
+    .then(() => true)
+    .catch(() => false);
+  const botPkgExists = await fs
+    .access(`${workdir}/bot/package.json`)
+    .then(() => true)
+    .catch(() => false);
+  if (botPkgExists) {
+    const botInstallCmd = botLockExists ? 'ci' : 'install';
+    const botInstall = await runCmd(
+      'npm',
+      [botInstallCmd, '--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'],
+      `${workdir}/bot`,
+    );
+    if (botInstall.exitCode !== 0) {
+      console.error(
+        `[hermes/git] bot npm ${botInstallCmd} returned exit ${botInstall.exitCode}. Pre-flight may fail. stderr: ${botInstall.stderr.slice(0, 300)}`,
+      );
+    }
   }
 
   // Install pre-commit hook to reject any commit that contains conflict markers.

--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -118,13 +118,25 @@ export async function dispatchHermesRun(
       await updateRun(created.id, { fixer_attempts: attempt, status: 'fixing' });
       await narrator?.onCoderStart?.(created.id, attempt, HERMES_DEFAULT_MAX_ATTEMPTS, input.issue_text);
 
-      const fixerOut = await runFixer({
-        issueText: input.issue_text,
-        workTreePath: workdir,
-        branchName,
-        attemptNumber: attempt,
-        previousCriticFeedback: lastFeedback,
-      });
+      let fixerOut;
+      try {
+        fixerOut = await runFixer({
+          issueText: input.issue_text,
+          workTreePath: workdir,
+          branchName,
+          attemptNumber: attempt,
+          previousCriticFeedback: lastFeedback,
+        });
+      } catch (err) {
+        // Coder's individual call failed (non-JSON output, CLI crash, etc).
+        // Treat as a soft failure - loop back rather than crashing the whole run.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[hermes/runner] fixer attempt ${attempt} threw: ${msg.slice(0, 300)}`);
+        lastFeedback = `Your previous response was not valid JSON. Output ONLY the JSON object per the system prompt - no prose before or after. Original error: ${msg.slice(0, 300)}`;
+        await narrator?.onRetry?.(created.id, attempt + 1, 'Coder returned non-JSON; retrying with stricter format reminder');
+        await resetToMain(workdir);
+        continue;
+      }
       totalIn += fixerOut.inputTokens;
       totalOut += fixerOut.outputTokens;
 


### PR DESCRIPTION
## Summary
Run b6998ebd hit two issues:

1. **Bot typecheck couldn't find `grammy` module** - root `npm ci` doesn't install bot/ deps because ZAO isn't a real npm workspace (root has pnpm-workspace.yaml; bot/ has its own package-lock.json).
2. **Coder attempt 2 wrapped JSON in prose** - parseJsonStrict threw, runner caught + marked 'failed' instead of looping.

## Fixes
- `git.ts`: cloneAndBranch ALSO runs `cd bot && npm ci --ignore-scripts` if bot/package.json exists
- `coder.ts`: parseJsonStrict extracts largest balanced { ... } block from prose-wrapped output before parsing
- `runner.ts`: try/catch around runFixer. On throw (non-JSON, CLI crash, etc), loop as soft failure with stricter format reminder, not hard run-failed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>