### PR TITLE
docs: reframe ZAOOS as Monorepo-as-Lab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - ZAO OS
+# CLAUDE.md - ZAOOS
 
 ## Session Start
 
@@ -6,7 +6,18 @@
 
 ## What This Is
 
-ZAO OS is a gated Farcaster social client for **The ZAO** (ZTalent Artist Organization) - a decentralized music community on Base chain. 301 API routes, 279 components, 19 hooks, 240+ research docs.
+**ZAOOS is the lab.** Where new ZAO-ecosystem things get prototyped before they earn their own home.
+
+The repo started as a gated Farcaster social client for **The ZAO** (188 members on Base) and grew into a monorepo where many ZAO experiments live side-by-side. Some have already graduated to their own repos (COC Concertz). Some are graduating now (ZAOstock 2026, Wed 2026-04-29). Some are paused (FISHBOWLZ). The rest are still being figured out.
+
+The pattern: **Monorepo as Lab.**
+
+- A thing graduates when it's ready for production + ready to share publicly + ready to attract new users.
+- On graduation: own repo, own DB, own domain. Code is **deleted** from ZAOOS so there's no drift. Routes redirect.
+- Sharing model: clone, no deps. Each graduate stands alone.
+- Research stays in ZAOOS forever - it's the institutional memory across every product.
+
+**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (graduating Wed), agent stack (ZOE, Hermes), music player components, 540+ research docs. 301 API routes, 279 components, 19 hooks.
 
 **Stack:** Next.js 16, React 19, Supabase (RLS), Neynar, XMTP, Stream.io, Wagmi/Viem, Tailwind v4, iron-session.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-# ZAO OS
+# ZAOOS
 
-**A gated, music-first Farcaster social client. Fork it, make it yours.**
+**The ZAO ecosystem lab. Where new things get prototyped before earning their own home.**
 
 [![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=next.js)](https://nextjs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue?logo=typescript)](https://typescriptlang.org)
@@ -19,7 +19,39 @@
 
 ---
 
-ZAO OS is a gated social platform for **The ZAO** — a decentralized music community where artists keep their revenue, curators earn reputation, and the community governs itself. Built on [Farcaster](https://farcaster.xyz) with encrypted messaging via [XMTP](https://xmtp.org), on-chain governance via [ORDAO](https://zao.frapps.xyz/), and inline music from 9 platforms.
+## What ZAOOS is
+
+ZAOOS is the lab. The repo started as a gated Farcaster social client for **The ZAO** (a decentralized music community of 188 members on Base) and grew into a monorepo where many ZAO experiments live side-by-side. Today it&rsquo;s the place where new ZAO-ecosystem things get prototyped before they earn their own home.
+
+The pattern: **Monorepo as Lab.**
+
+- A thing graduates when it&rsquo;s ready for production + ready to share publicly + ready to attract new users.
+- On graduation: own repo, own DB, own domain. The code is then **deleted** from ZAOOS so there&rsquo;s no drift. Routes redirect.
+- Sharing model: clone, no deps. Each graduate stands alone.
+- Research stays in ZAOOS forever — it&rsquo;s the institutional memory across every product.
+
+### What&rsquo;s in the lab right now
+
+| Thing | Status |
+|---|---|
+| Gated Farcaster client for The ZAO ([live at zaoos.com](https://zaoos.com)) | In production, also still being iterated |
+| ZAOstock 2026 dashboard + Telegram bot | **Graduating to its own repo + zaostock.com (Wed 2026-04-29)** |
+| Agent stack (ZOE, Hermes, others) | In R&D until one is solid + worth its own brand |
+| Music player components (Sonata-pattern, etc) | In R&D |
+| Research library (540+ docs across 13 topic areas) | Always stays here |
+
+### What&rsquo;s already graduated
+
+- **COC Concertz** — own repo, virtual concert community
+- **FISHBOWLZ** — was its own thing, paused 2026-04-16 (partnership with Juke). Code stays in ZAOOS as-is.
+
+---
+
+## The original product still lives here: a gated Farcaster client
+
+ZAOOS was born as a gated social platform for **The ZAO** — a decentralized music community where artists keep their revenue, curators earn reputation, and the community governs itself. Built on [Farcaster](https://farcaster.xyz) with encrypted messaging via [XMTP](https://xmtp.org), on-chain governance via [ORDAO](https://zao.frapps.xyz/), and inline music from 9 platforms.
+
+That client is still live, still iterated, still forkable.
 
 ### Fork it for your community
 


### PR DESCRIPTION
## Summary

Updates the public face of ZAOOS to match how it's actually being used: as a lab for prototyping ZAO-ecosystem things before they earn their own home.

## What changed
- **CLAUDE.md** - new \"What This Is\" section explains the Monorepo-as-Lab pattern, graduation criteria, and current state of the lab
- **README.md** - new \"What ZAOOS is\" section above the original Farcaster-client framing. Includes a status table of what's in the lab vs graduated. The original product framing stays - it's now one of the things in the lab.

## The pattern (now documented)

- ZAOOS is the lab.
- A thing graduates when it's ready for production + ready to share publicly + ready to attract new users.
- On graduation: own repo + own DB + own domain. Code is **deleted** from ZAOOS (no drift). Routes redirect.
- Sharing model: clone, no deps.
- Research stays in ZAOOS forever.

## Current state

| | |
|---|---|
| Already graduated | COC Concertz |
| Graduating Wed | ZAOstock 2026 |
| Paused, leave as-is | FISHBOWLZ (Juke partnership) |
| In lab | Farcaster client, agent stack (ZOE, Hermes), music player components, 540+ research docs |

## Memory
`~/.claude/projects/.../memory/project_zaoos_monorepo_as_lab.md` captures the pattern + graduation criteria so future sessions apply it consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)