### PR TITLE
docs(spinout): ZAOstock migration prep package

### DIFF
--- a/scripts/zaostock-spinout/README.md
+++ b/scripts/zaostock-spinout/README.md
@@ -1,0 +1,36 @@
+# ZAOstock spinout - prep folder
+
+Everything needed to migrate ZAOstock from this monorepo to its own home at `zaostock.com`. Per the [Monorepo-as-Lab pattern](../../CLAUDE.md), the code in ZAOOS gets deleted *only after* the new repo is confirmed live + working for 48h.
+
+## Files in here
+
+| File | What |
+|---|---|
+| `inventory.md` | Full list of files, tables, env vars, and shared deps to copy |
+| `migration-checklist.md` | 6-phase migration with safety gates between each |
+| `row-counts.md` | Snapshot of current `stock_*` table sizes (for post-migration verification) |
+| `export-schema.sh` | Script to dump current `stock_*` table schemas |
+
+## Where we are
+
+| Phase | Owner | Status |
+|---|---|---|
+| 1 - Infra setup | Zaal | **Pending** - need to create repo, Supabase project, Vercel project, point DNS |
+| 2 - Code copy + path strip | Claude | Blocked on Phase 1 |
+| 3 - DB migration | Claude + Zaal | Blocked on Phase 1 |
+| 4 - Deploy + cutover | Claude + Zaal | Blocked on Phase 1-3 |
+| 5 - Delete from ZAOOS | Claude | Blocked on Phase 4 + 48h |
+| 6 - Bot migration | Later | Out of scope this week |
+
+## What I&rsquo;m doing while waiting
+
+1. Inventory complete (`inventory.md`)
+2. Migration checklist with safety gates (`migration-checklist.md`)
+3. Row count baseline captured (`row-counts.md`)
+4. Schema export script ready (`export-schema.sh`)
+
+When the repo URL exists, drop it in chat. I clone, scaffold, copy. ~1-2 hours to a working `zaostock.com` Phase-2 build.
+
+## What you need to do
+
+Phase 1 of `migration-checklist.md`. Six checkboxes. Once `zaostock.com` resolves to a Vercel hello-world page, ping me and I take over.

--- a/scripts/zaostock-spinout/export-schema.sh
+++ b/scripts/zaostock-spinout/export-schema.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Export schema for all stock_* tables from current ZAOOS Supabase project.
+# Run after pg_dump is available locally + DATABASE_URL is set in env.
+#
+# Usage:
+#   DATABASE_URL=postgresql://... bash export-schema.sh
+#
+# Output: schema-export.sql in this dir, ready to paste into NEW Supabase
+# SQL Editor (with stock_ prefix stripped) for the zaostock project.
+
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "ERROR: set DATABASE_URL to your ZAOOS Supabase connection string"
+  echo "Find it in: Supabase dashboard -> Project Settings -> Database -> Connection string -> URI"
+  echo ""
+  echo "Example:"
+  echo "  DATABASE_URL='postgresql://postgres:PASS@db.efsx....supabase.co:5432/postgres' bash $0"
+  exit 1
+fi
+
+OUT="$(dirname "$0")/schema-export.sql"
+
+echo "Dumping schema for stock_* tables to $OUT..."
+
+pg_dump "$DATABASE_URL" \
+  --schema-only \
+  --no-owner \
+  --no-privileges \
+  --table='public.stock_*' \
+  > "$OUT"
+
+echo ""
+echo "Done. Review the file before pasting into the NEW Supabase project."
+echo ""
+echo "Next: strip the 'stock_' prefix from table + index names before pasting."
+echo "      sed -i '' 's/stock_//g' $OUT"
+echo ""
+echo "Then in the NEW Supabase SQL Editor:"
+echo "  1. Paste contents of $OUT"
+echo "  2. Run"
+echo "  3. Verify tables exist: SELECT tablename FROM pg_tables WHERE schemaname='public';"

--- a/scripts/zaostock-spinout/inventory.md
+++ b/scripts/zaostock-spinout/inventory.md
@@ -1,0 +1,153 @@
+# ZAOstock spinout - inventory
+
+> Source of truth for what moves to `zaostock` repo. Cross off as confirmed working in the new repo. **Nothing gets deleted from ZAOOS until cutover (Phase 4) is verified live.**
+
+## Files to copy
+
+### App routes (`src/app/stock/**` -> new repo `src/app/**`, drop the `/stock/` prefix)
+
+```
+src/app/stock/page.tsx                           -> src/app/page.tsx
+src/app/stock/PublicTeamGrid.tsx                 -> src/app/PublicTeamGrid.tsx
+src/app/stock/RSVPForm.tsx                       -> src/app/RSVPForm.tsx
+src/app/stock/apply/                             -> src/app/apply/
+src/app/stock/artist/[slug]/                     -> src/app/artist/[slug]/
+src/app/stock/circles/                           -> src/app/circles/
+src/app/stock/cypher/                            -> src/app/cypher/
+src/app/stock/onepagers/                         -> src/app/onepagers/
+src/app/stock/program/                           -> src/app/program/
+src/app/stock/sponsor/                           -> src/app/sponsor/
+src/app/stock/suggest/                           -> src/app/suggest/
+src/app/stock/team/                              -> src/app/team/
+src/app/stock/llms.txt/                          -> src/app/llms.txt/
+```
+
+### API routes (`src/app/api/stock/**` -> `src/app/api/**`)
+
+24 routes total - all under `src/app/api/stock/` move to `src/app/api/` in the new repo.
+
+### Lib (`src/lib/stock/**` -> `src/lib/**`)
+
+```
+src/lib/stock/artists.ts        -> src/lib/artists.ts
+src/lib/stock/log-activity.ts   -> src/lib/log-activity.ts
+src/lib/stock/members.ts        -> src/lib/members.ts
+src/lib/stock/onepagers.ts      -> src/lib/onepagers.ts
+```
+
+### Auth
+
+```
+src/lib/auth/stock-team-session.ts   -> src/lib/auth/session.ts (rename)
+```
+
+## Shared infra to inline (clone, no deps)
+
+These are the only things ZAOstock pulls from non-stock paths in ZAOOS. Per the Monorepo-as-Lab rule (no shared libs between repos), each of these gets copied into the new repo:
+
+```
+@/components/events/CountdownTimer  -> src/components/CountdownTimer.tsx
+@/lib/env                           -> src/lib/env.ts (trim to only zaostock vars)
+@/lib/db/supabase                   -> src/lib/db/supabase.ts
+@/lib/logger                        -> src/lib/logger.ts
+```
+
+## Database tables to migrate
+
+18 tables. All `stock_*`. Schema export at `schema-export.sql`, data export plan in `migration-checklist.md`.
+
+```
+stock_activity_log
+stock_artists
+stock_attachments
+stock_budget_entries
+stock_circle_members
+stock_circles
+stock_comments
+stock_contact_log
+stock_goals
+stock_meeting_notes
+stock_onepager_activity
+stock_onepagers
+stock_sponsors
+stock_suggestions
+stock_team_members
+stock_timeline
+stock_todos
+stock_volunteers
+```
+
+In the new Supabase project, drop the `stock_` prefix on all tables (since the whole DB is ZAOstock):
+
+```
+stock_activity_log    -> activity_log
+stock_artists         -> artists
+... etc
+```
+
+This requires updating every `from('stock_xxx')` call in the migrated code. ~150 call sites. Mechanical find-replace.
+
+## Bot (`bot/`)
+
+**Stays in ZAOOS for now.** Phase 5 migration. The bot's only DB connection is Supabase URL + service role key, so we just point its `.env` at the new ZAOstock Supabase project once Phase 3 lands. Code stays put until we&rsquo;re ready to move it.
+
+## Scripts
+
+```
+scripts/stock-add-stilo-eve-bacon-eduard.ts
+scripts/stock-missing-tables-migration.sql
+scripts/stock-team-skills-feed-migration.sql
+scripts/stock-team-status-text-migration.sql
+scripts/stock-team-tuesday-apr28-agenda.sql
+scripts/stock-archive/                         (full archive folder)
+```
+
+These move to `scripts/` in the new repo, dropping the `stock-` prefix where it doesn&rsquo;t add clarity.
+
+## Env vars needed in new repo
+
+```
+NEXT_PUBLIC_SUPABASE_URL          # NEW - point at zaostock supabase project
+NEXT_PUBLIC_SUPABASE_ANON_KEY     # NEW
+SUPABASE_SERVICE_ROLE_KEY         # NEW
+SESSION_SECRET                     # NEW (regenerate, do not reuse)
+NEXT_PUBLIC_APP_URL               # https://zaostock.com
+```
+
+The bot stays on the OLD ZAOOS env file until Phase 5, but its Supabase URL gets repointed to the NEW project after Phase 3.
+
+## Public profile pic / image hosts
+
+ZAOstock uses external image URLs (X profile images, postimages.org, etc). No image storage to migrate. **Photo URL pattern stays the same.**
+
+## What does NOT move
+
+- `research/` - stays in ZAOOS forever (institutional memory across all products)
+- `community.config.ts` - ZAOOS-specific, doesn&rsquo;t apply to zaostock
+- The Farcaster client routes (`src/app/(auth)`, `src/app/(public)`, etc) - ZAOOS-only
+- Agent stack (`src/lib/agents/`, ZOE, Hermes) - stays in lab
+- The bot (`bot/`) - stays for now, Phase 5 migration
+
+## Audit when migration is &ldquo;done&rdquo;
+
+Before deleting from ZAOOS, every one of these must be true on `zaostock.com`:
+
+- [ ] Login flow works (4-letter codes from old DB still valid)
+- [ ] Bio editor saves to NEW Supabase
+- [ ] Public profile (`/team/m/<slug>`) renders for at least 5 known members
+- [ ] Team directory loads with all members + scope filter works
+- [ ] Activity feed pulls from NEW Supabase
+- [ ] Onboarding checklist shows correct state
+- [ ] All 24 API routes return 200
+- [ ] Onepagers (overview + roddy + circle-checklists) render
+- [ ] Telegram bot can read + write to the NEW Supabase project
+- [ ] Email/social links from teammate profiles still resolve
+- [ ] No 404s when crawling the site
+
+Only after that 11-item checklist, run the deletion:
+
+```
+rm -rf src/app/stock src/app/api/stock src/lib/stock src/lib/auth/stock-team-session.ts
+```
+
+Plus add the redirect middleware (see `migration-checklist.md` Phase 4).

--- a/scripts/zaostock-spinout/migration-checklist.md
+++ b/scripts/zaostock-spinout/migration-checklist.md
@@ -1,0 +1,125 @@
+# ZAOstock spinout - migration checklist
+
+> **Safety rule:** Nothing gets deleted from ZAOOS until cutover is verified live on zaostock.com. Every deletion happens AFTER the new repo proves it works.
+
+Source of truth for the ordering. Cross off as you go. Each phase has a gate that must pass before the next phase starts.
+
+## Phase 1 - Infra setup (Zaal)
+
+You do these. I can&rsquo;t.
+
+- [ ] Create empty GitHub repo `bettercallzaal/zaostock` (private to start, flip to public later if you want)
+- [ ] Create new Supabase project named `zaostock`
+- [ ] Save the Supabase URL + anon key + service role key in `~/Documents/zaostock/.env.local` (NOT in this repo)
+- [ ] Create new Vercel project, connect it to the `bettercallzaal/zaostock` repo
+- [ ] Point `zaostock.com` DNS at Vercel (A or CNAME per Vercel guidance)
+- [ ] Verify the empty repo deploys a Next.js hello-world successfully
+
+**Gate:** `zaostock.com` resolves to a Vercel hello-world page. Don&rsquo;t move to Phase 2 until that&rsquo;s green.
+
+## Phase 2 - Code copy + path strip (me, after Phase 1)
+
+Once the repo URL exists, share it with me. Then I scaffold:
+
+- [ ] Clone the new empty repo locally
+- [ ] `npx create-next-app@latest` with the same Next.js 16 + Tailwind v4 + TypeScript stack as ZAOOS
+- [ ] Copy files per `inventory.md` paths (drop the `/stock/` prefix everywhere)
+- [ ] Inline the 4 shared deps (CountdownTimer, env, supabase, logger)
+- [ ] Strip `/stock/` from all internal `Link` href props + redirects
+- [ ] Strip the `stock_` prefix from every `from('stock_xxx')` Supabase call (renaming tables in the new DB - see Phase 3)
+- [ ] Wire env vars from `.env.example` (point at NEW Supabase project)
+- [ ] `npm install` + `npm run typecheck` clean
+- [ ] Local smoke: `/team` (login + dashboard), `/onepagers/overview`, `/apply`, `/sponsor`, `/program`
+
+**Gate:** Local dev server runs clean, typecheck passes, no broken imports. Open a PR on the new repo so the diff is reviewable.
+
+## Phase 3 - Database migration (me + Zaal)
+
+- [ ] Generate `schema.sql` from current ZAOOS Supabase (every `stock_*` table CREATE + RLS policies + indexes). Strip the `stock_` prefix in the new schema.
+- [ ] Paste schema into NEW zaostock Supabase SQL Editor, run it
+- [ ] `pg_dump --data-only` from current ZAOOS Supabase, filtered to `stock_*` tables only
+- [ ] Transform dump file: rename tables (`stock_team_members` -> `team_members`, etc) before import
+- [ ] Import into NEW Supabase
+- [ ] Verify row counts match per table (current snapshot in `row-counts.md`)
+- [ ] Spot-check 5 random rows in 3 tables (team_members, todos, sponsors) - same data as old?
+- [ ] Update bot `.env` on VPS to point at NEW Supabase URL + service role key
+- [ ] Verify bot still works: DM `@ZAOstockTeamBot`, hit `/help`, `/circles`, `/mytodos` - should respond using NEW DB
+- [ ] Verify cron jobs still fire (morning digest, etc) and read from NEW DB
+
+**Gate:** Bot reads/writes against the new DB cleanly. Row counts match. Spot checks pass.
+
+## Phase 4 - Deploy + cutover (me + Zaal)
+
+- [ ] Push code to `main` on `bettercallzaal/zaostock`
+- [ ] Vercel auto-deploys to `zaostock.com`
+- [ ] Run the 11-item audit from `inventory.md` against `zaostock.com`
+- [ ] Add a redirect middleware in ZAOOS:
+
+  ```typescript
+  // src/middleware.ts in ZAOOS - add to existing middleware
+  export async function middleware(req: NextRequest) {
+    const path = req.nextUrl.pathname;
+    if (path.startsWith('/stock')) {
+      const newPath = path.replace(/^\/stock/, '');
+      return NextResponse.redirect(`https://zaostock.com${newPath || '/'}`, 301);
+    }
+    // ... existing middleware
+  }
+  ```
+
+- [ ] Deploy ZAOOS with the redirect middleware
+- [ ] Test: visit `zaoos.com/stock/team` -> should 301 to `zaostock.com/team`
+- [ ] Test: visit `zaoos.com/stock/onepagers/overview` -> should 301 to `zaostock.com/onepagers/overview`
+- [ ] Pin the new URL in the ZAOstock TG group + Discord
+- [ ] Update `community.config.ts` in ZAOOS to drop the `/stock` nav links
+
+**Gate:** Redirects work, team can use `zaostock.com` for everything, no broken links from old URLs.
+
+**Wait 48 hours.** Watch the redirect logs. If anything is broken, this is the rollback window. Don&rsquo;t skip this.
+
+## Phase 5 - Delete from ZAOOS (me, after 48h confirmation)
+
+After 48 hours of zaostock.com working cleanly with no rollback:
+
+- [ ] Delete `src/app/stock/` from ZAOOS
+- [ ] Delete `src/app/api/stock/` from ZAOOS
+- [ ] Delete `src/lib/stock/` from ZAOOS
+- [ ] Delete `src/lib/auth/stock-team-session.ts` from ZAOOS
+- [ ] Update CLAUDE.md to mark ZAOstock as &ldquo;graduated&rdquo;
+- [ ] Update README.md to move ZAOstock from &ldquo;in lab&rdquo; to &ldquo;graduated&rdquo;
+- [ ] Keep the redirect middleware in ZAOOS forever (or until we sunset zaoos.com itself)
+- [ ] Keep `research/` docs about ZAOstock - those stay
+- [ ] Keep the bot in ZAOOS (Phase 5 of bot migration is later)
+
+**Gate:** Delete PR merges, ZAOOS routes still work for the Farcaster client, redirect middleware still routes the /stock paths.
+
+## Phase 6 - Bot migration (later, separate project)
+
+Not this week. Plan to do it when:
+- The bot has been running on the new Supabase URL for at least 2 weeks without issue
+- We have time to do a clean systemd unit migration on the VPS
+- Or when the bot itself is ready to graduate from the lab (when it&rsquo;s &ldquo;solid + worth its own brand&rdquo;)
+
+For now: bot lives in ZAOOS, talks to NEW Supabase, does its job.
+
+---
+
+## Rollback plan (if anything goes wrong)
+
+If at any point Phase 4 fails:
+1. Pull the redirect middleware from ZAOOS
+2. ZAOOS routes serve `/stock/*` again as before
+3. Diagnose the issue on `zaostock.com`
+4. Try cutover again when fixed
+
+If Phase 3 fails (data migration):
+1. Old ZAOOS DB is untouched - everything still works there
+2. Drop the new Supabase project, start fresh
+3. The new Vercel project doesn&rsquo;t have a working DB but no harm done
+
+If Phase 5 deletion happens prematurely and something&rsquo;s broken:
+1. `git revert` the deletion commit
+2. Push to ZAOOS, Vercel redeploys
+3. Code is back
+
+The only way this goes really wrong is if we delete from ZAOOS *before* zaostock.com is verified. The 48-hour rule prevents that.

--- a/scripts/zaostock-spinout/row-counts.md
+++ b/scripts/zaostock-spinout/row-counts.md
@@ -1,0 +1,22 @@
+# Table row counts (2026-04-28)
+
+| Table | Rows |
+|---|---|
+| stock_activity_log | 2 |
+| stock_artists | 9 |
+| stock_attachments | null |
+| stock_budget_entries | 15 |
+| stock_circle_members | 26 |
+| stock_circles | 8 |
+| stock_comments | null |
+| stock_contact_log | 1 |
+| stock_goals | 8 |
+| stock_meeting_notes | 4 |
+| stock_onepager_activity | 6 |
+| stock_onepagers | 3 |
+| stock_sponsors | 18 |
+| stock_suggestions | 0 |
+| stock_team_members | 26 |
+| stock_timeline | 60 |
+| stock_todos | 21 |
+| stock_volunteers | 0 |


### PR DESCRIPTION
Track A of the spinout: everything I can prep without the new repo existing.

Folder: scripts/zaostock-spinout/

- inventory.md - 92 stock files, 18 tables, 4 shared deps to clone
- migration-checklist.md - 6 phases with safety gates
- row-counts.md - current table sizes (verification baseline)
- export-schema.sh - schema dump runner

Safety rule: nothing gets deleted from ZAOOS until zaostock.com is verified live for 48h. Per Monorepo-as-Lab (PR #376).

Track B - waiting on you: create the empty GitHub repo, Supabase project, Vercel project, DNS. Phase 1 of migration-checklist.md, six checkboxes.