### PR TITLE
feat(stock-team): onboarding checklist + completeness + better save feedback + login refresh

### DIFF
--- a/src/app/stock/team/BioEditor.tsx
+++ b/src/app/stock/team/BioEditor.tsx
@@ -50,9 +50,21 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
   const [msg, setMsg] = useState<string | null>(null);
   const [photoBroken, setPhotoBroken] = useState(false);
   const [previewMode, setPreviewMode] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const isAdvisor = initialRole === 'advisory';
+
+  // Profile completeness across the four fields the team page shows
+  const completeness = (() => {
+    let pct = 0;
+    if (bio.trim().length >= 30) pct += 40;
+    else if (bio.trim().length > 0) pct += 20;
+    if (photoUrl.trim().length > 0) pct += 30;
+    if (scope.trim().length > 0 || isAdvisor) pct += 20;
+    if (links.trim().length > 0) pct += 10;
+    return pct;
+  })();
 
   // ----- Markdown formatting helpers -----------------------------------------
   function applyToSelection(transform: (selected: string, before: string, after: string) => { text: string; cursorOffset?: number }) {
@@ -118,6 +130,7 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
   async function save() {
     setBusy(true);
     setMsg(null);
+    setSaveError(null);
     try {
       const res = await fetch('/api/stock/team/profile', {
         method: 'PATCH',
@@ -125,16 +138,22 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
         body: JSON.stringify({ bio, links, photo_url: photoUrl, scope }),
       });
       if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        setMsg(data.error || 'Save failed');
+        const data = await res.json().catch(() => null);
+        const fallback = res.status === 401
+          ? 'Session expired. Refresh the page and log in again.'
+          : res.status === 413
+            ? 'Bio is too long - keep it under 2000 characters.'
+            : `Save failed (HTTP ${res.status})`;
+        setSaveError(data?.error || fallback);
       } else {
         setEditing(false);
         setPhotoBroken(false);
-        setMsg('Saved');
-        setTimeout(() => setMsg(null), 1500);
+        setMsg('Profile saved');
+        setTimeout(() => setMsg(null), 2500);
       }
-    } catch {
-      setMsg('Network error');
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Unknown';
+      setSaveError(`Network error - ${message}. Check your connection and try again.`);
     } finally {
       setBusy(false);
     }
@@ -145,8 +164,14 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
 
   return (
     <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08] space-y-3">
-      <div className="flex items-center justify-between">
-        <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Your Profile</p>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Your Profile</p>
+          <span className="text-[10px] text-gray-600">·</span>
+          <span className={`text-[10px] font-bold ${completeness === 100 ? 'text-emerald-400' : completeness >= 60 ? 'text-amber-300' : 'text-gray-500'}`}>
+            {completeness}% complete
+          </span>
+        </div>
         {!editing && hasBio && (
           <button
             onClick={() => setEditing(true)}
@@ -155,6 +180,12 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
             Edit
           </button>
         )}
+      </div>
+      <div className="h-0.5 w-full bg-[#0a1628] rounded-full overflow-hidden -mt-2">
+        <div
+          className={`h-full transition-all duration-500 ${completeness === 100 ? 'bg-emerald-400' : 'bg-[#f5a623]'}`}
+          style={{ width: `${completeness}%` }}
+        />
       </div>
 
       {!editing && hasBio && (
@@ -334,24 +365,35 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
             </div>
           )}
 
-          <div className="flex items-center gap-2">
+          {saveError && (
+            <div className="bg-red-500/10 border border-red-500/40 rounded-lg px-3 py-2.5 text-[12px] text-red-300 leading-relaxed">
+              <strong className="text-red-200">Couldn&rsquo;t save.</strong> {saveError}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3 flex-wrap">
             <button
               onClick={save}
               disabled={busy}
-              className="bg-[#f5a623] hover:bg-[#ffd700] disabled:opacity-50 text-black font-bold rounded px-3 py-1.5 text-xs transition-colors"
+              className="bg-[#f5a623] hover:bg-[#ffd700] disabled:opacity-50 text-black font-bold rounded px-4 py-2 text-sm transition-colors min-w-[88px]"
             >
               {busy ? 'Saving...' : 'Save'}
             </button>
             {hasBio && (
               <button
-                onClick={() => setEditing(false)}
+                onClick={() => { setEditing(false); setSaveError(null); }}
                 disabled={busy}
-                className="text-xs text-gray-500 hover:text-gray-300"
+                className="text-xs text-gray-500 hover:text-gray-300 px-2 py-1"
               >
                 Cancel
               </button>
             )}
-            {msg && <p className="text-[10px] text-emerald-400 ml-auto">{msg}</p>}
+            {msg && (
+              <div className="flex items-center gap-1.5 ml-auto bg-emerald-500/10 border border-emerald-500/40 rounded-full px-3 py-1">
+                <span className="text-emerald-400 text-xs" aria-hidden>&#10003;</span>
+                <span className="text-[11px] text-emerald-300 font-medium">{msg}</span>
+              </div>
+            )}
           </div>
           <p className="text-[10px] text-gray-600 italic">
             For the photo: right-click your X or Farcaster profile pic, Copy Image Address, paste above. Or use any image URL that starts with https://.

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -128,6 +128,8 @@ interface Props {
   rsvps: Rsvp[];
   budget: BudgetEntry[];
   meetingNotes: Note[];
+  myCirclesCount?: number;
+  myActivityCount?: number;
 }
 
 export function Dashboard({
@@ -143,6 +145,8 @@ export function Dashboard({
   rsvps,
   budget,
   meetingNotes,
+  myCirclesCount = 0,
+  myActivityCount = 0,
 }: Props) {
   const router = useRouter();
   const [tab, setTabRaw] = useState<Tab>('home');
@@ -251,6 +255,8 @@ export function Dashboard({
               artists={artists}
               milestones={milestones}
               onNavigate={(t) => setTab(t)}
+              inAnyCircle={myCirclesCount > 0}
+              hasFirstActivity={myActivityCount > 0}
             />
           </>
         )}

--- a/src/app/stock/team/LoginForm.tsx
+++ b/src/app/stock/team/LoginForm.tsx
@@ -36,38 +36,59 @@ export function LoginForm() {
   }
 
   return (
-    <div className="min-h-[100dvh] bg-[#0a1628] flex items-center justify-center px-4">
+    <div className="min-h-[100dvh] bg-[#0a1628] flex items-center justify-center px-4 py-10">
       <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold text-white">ZAOstock Team</h1>
-          <p className="text-sm text-gray-400 mt-2">Enter your 4-letter code</p>
-          <p className="text-[11px] text-gray-600 mt-1">First 4 letters of your name (any case)</p>
+        <div className="text-center mb-6">
+          <p className="text-[10px] text-[#f5a623] uppercase tracking-[0.3em] font-bold">ZAO Festivals presents</p>
+          <h1 className="text-3xl font-black text-white mt-1">ZAOstock 2026</h1>
+          <p className="text-xs text-gray-400 mt-1">Team Dashboard</p>
         </div>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            inputMode="text"
-            autoCapitalize="characters"
-            autoComplete="off"
-            maxLength={4}
-            placeholder="CODE"
-            value={code}
-            onChange={(e) => setCode(e.target.value.toUpperCase().slice(0, 4))}
-            required
-            className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-lg px-4 py-4 text-2xl font-bold text-white text-center tracking-[0.5em] placeholder-gray-700 focus:outline-none focus:border-[#f5a623]/50"
-          />
-          <button
-            type="submit"
-            disabled={loading || code.length < 2}
-            className="w-full bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors disabled:opacity-50"
-          >
-            {loading ? 'Signing in...' : 'Sign In'}
-          </button>
-          {error && <p className="text-red-400 text-xs text-center">{error}</p>}
-        </form>
-        <p className="text-[10px] text-gray-600 text-center mt-8">
-          Lost your code? Ask Zaal.
-        </p>
+
+        <div className="bg-[#0d1b2a] border border-white/[0.08] rounded-xl p-5 mb-4">
+          <p className="text-sm text-gray-300 mb-3">
+            <strong className="text-white">First time here?</strong> Zaal sent you a 4-letter code. Drop it below and you&rsquo;re in.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <input
+              type="text"
+              inputMode="text"
+              autoCapitalize="characters"
+              autoComplete="off"
+              maxLength={4}
+              placeholder="CODE"
+              value={code}
+              onChange={(e) => setCode(e.target.value.toUpperCase().slice(0, 4))}
+              required
+              className="w-full bg-[#0a1628] border border-white/[0.08] rounded-lg px-4 py-4 text-2xl font-bold text-white text-center tracking-[0.5em] placeholder-gray-700 focus:outline-none focus:border-[#f5a623]/50"
+            />
+            <button
+              type="submit"
+              disabled={loading || code.length < 4}
+              className="w-full bg-[#f5a623] hover:bg-[#ffd700] text-black font-bold rounded-lg px-4 py-3 text-sm transition-colors disabled:opacity-50"
+            >
+              {loading ? 'Signing in...' : 'Sign In'}
+            </button>
+            {error && (
+              <div className="bg-red-500/10 border border-red-500/30 rounded px-3 py-2">
+                <p className="text-red-300 text-xs">{error}</p>
+                {error.toLowerCase().includes('invalid') && (
+                  <p className="text-red-400/70 text-[11px] mt-1">
+                    Codes are 4 characters from {'A-Z'} and {'2-9'}. No 0/O/1/I/L. Check the DM Zaal sent.
+                  </p>
+                )}
+              </div>
+            )}
+          </form>
+        </div>
+
+        <div className="space-y-2 text-[11px] text-gray-500 text-center">
+          <p><strong className="text-gray-400">No code yet?</strong> DM <a href="https://x.com/bettercallzaal" target="_blank" rel="noreferrer" className="text-[#f5a623] hover:underline">@bettercallzaal</a> on X or Telegram.</p>
+          <p>
+            <a href="/stock/onepagers/overview" className="text-[#f5a623] hover:underline">What is ZAOstock?</a>
+            {' · '}
+            <a href="/stock" className="text-[#f5a623] hover:underline">Public site</a>
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/app/stock/team/OnboardingChecklist.tsx
+++ b/src/app/stock/team/OnboardingChecklist.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useMemo } from 'react';
+
+interface Member {
+  bio?: string;
+  links?: string;
+  photo_url?: string;
+  scope?: string;
+}
+
+interface Props {
+  member: Member;
+  inAnyCircle: boolean;
+  hasFirstActivity: boolean;
+}
+
+interface ChecklistItem {
+  key: string;
+  done: boolean;
+  label: string;
+  hint: string;
+  weight: number;
+}
+
+export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: Props) {
+  const items: ChecklistItem[] = useMemo(() => [
+    {
+      key: 'bio',
+      done: Boolean((member.bio ?? '').trim().length >= 30),
+      label: 'Add a bio (1-3 sentences)',
+      hint: 'Click "Your Profile" above. Tell the team who you are and what you bring.',
+      weight: 30,
+    },
+    {
+      key: 'photo',
+      done: Boolean((member.photo_url ?? '').trim()),
+      label: 'Add a profile photo',
+      hint: 'Right-click your X or Farcaster avatar -> Copy image address -> paste in Your Profile.',
+      weight: 20,
+    },
+    {
+      key: 'scope',
+      done: Boolean((member.scope ?? '').trim()),
+      label: 'Pick your team',
+      hint: 'Operations, Music, or Design. Affects which todos surface for you.',
+      weight: 15,
+    },
+    {
+      key: 'links',
+      done: Boolean((member.links ?? '').trim()),
+      label: 'Drop a link or two',
+      hint: 'X handle, Farcaster, your music, anything.',
+      weight: 10,
+    },
+    {
+      key: 'circle',
+      done: inAnyCircle,
+      label: 'Join a circle in the bot',
+      hint: 'DM @ZAOstockTeamBot, send /circles, then /join <slug>. Music, ops, partners, finance, merch, marketing, media, host.',
+      weight: 15,
+    },
+    {
+      key: 'activity',
+      done: hasFirstActivity,
+      label: 'Say hi or log your first contribution',
+      hint: 'Use the Quick Add box above to log something you worked on, or send /idea in the bot.',
+      weight: 10,
+    },
+  ], [member, inAnyCircle, hasFirstActivity]);
+
+  const completedWeight = items.filter((i) => i.done).reduce((sum, i) => sum + i.weight, 0);
+  const totalWeight = items.reduce((sum, i) => sum + i.weight, 0);
+  const pct = Math.round((completedWeight / totalWeight) * 100);
+  const allDone = items.every((i) => i.done);
+
+  if (allDone) return null;
+
+  const remaining = items.filter((i) => !i.done);
+  const completed = items.filter((i) => i.done);
+
+  return (
+    <div className="bg-[#0d1b2a] rounded-xl p-4 border border-[#f5a623]/30 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Get started</p>
+          <p className="text-sm text-white mt-0.5">
+            {pct === 0 ? 'Welcome - quick onboarding below' : `Profile ${pct}% complete - ${remaining.length} thing${remaining.length === 1 ? '' : 's'} left`}
+          </p>
+        </div>
+        <div className="text-right flex-shrink-0">
+          <p className="text-2xl font-bold text-[#f5a623]">{pct}%</p>
+        </div>
+      </div>
+
+      <div className="h-1.5 w-full bg-[#0a1628] rounded-full overflow-hidden">
+        <div
+          className="h-full bg-[#f5a623] transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      <ul className="space-y-2">
+        {remaining.map((item) => (
+          <li key={item.key} className="flex items-start gap-2.5 text-sm">
+            <span className="mt-0.5 inline-block w-4 h-4 rounded border border-white/20 flex-shrink-0" aria-hidden />
+            <div className="min-w-0 flex-1">
+              <div className="text-gray-200 font-medium">{item.label}</div>
+              <div className="text-[11px] text-gray-500 mt-0.5">{item.hint}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {completed.length > 0 && (
+        <details className="text-[11px] text-gray-500">
+          <summary className="cursor-pointer hover:text-gray-400 select-none">
+            {completed.length} done
+          </summary>
+          <ul className="mt-1 space-y-1 pl-2">
+            {completed.map((item) => (
+              <li key={item.key} className="flex items-center gap-2 text-gray-500 line-through">
+                <span aria-hidden>&#10003;</span>
+                <span>{item.label}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/app/stock/team/PersonalHome.tsx
+++ b/src/app/stock/team/PersonalHome.tsx
@@ -5,6 +5,7 @@ import { ResearchLinks } from './ResearchLinks';
 import { FestivalProgress } from './FestivalProgress';
 import { QuickAdd } from './QuickAdd';
 import { BioEditor } from './BioEditor';
+import { OnboardingChecklist } from './OnboardingChecklist';
 
 const FESTIVAL_DATE = new Date('2026-10-03T12:00:00-04:00');
 
@@ -55,6 +56,8 @@ interface Props {
   artists: Artist[];
   milestones: Milestone[];
   onNavigate: (tab: 'sponsors' | 'artists' | 'timeline' | 'overview') => void;
+  inAnyCircle?: boolean;
+  hasFirstActivity?: boolean;
 }
 
 const TEAM_LABEL: Record<string, string> = {
@@ -89,7 +92,7 @@ function daysToDue(date: string): number {
   return Math.ceil((new Date(date + 'T00:00:00').getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-export function PersonalHome({ member, allMembers, todos, sponsors, artists, milestones, onNavigate }: Props) {
+export function PersonalHome({ member, allMembers, todos, sponsors, artists, milestones, onNavigate, inAnyCircle = false, hasFirstActivity = false }: Props) {
   const daysToFest = daysUntil(FESTIVAL_DATE);
 
   const myTodos = useMemo(() => todos.filter((t) => t.owner?.id === member.id), [todos, member.id]);
@@ -131,6 +134,13 @@ export function PersonalHome({ member, allMembers, todos, sponsors, artists, mil
 
   return (
     <div className="space-y-6">
+      {/* Onboarding checklist - hides itself once complete */}
+      <OnboardingChecklist
+        member={member}
+        inAnyCircle={inAnyCircle}
+        hasFirstActivity={hasFirstActivity}
+      />
+
       {/* Festival-wide progress */}
       <FestivalProgress sponsors={sponsors} artists={artists} milestones={milestones} />
 

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -31,6 +31,8 @@ export default async function StockTeamPage() {
     budgetRes,
     notesRes,
     rsvpsRes,
+    myCirclesRes,
+    myActivityRes,
   ] = await Promise.allSettled([
     supabase.from('stock_goals').select('*').order('sort_order'),
     supabase
@@ -75,6 +77,14 @@ export default async function StockTeamPage() {
       .select('id, name, email, created_at')
       .eq('event_slug', 'zao-stock-2026')
       .order('created_at', { ascending: false }),
+    supabase
+      .from('stock_circle_members')
+      .select('circle_id', { count: 'exact', head: true })
+      .eq('member_id', member.memberId),
+    supabase
+      .from('stock_activity_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('actor_id', member.memberId),
   ]);
 
   const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
@@ -87,6 +97,8 @@ export default async function StockTeamPage() {
   const budget = budgetRes.status === 'fulfilled' ? budgetRes.value.data || [] : [];
   const meetingNotes = notesRes.status === 'fulfilled' ? notesRes.value.data || [] : [];
   const rsvps = rsvpsRes.status === 'fulfilled' ? rsvpsRes.value.data || [] : [];
+  const myCirclesCount = myCirclesRes.status === 'fulfilled' ? myCirclesRes.value.count ?? 0 : 0;
+  const myActivityCount = myActivityRes.status === 'fulfilled' ? myActivityRes.value.count ?? 0 : 0;
 
   return (
     <Dashboard
@@ -102,6 +114,8 @@ export default async function StockTeamPage() {
       rsvps={rsvps}
       budget={budget}
       meetingNotes={meetingNotes}
+      myCirclesCount={myCirclesCount}
+      myActivityCount={myActivityCount}
     />
   );
 }


### PR DESCRIPTION
## Summary

Pass A of the dashboard UX audit. Four small wins, zero new dependencies. New people landing on \`/stock/team\` now know what to do, can see how done their profile is, and get real feedback when they save.

### What changed

1. **Onboarding checklist** at the top of the dashboard. 6 items weighted by impact (bio 30, photo 20, scope 15, links 10, join a circle 15, log first activity 10). Hides itself once everything is done. Per-item hints tell people HOW to complete each step.

2. **Profile completeness %** lives in the BioEditor card header. 40 bio + 30 photo + 20 scope + 10 links. Color-coded (gray <60%, amber 60-99%, emerald 100%) with a thin progress bar.

3. **Better save feedback** — errors as a sticky red box with HTTP-aware messages (401 = session expired, 413 = too long, network errors include the actual error). Success as a green pill with checkmark, sticks 2.5s instead of 1.5s.

4. **Login form refresh** — first-time-friendly copy, public links to /stock and /stock/onepagers/overview, \"no code yet?\" pointer to Zaal, brand chrome (\"ZAO Festivals presents ZAOstock 2026\"), invalid-code hint shows the alphabet rule.

### Plumbing
\`page.tsx\` now also queries \`stock_circle_members\` count and \`stock_activity_log\` count for the current member, threaded through Dashboard → PersonalHome → OnboardingChecklist.

### Test plan
- [ ] Log in as a member with empty bio → onboarding checklist shows with 6 unchecked items
- [ ] Add a bio → completeness % jumps to 40, checklist shows bio as done
- [ ] Add photo, links, scope → completeness rises, items check off
- [ ] All 6 done → onboarding checklist hides itself
- [ ] Save with bad input → red error box with helpful text
- [ ] Save success → green pill confirms, lingers 2.5s
- [ ] Log out, hit /stock/team → new login UI shows public links

🤖 Generated with [Claude Code](https://claude.com/claude-code)