### PR TITLE
feat(bot): add /uptime command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -384,6 +384,11 @@ bot.command('version', async (ctx) => {
   await ctx.reply('v1.6 hermes loop');
 });
 
+bot.command('uptime', async (ctx) => {
+  const seconds = Math.floor(process.uptime());
+  await ctx.reply(`Bot has been alive for ${seconds} seconds`);
+});
+
 bot.command('health', async (ctx) => {
   if (!isAdmin(ctx)) {
     await ctx.reply('Admin only.');


### PR DESCRIPTION
## Summary
- Adds `/uptime` command to the Telegram bot that replies with `Bot has been alive for X seconds`
- Uses `process.uptime()` (floored to integer) for the value
- Placed next to the existing `/version` command for logical grouping

## Test plan
- [ ] Send `/uptime` in a DM to the bot, verify it replies with the expected format
- [ ] Confirm `/version` and other commands still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by Hermes Stock-Coder via Claude Code CLI (Max plan auth, model: opus). Verified by Hermes-Stock Critic before this PR opened._

_Rationale:_ The bot had no /uptime command. Added a simple handler next to /version that returns process.uptime() floored to whole seconds.

**Critic score:** 97/100
**Critic feedback:** Correct, minimal, matches issue exactly. No auth guard — /version and /health are also unguarded, so consistent. No security concerns. Could restrict to admin like /health, but issue doesn't require it.