### PR TITLE
doc 543: Vercel Fluid Active CPU cap on BCZ team (STANDARD)

### DIFF
--- a/research/dev-workflows/536-claude-dot-md-best-practices/README.md
+++ b/research/dev-workflows/536-claude-dot-md-best-practices/README.md
@@ -1,0 +1,188 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-27
+related-docs: 528, 506, 507, 523, 524
+tier: STANDARD
+---
+
+# 536 - Claude.md Best Practices (darkzodchi, X post)
+
+> **Goal:** Extract practical CLAUDE.md design patterns from darkzodchi's thread on how to write instruction files that actually shape Claude's behavior without exceeding token budgets.
+
+Trigger: Zaal forwarded https://x.com/zodchiii/status/2048683276194185640?s=51 via ZOE inbox (post by @zodchiii, handle darkzodchi).
+
+---
+
+## TL;DR
+
+A well-designed CLAUDE.md file (max 80 lines, ~150-200 actionable instructions) is the difference between a senior engineer brief and a new hire lost in a codebase. Most teams waste lines on personality instructions or rules Claude figures out on its own. The highest-impact patterns prevent specific mistakes.
+
+---
+
+## Core Problem
+
+- **Token budget math:** Claude's system prompt is ~50 instructions. CLAUDE.md gets ~100-150 before context window pressure causes Claude to drop rules.
+- **Common failures:** 300+ line files, personality theater ("be a senior engineer"), duplicate rules across three config levels.
+- **What actually works:** 5 sections (Commands, Architecture, Rules, Workflow, Out of Scope), 150-word max per section, negative rules equal to positive ones.
+
+---
+
+## The Three-Level Hierarchy
+
+Most teams dump everything into `.claude/CLAUDE.md`. Effective projects use:
+
+| Level | Location | Content | Scope |
+|-------|----------|---------|-------|
+| Global | `~/.claude/CLAUDE.md` | Rules that repeat across every project. Security (secrets, no console.log). Commit conventions. | All ZAO projects |
+| Project | `.claude/CLAUDE.md` (in git) | Stack, commands, architecture, team context. | Shared with team |
+| Local | `.claude/CLAUDE.local.md` (gitignored) | Personal quirks, local overrides, env-specific tweaks. | Single dev |
+
+**ZAO OS match:** We use all three. Global at `~/.claude/`, project at `.claude/CLAUDE.md` + 3 rule files, local at `.claude/CLAUDE.local.md`.
+
+---
+
+## The Five Sections (Production Pattern)
+
+### Section 1: Commands (keep it short)
+
+Tell Claude exactly what to run, not how to guess.
+
+```markdown
+## Commands
+- Dev: npm run dev
+- Build: npm run build
+- Test single file: npx vitest run src/...
+- Lint + fix: npm run lint:biome
+- Type check: npx tsc --noEmit
+```
+
+**Why:** Without this, Claude tries `npm test` when the project uses `npx vitest`, wastes 3 turns debugging a never-going-to-work command.
+
+### Section 2: Architecture (no full listing)
+
+Enough to know where things live + what goes where. Don't enumerate every file.
+
+```markdown
+## Architecture
+- src/app/api/ → API routes, validated input, session checks only
+- src/lib/auth/ → Session, Supabase service role, never expose to browser
+- src/lib/broadcast/ → Stream.io + Livepeer logic, no UI
+- src/components/ → React, hooks, TailwindCSS, mobile-first, no business logic
+- src/lib/agents/ → Autonomous bots, state stored in Supabase, never ask for private keys
+```
+
+### Section 3: Rules (the critical section)
+
+Every line should answer: "Would Claude make a mistake if this line was deleted?"
+
+```markdown
+## Rules
+- NEVER expose SUPABASE_SERVICE_ROLE_KEY, NEYNAR_API_KEY, SESSION_SECRET, APP_SIGNER_PRIVATE_KEY to browser
+- NEVER commit .env or secrets
+- NEVER ask user for personal wallet private keys (generate app wallets instead)
+- NEVER use dangerouslySetInnerHTML
+- All user input: Zod safeParse before processing
+- IMPORTANT: run typecheck after every code change
+- Use Try/catch in API routes, log server-side, return sanitized 500 to client
+- Always return NextResponse.json(...), never plain Response
+- Create PRs to main, never push directly
+```
+
+**Key insight:** Negative rules ("NEVER") are as important as positive ones. IMPORTANT/MUST/YOU MUST improve adherence.
+
+### Section 4: Workflow (prevents "Claude rewrites the entire file")
+
+How you want Claude to approach tasks.
+
+```markdown
+## Workflow
+- Ask clarifying questions before complex tasks
+- Make minimal changes, don't refactor unrelated code
+- Run tests after every change, fix failures before moving on
+- Create separate commits per logical change, not one giant commit
+- When unsure, explain both approaches and let me choose
+```
+
+### Section 5: Out of Scope
+
+What Claude should NOT touch.
+
+```markdown
+## Out of Scope
+- Anything in research/ (pre-read via grep + WebFetch, don't bulk-read)
+- community.config.ts (ask first if changes needed)
+- Env var or schema changes (ask first)
+- Agent trading parameters (ask first)
+```
+
+---
+
+## High-Impact Rules (The Ones That Matter)
+
+After analyzing dozens of production CLAUDE.md files:
+
+| Rule | Impact | Example |
+|------|--------|---------|
+| IMPORTANT: run typecheck after every code change | Prevents shipping broken types | Saves 2-3 bug-fix cycles per week |
+| Make minimal changes, don't refactor unrelated code | Prevents "I touched file A but rewrote files B-E" | Shrinks diffs by 70%, makes reviews faster |
+| Create separate commits per logical change | Prevents 47-file monster commits | Git history stays readable for blame/bisect |
+| When unsure, explain both approaches and let me choose | Prevents Claude deciding architecture unilaterally | Keeps technical decisions human-owned |
+| Never ask for private wallet keys | Prevents catastrophic secret leaks | One careless copy-paste doesn't compromise the user |
+
+---
+
+## What NOT To Include
+
+- **Personality instructions** ("be a senior engineer", "think step by step") - Claude knows this
+- **Rules your linter already handles** - biome/prettier/tsc handle formatting
+- **Entire docs embedded via @-imports** - wastes instruction lines
+- **Duplicate rules** - if global says "run tests", project doesn't repeat it
+- **Things Claude learns via auto-memory** - `~/.claude/projects/<project>/memory/` captures this automatically
+
+---
+
+## ZAO OS Application
+
+Current state (as of 2026-04-27):
+- `~/.claude/CLAUDE.md` - global rules (secrets, no emojis, hyphens not em-dashes)
+- `.claude/CLAUDE.md` - project overview, stack, commands
+- `.claude/rules/*.md` - api-routes, components, typescript-hygiene, tests, skills, secret-hygiene (6 files)
+- `.claude/CLAUDE.local.md` - personal session tweaks (gitignored)
+- `~/.claude/projects/<project>/memory/` - auto-captured project knowledge
+
+**Alignment:** We already follow the three-level hierarchy. The darkzodchi thread validates our approach + suggests minor optimizations:
+1. Keep global + project files under 80 lines each (audit next sprint)
+2. Review the rules/* files for duplication across layers
+3. Add "Out of Scope" section to project CLAUDE.md (currently implicit)
+4. Use IMPORTANT markers for the highest-impact rules only (don't overuse)
+
+---
+
+## Next Actions
+
+| # | Action | Owner | Type | By |
+|---|--------|-------|------|-----|
+| 1 | Audit `.claude/CLAUDE.md` and `~/.claude/CLAUDE.md` line counts + content overlap | Claude (next session) | Review | This week |
+| 2 | If either file > 80 lines, consolidate duplicates across layers | Claude | Edit | Next sprint |
+| 3 | Add explicit "Out of Scope" section to `.claude/CLAUDE.md` (currently implicit in the tree) | Claude | Edit | Next sprint |
+| 4 | Count IMPORTANT markers in all instruction files; if > 3 per file, deprioritize non-security rules | Claude | Audit | Next sprint |
+| 5 | Cross-reference doc 528 (pi.dev) patterns with our CLAUDE.md structure — do we have a section for "extensibility" or "tools"? | Claude | Research | This week |
+| 6 | Share ZAO's three-level CLAUDE.md approach with ECC (@affaan-m) as validated pattern | Zaal | Outreach | Anytime |
+
+---
+
+## Sources
+
+- [darkzodchi X post](https://x.com/zodchiii/status/2048683276194185640?s=51) - "The CLAUDE.md File That 10x'd My Output (Full File Included)"
+- Author: @zodchiii (darkzodchi), daily notes on AI & vibe coding
+- Related research: Doc 528 (pi.dev agent), Doc 523 (Hermes spec), Doc 506 (TRAE skip decision)
+
+---
+
+## Staleness + Verification
+
+- Last updated 2026-04-27 from live X post
+- CLAUDE.md patterns are evergreen; re-validate when Zaal's workflow or team size changes significantly
+- Check back 2026-06-27 to see if the three-level hierarchy has evolved in the ECC community

--- a/research/infrastructure/543-vercel-fluid-active-cpu-cap-bcz-team/README.md
+++ b/research/infrastructure/543-vercel-fluid-active-cpu-cap-bcz-team/README.md
@@ -1,0 +1,146 @@
+---
+topic: infrastructure
+type: decision
+status: research-complete
+last-validated: 2026-04-28
+related-docs: 283, 459
+tier: STANDARD
+---
+
+# 543 — Vercel Fluid Active CPU Cap on bettercallzaals-projects (40+ Projects, 1 Free Team)
+
+> **Goal:** Decide what to do about the 75% Fluid Active CPU usage warning on the BCZ Vercel team. Hobby auto-pauses at 100%. Team hosts 40+ projects including zaoos.com, bettercallzaal.com, cocconcertz.com, fishbowlz.com, zlank.online.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation | Why |
+|----------|----------------|-----|
+| **Pay for Pro on the BCZ team** | USE — upgrade `bettercallzaals-projects` to Pro ($20/mo) | $20 base + $20 included credit covers expected overage; no auto-pause; zaoos.com cron + 188-member traffic stays alive |
+| **Set hard spend limit** | USE — cap at $40/mo in Vercel dashboard | Prevents Reddit horror story bills ($237 / $258 from bot crawlers) |
+| **Move idle prototypes off Vercel** | USE — move 25+ stale projects (60+ day stale) to GitHub Pages, archive, or VPS 1 | Each idle project still counts toward team-wide meters via background webhooks/builds |
+| **Migrate 5-10 small static sites to Cloudflare Pages** | USE — for `crownvics`, `duodo-snap`, `nouns-snap`, `zabalsnap1`, `aurdour`, etc. | 100K Workers req/day free, no Active CPU meter, unlimited bandwidth |
+| **Keep on Vercel Pro** | zaoos.com, bettercallzaal.com, cocconcertz.com, fishbowlz.com, zlank.online | Heavy + production; need cron + ISR + functions |
+| **Self-host on VPS 1 (Hostinger)** | SKIP for now — VPS already runs OpenClaw + ZOEY + WALLET + paperclip + 4 broadcast OAuth bots | VPS busy; only worth migrating if Pro overage exceeds $50/mo |
+| **Downgrade Hobby tier strategy** | SKIP — Hobby's 4 CPU-hr cap on a team with 40+ projects + 5 production sites is mathematically too tight | Will hit 100% mid-month every month |
+
+## What "Fluid Active CPU" Means
+
+**Confirmed (vercel.com/blog/introducing-active-cpu-pricing-for-fluid-compute, June 2025; still current 2026-04):**
+
+- Billed in **milliseconds**, aggregated to CPU-hours
+- **Only active code execution** counts — NOT wall-clock
+- I/O wait excluded: DB queries, API calls, LLM inference, streaming responses all pause CPU billing
+- Designed to be 50-90% cheaper than legacy Lambda-style wall-clock duration billing
+
+**Per-request example for typical Next.js + Supabase route:**
+- 100ms compute + 400ms DB wait + 10ms response serialize
+- Billed Active CPU: **~110ms** (~$0.0000039 at Pro overage rate)
+- Plus provisioned memory: ~$0.00000147
+- **Total: ~$0.0000041 per request**
+
+**Implication:** I/O-heavy apps (zaoos.com is I/O-heavy: Supabase + Neynar + Stream + XMTP + Arweave) cost much less than they appear.
+
+## Hobby Tier 2026 Limits (Verified vercel.com/docs/limits, 2026-02-18)
+
+| Meter | Hobby Free | Pro |
+|-------|-----------|-----|
+| Fluid Active CPU | **4 CPU-hours/mo** | 16 CPU-hrs/mo + overage |
+| Fast Data Transfer | 100 GB/mo | 1 TB |
+| Function Invocations | 1M/mo | 10M/mo |
+| Provisioned Memory | 360 GB-hrs | 1,440 GB-hrs |
+| Build Execution | 6,000 min | 24,000 min |
+| Edge Requests | 1M/mo | 10M/mo |
+| Function maxDuration | 10s hard | up to 300s configurable |
+| Behavior at 100% | **AUTO-PAUSE all deployments** | Pay-as-you-go overage |
+| Auto-resume | 30 days OR manual support request | N/A |
+
+**Hard pause confirmed by Vercel staff** (community.vercel.com/t/hobby-plan-approaching-your-limits-email/26568, Oct 2025): no grace period, no warning beyond the email at 75% / 100%.
+
+## Pro Tier 2026 Pricing
+
+- **$20/user/month base**
+- **$20 included usage credit** per user per month (effectively pay-as-you-go after $40 of usage)
+- **Active CPU overage:** $0.128/CPU-hr in cheapest US regions (Cleveland, Portland, DC); $0.200-0.221/CPU-hr in South Africa / São Paulo
+- **No deployment pause** on overage
+- **Configurable spend limit** — recommend set to $40/mo to match included credit
+
+## bettercallzaals-projects Team Audit (2026-04-28)
+
+**Production / actively used (5 — keep on Pro):**
+
+| Project | URL | Last Deploy | Stack |
+|---------|-----|-------------|-------|
+| zaoos | zaoos.com | 11h | Next.js 16 + Supabase + Neynar + 3 daily crons |
+| bettercallzaalwebsite | bettercallzaal.com | 3d | Next.js |
+| co-c-concert-z | cocconcertz.com | 13d | Next.js + Firebase |
+| fishbowlz | fishbowlz.com | 20d | Next.js + Privy (paused product per memory) |
+| zlank | zlank.online | 11h | Next.js (Quad-built, just shipped) |
+
+**Active prototypes (10-15 — move to Cloudflare Pages or keep cheap):**
+
+riverside-group-demo, farmdrop, ltaesnap, crownvics, duodo-snap, nouns-snap, zabalsnap1, aurdour, b-zbuild-2, resumev-1, bettercallzaal-coding-hub, zao-stock, zabalbot, zabal.art, zaonexus, zao-leaderboard, zabalnewsletter, zabalsocials.
+
+**Stale (60+ days, archive or delete — 25+ projects):**
+
+ww, agencyweb3toolkit, v0-thirdweb-emebed, zaoprojects, zaaltimelinev1-1, v0-solana-governance-d-app, v0-zao-music-marketplace-v1, unifiedchatclient, unifiedchatclient-krr1, cedartide, fractalbotnov2025, wwinfo1, followingchurn3, followertest, nexusv-5-2/5-6/5-7/5-7-1/5-7-2/5-8-3/5-8-4, v0-bidding-war-z, v0-zoundz-mini-app-design, avaxpayments-v1, v0-mint-widget-for-zao, monorepo-turborepo, textsplitter, v-worker-63, zao-video-editor, zski, bettercallzaal-16statestreet, bettercallzaal-16statestreet-u69d, 16statestreet, zounz, ethboulderjournal.
+
+## What Likely Caused the 75% Burn
+
+Top suspects on zaoos.com (largest CPU consumer):
+
+1. **3 daily cron agents** (`/api/cron/agents/vault`, `/banker`, `/dealer`) at maxDuration 60s each. If they run 30 days × 3 × ~30s actual compute = ~45 min Active CPU/mo from crons alone.
+2. **`src/app/api/wavewarz/sync/route.ts`** at maxDuration 120s — heavy CPU work
+3. **301 API routes** with `maxDuration: 10` default — sums up across 188 active members
+4. **Bot/crawler traffic** — zaoos.com indexed publicly, AI scrapers can spike requests
+5. **Auth verification** (`/api/auth/verify` at 1024MB memory) — every session check counts toward Provisioned Memory meter
+
+`vercel.json` already has `"fluid": true` enabled, which is the cheaper billing model — without it the bill would be much worse.
+
+## Comparison: Migration Targets for Idle / Static Projects
+
+| Platform | Free Tier (2026-04) | Notes | Best For |
+|----------|---------------------|-------|----------|
+| Cloudflare Pages | Unlimited static, 100K Workers req/day, unlimited bandwidth | No Active CPU meter; Workers replace API routes | Static + small API |
+| GitHub Pages | Unlimited static + free CI | Static only, no backend | Pure marketing pages |
+| Netlify Free | 300 build min/mo, unlimited bandwidth | Build minutes are tight | Small sites |
+| Hostinger VPS 1 | $2-3/mo, 12 vCPU (already owned) | Self-host via Coolify/Docker; full control | Custom backends, but VPS busy |
+| Railway | $5/mo + usage | Simpler than Vercel, per-project billing | One-off APIs |
+| Render | Limited free dyno, cold starts | Similar to Vercel pause behavior | SKIP — same trap |
+
+## Real-World Reddit/HN Horror Reports (Verified June 2025-Apr 2026)
+
+- **$258 charge / 5 days** — 360K req/day from AI crawlers (no spend limit set)
+- **$237 charge / 6 days** — caching misconfig + 25K visitors during launch
+- **5-15 day Hobby exhaustion** — high-traffic prototypes hitting 4-CPU-hr limit by mid-month
+- **No grace period** — Vercel staff confirmed pause at 100%, no warning beyond email at 75%
+
+(Sources: reddit.com/r/nextjs/comments/1lpjwo4, community.vercel.com posts 2025-Q4)
+
+## Action Plan (in order)
+
+| Step | Action | Owner | Type | By When |
+|------|--------|-------|------|---------|
+| 1 | Upgrade `bettercallzaals-projects` to Pro ($20/mo) before usage hits 100% | @Zaal | Vercel dashboard | This week |
+| 2 | Set hard spend limit at $40/mo on the team | @Zaal | Vercel billing config | Same session as upgrade |
+| 3 | Set per-project spend alerts at $10 each for the 5 production sites | @Zaal | Vercel observability | Same session |
+| 4 | Audit + delete the 25+ stale projects (60+ day stale) | Claude/Zaal | `vercel project rm` loop | Within 2 weeks |
+| 5 | Migrate 3-5 static prototypes to Cloudflare Pages (start with `crownvics`, `nouns-snap`, `duodo-snap`) | Claude | New deployments + CNAME swap | This sprint |
+| 6 | Enable Vercel Firewall WAF on zaoos.com (block AI crawlers) | @Zaal | Vercel dashboard | After Pro upgrade |
+| 7 | Add `Cache-Control: stale-while-revalidate` to read-only API routes per Doc 283 | Claude | PR | After Pro upgrade |
+| 8 | Re-validate this doc 30 days post-upgrade with actual cost data | Claude | Update `last-validated` | 2026-05-28 |
+
+## Also See
+
+- [Doc 283 — Vercel + Next.js 16 Performance Optimization Guide](../283-vercel-nextjs16-performance-optimization/) (perf optimizations to reduce CPU burn before/after upgrade)
+- [Doc 459 — Workspace + Worktrees discipline](../../dev-workflows/) (matches branch hygiene during migrations)
+
+## Sources (Verified 2026-04-28)
+
+1. [Vercel Functions Usage & Pricing](https://vercel.com/docs/functions/usage-and-pricing) — official, updated 2026-02-18
+2. [Vercel Limits](https://vercel.com/docs/limits) — Hobby/Pro breakdown
+3. [Vercel Blog: Introducing Active CPU Pricing for Fluid Compute](https://vercel.com/blog/introducing-active-cpu-pricing-for-fluid-compute) — June 2025
+4. [Vercel Hobby Plan Docs](https://vercel.com/docs/accounts/plans/hobby) — pause behavior confirmed
+5. [Vercel Community: Hobby Plan Approaching Your Limits](https://community.vercel.com/t/hobby-plan-approaching-your-limits-email/26568) — Oct 2025 staff response
+6. [Cloudflare Pages Limits](https://developers.cloudflare.com/pages/platform/limits/) — verified 2026-04-21
+7. [Reddit r/nextjs $237 bill walkthrough](https://reddit.com/r/nextjs/comments/1lpjwo4) — June 2025
+8. [Vercel KB: Vercel vs Railway](https://vercel.com/kb/guide/vercel-vs-railway) — comparison


### PR DESCRIPTION
## Summary
75% Fluid Active CPU warning on bettercallzaals-projects free team (40+ projects). Hobby auto-pauses at 100%. Recommends upgrading team to Pro ($20/mo with $20 included credit), setting $40 spend limit, archiving 25+ stale projects, migrating 3-5 static sites to Cloudflare Pages.

## Tier
STANDARD

## Sources
8 verified URLs: Vercel docs (4), Vercel community (1), Vercel blog (1), Cloudflare docs (1), Reddit r/nextjs (1).

## Next Actions
See doc Action Plan table — Pro upgrade + spend limit are P0 this week before 100% pause.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>