### PR TITLE
feat(stock-team): help page + team directory + status text + reach-out (Pass C1)

### DIFF
--- a/scripts/stock-team-status-text-migration.sql
+++ b/scripts/stock-team-status-text-migration.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- ZAOstock Team - add status_text column
+-- ============================================================================
+-- One short line per teammate describing what they're working on right now.
+-- Surfaces in the dashboard, on the public profile, and in the Team directory.
+--
+-- Idempotent. Safe to re-run.
+-- ============================================================================
+
+ALTER TABLE stock_team_members
+  ADD COLUMN IF NOT EXISTS status_text TEXT DEFAULT '';
+
+-- Verify
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_name = 'stock_team_members'
+  AND column_name = 'status_text';

--- a/src/app/api/stock/team/profile/route.ts
+++ b/src/app/api/stock/team/profile/route.ts
@@ -16,6 +16,7 @@ const patchSchema = z.object({
       { message: 'Photo URL must start with https://' },
     ),
   scope: z.enum(['', 'ops', 'music', 'design']).optional(),
+  status_text: z.string().max(140).optional(),
 });
 
 export async function PATCH(request: NextRequest) {
@@ -40,6 +41,7 @@ export async function PATCH(request: NextRequest) {
     if (parsed.data.links !== undefined) updates.links = parsed.data.links;
     if (parsed.data.photo_url !== undefined) updates.photo_url = parsed.data.photo_url;
     if (parsed.data.scope !== undefined) updates.scope = parsed.data.scope;
+    if (parsed.data.status_text !== undefined) updates.status_text = parsed.data.status_text;
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
@@ -50,7 +52,7 @@ export async function PATCH(request: NextRequest) {
       .from('stock_team_members')
       .update(updates)
       .eq('id', session.memberId)
-      .select('id, name, bio, links, photo_url')
+      .select('id, name, bio, links, photo_url, status_text')
       .single();
 
     if (error) {

--- a/src/app/stock/team/BioEditor.tsx
+++ b/src/app/stock/team/BioEditor.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { RichBioEditor } from './RichBioEditor';
+import { HelpIcon } from './HelpIcon';
 
 function splitLinks(raw: string): string[] {
   return raw
@@ -72,15 +73,17 @@ interface Props {
   initialPhotoUrl: string;
   initialScope: string;
   initialRole: string;
+  initialStatusText?: string;
 }
 
-export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUrl, initialScope, initialRole }: Props) {
+export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUrl, initialScope, initialRole, initialStatusText }: Props) {
   const [bio, setBio] = useState(initialBio);
   const [linkRows, setLinkRows] = useState<string[]>(() => {
     const initial = splitLinks(initialLinks);
     return initial.length > 0 ? initial : [''];
   });
   const links = useMemo(() => joinLinks(linkRows), [linkRows]);
+  const [statusText, setStatusText] = useState(initialStatusText ?? '');
   const [photoUrl, setPhotoUrl] = useState(initialPhotoUrl);
   const [scope, setScope] = useState(initialScope);
   const [editing, setEditing] = useState(initialBio.trim().length === 0);
@@ -110,7 +113,7 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
       const res = await fetch('/api/stock/team/profile', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bio, links, photo_url: photoUrl, scope }),
+        body: JSON.stringify({ bio, links, photo_url: photoUrl, scope, status_text: statusText }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
@@ -141,7 +144,10 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
     <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08] space-y-3">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 min-w-0">
-          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Your Profile</p>
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold flex items-center gap-1">
+            Your Profile
+            <HelpIcon section="profile" />
+          </p>
           <span className="text-[10px] text-gray-600">·</span>
           <span className={`text-[10px] font-bold ${completeness === 100 ? 'text-emerald-400' : completeness >= 60 ? 'text-amber-300' : 'text-gray-500'}`}>
             {completeness}% complete
@@ -174,6 +180,12 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
             />
           )}
           <div className="flex-1 min-w-0 space-y-1">
+            {statusText.trim() && (
+              <div className="flex items-center gap-1.5 text-[11px] text-emerald-300 mb-1">
+                <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block" />
+                <span className="truncate">{statusText}</span>
+              </div>
+            )}
             <div className="bio-rendered text-sm text-gray-200 leading-relaxed">
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{bio}</ReactMarkdown>
             </div>
@@ -212,6 +224,24 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
               className="w-20 h-20 rounded-full object-cover border border-[#f5a623]/30"
             />
           )}
+
+          <div className="space-y-1">
+            <label className="text-[10px] uppercase tracking-wider text-gray-500 font-bold flex items-center gap-1">
+              Status
+              <HelpIcon section="profile" />
+              <span className="text-gray-700 font-normal normal-case">(what you&rsquo;re working on right now)</span>
+            </label>
+            <div className="relative">
+              <span aria-hidden className="absolute left-2.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rounded-full bg-emerald-400" />
+              <input
+                value={statusText}
+                onChange={(e) => setStatusText(e.target.value)}
+                placeholder="e.g. drafting Roddy follow-up · prepping Cypher set · in flight"
+                maxLength={140}
+                className="w-full bg-[#0a1628] border border-white/[0.08] rounded pl-6 pr-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+              />
+            </div>
+          </div>
 
           <input
             value={photoUrl}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -120,7 +120,7 @@ interface Props {
   memberId: string;
   goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
   todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
-  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string }>;
+  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string }>;
   sponsors: Sponsor[];
   artists: Artist[];
   milestones: Milestone[];
@@ -176,6 +176,13 @@ export function Dashboard({
           </div>
           <div className="flex items-center gap-3">
             <span className="text-xs text-[#f5a623] font-medium">{memberName}</span>
+            <a
+              href="/stock/team/help"
+              className="text-xs text-gray-500 hover:text-[#f5a623]"
+              title="How to use the dashboard"
+            >
+              Help
+            </a>
             <button onClick={handleLogout} className="text-xs text-gray-500 hover:text-gray-300">
               Logout
             </button>

--- a/src/app/stock/team/HelpIcon.tsx
+++ b/src/app/stock/team/HelpIcon.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+
+interface Props {
+  section: string;
+  label?: string;
+}
+
+/**
+ * Tiny "?" icon that links to /stock/team/help#<section>.
+ * Drop next to any feature heading so users can self-serve.
+ */
+export function HelpIcon({ section, label = 'Help' }: Props) {
+  return (
+    <Link
+      href={`/stock/team/help#${section}`}
+      title={`What is this? Open the help page.`}
+      aria-label={label}
+      className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-white/[0.06] hover:bg-[#f5a623]/30 text-[10px] text-gray-400 hover:text-[#f5a623] transition-colors leading-none"
+    >
+      ?
+    </Link>
+  );
+}

--- a/src/app/stock/team/OnboardingChecklist.tsx
+++ b/src/app/stock/team/OnboardingChecklist.tsx
@@ -21,6 +21,20 @@ interface ChecklistItem {
   label: string;
   hint: string;
   weight: number;
+  // Where to scroll on click. 'anchor' is an element id on this page;
+  // 'href' wins if both are set (used for off-page nav like the bot link).
+  anchor?: string;
+  href?: string;
+}
+
+function scrollToAnchor(id: string) {
+  if (typeof window === 'undefined') return;
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  // Subtle pulse so the user sees what was targeted
+  el.classList.add('onboarding-pulse');
+  setTimeout(() => el.classList.remove('onboarding-pulse'), 1500);
 }
 
 export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: Props) {
@@ -28,44 +42,50 @@ export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: P
     {
       key: 'bio',
       done: Boolean((member.bio ?? '').trim().length >= 30),
-      label: 'Add a bio (1-3 sentences)',
-      hint: 'Click "Your Profile" above. Tell the team who you are and what you bring.',
+      label: 'Add a bio',
+      hint: '1-3 sentences. Who you are and what you bring.',
       weight: 30,
+      anchor: 'profile-anchor',
     },
     {
       key: 'photo',
       done: Boolean((member.photo_url ?? '').trim()),
       label: 'Add a profile photo',
-      hint: 'Right-click your X or Farcaster avatar -> Copy image address -> paste in Your Profile.',
+      hint: 'Right-click your X / Farcaster avatar -> Copy image address -> paste.',
       weight: 20,
+      anchor: 'profile-anchor',
     },
     {
       key: 'scope',
       done: Boolean((member.scope ?? '').trim()),
       label: 'Pick your team',
-      hint: 'Operations, Music, or Design. Affects which todos surface for you.',
+      hint: 'Operations, Music, or Design. Filters which todos you see.',
       weight: 15,
+      anchor: 'profile-anchor',
     },
     {
       key: 'links',
       done: Boolean((member.links ?? '').trim()),
       label: 'Drop a link or two',
-      hint: 'X handle, Farcaster, your music, anything.',
+      hint: 'X, Farcaster, your music, anything. Hit + Add another link for more.',
       weight: 10,
+      anchor: 'profile-anchor',
     },
     {
       key: 'circle',
       done: inAnyCircle,
       label: 'Join a circle in the bot',
-      hint: 'DM @ZAOstockTeamBot, send /circles, then /join <slug>. Music, ops, partners, finance, merch, marketing, media, host.',
+      hint: 'DM @ZAOstockTeamBot, send /circles, then /join <slug>.',
       weight: 15,
+      href: 'https://t.me/ZAOstockTeamBot',
     },
     {
       key: 'activity',
       done: hasFirstActivity,
-      label: 'Say hi or log your first contribution',
-      hint: 'Use the Quick Add box above to log something you worked on, or send /idea in the bot.',
+      label: 'Log your first contribution',
+      hint: 'Use the Quick Add box or send /idea in the bot.',
       weight: 10,
+      anchor: 'quick-add-anchor',
     },
   ], [member, inAnyCircle, hasFirstActivity]);
 
@@ -76,8 +96,16 @@ export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: P
 
   if (allDone) return null;
 
-  const remaining = items.filter((i) => !i.done);
-  const completed = items.filter((i) => i.done);
+  // First not-done item is the "active" one. Anything past it is greyed.
+  const firstUndoneIdx = items.findIndex((i) => !i.done);
+
+  function handleClick(item: ChecklistItem) {
+    if (item.href) {
+      window.open(item.href, '_blank', 'noopener,noreferrer');
+      return;
+    }
+    if (item.anchor) scrollToAnchor(item.anchor);
+  }
 
   return (
     <div className="bg-[#0d1b2a] rounded-xl p-4 border border-[#f5a623]/30 space-y-3">
@@ -85,7 +113,9 @@ export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: P
         <div>
           <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Get started</p>
           <p className="text-sm text-white mt-0.5">
-            {pct === 0 ? 'Welcome - quick onboarding below' : `Profile ${pct}% complete - ${remaining.length} thing${remaining.length === 1 ? '' : 's'} left`}
+            {pct === 0
+              ? 'Welcome - 6 quick steps to a complete profile'
+              : `Profile ${pct}% complete - click the next step to jump there`}
           </p>
         </div>
         <div className="text-right flex-shrink-0">
@@ -100,33 +130,91 @@ export function OnboardingChecklist({ member, inAnyCircle, hasFirstActivity }: P
         />
       </div>
 
-      <ul className="space-y-2">
-        {remaining.map((item) => (
-          <li key={item.key} className="flex items-start gap-2.5 text-sm">
-            <span className="mt-0.5 inline-block w-4 h-4 rounded border border-white/20 flex-shrink-0" aria-hidden />
-            <div className="min-w-0 flex-1">
-              <div className="text-gray-200 font-medium">{item.label}</div>
-              <div className="text-[11px] text-gray-500 mt-0.5">{item.hint}</div>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <ol className="space-y-1.5">
+        {items.map((item, i) => {
+          const stepNum = i + 1;
+          const isActive = !item.done && i === firstUndoneIdx;
+          const isFuture = !item.done && i > firstUndoneIdx;
+          const clickable = !item.done;
 
-      {completed.length > 0 && (
-        <details className="text-[11px] text-gray-500">
-          <summary className="cursor-pointer hover:text-gray-400 select-none">
-            {completed.length} done
-          </summary>
-          <ul className="mt-1 space-y-1 pl-2">
-            {completed.map((item) => (
-              <li key={item.key} className="flex items-center gap-2 text-gray-500 line-through">
-                <span aria-hidden>&#10003;</span>
-                <span>{item.label}</span>
-              </li>
-            ))}
-          </ul>
-        </details>
-      )}
+          return (
+            <li key={item.key}>
+              <button
+                type="button"
+                disabled={!clickable}
+                onClick={() => handleClick(item)}
+                className={`w-full text-left flex items-start gap-2.5 p-2 rounded-lg transition-colors ${
+                  isActive
+                    ? 'bg-[#f5a623]/10 border border-[#f5a623]/30 hover:bg-[#f5a623]/15 cursor-pointer'
+                    : isFuture
+                      ? 'border border-white/[0.04] cursor-pointer hover:bg-white/[0.02] opacity-60'
+                      : 'border border-emerald-500/20 bg-emerald-500/[0.04] cursor-default opacity-70'
+                }`}
+              >
+                <span
+                  className={`mt-0.5 inline-flex items-center justify-center w-5 h-5 rounded-full flex-shrink-0 text-[10px] font-bold ${
+                    item.done
+                      ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/40'
+                      : isActive
+                        ? 'bg-[#f5a623]/20 text-[#f5a623] border border-[#f5a623]/50'
+                        : 'bg-white/[0.04] text-gray-600 border border-white/[0.08]'
+                  }`}
+                  aria-hidden
+                >
+                  {item.done ? '✓' : stepNum}
+                </span>
+
+                <div className="min-w-0 flex-1">
+                  <div
+                    className={`text-sm font-medium leading-snug ${
+                      item.done
+                        ? 'text-emerald-300/70 line-through'
+                        : isActive
+                          ? 'text-white'
+                          : 'text-gray-500'
+                    }`}
+                  >
+                    Step {stepNum}: {item.label}
+                    {isActive && (
+                      <span className="ml-2 text-[10px] uppercase tracking-wider font-bold text-[#f5a623]">
+                        Next
+                      </span>
+                    )}
+                  </div>
+                  <div
+                    className={`text-[11px] mt-0.5 leading-relaxed ${
+                      isActive ? 'text-gray-300' : 'text-gray-600'
+                    }`}
+                  >
+                    {item.hint}
+                  </div>
+                </div>
+
+                {clickable && (
+                  <span
+                    className={`text-base flex-shrink-0 self-center ${
+                      isActive ? 'text-[#f5a623]' : 'text-gray-700'
+                    }`}
+                    aria-hidden
+                  >
+                    &rarr;
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+
+      <style>{`
+        .onboarding-pulse {
+          animation: onboarding-pulse 1.5s ease-out;
+        }
+        @keyframes onboarding-pulse {
+          0% { box-shadow: 0 0 0 0 rgba(245, 166, 35, 0.5); }
+          100% { box-shadow: 0 0 0 16px rgba(245, 166, 35, 0); }
+        }
+      `}</style>
     </div>
   );
 }

--- a/src/app/stock/team/PersonalHome.tsx
+++ b/src/app/stock/team/PersonalHome.tsx
@@ -145,18 +145,22 @@ export function PersonalHome({ member, allMembers, todos, sponsors, artists, mil
       <FestivalProgress sponsors={sponsors} artists={artists} milestones={milestones} />
 
       {/* Quick add */}
-      <QuickAdd currentMemberId={member.id} />
+      <div id="quick-add-anchor" className="scroll-mt-24">
+        <QuickAdd currentMemberId={member.id} />
+      </div>
 
       {/* Bio editor */}
-      <BioEditor
-        memberName={member.name}
-        initialBio={member.bio || ''}
-        initialLinks={member.links || ''}
-        initialPhotoUrl={member.photo_url || ''}
-        initialScope={member.scope || ''}
-        initialRole={member.role || 'member'}
-        initialStatusText={member.status_text || ''}
-      />
+      <div id="profile-anchor" className="scroll-mt-24">
+        <BioEditor
+          memberName={member.name}
+          initialBio={member.bio || ''}
+          initialLinks={member.links || ''}
+          initialPhotoUrl={member.photo_url || ''}
+          initialScope={member.scope || ''}
+          initialRole={member.role || 'member'}
+          initialStatusText={member.status_text || ''}
+        />
+      </div>
 
       {/* Welcome banner */}
       <div className="bg-gradient-to-br from-[#f5a623]/20 via-[#f5a623]/5 to-transparent rounded-xl p-5 border border-[#f5a623]/30">

--- a/src/app/stock/team/PersonalHome.tsx
+++ b/src/app/stock/team/PersonalHome.tsx
@@ -9,7 +9,7 @@ import { OnboardingChecklist } from './OnboardingChecklist';
 
 const FESTIVAL_DATE = new Date('2026-10-03T12:00:00-04:00');
 
-interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; }
+interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string; }
 
 interface Todo {
   id: string;
@@ -155,6 +155,7 @@ export function PersonalHome({ member, allMembers, todos, sponsors, artists, mil
         initialPhotoUrl={member.photo_url || ''}
         initialScope={member.scope || ''}
         initialRole={member.role || 'member'}
+        initialStatusText={member.status_text || ''}
       />
 
       {/* Welcome banner */}

--- a/src/app/stock/team/TeamRoles.tsx
+++ b/src/app/stock/team/TeamRoles.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { slugify, parseLinks } from '@/lib/stock/members';
+import { slugify, parseLinks, type ParsedLink } from '@/lib/stock/members';
+import { HelpIcon } from './HelpIcon';
 
 interface Member {
   id: string;
@@ -13,6 +14,7 @@ interface Member {
   bio?: string;
   links?: string;
   photo_url?: string;
+  status_text?: string;
 }
 
 const SCOPE_LABEL: Record<string, string> = {
@@ -35,24 +37,98 @@ const ROLE_LABEL: Record<string, string> = {
   member: 'Member',
 };
 
+const ALL_SCOPES = ['', 'ops', 'music', 'finance', 'design'];
+
+function pickReachOutLink(links: ParsedLink[]): ParsedLink | null {
+  // Prefer X handle, then Farcaster, then email, then any link.
+  return (
+    links.find((l) => /x\.com|twitter\.com/i.test(l.href)) ||
+    links.find((l) => /farcaster|warpcast/i.test(l.href)) ||
+    links.find((l) => l.href.startsWith('mailto:')) ||
+    links[0] ||
+    null
+  );
+}
+
 export function TeamRoles({ members }: { members: Member[] }) {
+  const [query, setQuery] = useState('');
+  const [scopeFilter, setScopeFilter] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return members.filter((m) => {
+      if (scopeFilter && m.scope !== scopeFilter) return false;
+      if (!q) return true;
+      const haystack = `${m.name} ${m.bio ?? ''} ${m.links ?? ''} ${m.scope ?? ''} ${m.role ?? ''} ${m.status_text ?? ''}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [members, query, scopeFilter]);
+
   return (
     <div className="space-y-3">
-      <h2 className="text-lg font-bold text-white">Team</h2>
-      <p className="text-xs text-gray-500">
-        Each teammate edits their own profile from the Home tab. If yours is blank, login and add a bio + photo.
-      </p>
-      <div className="space-y-2">
-        {members.map((m) => (
-          <MemberCard key={m.id} member={m} />
-        ))}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <h2 className="text-lg font-bold text-white flex items-center gap-1.5">
+          Team
+          <HelpIcon section="directory" />
+        </h2>
+        <span className="text-[11px] text-gray-500">{filtered.length} of {members.length}</span>
       </div>
+
+      <div className="flex gap-2 items-center flex-wrap">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search name, bio, link..."
+          className="flex-1 min-w-[160px] bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/40"
+        />
+        <div className="flex gap-1 flex-wrap">
+          {ALL_SCOPES.map((s) => (
+            <button
+              key={s || 'all'}
+              type="button"
+              onClick={() => setScopeFilter(s)}
+              className={`text-[10px] px-2 py-1 rounded border transition-colors ${
+                scopeFilter === s
+                  ? 'bg-[#f5a623]/15 border-[#f5a623]/50 text-[#f5a623]'
+                  : 'bg-[#0a1628] border-white/[0.08] text-gray-400 hover:border-white/20'
+              }`}
+            >
+              {s ? SCOPE_LABEL[s] || s : 'All'}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-500">
+        Each teammate edits their own profile from the Home tab. Click a name for the public profile, or hit &ldquo;Reach out&rdquo; to ping them.
+      </p>
+
+      {filtered.length === 0 ? (
+        <div className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-6 text-center">
+          <p className="text-sm text-gray-500">No teammates match.</p>
+          <button
+            type="button"
+            onClick={() => { setQuery(''); setScopeFilter(''); }}
+            className="text-[11px] text-[#f5a623] hover:underline mt-1"
+          >
+            Clear filters
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {filtered.map((m) => (
+            <MemberCard key={m.id} member={m} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
 function MemberCard({ member: m }: { member: Member }) {
   const [photoBroken, setPhotoBroken] = useState(false);
+  const [shareCopied, setShareCopied] = useState(false);
   const showPhoto = m.photo_url && m.photo_url.trim() && !photoBroken;
   const initials = m.name
     .split(/\s+/)
@@ -61,6 +137,19 @@ function MemberCard({ member: m }: { member: Member }) {
     .slice(0, 2)
     .toUpperCase();
   const slug = slugify(m.name);
+  const parsedLinks = m.links && m.links.trim() ? parseLinks(m.links) : [];
+  const reachOut = pickReachOutLink(parsedLinks);
+
+  async function copyShare() {
+    const url = `${typeof window !== 'undefined' ? window.location.origin : ''}/stock/team/m/${slug}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setShareCopied(true);
+      setTimeout(() => setShareCopied(false), 1500);
+    } catch {
+      window.prompt('Copy this URL:', url);
+    }
+  }
 
   return (
     <div className="bg-[#0d1b2a] rounded-lg border border-white/[0.06] p-3 flex items-start gap-3">
@@ -93,14 +182,23 @@ function MemberCard({ member: m }: { member: Member }) {
             {ROLE_LABEL[m.role] || m.role}
           </span>
         </div>
+
+        {m.status_text && m.status_text.trim() && (
+          <div className="flex items-center gap-1.5 text-[11px] text-emerald-300">
+            <span aria-hidden className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block" />
+            <span className="truncate">{m.status_text}</span>
+          </div>
+        )}
+
         {m.bio && m.bio.trim() ? (
-          <p className="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed">{m.bio}</p>
+          <p className="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed line-clamp-3">{m.bio}</p>
         ) : (
           <p className="text-[11px] text-gray-600 italic">No bio yet.</p>
         )}
-        {m.links && m.links.trim() && (
+
+        {parsedLinks.length > 0 && (
           <div className="flex flex-wrap gap-x-2 gap-y-0.5">
-            {parseLinks(m.links).map((l) => (
+            {parsedLinks.slice(0, 5).map((l) => (
               <a
                 key={l.href}
                 href={l.href}
@@ -111,14 +209,37 @@ function MemberCard({ member: m }: { member: Member }) {
                 {l.display}
               </a>
             ))}
+            {parsedLinks.length > 5 && (
+              <span className="text-[10px] text-gray-600">+{parsedLinks.length - 5} more</span>
+            )}
           </div>
         )}
-        <Link
-          href={`/stock/team/m/${slug}`}
-          className="inline-block text-[10px] text-[#f5a623] hover:text-[#ffd700] mt-1"
-        >
-          Public profile: /stock/team/m/{slug} -&gt;
-        </Link>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          {reachOut && (
+            <a
+              href={reachOut.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[10px] bg-[#f5a623]/10 hover:bg-[#f5a623]/20 text-[#f5a623] border border-[#f5a623]/30 rounded-full px-2.5 py-0.5 transition-colors"
+            >
+              <span aria-hidden>&rarr;</span> Reach out
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={copyShare}
+            className="inline-flex items-center gap-1 text-[10px] bg-[#0a1628] hover:bg-white/[0.04] text-gray-300 border border-white/[0.08] rounded-full px-2.5 py-0.5 transition-colors"
+          >
+            {shareCopied ? 'Link copied' : 'Share profile'}
+          </button>
+          <Link
+            href={`/stock/team/m/${slug}`}
+            className="inline-flex items-center gap-1 text-[10px] text-gray-500 hover:text-gray-300 px-1 py-0.5"
+          >
+            Public profile &rarr;
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/stock/team/help/page.tsx
+++ b/src/app/stock/team/help/page.tsx
@@ -1,0 +1,194 @@
+import Link from 'next/link';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ZAOstock Team - Help',
+  robots: { index: false, follow: false },
+};
+
+interface HelpEntry {
+  id: string;
+  title: string;
+  body: React.ReactNode;
+}
+
+const ENTRIES: HelpEntry[] = [
+  {
+    id: 'login',
+    title: 'How do I log in?',
+    body: (
+      <>
+        <p>You have a private 4-letter code (Zaal DM&rsquo;d it to you). Codes use the alphabet A-Z and digits 2-9 - no 0, O, 1, I, or L because those look alike.</p>
+        <p>Hit <Link href="/stock/team" className="text-[#f5a623] hover:underline">/stock/team</Link>, drop your code, you&rsquo;re in. The session lasts 30 days. If you lose the code, ping <a href="https://x.com/bettercallzaal" className="text-[#f5a623] hover:underline" target="_blank" rel="noreferrer">@bettercallzaal</a>.</p>
+      </>
+    ),
+  },
+  {
+    id: 'profile',
+    title: 'Setting up your profile',
+    body: (
+      <>
+        <p>On the home tab there&rsquo;s a card called <strong>Your Profile</strong>. Click Edit and you can set:</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li><strong>Photo</strong> - paste any image URL ending in .jpg / .png / .webp. Right-click your X or Farcaster avatar -&gt; &ldquo;Copy image address&rdquo; works great.</li>
+          <li><strong>Bio</strong> - the rich-text editor lets you bold, italicize, add headings, lists, links. Just like Notion or Google Docs.</li>
+          <li><strong>Links</strong> - one row per link. Hit &ldquo;+ Add another link&rdquo; for more. We auto-detect what each is (X, Farcaster, email, website).</li>
+          <li><strong>Status</strong> - one short line of what you&rsquo;re working on right now. Updates often. Shows up on your profile and in the Team directory.</li>
+          <li><strong>Team</strong> - which circle you&rsquo;re in. Filters which todos you see by default.</li>
+        </ul>
+        <p>Profile complete % shows in the card header. Aim for green (100%).</p>
+      </>
+    ),
+  },
+  {
+    id: 'editor',
+    title: 'Using the bio editor',
+    body: (
+      <>
+        <p>The bio editor is WYSIWYG - what you see is what you get. No markdown syntax to remember.</p>
+        <p><strong>Toolbar</strong> across the top: B (bold) / I (italic) / H (heading) / h (subheading) / bullet list / numbered list / quote / link / divider / clear formatting.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Select some text, click <strong>B</strong> -&gt; instantly bold</li>
+          <li>Click <strong>Link</strong> with text selected -&gt; URL prompt opens, paste a URL</li>
+          <li>Hit Enter twice for a new paragraph (blank line between)</li>
+          <li>Type <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">## </code> at the start of a line for a heading</li>
+          <li>Type <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">- </code> at the start for a bullet list</li>
+          <li>Paste from Notion, Google Docs, or anywhere - formatting carries over</li>
+        </ul>
+        <p>Toolbar buttons highlight when your cursor is inside that style. Char counter (top right) goes red over 2000.</p>
+      </>
+    ),
+  },
+  {
+    id: 'directory',
+    title: 'Finding teammates (the Team tab)',
+    body: (
+      <>
+        <p>The Team tab shows everyone on the roster.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li><strong>Search</strong> by name, bio, link, or status - matches anywhere in the text</li>
+          <li><strong>Filter</strong> by scope (Operations / Music / Finance / Design)</li>
+          <li><strong>Reach out</strong> button - opens their X / Farcaster / email directly (whichever they listed first)</li>
+          <li><strong>Share profile</strong> - copies a URL to their public page so you can drop it in DMs</li>
+          <li>Click a name -&gt; their public profile at <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/stock/team/m/&lt;name&gt;</code></li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    id: 'circles',
+    title: 'Circles (governance + team membership)',
+    body: (
+      <>
+        <p>ZAOstock has 8 working circles: Music, Ops, Partners, Finance, Merch, Marketing, Media, Host. You can be in 1 or many.</p>
+        <p>Circles are managed via the team Telegram bot (<a href="https://t.me/ZAOstockTeamBot" target="_blank" rel="noreferrer" className="text-[#f5a623] hover:underline">@ZAOstockTeamBot</a>), not the dashboard:</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li><code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/circles</code> - see all 8 + who coordinates each</li>
+          <li><code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/join &lt;slug&gt;</code> - grab one (e.g. <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/join music</code>)</li>
+          <li><code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/leave &lt;slug&gt;</code> - step out</li>
+          <li><code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/mycircles</code> - your list</li>
+          <li><code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/buddy</code> - get auto-paired with a teammate</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    id: 'onboarding',
+    title: 'Onboarding checklist',
+    body: (
+      <>
+        <p>First time in, you see a card titled <strong>Get started</strong> at the top of your home tab. It tracks 6 things:</p>
+        <ol className="list-decimal pl-5 space-y-1">
+          <li>Add a bio (1-3 sentences)</li>
+          <li>Add a profile photo</li>
+          <li>Pick your team (scope)</li>
+          <li>Drop a link or two</li>
+          <li>Join a circle in the bot</li>
+          <li>Log your first contribution (use Quick Add or the bot)</li>
+        </ol>
+        <p>The card hides itself once all 6 are done. Each one has a small hint underneath telling you exactly what to do.</p>
+      </>
+    ),
+  },
+  {
+    id: 'todos',
+    title: 'Todos + tracking your work',
+    body: (
+      <>
+        <p>The home tab shows what&rsquo;s assigned to you. Open the Overview tab for a full kanban board.</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li><strong>Quick add</strong> on home: type "Did X" or "Going to do Y" and the system parses it.</li>
+          <li><strong>Bot shortcuts</strong> in DM: <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/do &lt;text&gt;</code> to log work, <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/mytodos</code> to see what you own, <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/mytodos_all</code> to see everything open.</li>
+          <li><strong>Status</strong> moves todo -&gt; in_progress -&gt; done. Click to update.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    id: 'whats-changing',
+    title: 'What if something looks wrong?',
+    body: (
+      <>
+        <p>The dashboard is shipped weekly. If something&rsquo;s broken or feels off:</p>
+        <ul className="list-disc pl-5 space-y-1">
+          <li>Tag <a href="https://x.com/bettercallzaal" target="_blank" rel="noreferrer" className="text-[#f5a623] hover:underline">@bettercallzaal</a> in the team Telegram group</li>
+          <li>Or send <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/idea your-feedback-here</code> in DM to the bot - it goes into the suggestions pool</li>
+          <li>Don&rsquo;t lose your work. Save shows a green &ldquo;Profile saved&rdquo; pill when it goes through. If you see a red error box, the save did NOT happen.</li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    id: 'public-profile',
+    title: 'Your public profile',
+    body: (
+      <>
+        <p>Your bio + photo + links are public at <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">zaoos.com/stock/team/m/&lt;your-name&gt;</code>. Anyone (no login) can see it.</p>
+        <p>What is NOT public: your code, your scope, your todos, your status text. Those are internal-only.</p>
+        <p>The team grid on the public ZAOstock page (<Link href="/stock" className="text-[#f5a623] hover:underline">/stock</Link>) pulls from your bio + photo too.</p>
+      </>
+    ),
+  },
+];
+
+export default function HelpPage() {
+  return (
+    <main className="min-h-[100dvh] bg-[#0a1628] text-slate-100">
+      <div className="max-w-3xl mx-auto px-4 py-10">
+        <header className="mb-10">
+          <Link href="/stock/team" className="text-[10px] text-[#f5a623] hover:underline uppercase tracking-wider">
+            &larr; Back to dashboard
+          </Link>
+          <h1 className="text-3xl font-bold text-white mt-3">Help &amp; how-to</h1>
+          <p className="mt-2 text-sm text-gray-400 max-w-2xl">
+            Quick answers to everything in the ZAOstock team dashboard. Each section corresponds to a feature you&rsquo;ll see in the app. Anchor links take you straight to the topic.
+          </p>
+        </header>
+
+        <nav className="mb-10 grid grid-cols-2 gap-x-4 gap-y-1.5 text-sm bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08]">
+          <p className="col-span-2 text-[10px] uppercase tracking-wider text-[#f5a623] font-bold mb-2">Jump to</p>
+          {ENTRIES.map((e) => (
+            <a key={e.id} href={`#${e.id}`} className="text-gray-300 hover:text-[#f5a623] py-0.5">
+              {e.title}
+            </a>
+          ))}
+        </nav>
+
+        <div className="space-y-8">
+          {ENTRIES.map((e) => (
+            <section key={e.id} id={e.id} className="scroll-mt-6 bg-[#0d1b2a] rounded-xl p-6 border border-white/[0.08]">
+              <h2 className="text-lg font-bold text-[#f5a623] mb-3">{e.title}</h2>
+              <div className="text-sm text-gray-300 leading-relaxed space-y-2">{e.body}</div>
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-12 pb-6 text-center">
+          <p className="text-xs text-gray-500">
+            Missing something? Drop a <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/idea</code> in the bot or tag <a href="https://x.com/bettercallzaal" target="_blank" rel="noreferrer" className="text-[#f5a623] hover:underline">@bettercallzaal</a>.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/stock/team/m/[slug]/MemberProfileView.tsx
+++ b/src/app/stock/team/m/[slug]/MemberProfileView.tsx
@@ -44,6 +44,12 @@ export function MemberProfileView({ member }: Props) {
               {publicLabel}
             </span>
           </div>
+          {member.status_text && member.status_text.trim() && (
+            <div className="mt-3 flex items-center gap-2 text-sm text-emerald-300">
+              <span aria-hidden className="w-2 h-2 rounded-full bg-emerald-400 inline-block" />
+              <span>{member.status_text}</span>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -40,7 +40,7 @@ export default async function StockTeamPage() {
       .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
       .order('status')
       .order('created_at', { ascending: false }),
-    supabase.from('stock_team_members').select('id, name, role, scope, secondary_scope, bio, links, photo_url').neq('active', false).order('created_at'),
+    supabase.from('stock_team_members').select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text').neq('active', false).order('created_at'),
     supabase
       .from('stock_sponsors')
       .select('*, owner:stock_team_members!owner_id(id, name)')

--- a/src/lib/stock/members.ts
+++ b/src/lib/stock/members.ts
@@ -47,6 +47,7 @@ export interface PublicMember {
   bio: string;
   links: string;
   photo_url: string;
+  status_text: string;
   slug: string;
 }
 
@@ -87,7 +88,7 @@ export async function getPublicMembers(): Promise<PublicMember[]> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('stock_team_members')
-    .select('id, name, role, scope, secondary_scope, bio, links, photo_url, active')
+    .select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text, active')
     .neq('active', false)
     .order('created_at');
 
@@ -102,6 +103,7 @@ export async function getPublicMembers(): Promise<PublicMember[]> {
     bio: m.bio || '',
     links: m.links || '',
     photo_url: m.photo_url || '',
+    status_text: m.status_text || '',
     slug: slugify(m.name),
   }));
 }


### PR DESCRIPTION
## Summary

Pass C1 of the dashboard UX audit. For a 20+ person team that's still onboarding, this drops 5 things:

1. **/stock/team/help** - dedicated docs page (9 sections: login, profile, editor, directory, circles, onboarding, todos, public profile, reporting issues). Linked from the dashboard header.
2. **HelpIcon component** - small \"?\" pill that links to a help anchor. Wired next to \"Your Profile\" and \"Team\" so people self-serve.
3. **Team directory upgrades** (Team tab) - search by name/bio/link, scope filter pills, \"Reach out\" button (opens X / Farcaster / email), \"Share profile\" button (copies public URL), per-card status text, filter count.
4. **Status text field** - one-line \"what you're working on now\" on \`stock_team_members.status_text\`. Surfaces in the dashboard, on the public profile, and in the directory.
5. **API + types** - \`/api/stock/team/profile\` accepts status_text (max 140), threaded through PublicMember + page queries.

## DB migration required
Run before deploy:
\`\`\`sql
-- scripts/stock-team-status-text-migration.sql
ALTER TABLE stock_team_members ADD COLUMN IF NOT EXISTS status_text TEXT DEFAULT '';
\`\`\`
Idempotent. Without it, the status field still renders but won't persist.

## Test plan
- [ ] Visit /stock/team/help - 9 sections render, anchor links work
- [ ] Click \"Help\" in dashboard header - lands on help page
- [ ] Edit your profile - new \"Status\" field with a green dot. Type \"drafting Roddy follow-up\". Save. Reload. Status persists.
- [ ] Status appears in profile card header, public profile, and team directory card
- [ ] Team tab: type a name in search - list filters
- [ ] Click a scope pill (e.g. Music) - filters to that scope
- [ ] Click \"Reach out\" on a teammate with an X handle - opens X profile
- [ ] Click \"Share profile\" - clipboard gets /stock/team/m/<slug> URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)