### PR TITLE
feat(stock-team): updates feed + completeness leaderboard + skills (Pass C2)

### DIFF
--- a/scripts/stock-team-skills-feed-migration.sql
+++ b/scripts/stock-team-skills-feed-migration.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- ZAOstock Team - skills column (Pass C2)
+-- ============================================================================
+-- One free-text comma-separated list of skills/tags per teammate.
+-- Examples: "video, sound, sponsorship", "music production, cypher host".
+-- Used for filtering the directory + showing what each teammate offers.
+--
+-- Idempotent. Safe to re-run.
+-- ============================================================================
+
+ALTER TABLE stock_team_members
+  ADD COLUMN IF NOT EXISTS skills TEXT DEFAULT '';
+
+-- Verify
+SELECT column_name, data_type, column_default
+FROM information_schema.columns
+WHERE table_name = 'stock_team_members'
+  AND column_name = 'skills';

--- a/src/app/api/stock/team/profile/route.ts
+++ b/src/app/api/stock/team/profile/route.ts
@@ -17,6 +17,7 @@ const patchSchema = z.object({
     ),
   scope: z.enum(['', 'ops', 'music', 'design']).optional(),
   status_text: z.string().max(140).optional(),
+  skills: z.string().max(500).optional(),
 });
 
 export async function PATCH(request: NextRequest) {
@@ -42,6 +43,7 @@ export async function PATCH(request: NextRequest) {
     if (parsed.data.photo_url !== undefined) updates.photo_url = parsed.data.photo_url;
     if (parsed.data.scope !== undefined) updates.scope = parsed.data.scope;
     if (parsed.data.status_text !== undefined) updates.status_text = parsed.data.status_text;
+    if (parsed.data.skills !== undefined) updates.skills = parsed.data.skills;
 
     if (Object.keys(updates).length === 0) {
       return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
@@ -52,7 +54,7 @@ export async function PATCH(request: NextRequest) {
       .from('stock_team_members')
       .update(updates)
       .eq('id', session.memberId)
-      .select('id, name, bio, links, photo_url, status_text')
+      .select('id, name, bio, links, photo_url, status_text, skills')
       .single();
 
     if (error) {

--- a/src/app/stock/team/BioEditor.tsx
+++ b/src/app/stock/team/BioEditor.tsx
@@ -74,9 +74,10 @@ interface Props {
   initialScope: string;
   initialRole: string;
   initialStatusText?: string;
+  initialSkills?: string;
 }
 
-export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUrl, initialScope, initialRole, initialStatusText }: Props) {
+export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUrl, initialScope, initialRole, initialStatusText, initialSkills }: Props) {
   const [bio, setBio] = useState(initialBio);
   const [linkRows, setLinkRows] = useState<string[]>(() => {
     const initial = splitLinks(initialLinks);
@@ -84,6 +85,7 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
   });
   const links = useMemo(() => joinLinks(linkRows), [linkRows]);
   const [statusText, setStatusText] = useState(initialStatusText ?? '');
+  const [skills, setSkills] = useState(initialSkills ?? '');
   const [photoUrl, setPhotoUrl] = useState(initialPhotoUrl);
   const [scope, setScope] = useState(initialScope);
   const [editing, setEditing] = useState(initialBio.trim().length === 0);
@@ -113,7 +115,7 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
       const res = await fetch('/api/stock/team/profile', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bio, links, photo_url: photoUrl, scope, status_text: statusText }),
+        body: JSON.stringify({ bio, links, photo_url: photoUrl, scope, status_text: statusText, skills }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => null);
@@ -200,6 +202,18 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
                     <span className="text-[#f5a623]">{describeLink(row)}</span>
                     <span className="text-gray-600"> · </span>
                     <span>{row.length > 40 ? row.slice(0, 40) + '...' : row}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+            {skills.trim() && (
+              <div className="flex flex-wrap gap-1 pt-0.5">
+                {skills.split(/[,;]+/).map((s) => s.trim()).filter(Boolean).slice(0, 12).map((s, i) => (
+                  <span
+                    key={i}
+                    className="text-[10px] bg-[#f5a623]/10 border border-[#f5a623]/20 rounded-full px-2 py-0.5 text-[#fbbf24]"
+                  >
+                    {s}
                   </span>
                 ))}
               </div>
@@ -326,6 +340,23 @@ export function BioEditor({ memberName, initialBio, initialLinks, initialPhotoUr
             </button>
             <p className="text-[10px] text-gray-600 italic">
               Drop your X / Farcaster / website / SoundCloud / anything. We&rsquo;ll auto-detect what each is.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-[10px] uppercase tracking-wider text-gray-500 font-bold flex items-center gap-1">
+              Skills <HelpIcon section="skills" />
+              <span className="text-gray-700 font-normal normal-case">(comma-separated)</span>
+            </label>
+            <input
+              value={skills}
+              onChange={(e) => setSkills(e.target.value)}
+              placeholder="video, sound, sponsorship outreach, photography, music production..."
+              maxLength={500}
+              className="w-full bg-[#0a1628] border border-white/[0.08] rounded px-3 py-2 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-[#f5a623]/30"
+            />
+            <p className="text-[10px] text-gray-600 italic">
+              What you can offer the team. Up to 500 chars. Used to match you to work that needs done.
             </p>
           </div>
 

--- a/src/app/stock/team/CompletenessLeaderboard.tsx
+++ b/src/app/stock/team/CompletenessLeaderboard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Link from 'next/link';
+import { slugify } from '@/lib/stock/members';
+import { HelpIcon } from './HelpIcon';
+
+interface Member {
+  id: string;
+  name: string;
+  role: string;
+  scope: string;
+  bio?: string;
+  links?: string;
+  photo_url?: string;
+  status_text?: string;
+}
+
+interface Props {
+  members: Member[];
+  currentMemberId: string;
+}
+
+function completeness(m: Member): number {
+  let pct = 0;
+  if ((m.bio ?? '').trim().length >= 30) pct += 40;
+  else if ((m.bio ?? '').trim().length > 0) pct += 20;
+  if ((m.photo_url ?? '').trim().length > 0) pct += 30;
+  if ((m.scope ?? '').trim().length > 0 || m.role === 'advisory') pct += 20;
+  if ((m.links ?? '').trim().length > 0) pct += 10;
+  return pct;
+}
+
+export function CompletenessLeaderboard({ members, currentMemberId }: Props) {
+  const ranked = members
+    .map((m) => ({ ...m, pct: completeness(m) }))
+    .sort((a, b) => b.pct - a.pct || a.name.localeCompare(b.name));
+
+  const top = ranked.slice(0, 5);
+  const myRank = ranked.findIndex((m) => m.id === currentMemberId);
+  const me = ranked.find((m) => m.id === currentMemberId);
+
+  return (
+    <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08] space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Most-complete profiles</p>
+          <HelpIcon section="leaderboard" />
+        </div>
+        {me && (
+          <span className="text-[10px] text-gray-500">
+            You: <span className="text-white font-bold">#{myRank + 1}</span> ({me.pct}%)
+          </span>
+        )}
+      </div>
+
+      <ol className="space-y-1.5">
+        {top.map((m, i) => {
+          const isYou = m.id === currentMemberId;
+          const medal = i === 0 ? '🏆' : i === 1 ? '·' : i === 2 ? '·' : '·';
+          return (
+            <li key={m.id}>
+              <Link
+                href={`/stock/team/m/${slugify(m.name)}`}
+                className={`flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg transition-colors ${
+                  isYou
+                    ? 'bg-[#f5a623]/10 border border-[#f5a623]/30'
+                    : 'hover:bg-white/[0.03] border border-transparent'
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-[10px] text-gray-500 font-mono w-4 text-right" aria-hidden>
+                    {i === 0 ? medal : `${i + 1}.`}
+                  </span>
+                  <span className={`text-xs font-medium truncate ${isYou ? 'text-[#f5a623]' : 'text-white'}`}>
+                    {m.name}{isYou ? ' (you)' : ''}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="h-1 w-12 bg-[#0a1628] rounded-full overflow-hidden">
+                    <div
+                      className={`h-full ${m.pct === 100 ? 'bg-emerald-400' : 'bg-[#f5a623]'}`}
+                      style={{ width: `${m.pct}%` }}
+                    />
+                  </div>
+                  <span className={`text-[10px] font-bold w-9 text-right ${
+                    m.pct === 100 ? 'text-emerald-400' : m.pct >= 60 ? 'text-amber-300' : 'text-gray-500'
+                  }`}>
+                    {m.pct}%
+                  </span>
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+
+      {me && myRank >= top.length && (
+        <div className="pt-2 border-t border-white/[0.04]">
+          <Link
+            href={`/stock/team/m/${slugify(me.name)}`}
+            className="flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg bg-[#f5a623]/10 border border-[#f5a623]/30"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-[10px] text-gray-500 font-mono w-4 text-right">{myRank + 1}.</span>
+              <span className="text-xs font-medium text-[#f5a623]">You</span>
+            </div>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <div className="h-1 w-12 bg-[#0a1628] rounded-full overflow-hidden">
+                <div
+                  className={`h-full ${me.pct === 100 ? 'bg-emerald-400' : 'bg-[#f5a623]'}`}
+                  style={{ width: `${me.pct}%` }}
+                />
+              </div>
+              <span className={`text-[10px] font-bold w-9 text-right ${
+                me.pct === 100 ? 'text-emerald-400' : me.pct >= 60 ? 'text-amber-300' : 'text-gray-500'
+              }`}>
+                {me.pct}%
+              </span>
+            </div>
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -120,7 +120,7 @@ interface Props {
   memberId: string;
   goals: Array<{ id: string; title: string; status: 'locked' | 'wip' | 'tbd'; details: string; category: string; sort_order: number }>;
   todos: Array<{ id: string; title: string; status: 'todo' | 'in_progress' | 'done'; notes: string; owner: { id: string; name: string } | null; creator: { id: string; name: string } | null; created_at: string }>;
-  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string }>;
+  members: Array<{ id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string; skills?: string }>;
   sponsors: Sponsor[];
   artists: Artist[];
   milestones: Milestone[];
@@ -130,6 +130,16 @@ interface Props {
   meetingNotes: Note[];
   myCirclesCount?: number;
   myActivityCount?: number;
+  feed?: Array<{
+    id: string;
+    actorName: string | null;
+    actorId: string | null;
+    entityType: string;
+    action: string;
+    fieldChanged: string | null;
+    newValue: string | null;
+    createdAt: string;
+  }>;
 }
 
 export function Dashboard({
@@ -147,6 +157,7 @@ export function Dashboard({
   meetingNotes,
   myCirclesCount = 0,
   myActivityCount = 0,
+  feed = [],
 }: Props) {
   const router = useRouter();
   const [tab, setTabRaw] = useState<Tab>('home');
@@ -264,6 +275,7 @@ export function Dashboard({
               onNavigate={(t) => setTab(t)}
               inAnyCircle={myCirclesCount > 0}
               hasFirstActivity={myActivityCount > 0}
+              feed={feed}
             />
           </>
         )}

--- a/src/app/stock/team/PersonalHome.tsx
+++ b/src/app/stock/team/PersonalHome.tsx
@@ -6,10 +6,12 @@ import { FestivalProgress } from './FestivalProgress';
 import { QuickAdd } from './QuickAdd';
 import { BioEditor } from './BioEditor';
 import { OnboardingChecklist } from './OnboardingChecklist';
+import { UpdatesFeed, type FeedEntry } from './UpdatesFeed';
+import { CompletenessLeaderboard } from './CompletenessLeaderboard';
 
 const FESTIVAL_DATE = new Date('2026-10-03T12:00:00-04:00');
 
-interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string; }
+interface Member { id: string; name: string; role: string; scope: string; bio?: string; links?: string; photo_url?: string; status_text?: string; skills?: string; }
 
 interface Todo {
   id: string;
@@ -58,6 +60,7 @@ interface Props {
   onNavigate: (tab: 'sponsors' | 'artists' | 'timeline' | 'overview') => void;
   inAnyCircle?: boolean;
   hasFirstActivity?: boolean;
+  feed?: FeedEntry[];
 }
 
 const TEAM_LABEL: Record<string, string> = {
@@ -92,7 +95,7 @@ function daysToDue(date: string): number {
   return Math.ceil((new Date(date + 'T00:00:00').getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 }
 
-export function PersonalHome({ member, allMembers, todos, sponsors, artists, milestones, onNavigate, inAnyCircle = false, hasFirstActivity = false }: Props) {
+export function PersonalHome({ member, allMembers, todos, sponsors, artists, milestones, onNavigate, inAnyCircle = false, hasFirstActivity = false, feed = [] }: Props) {
   const daysToFest = daysUntil(FESTIVAL_DATE);
 
   const myTodos = useMemo(() => todos.filter((t) => t.owner?.id === member.id), [todos, member.id]);
@@ -159,8 +162,15 @@ export function PersonalHome({ member, allMembers, todos, sponsors, artists, mil
           initialScope={member.scope || ''}
           initialRole={member.role || 'member'}
           initialStatusText={member.status_text || ''}
+          initialSkills={member.skills || ''}
         />
       </div>
+
+      {/* Recent activity */}
+      <UpdatesFeed entries={feed} currentMemberId={member.id} />
+
+      {/* Profile completeness leaderboard */}
+      <CompletenessLeaderboard members={allMembers} currentMemberId={member.id} />
 
       {/* Welcome banner */}
       <div className="bg-gradient-to-br from-[#f5a623]/20 via-[#f5a623]/5 to-transparent rounded-xl p-5 border border-[#f5a623]/30">

--- a/src/app/stock/team/TeamRoles.tsx
+++ b/src/app/stock/team/TeamRoles.tsx
@@ -15,6 +15,7 @@ interface Member {
   links?: string;
   photo_url?: string;
   status_text?: string;
+  skills?: string;
 }
 
 const SCOPE_LABEL: Record<string, string> = {
@@ -59,7 +60,7 @@ export function TeamRoles({ members }: { members: Member[] }) {
     return members.filter((m) => {
       if (scopeFilter && m.scope !== scopeFilter) return false;
       if (!q) return true;
-      const haystack = `${m.name} ${m.bio ?? ''} ${m.links ?? ''} ${m.scope ?? ''} ${m.role ?? ''} ${m.status_text ?? ''}`.toLowerCase();
+      const haystack = `${m.name} ${m.bio ?? ''} ${m.links ?? ''} ${m.scope ?? ''} ${m.role ?? ''} ${m.status_text ?? ''} ${m.skills ?? ''}`.toLowerCase();
       return haystack.includes(q);
     });
   }, [members, query, scopeFilter]);
@@ -194,6 +195,19 @@ function MemberCard({ member: m }: { member: Member }) {
           <p className="text-xs text-gray-300 whitespace-pre-wrap leading-relaxed line-clamp-3">{m.bio}</p>
         ) : (
           <p className="text-[11px] text-gray-600 italic">No bio yet.</p>
+        )}
+
+        {m.skills && m.skills.trim() && (
+          <div className="flex flex-wrap gap-1">
+            {m.skills.split(/[,;]+/).map((s) => s.trim()).filter(Boolean).slice(0, 6).map((s, i) => (
+              <span
+                key={i}
+                className="text-[10px] bg-[#f5a623]/10 border border-[#f5a623]/20 rounded-full px-2 py-0.5 text-[#fbbf24]"
+              >
+                {s}
+              </span>
+            ))}
+          </div>
         )}
 
         {parsedLinks.length > 0 && (

--- a/src/app/stock/team/UpdatesFeed.tsx
+++ b/src/app/stock/team/UpdatesFeed.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Link from 'next/link';
+import { slugify } from '@/lib/stock/members';
+import { HelpIcon } from './HelpIcon';
+
+export interface FeedEntry {
+  id: string;
+  actorName: string | null;
+  actorId: string | null;
+  entityType: string;
+  action: string;
+  fieldChanged: string | null;
+  newValue: string | null;
+  createdAt: string;
+}
+
+interface Props {
+  entries: FeedEntry[];
+  currentMemberId: string;
+}
+
+function timeAgo(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  const w = Math.floor(d / 7);
+  return `${w}w ago`;
+}
+
+function describe(entry: FeedEntry): string {
+  const subject = entry.actorName || 'Someone';
+  const action = entry.action;
+  const entity = entry.entityType;
+  const field = entry.fieldChanged;
+
+  // Profile updates
+  if (entity === 'team_member' || entity === 'profile') {
+    if (field === 'bio') return `${subject} updated their bio`;
+    if (field === 'photo_url') return `${subject} added a profile photo`;
+    if (field === 'links') return `${subject} updated their links`;
+    if (field === 'status_text') return `${subject} updated their status`;
+    if (field === 'scope') return `${subject} picked a team`;
+    return `${subject} updated their profile`;
+  }
+
+  // Common verbs
+  if (entity === 'todo') {
+    if (action === 'created') return `${subject} added a todo`;
+    if (action === 'completed' || action === 'done') return `${subject} finished a todo`;
+    if (action === 'updated') return `${subject} updated a todo`;
+    return `${subject} ${action} a todo`;
+  }
+  if (entity === 'sponsor') return `${subject} ${action} sponsor activity`;
+  if (entity === 'artist') return `${subject} ${action} artist activity`;
+  if (entity === 'idea') return `${subject} dropped an idea`;
+  if (entity === 'note') return `${subject} added a note`;
+  if (entity === 'gemba') return `${subject} logged a standup note`;
+  if (entity === 'contact_log') return `${subject} logged a contact`;
+
+  return `${subject} ${action} ${entity}`;
+}
+
+export function UpdatesFeed({ entries, currentMemberId }: Props) {
+  if (entries.length === 0) {
+    return (
+      <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08]">
+        <div className="flex items-center gap-1.5 mb-2">
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Recent activity</p>
+          <HelpIcon section="updates-feed" />
+        </div>
+        <p className="text-xs text-gray-500 italic">
+          Nothing yet. Drop a status, log a contribution, finish a todo - it all shows up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08] space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <p className="text-[10px] uppercase tracking-wider text-[#f5a623] font-bold">Recent activity</p>
+          <HelpIcon section="updates-feed" />
+        </div>
+        <span className="text-[10px] text-gray-600">last {entries.length}</span>
+      </div>
+
+      <ul className="divide-y divide-white/[0.04]">
+        {entries.map((e) => {
+          const isYou = e.actorId === currentMemberId;
+          const summary = describe(e);
+          const linkable = e.actorId && e.actorName;
+          return (
+            <li key={e.id} className="py-2 flex items-start gap-2.5">
+              <span aria-hidden className="mt-1.5 w-1.5 h-1.5 rounded-full bg-[#f5a623]/60 flex-shrink-0" />
+              <div className="min-w-0 flex-1">
+                <p className="text-xs text-gray-200 leading-relaxed">
+                  {linkable && e.actorId !== currentMemberId ? (
+                    <Link
+                      href={`/stock/team/m/${slugify(e.actorName!)}`}
+                      className="text-[#f5a623] hover:underline font-medium"
+                    >
+                      {e.actorName}
+                    </Link>
+                  ) : (
+                    <span className={isYou ? 'text-[#f5a623] font-medium' : 'text-white'}>
+                      {isYou ? 'You' : (e.actorName || 'Someone')}
+                    </span>
+                  )}
+                  {' '}
+                  <span className="text-gray-300">{summary.replace(/^\S+\s+/, '')}</span>
+                </p>
+                <p className="text-[10px] text-gray-600 mt-0.5">{timeAgo(e.createdAt)}</p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/stock/team/help/page.tsx
+++ b/src/app/stock/team/help/page.tsx
@@ -125,6 +125,39 @@ const ENTRIES: HelpEntry[] = [
     ),
   },
   {
+    id: 'updates-feed',
+    title: 'Recent activity feed',
+    body: (
+      <>
+        <p>The home tab shows what other teammates have been doing - bio updates, todos closed, ideas dropped, contacts logged. Last 15 events.</p>
+        <p>Click a name to jump to their public profile.</p>
+        <p>If your name shows up here, your work is being noticed. If it never does, log contributions through the bot or Quick Add - try <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/idea</code> or <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/do</code>.</p>
+      </>
+    ),
+  },
+  {
+    id: 'leaderboard',
+    title: 'Most-complete profiles',
+    body: (
+      <>
+        <p>Top 5 most-complete profiles plus your own rank. Light social pressure, no actual stakes - just makes it easy to see who&rsquo;s set up and who isn&rsquo;t.</p>
+        <p>Scoring: bio 40 (full = 40, partial = 20), photo 30, scope 20, links 10. Total = 100.</p>
+        <p>Click anyone&rsquo;s name to open their public profile.</p>
+      </>
+    ),
+  },
+  {
+    id: 'skills',
+    title: 'Skills (what you offer)',
+    body: (
+      <>
+        <p>One free-text comma-separated list. Examples: &ldquo;video, sound, sponsorship outreach, photography, music production&rdquo;.</p>
+        <p>Renders as gold pill tags on your profile and in the Team directory. Searchable - if someone needs a videographer, typing &ldquo;video&rdquo; in the team search filters to people who listed it.</p>
+        <p>Used for matching teammates to work that needs done. The more specific, the better.</p>
+      </>
+    ),
+  },
+  {
     id: 'whats-changing',
     title: 'What if something looks wrong?',
     body: (

--- a/src/app/stock/team/m/[slug]/MemberProfileView.tsx
+++ b/src/app/stock/team/m/[slug]/MemberProfileView.tsx
@@ -50,6 +50,18 @@ export function MemberProfileView({ member }: Props) {
               <span>{member.status_text}</span>
             </div>
           )}
+          {member.skills && member.skills.trim() && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {member.skills.split(/[,;]+/).map((s) => s.trim()).filter(Boolean).slice(0, 16).map((s, i) => (
+                <span
+                  key={i}
+                  className="text-[11px] bg-[#f5a623]/10 border border-[#f5a623]/20 rounded-full px-2.5 py-0.5 text-[#fbbf24]"
+                >
+                  {s}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/app/stock/team/page.tsx
+++ b/src/app/stock/team/page.tsx
@@ -33,6 +33,7 @@ export default async function StockTeamPage() {
     rsvpsRes,
     myCirclesRes,
     myActivityRes,
+    feedRes,
   ] = await Promise.allSettled([
     supabase.from('stock_goals').select('*').order('sort_order'),
     supabase
@@ -40,7 +41,7 @@ export default async function StockTeamPage() {
       .select('*, owner:stock_team_members!owner_id(id, name), creator:stock_team_members!created_by(id, name)')
       .order('status')
       .order('created_at', { ascending: false }),
-    supabase.from('stock_team_members').select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text').neq('active', false).order('created_at'),
+    supabase.from('stock_team_members').select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text, skills').neq('active', false).order('created_at'),
     supabase
       .from('stock_sponsors')
       .select('*, owner:stock_team_members!owner_id(id, name)')
@@ -85,6 +86,11 @@ export default async function StockTeamPage() {
       .from('stock_activity_log')
       .select('id', { count: 'exact', head: true })
       .eq('actor_id', member.memberId),
+    supabase
+      .from('stock_activity_log')
+      .select('id, actor_id, entity_type, action, field_changed, new_value, created_at, actor:stock_team_members!actor_id(id, name)')
+      .order('created_at', { ascending: false })
+      .limit(15),
   ]);
 
   const goals = goalsRes.status === 'fulfilled' ? goalsRes.value.data || [] : [];
@@ -99,6 +105,31 @@ export default async function StockTeamPage() {
   const rsvps = rsvpsRes.status === 'fulfilled' ? rsvpsRes.value.data || [] : [];
   const myCirclesCount = myCirclesRes.status === 'fulfilled' ? myCirclesRes.value.count ?? 0 : 0;
   const myActivityCount = myActivityRes.status === 'fulfilled' ? myActivityRes.value.count ?? 0 : 0;
+
+  type FeedRow = {
+    id: string;
+    actor_id: string | null;
+    entity_type: string;
+    action: string;
+    field_changed: string | null;
+    new_value: string | null;
+    created_at: string;
+    actor: { id: string; name: string } | { id: string; name: string }[] | null;
+  };
+  const feedRows = (feedRes.status === 'fulfilled' ? feedRes.value.data || [] : []) as unknown as FeedRow[];
+  const feed = feedRows.map((row) => {
+    const actor = Array.isArray(row.actor) ? row.actor[0] : row.actor;
+    return {
+      id: row.id,
+      actorName: actor?.name ?? null,
+      actorId: row.actor_id,
+      entityType: row.entity_type,
+      action: row.action,
+      fieldChanged: row.field_changed,
+      newValue: row.new_value,
+      createdAt: row.created_at,
+    };
+  });
 
   return (
     <Dashboard
@@ -116,6 +147,7 @@ export default async function StockTeamPage() {
       meetingNotes={meetingNotes}
       myCirclesCount={myCirclesCount}
       myActivityCount={myActivityCount}
+      feed={feed}
     />
   );
 }

--- a/src/lib/stock/members.ts
+++ b/src/lib/stock/members.ts
@@ -48,6 +48,7 @@ export interface PublicMember {
   links: string;
   photo_url: string;
   status_text: string;
+  skills: string;
   slug: string;
 }
 
@@ -88,7 +89,7 @@ export async function getPublicMembers(): Promise<PublicMember[]> {
   const supabase = getSupabaseAdmin();
   const { data, error } = await supabase
     .from('stock_team_members')
-    .select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text, active')
+    .select('id, name, role, scope, secondary_scope, bio, links, photo_url, status_text, skills, active')
     .neq('active', false)
     .order('created_at');
 
@@ -104,6 +105,7 @@ export async function getPublicMembers(): Promise<PublicMember[]> {
     links: m.links || '',
     photo_url: m.photo_url || '',
     status_text: m.status_text || '',
+    skills: m.skills || '',
     slug: slugify(m.name),
   }));
 }


### PR DESCRIPTION
## Summary

Pass C2 of the dashboard UX audit. Three additions for the team home tab.

### 1. Recent activity feed
\`UpdatesFeed\` component shows the last 15 events from \`stock_activity_log\` - bio updates, todos closed, ideas dropped, contacts logged. Each row shows actor (linked to public profile) + relative time. Empty state nudges people to drop a status / log a contribution.

### 2. Completeness leaderboard
\`CompletenessLeaderboard\` ranks all teammates by profile completeness. Top 5 + your own rank pinned at the bottom if you're not in the top 5. Light social pressure, no actual stakes.

### 3. Skills field
New \`skills\` column on \`stock_team_members\`. Free-text comma-separated list (\"video, sound, sponsorship outreach, photography\"). Renders as gold pill tags on:
- Dashboard profile card (when not editing)
- Public profile at \`/stock/team/m/[slug]\`
- Team directory cards
- Already searchable via the directory's existing search

3 new help page sections (\`#updates-feed\`, \`#leaderboard\`, \`#skills\`) + HelpIcon next to each new feature.

## DB migration required
\`\`\`sql
-- scripts/stock-team-skills-feed-migration.sql
ALTER TABLE stock_team_members
  ADD COLUMN IF NOT EXISTS skills TEXT DEFAULT '';
\`\`\`
Idempotent. Run before deploy or skills won't persist (same dance as Pass C1's status_text).

## Test plan
- [ ] Run migration in Supabase SQL Editor
- [ ] Edit profile, add skills like \"video, sound, photography\", save → 3 gold pills appear in profile card
- [ ] Visit /stock/team/m/<your-slug> → skills pills render under your name
- [ ] Open Team tab → your skills show on your card; type \"video\" in search → filters to people who listed it
- [ ] Recent activity card shows your bio update from above
- [ ] Leaderboard shows top 5 + your rank if outside top 5; click a name → opens their profile
- [ ] /stock/team/help has 3 new sections; \"?\" icons in dashboard link correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)