### PR TITLE
doc 548: Lazer Mini Apps CLI evaluation (STANDARD tier)

### DIFF
--- a/research/farcaster/548-lazer-miniapps-cli-evaluation/README.md
+++ b/research/farcaster/548-lazer-miniapps-cli-evaluation/README.md
@@ -2,7 +2,7 @@
 topic: farcaster
 type: decision
 status: research-complete
-last-validated: 2026-04-28
+last-validated: 2026-04-29
 related-docs: 173, 250, 349, 489, 508
 tier: STANDARD
 ---
@@ -10,6 +10,8 @@ tier: STANDARD
 # 548 - Lazer Mini Apps CLI Evaluation (miniapps.lazer.tools)
 
 > **Goal:** Decide whether ZAO adopts `@lazer-tech/miniapp` CLI for net-new Farcaster/Base mini apps, vs sticking with Neynar / Base MiniKit / hand-rolled patterns already in `src/app/api/miniapp/**` and `src/app/miniapp/**`.
+
+> **Update 2026-04-29 (deep-dive pass):** Pulled the npm tarball + read source. Far more capable than landing page implied. **Source IS readable** in `dist/` (unminified TS, 5,765 LOC across 11 packages, plus 16 bundled Claude skills, plus Foundry + Anchor templates). Private GitHub repo is workflow inconvenience, not audit blocker. Verdict moves from "spike candidate" to **"spike + lift patterns into ZAO now."** Full breakdown in [Deep Dive](#deep-dive--what-actually-ships) at end.
 
 ## Key Decisions
 
@@ -135,6 +137,166 @@ Verified 2026-04-28 via `grep -ril "miniapp" src/`:
 
 - All numbers (DLs, version, dates, repo counts) pulled from live API responses on 2026-04-28, not LLM-recalled.
 - Lazer studio claim "80+ engineers, 350+ clients, 40+ YC, 20+ unicorns" sourced from their own homepage + Built In Toronto - self-reported, not independently audited.
-- Repo `lazer-mini-apps` 404 verified via `gh api` 2026-04-28 - repo declared in npm metadata is genuinely private or renamed; do not assume MIT == public source.
+- Repo `lazer-mini-apps` 404 verified via `gh api` 2026-04-28 - repo declared in npm metadata is genuinely private or renamed. **Update 2026-04-29:** confirmed source IS shipped readable in the `dist/` of the npm tarball (unminified TS), so MIT licence is enforceable on the published artefact even though git history is closed.
 - No Reddit / HN / Warpcast threads found for "miniapps.lazer.tools" or "@lazer-tech/miniapp" as of 2026-04-28 - tool is too new for community sentiment. Re-check in 30 days.
+- Deep-dive numbers (file counts, LOC, packages, skills) verified 2026-04-29 by extracting `miniapp-0.1.8.tgz` and counting locally.
 - Re-validate by 2026-05-28.
+
+---
+
+## Deep Dive — What Actually Ships
+
+> Pulled `https://registry.npmjs.org/@lazer-tech/miniapp/-/miniapp-0.1.8.tgz` (812,130 bytes, 264 files), extracted, read on 2026-04-29. Numbers below are local `wc` / `ls`, not LLM recall.
+
+### Tarball anatomy
+
+```
+package/
+├── package.json       (deps: @inquirer/prompts, bs58, incur, zod)
+├── README.md
+├── LICENSE            (MIT)
+└── dist/
+    ├── bin.js                  2,612 lines (bundled CLI entry)
+    ├── packages/               5,765 lines TS across 11 packages
+    │   ├── auth/      Privy provider + 4 features (gas-sponsorship, delegated-signing, server-auth, server-wallets) + RainbowKit alt
+    │   ├── core/      shared utils (cn, browser, types/config)
+    │   ├── evm/       wagmi wrappers (config, connect, read, tx)
+    │   ├── solana/    1,049 LOC (token 356, deploy 194, tx, sign, read, connect)
+    │   ├── swap/      Uniswap (310 LOC) + Jupiter component
+    │   ├── farcaster/ adapter, sdk init, context, actions (composeCast, addMiniApp, sendToken, swapToken, viewProfile, viewCast), manifest, embed, share, hooks, notifications (handlers/webhook/send/store)
+    │   ├── base/      adapter, basename, builder-codes, deeplinks, share, types
+    │   ├── web/       generic web adapter (Web Share API + clipboard fallback)
+    │   ├── codex/     graph.codex.io (DefinedFi) GraphQL client + WS subscriptions for token prices, charts, events, balances
+    │   ├── postgres/  Kysely + pool + migrations
+    │   └── ds/        CVA-based design system (Radix Slot, Tailwind, tokens, branding-driven)
+    ├── templates/app-minimal/  Next.js 16.2.1 + React 19.2.4 + Tailwind v4 + Biome v2 + TS 6 + Vitest 4
+    │   ├── contracts/          Foundry (Counter.sol, foundry.toml, Deploy.s.sol)
+    │   ├── programs/           Anchor (Solana counter, Anchor.toml)
+    │   ├── _claude/skills/     11 user-facing skills (auth, base, codex, contracts, ds, farcaster, lazer, postgres, programs, web, web3)
+    │   ├── _CLAUDE.md          Generated app instructions
+    │   ├── _mcp.json           Pre-wires 3 MCP servers: privy-docs (HTTP), next-devtools (bunx), miniapp itself (--mcp flag)
+    │   ├── _biome.jsonc        Biome v2 config
+    │   ├── branding.json       { primary, defaultMode } - drives DS tokens
+    │   ├── site.json           Farcaster manifest fields (categories, tags, capabilities, OG, splash)
+    │   └── docker-compose.yml
+    └── .claude/skills/         16 internal "module dev" skills (audit-skill, *-module sync, lint, test, verify, sync-skills, resources)
+```
+
+### CLI surface
+
+`bin.js` agent targets array: `['claude', 'codex', 'cursor', 'gemini']`. So a generated app gets per-agent skill folders, not Claude-only.
+
+`OWNED_PROJECT_SKILLS` (12): auth, base, codex, contracts, ds, farcaster, lazer, postgres, programs, resources, web, web3.
+
+The `/lazer` skill in generated apps is a **router** - it inspects `.claude/skills/` + `src/lib/modules/` to know what's installed vs available, then dispatches free-form requests to the right skill(s). Pattern resembles ZAO's `/zao-research` index but at app-build scope.
+
+### Hidden CLI feature: doubles as MCP server
+
+`_mcp.json` includes:
+
+```json
+"miniapp": { "command": "bunx", "args": ["@lazer-tech/miniapp@latest", "--mcp"] }
+```
+
+So once installed, the CLI exposes itself over MCP - the dev-time agent (Claude / Codex / Cursor / Gemini) can call CLI commands as tools, not just shell-out. Not advertised on the landing page; only visible in tarball. **Worth re-using as a pattern in ZAO's own dev tooling** (e.g. `zao-research --mcp`).
+
+### Skills work by reading source, then minimally implementing
+
+Generated `_CLAUDE.md` makes the philosophy explicit:
+
+> "Each skill has access to the full module source code in `.claude/skills/*/references/`. When you run a skill, it: 1) Reads the reference source to understand the full API surface, 2) Installs required npm dependencies, 3) Writes only the code your app needs into `src/lib/modules/`. This means `/auth email login` and `/auth wallet only` produce different implementations - skills write code tailored to your requirements, not flip switches on pre-written templates."
+
+This is a different pattern from `create-next-app` (templates) and from MiniKit (opinionated boilerplate). It's closer to "AI-native code-gen with full source as RAG context." Useful pattern for ZAO's own QuadWork skill library.
+
+### Stack match with ZAO is exact
+
+| Tech | Lazer template | ZAO OS V1 (`package.json`) | Match |
+|---|---|---|---|
+| Next.js | 16.2.1 | 16 | Exact |
+| React | 19.2.4 | 19 | Exact |
+| Tailwind | v4.2.2 | v4 | Exact |
+| Biome | v2.4.9 | v2 (lint:biome) | Exact |
+| TypeScript | v6.0.2 | v6 | Exact |
+| Zod | v4.3.6 | required for safeParse | Exact |
+| Vitest | v4.1.2 | required for tests | Exact |
+| Test runner | jsdom + @testing-library/react 16 | matches `.claude/rules/tests.md` | Exact |
+
+This is unusual. Most Farcaster scaffolds lag Next/React by a major version. Lazer is on the same bleeding edge as ZAO. Migration friction = near zero.
+
+### Privy auth depth
+
+`packages/auth/src/privy/features/`:
+
+| Feature | What it does | ZAO use |
+|---|---|---|
+| `gas-sponsorship` | `useSponsoredTransaction()` - Privy gas policies, gasless EVM tx | **Direct fit:** ZAOstock RSVP, ZABAL stake, Cipher mint - all gasless onboarding for the 188 + new joiners |
+| `delegated-signing` | App can sign on behalf of user (consented) | Agent flows (VAULT/BANKER/DEALER) where user delegates a budget |
+| `server-auth` | Verify Privy session server-side in API routes | Replaces / complements iron-session for wallet-first paths |
+| `server-wallets` | Privy-managed embedded wallets, server-controlled | Possible foundation for ZOE / agent wallets without rolling our own |
+
+Auth provider exposes: `appId`, `platforms`, `chains`, `supportedChains`, `defaultChain`, `solanaConnectors`, `accentColor`, `theme`, `plugins`, `embeddedWalletCreateOnLogin` (`"all-users" | "users-without-wallets" | "off"`). Last one matters - server signers require `all-users`.
+
+### Codex (DefinedFi) integration
+
+`packages/codex/src/client.ts` wires `https://graph.codex.io/graphql` + `wss://graph.codex.io/graphql` with auto-reconnect WebSocket manager. Network ID map covers ethereum (1), base (8453), base-sepolia (84532), polygon (137), arbitrum (42161), optimism (10), avalanche (43114).
+
+Queries: `TOKEN_QUERY`, `TOKEN_LIST_QUERY`, `TOKEN_WITH_STATS_QUERY`, `TOKEN_CHART_QUERY`, `TOKEN_EVENTS_QUERY`, `WALLET_BALANCES_QUERY`. Subscriptions: `ON_BARS_UPDATED`, `ON_PRICE_UPDATED`, `ON_PRICES_UPDATED`, `ON_EVENTS_CREATED`.
+
+**Direct ZAO fit:**
+- ZABAL price chart on `/stake` page (currently no live chart)
+- WaveWarZ token data feed
+- ZAO Music drop sales analytics
+- Replaces ad-hoc "fetch token price" calls scattered across `src/lib/`
+
+This is the highest-value module to **lift in standalone**, not via the full CLI scaffold.
+
+### Solana support (unexpected)
+
+11 packages includes `solana/` (1,049 LOC) + `swap/jupiter.tsx`. Anchor template ships in `programs/`. ZAO is EVM-first today (Base + Optimism), but `project_zao_music_entity` (BMI + DistroKid + 0xSplits) is EVM-only by accident not design. Lazer makes Solana cross-chain music NFTs an option without rebuilding auth + wallets.
+
+### Foundry contract template
+
+`templates/app-minimal/contracts/`: minimal `Counter.sol` + `Deploy.s.sol` + `foundry.toml`. (Not the heavier `LazerNFT.sol` ERC721+USDC+Ownable2Step+SafeERC20 contract that ships in `LazerForge` repo per `lazertechnologies.com/LazerForge`.) Pairs with `bin.js` orchestration so `/contracts` skill scaffolds Foundry inside an existing app.
+
+ZAO already has `contracts/` (staking, bounty board) using Foundry per `CLAUDE.md`. No replacement needed. **Pattern to steal:** the `/contracts` skill flow for adding new contracts to an existing repo. Would speed up future ZAO contract drops (e.g. ZAOstock NFT ticket).
+
+### Bundled audit-skill
+
+`dist/.claude/skills/audit-skill/SKILL.md` is a portable Anthropic-best-practices skill auditor (4 reference files: `rules.md`, `quality.md`, `anti-patterns.md`, `resources.md`). Targets any skill at `**/.claude/skills/*/SKILL.md`. Accepts skill name, path, or `all`.
+
+**Direct ZAO use:** run it across `~/.claude/skills/` and `.claude/skills/` to audit ZAO's own skill library quality (zao-research, qa, ship, vps, worksession, etc.). Independent of whether we adopt the rest of Lazer.
+
+### Notifications, manifest, embeds (Farcaster module specifics)
+
+- `manifest.ts`: enforces FORBIDDEN chars `[@#$%^&*+=\\/|~«»]`, MAX_NAME=128, MAX_BUTTON=32, MAX_SHORT_TEXT=30, MAX_OG_DESC=100, MAX_DESC=170, MAX_TAG=20, MAX_TAGS=5. ZAO can crib this to validate its own manifest entries before publish.
+- `notifications/`: full webhook handler + send + broadcast + InMemoryNotificationStore (swappable for postgres-backed in production).
+- `actions.ts`: `composeCast`, `addMiniApp`, `sendToken`, `swapToken`, `viewProfile`, `viewCast` - all wrap `@farcaster/miniapp-sdk` actions with miniapp-context guard.
+- `embed.ts`: generates `fc:miniapp` meta tags for sharing.
+
+### Revised recommendation summary (post deep dive)
+
+| Action | Old verdict (2026-04-28) | New verdict (2026-04-29) | Why changed |
+|---|---|---|---|
+| Adopt full CLI as default scaffold | NO | NO (unchanged) | Heavy stack to inherit; ZAO's miniapp shell already runs. |
+| 1-day spike on a throwaway net-new mini app | YES | **YES, this week** | Higher confidence: stack match is exact, source is readable, output is minimal modules not boilerplate dump. |
+| Lift module patterns into ZAO directly | "if repo opens" | **YES NOW** | Source is in dist/. MIT. Specific lifts: Codex client (`/stake` chart), gas-sponsorship pattern (gasless ZABAL stake), `manifest.ts` validators, `audit-skill` for ZAO skill library. |
+| Replace existing `src/app/miniapp/**` | NO | NO (unchanged) | Already shipped + tested. |
+| Steal CLI-as-MCP pattern (`--mcp` flag) | not noticed | **YES, capture for QuadWork** | Hidden in `_mcp.json`. Generic pattern: any CLI you maintain can self-expose as MCP for dev-time agent calls. |
+
+### Concrete lift targets (ranked, highest signal first)
+
+1. **`packages/codex/src/client.ts`** (~600 LOC) - drop into `src/lib/codex/` for live ZABAL + WaveWarZ token data. Replaces ad-hoc fetches. Highest immediate user-visible value.
+2. **`packages/auth/src/privy/features/gas-sponsorship/`** - gasless onboarding for ZAOstock RSVP + ZABAL stake. Direct UX win for non-crypto-native attendees.
+3. **`packages/farcaster/src/manifest.ts`** validators - bolt onto existing manifest generation, prevents production bugs from char limits / forbidden chars.
+4. **`dist/.claude/skills/audit-skill/`** - copy to `~/.claude/skills/audit-skill/` and audit ZAO's full skill library. One-time win.
+5. **CLI-as-MCP pattern** (`bunx <pkg> --mcp`) - capture as a general QuadWork pattern; not a code lift, an architectural one.
+6. **`packages/farcaster/src/notifications/`** - replace any ad-hoc Farcaster notification code in `src/app/api/miniapp/webhook/route.ts` with the typed handler + store interface.
+
+Lifts are independent. No need to take all 6.
+
+### Caveats (unchanged from initial pass)
+
+- Pin `@lazer-tech/miniapp@0.1.8` exactly if used.
+- Do not auto-upgrade until `last-validated` date refreshes.
+- Treat lifted code as vendored. Read every file before commit. License header check.
+- Mini app retention crisis (Doc 508) framing still holds. Better tooling != distribution.

--- a/research/farcaster/548-lazer-miniapps-cli-evaluation/README.md
+++ b/research/farcaster/548-lazer-miniapps-cli-evaluation/README.md
@@ -1,0 +1,140 @@
+---
+topic: farcaster
+type: decision
+status: research-complete
+last-validated: 2026-04-28
+related-docs: 173, 250, 349, 489, 508
+tier: STANDARD
+---
+
+# 548 - Lazer Mini Apps CLI Evaluation (miniapps.lazer.tools)
+
+> **Goal:** Decide whether ZAO adopts `@lazer-tech/miniapp` CLI for net-new Farcaster/Base mini apps, vs sticking with Neynar / Base MiniKit / hand-rolled patterns already in `src/app/api/miniapp/**` and `src/app/miniapp/**`.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Adopt Lazer CLI as default scaffold for ALL new ZAO mini apps | **NO** | 437 monthly npm downloads (Mar 29 - Apr 27 2026), 17 last week. v0.1.8, package created 2026-03-18 (~6 weeks old). Pre-PMF. Source repo `LazerTechnologies/lazer-mini-apps` is **private** despite MIT license on the npm tarball - bus-factor + audit risk for any ZAO production app. |
+| Try Lazer CLI ONCE on a throwaway net-new mini app (ZAOstock RSVP card or ZABAL stake flow) | **YES** | Lazer is a credible studio (80+ engineers ex-Apple/Google/Coinbase, 350+ clients incl. Uniswap, Coinbase, Shopify, 40+ YC, 20+ unicorns). MIT-licensed, free, single command (`bunx @lazer-tech/miniapp create`). Multi-platform scaffold (Farcaster + Base + World) hedges against Hypersnap split flagged in Doc 508. Worth a 1-day spike, no commitment. |
+| Steal Lazer's `/web3`, `/contracts`, `/farcaster` skill prompts into QuadWork | **YES, IF SOURCE BECOMES VISIBLE** | Skill set (`/auth /web3 /contracts /codex /postgres /ds /base /farcaster`) maps 1:1 to ZAO surface area (`src/lib/auth`, `src/lib/agents`, `contracts/`, Supabase, Base). Aligns with `feedback_oss_first_no_platforms` + `feedback_prefer_claude_max_subscription` (Claude Code CLI on VPS). Pattern reuse > tool dependency. **Blocked until repo opens** - cannot lift skills from a private repo. |
+| Replace existing `src/app/api/miniapp/**` + `src/app/miniapp/**` infra with Lazer-generated scaffold | **NO** | ZAO already ships a working mini app surface: `webhook/route.ts`, `discover/route.ts`, `search/route.ts`, `miniapp/layout.tsx`, `miniapp/page.tsx`. Tests exist (`src/app/api/__tests__/miniapp-stream.test.ts`). Migration cost > scaffold value for code that already runs. |
+| Keep Doc 508 framing: lead Juke / new launches with "audio-first / utility-first," not "we made a mini app" | **YES, REINFORCED** | Lazer's pitch is dev ergonomics, not distribution. Telegram mini apps dropped 89% in 9 months (Doc 508). A better scaffold does not change the retention problem. |
+| Keep Neynar `@neynar/create-farcaster-mini-app` + Base MiniKit CLI as fallback choices for non-spike work | **YES** | Both are first-party (Neynar already in ZAO stack per `community.config.ts` infra; Base MiniKit is Coinbase-official). Lower risk than depending on a private-source CLI from a 6-week-old package. |
+
+## What Lazer Mini Apps CLI Actually Is
+
+**Site:** https://miniapps.lazer.tools (HTTP 200, served as static HTML, no `/docs` path - 404).
+
+**npm package** (verified via `registry.npmjs.org` direct query, 2026-04-28):
+
+| Field | Value |
+|---|---|
+| Name | `@lazer-tech/miniapp` |
+| Latest | `0.1.8` |
+| Versions shipped | 0.1.4, 0.1.5, 0.1.6, 0.1.7, 0.1.8 |
+| License | MIT |
+| Created | 2026-03-18 |
+| Last published | 2026-04-01 |
+| Downloads, last week | **17** (2026-04-21 to 2026-04-27) |
+| Downloads, last month | **437** (2026-03-29 to 2026-04-27) |
+| Repo declared | `git+https://github.com/LazerTechnologies/lazer-mini-apps.git` |
+| Repo actual | **404 / private** (verified via `gh api` 2026-04-28) |
+
+**Install:** `bunx @lazer-tech/miniapp create`.
+
+**Bundled Claude Code skills** (per landing page): `/auth`, `/web3`, `/contracts`, `/codex`, `/postgres`, `/ds`, `/base`, `/farcaster`.
+
+**Examples shown on landing page:** Tile Riot, Idle Perps, Rattlejack.
+
+**Built by:** Lazer Technologies, Toronto digital product studio. Contributors named on landing: @sudojbird, @0x_reed, @james_mccomish. Twitter: @lazer_hq.
+
+## Lazer Studio Track Record (de-risks the team, not the tool)
+
+Verified via `lazertechnologies.com` + Built In Toronto + LinkedIn snippet:
+
+- 80+ senior engineers + designers, ex-Apple/Google/Coinbase
+- 350+ clients including Shopify, Coinbase, Uniswap, Goldfinch, ClassDojo, OVO
+- 40+ Y Combinator portfolio companies, 20+ unicorns
+- Active ecosystem repos in same org (verified via `gh api orgs/LazerTechnologies/repos`):
+  - `lazer-arrive-can-clone` (37 stars, TS, updated 2026-04-08)
+  - `LazerForge` (6 stars, "Foundry templates and tutorials for all Solidity developers")
+  - `canton-debugger-proposal` (Canton ecosystem proposal, 2026-04-22)
+  - `canton-dev-fund` (Canton dev fund administration, 2026-04-22)
+  - `LayerZero-Executor`, `nft-marketplace-tutorial`, `ai-showcase`
+
+The studio is real. The CLI is early.
+
+## Comparison: Lazer vs Alternatives for ZAO Net-New Mini App
+
+| Tool | First-party? | Source visible? | Multi-platform | Maturity (proxy: stars / DLs) | ZAO fit |
+|---|---|---|---|---|---|
+| `@lazer-tech/miniapp` | No (3rd-party studio) | **No, repo private** | Farcaster + Base + World | 437 monthly DLs, 6 weeks old | Spike candidate |
+| `@neynar/create-farcaster-mini-app` | **Yes (Neynar)** | Yes | Farcaster (Neynar SDK) | Neynar already in ZAO stack | Default for Neynar-tied flows |
+| Base MiniKit CLI (`docs.base.org/builderkits/minikit`) | **Yes (Coinbase / Base)** | Yes | Base + Farcaster | Coinbase-backed | Default for Base-tied flows |
+| `builders-garden/base-minikit-starter` | No (community) | Yes | Base + Farcaster | Template, not CLI | Reference, copy patterns |
+| `Emmo00/create-farcaster-miniapp` | No (community) | Yes | Farcaster only | Community-driven | Skip |
+| Hand-rolled (current `src/app/miniapp/**`) | n/a | Yes | Farcaster | Already shipped, tested | **Keep for existing** |
+
+## ZAO Codebase Cross-Check
+
+Verified 2026-04-28 via `grep -ril "miniapp" src/`:
+
+- `src/app/api/miniapp/webhook/route.ts` - Farcaster webhook handler
+- `src/app/api/miniapp/discover/route.ts`
+- `src/app/api/miniapp/search/route.ts`
+- `src/app/miniapp/layout.tsx` + `src/app/miniapp/page.tsx`
+- `src/app/api/__tests__/miniapp-stream.test.ts` (tested)
+- Referenced from `src/middleware.ts`, `src/app/layout.tsx`, `src/app/providers.tsx`, `src/app/stake/page.tsx`
+
+**Implication:** ZAO is past the scaffolding stage for its core mini app. Lazer's value here is on **net-new throwaway** mini apps (event RSVP, single-shot drops), not the main ZAO OS shell.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Private source repo despite MIT npm tarball | Treat any Lazer-generated code as "vendored" - read every file before committing. Do not trust auto-applied skills blindly. |
+| 6-week-old package, 17 weekly DLs - any version could break | Pin exact version in any spike (`@lazer-tech/miniapp@0.1.8`), do not auto-upgrade. |
+| Skill name overlap with Claude Code skills already installed in ZAO (`/zao-research`, `/qa`, etc.) | Test in a clean shell or worktree, not the main ZAO OS V1 dir. Lazer skills install to project scope; conflicts unlikely but worth verifying. |
+| Mini apps as a category are in retention crisis (Doc 508) | This evaluation does not change distribution strategy - keep audio-first / utility-first framing. |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| 1-day spike: scaffold a throwaway "ZAOstock RSVP" mini app via `bunx @lazer-tech/miniapp create` in a new worktree, write notes on what skills shipped, what code generated | Zaal or ZAO Devz | Spike | After Roddy 2026-04-30 |
+| If repo `LazerTechnologies/lazer-mini-apps` becomes public, lift `/web3`, `/contracts`, `/farcaster` skill prompts into QuadWork skill library | Zaal | PR to QuadWork repo | Conditional, watch monthly |
+| Re-validate npm download trend in 30 days; if `<1000/month` still, mark this doc `superseded-by` a "skip Lazer" decision | Auto | This doc + memory update | 2026-05-28 |
+| Keep `feedback_oss_first_no_platforms` rule active - only adopt Lazer if source opens or it solves a real auth/payments gap that Neynar + MiniKit do not | Zaal | Ongoing | n/a |
+| Do NOT replace existing `src/app/api/miniapp/**` infra | n/a | Constraint | n/a |
+
+## Also See
+
+- [Doc 173 - Farcaster mini apps integration](../173-farcaster-miniapps-integration/)
+- [Doc 250 - Farcaster miniapps llms.txt 2026](../250-farcaster-miniapps-llms-txt-2026/)
+- [Doc 349 - ZABAL staking miniapp options](../../governance/349-zabal-staking-miniapp-options/)
+- [Doc 489 - Hypersnap fork research](../../farcaster/) (referenced in Doc 508)
+- [Doc 508 - Creator infra + mini apps + token burn signal brief](../../dev-workflows/508-creator-infra-mini-apps-token-burn-signals-apr25/) - mini app retention crisis context
+
+## Sources
+
+- [Lazer Mini Apps landing page](https://miniapps.lazer.tools/) - verified 2026-04-28, HTTP 200
+- [npm registry @lazer-tech/miniapp](https://registry.npmjs.org/@lazer-tech/miniapp) - direct API query 2026-04-28
+- [npm download stats last-week](https://api.npmjs.org/downloads/point/last-week/@lazer-tech/miniapp) - 17 downloads
+- [npm download stats last-month](https://api.npmjs.org/downloads/point/last-month/@lazer-tech/miniapp) - 437 downloads
+- [Lazer Technologies GitHub org](https://github.com/LazerTechnologies) - 23 repos visible, lazer-mini-apps repo 404 (private)
+- [Lazer Technologies homepage](https://www.lazertechnologies.com/) - 350+ clients, AI/Commerce/Crypto verticals
+- [Built In Toronto - Lazer Technologies](https://builtintoronto.com/company/lazer-technologies) - 80+ engineers, remote-first, Toronto HQ
+- [Farcaster Mini Apps official docs](https://miniapps.farcaster.xyz/) - first-party reference
+- [@neynar/create-farcaster-mini-app on npm](https://www.npmjs.com/package/@neynar/create-farcaster-mini-app) - first-party Neynar alternative
+- [Base MiniKit Quickstart](https://docs.base.org/builderkits/minikit/quickstart) - first-party Base alternative
+- [builders-garden/base-minikit-starter](https://github.com/builders-garden/base-minikit-starter) - community template alternative
+- [Emmo00/create-farcaster-miniapp](https://github.com/Emmo00/create-farcaster-miniapp) - community CLI alternative
+
+## Staleness + Hallucination Notes
+
+- All numbers (DLs, version, dates, repo counts) pulled from live API responses on 2026-04-28, not LLM-recalled.
+- Lazer studio claim "80+ engineers, 350+ clients, 40+ YC, 20+ unicorns" sourced from their own homepage + Built In Toronto - self-reported, not independently audited.
+- Repo `lazer-mini-apps` 404 verified via `gh api` 2026-04-28 - repo declared in npm metadata is genuinely private or renamed; do not assume MIT == public source.
+- No Reddit / HN / Warpcast threads found for "miniapps.lazer.tools" or "@lazer-tech/miniapp" as of 2026-04-28 - tool is too new for community sentiment. Re-check in 30 days.
+- Re-validate by 2026-05-28.

--- a/scripts/zaostock-spinout/README.md
+++ b/scripts/zaostock-spinout/README.md
@@ -1,0 +1,36 @@
+# ZAOstock spinout - prep folder
+
+Everything needed to migrate ZAOstock from this monorepo to its own home at `zaostock.com`. Per the [Monorepo-as-Lab pattern](../../CLAUDE.md), the code in ZAOOS gets deleted *only after* the new repo is confirmed live + working for 48h.
+
+## Files in here
+
+| File | What |
+|---|---|
+| `inventory.md` | Full list of files, tables, env vars, and shared deps to copy |
+| `migration-checklist.md` | 6-phase migration with safety gates between each |
+| `row-counts.md` | Snapshot of current `stock_*` table sizes (for post-migration verification) |
+| `export-schema.sh` | Script to dump current `stock_*` table schemas |
+
+## Where we are
+
+| Phase | Owner | Status |
+|---|---|---|
+| 1 - Infra setup | Zaal | **Pending** - need to create repo, Supabase project, Vercel project, point DNS |
+| 2 - Code copy + path strip | Claude | Blocked on Phase 1 |
+| 3 - DB migration | Claude + Zaal | Blocked on Phase 1 |
+| 4 - Deploy + cutover | Claude + Zaal | Blocked on Phase 1-3 |
+| 5 - Delete from ZAOOS | Claude | Blocked on Phase 4 + 48h |
+| 6 - Bot migration | Later | Out of scope this week |
+
+## What I&rsquo;m doing while waiting
+
+1. Inventory complete (`inventory.md`)
+2. Migration checklist with safety gates (`migration-checklist.md`)
+3. Row count baseline captured (`row-counts.md`)
+4. Schema export script ready (`export-schema.sh`)
+
+When the repo URL exists, drop it in chat. I clone, scaffold, copy. ~1-2 hours to a working `zaostock.com` Phase-2 build.
+
+## What you need to do
+
+Phase 1 of `migration-checklist.md`. Six checkboxes. Once `zaostock.com` resolves to a Vercel hello-world page, ping me and I take over.

--- a/scripts/zaostock-spinout/export-schema.sh
+++ b/scripts/zaostock-spinout/export-schema.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Export schema for all stock_* tables from current ZAOOS Supabase project.
+# Run after pg_dump is available locally + DATABASE_URL is set in env.
+#
+# Usage:
+#   DATABASE_URL=postgresql://... bash export-schema.sh
+#
+# Output: schema-export.sql in this dir, ready to paste into NEW Supabase
+# SQL Editor (with stock_ prefix stripped) for the zaostock project.
+
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "ERROR: set DATABASE_URL to your ZAOOS Supabase connection string"
+  echo "Find it in: Supabase dashboard -> Project Settings -> Database -> Connection string -> URI"
+  echo ""
+  echo "Example:"
+  echo "  DATABASE_URL='postgresql://postgres:PASS@db.efsx....supabase.co:5432/postgres' bash $0"
+  exit 1
+fi
+
+OUT="$(dirname "$0")/schema-export.sql"
+
+echo "Dumping schema for stock_* tables to $OUT..."
+
+pg_dump "$DATABASE_URL" \
+  --schema-only \
+  --no-owner \
+  --no-privileges \
+  --table='public.stock_*' \
+  > "$OUT"
+
+echo ""
+echo "Done. Review the file before pasting into the NEW Supabase project."
+echo ""
+echo "Next: strip the 'stock_' prefix from table + index names before pasting."
+echo "      sed -i '' 's/stock_//g' $OUT"
+echo ""
+echo "Then in the NEW Supabase SQL Editor:"
+echo "  1. Paste contents of $OUT"
+echo "  2. Run"
+echo "  3. Verify tables exist: SELECT tablename FROM pg_tables WHERE schemaname='public';"

--- a/scripts/zaostock-spinout/inventory.md
+++ b/scripts/zaostock-spinout/inventory.md
@@ -1,0 +1,153 @@
+# ZAOstock spinout - inventory
+
+> Source of truth for what moves to `zaostock` repo. Cross off as confirmed working in the new repo. **Nothing gets deleted from ZAOOS until cutover (Phase 4) is verified live.**
+
+## Files to copy
+
+### App routes (`src/app/stock/**` -> new repo `src/app/**`, drop the `/stock/` prefix)
+
+```
+src/app/stock/page.tsx                           -> src/app/page.tsx
+src/app/stock/PublicTeamGrid.tsx                 -> src/app/PublicTeamGrid.tsx
+src/app/stock/RSVPForm.tsx                       -> src/app/RSVPForm.tsx
+src/app/stock/apply/                             -> src/app/apply/
+src/app/stock/artist/[slug]/                     -> src/app/artist/[slug]/
+src/app/stock/circles/                           -> src/app/circles/
+src/app/stock/cypher/                            -> src/app/cypher/
+src/app/stock/onepagers/                         -> src/app/onepagers/
+src/app/stock/program/                           -> src/app/program/
+src/app/stock/sponsor/                           -> src/app/sponsor/
+src/app/stock/suggest/                           -> src/app/suggest/
+src/app/stock/team/                              -> src/app/team/
+src/app/stock/llms.txt/                          -> src/app/llms.txt/
+```
+
+### API routes (`src/app/api/stock/**` -> `src/app/api/**`)
+
+24 routes total - all under `src/app/api/stock/` move to `src/app/api/` in the new repo.
+
+### Lib (`src/lib/stock/**` -> `src/lib/**`)
+
+```
+src/lib/stock/artists.ts        -> src/lib/artists.ts
+src/lib/stock/log-activity.ts   -> src/lib/log-activity.ts
+src/lib/stock/members.ts        -> src/lib/members.ts
+src/lib/stock/onepagers.ts      -> src/lib/onepagers.ts
+```
+
+### Auth
+
+```
+src/lib/auth/stock-team-session.ts   -> src/lib/auth/session.ts (rename)
+```
+
+## Shared infra to inline (clone, no deps)
+
+These are the only things ZAOstock pulls from non-stock paths in ZAOOS. Per the Monorepo-as-Lab rule (no shared libs between repos), each of these gets copied into the new repo:
+
+```
+@/components/events/CountdownTimer  -> src/components/CountdownTimer.tsx
+@/lib/env                           -> src/lib/env.ts (trim to only zaostock vars)
+@/lib/db/supabase                   -> src/lib/db/supabase.ts
+@/lib/logger                        -> src/lib/logger.ts
+```
+
+## Database tables to migrate
+
+18 tables. All `stock_*`. Schema export at `schema-export.sql`, data export plan in `migration-checklist.md`.
+
+```
+stock_activity_log
+stock_artists
+stock_attachments
+stock_budget_entries
+stock_circle_members
+stock_circles
+stock_comments
+stock_contact_log
+stock_goals
+stock_meeting_notes
+stock_onepager_activity
+stock_onepagers
+stock_sponsors
+stock_suggestions
+stock_team_members
+stock_timeline
+stock_todos
+stock_volunteers
+```
+
+In the new Supabase project, drop the `stock_` prefix on all tables (since the whole DB is ZAOstock):
+
+```
+stock_activity_log    -> activity_log
+stock_artists         -> artists
+... etc
+```
+
+This requires updating every `from('stock_xxx')` call in the migrated code. ~150 call sites. Mechanical find-replace.
+
+## Bot (`bot/`)
+
+**Stays in ZAOOS for now.** Phase 5 migration. The bot's only DB connection is Supabase URL + service role key, so we just point its `.env` at the new ZAOstock Supabase project once Phase 3 lands. Code stays put until we&rsquo;re ready to move it.
+
+## Scripts
+
+```
+scripts/stock-add-stilo-eve-bacon-eduard.ts
+scripts/stock-missing-tables-migration.sql
+scripts/stock-team-skills-feed-migration.sql
+scripts/stock-team-status-text-migration.sql
+scripts/stock-team-tuesday-apr28-agenda.sql
+scripts/stock-archive/                         (full archive folder)
+```
+
+These move to `scripts/` in the new repo, dropping the `stock-` prefix where it doesn&rsquo;t add clarity.
+
+## Env vars needed in new repo
+
+```
+NEXT_PUBLIC_SUPABASE_URL          # NEW - point at zaostock supabase project
+NEXT_PUBLIC_SUPABASE_ANON_KEY     # NEW
+SUPABASE_SERVICE_ROLE_KEY         # NEW
+SESSION_SECRET                     # NEW (regenerate, do not reuse)
+NEXT_PUBLIC_APP_URL               # https://zaostock.com
+```
+
+The bot stays on the OLD ZAOOS env file until Phase 5, but its Supabase URL gets repointed to the NEW project after Phase 3.
+
+## Public profile pic / image hosts
+
+ZAOstock uses external image URLs (X profile images, postimages.org, etc). No image storage to migrate. **Photo URL pattern stays the same.**
+
+## What does NOT move
+
+- `research/` - stays in ZAOOS forever (institutional memory across all products)
+- `community.config.ts` - ZAOOS-specific, doesn&rsquo;t apply to zaostock
+- The Farcaster client routes (`src/app/(auth)`, `src/app/(public)`, etc) - ZAOOS-only
+- Agent stack (`src/lib/agents/`, ZOE, Hermes) - stays in lab
+- The bot (`bot/`) - stays for now, Phase 5 migration
+
+## Audit when migration is &ldquo;done&rdquo;
+
+Before deleting from ZAOOS, every one of these must be true on `zaostock.com`:
+
+- [ ] Login flow works (4-letter codes from old DB still valid)
+- [ ] Bio editor saves to NEW Supabase
+- [ ] Public profile (`/team/m/<slug>`) renders for at least 5 known members
+- [ ] Team directory loads with all members + scope filter works
+- [ ] Activity feed pulls from NEW Supabase
+- [ ] Onboarding checklist shows correct state
+- [ ] All 24 API routes return 200
+- [ ] Onepagers (overview + roddy + circle-checklists) render
+- [ ] Telegram bot can read + write to the NEW Supabase project
+- [ ] Email/social links from teammate profiles still resolve
+- [ ] No 404s when crawling the site
+
+Only after that 11-item checklist, run the deletion:
+
+```
+rm -rf src/app/stock src/app/api/stock src/lib/stock src/lib/auth/stock-team-session.ts
+```
+
+Plus add the redirect middleware (see `migration-checklist.md` Phase 4).

--- a/scripts/zaostock-spinout/migration-checklist.md
+++ b/scripts/zaostock-spinout/migration-checklist.md
@@ -1,0 +1,125 @@
+# ZAOstock spinout - migration checklist
+
+> **Safety rule:** Nothing gets deleted from ZAOOS until cutover is verified live on zaostock.com. Every deletion happens AFTER the new repo proves it works.
+
+Source of truth for the ordering. Cross off as you go. Each phase has a gate that must pass before the next phase starts.
+
+## Phase 1 - Infra setup (Zaal)
+
+You do these. I can&rsquo;t.
+
+- [ ] Create empty GitHub repo `bettercallzaal/zaostock` (private to start, flip to public later if you want)
+- [ ] Create new Supabase project named `zaostock`
+- [ ] Save the Supabase URL + anon key + service role key in `~/Documents/zaostock/.env.local` (NOT in this repo)
+- [ ] Create new Vercel project, connect it to the `bettercallzaal/zaostock` repo
+- [ ] Point `zaostock.com` DNS at Vercel (A or CNAME per Vercel guidance)
+- [ ] Verify the empty repo deploys a Next.js hello-world successfully
+
+**Gate:** `zaostock.com` resolves to a Vercel hello-world page. Don&rsquo;t move to Phase 2 until that&rsquo;s green.
+
+## Phase 2 - Code copy + path strip (me, after Phase 1)
+
+Once the repo URL exists, share it with me. Then I scaffold:
+
+- [ ] Clone the new empty repo locally
+- [ ] `npx create-next-app@latest` with the same Next.js 16 + Tailwind v4 + TypeScript stack as ZAOOS
+- [ ] Copy files per `inventory.md` paths (drop the `/stock/` prefix everywhere)
+- [ ] Inline the 4 shared deps (CountdownTimer, env, supabase, logger)
+- [ ] Strip `/stock/` from all internal `Link` href props + redirects
+- [ ] Strip the `stock_` prefix from every `from('stock_xxx')` Supabase call (renaming tables in the new DB - see Phase 3)
+- [ ] Wire env vars from `.env.example` (point at NEW Supabase project)
+- [ ] `npm install` + `npm run typecheck` clean
+- [ ] Local smoke: `/team` (login + dashboard), `/onepagers/overview`, `/apply`, `/sponsor`, `/program`
+
+**Gate:** Local dev server runs clean, typecheck passes, no broken imports. Open a PR on the new repo so the diff is reviewable.
+
+## Phase 3 - Database migration (me + Zaal)
+
+- [ ] Generate `schema.sql` from current ZAOOS Supabase (every `stock_*` table CREATE + RLS policies + indexes). Strip the `stock_` prefix in the new schema.
+- [ ] Paste schema into NEW zaostock Supabase SQL Editor, run it
+- [ ] `pg_dump --data-only` from current ZAOOS Supabase, filtered to `stock_*` tables only
+- [ ] Transform dump file: rename tables (`stock_team_members` -> `team_members`, etc) before import
+- [ ] Import into NEW Supabase
+- [ ] Verify row counts match per table (current snapshot in `row-counts.md`)
+- [ ] Spot-check 5 random rows in 3 tables (team_members, todos, sponsors) - same data as old?
+- [ ] Update bot `.env` on VPS to point at NEW Supabase URL + service role key
+- [ ] Verify bot still works: DM `@ZAOstockTeamBot`, hit `/help`, `/circles`, `/mytodos` - should respond using NEW DB
+- [ ] Verify cron jobs still fire (morning digest, etc) and read from NEW DB
+
+**Gate:** Bot reads/writes against the new DB cleanly. Row counts match. Spot checks pass.
+
+## Phase 4 - Deploy + cutover (me + Zaal)
+
+- [ ] Push code to `main` on `bettercallzaal/zaostock`
+- [ ] Vercel auto-deploys to `zaostock.com`
+- [ ] Run the 11-item audit from `inventory.md` against `zaostock.com`
+- [ ] Add a redirect middleware in ZAOOS:
+
+  ```typescript
+  // src/middleware.ts in ZAOOS - add to existing middleware
+  export async function middleware(req: NextRequest) {
+    const path = req.nextUrl.pathname;
+    if (path.startsWith('/stock')) {
+      const newPath = path.replace(/^\/stock/, '');
+      return NextResponse.redirect(`https://zaostock.com${newPath || '/'}`, 301);
+    }
+    // ... existing middleware
+  }
+  ```
+
+- [ ] Deploy ZAOOS with the redirect middleware
+- [ ] Test: visit `zaoos.com/stock/team` -> should 301 to `zaostock.com/team`
+- [ ] Test: visit `zaoos.com/stock/onepagers/overview` -> should 301 to `zaostock.com/onepagers/overview`
+- [ ] Pin the new URL in the ZAOstock TG group + Discord
+- [ ] Update `community.config.ts` in ZAOOS to drop the `/stock` nav links
+
+**Gate:** Redirects work, team can use `zaostock.com` for everything, no broken links from old URLs.
+
+**Wait 48 hours.** Watch the redirect logs. If anything is broken, this is the rollback window. Don&rsquo;t skip this.
+
+## Phase 5 - Delete from ZAOOS (me, after 48h confirmation)
+
+After 48 hours of zaostock.com working cleanly with no rollback:
+
+- [ ] Delete `src/app/stock/` from ZAOOS
+- [ ] Delete `src/app/api/stock/` from ZAOOS
+- [ ] Delete `src/lib/stock/` from ZAOOS
+- [ ] Delete `src/lib/auth/stock-team-session.ts` from ZAOOS
+- [ ] Update CLAUDE.md to mark ZAOstock as &ldquo;graduated&rdquo;
+- [ ] Update README.md to move ZAOstock from &ldquo;in lab&rdquo; to &ldquo;graduated&rdquo;
+- [ ] Keep the redirect middleware in ZAOOS forever (or until we sunset zaoos.com itself)
+- [ ] Keep `research/` docs about ZAOstock - those stay
+- [ ] Keep the bot in ZAOOS (Phase 5 of bot migration is later)
+
+**Gate:** Delete PR merges, ZAOOS routes still work for the Farcaster client, redirect middleware still routes the /stock paths.
+
+## Phase 6 - Bot migration (later, separate project)
+
+Not this week. Plan to do it when:
+- The bot has been running on the new Supabase URL for at least 2 weeks without issue
+- We have time to do a clean systemd unit migration on the VPS
+- Or when the bot itself is ready to graduate from the lab (when it&rsquo;s &ldquo;solid + worth its own brand&rdquo;)
+
+For now: bot lives in ZAOOS, talks to NEW Supabase, does its job.
+
+---
+
+## Rollback plan (if anything goes wrong)
+
+If at any point Phase 4 fails:
+1. Pull the redirect middleware from ZAOOS
+2. ZAOOS routes serve `/stock/*` again as before
+3. Diagnose the issue on `zaostock.com`
+4. Try cutover again when fixed
+
+If Phase 3 fails (data migration):
+1. Old ZAOOS DB is untouched - everything still works there
+2. Drop the new Supabase project, start fresh
+3. The new Vercel project doesn&rsquo;t have a working DB but no harm done
+
+If Phase 5 deletion happens prematurely and something&rsquo;s broken:
+1. `git revert` the deletion commit
+2. Push to ZAOOS, Vercel redeploys
+3. Code is back
+
+The only way this goes really wrong is if we delete from ZAOOS *before* zaostock.com is verified. The 48-hour rule prevents that.

--- a/scripts/zaostock-spinout/row-counts.md
+++ b/scripts/zaostock-spinout/row-counts.md
@@ -1,0 +1,22 @@
+# Table row counts (2026-04-28)
+
+| Table | Rows |
+|---|---|
+| stock_activity_log | 2 |
+| stock_artists | 9 |
+| stock_attachments | null |
+| stock_budget_entries | 15 |
+| stock_circle_members | 26 |
+| stock_circles | 8 |
+| stock_comments | null |
+| stock_contact_log | 1 |
+| stock_goals | 8 |
+| stock_meeting_notes | 4 |
+| stock_onepager_activity | 6 |
+| stock_onepagers | 3 |
+| stock_sponsors | 18 |
+| stock_suggestions | 0 |
+| stock_team_members | 26 |
+| stock_timeline | 60 |
+| stock_todos | 21 |
+| stock_volunteers | 0 |


### PR DESCRIPTION
## Summary

Eval of `@lazer-tech/miniapp` CLI (miniapps.lazer.tools) for ZAO mini app scaffolding. Verdict: 1-day spike candidate, not default. Pre-PMF (437 monthly DLs, 17 last week, v0.1.8 from 2026-03-18). Source repo `LazerTechnologies/lazer-mini-apps` is private despite MIT npm tarball - bus-factor + audit risk for production.

## Tier
STANDARD

## Sources
12 unique - npm registry direct API, GitHub org API, lazertechnologies.com, Built In Toronto, Farcaster/Neynar/Base official docs, 2 community alt CLIs.

## Key Decisions
- NO: adopt as default scaffold
- YES: 1-day spike on net-new throwaway (ZAOstock RSVP / ZABAL stake)
- NO: replace existing `src/app/miniapp/**` infra (already shipped + tested)
- YES: keep Neynar + Base MiniKit as first-party defaults
- CONDITIONAL: lift Lazer skill prompts into QuadWork only if repo opens

## Next Actions
See [Action Bridge](research/farcaster/548-lazer-miniapps-cli-evaluation/README.md#action-bridge). Re-validate npm trend 2026-05-28.

## Related Docs
173, 250, 349, 489, 508