### PR TITLE
docs: drop empty Recording section + fold 'for the team' wording

### DIFF
--- a/research/events/_zaostock-hub/standups/2026-04-28.md
+++ b/research/events/_zaostock-hub/standups/2026-04-28.md
@@ -1,11 +1,72 @@
 # ZAOstock standup - Tuesday April 28, 2026
 
-> **10:00am - 11:00am ET · Google Meet only · Recorded**
+> **10:00am - 11:00am ET · Google Meet · Recorded**
 > Meet: https://meet.google.com/meg-dipk-euo
 
-**Goal today:** every teammate finishes their bio + photo on the call. Aim is a fully-stocked team page by end of week, ready to share publicly.
+**Goal:** every teammate finishes their bio + photo on the call. Aim is a fully-stocked team page by end of week, ready to share publicly.
 
 **Core principle:** Music first. Community second. Technology third.
+
+---
+
+## Recap (post-call)
+
+**Attended:** Zaal, DFresh, Tom Fellenz, Adam Place, Jake (GeekMyth), Shawn Porter, FailOften, Candy Sam.
+
+**Headline:** First Meet-only call. Smaller turnout than Discord weeks but tight, focused, and recorded. Switched venue mid-meeting for FailOften + Geek + Shawn (originally on Discord). Going forward = Meet by default, more accessible for non-Discord folks (Bar Harbor Chamber of Commerce coming next week).
+
+### What got covered
+
+1. **Dashboard walkthrough** at `zaoos.com/stock/team`. Three things every teammate is asked to do this week:
+   - Add a **bio** (1-3 sentences)
+   - Add a **photo** (right-click X profile pic -> Copy image address -> paste)
+   - Join at least one **circle** in the Telegram bot (`/circles` then `/join <slug>`)
+2. **Public team page** at `zaoos.com/stock` already shows Sean, Edward, Bacon, Iman, and Zaal with photos. Goal: full grid by Sunday so we can share it in next week's newsletter.
+3. **Telegram bot tour** at [@ZAOstockTeamBot](https://t.me/ZAOstockTeamBot). Live commands: `/help`, `/whoami`, `/status`, `/circles`, `/join`, `/leave`. Note: bot is rule-based right now, not AI. Two AI agents are in development with the ZAO Devz testing chat.
+4. **Two-tier teammate model** introduced:
+   - **Initial volunteer** = anyone who shows up
+   - **Committed volunteer** = bio + photo + at least one circle joined
+5. **Live during the call:** DFresh joined the Host circle (`/join host`) - it worked.
+
+### Key decisions
+
+- **Migrating zaoos.com/stock → zaostock.com this week.** Fresh repo, fresh Supabase, own domain (existing memory + GitHub issue #339).
+- **Discord standup format dropped.** Meet only going forward.
+- **Per-circle Telegram channels coming** - one per circle, auto-muted for non-members. Today only the ops channel exists.
+- **All 8 circles currently have Zaal as coordinator.** Looking to hand off to anyone interested. Speak up in TG.
+- **Curated post auto-publish** for the @ZAOFestivals X account is on the build list. Pattern: anyone proposes a post, 2 other members approve, auto-posts. Borrowed from Zaal's existing token-vote feature in another app. Lets people draft + ship overnight without Zaal in the loop.
+
+### Updates from Zaal
+
+- **Roddy (Parks/Rec) meeting moved to Thursday.** Venue confirmation update next week.
+- **ZAOville event with DCoop, July, DMV.** Side track but big content opportunity for the team.
+- **POIDH bounty for clip-up** of yesterday's YouTube video - $15, 3 clips already submitted overnight. Pattern to repeat for community-curated content.
+- **Fresh Farm Foods vendor lead** - Zaal will intro to GeekMyth in a couple months for healthy day-of meal planning.
+
+### Open questions raised on the call
+
+- **Wifi / livestream connectivity at the Parklet** (Zaal): may bring own router or extend a public network for the day. Tom Fellenz raised this; Zaal flagged he doesn't have a complete answer yet. Goes to the **Host** circle.
+- **Cameras for livestream** (Tom Fellenz): may be able to lend gear from the existing setup. Zaal to follow up.
+- **Sound vendor coverage** (Shawn Porter): something to chop up further. Music circle followup.
+
+### Two non-negotiables for Oct 3 (Zaal)
+
+1. The event is solid enough that we can do it again next year.
+2. We livestream it.
+
+Everything else (Wave Boards event, drinks, food, day-of partners) gets confirmed closer in.
+
+### Action items - this week
+
+| Owner | Action | Due |
+|---|---|---|
+| Everyone | Add bio + photo at zaoos.com/stock/team | Sunday May 4 |
+| Everyone | Join at least one circle via [@ZAOstockTeamBot](https://t.me/ZAOstockTeamBot) `/join <slug>` | Sunday May 4 |
+| Zaal | Meet Roddy at City Hall | Thursday April 30 |
+| Zaal | Lock venue + post update | After Roddy meeting |
+| Zaal + Candy + Toybox + Tricky | Start posting Zalapalooza past content from @ZAOFestivals X | This week |
+| Zaal | Spin out zaostock repo + DB + domain | Wednesday April 29 |
+
 
 ---
 


### PR DESCRIPTION
Replaces #369 (had merge conflicts). Two tiny tweaks to research/events/_zaostock-hub/standups/2026-04-28.md: drop the empty 'Recording' section since we're not posting a Drive URL, fold in the 'for the team' wording on the ZAOville bullet.