### PR TITLE
feat(bot): add /ping command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -380,6 +380,10 @@ bot.command('whoami', async (ctx) => {
   );
 });
 
+bot.command('ping', async (ctx) => {
+  await ctx.reply(`pong ${Date.now()}`);
+});
+
 bot.command('version', async (ctx) => {
   await ctx.reply('v1.6 hermes loop');
 });


### PR DESCRIPTION
## Summary
- Adds a `/ping` command to `bot/src/index.ts` that replies `pong <millisecond timestamp>` using `Date.now()`
- Useful for checking bot liveness and round-trip latency

## Test plan
- [ ] Send `/ping` to the bot in Telegram, verify it replies `pong <number>`
- [ ] Verify existing commands still work (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by Hermes Stock-Coder via Claude Code CLI (Max plan auth, model: opus). Verified by Hermes-Stock Critic before this PR opened._

_Rationale:_ Issue requests a /ping command that replies "pong" with Date.now(). Added a simple bot.command handler next to the existing /version command.

**Critic score:** 97/100
**Critic feedback:** Correct, minimal, no security issues. Minor: timestamp could be labeled for clarity (e.g. 'pong 1745000000000ms') but not required. Ships as-is.