### PR TITLE
feat(bot): add build date to /version command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -381,7 +381,8 @@ bot.command('whoami', async (ctx) => {
 });
 
 bot.command('version', async (ctx) => {
-  await ctx.reply('v1.6 hermes loop');
+  const buildDate = new Date().toISOString().slice(0, 10);
+  await ctx.reply(`v1.6 hermes loop (build: ${buildDate})`);
 });
 
 bot.command('health', async (ctx) => {


### PR DESCRIPTION
## Summary
- Updated `/version` command in `bot/src/index.ts` to include the current date
- Output changes from `v1.6 hermes loop` to `v1.6 hermes loop (build: YYYY-MM-DD)`
- Uses `new Date().toISOString().slice(0, 10)` as specified in the issue

## Test plan
- [ ] Send `/version` to the bot and verify the response includes today's date in `YYYY-MM-DD` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by Hermes Stock-Coder via Claude Code CLI (Max plan auth, model: opus). Verified by Hermes-Stock Critic before this PR opened._

_Rationale:_ The /version command returned a static string. Updated it to also include the current date via `new Date().toISOString().slice(0, 10)` as requested.

**Critic score:** 72/100
**Critic feedback:** Works and matches issue. Minor: new Date() returns runtime date, not a static build date — each call shows today's date, not when the bot was deployed. Acceptable for now but misleading label.