### PR TITLE
docs(CLAUDE.md): add Workflow Orchestration section (6 rules)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,15 @@ Env vars: see `.env.example`. App wallet: `npx tsx scripts/generate-wallet.ts`.
 - Use CSS modules or inline styles (Tailwind only)
 - Pre-read large directories (spaces/ music/ governance/ zounz/) unless task requires it
 
+## Workflow Orchestration
+
+1. **Plan first.** For any task with 3+ steps or architectural decisions, enter plan mode (or use `/plan-eng-review` / `/plan-ceo-review`). Never start a non-trivial task without a plan visible to Zaal.
+2. **Subagents over inline work.** Offload research, code search, and multi-file analysis to Task/Agent tools. Keep main context for synthesis + decisions.
+3. **Self-improvement loop.** When Zaal corrects an approach, save the pattern to `~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/feedback_*.md`. Re-read relevant feedback memories at session start.
+4. **Verification before "done".** Never mark a task complete without proof: tests pass, build green, screenshot of UI, or explicit Zaal approval. Run `/qa` for UI features, `npm run typecheck` for code.
+5. **Elegance check on non-trivial changes.** Before committing, ask: "is there a simpler way?" Skip for trivial fixes.
+6. **Autonomous bug fixing.** Given a bug report, fix it without asking permission for each step. Use `/investigate` for root cause; only escalate if blocked.
+
 ## Per-File Commands
 
 | File Pattern | Test | Lint |


### PR DESCRIPTION
## Summary
Adds a 9-line Workflow Orchestration section to root CLAUDE.md with 6 rules:
1. Plan first (3+ step tasks)
2. Subagents over inline work
3. Self-improvement loop via memory feedback files
4. Verification before "done"
5. Elegance check on non-trivial changes
6. Autonomous bug fixing

## Source
Synthesized from:
- doc 536 - darkzodchi CLAUDE.md best practices
- doc 537 - Shann's superpowers planning framework

Most patterns are already enforced by installed skills (superpowers, /qa, /ship, /investigate, auto-memory). This PR makes the discipline explicit at the project level so it's visible without skill discovery.

## Diff
9 lines added between Boundaries and Per-File Commands sections. CLAUDE.md grows from 109 to 118 lines (still well under the 200-line target from doc 536).

## Test plan
- [ ] Read root CLAUDE.md to confirm new section renders cleanly
- [ ] Confirm rules don't conflict with global ~/.claude/CLAUDE.md or .claude/rules/* files
- [ ] Validate links: /plan-eng-review, /plan-ceo-review, /qa, /investigate

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>