### PR TITLE
docs: rename volunteer tiers to Resource / Volunteer

### DIFF
--- a/research/events/_zaostock-hub/standups/2026-04-28.md
+++ b/research/events/_zaostock-hub/standups/2026-04-28.md
@@ -24,8 +24,8 @@
 2. **Public team page** at `zaoos.com/stock` already shows Sean, Edward, Bacon, Iman, and Zaal with photos. Goal: full grid by Sunday so we can share it in next week's newsletter.
 3. **Telegram bot tour** at [@ZAOstockTeamBot](https://t.me/ZAOstockTeamBot). Live commands: `/help`, `/whoami`, `/status`, `/circles`, `/join`, `/leave`. Note: bot is rule-based right now, not AI. Two AI agents are in development with the ZAO Devz testing chat.
 4. **Two-tier teammate model** introduced:
-   - **Initial volunteer** = anyone who shows up
-   - **Committed volunteer** = bio + photo + at least one circle joined
+   - **Resource** = anyone helping from outside the public team page. Some people stay here by choice and that's good - welcome.
+   - **Volunteer** = bio + photo + introduced via an @ZAOFestivals announcement post. Earns a spot on the public team page at zaoos.com/stock.
 5. **Live during the call:** DFresh joined the Host circle (`/join host`) - it worked.
 
 ### Key decisions


### PR DESCRIPTION
Replaces #372. Two-tier model: Resource (helping from outside the team page, some stay by choice) → Volunteer (bio + photo + announced via @ZAOFestivals).