### PR TITLE
docs 558-561: writing.md + wetware/ww + openwhisp + djOS (STANDARD)

### DIFF
--- a/research/agents/559-wetware-ww-p2p-agent-os/README.md
+++ b/research/agents/559-wetware-ww-p2p-agent-os/README.md
@@ -1,0 +1,137 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 506, 507, 548, 555
+tier: STANDARD
+---
+
+# 559 - Wetware (`ww`): P2P OS for Autonomous Agents
+
+> **Goal:** Decide whether `wetware/ww` (P2P OS, capability-based security, libp2p + Cap'n Proto + WASM) belongs in ZAO's agent stack alongside QuadWork / ECC / 1code.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Adopt `ww` as a runtime for ZAO agents (ZOE, VAULT, BANKER, DEALER, etc.) | **NO** | 16 stars on GitHub. Rust-only. ZAO is TypeScript/JavaScript-native. Adoption cost > current ceiling, even though the architecture is interesting. |
+| Track as a research signal for "where capability-based security + agent meshes are heading" | **YES** | Niche but coherent: WASM agents + capability tokens + libp2p + Cap'n Proto. If multi-agent ZAO ever needs sandbox isolation across machines, this is a reference design. |
+| Lift the **capability-based security pattern** as a design check for ZAO agents | **YES, AS DESIGN PRINCIPLE** | "Replaces ambient authority with capability-based security" maps cleanly to ZAO agent budgets (memory `feedback_no_unsolicited_features` + autonomous trading). Use as a code-review checklist item. |
+| Adopt the membrane / epoch-scoped capabilities pattern for ZAO agent token-spend limits | **CONDITIONAL** | If we re-architect agent budgeting (`x402` skill is a closer fit; see Doc 555 follow-up), revisit. Otherwise hold. |
+| Replace QuadWork / 1code with `ww` | **NO** | Wrong layer. `ww` is an agent runtime, QuadWork/1code are dev orchestrators. Different problems. |
+
+## What `ww` Is (Verified 2026-04-29)
+
+| Field | Value |
+|---|---|
+| Repo | `github.com/wetware/ww` |
+| Description | "P2P operating system for autonomous agents" |
+| Language | Rust (96.9%) |
+| Stars | **16** |
+| Total commits | 916 |
+| License | Not stated in fetched content |
+| Install | `curl -sSL https://wetware.run/install \| sh` |
+| Platforms | Linux/Unix + container (Podman/Docker) |
+
+### Architecture
+
+- **Sandboxed WASM agents** running on `wasm32-wasip2` target
+- **Capability-based security** - no ambient authority; each agent gets explicit capability tokens
+- **Cap'n Proto RPC** - typed serialization, low overhead
+- **Membrane system** - "epoch-scoped capabilities" (capabilities expire per epoch boundary)
+- **Glia shell** - Clojure-inspired language with first-class capabilities, used to orchestrate
+- **Cell modes**:
+  - `vat` - RPC service mesh
+  - `raw` - libp2p streams
+  - `HTTP/WAGI` - HTTP request handling
+
+### Networking Stack
+
+- libp2p swarm (port 2025)
+- IPFS via Kubo
+- Cap'n Proto for the RPC layer
+
+## Why It's Interesting (Even Though We Won't Adopt)
+
+ZAO has agents (ZOE, VAULT, BANKER, DEALER, ROLO + more per memory `project_agent_squad_dashboard`) that increasingly need:
+
+1. **Sandbox isolation** - so a misbehaving agent can't drain wallets
+2. **Token / budget caps** - per memory `feedback_no_unsolicited_features` + autonomous-trading guards
+3. **Cross-machine deployment** - VPS 1 + Mac dev + future infra
+4. **Auditability** - what did each agent do, with what authority
+
+`ww` is a coherent answer to all four, just in the wrong language for us.
+
+## Pattern Lifts (No Code, Just Principles)
+
+### Pattern 1 - Capability tokens > ambient authority
+
+**Today:** ZAO agents inherit env vars (`ANTHROPIC_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`). Any agent can do anything within its env.
+
+**`ww` pattern:** Each agent gets a *capability token* describing what it can do (e.g. "post to Telegram channel X", "read Supabase table Y"). Capabilities expire per epoch.
+
+**ZAO application:** in `src/lib/agents/runner.ts`, wrap agent calls in a capability shim that injects only the env vars needed. Reject capability requests that exceed budget. Skill: `/security-review` from ECC catches absent capability checks.
+
+### Pattern 2 - Membrane / epoch boundary
+
+**Today:** ZAO agents run continuously; budget is checked per call.
+
+**`ww` pattern:** Capabilities live for one epoch (e.g. 1 hour, 1 day). Renewal requires explicit grant.
+
+**ZAO application:** ZOE / VAULT / BANKER / DEALER could rotate capability tokens daily. After 24h, agent must re-request from a Head agent. Aligns with QuadWork's Head-Dev-Reviewer pattern (Doc 555).
+
+### Pattern 3 - WASM as the agent boundary
+
+**Today:** ZAO agents run as Node processes inheriting full host access.
+
+**`ww` pattern:** Agents are WASM modules. Host controls every syscall via WASI capabilities.
+
+**ZAO application:** **defer.** WASM-ifying TypeScript agents is a major refactor and the security gain is offset by the operational complexity. Watch wasm32-wasip2 ecosystem maturity.
+
+## Why ZAO Picks Different Tools
+
+| ZAO need | Tool we use | Why not `ww` |
+|---|---|---|
+| Multi-agent dev squad | QuadWork v1.12.0 | Different layer (dev orchestration, not agent runtime) |
+| Code generation by agents | Claude Code CLI | Different layer |
+| Agent budget enforcement | `x402` skill (per `everything-claude-code:agent-payment-x402`) | Solves the same budget problem in our stack |
+| Cross-machine deploy | VPS 1 + Cloudflare Tunnel | Existing infra; `ww`'s libp2p mesh is overkill for 1-VPS setup |
+| Sandbox isolation | Vercel Functions (per route) + RLS (per row) | Adequate for current scale |
+
+## Risks (If We Did Adopt)
+
+| Risk | Severity |
+|---|---|
+| Rust skill gap on the team | High |
+| 16-star repo - bus factor unknown | High |
+| No license - cannot redistribute / fork safely | High |
+| WASM agent toolchain still maturing | Medium |
+| `wasm32-wasip2` target is recent (2025+) | Medium |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Add capability-token check to `src/lib/agents/runner.ts` review checklist | Zaal | Code-review item | This sprint |
+| Document `x402` skill as canonical agent-budget tool (closer fit than `ww`) | Zaal | Memory or skill note | This week |
+| Re-check `wetware/ww` star count + license + activity quarterly | n/a | Calendar | 2026-07-29 |
+| If `ww` ever ships TS bindings or hits 1K stars, re-open this doc | n/a | Conditional | n/a |
+
+## Also See
+
+- [Doc 506 - TRAE skip](../../dev-workflows/506-trae-ai-solo-bytedance-coding-agent/) - canon agent-stack picks
+- [Doc 555 - Agent harness shootout](../../dev-workflows/555-agent-harness-shootout/) - sister doc on dev-orchestration layer
+- [Doc 548 - Lazer Mini Apps CLI](../../farcaster/548-lazer-miniapps-cli-evaluation/) - shares "skill ships source" pattern, different layer
+- `everything-claude-code:agent-payment-x402` skill - direct fit for ZAO budget needs
+- Memory `project_agent_squad_dashboard` - 8+ ZAO agents that would benefit from capability tokens
+
+## Sources
+
+- [wetware/ww on GitHub](https://github.com/wetware/ww) - 16 stars, 916 commits, Rust 96.9%, no license stated, last fetched 2026-04-29
+- [wetware.run install endpoint](https://wetware.run/install) - one-line install
+- libp2p, Cap'n Proto, IPFS Kubo - all referenced as deps in fetched content
+
+## Staleness Notes
+
+Niche project at 16 stars. Re-validate quarterly. If activity stalls, mark as superseded by whatever capability-OS pattern wins.

--- a/research/dev-workflows/558-anbeeld-writing-md/README.md
+++ b/research/dev-workflows/558-anbeeld-writing-md/README.md
@@ -1,0 +1,122 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 432, 552, 553
+tier: STANDARD
+---
+
+# 558 - Anbeeld WRITING.md (AI-Prose Diagnostic Toolkit)
+
+> **Goal:** Decide whether to fold Anbeeld's WRITING.md ruleset into ZAO content skills (`/socials`, `/newsletter`, `/onepager`, `/article-writing`). Aim is less "AI-detector evasion," more "writing that fits its medium and reader."
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Fold a curated subset of WRITING.md rules into ZAO content skills | **YES** | 14 rules. Diagnostic, not prescriptive. Fits Zaal's `feedback_brainstorm_before_writing` (already a memory) and the project's "concrete specificity over polished generality" pattern. |
+| Adopt the 5-10 required-checks gate before publishing any newsletter / 1-pager / pitch | **YES** | Tightens an already-good cycle. Use as a ZAO-internal pre-publish lint, not a public rule. |
+| Mirror the entire 296-line ruleset verbatim into a ZAO skill | **NO** | License unspecified. Lift specific rule patterns and rewrite in Zaal's voice; cite Anbeeld as influence. |
+| Treat as anti-AI-detector tool | **NO** | Author explicitly rejects optimising for "sounding human" or beating detectors. Use it for fit-to-medium discipline, not adversarial framing. |
+
+## What WRITING.md Actually Is
+
+Verified 2026-04-29 from `github.com/Anbeeld/WRITING.md`:
+
+| Field | Value |
+|---|---|
+| Repo | `Anbeeld/WRITING.md` |
+| Stars | 123 |
+| Forks | 10 |
+| Length | 296 lines (208 of "code") |
+| License | **None specified** |
+| Author identity | Not disclosed in repo |
+
+Document structure (per fetch):
+
+1. Purpose statement (writing fits medium + audience + purpose, not "sound human")
+2. Detector limits (does not chase AI-detector scores)
+3. Precedence framework (when rules conflict, which wins)
+4. Medium routing (chat vs. document vs. long-form)
+5. Safety rails
+6. **Core rules** (14 rules)
+7. Required checks (5-10 depending on length)
+8. Optional diagnostics
+9. Formula phrases to scrutinise
+10. Provenance guidance
+
+## The 14 Core Rules (Synthesised From Fetch)
+
+The fetch summarised: anchor to actual reader needs, match format to medium, prefer concrete specificity over polished generality, plain words with ordinary repetition, avoid performative tone, watch for suspicious regularity in sentence patterns. Specific 14 rules not enumerated in fetched summary - full doc fetch needed for verbatim extraction (avoid hallucination).
+
+**Action:** verbatim 14-rule list extraction is a separate task. For now, rule families above are sufficient to inform ZAO content skill upgrades.
+
+## ZAO Content Skill Audit (Where WRITING.md Could Land)
+
+| Skill | What it does today | Where WRITING.md helps |
+|---|---|---|
+| `/socials` (global) | Generate platform-specific posts | Add: "concrete specificity over polished generality" check. Force one specific number/name/quote per post. |
+| `/newsletter` (project) | Draft "Year of the ZABAL" daily post in Zaal's voice | Add: "watch suspicious regularity" check. Catch parallel-structure overuse common in newsletter sections. |
+| `/onepager` (project) | ZAOstock sponsor / partner / venue briefings | Add: "match format to medium" - 1-pager rules differ from email rules. |
+| `/article-writing` (ECC plugin) | Articles + guides | Already has structure; add WRITING.md required-checks as the pre-publish gate. |
+| `/bcz-yapz-description` | YouTube description renderer | Add: avoid formula phrases ("In this episode," "Today we discuss"). |
+
+## How to Cherry-Pick Without License Risk
+
+License is unspecified upstream. Defensive approach:
+
+1. Read `Anbeeld/WRITING.md` once, manually
+2. Pull rule **principles** (idea-level, not verbatim text)
+3. Reword in ZAO voice + add ZAO-specific examples
+4. Cite Anbeeld in the source list of any ZAO skill that adopts a rule
+5. Don't host or redistribute the original text
+
+This is identical to how we treat `superpowers:writing-skills` rules: principle-level adoption.
+
+## Concrete Lift: 5 Rules To Adopt First (Zaal-Voice Restatement)
+
+These are restatements, not quotes. Each maps to an Anbeeld rule family per the fetch.
+
+1. **Reader before audience.** Write for one specific person who will read this. If it's Zaal's newsletter, write for the ZABAL holder who almost-but-didn't-read yesterday's post.
+2. **One concrete per paragraph.** Every paragraph should have one number, name, date, or quote. If a paragraph has none, it's smoke.
+3. **Plain words, ordinary repetition.** Don't avoid the word you already used. Don't reach for the synonym to look polished.
+4. **No performative empathy.** "I get it, building is hard." Cut. The reader knows.
+5. **Suspicious regularity is a smell.** If three sentences in a row start the same way, one is wrong.
+
+These five alone should sharpen `/newsletter` + `/socials` + `/onepager` outputs.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| License is unspecified - reuse risk | Principle-level lifts only; cite Anbeeld; don't redistribute text |
+| Author identity unclear (no biography) | Cite as `Anbeeld (GitHub user)` not as a named expert |
+| Doc could change or disappear | Capture key principles in a ZAO-local doc (this one) so we're not dependent |
+| Over-applying turns voice mechanical | Use rules as diagnostics on draft, not prescriptions during draft |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Manually read all 14 rules from `Anbeeld/WRITING.md` | Zaal or one-shot session | Reading | This week |
+| Update `/newsletter` + `/socials` + `/onepager` skill docs with the 5 rules above | Zaal | Skill PR | This week |
+| Add WRITING.md required-checks as a "pre-publish gate" snippet in `~/.claude/skills/article-writing/` (if owned globally) | Zaal | Skill PR | Next sprint |
+| Re-validate after first month of skill usage | Zaal | Reflection | 2026-05-29 |
+
+## Also See
+
+- [Doc 432 - The ZAO master positioning (Tricky Buddha)](../../community/432-tricky-buddha-zao-master-context/) - brand voice constraints
+- [Doc 552 - ZAO skill library audit](../552-zao-skill-library-audit/)
+- Memory `feedback_brainstorm_before_writing` - aligns with WRITING.md's "anchor to actual reader needs"
+- Memory `feedback_no_em_dashes`, `feedback_no_emojis` - existing ZAO style rules
+- `superpowers:writing-skills` upstream skill - skill-creation rules (different scope)
+
+## Sources
+
+- [Anbeeld/WRITING.md on GitHub](https://github.com/Anbeeld/WRITING.md/blob/main/WRITING.md) - 123 stars, 10 forks, 296 lines, no license stated
+- ZAO content skills already on disk (`/newsletter`, `/socials`, `/onepager`, `/bcz-yapz-description`)
+
+## Staleness Notes
+
+Author may add license or update rules. Re-validate by 2026-07-29 or on any major repo update.

--- a/research/dev-workflows/560-openwhisp-local-speech-to-text/README.md
+++ b/research/dev-workflows/560-openwhisp-local-speech-to-text/README.md
@@ -1,0 +1,153 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 432, 471, 558
+tier: STANDARD
+---
+
+# 560 - OpenWhisp: Local Speech-to-Text for ZAO Content + Voice Notes
+
+> **Goal:** Decide whether to install OpenWhisp on Zaal's Mac for voice-to-text capture across the ZAO content pipeline (newsletter, 1-pagers, Telegram replies, research notes). Memory `project_research_followups_apr21` lists OpenWhisp as a parked install - this doc unparks it.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Install OpenWhisp on Zaal's MacBook Pro (Apple Silicon) | **YES** | MIT, 138 stars, local-only (no API), runs Whisper Base Multilingual + Ollama-powered text refinement. Hold-Fn-and-speak UX. Removes typing friction for voice-first capture. |
+| Use OpenWhisp as the default voice-to-text path for newsletter + 1-pager + Telegram drafts | **YES** | ZAO's content workflow already routes through `/newsletter`, `/onepager`, `/socials` skills. OpenWhisp output drops cleanly into any of them as a starting draft. |
+| Pair with Anbeeld's WRITING.md rules (Doc 558) as the "speak first, refine second" pipeline | **YES** | Speak draft -> OpenWhisp polishes -> Doc 558 5-rule check -> ZAO content skill ships final. |
+| Use for sensitive / private content (legal, financial, internal) | **YES** | Local-only is the killer feature. No API call leaves the laptop. Aligns with `feedback_oss_first_no_platforms` + `feedback_never_accept_pasted_secrets`. |
+| Use for podcast / interview transcription (e.g. BCZ YapZ episodes) | **NOT YET** | OpenWhisp is dictation-mode (Hold Fn). For batch transcription of long audio, vanilla Whisper + a Whisper-server tool is better. Revisit if OpenWhisp adds batch mode. |
+
+## What OpenWhisp Is (Verified 2026-04-29)
+
+| Field | Value |
+|---|---|
+| Repo | `github.com/giusmarci/openwhisp` |
+| License | MIT |
+| Stars | 138 |
+| Platform | macOS (Apple Silicon recommended) |
+| ASR engine | Whisper Base Multilingual (~150 MB) via `@huggingface/transformers` |
+| Refinement | Local Ollama LLM (filter levels: No / Soft / Medium / High; styles: Conversation, Vibe Coding) |
+| UX | Hold `Fn`, speak, release. Output pasted into focused app. |
+| Disk | ~10 GB for models + Ollama |
+| Network use | None at runtime (after model download) |
+
+### Install
+
+```bash
+git clone https://github.com/giusmarci/openwhisp.git
+cd openwhisp
+npm install && npm run build:native && npm run dev
+```
+
+Native build because of macOS audio-capture bridges. First launch downloads the Whisper model + warms Ollama.
+
+## Why ZAO Wants This
+
+### Use case 1 - Voice-first newsletter draft
+
+Today: Zaal types newsletter posts. `/newsletter` skill drafts in Zaal's voice from a prompt.
+
+With OpenWhisp: Hold Fn, speak the day's idea raw. Release. Get polished prose pasted into the editor. Pipe through `/newsletter` for final voice + structure pass.
+
+Time saved: ~5-10 min per post. Compounds across daily posts.
+
+### Use case 2 - 1-pager + pitch capture
+
+Today: Zaal opens a doc, stares, types.
+
+With OpenWhisp: Speak the pitch as if to a sponsor on the phone. Get clean text. `/onepager` skill structures it.
+
+Direct fit for ZAOstock sponsor outreach (memory `project_zao_stock_team`, `project_zaostock_master_strategy`).
+
+### Use case 3 - Telegram replies (ZAO Stock team, RaidSharks, etc.)
+
+Today: thumb-typing on phone or keyboard sprint at desk.
+
+With OpenWhisp: speak reply, release Fn, send.
+
+Caveat: keep an eye on tone - OpenWhisp's Ollama polish can sand off voice. Use "No Filter" for casual chat, "Medium" for formal.
+
+### Use case 4 - Research note capture
+
+Today: idea hits during a walk, gets lost.
+
+With OpenWhisp on iPhone Voice Memo + AirDrop -> macOS Hold Fn paste: zero loss. Or simpler: Voice Memo -> OpenWhisp transcribes when at desk.
+
+(OpenWhisp itself is desktop-only; iPhone Voice Memo is the mobile capture step.)
+
+## What It's Not
+
+- Not a server-side ASR (use Whisper directly via OpenAI API or self-host whisper.cpp for that)
+- Not a real-time live captioning tool (dictation mode only)
+- Not a podcast transcriber for hour-long audio (batch mode missing as of 2026-04-29)
+
+For BCZ YapZ episode transcription, keep using whatever current pipeline (likely OpenAI Whisper API per `feedback_oss_first_no_platforms` cost-cheap exception). Revisit if OpenWhisp ships a batch CLI.
+
+## Filter Levels - Pick Defaults
+
+| Level | When to use |
+|---|---|
+| No Filter | Telegram casual chat, raw research notes |
+| Soft | Newsletter draft, internal docs |
+| Medium | 1-pager, pitch, public blog draft |
+| High | Press release, formal email, board update |
+
+| Style | When |
+|---|---|
+| Conversation | Default for most ZAO content |
+| Vibe Coding | When dictating into code comments / commit messages |
+
+## Pairing with Other ZAO Tools
+
+| Tool | Pair pattern |
+|---|---|
+| `/newsletter` | OpenWhisp captures raw idea -> `/newsletter` does voice + structure pass |
+| `/socials` | OpenWhisp captures core thought -> `/socials` adapts per platform (X, Farcaster, LinkedIn, GCs) |
+| `/onepager` | OpenWhisp captures pitch -> `/onepager` formats into ZAOstock template |
+| `/inbox` | OpenWhisp drafts replies to ZOE inbox forwards |
+| `/clipboard` | OpenWhisp output -> `/clipboard` if sharing externally |
+| Anbeeld WRITING.md (Doc 558) | OpenWhisp output -> 5-rule check before publish |
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Ollama model on disk consumes ~10 GB | Mac Pro has the space; check before install |
+| Whisper Base accuracy < Large for technical jargon | Acceptable for first-pass dictation; final pass via skill |
+| `Fn` key already mapped on Zaal's MBP | OpenWhisp may allow rebind; check at install |
+| macOS audio-capture permissions | Grant Microphone access on first run |
+| Sensitive transcripts cached locally | Verify cache location + add to backup-exclude list |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Clone + build OpenWhisp on MBP, run first dictation | Zaal | One-shot | Today |
+| Verify Apple Silicon performance + Ollama warm-up time | Zaal | Spike | Same |
+| Decide default filter level + style (recommended: Soft + Conversation) | Zaal | Config | Same |
+| Test OpenWhisp -> `/newsletter` draft loop | Zaal | Workflow | This week |
+| Update memory `project_research_followups_apr21` to mark OpenWhisp = installed | Zaal | Memory edit | After install |
+| If batch mode ships, re-evaluate for BCZ YapZ transcription | Zaal | Conditional | Quarterly |
+
+## Also See
+
+- [Doc 558 - Anbeeld WRITING.md](../558-anbeeld-writing-md/) - companion polish layer
+- [Doc 471 - Vercel OAuth + Claude solo quick wins](../../security/471-) (referenced in memory `project_research_followups_apr21` as parked items)
+- Memory `project_research_followups_apr21` - lists OpenWhisp as parked install (this doc unparks it)
+- Memory `feedback_oss_first_no_platforms` - aligns with local-first philosophy
+- Memory `feedback_never_accept_pasted_secrets` - local-only ASR avoids cloud transcription of sensitive content
+- Existing skills: `/newsletter`, `/socials`, `/onepager`, `/inbox`, `/clipboard`
+
+## Sources
+
+- [giusmarci/openwhisp on GitHub](https://github.com/giusmarci/openwhisp) - 138 stars, MIT, ~10 GB disk, fetched 2026-04-29
+- `@huggingface/transformers` - bundled Whisper Base Multilingual
+- Ollama - local LLM for refinement layer
+
+## Staleness Notes
+
+Watch for batch mode ship + filter-level changes. Re-validate by 2026-07-29 or on major repo update.

--- a/research/music/561-djos-ai-dj-copilot-mainstream/README.md
+++ b/research/music/561-djos-ai-dj-copilot-mainstream/README.md
@@ -1,0 +1,162 @@
+---
+topic: music
+type: market-research
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 432, 475, 530, 549, 557
+tier: STANDARD
+---
+
+# 561 - djOS™ AI DJ Co-Pilot (Mainstream Entertainment Group, Apr 27 2026)
+
+> **Goal:** Decide what ZAO does about djOS™. Three lenses: 1) Tool ZAOstock could use day-of (Oct 3). 2) Strategic signal for ZAO Music + WaveWarZ. 3) Partnership / collaboration angle - patent-pending AI-DJ coordination is adjacent to ZAO's artist-first stack.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Reach out to djOS / Cory Poccia (DJ Cory P) for a partnership conversation | **YES, EXPLORATORY** | djOS is in development, just announced 2026-04-27. Founder is a working DJ since 2002. ZAO is artist-first (memory `project_zao_master_context`) + ZAOstock Oct 3 needs day-of music programming. Talking now is cheap; partnership later is easier with relationship in place. |
+| Pilot djOS at ZAOstock Oct 3 if available by then | **MAYBE - DEPENDS ON BETA ACCESS** | Patent-pending, in development, no public pricing. Day-of festival is high-risk slot for unproven tech. Only pilot if djOS gives us a sandbox + their DJ on standby. |
+| Adopt djOS's "crowd heat mapping" pattern as inspiration for WaveWarZ artist signals | **YES, AS PATTERN** | djOS uses optical-flow + audio source-separation to score crowd energy in real time. WaveWarZ runs prediction markets on artists - similar telemetry could power "live performance score" markets. Patterns lifted are not patent-blocked; only djOS's specific implementation is. |
+| Compete with djOS by building our own | **NO** | Out of scope. ZAO's edge is artist + community + onchain attribution, not DJ-software UX. djOS is solving a different layer. |
+| Watch as canary for "AI co-pilot for live performance" category | **YES** | Plus PulseDJ + VirtualDJ 2026's AI features (set building, lyrics). Category is heating up. |
+
+## What djOS Is (Verified 2026-04-29)
+
+| Field | Value |
+|---|---|
+| Company | Mainstream Entertainment Group Inc. |
+| Founder | **Cory Poccia (DJ Cory P)**, club DJ since 2002 |
+| Announced | **2026-04-27** (2 days ago at this doc's authoring) |
+| Site | `djos.ai` |
+| Patent status | **Patent-pending** in US + international, filings April 2025 |
+| Status | In development, soliciting platform devs / venue ops / broadcasters / investors |
+| Public pricing | Not disclosed |
+
+### Architecture (per press release)
+
+djOS is an **operating system layer**, not a DJ application. It integrates with major DJ platforms:
+
+- Serato
+- Rekordbox
+- Traktor
+- VirtualDJ
+
+Patent claims cover an **integrated architecture** combining:
+
+1. Constraint-satisfaction setlist generation
+2. Library-reconciled platform-specific export
+3. Privacy-preserving real-time telemetry
+4. Feasibility-constrained transition repair
+5. Deviation-weighted learning
+
+### Core flow
+
+**Before the event:**
+- Ingests DJ's music library + historical performance data + client-defined event parameters (must-play, do-not-play, energy curves, scheduled timing cues)
+- Generates a structured, acoustically optimised setlist
+- When a track can't be resolved in the local library, **substitutes a harmonically + energetically compatible alternative**
+
+**During the set:**
+- Top-down camera over the booth + dedicated ambient mic
+- "Privacy-preserving telemetry pipeline":
+  - **Dense optical flow** on dance-floor movement
+  - **Deep-learning source separation** to isolate crowd audio from music
+- **Crowd heat mapping** monitors energy in real time
+- Adapts setlist on the fly - suggests track changes based on loops, skips, transitions
+
+### Products
+
+- **djOS Pulse** - flagship product for professional + working DJs. Setlist gen + crowd monitoring + recommendations.
+- **DNA feature** - AI modelling of "elite DJ styles" so any DJ can perform in the tradition of globally recognised artists.
+
+## Why djOS Matters to ZAO
+
+### Angle 1 - ZAOstock Oct 3 day-of
+
+ZAOstock has 8+ hours of music programming on Franklin St Parklet. Talent is open-call (memory `project_zaostock_open_call`). DJ slots between live acts.
+
+If djOS ships a beta by August/September 2026, it could:
+- Help curate transitions between artists (genre changes, energy curves)
+- Give the day-of stage manager a real-time crowd-energy signal
+- Auto-substitute track when an artist doesn't show
+
+**Risk:** new tech at a flagship event. Only pilot with their team on-site or on-call.
+
+### Angle 2 - WaveWarZ prediction markets
+
+ZAO runs WaveWarZ - prediction markets on artists. Today scoring is from public signals (followers, plays, Farcaster engagement). djOS's crowd-heat-mapping is a different signal class: **live performance energy**.
+
+Pattern lift (not direct integration): WaveWarZ could include a "live performance score" market component if any data partner provides crowd-energy telemetry. djOS doesn't need to be the partner - the pattern applies to any venue with the kit.
+
+### Angle 3 - ZAO Music attribution + artist owns data
+
+Memory `project_zao_music_entity` says ZAO Music = 0xSplits + on-chain attribution + artist-first by design. Korea voice actor crisis (Doc 508) is the cautionary tale.
+
+djOS captures **performance data per show**. Question for any partnership: who owns the captured data? In ZAO's framing, the **DJ owns** their performance telemetry. djOS as a tool that lets the artist export + monetise their own performance signal is interesting; djOS as a platform that aggregates performance data into a labels-style aggregator is the opposite.
+
+This is the strategic question to put to Cory P early.
+
+### Angle 4 - The category is real
+
+Adjacent products discovered in same search:
+- **PulseDJ** - "AI DJ Copilot" (pulsedj.com)
+- **VirtualDJ 2026** - now ships AI lyrics + AI set building + new FX engine
+- **DJ.Studio** - AI workflows guide
+
+So djOS is one of several entrants. ZAO's read should be: this is a 2026 trend, not a one-off. Worth tracking the category, not just djOS.
+
+## Outreach Pattern (If Zaal Greenlights)
+
+Memory `feedback_dont_invent_outreach` says do not draft emails to people Zaal didn't bring up. **Zaal didn't ask for outreach drafts in this research.** This doc proposes the angle but does NOT include a draft email.
+
+If Zaal greenlights outreach, the conversation hooks are:
+
+1. ZAOstock Oct 3 = real festival, real DJ slots, real beta opportunity
+2. ZAO Music = artist-first attribution model, philosophical alignment with "DJ-built tool that respects DJ data"
+3. WaveWarZ = adjacent market for live performance signal (pattern lift, no direct integration request)
+4. Cory P is a working DJ since 2002; Zaal's network (Steve Peer per memory `project_steve_peer`, ZAO music task forces) overlaps the indie / club DJ world
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Patent-pending coverage may extend to patterns we adopt | Lift principles only; don't replicate the specific 5-claim architecture |
+| In-development means no SLA; ZAOstock can't gate critical path on djOS | Treat as nice-to-have, not load-bearing |
+| Founder is solo (or small team); bus factor unknown | Start with conversation, not commitment |
+| AI on stage at a festival is press-magnet - good and bad | Decide messaging upfront if we pilot |
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Decide whether to reach out to Cory P / djOS | **Zaal** (per `feedback_dont_invent_outreach`) | Decision | This week |
+| If yes, log in `project_djos_relationship.md` memory + draft a single outreach message Zaal approves | Zaal | Memory + draft | Conditional |
+| Track djOS beta launch + pricing | n/a | Calendar / signup at djos.ai | Ongoing |
+| Monitor PulseDJ + VirtualDJ 2026 + DJ.Studio for category movement | n/a | Quarterly research | 2026-07-29 |
+| Add "live performance score" pattern to WaveWarZ design notes | Zaal | Design memo | When WaveWarZ V3 lands |
+
+## Also See
+
+- [Doc 432 - The ZAO master positioning](../../community/432-tricky-buddha-zao-master-context/) - artist-first frame
+- [Doc 475 - ZAO Music entity](../) - artist owns attribution
+- [Doc 530 - ZOUNZ artist trait brief](../../community/530-zounz-artist-trait-brief/)
+- [Doc 549 - 21st.dev hub](../../dev-workflows/549-21st-dev-component-platform/) - source of `/21st` for any DJ-facing UI we'd build
+- [Doc 557 - Onchain festival ticketing for ZAOstock](../../dev-workflows/557-onchain-festival-ticketing-zaostock/) - day-of festival infra
+- Memory `project_steve_peer` - Ellsworth drummer + ZAOstock co-curator; potential warm intro to indie-DJ world
+- Memory `feedback_dont_invent_outreach` - reason this doc proposes but doesn't draft outreach
+- Memory `feedback_no_unconfirmed_anchor_partners` - djOS is NOT confirmed; never list as anchor partner
+
+## Sources
+
+- [djOS official press release (wfmz.com)](https://www.wfmz.com/online_features/press_releases/djos-launches-patent-pending-ai-co-pilot-transforming-live-dj-performance-into-an-adaptive-experience/article_d2908a77-d3c8-54f0-bce1-cb559e68031a.html)
+- [djOS press release (einpresswire)](https://www.einpresswire.com/article/908159078/djos-launches-patent-pending-ai-co-pilot-transforming-live-dj-performance-into-an-adaptive-experience)
+- [djos.ai official site](https://djos.ai/)
+- [aimusicpreneur.com - djOS AI Co-Pilot](https://www.aimusicpreneur.com/ai-tools-news/djos-ai-co-pilot-live-dj-performance-2026/)
+- [PulseDJ blog - AI DJ Software](https://blog.pulsedj.com/ai-dj-software) - category context
+- [DJ.Studio - AI Workflows in 2026](https://dj.studio/blog/ai-workflows-djs-preparation-performance) - category context
+- [VirtualDJ 2026 AI features (gearnews)](https://www.gearnews.com/virtualdj-2026-dj/) - category context
+
+## Staleness Notes
+
+djOS announced 2 days before this doc. Pricing, beta access, and feature scope will evolve fast. Re-validate monthly until beta lands. If category shifts (PulseDJ acquires djOS, or vice versa), supersede this doc.


### PR DESCRIPTION
## Summary

4 separate STANDARD-tier research docs from a /zao-research batch on 4 URLs.

### 558 - Anbeeld WRITING.md
14-rule diagnostic toolkit for AI prose. 123 stars, no license stated.

**Verdict:** Lift principles (not text) into `/newsletter`, `/socials`, `/onepager` skills. Doc includes 5-rule Zaal-voice restatement.

### 559 - wetware/ww
P2P OS for autonomous agents. Rust, 16 stars, capability-based security, libp2p + Cap'n Proto + WASM.

**Verdict:** SKIP adoption (Rust, niche). Lift capability-token pattern as design principle for `src/lib/agents/runner.ts`.

### 560 - OpenWhisp
macOS local speech-to-text. MIT, 138 stars. Whisper Base + Ollama refinement.

**Verdict:** UNPARK from `project_research_followups_apr21`. Install on Mac. Pair with Doc 558 + `/newsletter` for voice-first content pipeline. Local-only fits `feedback_oss_first_no_platforms`.

### 561 - djOS AI DJ Co-Pilot
Patent-pending AI co-pilot for live DJs, announced 2026-04-27 by Cory Poccia. Integrates Serato/Rekordbox/Traktor/VirtualDJ. Crowd-heat-mapping via optical flow + audio source separation.

**Verdict:** Three ZAO angles —
1. ZAOstock Oct 3 pilot (only if their team on-call)
2. WaveWarZ live-performance score pattern lift (yes)
3. Outreach to Cory P (Zaal decides — per `feedback_dont_invent_outreach` this doc does NOT draft outreach)

## Tier
STANDARD per doc. 4 unrelated topics so no hub.

## Sources
~12 unique. GitHub APIs, npm-equiv URL fetches, press release coverage of djOS, category context (PulseDJ, VirtualDJ 2026, DJ.Studio).

## Next Actions
- Install OpenWhisp on Zaal's Mac (Doc 560)
- Update content skills with WRITING.md 5-rule check (Doc 558)
- Add capability-token check to agents/runner.ts review checklist (Doc 559)
- Zaal decides on djOS outreach (Doc 561)

## Related
432, 471, 475, 506, 530, 549, 555, 557