### PR TITLE
fix(stock-team): unblock CI - escape entities + swap a→Link

### DIFF
--- a/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
+++ b/research/agents/531-hermes-honest-audit-pivot-or-persist/README.md
@@ -3,7 +3,7 @@ topic: agents
 type: audit
 status: research-complete
 last-validated: 2026-04-27
-related-docs: 461, 506, 507, 523, 524, 527, 529
+related-docs: 461, 506, 507, 523, 524, 527, 528, 529
 tier: DISPATCH
 ---
 
@@ -112,7 +112,7 @@ Defer all. Ship the simplification, prove 3 clean /fix runs back-to-back, then r
 - github.com/Aider-AI/aider - 43K stars, 6yr mature
 - github.com/All-Hands-AI/OpenHands - 70K stars, $18.8M Series A, 53% SWE-bench
 - github.com/anthropics/claude-code-action - official, would need Telegram bridge
-- Doc 521-529 prior Hermes design
+- Doc 523, 524, 527, 528, 529 prior Hermes design
 
 ## Staleness + Verification
 
@@ -123,7 +123,7 @@ Defer all. Ship the simplification, prove 3 clean /fix runs back-to-back, then r
 
 | # | Action | Owner | Type | By |
 |---|--------|-------|------|-----|
-| 1 | Ship simplification PR: remove biome from preflight.ts, simplify scope routing | Claude | Code | Today |
+| 1 | Ship simplification PR: remove biome from preflight.ts, simplify scope routing | Claude | Code | DONE - PR #334 merged 2026-04-27 09:52 UTC |
 | 2 | Pull on VPS + restart zao-devz-stack | Claude | SSH | Today |
 | 3 | Test 3 /fix runs back-to-back, all task types | Zaal | Manual | After step 2 |
 | 4 | If 3/3 succeed: declare foundation locked, move to next features | Zaal+Claude | Decision | After step 3 |

--- a/src/app/stock/circles/CirclesView.tsx
+++ b/src/app/stock/circles/CirclesView.tsx
@@ -83,7 +83,7 @@ export function CirclesView() {
     return (
       <div className="rounded-xl border border-rose-500/30 bg-rose-500/5 p-6 text-sm text-rose-300">
         {error || 'No circles available yet.'}
-        <p className="mt-2 text-xs text-slate-500">If circles tables don't exist, run scripts/stock-circles-v1-migration.sql in Supabase.</p>
+        <p className="mt-2 text-xs text-slate-500">If circles tables don&apos;t exist, run scripts/stock-circles-v1-migration.sql in Supabase.</p>
       </div>
     );
   }
@@ -94,7 +94,7 @@ export function CirclesView() {
     <div className="space-y-4">
       {!isLoggedIn && (
         <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200">
-          You're viewing as a guest. Sign in at <a href="/stock/team" className="underline">/stock/team</a> to join circles.
+          You&apos;re viewing as a guest. Sign in at <a href="/stock/team" className="underline">/stock/team</a> to join circles.
         </div>
       )}
       {error && (
@@ -141,7 +141,7 @@ export function CirclesView() {
                   </span>
                 )}
                 {c.is_coordinator && (
-                  <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-emerald-300">that's you</span>
+                  <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-emerald-300">that&apos;s you</span>
                 )}
               </div>
               {c.members.length > 0 && (

--- a/src/app/stock/onepagers/page.tsx
+++ b/src/app/stock/onepagers/page.tsx
@@ -37,7 +37,7 @@ export default async function OnePagersPage() {
 
       {!session && (
         <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-200">
-          You're viewing as a guest - only public one-pagers are listed. <a href="/stock/team" className="underline">Sign in</a> to see internal drafts.
+          You&apos;re viewing as a guest - only public one-pagers are listed. <a href="/stock/team" className="underline">Sign in</a> to see internal drafts.
         </div>
       )}
 

--- a/src/app/stock/team/Dashboard.tsx
+++ b/src/app/stock/team/Dashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { GoalsBoard } from './GoalsBoard';
 import { TodoList } from './TodoList';
 import { TeamRoles } from './TeamRoles';
@@ -208,13 +209,13 @@ export function Dashboard({
           >
             Circles -&gt;
           </a>
-          <a
+          <Link
             href="/stock/onepagers"
             className="px-3 py-1.5 rounded-lg text-xs font-medium text-amber-300 border border-amber-500/30 bg-amber-500/5 hover:bg-amber-500/10 whitespace-nowrap"
             title="Briefing docs for sponsors, partners, venues"
           >
             One-pagers -&gt;
-          </a>
+          </Link>
           {!showMore && (
             <button
               onClick={() => setShowMore(true)}

--- a/src/app/stock/team/LoginForm.tsx
+++ b/src/app/stock/team/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 export function LoginForm() {
@@ -84,7 +85,7 @@ export function LoginForm() {
         <div className="space-y-2 text-[11px] text-gray-500 text-center">
           <p><strong className="text-gray-400">No code yet?</strong> DM <a href="https://x.com/bettercallzaal" target="_blank" rel="noreferrer" className="text-[#f5a623] hover:underline">@bettercallzaal</a> on X or Telegram.</p>
           <p>
-            <a href="/stock/onepagers/overview" className="text-[#f5a623] hover:underline">What is ZAOstock?</a>
+            <Link href="/stock/onepagers/overview" className="text-[#f5a623] hover:underline">What is ZAOstock?</Link>
             {' · '}
             <a href="/stock" className="text-[#f5a623] hover:underline">Public site</a>
           </p>

--- a/src/app/stock/team/help/page.tsx
+++ b/src/app/stock/team/help/page.tsx
@@ -117,7 +117,7 @@ const ENTRIES: HelpEntry[] = [
       <>
         <p>The home tab shows what&rsquo;s assigned to you. Open the Overview tab for a full kanban board.</p>
         <ul className="list-disc pl-5 space-y-1">
-          <li><strong>Quick add</strong> on home: type "Did X" or "Going to do Y" and the system parses it.</li>
+          <li><strong>Quick add</strong> on home: type &ldquo;Did X&rdquo; or &ldquo;Going to do Y&rdquo; and the system parses it.</li>
           <li><strong>Bot shortcuts</strong> in DM: <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/do &lt;text&gt;</code> to log work, <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/mytodos</code> to see what you own, <code className="bg-[#0a1628] px-1 rounded text-[#c7d2fe]">/mytodos_all</code> to see everything open.</li>
           <li><strong>Status</strong> moves todo -&gt; in_progress -&gt; done. Click to update.</li>
         </ul>


### PR DESCRIPTION
## Summary

Fix 10 lint errors in `src/app/stock/*` files (introduced in PRs #350–#353) that are currently blocking CI on every PR including doc-only ones. Main has been red for hours on these errors.

## Why a separate PR

Originally bundled with #356 (doc 531 audit fixes). #356 was merged externally before this lint fix could land, so reopening it here as a focused PR.

## Changes

- `CirclesView.tsx` — escape 3 unescaped apostrophes (`don't`, `You're`, `that's`)
- `onepagers/page.tsx` — escape 1 unescaped apostrophe (`You're`)
- `team/help/page.tsx` — escape 4 unescaped quote marks (`"Did X"`, `"Going to do Y"`)
- `team/Dashboard.tsx` — `<a href="/stock/onepagers">` → `<Link>` (added `next/link` import)
- `team/LoginForm.tsx` — `<a href="/stock/onepagers/overview">` → `<Link>` (added `next/link` import)

## Verification

Ran `npx eslint --max-warnings 15` locally: **0 errors, 15 warnings** (under max). Same command CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)