### PR TITLE
docs: ZAOstock standup agenda for Apr 28

### DIFF
--- a/research/events/_zaostock-hub/standups/2026-04-28.md
+++ b/research/events/_zaostock-hub/standups/2026-04-28.md
@@ -1,0 +1,134 @@
+# ZAOstock standup - Tuesday April 28, 2026
+
+> **10:00am - 11:00am ET · Google Meet only · Recorded**
+> Meet: https://meet.google.com/meg-dipk-euo
+
+**Goal today:** every teammate finishes their bio + photo on the call. Aim is a fully-stocked team page by end of week, ready to share publicly.
+
+**Core principle:** Music first. Community second. Technology third.
+
+---
+
+## Pre-reads (5 min before the call)
+
+- **Dashboard** - log in with your 4-letter code: [zaoos.com/stock/team](https://zaoos.com/stock/team)
+- **Help / how-to** - 12 sections covering everything: [zaoos.com/stock/team/help](https://zaoos.com/stock/team/help)
+- **Public team page** (where your bio shows up): [zaoos.com/stock](https://zaoos.com/stock)
+
+If you've never logged in: your code came from Zaal in DM. Lost it? Ping `@bettercallzaal` on Telegram or X.
+
+---
+
+## Agenda (60 min target)
+
+### 10:00-10:05 (5 min) - Where we are
+
+- 158 days to Oct 3
+- Roddy meeting moved to Thursday
+- Last week shipped: bot live, dashboard live, 14 teammates pre-linked, 3 fully linked, 5 new added (Stilo World, Eve, Bacon, Eduard, Thy Revolution), Geek -> GeekMyth rename, Adam joined ops
+- This week shipped: full dashboard UX overhaul - onboarding checklist, WYSIWYG bio editor, status text, skills, activity feed, completeness leaderboard, help docs
+
+### 10:05-10:35 (30 min) - LIVE WALKTHROUGH (Zaal screen-shares)
+
+**The whole point of today: every teammate gets their profile to 100% on this call.**
+
+#### Part A - dashboard tour (15 min)
+
+1. `/stock/team` - log in flow
+2. **Onboarding checklist** at the top of home tab - click step 1 (bio), it scrolls you to the editor
+3. **Bio editor** - WYSIWYG (B / I / H / lists / link / quote / divider). Type, select, click - no markdown to remember.
+4. **Status text** - one line, what you're working on right now
+5. **Skills** - comma-separated tags ("video, sound, sponsorship outreach"). Searchable in the team directory.
+6. **Links** - one row per link. + Add another link for more. Auto-detects type.
+7. **Save** - green pill confirms
+8. **Team tab** - search anyone, scope filter, "Reach out" opens their X / Farcaster / email, "Share profile" copies their public URL
+9. **Public profile** - shareable URL (`/stock/team/m/<your-name>`)
+10. **Recent activity feed + leaderboard** on the home tab
+11. **Help page** (top right of dashboard) - 12 sections, use it BEFORE pinging Zaal
+
+#### Part B - Telegram bot tour (10 min)
+
+DM [@ZAOstockTeamBot](https://t.me/ZAOstockTeamBot). The bot is the second half of the team OS - the dashboard is for editing your stuff, the bot is for fast logging + queries.
+
+Commands worth knowing:
+
+| Command | What it does |
+|---|---|
+| `/help` | Full list |
+| `/status` | Festival snapshot - sponsor $, artists confirmed, days to Oct 3 |
+| `/circles` | All 8 circles + who coordinates each |
+| `/join <slug>` | Grab a circle (e.g. `/join music`) |
+| `/mycircles` | Your circles |
+| `/mytodos` | Your todos |
+| `/mytodos_all` | Everything open across the team |
+| `/do <text>` | Log work in plain English ("did X", "going to do Y") |
+| `/idea <text>` | Drop into the suggestions pool, Zaal sees daily |
+| `/note <text>` | Meeting note straight to the dashboard |
+| `/ask <question>` | Ask the bot anything, no DB write |
+| `/op` | List of one-pager briefings (sponsor, partner, venue) |
+
+The bot also runs:
+- Morning digest at 6am ET (festival snapshot)
+- Evening recap at 6pm ET (what shipped today)
+- Monday week-ahead at 9am ET (what's due this week)
+- Friday retro at 5pm ET (what landed)
+
+#### Part C - everyone fills out their profile (5 min)
+
+Stay on the call. Open `/stock/team` in your own laptop. Use the onboarding checklist. Get to 100%.
+
+If you finish early: drop your profile URL in the chat for someone else to react to.
+
+### 10:35-10:50 (15 min) - Circle round-robin
+
+2-3 min per circle. Each lead gives:
+- 1 thing moved this week
+- 1 blocker or stuck thing
+- 1 ask for the team
+
+Order:
+1. **Music** (DCoop / Shawn) - artist pipeline, sound plan, Cypher prep
+2. **Ops** (Zaal + crew) - venue, power, vendors, permits
+3. **Partners** (Zaal) - sponsors pipeline, local biz outreach
+4. **Finance** (Tyler advisory) - budget snapshot
+5. **Marketing** - socials, newsletter, local press, signage
+6. **Media** - photo / video / docs pipeline
+7. **Merch** - day-of merch, T-shirts, posters
+8. **Host** - artist hospitality, volunteer coord
+
+If a circle has no lead, name it on the call so we can fill it.
+
+### 10:50-10:55 (5 min) - Roddy meeting prep (Thursday)
+
+Roddy is the City of Ellsworth Parks/Rec director. Locks the venue + city support.
+
+- Anything you want me to surface with him?
+- The city is running ~10 Thursday-night concerts at the Parklet June-Sept. We want in. What's the path?
+- Year 1 = relationship. NOT asking for money. Asking for his voice in the room.
+
+### 10:55-11:00 (5 min) - Wrap + commitments
+
+Each person commits to **1 thing through Tuesday May 5**. Drop it in TG chat after the call.
+
+---
+
+## After the call
+
+- Recording uploaded to Drive within 1 hour, link drops in TG group
+- Action items show up on the dashboard at `/stock/team` -> Notes tab
+- This page stays at the URL above as the canonical agenda for this week
+
+**Next call:** Tuesday May 5, 10:00am ET. Same Meet link.
+
+---
+
+## Context for new teammates landing on this page cold
+
+ZAOstock 2026 is a one-day outdoor music festival on **Saturday October 3, 2026** at the Franklin Street Parklet in downtown Ellsworth, Maine. Run end-to-end by **The ZAO** - a 188-member global decentralized music community founded by Zaal Panthaki. Year 1 = relationship over scale.
+
+ZAOstock is the flagship of the **ZAO Festivals** umbrella.
+
+- Public site: [zaoos.com/stock](https://zaoos.com/stock)
+- Overview brief: [zaoos.com/stock/onepagers/overview](https://zaoos.com/stock/onepagers/overview)
+- Newsletter: [paragraph.com/@thezao](https://paragraph.com/@thezao)
+- Contact: zaal@thezao.com


### PR DESCRIPTION
Hostable agenda for today's 10am team call. Lives in the festival hub so it has a stable GitHub URL for the GCal invite + after-meeting share.