### PR TITLE
docs(531): normalize timestamp and arxiv reference formatting

### DIFF
--- a/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
+++ b/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
@@ -25,7 +25,7 @@ tier: DISPATCH
 | Bug surface rate | **1 new mechanical bug per 8.4 min of agent runtime** |
 | Trajectory | **Diverging, not converging** |
 
-**The 1 successful run shipped BEFORE pre-flight gate existed.** Every test since pre-flight (#325 Apr 26 5:40 PM UTC) has either failed or escalated. Hermes worked better without the safety net we added to make it safer.
+**The 1 successful run shipped BEFORE pre-flight gate existed.** Every test since pre-flight (#325 Apr 26 17:40 UTC) has either failed or escalated. Hermes worked better without the safety net we added to make it safer.
 
 ## Mechanical Bugs Surfaced In Order
 
@@ -107,7 +107,7 @@ Defer all. Ship the simplification, prove 3 clean /fix runs back-to-back, then r
 - Agent 1 architecture audit: pre-flight as fragility source, drop biome, add Docker
 - Agent 2 alternatives comparison: stick with custom Hermes, migration not worth it
 - Agent 3 production timeline: 1 success / 8 failure rate, 8.4 min between bugs, diverging trajectory
-- arxiv 2604.03551 - AgenticFlict 27.67% conflict rate baseline
+- arxiv.org/abs/2604.03551 - AgenticFlict dataset, 27.67% conflict rate baseline
 - decodingai.com/p/ralph-loops - Boris Cherny Claude Code creator: verification signal 2-3x quality
 - github.com/Aider-AI/aider - 43K stars, 6yr mature
 - github.com/All-Hands-AI/OpenHands - 70K stars, $18.8M Series A, 53% SWE-bench


### PR DESCRIPTION
## Summary

Minor consistency cleanup of `research/agents/531-hermes-honest-audit-pivot-or-persist/README.md` per review intent.

## Changes

- **Timestamp format**: `Apr 26 5:40 PM UTC` → `Apr 26 17:40 UTC` to match the 24-hour format used in the same section (`Apr 26 03:40 UTC`).
- **arxiv reference**: `arxiv 2604.03551` → `arxiv.org/abs/2604.03551` (matches sibling doc 529's citation format and yields a clickable URL when rendered). Added 'dataset,' connector to mirror the way the same paper is cited in doc 529.

## Why

Research docs are increasingly cross-linked; consistent timestamp + citation formats reduce reader friction and make it obvious that 531 and 529 cite the same paper.

## Out of scope

Did not touch the doc's content, structure, or conclusions. No edits to other docs.

---
_Generated by Hermes Stock-Coder via Claude Code CLI (Max plan auth, model: opus). Verified by Hermes-Stock Critic before this PR opened._

_Rationale:_ Doc 531 had two minor consistency issues — a 12-hour timestamp ('5:40 PM UTC') that didn't match the 24-hour format used elsewhere in the same table section, and an arxiv reference missing the '.org/abs/' path that sibling doc 529 uses. Normalized both for clarity without altering content.

**Critic score:** 95/100
**Critic feedback:** Both edits are minimal and correct: 12h→24h time normalization removes ambiguity, and expanding the arxiv citation to a full URL improves navigability. No scope creep, no code touched, no security or pattern issues.