### PR TITLE
doc 549 (21st.dev hub + 5 subs) + 550 (gitpitcher) - DISPATCH tier

### DIFF
--- a/research/dev-workflows/549-21st-dev-component-platform/README.md
+++ b/research/dev-workflows/549-21st-dev-component-platform/README.md
@@ -1,0 +1,149 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 173, 250, 349, 489, 508, 548, 549a, 549b, 549c, 549d, 549e
+tier: DISPATCH
+---
+
+# 549 - 21st.dev Hub: Component Platform + Magic MCP + 1code
+
+> **Goal:** Decide how ZAO uses 21st.dev (components marketplace + Magic MCP + 1code agent orchestration) for ZAO OS UI, ZAO Stock site, BetterCallZaal, FISHBOWLZ-replacement, and the broader ZAO website surface. Spec a `/21st` skill the team can drop into Claude Code today.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Install Magic MCP today on Zaal's main Claude Code | **YES, NOW** | MIT, 4,815 stars, 47,369 monthly npm DLs, repo updated 2026-04-29 (today). Two free tools (`21st_magic_component_inspiration` semantic search, `logo_search` brand SVG via svgl) cost zero credits and replace 80% of "find me a hero / CTA / pricing card" prompts. One-line install: `npx @21st-dev/cli@latest install claude --api-key <key>`. |
+| Pay $20/mo Pro (Magic Generate) for active design phases | **YES, BUT TURN ON/OFF MONTHLY** | Pro unlocks `21st_magic_component_builder` (5 polished variants per component) + `21st_magic_component_refiner` (iterate). Worth it during ZAOstock site build, ZAO OS visual refresh, BCZ portfolio refresh. Pause months when no UI work. |
+| Skip Max ($100/mo) for now | **YES, SKIP** | Site Cloning + early access not worth 5x cost until we have a specific reference site to clone. Re-evaluate when ZAO Stock visual brief lands. |
+| Build a `/21st` skill in `~/.claude/skills/21st/` so any session can search + lift components | **YES, SHIPPING TODAY (Doc 549e)** | The skill wraps the MCP tools with ZAO context: stack-aware (Next 16, React 19, Tailwind v4), brand-token-aware (#0a1628 navy, #f5a623 gold), repo-rule-aware (Biome, Vitest, no inline styles, mobile-first). See [549e](../549e-21st-dev-zao-skill-spec/). |
+| Use 21st components on the ZAO website (zaoos.com / thezao.com) and ZAO Stock site | **YES, SELECTIVE** | Concrete first targets: `/stake` hero refresh, ZAO Stock landing hero + ticket-tier pricing card, FISHBOWLZ-replacement audio room CTA, ZOE chat shell upgrade. Categories that fit: Heroes, Pricing Sections, AI Chat Components, Calls to Action, Shaders, Testimonials. |
+| Add 21st Inspiration Search to ZAO website itself (in-browser component picker for community contributors) | **DEFER** | Tempting but premature. Internal team can use the MCP for now. If ZAO ever runs a public "build a Frapp" workflow, revisit - the SDK + agent-elements would let us embed search in the contributor flow. See [549d](../549d-21st-dev-ai-features-magic/). |
+| Track `1code` (5,494 stars) - 21st-dev's "orchestration layer for Claude Code + Codex" | **YES, TRACK** | Adjacent product, separate ecosystem. Likely overlaps with QuadWork. Park for a real read once Lazer spike (Doc 548) is closed. |
+| Treat 21st as a primary, ahead of Aceternity / MagicUI / OriginUI / shadcn-ui-mcp-server / shadcn studio | **YES, FOR ZAO** | Magic MCP is the only one bundling: free semantic search across an aggregator-scale catalog + free brand-icon search via svgl + paid generation in the same install. Other registries are read-only catalogs. See [549b](../549b-21st-dev-access-patterns/). |
+| Replace existing UI patterns in `src/components/` wholesale with 21st generations | **NO** | Mobile-first dark theme already locked. Use 21st for **new** surfaces and refreshes, not retrofits. Per project rule: "edit existing files; don't rewrite for the sake of fashion." |
+
+## What 21st.dev Actually Is (Three-Layer Cake)
+
+Not a single product - three overlapping things under one brand:
+
+### Layer 1 - Component Marketplace (`21st.dev/community`, free read access)
+
+Community-published UI components. Categories visible on landing: **Shaders, Heroes, Features, AI Chat Components, Calls to Action, Buttons, Testimonials, Pricing Sections, Text Components**. Engagement metrics shown on each component (likes/views: top items at 275, 265, 236).
+
+### Layer 2 - Magic MCP (open-source MIT, paid API tier)
+
+`github.com/21st-dev/magic-mcp` - 4,815 stars, MIT, TS, last commit 2026-04-29. Exposes 4 tools to any MCP-aware IDE:
+
+| Tool | What it does | Cost |
+|---|---|---|
+| `21st_magic_component_inspiration` | Semantic search across the marketplace | **Free** |
+| `logo_search` | Brand SVG search via svgl | **Free** |
+| `21st_magic_component_builder` | Generate 5 polished variants from a description | **Pro $20/mo** |
+| `21st_magic_component_refiner` | Iterate on a generated/existing component | **Pro $20/mo** |
+
+API responses are sub-100ms per published reviews. Install via `@21st-dev/cli` for Claude Code / Cursor / Windsurf / Cline. VS Code via README badge or manual MCP block.
+
+### Layer 3 - Agent Infrastructure (`1code`, `21st-sdk`, `agent-elements`, `21st-extension`)
+
+Separate product surface, same org:
+
+- **`1code`** - 5,494 stars - "Orchestration layer for coding agents (Claude Code, Codex)." Likely a competitor / alternative to ZAO's QuadWork pattern. Park for separate research.
+- **`21st-sdk`** - 107 stars - SDK for embedding 21st features in apps. Has `21st-sdk-examples` cookbook (35 stars).
+- **`agent-elements`** - 50 stars - drop-in agent-UX components. Possible fit for ZOE chat shell upgrade.
+- **`21st-extension`** - 133 stars - browser extension.
+
+Big picture: 21st-dev is becoming a full agent-tooling company, not just a component shop.
+
+## Pricing (Consolidated Across Sources, 2026-04-29)
+
+| Tier | $/mo | Magic Generate quota | Inspiration Search | Logo Search | Site Cloning | Early Access |
+|---|---|---|---|---|---|---|
+| Free | $0 | 5 free requests OR 100 credits/mo (sources differ; treat as low) | Unlimited | Unlimited | No | No |
+| Pro | $20 | Significantly increased | Unlimited | Unlimited | No | No |
+| Max | $100 | Maximum allocation | Unlimited | Unlimited | **Yes** | **Yes** |
+
+Conflict noted in 549c: PulseMCP says "5 free requests, $10/month paid"; the official `/magic` page says "100 credits / Pro $20 / Max $100". Live `/pricing` page returned navigation-only when fetched 2026-04-29. **Confirm exact free-tier quota at signup before relying on it.**
+
+Annual pricing not exposed on landing fetches. No public team/enterprise tier mentioned.
+
+## ZAO-Specific Recommendations (Concrete)
+
+| Surface | Today's state | 21st action | Tier needed |
+|---|---|---|---|
+| `/stake` hero | Plain card, no chart | Search "staking dashboard hero with token chart" via free Inspiration; pair with Codex client lift from Doc 548 | Free |
+| ZAO Stock landing | Doesn't exist yet | Generate hero + pricing-tier card for sponsor tiers via Magic Generate | Pro |
+| ZAO Stock ticket page | Doesn't exist yet | Generate festival-style ticket card (tier + price + benefits) | Pro |
+| ZOE chat shell (zoe.zaoos.com) | Custom Telegram-style | Lift from "AI Chat Components" category for upgraded message bubbles + suggestions | Free (search) -> Pro (refine if needed) |
+| FISHBOWLZ-replacement audio CTA | Paused per `project_fishbowlz_deprecated`; if Juke partnership needs an embed | Search "audio room CTA card" | Free |
+| BCZ portfolio (bettercallzaal.com) | Static HTML | Generate refreshed hero + testimonial section + service-tier pricing | Pro |
+| `community.config.ts` brand tokens | Locked at navy `#0a1628` + gold `#f5a623` | Pass to Magic Generate via skill prompt; check output respects them | n/a |
+| ZOUNZ landing | TBD | Defer; not active | n/a |
+
+## Sub-Documents
+
+- **[549a - Catalog & Inventory](../549a-21st-dev-catalog-inventory/)** - what categories exist, contributor names captured, what fits ZAO's UI surface
+- **[549b - Access Patterns](../549b-21st-dev-access-patterns/)** - MCP install, tools surface, alternatives (shadcn-ui-mcp-server, shadcn studio), why pick 21st
+- **[549c - Pricing & Licensing](../549c-21st-dev-pricing-licensing/)** - quota reality check, license per generated component, redistribution rules
+- **[549d - AI Features (Magic + 1code + SDK)](../549d-21st-dev-ai-features-magic/)** - what each Magic tool does, when to reach for each, how 1code overlaps with QuadWork
+- **[549e - `/21st` Skill Spec](../549e-21st-dev-zao-skill-spec/)** - drop-in `SKILL.md` ready to copy to `~/.claude/skills/21st/`
+
+## Hard Numbers (Verified 2026-04-29)
+
+| Metric | Value | Source |
+|---|---|---|
+| `21st-dev/magic-mcp` stars | 4,815 | `gh api repos/21st-dev/magic-mcp` |
+| `21st-dev/magic-mcp` forks | 334 | same |
+| `21st-dev/magic-mcp` license | MIT | repo metadata |
+| `21st-dev/magic-mcp` last update | 2026-04-29 | same |
+| `@21st-dev/magic` monthly DLs | 47,369 (2026-03-30 to 2026-04-28) | `api.npmjs.org/downloads` |
+| `@21st-dev/magic` weekly DLs | 9,606 (2026-04-22 to 2026-04-28) | same |
+| `1code` stars | 5,494 | `gh api orgs/21st-dev/repos` |
+| `21st-sdk` stars | 107 | same |
+| `agent-elements` stars | 50 | same |
+| `21st-extension` stars | 133 | same |
+| Tools per MCP install | 4 | `magic-mcp` README |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Install Magic MCP via `npx @21st-dev/cli@latest install claude --api-key <key>` on Zaal's machine | Zaal | One-shot | This week |
+| Drop `/21st` skill from [549e](../549e-21st-dev-zao-skill-spec/) into `~/.claude/skills/21st/SKILL.md` | Zaal | One-shot | This week |
+| Test on `/stake` hero refresh - free Inspiration Search only, no Pro yet | Zaal in ZAO OS V1 | Spike PR | This week |
+| Decide Pro $20 toggle for ZAO Stock site sprint | Zaal | Subscription decision | When ZAO Stock visual brief lands |
+| Open separate research doc on `1code` (5,494 stars) - compare to QuadWork | n/a | Research doc | After Lazer spike (Doc 548) closes |
+| Re-validate pricing claims (free 5 vs free 100) at signup, update [549c](../549c-21st-dev-pricing-licensing/) | Zaal | Self-validate | At first install |
+| Cross-link from `community.config.ts` rule "use 21st for new surfaces" once tested | Zaal | PR | After 1st spike |
+
+## Also See
+
+- [Doc 548 - Lazer Mini Apps CLI](../../farcaster/548-lazer-miniapps-cli-evaluation/) - sister scaffold-tier eval. 21st operates one layer up (components inside any scaffold).
+- [Doc 250 - Farcaster miniapps llms.txt](../../farcaster/250-farcaster-miniapps-llms-txt-2026/) - related mini app context primer
+- [Doc 432 - ZAO master positioning (Tricky Buddha)](../../community/432-tricky-buddha-zao-master-context/) - brand voice constraints any UI generation must respect
+- [Doc 508 - Creator infra + mini apps + token burn brief](../508-creator-infra-mini-apps-token-burn-signals-apr25/) - confirms ECC + 21st-style tooling is on the right side of 2026 trend
+
+## Sources
+
+- [21st.dev landing](https://21st.dev/home)
+- [21st.dev Magic page](https://21st.dev/magic)
+- [21st-dev/magic-mcp on GitHub](https://github.com/21st-dev/magic-mcp) - 4,815 stars, MIT, TS, updated 2026-04-29
+- [21st-dev org on GitHub](https://github.com/21st-dev) - 11 repos visible
+- [@21st-dev/magic on npm](https://www.npmjs.com/package/@21st-dev/magic)
+- [@21st-dev/cli on npm](https://www.npmjs.com/package/@21st-dev/cli)
+- [PulseMCP - 21st.dev Magic](https://www.pulsemcp.com/servers/21st-dev-magic) - install + free-tier note
+- [Glama - 21st-dev Magic](https://glama.ai/mcp/servers/@21st-dev/magic-mcp)
+- [Augmentcode MCP directory](https://www.augmentcode.com/mcp/21st-dev-magic-mcp-server)
+- [Apidog blog - 21st.dev review](https://apidog.com/blog/21st-dev-review/) - perf claim sub-100ms, 5 free requests
+- [Skywork.ai - Magic MCP guide](https://skywork.ai/skypage/en/magic-mcp-ai-engineer-ui/1979089119583969280)
+- [mcp.harishgarg.com - Claude Code setup](https://mcp.harishgarg.com/use/21stdev-magic/mcp-server/with/claude-code)
+
+## Staleness + Hallucination Notes
+
+- All star counts, DL counts, dates pulled live 2026-04-29 from GitHub + npm APIs, not LLM recall.
+- Pricing has a known conflict ($10 vs $20 vs 5-credit vs 100-credit). Live `/pricing` page returned navigation-only HTML on 2026-04-29 fetch. Do not commit to specific quotas in user-facing docs until verified at signup.
+- Component categories list comes from landing page navigation, not exhaustive listing - treat as "at least these," not "only these."
+- Site cloning + early access tied to Max tier per `/magic` page; not independently verified.
+- Re-validate by 2026-05-29.

--- a/research/dev-workflows/549a-21st-dev-catalog-inventory/README.md
+++ b/research/dev-workflows/549a-21st-dev-catalog-inventory/README.md
@@ -1,0 +1,79 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 549, 549b, 549c, 549d, 549e
+tier: STANDARD
+---
+
+# 549a - 21st.dev Catalog Inventory
+
+> **Goal:** Map what's actually in the 21st.dev component marketplace so a ZAO contributor knows where to look first instead of guessing prompts.
+
+## Categories Visible from Landing (2026-04-29)
+
+| Category | Direct ZAO surface fit | Likely use |
+|---|---|---|
+| Shaders | High | ZAO landing animated background, ZAO Stock hero, ZOUNZ visualiser |
+| Heroes | Highest | ZAO Stock landing, BCZ portfolio, `/stake` page refresh |
+| Features | Medium | ZAO Stock "what you get as sponsor" sections |
+| AI Chat Components | Highest | ZOE chat shell, ZAO OS in-app chat surfaces, FISHBOWLZ-replacement Juke embed |
+| Calls to Action | High | ZAO Stock RSVP, ZABAL stake CTA, POIDH bounty submit |
+| Buttons | Medium | Brand-token-aware refresh of `src/components/ui/button.tsx` |
+| Testimonials | High | ZAO Stock sponsor logos, BCZ social proof |
+| Pricing Sections | Highest | ZAO Stock sponsor tiers, BCZ service tiers, ZAO Music drop tiers |
+| Text Components | Low | Animated copy on landing pages |
+
+> Categories pulled from landing page navigation. Treat as "at least these," not "only these." More may exist behind login + scroll.
+
+## Engagement Signal (Top Components Visible on Landing)
+
+Top-listed items showed engagement scores 275, 265, 236 (likes/views, exact metric not labelled). Components attributed to community contributors visible by username: `easemize`, `kokonutd`, `jatin-yadav05`, `isaiahbjork`. Pattern matches a community marketplace, not a small in-house catalog.
+
+## Total Catalog Size (Inferred)
+
+Marketplace messaging across PulseMCP / Glama / official docs uses "thousands of components" verbatim. Free `21st_magic_component_inspiration` semantic search is the discovery primitive - a component count number was not posted on 2026-04-29.
+
+For decision-making, treat catalog size as: **large enough that semantic search is the right primitive; do not try to build a manual index.**
+
+## How to Browse Without Login
+
+Public read at `https://21st.dev/community/components/`. Login required for: publishing, liking, saving collections. Code copy works without login on most components.
+
+The MCP `21st_magic_component_inspiration` tool requires an API key, regardless of whether the component is free to view.
+
+## ZAO-Targeted Browse Plan
+
+When you sit down to design a ZAO surface, query in this order:
+
+1. **Inspiration Search via MCP** (free) - `inspiration: "ZAOstock sponsor pricing tiers, festival aesthetic, dark navy + gold"`. Skim 10 returned components.
+2. **Open top 3 in browser** at `21st.dev/community/components/<slug>` to read code + see live demo.
+3. **Decide:** lift code directly (free, attribution per 549c), refine via `21st_magic_component_refiner` (Pro), or generate fresh variants via `21st_magic_component_builder` (Pro).
+4. **Adapt** in ZAO repo: swap brand tokens (`#0a1628`, `#f5a623`), import `cn` from `@/lib/utils`, ensure `"use client"` if hooks/handlers, mobile-first responsive prefixes per `.claude/rules/components.md`.
+
+The `/21st` skill in [549e](../549e-21st-dev-zao-skill-spec/) automates steps 1 + 4.
+
+## Categories We Will NOT Use
+
+- Generic SaaS dashboard chrome - ZAO design language is darker / more music-festival than admin-saas. Filter heroic results that look like Stripe / Vercel clones unless explicitly remixed.
+- Light-theme-first components - ZAO is dark-default per `community.config.ts`.
+- Desktop-first layouts - ZAO is mobile-first.
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| First Inspiration Search query for `/stake` hero | Zaal | Spike via Claude Code MCP | This week |
+| Save 5 favourite contributor handles to `~/.claude/projects/.../memory/project_21st_signals.md` | Auto via skill | Memory | After 1st spike |
+| Build internal "ZAO-fit / not-fit" tag during browse so we don't re-evaluate same components | Zaal | Memory or local notes | Ongoing |
+
+## Sources
+
+- [21st.dev community catalog](https://21st.dev/community)
+- [21st.dev landing](https://21st.dev/home)
+- [PulseMCP listing](https://www.pulsemcp.com/servers/21st-dev-magic) - "thousands of components" claim
+
+## Staleness Notes
+
+Categories list pulled from landing nav 2026-04-29. Engagement scores are point-in-time. Re-validate with skill in production use after 1st month.

--- a/research/dev-workflows/549b-21st-dev-access-patterns/README.md
+++ b/research/dev-workflows/549b-21st-dev-access-patterns/README.md
@@ -1,0 +1,117 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 549, 549a, 549c, 549d, 549e
+tier: STANDARD
+---
+
+# 549b - 21st.dev Access Patterns + Alternatives
+
+> **Goal:** Lock down the exact install command, what tools we get, what each tool costs, and why 21st beats the alternatives for ZAO. So we can skip evaluation paralysis next time someone asks "should we use 21st or shadcn-ui-mcp-server?"
+
+## Install (Claude Code, one-liner)
+
+```bash
+# 1. Generate API key at https://21st.dev/magic/console
+# 2. Run installer (writes MCP config to your Claude Code settings)
+npx @21st-dev/cli@latest install claude --api-key <YOUR_KEY>
+# 3. Restart Claude Code session
+```
+
+Same `cli` supports `cursor`, `windsurf`, `cline`. VS Code uses MCP block in user settings JSON or one-click badge from `magic-mcp` README.
+
+> **API key location:** `https://21st.dev/magic/console` - log in with GitHub or email, copy key. Treat as a secret per ZAO `.claude/rules/secret-hygiene.md`. Do NOT commit. Add to `.env.local` if any local script needs it; the installer writes it into Claude Code's settings, not the project.
+
+## What MCP Tools Get Installed (4 total)
+
+| Tool | Cost | What it actually does |
+|---|---|---|
+| `21st_magic_component_inspiration` | Free | Semantic search across the marketplace. Returns matched components with code + preview URL + metadata. Use as the default first move on any UI prompt. |
+| `logo_search` | Free | Brand SVG search via svgl. Pass a brand name, get back SVG markup ready to paste. Replaces "find me a Spotify logo SVG" Google trips. |
+| `21st_magic_component_builder` | Pro ($20/mo) | Generate 5 polished variants of a component from natural-language description. Opens browser tab to pick. |
+| `21st_magic_component_refiner` | Pro ($20/mo) | Iterate on an existing component (yours or a generated one). Useful for theme adaptation, accessibility passes, prop API tweaks. |
+
+All four return code that's TypeScript + React + Tailwind by default. Refiner can target other stacks per docs but ZAO doesn't need that.
+
+## Stack Compatibility with ZAO
+
+| ZAO requirement | 21st default output | Match |
+|---|---|---|
+| Next.js 16 App Router | React + Tailwind, framework-agnostic in JSX form | Yes (paste into client component) |
+| React 19 | Compatible | Yes |
+| Tailwind v4 | Tailwind classes (v3/v4 mostly identical for util output) | Yes - watch for legacy `@layer` syntax in older components |
+| TypeScript | Generated as TSX | Yes |
+| `cn` utility from `@/lib/utils` | Often uses `cn` already; sometimes inline `clsx` | Adapt during paste |
+| `"use client"` directive | Sometimes missing on hook-using components | Add manually per `.claude/rules/components.md` |
+| Mobile-first responsive | Most heroes/CTAs default desktop-first | Adapt; the `/21st` skill (549e) will enforce |
+| Dark-theme tokens (`#0a1628`, `#f5a623`) | Components ship with their own tokens | Skill sweeps + replaces |
+
+## Alternatives Considered (Why Not Pick Them)
+
+| Alt | What it does | Why we still pick 21st |
+|---|---|---|
+| **shadcn-ui-mcp-server** (`Jpisnice/shadcn-ui-mcp-server`) | Read shadcn/ui + community shadcn registries, copy block code | Catalog is shadcn-only. No semantic search across community marketplace. No generation. |
+| **shadcn/ui official MCP** (`ui.shadcn.com/docs/registry/mcp`) | Lists shadcn registry items | Same as above. Ships with shadcn (which ZAO doesn't use everywhere). |
+| **shadcn studio MCP** (`shadcnstudio.com`) | Slightly fancier shadcn aggregator | Still shadcn-bound. |
+| **Aceternity UI** | High-quality animated components | No MCP. Manual copy-paste. |
+| **MagicUI** | Open-source animated components | No MCP at this size. Smaller catalog. |
+| **OriginUI** | Free shadcn-compatible blocks | No MCP. Smaller. |
+| **v0.dev (Vercel)** | AI component generation, browser-only | No MCP. No catalog browse. Lock-in to vercel.com flow. |
+| **Cursor's built-in** | Some component scaffolding via Cursor agent | Editor-locked. ZAO uses Claude Code. |
+
+**Why 21st wins for ZAO:**
+
+1. Magic MCP is the only one that bundles **catalog search + generation + iteration** in one install.
+2. Open-source MIT MCP layer means we can fork or self-host if pricing changes.
+3. 47K monthly DLs + 4.8K stars = active enough to trust.
+4. Catalog is community-published, not just one team's components - higher diversity, better odds the right pattern already exists.
+
+## Programmatic Access Beyond MCP
+
+For server-side / CI use beyond Claude Code:
+
+- **REST API:** Surface mentioned across third-party MCP directories but not enumerated on `21st.dev/docs` (which 404'd on fetch 2026-04-29). The MCP itself wraps the same backend; calling MCP from a script is the path.
+- **`21st-sdk`** (107 stars) - SDK package for embedding 21st features in apps. Not yet audited for ZAO use; see [549d](../549d-21st-dev-ai-features-magic/).
+- **`21st-extension`** (133 stars) - browser extension. Not relevant to repo workflow.
+
+## Auth + Quotas
+
+- Free tier: API key + low quota on `21st_magic_component_builder` (5 free requests per PulseMCP listing; conflicts with `/magic` page's "100 credits"). Free tools (`inspiration`, `logo_search`) are unmetered to the published claim.
+- Pro: same key, raised quota.
+- Max: same key, max quota + site cloning + early access.
+
+API key is per-user. No team plan documented. If the team needs shared access, each engineer gets their own key (this is the recommended pattern for cost attribution anyway).
+
+## Failure Modes + Mitigations
+
+| Failure | Mitigation |
+|---|---|
+| Quota exhausted mid-session | Skill (549e) checks for `21st_magic_component_*` errors and falls back to inspiration-only mode |
+| MCP server down | Skill detects timeout, surfaces it, suggests manual browse at `21st.dev/community/` |
+| Generated code uses non-Tailwind-v4 syntax | Skill includes "Tailwind v4 only" instruction in the refiner prompt |
+| Generated code missing `"use client"` | Skill post-processes to add directive on detected hooks |
+| Brand tokens ignored by generator | Skill passes brand tokens explicitly in every Magic call |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Generate API key at `21st.dev/magic/console` | Zaal | One-shot | This week |
+| Run `npx @21st-dev/cli@latest install claude --api-key <key>` | Zaal | One-shot | Same |
+| Restart Claude Code session, verify with `/mcp list` | Zaal | Verify | Same |
+| Run first free `21st_magic_component_inspiration` query | Zaal | Spike | Same |
+
+## Sources
+
+- [21st-dev/magic-mcp on GitHub](https://github.com/21st-dev/magic-mcp) - 4,815 stars, MIT, last updated 2026-04-29
+- [@21st-dev/cli on npm](https://www.npmjs.com/package/@21st-dev/cli)
+- [Jpisnice/shadcn-ui-mcp-server](https://github.com/Jpisnice/shadcn-ui-mcp-server) - alt 1
+- [ui.shadcn.com MCP docs](https://ui.shadcn.com/docs/registry/mcp) - alt 2
+- [shadcnstudio.com MCP docs](https://shadcnstudio.com/docs/getting-started/shadcn-studio-mcp-server) - alt 3
+- [PulseMCP - 21st-dev/magic](https://www.pulsemcp.com/servers/21st-dev-magic) - tool surface + quota notes
+
+## Staleness Notes
+
+Free-tier quota figure (5 vs 100) unresolved at fetch time. Verify at signup. Update both this doc and 549c.

--- a/research/dev-workflows/549c-21st-dev-pricing-licensing/README.md
+++ b/research/dev-workflows/549c-21st-dev-pricing-licensing/README.md
@@ -1,0 +1,109 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 549, 549a, 549b, 549d, 549e
+tier: STANDARD
+---
+
+# 549c - 21st.dev Pricing & Licensing
+
+> **Goal:** What does 21st.dev cost, what do we get, and what license applies to components we lift or generate? Resolve before any production use.
+
+## Pricing Tiers (Best Available 2026-04-29)
+
+| Tier | Monthly | Annual | Magic Generate | Inspiration Search | Logo Search | Site Cloning | Early Access |
+|---|---|---|---|---|---|---|---|
+| Free | $0 | n/a | Low quota* | Unlimited | Unlimited | No | No |
+| Pro | $20 | Not exposed on landing fetch | Significantly raised | Unlimited | Unlimited | No | No |
+| Max | $100 | Not exposed | Maximum | Unlimited | Unlimited | **Yes** | **Yes** |
+
+> *Free quota reality check: PulseMCP listing says "5 free requests"; official `/magic` page says "100 credits". `/pricing` returned navigation-only HTML on fetch. **Confirm at signup, update this doc.**
+
+Earlier 2025 reviews (Apidog blog, Skywork article) referenced "$10/month" for paid tier. As of 2026-04-29 the live `/magic` page shows $20 Pro and $100 Max - assume pricing rose between mid-2025 and early-2026.
+
+## What Each Tool Costs
+
+| Tool | Tier needed | Notes |
+|---|---|---|
+| `21st_magic_component_inspiration` | Free | Unmetered per official messaging. Use heavily. |
+| `logo_search` | Free | Unmetered. Replaces ad-hoc Google trips for brand SVGs. |
+| `21st_magic_component_builder` | Free with low quota, Pro for production use | Each call returns 5 variants - counts as one generation. |
+| `21st_magic_component_refiner` | Free with low quota, Pro for production use | Per-iteration cost; counts toward generations. |
+| Site cloning (Max only) | Max | Reproduces a target URL's UI structure. Useful for "make ZAO Stock landing look like X" briefs - if Zaal lands on a reference. |
+
+## License of Generated / Lifted Components
+
+This is the part that mattered most and was hardest to pin down on 2026-04-29.
+
+### Magic-generated components
+
+Generated TypeScript/React/Tailwind code is written into your repo. Standard practice across AI-generation tools (v0, Cursor, Lovable) is that the generated code is yours to use commercially without attribution. **21st has not posted explicit terms on the landing or `/magic` page** as of 2026-04-29 fetch; assume similar but verify in signup ToS.
+
+**Recommendation:** treat generated code as fully owned + commercially usable; keep the prompt that produced it logged in the PR description for provenance. If 21st posts conflicting terms later, this doc supersedes itself with a corrected note.
+
+### Catalog (community-published) components
+
+Each contributor uploads their own component. License per component is not consistently labelled in the catalog browse. Default assumption from marketplace patterns: **MIT or similar permissive**, but per-component verification is required for any commercial use.
+
+**Recommendation:** when lifting a community component:
+
+1. Open the component page at `21st.dev/community/components/<slug>`.
+2. Look for explicit license notes; if absent, treat as "ask before commercial use."
+3. For ZAO public-facing surfaces (zaoos.com, ZAO Stock landing, BCZ portfolio), prefer Magic-generated code over uncertain-license community components.
+4. For internal tools (devz, zoe.zaoos.com behind login), community lifts are lower risk.
+
+### Brand SVGs from `logo_search`
+
+Powered by **svgl** (`svgl.app`). svgl's terms cover usage. Brand logos remain property of their owners; svgl indexes publicly available marks. **Do not** modify brand logos. **Do not** use them to imply endorsement.
+
+For ZAO: fine to use platform logos (Farcaster, Base, Spotify, etc.) on integrations pages, partner lists, share-as buttons. Not fine to put a major brand logo on the front page implying partnership.
+
+## Refunds + Payment
+
+Not posted on landing pages. Industry default: monthly subscriptions are non-refundable mid-cycle. Cancel before next renewal to stop charges.
+
+Payment methods not enumerated on landing. Industry default: Stripe-style card processing.
+
+## Cost Forecast for ZAO
+
+| Phase | Plan | Why |
+|---|---|---|
+| Now (eval) | Free | Inspect catalog + run free Inspiration / logo searches |
+| ZAO Stock site sprint | Pro $20 | Generate hero, pricing tiers, CTA, testimonials |
+| ZAO OS visual refresh | Pro $20 | Generate AI Chat shell, refresh Hero, refine `/stake` |
+| Continuous low-volume | Free | After visual sprint, pause Pro until next refresh |
+| Aggressive multi-site phase | Max $100 | Only if ZAOstock + ZAO Music drop sites + BCZ refresh land in the same month |
+
+Annualised: 2-3 Pro months / year = ~$40-$60. Cheap insurance vs hand-coding equivalent UI.
+
+## Risk Register
+
+| Risk | Mitigation |
+|---|---|
+| Pricing changes mid-sprint | Pin sprint plan to Pro tier; if 21st jacks rates, fall back to free Inspiration + manual coding |
+| 21st sunsets free tier | Magic MCP is MIT and on GitHub; community fork would emerge. Track via `gh api repos/21st-dev/magic-mcp/releases` |
+| Generated code license terms get tightened later | Keep PR descriptions referencing 21st prompt as evidence the generation predated any later term change |
+| Community component without license tag | Skip for public surfaces; safe for internal-only use |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Verify free-tier quota (5 vs 100) at signup, update [549b](../549b-21st-dev-access-patterns/) | Zaal | Self-validate | At first install |
+| Capture exact `/pricing` page once it stops returning nav-only HTML | Zaal or skill | Re-fetch | When 21st updates SPA |
+| Add 21st license note to any PR that lifts community code | Zaal | PR convention | Per PR |
+| Annual budget line: $40-$60 forecast | Zaal | BCZ ops | Plan for FY26 |
+
+## Sources
+
+- [21st.dev/pricing](https://21st.dev/pricing) - returned nav-only HTML on fetch 2026-04-29
+- [21st.dev/magic](https://21st.dev/magic) - Free 100 credits, Pro $20, Max $100
+- [PulseMCP listing](https://www.pulsemcp.com/servers/21st-dev-magic) - "5 free requests, $10/month" (older)
+- [Apidog blog](https://apidog.com/blog/21st-dev-review/) - third-party review with pricing notes
+- [svgl.app](https://svgl.app) - brand SVG source
+
+## Staleness Notes
+
+Pricing has 3 conflicting sources. Verify at signup. Re-validate by 2026-05-29.

--- a/research/dev-workflows/549d-21st-dev-ai-features-magic/README.md
+++ b/research/dev-workflows/549d-21st-dev-ai-features-magic/README.md
@@ -1,0 +1,143 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 549, 549a, 549b, 549c, 549e, 415, 506, 507, 508
+tier: STANDARD
+---
+
+# 549d - 21st.dev AI Features: Magic, 1code, SDK
+
+> **Goal:** Understand the rest of 21st-dev's product surface beyond Magic MCP - especially `1code` (5,494 stars), the `21st-sdk`, and `agent-elements` - so we know which to lift, track, or skip.
+
+## The 21st-dev Product Family (verified 2026-04-29)
+
+| Product | Stars | What it is | ZAO action |
+|---|---|---|---|
+| `magic-mcp` | 4,815 | UI component MCP (search + generate + refine + logos) | **Install now** (covered in 549, 549b) |
+| `1code` | **5,494** | "Orchestration layer for coding agents (Claude Code, Codex)" | **Track**; possible QuadWork comparator. Separate research doc. |
+| `21st-sdk` | 107 | SDK for embedding 21st features in apps | Track; ZAO website if we want public Inspiration Search |
+| `21st-sdk-examples` | 35 | Cookbook for the SDK | Read once SDK is on the table |
+| `21st-sdk-go` | 0 | Go SDK | Skip (ZAO is TS) |
+| `agent-elements` | 50 | Drop-in agent-UX components | Possible fit for ZOE chat shell |
+| `21st-extension` | 133 | Browser extension | Skip (out of repo scope) |
+| `phion` | 7 | Unclear, low-signal | Skip |
+| `vite-builder` | 5 | Vite scaffolding | Skip (ZAO uses Next, not Vite) |
+| `cli` | 17 | The MCP installer | Already used via `npx` |
+
+## Magic MCP - 4 Tools In Practice
+
+### `21st_magic_component_inspiration` (Free, daily driver)
+
+Semantic search across the marketplace. Pass natural-language. Returns code + preview.
+
+**ZAO patterns to feed it:**
+- "Festival lineup card with artist photo + set time + ticket price, dark theme"
+- "Sponsor pricing tiers, Bronze / Silver / Gold / Founder, with crypto + fiat"
+- "AI chat input bar with suggestion chips and tool indicators"
+- "Audio room CTA card with live listener count"
+- "Wallet connect button with multi-chain dropdown"
+
+This is the bulk of the value. Use 50-100x more often than the paid generators.
+
+### `logo_search` (Free)
+
+Brand SVG via svgl. Pass a name, get SVG.
+
+**ZAO patterns:**
+- `logo_search "farcaster"` -> Farcaster mark for share-as buttons
+- `logo_search "base"` -> Base logo for stake page chain indicator
+- `logo_search "spotify"` -> Spotify icon on ZAO Music landing partner row
+
+Replaces "find me a clean SVG" rabbit holes.
+
+### `21st_magic_component_builder` (Pro)
+
+Pass a description, get 5 polished variants. Browser tab opens to pick. Selected variant writes into your project.
+
+**Use when:**
+- No close inspiration match exists
+- Need 5 angles fast (e.g. "5 takes on a ZAOstock RSVP card")
+- Brand-consistent generation (pass tokens in the prompt)
+
+**Skip when:**
+- Inspiration already has a great match (lift + adapt is faster)
+- Component is brand-critical (manual control beats AI guess)
+
+### `21st_magic_component_refiner` (Pro)
+
+Pass an existing component (yours OR a generated one). Iterate.
+
+**Use when:**
+- Lifted a community component but it needs theme adaptation
+- Generated component is 80% there, want one specific tweak
+- Need an accessibility pass (color contrast, focus rings, ARIA)
+- Need to swap from desktop-first to mobile-first
+
+## `1code` - The Sleeper
+
+5,494 stars on a repo many haven't heard of. Description: "Orchestration layer for coding agents (Claude Code, Codex)."
+
+**What it likely does:** competes with or complements:
+- ZAO's QuadWork pattern (memory `feedback_prefer_claude_max_subscription`)
+- DevFleet (memory `everything-claude-code:devfleet`)
+- Anthropic Managed Agents
+- Lazer's `/lazer` skill router (Doc 548)
+
+**Why it matters to ZAO:**
+- If `1code` is meaningfully better than QuadWork at multi-task orchestration, that's a candidate for adoption
+- 21st-dev's mass distribution + 5.5K stars suggests they have real opinions on agent UX
+- `agent-elements` (50 stars) likely ships UI for `1code` workflows
+
+**Decision now:** **track, don't adopt.** Open a separate research doc once the Lazer spike (Doc 548) closes and we have bandwidth for an honest agent-orchestration comparison. Add to memory as a "to-research" item.
+
+## `21st-sdk` + `agent-elements` - Possible Embeds
+
+`21st-sdk` lets external apps embed 21st features. Concrete possibilities for ZAO:
+
+| Where | What | Tier (free / paid 21st access) |
+|---|---|---|
+| ZAO Devz portal | Embed Inspiration Search so contributors can browse before committing UI work | Free if API key is server-side and rate-limited |
+| FRAPP submission flow (fractal app submission, memory `project_fractal_process`) | Component picker for community devs proposing UIs | Free |
+| ZAO OS public docs site | "Show me a button like this" interactive widget | Free |
+
+**Decision now:** **defer.** Tempting but premature - the in-repo MCP install handles every internal need. Revisit when ZAO has a public contributor-facing UX surface and we want to monetise / brand around component discovery.
+
+`agent-elements` for ZOE chat shell is more interesting because ZOE chat is already in build (memory `project_zoe_v2_redesign`, `project_zoe_dashboard`). Worth a 1-day audit during ZOE v2 sprint.
+
+## How This Connects to ECC + Other Skill Stacks
+
+Memory `project_trae_ai_skip` flagged ECC + obra/superpowers as the canonical agent-tooling stack for ZAO. 21st-dev does NOT compete with ECC's review/build/test skills - it competes with the **component-layer** part. They stack:
+
+```
+ECC (review, build, test, lint, devops)
++ obra/superpowers (planning, brainstorming, TDD discipline)
++ 21st Magic MCP (component search + generation)
++ Lazer (scaffold + multi-platform mini app, Doc 548 - spike only)
++ QuadWork (Claude Code on VPS, multi-agent dev squad)
++ ZAO native skills (zao-research, qa, ship, vps, worksession, etc.)
+```
+
+No overlap. 21st fills a gap nobody else fills.
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Open separate doc `1code-vs-quadwork` once Lazer spike closes | n/a | Research | After Doc 548 PR merged |
+| Audit `agent-elements` during ZOE v2 sprint | Zaal | Spike | When ZOE v2 starts |
+| Defer `21st-sdk` embed until public contributor flow exists | n/a | Tracked | Re-evaluate end of Q2 2026 |
+| Skip `phion`, `vite-builder`, `21st-sdk-go`, `21st-extension` | n/a | Decision | n/a |
+
+## Sources
+
+- [21st-dev GitHub org](https://github.com/21st-dev) - 11 repos visible
+- [21st-dev/1code](https://github.com/21st-dev/1code) - 5,494 stars
+- [21st-dev/21st-sdk](https://github.com/21st-dev/21st-sdk) - 107 stars
+- [21st-dev/agent-elements](https://github.com/21st-dev/agent-elements) - 50 stars
+- [21st-dev/21st-sdk-examples](https://github.com/21st-dev/21st-sdk-examples) - 35 stars
+
+## Staleness Notes
+
+`1code` star count rising fast (jumped past `magic-mcp`). Re-validate monthly. If `1code` becomes the headline product, this doc gets a successor.

--- a/research/dev-workflows/549e-21st-dev-zao-skill-spec/README.md
+++ b/research/dev-workflows/549e-21st-dev-zao-skill-spec/README.md
@@ -1,0 +1,228 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 549, 549a, 549b, 549c, 549d
+tier: STANDARD
+---
+
+# 549e - `/21st` Skill Spec for ZAO
+
+> **Goal:** A drop-in `SKILL.md` that wraps the 21st.dev Magic MCP tools with ZAO context (stack, brand tokens, repo rules) so any Claude Code session in any ZAO repo can search + lift + adapt components in one command.
+
+## Where This Skill Lives
+
+Create at: `~/.claude/skills/21st/SKILL.md`
+
+Then it's invocable from any ZAO project session as `/21st <query>`.
+
+## Prereqs (Run Once Per Machine)
+
+```bash
+# 1. Get API key at https://21st.dev/magic/console (login with GitHub)
+# 2. Install Magic MCP into Claude Code
+npx @21st-dev/cli@latest install claude --api-key <YOUR_KEY>
+# 3. Restart Claude Code
+# 4. Verify in any session: /mcp list   (should show "magic-mcp")
+```
+
+API key handling: per `.claude/rules/secret-hygiene.md`, never paste in chat or commit. The installer writes it into Claude Code's settings file - that's an acceptable destination because settings stay local.
+
+## The SKILL.md (Copy This Verbatim)
+
+```markdown
+---
+name: 21st
+description: Search, generate, and adapt UI components from 21st.dev's marketplace + Magic MCP for ZAO surfaces (ZAO OS, ZAO Stock, BCZ, FISHBOWLZ-replacement, ZOE chat). Use when adding/refreshing a UI surface and you want to start from a vetted pattern instead of from scratch. Auto-applies ZAO stack (Next 16, React 19, Tailwind v4) + brand tokens (#0a1628 navy, #f5a623 gold) + repo rules (mobile-first, "use client", Biome, no inline styles).
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob, mcp__magic-mcp__21st_magic_component_inspiration, mcp__magic-mcp__21st_magic_component_builder, mcp__magic-mcp__21st_magic_component_refiner, mcp__magic-mcp__logo_search
+argument-hint: "<natural-language description of the component or surface you want>"
+---
+
+# /21st - ZAO Component Search + Generate + Adapt
+
+Wraps 21st.dev Magic MCP for ZAO repos. Cost-aware: free tools first, paid only on user confirmation.
+
+## Decision Tree (run this in order)
+
+### Step 1 - Understand intent
+
+Parse `$ARGUMENTS` into:
+- **Surface** (which ZAO project / page): if not stated, ask. Default to the repo you're invoked from.
+- **Component type** (hero, CTA, pricing, chat, etc.): pick the closest 21st category from doc 549a.
+- **Constraints** (mobile-first, dark theme, brand tokens) - default to ZAO defaults below.
+
+### Step 2 - Always start with FREE Inspiration Search
+
+Call `21st_magic_component_inspiration` with a query that includes:
+- Component type
+- "dark theme, navy + gold" (ZAO default)
+- "mobile-first" (ZAO default)
+- The surface context (e.g. "festival sponsor tier", "wallet-gated audio room")
+
+Skim results. Surface top 3-5 to the user with brief one-line summaries.
+
+### Step 3 - Brand SVG search if any logos referenced
+
+If `$ARGUMENTS` mentions brand logos (Farcaster, Base, Spotify, etc.), call `logo_search` for each. Both free.
+
+### Step 4 - Decide path with the user
+
+Present 3 options:
+
+A. **Lift directly** (free, fastest): pick top Inspiration result; this skill adapts it.
+B. **Refine an Inspiration result** (Pro tier - $20/mo): one MCP call to `21st_magic_component_refiner` with ZAO context.
+C. **Generate fresh variants** (Pro tier): call `21st_magic_component_builder` with brand tokens; user picks 1 of 5.
+
+If no Pro key OR user prefers free, default to A. Never silently spend Pro credits.
+
+### Step 5 - Adapt to ZAO stack (always run)
+
+Whether lifted or generated, sweep the code for:
+
+| Sweep | Action |
+|---|---|
+| Tailwind v3 `@layer` syntax | Convert to v4 |
+| Missing `"use client"` directive on hook-using component | Add at top |
+| Inline styles | Convert to Tailwind classes |
+| CSS modules | Convert to Tailwind classes |
+| Hardcoded colors (any `#` color that isn't `#0a1628` or `#f5a623`) | Flag, replace with brand tokens or Tailwind dark palette |
+| `clsx(...)` import | Replace with `cn` from `@/lib/utils` |
+| Desktop-first responsive (`lg:` then narrower) | Restructure mobile-first (`sm:`, `md:`, `lg:` ascending) |
+| No accessibility focus rings | Add `focus-visible:ring-2 focus-visible:ring-amber-400` |
+| Image src with external URL | Confirm with user; default to local `/public/images/...` |
+
+Use `Edit` to apply sweeps; never `Write` over a freshly generated file before sweeping.
+
+### Step 6 - Place the file in the right ZAO directory
+
+| ZAO project | Default dir |
+|---|---|
+| ZAO OS V1 | `src/components/<feature>/` (per `.claude/rules/components.md`) |
+| ZAO Stock site (TBD repo) | `app/components/` per its conventions |
+| BCZ portfolio | `components/` |
+| FISHBOWLZ-replacement / Juke embed | `src/components/audio/` |
+| ZOE dashboard | `apps/zoe/components/` |
+
+Always confirm the path with the user before writing.
+
+### Step 7 - Tell the user
+
+Output:
+- File path written
+- Source (Inspiration slug or generation prompt)
+- Cost (free / Pro N credits)
+- Sweep summary ("converted 3 inline styles, added use client, swapped 2 colors to brand tokens")
+- Next step suggestion ("preview at http://localhost:3000/<route>?")
+
+## ZAO Defaults (Always Pass to Magic MCP)
+
+```
+brand_tokens: { primary: "#f5a623", background: "#0a1628", text: "#e2e8f0" }
+stack: "Next.js 16 App Router, React 19, Tailwind v4, TypeScript 6"
+constraints: ["dark theme", "mobile-first", "no inline styles", "use cn from @/lib/utils", "use client where hooks/handlers"]
+```
+
+## Cost Awareness
+
+| Tool | Cost | When to use |
+|---|---|---|
+| `21st_magic_component_inspiration` | Free | Always first |
+| `logo_search` | Free | Whenever brand logos referenced |
+| `21st_magic_component_builder` | Pro | Only on user confirmation, only when no Inspiration match works |
+| `21st_magic_component_refiner` | Pro | Only on user confirmation, only when one Inspiration result is 80% there but needs theme adaptation beyond Step 5 sweeps |
+
+If quota errors come back from any paid tool: degrade gracefully to lift-and-sweep, surface error to user, do NOT auto-retry.
+
+## Anti-Patterns (Skip)
+
+- Calling `21st_magic_component_builder` when Step 2 returned a strong match
+- Generating without passing brand tokens
+- Writing files without sweep
+- Lifting components with unclear license for ZAO public-facing surfaces (per doc 549c, prefer Magic-generated for `zaoos.com` / `thezao.com` / `bettercallzaal.com`)
+- Mixing Tailwind v3 + v4 syntax
+- Touching `community.config.ts` without explicit user request
+
+## Example Invocations
+
+```
+/21st sponsor tier pricing card with Bronze/Silver/Gold/Founder for ZAO Stock landing
+/21st AI chat input bar with tool indicators for ZOE shell
+/21st audio room CTA with live listener count for FISHBOWLZ replacement
+/21st refresh /stake hero with token chart placeholder
+/21st RSVP button card mobile-first
+```
+
+## Failure Modes
+
+| Symptom | Recovery |
+|---|---|
+| `magic-mcp` not in `/mcp list` | Install: `npx @21st-dev/cli@latest install claude --api-key <key>`, restart Claude Code |
+| Quota error | Surface to user; offer free fallback |
+| Generated code uses non-Tailwind-v4 syntax | Apply Step 5 sweep; if still broken, ask user to manually review |
+| Brand tokens ignored | Re-prompt the refiner with explicit brand tokens; if still off, manual swap |
+| Mobile-first violation | Apply Step 5 restructure; verify with user before commit |
+
+## Memory Hooks
+
+After successful use, suggest saving:
+- Top 3 contributor handles whose components fit ZAO -> `feedback_21st_signals.md`
+- Patterns that worked -> `feedback_21st_wins.md`
+- Patterns that didn't -> `feedback_21st_losses.md`
+
+This builds a project-specific 21st taste over time.
+
+## Cross-References
+
+- Doc 549 (hub) - decision matrix
+- Doc 549a - catalog inventory
+- Doc 549b - access patterns
+- Doc 549c - pricing & licensing
+- Doc 549d - other 21st-dev products (1code, sdk)
+- `.claude/rules/components.md` - ZAO component conventions
+- `.claude/rules/typescript-hygiene.md` - TS rules
+- `community.config.ts` - brand tokens source of truth
+```
+
+## How to Install This Skill
+
+```bash
+# 1. Make the skill dir
+mkdir -p ~/.claude/skills/21st
+
+# 2. Save the SKILL.md content above (the block between the ```markdown fences)
+# Copy from this doc, paste into the file
+nano ~/.claude/skills/21st/SKILL.md   # or use your editor
+
+# 3. Verify Claude Code picks it up
+# In any session: /21st test query
+```
+
+## How To Iterate The Skill
+
+This skill ships v0.1. Expected to refine after first ZAO Stock site sprint - brand-token sweeps, default invocation patterns, contributor-handle memory. Update process:
+
+1. After each meaningful use, note what worked / didn't in a session-end reflection
+2. Once a month, refine `Step 5 - Sweep` table with new rules learned
+3. After first 10 uses, post a "what changed" doc as 549e1 (no hyphen) if material
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Drop the SKILL.md into `~/.claude/skills/21st/SKILL.md` | Zaal | One-shot | This week |
+| First test on `/stake` hero refresh | Zaal | Spike | Same |
+| Refine Step 5 sweep rules from spike findings | Zaal or auto | PR to skill | After 1st use |
+| Capture top-fit contributor handles to memory | Auto via skill | Memory | Ongoing |
+
+## Sources
+
+- [21st-dev/magic-mcp tool surface](https://github.com/21st-dev/magic-mcp) - exact tool names + behaviour
+- ZAO `.claude/rules/components.md` - in-repo component conventions
+- ZAO `.claude/rules/typescript-hygiene.md` - in-repo TS hygiene
+- `community.config.ts` - brand tokens source of truth
+- Doc 549b - install command verified
+
+## Staleness Notes
+
+Tool names (`21st_magic_component_*`, `logo_search`) verified from `magic-mcp` README on 2026-04-29. If 21st-dev renames tools, this skill needs updating - watch repo releases.

--- a/research/dev-workflows/550-gitpitcher-evaluation/README.md
+++ b/research/dev-workflows/550-gitpitcher-evaluation/README.md
@@ -1,0 +1,117 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 506, 507, 508, 548, 549
+tier: STANDARD
+---
+
+# 550 - GitPitcher Evaluation (gitpitcher.com)
+
+> **Goal:** Decide whether ZAO uses gitpitcher.com to turn unknown GitHub repos into agent-ready Build Packs. Sister doc to 549 (21st.dev) and 548 (Lazer); same week, same lens: "what does this tool buy us that we can't already do with our own skills?"
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Subscribe to GitPitcher Pro ($19/mo) | **NO, NOT YET** | Overlaps with ZAO's existing `/zao-research`, `superpowers:writing-plans`, ECC `prp-plan` + `codebase-onboarding` + `agent-sort`, and the obra Plan flow. We already have agent-ready repo-onboarding pipelines. GitPitcher's edge is the polished UI + shareable artifact, not the analysis. |
+| Try free tier (12 credits/mo, 1 credit Repo Read, 5 Audit, 6 Build Pack) on 1-2 repos | **YES** | $0, low effort. Run it on a repo we already analysed via our skills (e.g. Sonata or Herocast from `project_music_research`) and compare outputs. Worth ~30 min. |
+| Use GitPitcher to brief external collaborators on ZAO repo forks | **MAYBE** | Shareable Markdown output is real value if we want a non-engineer (sponsor, board) to grok a repo. Otherwise our internal docs do the job. |
+| Build a `/gitpitcher` skill | **NO** | Output is web-only artifact; no MCP integration documented as of 2026-04-29. Skill would just be a "go visit URL X" wrapper. Not worth the file. |
+| Track for ZAO Stock partner / contributor onboarding | **YES, OPTIONAL** | If ZAO Stock ever has a "here's the open-source codebase, propose a contribution" flow for community devs, GitPitcher's Build Pack could be the polished briefing format. Far future. |
+
+## What GitPitcher Actually Does
+
+Input: a public GitHub repo URL.
+
+Output (one of):
+
+| Artifact | Credits | What it produces |
+|---|---|---|
+| **Repo Read** | 1 | Stack detection + commercial plumbing analysis (auth, billing, tests, docs, observability gaps) |
+| **Audit** | 5 | Evidence sheet flagging missing pieces, risks, and blockers |
+| **Build Pack** | 6 | Build-from-scratch execution blueprint with agent-ready prompts |
+| **Prompt Pack** | (bundled) | Copy-ready prompts for Codex, Cursor, Claude Code, GitHub Copilot |
+
+All outputs are Markdown + shareable links + revision history.
+
+The pitch: a deterministic signal layer (README, manifests, deps, issues, commits) feeds the AI step, so analysis is grounded in repo evidence not vibes.
+
+## Pricing (verified 2026-04-29)
+
+| Tier | $/mo (annual 20% off) | Credits/mo | Includes |
+|---|---|---|---|
+| Free | $0 | 12 | All artifact types, full document sections, email completion notifications, past artifact dashboard |
+| Pro | $19 | 80 | + private repos via GitHub App, Markdown export, GitHub issue export, shareable links, revision management |
+| Team | $49 | 240 | + admin-assisted onboarding, beta priority support, early access to team workflow |
+
+Annual = 20% off. Stripe. Cancel anytime. Refund policy not posted.
+
+## Why GitPitcher Loses To Our Stack For Most ZAO Use Cases
+
+| Need | GitPitcher | What ZAO already has |
+|---|---|---|
+| "What does this repo do?" | Repo Read (1 credit) | `everything-claude-code:codebase-onboarding` skill, free, runs locally with full repo cloned |
+| "What's missing in this repo?" | Audit (5 credits) | `everything-claude-code:agent-sort` + `everything-claude-code:repo-scan` |
+| "How do we build something like this?" | Build Pack (6 credits) | `superpowers:writing-plans`, `everything-claude-code:prp-plan`, `everything-claude-code:blueprint`, ZAO `/plan-eng-review` |
+| "Prompts to feed Claude Code" | Prompt Pack | We are Claude Code; native skills > exported prompts |
+| "Shareable Markdown for non-engineer" | Yes, polished output | Our research docs already in Markdown; PR comments shareable |
+| "Private repo analysis" | Pro tier | `gh` CLI + `Read` tool, private since the agent runs locally |
+
+## Where GitPitcher Wins
+
+1. **Polish.** The output looks designed-for-share-with-investors, not designed-for-internal-eng. If we ever brief a sponsor on "here's a repo we're forking and why," GitPitcher's artifact is more presentable than a `research/<n>/README.md`.
+
+2. **Credibility signal.** The landing names Next.js, Supabase, LangChain, and shadcn/ui as trust signals. If those teams use it, the analysis quality is at least decent.
+
+3. **Speed for one-off questions.** If Zaal sees a repo on Twitter at 11pm and wants "should I care about this?" - GitPitcher gives a 1-credit answer faster than running a full skill chain.
+
+4. **No setup.** No MCP install, no key management, no skill maintenance. Web app, paste URL, get artifact.
+
+## Concrete ZAO Try Plan (Free Tier, 12 Credits)
+
+If we test it, run on these 4 repos to compare outputs:
+
+| Repo | What we already know (from existing memory/docs) | Test |
+|---|---|---|
+| Sonata (MIT music player, `project_music_research`) | Reference player for ZAO Music Phase 2 | Repo Read (1 credit) - does GitPitcher catch the licensing + stack we already mapped? |
+| Herocast (AGPL Farcaster client, `project_music_research`) | License risk for fork | Audit (5 credits) - does it flag AGPL implication? |
+| `21st-dev/1code` (5,494 stars, Doc 549d) | "Orchestration layer for coding agents" | Build Pack (6 credits) - does it summarise it well enough we don't need a separate research session? |
+
+Total: 12 credits, fits free tier exactly. After the test, decide: useful enough to subscribe, or stick with our skill stack?
+
+## Risks + Caveats
+
+- **Beta product.** Public beta per Product Hunt + landing. Pricing or feature scope can shift.
+- **No GitHub link found** for an open-source version - it's a hosted SaaS, full lock-in.
+- **Output quality unknown** until we run the test above.
+- **Private repo support requires Pro + GitHub App grant** - extra trust burden if we point it at any ZAO private repo.
+- **Pricing conflict noted.** Initial fetch reported "Audit 2, Build 3"; pricing page detail says "Audit 5, Build 6". Trust the pricing page (more recent / more specific).
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Sign up for GitPitcher free tier | Zaal | One-shot | Optional, this week |
+| Run the 4-repo test plan above (Sonata, Herocast, 1code) | Zaal | Spike | Optional, this week |
+| If outputs beat our `codebase-onboarding` + `prp-plan` skills, document specific wins in this doc | Zaal | Update doc | Conditional |
+| If outputs are at-parity or worse, mark this doc `status: research-complete` and skip subscription | Zaal | n/a | n/a |
+| Reconsider for ZAO Stock contributor onboarding flow if/when that exists | n/a | Tracked | 2026 Q3+ |
+
+## Also See
+
+- [Doc 548 - Lazer Mini Apps CLI](../../farcaster/548-lazer-miniapps-cli-evaluation/) - sister scaffold-tier eval
+- [Doc 549 - 21st.dev hub](../549-21st-dev-component-platform/) - sister component-tier eval
+- [Doc 506 - TRAE AI skip](../506-trae-ai-solo-bytedance-coding-agent/) - canon ECC + obra/superpowers stack
+- [Doc 508 - Creator infra brief](../508-creator-infra-mini-apps-token-burn-signals-apr25/) - 2026 trend frame
+
+## Sources
+
+- [GitPitcher landing](https://gitpitcher.com/) - product description + integrations list
+- [GitPitcher pricing](https://gitpitcher.com/pricing) - Free/Pro/Team tiers verified
+- [Product Hunt - GitPitcher](https://www.producthunt.com/products/git-pitcher) - public beta status
+
+## Staleness Notes
+
+Pricing details verified at `/pricing` 2026-04-29. Beta status means features can shift. Re-validate at 2026-05-29 if interest renews.

--- a/research/identity/548-bonfire-first-week-context-teaching/README.md
+++ b/research/identity/548-bonfire-first-week-context-teaching/README.md
@@ -1,0 +1,574 @@
+---
+topic: identity
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 432, 542, 543, 544, 545, 546, 547
+tier: DEEP
+---
+
+# 548 - Bonfire First-Week Context Teaching Playbook
+
+> **Goal:** Teach a newly-deployed graph agent (ZABAL Bonfire Bot) the ZAO ecosystem so it answers like a senior insider on day 7, not day 90. This doc provides the intake protocol, phrasing rules, deduplication strategy, and day-by-day playbook to maximize learning velocity in week 1.
+
+**Context:** Zaal deployed the Bonfire Bot on 2026-04-28. Doc 542 (strategic evaluation) recommended keeping Bonfire. This doc (548) is the tactical first-week guide.
+
+---
+
+## Key Decisions (Recommendations FIRST)
+
+| Decision | Recommendation | Why |
+|----------|---|---|
+| **What to load first (minimum viable context)** | **5 seed entities + 20 day-1 entities = 25 total by EOD day 1.** Then 5-10 per day in week 1. | ETHBoulder loaded 7 primary topic clusters (Ecology, Humans, Language, Artifacts, Methodology, Training, Sessions) with ~20 seed nodes day 1, scaled to 88K by day 7 (verified: paragraph.com/@joshuab/ethboulder). Small seed set reduces hallucination; explicit daily quota prevents overwhelm. |
+| **Phrasing strategy for extraction** | **Use "verifiable triple" format: subject-predicate-object with explicit dates, quantities, and outcomes.** BAD: "ZAO Fractals runs on Mondays." GOOD: "ZAO Fractals is a weekly session. It occurs on Mondays at 6pm Eastern. It has run continuously for 90+ weeks as of 2026-04-29." | Cited: Joshua Yu GenKM framework (medium.com/@yu-joshua/unified-framework), sift-kg phrasing guide (entity names + descriptors + evidence). Vague phrasing produces vague nodes. |
+| **kEngram strategy** | **Hybrid (option d): One kEngram per "source session" (Telegram batch, meeting notes, research doc load).** E.g. `kengram:zodiac-launch-2026-04`, `kengram:fractal-week-90`. Not per-entity (too fragmented), not single monolith (too opaque for audit). | Allows Bonfire to track provenance per context window. Enables selective verify/rollback. ETHBoulder used episodic construction (paragraph.com/@joshuab) - each event/topic was a source event, not free-form updates. |
+| **Confirmation discipline week 1** | **Hybrid (strict for new types, relaxed for additions).** First mention of a new entity type (e.g. "PERSON Iman") = strict (bot paraphrase + confirm). Addition to existing entity (e.g. "Iman is a musician") = relaxed (batch 5-10, review once/day). | Prevents typos on new categories (no spurious entity types). Keeps pace on enrichment. ZOE team validated this on doc 546 memory-learning pattern. |
+| **Deduplication pattern** | **All three (option d): preferred_label attribute + aliases dict + daily kEngram verify.** E.g. `{preferred_label: "ZABAL", aliases: ["zabal-coin", "zabal token", "zabal", "ZABAL"], confidence: 1.0}`. | Cites sift-kg 4-layer dedup (pre-dedup + fuzzy match + LLM resolution + human review). Pre-load aliases dict for ZAO canonical names (doc at https://github.com/jruder/sift-kg). Daily verify catches new duplicates as they arrive. |
+| **Attribution metadata** | **Standard 6-tuple: source_user (string), source_at (ISO 8601), source_kind (enum: telegram_dm, telegram_group, research_doc, manual_seed, fractal_log, zoom_transcript), confidence (0.0-1.0), provenance_doc (path or URL), verified_by (user or "auto").** | Enables audit trail. Bonfire's graph.bonfires.ai UI can render provenance. Helps Zaal diff what came from meeting vs. Telegram vs. research/. |
+| **Extraction prompt tuning** | **YES: Add `intake_extraction` trait to bot system instructions.** "When a user states a fact in Telegram, you FIRST extract entities, relations, and confidence as structured JSON before paraphrasing or synthesizing. Do not merge facts; extract atomically." | Prevents the bot from inferring ungrounded relationships. Keeps extraction phase separate from reasoning phase (Joshua Yu GenKM: Extract → Cluster → Query). |
+| **Batch vs stream ingest** | **BATCH: All 540+ research/ docs (via document loader if available). STREAM: All new Telegram DMs, meeting notes, fractal transcripts.** Batch runs nightly; stream processes live (Bonfire's default mode). | Batch = high-latency, high-coverage (extract from corpus once, use forever). Stream = real-time memory capture (critical for fractal decisions, Telegram updates). Different SLAs. |
+| **Quality filters (3-tier)** | **Tier A (load as authoritative): community.config.ts, doc 432 (master context), project_zao_canonical_pitch.** **Tier B (load as "aspirational"): Most research/ docs + flag with confidence 0.7-0.8.** **Tier C (skip): Any doc tagged status:deprecated or status:archived, or explicitly marked "SKIP" in memory.** | Prevents hallucination on deferred projects (e.g. project_zlank, project_fishbowlz_deprecated). Confidence attribute allows queries to weight older/speculative facts lower. |
+| **Personality trait for ingestion** | **Add to system instructions: "Intake Mode: You extract facts atomically. You do NOT synthesize, infer, or merge. You ask for clarification if a statement is ambiguous. You default to 'no relation' rather than guess. You cite the source for every node."** | Prevents the bot from becoming too creative. First-week learning should be conservative. (Cited: Claude Code guidelines on agentic extraction, doc 546 ZOE memory discipline.) |
+
+---
+
+## Question 1: What to Load First
+
+**Answer:** 5 founding seed entities + 20 day-1 core entities = 25 total by end of day 1. Then 5-10 new entities per day (rate varies, no quota).
+
+**Why this minimum:**
+
+ETHBoulder's case study (verified Feb 2026, paragraph.com/@joshuab/ethboulder-lets-make-sense) reports: "The Boulder Bonfire synthesized insights from over 150 unique contributors into a structured framework covering 7 dimensions: Ecology, Humans, Language, Artifacts, Methodology, Training, and Sessions." The breakthrough came on day 3 when they had ~30 seed nodes (people, sessions, outcomes) and started using queries like "@Bonfires What did we learn about X?" This jump from chaos to clarity happened with ~30 nodes, not 500.
+
+**Starting seed (5 entities):**
+1. **Organization: The ZAO** - the canonical entity anchoring all others
+2. **Location: Franklin St Parklet, Ellsworth** - ZAOstock venue (Oct 3 2026)
+3. **Person: Zaal Panthaki** - founder, decision-maker
+4. **Event: ZAOstock 2026** - Phase 0 proof-of-concept
+5. **Decision: ZAO canonical pitch** - "decentralized impact network bringing profit margin, data, IP to artists"
+
+These 5 are the skeleton. Everything else hangs from them.
+
+---
+
+## Question 2: Phrasing Patterns for Clean Extraction
+
+**Good phrasing (yields clean LLM extraction):**
+
+| Pattern | Example | Why It Works |
+|---------|---------|---|
+| **Full descriptors, explicit dates** | "ZAO Fractals is a weekly governance session. It runs on Mondays at 6pm Eastern Time. It has run for over 90 weeks as of 2026-04-29. Facilitators: Dan and Tadas. Outcome: Respect scores assigned to members." | Dates + times + people + outcomes = multiple extraction targets. LLM sees concrete facts, not vague claims. Joshua Yu GenKM: "Extract what you can verify" (medium.com/@yu-joshua/a-unified-framework). |
+| **Subject-Predicate-Object triples** | "Iman is a musician and contributor to The ZAO. Iman's roles: composer for Cipher release, BCZ Strategies team member. Iman joined ZAO in 2026." | Atomic facts, each one a potential edge. Prevents "Iman did many things" vagueness. |
+| **Quantities, not approximations** | "ZABAL distribution: 10K allocated to ZAO members, 5K to reserves, 15K to treasury." NOT "ZABAL was distributed" | Extractable as ZABAL.allocation_members=10K, etc. No ambiguity. |
+| **Conditional facts with sources** | "Per doc 432 (master context), the ZAO's mission is to return profit margin, data, and IP to artists. This is the canonical framing as of 2026-04-28." | Flags speculation vs. fact. Provenance is explicit. Bonfire can weight by source_kind. |
+| **Temporal markers (event + outcome)** | "On 2026-04-28, Zaal deployed ZABAL Bonfire Bot. Outcome: agents now have real-time access to ZAO graph. Status: live, testing phase 1." | Before-after clarity. Enables queries like "What changed on 4/28?" |
+
+**Bad phrasing (ambiguous extraction):**
+
+- "There's a thing called ZAO Fractals that runs meetings" -> LLM extracts: event=Fractals, frequency=?, people=?
+- "ZABAL is important" -> LLM extracts: ZABAL has property "important" (useless)
+- "Everyone contributes to The ZAO" -> LLM creates spurious edges between all 188 members + ZAO
+
+**Extraction prompt to embed in bot system instructions:**
+
+```
+When a user states a fact in Telegram:
+1. EXTRACT: Identify entities (type: PERSON, ORG, EVENT, DECISION, OUTCOME, LOCATION).
+2. IDENTIFY RELATIONS: What does entity A have to do with entity B?
+3. CITE SOURCE: Which message/doc/person made this claim?
+4. ASSIGN CONFIDENCE: Is this fact stated directly (1.0) or inferred (0.6)?
+5. ASK FOR CLARIFICATION if any fact is ambiguous.
+
+Example:
+User: "Zaal met with Roddy about the parklet."
+Bot extracts:
+  - PERSON: Zaal, Roddy
+  - LOCATION: Franklin St Parklet
+  - EVENT: meeting (type=venue_coordination)
+  - RELATION: Zaal met_with Roddy
+  - RELATION: meeting location=Parklet
+  - CONFIDENCE: 1.0 (explicit statement)
+  - SOURCE_KIND: telegram_group, timestamp=[now]
+
+Do NOT infer: "Zaal and Roddy are friends" or "the meeting was productive."
+```
+
+---
+
+## Question 3: kEngram Strategy for Week 1
+
+**Recommendation: Hybrid per "source session" (option d)**
+
+**Definition:** Each kEngram = one logical source event. Examples:
+- `kengram:zaosток-schema-2026-04-29` (initial ZAOstock schema load)
+- `kengram:fractal-week-90-2026-04-29` (Fractal #90 Telegram transcript)
+- `kengram:research-batch-identity-2026-04-29` (doc 271 + 542 + 546 batch load)
+- `kengram:roddy-meeting-parklet-2026-04-28` (Roddy conversation notes)
+
+**Why hybrid, not (a), (b), or (c):**
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| (a) Single canonical ZABAL kEngram | Simple audit trail. Easy verify/rollback. | Monolithic. If one source corrupts, whole graph suspect. Scales poorly past 100 entities. | NO for week 1 |
+| (b) One per project (8+ kEngrams) | Organized by domain. | Premature. Week 1 we don't know if entity ontology is right. Splitting too early risks inconsistent schemas across kEngrams. | NO for week 1 |
+| (c) One per "topic session" (source-driven) | **YES - this is (d).** Allows selective verify. Audit trail per source. Schema can evolve across kEngrams if needed. | None if organized clearly. | YES |
+| (d) Hybrid | Flexibility. Provenance tracking. Selective rollback. | Requires naming discipline. | YES |
+
+**Implementation:** Each kEngram JSON payload includes metadata:
+
+```json
+{
+  "kengram_id": "zaosток-schema-2026-04-29",
+  "source_kind": "manual_seed",
+  "source_user": "zaal@bcz",
+  "source_at": "2026-04-29T06:00:00Z",
+  "nodes": [...],
+  "edges": [...],
+  "verified_by": "awaiting-day-6-dedup-pass",
+  "status": "draft"  // moves to "verified" on day 6 merge pass
+}
+```
+
+ETHBoulder used "episodic" construction (paragraph.com/@joshuab): each conference talk was a source event, not a free-form update stream. Borrowed that pattern here.
+
+---
+
+## Question 4: Confirmation Discipline
+
+**Recommendation: Hybrid (strict for new types, relaxed for additions)**
+
+**Week 1 discipline:**
+
+| Entity Phase | Confirmation Mode | Quota | Example |
+|---|---|---|---|
+| **New entity type** | Strict | 1-2 per day | "This is the first MUSICIAN entity (Iman). Bot paraphrases: 'Iman is a musician who...' Zaal approves or rejects." |
+| **New entity (existing type)** | Relaxed | 5-10 per day | "Adding person Steve Peer. Bot learns: Steve Peer is ZAO Stock curator, Ellsworth drummer, house concert organizer. Batch 3 similar additions, review once daily." |
+| **Attribute addition** | Relaxed | 10+ per day | "Steve Peer.house_concerts = 430. Bot verifies: found in memory. Batched with 10 other attribute updates, no individual confirm." |
+
+**Why hybrid:**
+
+- **Strict on new types:** Prevents the bot from inventing spurious entity types (e.g., "ZABAL_HOLDER" as a type when we just mean PERSON with attribute). Joshua Yu GenKM: "Schema should be tight" (medium.com/@yu-joshua).
+- **Relaxed on additions:** Keeps velocity. Day 1 we can't review every single node; we trust the bot on PERSON types once Zaal approves 2-3 examples.
+
+**Implementation: Modify bot system prompt to:**
+
+```
+Confirmation Protocol:
+- NEW ENTITY TYPE (first ever): Ask Zaal: "Should I create entity type [TYPE]? Example: [entity]. Approve?"
+- NEW ENTITY (existing type): Batch 5 similar entities, show Zaal once daily: "Adding 5 PERSONs today. Review summary?"
+- ATTRIBUTE UPDATE: No confirmation. Bonfire tracks confidence 0.9+.
+- RELATION CREATION: Strict if confidence <0.8. Relaxed if confidence ≥0.8 (inferred from existing facts).
+```
+
+---
+
+## Question 5: Deduplication Prevention
+
+**Recommendation: All three (option d)**
+
+1. **Preferred label + aliases dict (loaded day 1):**
+
+```json
+{
+  "entity_id": "zabal-1",
+  "type": "TOKEN",
+  "preferred_label": "ZABAL",
+  "aliases": ["zabal", "zabal-coin", "zabal token", "ZABAL coin"],
+  "source": "community.config.ts"
+}
+```
+
+2. **Load canonical alias dictionary (pulled from memory + community.config):**
+
+Spellings we MUST deduplicate on day 1:
+- WaveWarZ (never "Wave Wars", "Wavewarz")
+- COC Concertz (never "COC Concerts", "CocConcertz")
+- The ZAO (never "the Zao", "ZAO", "Zao")
+- BetterCallZaal (never "Bettercallzaal", "Better Call Zaal")
+- Iman (never "Imaan", "Iman")
+- Tadas (never "Tad")
+- ZOE (never "Zoe")
+- ZABAL (never "Zabal", "zabal")
+
+Load this dict into Bonfire on day 1, before any other entity processing.
+
+3. **Daily merge pass (day 6):**
+
+Command: `bonfire kengram verify --dedup-pass --confidence-threshold 0.85`
+
+Process:
+- Scan all entities added in `kengram:*` kEngrams across week 1
+- Run sift-kg resolve logic (cite: github.com/jruder/sift-kg, verified 2026-02-25): fuzzy name matching (SemHash 0.95 threshold), semantic clustering, LLM entity-resolution vote
+- Generate `merge_proposals.yaml` with confidence scores
+- Zaal reviews + approves merges
+- Apply on day 7
+
+**Citation:** sift-kg 4-layer dedup (mintlify.com/juanceresa/sift-kg/concepts/entity-resolution): Layer 1 pre-dedup (exact match, fuzzy), Layer 2 LLM resolution, Layer 3 human review, Layer 4 apply. We're doing: (1) pre-load canonical aliases, (2) LLM live extraction with preferred_label, (3) daily batch resolve, (4) human approve.
+
+---
+
+## Question 6: Attribution + Provenance
+
+**Standard metadata on every entity:**
+
+```json
+{
+  "entity_id": "zaal-panthaki-1",
+  "type": "PERSON",
+  "preferred_label": "Zaal Panthaki",
+  "source_user": "zaal@bcz",           // who stated/created the entity
+  "source_at": "2026-04-29T06:00:00Z",   // ISO 8601 timestamp
+  "source_kind": "manual_seed",          // enum: manual_seed, telegram_dm, telegram_group, research_doc, fractal_log, zoom_transcript, meeting_notes
+  "confidence": 1.0,                     // 0.0 = hallucinated, 0.5 = inferred, 1.0 = explicitly stated
+  "provenance_doc": "research/identity/542-bonfires-ai.md",  // relative path or URL
+  "verified_by": "zaal@bcz",            // who confirmed (null if auto/draft)
+  "verified_at": "2026-04-29T18:00:00Z"  // ISO 8601 timestamp
+}
+```
+
+**Default values (week 1):**
+
+| Field | Day 1 Default | Can Change | Reasoning |
+|---|---|---|---|
+| `source_user` | "zaal@bcz" | Yes (if other contributors) | Zaal is primary for manual seed. |
+| `source_at` | Day load timestamp | No | Source of truth for ordering. |
+| `source_kind` | "manual_seed" or context | No | Immutable audit trail. |
+| `confidence` | 1.0 if from community.config / doc 432; 0.8 if research/; 0.7 if inferred | Updatable on day 6 | LLM extraction can lower confidence if fuzzy. |
+| `provenance_doc` | Relative path to source | No | Enables audit: "which doc had this?" |
+| `verified_by` | null (until day 6) | Yes | Batch verification on day 6. |
+
+---
+
+## Question 7: Extraction Prompt Tuning
+
+**YES: Add `intake_extraction` trait.**
+
+Add to bot system prompt:
+
+```
+INTAKE EXTRACTION MODE:
+When processing a new fact (from Telegram, meeting notes, or research doc):
+1. DO NOT synthesize or infer beyond what's stated.
+2. Extract FIRST: entities, relations, confidence, source.
+3. Ask for clarification if ambiguous.
+4. Default to "no relation" rather than guess.
+5. Every node gets source_kind, source_at, confidence.
+
+Example:
+Input: "Roddy from City is cool with the parklet event in October."
+Output (before synthesis):
+  - PERSON: Roddy
+  - LOCATION: Franklin St Parklet
+  - EVENT: parklet event, date=October 2026
+  - RELATION: Roddy approved_parklet_event (confidence=0.8)
+  - SOURCE: telegram_group, 2026-04-28
+NOT: "Roddy is enthusiastic" or "The event will be amazing"
+
+This extraction trait prevents the bot from becoming creative.
+It maps to Joshua Yu's GenKM Stage 2 (Entity-Relation extraction, separate from Stage 3 Clustering / synthesis).
+```
+
+---
+
+## Question 8: Batch vs Stream Ingestion
+
+**BATCH:** All research/identity/* + research/community/432 + community.config.ts
+
+**STREAM:** All Telegram DMs, meeting notes, fractal transcripts, live updates
+
+| Ingest Path | Trigger | Latency | Coverage | Runs |
+|---|---|---|---|---|
+| **Batch (research docs)** | Manual (Zaal triggers) or nightly cron | ~1hr | 100% corpus | Once per load, then on manual refresh |
+| **Batch (Telegram archives)** | Weekly (every Friday) | Delayed | All past week's Telegram | 1x/week, captures week-old decisions |
+| **Stream (live Telegram)** | Real-time (20min intervals per doc 542) | 20min | New messages only | Continuous |
+| **Stream (fractal transcripts)** | Post-session (within 1hr) | ~1hr | One session per week | Every Monday post-session |
+
+**Batch implementation (Bonfire API):**
+
+```python
+# Pseudo-code for week 1 day 1
+manifest = {
+  "kengram_id": "research-batch-identity-2026-04-29",
+  "source_kind": "research_doc",
+  "nodes": [
+    # Parse from research/identity/271, 432, 542, 546, 547
+    {"type": "ORG", "preferred_label": "The ZAO", "source": "doc 432", ...},
+    {"type": "PERSON", "preferred_label": "Zaal Panthaki", "source": "community.config.ts", ...},
+    # ... 20+ entities
+  ],
+  "edges": [
+    # Relations from parsed docs
+    {"source": "The ZAO", "relation": "founded_by", "target": "Zaal Panthaki", ...},
+    # ...
+  ]
+}
+bonfire.kengrams.batch(manifest_id="research-batch-identity-2026-04-29", manifest=manifest, sync_to_kg=True)
+```
+
+Stream runs automatically via Bonfire's Telegram agent connector (built-in per doc 542).
+
+---
+
+## Question 9: Quality Filters (3-Tier)
+
+**Tier A: Load as authoritative (confidence 1.0)**
+
+| Source | Criteria | Example |
+|---|---|---|
+| `community.config.ts` | Source of truth for channels, contracts, admin FIDs | App FID 19640, member channels, contract addresses |
+| `doc 432` (master context) | Zaal's canonical framing (master positioning) | "Music first, community second, tech third." Deci sions from Apr 17 2026 Tricky Buddha Space. |
+| `project_zao_canonical_pitch.md` (memory) | Canonical one-liner (Zaal-approved as of 2026-04-28) | "Decentralized impact network bringing profit margin, data, IP to artists." |
+
+**Tier B: Load as "aspirational" (confidence 0.7-0.8, flag)**
+
+Most `research/` docs and project memories. These are current research or brainstorms, not decisions locked in.
+
+| Source | Criteria | Attribute | Example |
+|---|---|---|---|
+| `research/identity/*` | Latest info on member ID, crypto, reputation | `status: "research-in-progress"` or `status: "aspirational"` | doc 271 (ZID plan), doc 546 (Hefty eval) |
+| `research/community/*` | Community research, event planning, partnerships | Same | doc 432 is exception (canonical), others are context |
+| `project_*` memory files | Project status, next actions, decisions | Check file status field | If status says "paused" or "deferred", load as 0.7 |
+| `research/agents/*` | Agent research, capability evaluation | Same | Hermes gaps, Claude Code integration ideas |
+
+**Tier C: DO NOT LOAD (confidence N/A, skip)**
+
+| Source | Criteria | Action |
+|---|---|---|
+| `status: deprecated` | Doc is superseded | Skip entirely. Comment: "See [new doc] instead." |
+| `status: archived` | Old decision, not actionable | Skip. Can load if explicitly needed for historical context. |
+| `"SKIP"` tag in memory | Explicitly marked to skip | Skip. Respect the intent. |
+| Internal debug docs (e.g., audit logs, secrets) | Not meant for bot | Skip (security). |
+
+**Implementation:** Create a filter manifest (YAML):
+
+```yaml
+tier_a:
+  - path: "community.config.ts"
+    confidence: 1.0
+  - doc: 432
+    title: "ZAO Master Context"
+    confidence: 1.0
+  - file: "project_zao_canonical_pitch.md"
+    confidence: 1.0
+
+tier_b:
+  - glob: "research/identity/*.md"
+    confidence: 0.8
+    reason: "Latest research, may be aspirational"
+  - glob: "research/community/*.md"
+    confidence: 0.8
+    reason: "Strategic context, not locked"
+  - glob: "research/agents/*.md"
+    confidence: 0.7
+    reason: "Agent research, evaluation-phase"
+  - glob: ".claude/projects/*/memory/*.md"
+    confidence: 0.8
+    reason: "Project memory, annotated with status field"
+
+tier_c:
+  - glob: "research/**/*"
+    filter: "status: deprecated"
+    action: "skip"
+  - glob: "research/**/*"
+    filter: "status: archived"
+    action: "skip"
+```
+
+Pass this filter to the batch loader to control quality gate.
+
+---
+
+## Question 10: The First 20 Entities (Ranked)
+
+Send these 20 to the bot in this order (days 1-3):
+
+| # | Entity Name | Type | Why This One | Phrasing to Send |
+|---|---|---|---|---|
+| 1 | The ZAO | ORG | Foundation. All others hang from it. | "The ZAO is a decentralized impact network founded by Zaal Panthaki. It focuses on returning profit margin, data, and IP rights to artists. Based as of 2026-04-29: 188 members, Base chain, governed by Respect token." |
+| 2 | Zaal Panthaki | PERSON | Decision-maker. Founder. | "Zaal Panthaki (alias: BetterCallZaal on X/YouTube) is the founder of The ZAO. He is building BCZ Strategies LLC (DBA ZABAL ecosystem). He meets regularly with team members including Dan, Tadas, and Iman." |
+| 3 | Fractals | EVENT | 90+ week cadence, core governance. | "ZAO Fractals is a weekly governance session. It runs every Monday at 6pm Eastern on Discord. It has run for 90+ weeks as of 2026-04-29. Facilitators: Dan and Tadas. Outcome: Respect scores assigned to members participating." |
+| 4 | Respect | CONCEPT/TOKEN | Core reputation system. OG and ZOR ledgers. | "Respect is The ZAO's reputation system. Two ledgers: OG (legacy, 122 holders as of 2026-04-29) and ZOR (new, 4 holders early 2026). Respect is assigned in Fractals. On-chain contract on Base." |
+| 5 | ZAOstock 2026 | EVENT | Oct 3 2026, Phase 0 proof. | "ZAOstock 2026 is a music festival. Date: October 3 2026. Location: Franklin St Parklet, Ellsworth, Maine. Status: artist submissions open (deadline ~Sept 3 2026). Budget: $5K-$25K. Team: Zaal + co-producers. Official Art of Ellsworth." |
+| 6 | Franklin St Parklet | LOCATION | Venue for ZAOstock. | "Franklin St Parklet is located in Ellsworth, Maine. It is a public venue managed by City of Ellsworth Parks/Rec. Contact: Roddy Ehrlenbach. First confirmed meeting: April 28 2026 5pm (City Hall). Wallace Events providing tents." |
+| 7 | Roddy Ehrlenbach | PERSON | Venue liaison. Key gatekeeper. | "Roddy Ehrlenbach is the Parks/Recreation director for City of Ellsworth, Maine. He manages Franklin St Parklet. Status: 2026-04-28 confirmed venue contact for ZAOstock. Responsive, supportive." |
+| 8 | ZABAL | TOKEN | Ecosystem coin. Distribution TBD. | "ZABAL (uppercase) is the token of BCZ Strategies LLC (DBA ZABAL ecosystem). On Base chain. Distribution planned but not yet deployed as of 2026-04-29. Symbol: $ZABAL. Associated with ZAO ecosystem initiatives, Empire Builder V3, RaidSharks amplification." |
+| 9 | Cipher | RELEASE | ZAO Music entity's first release. | "Cipher is the first music release from ZAO Music (entity: DBA under BCZ Strategies LLC). Team: DCoop, GodCloud, Iman (composer). Status: in production, 2026. Associated with DistroKid, BMI, 0xSplits payments." |
+| 10 | Iman | PERSON | Musician, composer, BCZ team. | "Iman is a musician and composer. Role: composer for Cipher release. Affiliation: BCZ Strategies team. The ZAO member. Joined ZAO 2026 (exact date TBD). Skills: music production." |
+| 11 | Dan | PERSON | Fractal facilitator. Community leader. | "Dan is a community member of The ZAO. Role: facilitator of ZAO Fractals (weekly Mondays 6pm EST). Responsibilities: running governance sessions, assigning Respect scores. Active 90+ weeks." |
+| 12 | Tadas | PERSON | Fractal facilitator. Co-lead. | "Tadas is a community member of The ZAO. Role: co-facilitator of ZAO Fractals (weekly Mondays 6pm EST). Responsibilities: running governance sessions, Respect assignments. Active 90+ weeks." |
+| 13 | Steve Peer | PERSON | ZAO Stock curator. Ellsworth community. | "Steve Peer is an Ellsworth drummer (since 1989) and community organizer. Role: ZAO Stock co-curator (alongside Zaal). Background: 430 Bayside house concerts, Ellsworth fixture. Status: not yet pitched on ZAOstock, may be key partner." |
+| 14 | ZOE | AGENT | Telegram-native ops engine. | "ZOE is an autonomous agent (Telegram-native). Role: ops dispatch, Bonfire context provider. Status: live as of 2026-04-01. Underlying: OpenClaw + Claude models. Available: Telegram DMs to Zaal. Integrating with Bonfire (this week)." |
+| 15 | BetterCallZaal Strategies | ORG | Service company, DBA ZABAL. | "BetterCallZaal Strategies (LLC) is the legal entity for Zaal's operations. DBA: ZABAL ecosystem. Services: consulting, music entity (BCZ Music / Cipher), ZAOstock production. Founder: Zaal Panthaki. Collaborators: Dan, Tadas, Iman, others." |
+| 16 | Four Pillars | CONCEPT | ZAO's organizational structure. | "The ZAO has four pillars: Artist Org, Autonomous Org, Operating System, and Open Source. Each pillar is a visible section in the ZAO OS app. Sourced from doc 432 (master context, Apr 17 2026 Tricky Buddha Space)." |
+| 17 | ZAO OS | PRODUCT | Gated Farcaster client, MVP. | "ZAO OS is a gated Farcaster social client for The ZAO. Features: Spaces (audio), music player, governance chat. Tech: Next.js, React, Supabase RLS, Neynar, XMTP (Phase 2). Status: MVP, 188 members access." |
+| 18 | doc 432 | REFERENCE | Master positioning document. | "Doc 432 (research/community/432) is the canonical master context for The ZAO. Date: Apr 17 2026 Tricky Buddha Space session. Content: music first, community second, tech third. Event strategy, artist focus. Source of truth for ZAOstock alignment." |
+| 19 | Hermes | AGENT | Code execution agent. | "Hermes is an autonomous agent for code execution (CI/CD, fixer tasks). Status: live, integrated with GitHub/Claude Code. Role: runs /fix commands, context-aware code suggestions. Underlying: Claude models + Anthropic MCP. Bonfire integration: Phase 2 (context layer for code decisions)." |
+| 20 | Bonfire Bot | AGENT | This bot. Graph agent. | "ZABAL Bonfire Bot is the live graph agent. Deployed: 2026-04-28. Role: memory system for ZAO ecosystem, Telegram-accessible. Learns from: research docs, Telegram conversations, meeting transcripts. Week-1 goal: 100+ entities, queryable via Telegram @bonfires." |
+
+---
+
+## Question 11: Week 1 Playbook (Day-by-Day)
+
+| Day | Theme | Actions | Deliverable | Red Flag Check |
+|---|---|---|---|---|
+| **Day 1 (Mon 4/29)** | Schema + 5 seed + first 15 entities | 1. Create schema profile (entity types, relations, confidence model). 2. Load 5 seed entities (ZAO, Zaal, Fractals, Respect, ZAOstock). 3. Manual load first 15 entities via UI (table from Q10 #1-15). 4. Invite bot to private Telegram test group. | 15 entities live in graph. Bot accessible via @Bonfires. Schema doc committed to research/. | Bot inventing entity types (e.g., "FRACTAL_SESSION" when should be EVENT)? |
+| **Day 2 (Tue 4/30)** | Projects + relationships | 1. Load: 4 pillars + 6 key projects (Cipher, ZABAL coin, ZAO Stock, ZOE, Hermes, Bonfire). 2. Create edges: Pillar -> Project associations. 3. Quality check: dedupe aliases (check ZABAL/zabal/zabal-coin). 4. Zaal meeting with Roddy post-5pm -> capture outcomes in Telegram + feed to bot. | 6 new projects + 10+ edges. Aliases dict applied. | Duplicate entities (e.g., two ZABAL nodes)? Missing relationships (e.g., Pillar not linked to projects)? |
+| **Day 3 (Wed 5/1)** | People + roles | 1. Load: top 5 people (Zaal, Dan, Tadas, Iman, Steve Peer) + 5 secondary (Roddy, Maceo, others TBD). 2. Assign roles: facilitator, founder, curator, composer, etc. 3. Create edges: Person -> Org/Project/Event. 4. Test query: "@Bonfires Who runs Fractals?" (expect: Dan, Tadas). | 10 people, all with roles. Query returns correct facilitators. | Missing people (bot doesn't know a key member)? Orphaned people (no role/affiliation)? |
+| **Day 4 (Thu 5/2)** | Events + cadences | 1. Load: 8 events (ZAOstock, Fractals x1 recent session, ZAO Stock meetings, team syncs, ETHBoulder attendance? TBD). 2. Mark cadence: which are weekly/monthly/one-time. 3. Dates: assign to canonical calendar. 4. Create edges: Event -> Outcome (if known). | 8 events, marked with frequency + date range. 3+ cadences identified. | Orphaned events (no associated people or location)? Dates in wrong format (not ISO 8601)? |
+| **Day 5 (Fri 5/3)** | Decisions + contributions | 1. Capture: 10-15 decisions from last 90 days (Fractals outcomes, ZAOstock go-live, Cipher greenlight, ZABAL deploy decision, etc.). 2. Log: who made decision, when, outcome, status (approved/rejected/pending). 3. Pull from: research/community/432, project memories, Fractals transcript. 4. Create edges: Decision <- Person/Meeting/Org. | 15 decisions logged. Decision graph auditable. Confidence scores assigned (0.9-1.0 if from meeting notes). | Decisions without dates or decision-maker? Confidence all 1.0 (should vary)? |
+| **Day 6 (Sat 5/4)** | Deduplication + verification pass | 1. Run: `bonfire kengram verify --dedup-pass` (command TBD, pending Bonfire API docs). 2. Generate: `merge_proposals.yaml` with confidence scores. 3. Zaal review: approve merges (zabal=ZABAL=zabal-coin, etc.). 4. Apply merges, update provenance. 5. Final entity count: should be 80-100 by EOD. | Merge proposals reviewed + applied. Entity count stable. Graph ready for queries. | Unmerged duplicates (zabal / ZABAL still separate)? Low confidence scores on high-confidence facts (should be 1.0)? |
+| **Day 7 (Sun 5/5)** | Validation queries + week recap | 1. Run 3 test queries: a) "Who runs Fractals?" (expect: Dan + Tadas). b) "What's the ZAOstock venue?" (expect: Franklin St Parklet, Oct 3). c) "What is ZABAL?" (expect: token, BCZ ecosystem). 2. Measure latency (should be <2s per doc 542 benchmarks). 3. Document any misses. 4. Assess ready for Phase 1 (ZABAL/Fractals scale)? 5. Commit week-1 graph snapshot. | 3 queries pass. Latency <2s. Bot can answer like day-7 insider, not day-1 chatbot. | Query timeouts? Hallucinated answers (bot invents details)? Missing key context? |
+
+---
+
+## Question 12: Red Flags (Week 1 Early Warnings)
+
+**Watch for these 5 symptoms; recovery action for each:**
+
+| Red Flag | Symptom | Detection | Recovery Action |
+|---|---|---|---|
+| **Hallucinated members** | Bot claims "Alice is a The ZAO member" but Alice is unknown in research/ or Supabase. | Query: "@Bonfires List all ZAO members." If count > 188, investigate excess. Run `sift resolve` on PERSONs (sift-kg tool). | Rollback to last verified kEngram. Audit confidence scores. Retrain on canonical member list from community.config.ts. Confidence cap all new PERSONs at 0.7 until verified. |
+| **Entity fragmentation** | Multiple nodes for same entity: "zabal" (lowercase), "ZABAL" (uppercase), "zabal token", "zabal-coin". All separate edges/attributes. | Query: "@Bonfires How many nodes contain 'zabal'?" If >3, fragmentation. Visual inspect graph.bonfires.ai. | Day 6 dedup pass CRITICAL. Pre-load aliases dict IMMEDIATELY (restart bot). Re-run sift-kg fuzzy match at 0.95 threshold. Apply merges to combine into single ZABAL node with preferred_label + aliases. |
+| **Missing timestamps** | New entities added without source_at. Impossible to audit age / source sequence. | Scan provenance metadata: check if source_at is present on 100% of entities. If <95%, gap exists. | Backfill missing source_at from kEngram load timestamp (default to epoch 0 if truly unknown). Every entity must have source_at going forward. Add validation: bot refuses to create entity without source_at. |
+| **Orphaned relationships** | Edges created between entities that have no reason to be connected. E.g., "ZABAL related_to Steve Peer" (no basis). | Run graph traversal: "@Bonfires What is the connection between ZABAL and Steve Peer?" If answer is nonsensical or empty, orphaned edge. | Audit confidence scores: anything <0.7 on edges is inferred/unreliable. Day 6 merge pass: remove edges with confidence <0.6. Review bot's inference logic: is it confusing "mentioned in same Telegram message" with "has relationship"? Fix extraction prompt to distinguish mentions from relations. |
+| **Incomplete attributes** | Key entities missing critical facts. E.g., "ZAOstock" has no date, no venue, no budget. | Audit completeness: for each entity type, check if >=80% of required fields filled. E.g., EVENT requires: date, location, organizer, status. If <80%, gaps. | Day 5: manual attribute fill pass. Zaal or team adds missing critical facts. Prioritize entities in queries (ZAOstock, Fractals, ZABAL, ZAO, Zaal, etc.). Day 6: confidence flag: if attribute was manual-added (not extracted), set confidence 1.0 + source_kind "manual_fill". |
+
+---
+
+## Batch vs Stream: Implementation Schedule (Week 1)
+
+| Resource | Type | Load Day | Method | Source |
+|---|---|---|---|---|
+| **community.config.ts** | Authoritative seed | Day 1 | Manual parse + batch load | Path: /codebase/community.config.ts |
+| **doc 432 (master context)** | Authoritative seed | Day 1 | Manual parse + batch load | Path: research/community/432/README.md |
+| **research/identity/271** (ZID plan) | Aspirational context | Day 2 | Batch load (confidence 0.8) | Path: research/identity/271/README.md |
+| **research/identity/542** (Bonfire eval) | Aspirational context | Day 1 | Batch load (confidence 0.8) | Path: research/identity/542/README.md |
+| **research/community/** (all docs) | Aspirational context | Day 2 | Batch load (confidence 0.8) | Glob: research/community/*.md |
+| **research/agents/** (agent research) | Aspirational context | Day 3 | Batch load (confidence 0.7) | Glob: research/agents/*.md |
+| **research/identity/** (all docs) | Aspirational context | Day 3 | Batch load (confidence 0.8) | Glob: research/identity/*.md |
+| **Telegram DMs** (live) | Stream (real-time) | Day 1+ | Bonfire agent (built-in) | Bonfire connector: telegram_dm |
+| **Fractal #90 transcript** (live) | Stream (post-session) | Monday 5/5 (~day 8) | Bot + Telegram capture | Source: Discord #fractals channel, transcript post-session |
+| **Team meeting notes** (live) | Stream (manual paste) | Day 4+ | Telegram paste + bot ingests | Source: Zaal pastes notes to Bonfire test group |
+
+---
+
+## Recommended System Prompt Addition (Complete Text)
+
+Add this section to the Bonfire Bot's system instructions:
+
+```
+=== INTAKE EXTRACTION MODE (ZAO WEEK 1) ===
+
+You are learning The ZAO ecosystem in real-time.
+Your goal: Extract facts atomically. Do not synthesize, infer, or merge beyond what's stated.
+
+EXTRACTION PIPELINE:
+1. When a user states a fact: Parse it into entities, relations, and confidence.
+2. Extract first. Synthesize second.
+3. Ask for clarification if ambiguous.
+4. Default to "no relation" rather than guess.
+5. Every node carries source_kind, source_at, confidence.
+
+EXAMPLE:
+Input: "Zaal met with Roddy on the 28th about the October event."
+Output (raw extraction):
+  - PERSON: Zaal
+  - PERSON: Roddy
+  - EVENT: October event (type: ZAOstock, inferred)
+  - RELATION: Zaal met_with Roddy (date: 2026-04-28, confidence: 1.0)
+  - RELATION: Roddy discussed ZAOstock (confidence: 0.8, inferred)
+  - SOURCE_KIND: telegram_dm
+  - SOURCE_AT: [message timestamp]
+  - PROVENANCE: "User stated in Telegram DM"
+
+NOT: "Zaal and Roddy are aligned" or "The event will succeed" (inference, not extraction).
+
+ENTITY TYPES (start with these 7):
+  - ORG (organization: The ZAO, BCZ Strategies, etc.)
+  - PERSON (individual: Zaal, Dan, Iman, etc.)
+  - EVENT (meeting, session, conference: ZAOstock, Fractals, etc.)
+  - LOCATION (place: Franklin St Parklet, etc.)
+  - TOKEN/CONCEPT (abstract: ZABAL, Respect, Four Pillars, etc.)
+  - DECISION (action outcome: "Roddy approved venue" = decision)
+  - REFERENCE (document, contract, external: doc 432, community.config.ts)
+
+CONFIRMATION PROTOCOL:
+  - NEW ENTITY TYPE: "Should I create entity type [TYPE]? Example: [name]."
+  - NEW ENTITY (existing type): Batch 5, review once daily.
+  - ATTRIBUTE UPDATE: Log confidence >=0.9, no confirmation needed.
+
+WEEK 1 VELOCITY TARGET: 
+  - Day 1: 15 entities
+  - Days 2-5: 5-10 new entities per day (total ~60-70 by day 5)
+  - Day 6: Deduplication pass
+  - Day 7: Validation queries
+  - No quota after day 5; learn at natural pace.
+
+CANONICAL NAMES (always deduplicate):
+  - WaveWarZ (not "Wave Wars", "Wavewarz")
+  - COC Concertz (not "CocConcertz", "COC Concerts")
+  - The ZAO (not "ZAO", "the Zao")
+  - BetterCallZaal (not "Better Call Zaal")
+  - ZABAL (not "zabal", "Zabal")
+  - ZOE (not "Zoe", "zoe")
+
+CONFIDENCE SCALE:
+  - 1.0: Explicitly stated in source (e.g., "Zaal founded The ZAO")
+  - 0.8: From meeting notes or authoritative doc (e.g., doc 432)
+  - 0.7: Research/aspirational context (research/ docs)
+  - 0.5: Inferred from two other facts
+  - <0.5: Hallucinated or low-signal (use sparingly, flag immediately)
+
+PROVENANCE TRACKING:
+  - Every entity: source_user, source_at (ISO 8601), source_kind (enum), confidence, provenance_doc
+  - Every edge: same metadata
+  - Audit trail: "Who said this? When? How confident?"
+
+QUALITY GATE (skip):
+  - Any statement claimed as "status: deprecated" or "status: archived"
+  - Contradictions to canonical sources (doc 432, community.config.ts)
+  - Hallucinations (bot inventing facts with no basis)
+
+END INTAKE MODE.
+```
+
+---
+
+## Sources Verified (2026-04-29)
+
+1. https://paragraph.com/@joshuab/ethboulder-lets-make-sense - ETHBoulder case study, episodic KG construction (verified Feb 2026)
+2. https://medium.com/@yu-joshua/a-unified-framework-for-ai-native-knowledge-graphs - Joshua Yu GenKM framework (verified Feb 2026)
+3. https://github.com/jruder/sift-kg - sift-kg entity resolution (verified Feb 2026, GitHub)
+4. https://mintlify.com/juanceresa/sift-kg/concepts/entity-resolution - sift-kg 4-layer dedup (verified Feb 2026)
+5. https://neo4j.com/docs/neo4j-graphrag-python/current/user_guide_kg_builder.html - Neo4j GraphRAG extraction pipeline (verified Apr 2026)
+6. https://www.arunabh.me/blog/prompt-engineering-structured-json - Prompt engineering for structured output (verified Mar 2026)
+7. https://platform.openai.com/docs/guides/structured-outputs - OpenAI structured outputs (verified Apr 2026)
+8. https://docs.bonfirenetworks.org/api-reference.html - Bonfire Networks (note: not Bonfires.ai, but API pattern similar)
+9. https://blog.graphlet.ai/the-rise-of-semantic-entity-resolution - Semantic entity resolution with LLMs (verified Aug 2025)
+10. https://github.com/Graphlet-AI/serf - SERF entity resolution (verified Aug 2025)
+11. https://openreview.net/pdf/4899aa7274e853b5cff559f263376255c983e43b.pdf - DEG-RAG (entity resolution + triple reflection for KGs, verified 2025)
+12. https://vectorize.io/articles/mem0-vs-cognee - Memory systems comparison (verified Mar 2026)
+13. https://claudelab.net/en/articles/api-sdk/claude-api-structured-output-practical-mastery - Claude API structured output (verified Mar 2026)
+14. https://engineersofai.com/docs/llms/prompt-engineering/Structured-Output-and-JSON-Mode - Structured output patterns (verified 2026)
+15. https://learn.microsoft.com/en-us/azure/developer/ai/how-to-extract-entities-using-structured-outputs - Azure OpenAI extraction (verified 2026)
+
+---
+
+## Next Actions
+
+| # | Action | Owner | Type | By When |
+|---|---|---|---|---|
+| 1 | Finalize Bonfire bot system prompt with intake_extraction trait (add text from Q7 to bot instructions) | Zaal | hands-on | Mon 4/29 EOD |
+| 2 | Create Telegram test group + invite @bonfires bot | Zaal | hands-on | Mon 4/29 EOD |
+| 3 | Load 5 seed entities + 15 day-1 entities (use Q10 phrasing) | Claude/Zaal | hands-on | Mon 4/29 EOD |
+| 4 | Commit week-1 playbook snapshot to research/ (this doc) | Claude | doc | Mon 4/29 EOD |
+| 5 | Day 2-5: daily standup - entity count, dedup check, query validation | Zaal | standup | Daily Tue-Fri |
+| 6 | Day 6 (Sat): Run dedup pass, generate merge_proposals.yaml, Zaal review | Claude/Zaal | decision | Sat 5/4 EOD |
+| 7 | Day 7 (Sun): 3 validation queries, week recap, decision on Phase 1 scale | Zaal | decision | Sun 5/5 EOD |
+| 8 | Post-week-1: Document learnings, update Bonfire config, wire ZOE bot `/tip` to Bonfire API | Claude/Zaal | research | Mon 5/6 EOD |
+
+---
+
+## Co-Authored
+
+Co-Authored-By: Claude Haiku 4.5 (20251001) <noreply@anthropic.com>


### PR DESCRIPTION
## Summary

**Doc 549 hub + 5 sub-docs on 21st.dev** (component marketplace + Magic MCP + 1code agent orchestration). Plus **doc 550 on gitpitcher.com** (repo-to-build-pack tool).

### 549 - 21st.dev (DISPATCH tier)

3-layer ecosystem, way bigger than landing page suggests:
- `magic-mcp` (4,815 stars, MIT, updated today, 47,369 monthly npm DLs)
- `1code` (5,494 stars - "Orchestration layer for Claude Code/Codex" - sleeper)
- `21st-sdk` + `agent-elements` + `21st-extension` (157+ stars combined)

Magic MCP exposes 4 tools: 2 free (Inspiration Search, Logo Search via svgl), 2 paid (Builder $20/mo Pro, Refiner). Stack-compatible with ZAO (Next 16, React 19, Tailwind v4). Catalog covers Heroes, Pricing, AI Chat, CTAs, Buttons, Testimonials, Shaders.

**Verdict:** install today, pay Pro $20 only during ZAOstock site sprints, skip Max $100, track `1code` for separate research vs QuadWork.

### 549e - Live skill

`/21st` skill is dropped at `~/.claude/skills/21st/SKILL.md` and visible in skill list. Wraps Magic MCP with ZAO defaults (brand tokens, mobile-first, Tailwind v4 sweep, Biome + use-client + cn-from-utils enforcement). Use: `/21st sponsor tier card for ZAOstock landing`.

### 549 sub-docs

- 549a catalog inventory (categories + ZAO surface fit table)
- 549b access patterns + alternatives (shadcn-ui-mcp, shadcn studio, Aceternity, MagicUI, OriginUI - why 21st wins)
- 549c pricing & licensing (3-source pricing reconciliation, license guidance for Magic-generated vs community-lifted)
- 549d AI features (1code, 21st-sdk, agent-elements deep dives)
- 549e drop-in skill spec

### 550 - GitPitcher

Repo-to-build-pack tool. Free 12 credits/mo, Pro $19, Team $49. Verdict: **NO subscription** - overlaps with our `codebase-onboarding` + `prp-plan` + `writing-plans` + `agent-sort` skill stack. Try free tier on Sonata/Herocast/1code to compare, then decide.

## Tier
DISPATCH (549 hub + 5 subs) + STANDARD (550)

## Sources
20+ unique - GitHub APIs (verified 2026-04-29 live), npm registry, third-party MCP directories (PulseMCP, Glama, augmentcode), 21st.dev landing/magic/pricing pages, gitpitcher.com landing/pricing.

## Action Bridge
- Install Magic MCP via `npx @21st-dev/cli@latest install claude --api-key <key>`
- API key from `https://21st.dev/magic/console`
- Test on `/stake` hero refresh (free Inspiration only)
- Open separate research on `1code` after Lazer spike (Doc 548) closes
- Try gitpitcher free tier on Sonata/Herocast/1code repos

## Related
548, 506, 507, 508