### PR TITLE
fix(devz): ESM import for node:http (PR #340 followup)

### DIFF
--- a/bot/src/devz/index.ts
+++ b/bot/src/devz/index.ts
@@ -23,6 +23,7 @@ import { dispatchHermesRun, type HermesNarrator } from '../hermes/runner';
 import { listOpenRuns, getRun } from '../hermes/db';
 import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
+import * as http from 'node:http';
 
 const devzToken = process.env.ZAO_DEVZ_BOT_TOKEN;
 const hermesToken = process.env.HERMES_BOT_TOKEN;
@@ -398,7 +399,6 @@ function startHermesHttpListener(): void {
     console.warn('[devz] HERMES_DISPATCH_SECRET not set - HTTP dispatch listener disabled');
     return;
   }
-  const http = require('node:http') as typeof import('node:http');
   http
     .createServer(async (req, res) => {
       if (req.method !== 'POST' || req.url !== '/hermes-dispatch') {


### PR DESCRIPTION
## Summary

- PR #340's `startHermesHttpListener` used `const http = require('node:http')` inside an ESM module (`bot/package.json` is `"type":"module"`), throwing `ReferenceError: require is not defined` at startup
- Caught in production: `zao-devz-stack` crash-looped ~353 times after deploy until VPS-side Claude patched the runtime copy
- This commit lands the same fix in source (top-level `import * as http from 'node:http'`) so the next runtime sync doesn't regress

## Test plan

- [x] `tsc --noEmit` passes
- [x] Runtime patched on VPS confirmed `[devz] hermes-dispatch HTTP listener on 127.0.0.1:3007`
- [ ] After merge: re-sync VPS to confirm source matches the live patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)