### PR TITLE
docs(531): fix stale refs in Hermes audit

### DIFF
--- a/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
+++ b/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
@@ -3,7 +3,7 @@ topic: agents
 type: audit
 status: research-complete
 last-validated: 2026-04-27
-related-docs: 461, 506, 507, 523, 524, 527, 529
+related-docs: 461, 506, 507, 523, 524, 527, 528, 529
 tier: DISPATCH
 ---
 
@@ -112,7 +112,7 @@ Defer all. Ship the simplification, prove 3 clean /fix runs back-to-back, then r
 - github.com/Aider-AI/aider - 43K stars, 6yr mature
 - github.com/All-Hands-AI/OpenHands - 70K stars, $18.8M Series A, 53% SWE-bench
 - github.com/anthropics/claude-code-action - official, would need Telegram bridge
-- Doc 521-529 prior Hermes design
+- Doc 523, 524, 527, 528, 529 prior Hermes design
 
 ## Staleness + Verification
 
@@ -123,7 +123,7 @@ Defer all. Ship the simplification, prove 3 clean /fix runs back-to-back, then r
 
 | # | Action | Owner | Type | By |
 |---|--------|-------|------|-----|
-| 1 | Ship simplification PR: remove biome from preflight.ts, simplify scope routing | Claude | Code | Today |
+| 1 | Ship simplification PR: remove biome from preflight.ts, simplify scope routing | Claude | Code | DONE - PR #334 merged 2026-04-27 09:52 UTC |
 | 2 | Pull on VPS + restart zao-devz-stack | Claude | SSH | Today |
 | 3 | Test 3 /fix runs back-to-back, all task types | Zaal | Manual | After step 2 |
 | 4 | If 3/3 succeed: declare foundation locked, move to next features | Zaal+Claude | Decision | After step 3 |


### PR DESCRIPTION
## Summary

Three small targeted fixes to `research/agents/531-hermes-honest-audit-pivot-or-persist/README.md` discovered during act-session doc review.

## Changes

1. **Frontmatter `related-docs`** - added `528` (referenced twice in body but missing from index field)
2. **Sources** - replaced `Doc 521-529 prior Hermes design` with the actually-extant docs `523, 524, 527, 528, 529` (verified `521` and `522` do not exist anywhere under `research/`)
3. **Next Actions #1** - marked simplification PR done; it shipped as PR #334 merged 2026-04-27 09:52 UTC, before the audit's "Today" deadline. Future readers shouldn't think the action is still open.

## Why

Doc was written today (2026-04-27) so most of it is current. These three were the only stale or broken items that materially affect a reader's ability to navigate the audit's references and action state.

## Out of scope

Did not touch the architectural verdicts, metrics, or the deferred-work list - those reflect the moment of the audit and shouldn't be retroactively edited. If `Action #2` (VPS pull) and `Action #3` (3 back-to-back runs) have status updates, those belong in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)