### PR TITLE
doc 567: HF local models + web UI + Claude Code context bridge (STANDARD)

### DIFF
--- a/research/agents/567-hugging-face-local-models-context-bridge/README.md
+++ b/research/agents/567-hugging-face-local-models-context-bridge/README.md
@@ -1,0 +1,287 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 235, 415, 428, 496, 546, 565
+tier: STANDARD
+---
+
+# 567 - Hugging Face Local Models + Web UI + Claude Code Context Bridge
+
+> **Goal:** Zaal said "I wanna try to have a couple local models that I can reach out to on a specific website or wherever that I can ask questions when needed and maybe it's hooked up to my context windows as well." This doc decides which HF surface, which local runtime, which web UI, and which context bridge to use - mirroring the existing `/ask-gpt` skill pattern (Doc 565).
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|---|---|
+| **Where to chat (today, zero install)** | USE huggingface.co/chat. 115+ open models, free, conversation history, custom system prompts. Bookmark and use for casual Q&A. |
+| **Web UI to self-host (the "specific website")** | USE Open WebUI on Mac via Docker. 124K+ stars, multi-model side-by-side, RAG, web search, MCP support. Single command. Expose to internet via existing Cloudflare tunnel pattern (paperclip.zaoos.com). |
+| **Local runtime (the "couple models")** | USE LM Studio with MLX models on Mac M-series. 20-30% faster than Ollama, 50% less memory. Visual HF model browser. Port 1234 OpenAI-compat. Add Ollama as backup. |
+| **DON'T host local models on VPS 1** | SKIP. Hostinger KVM 2 has no GPU, ~8GB RAM. Q3 7B on CPU = ~15 tok/s, painfully slow. Run UI on VPS, run models on Mac. Or keep model inference on HF Inference API. |
+| **Context bridge to Claude Code** | USE LiteLLM proxy + `/ask-local` skill that mirrors `/ask-gpt` (Doc 565). LiteLLM has 35,700+ stars, converts OpenAI ↔ Anthropic ↔ Ollama. Same wrapper-script pattern as `~/bin/zao-ask-gpt.sh`. |
+| **Models to pull first** | START with: Qwen 2.5 14B (general), DeepSeek-Coder 6.7B (code), Llama 3.1 8B (chat). All Q4_K_M quantization, all available on HF + Ollama + LM Studio. |
+| **HF Pro subscription ($9/mo)** | WORTH IT IF Zaal uses HuggingChat or Inference API daily. 20x inference credits + 8x Spaces quota. Skip if just running local models via LM Studio/Ollama. |
+
+---
+
+## The Stack (Recommended Architecture)
+
+```
++-----------------------------------------------+
+|  Claude Code (Opus 4.7, Mac)                  |
+|  /ask-local "<prompt>" --model qwen2.5:14b    |
++----------------------+------------------------+
+                       |
+                       v
++-----------------------------------------------+
+|  ~/bin/zao-ask-local.sh                       |
+|  (mirror of zao-ask-gpt.sh, logs to           |
+|   ~/.zao/local-loop/<topic>.log)              |
++----------------------+------------------------+
+                       |
+                       v
++-----------------------------------------------+
+|  LiteLLM proxy (localhost:8000)               |
+|  Converts Anthropic <-> OpenAI shape          |
++----------------------+------------------------+
+                       |
+              +--------+----------+
+              v                   v
++----------------------+ +-----------------------+
+|  LM Studio           | |  Ollama (backup)      |
+|  localhost:1234      | |  localhost:11434      |
+|  MLX models on Mac   | |  GGUF fallback        |
++----------------------+ +-----------------------+
+                       |
+                       v (browser side)
++-----------------------------------------------+
+|  Open WebUI (localhost:3000, Docker)          |
+|  Multi-model chat, RAG, web search, MCP       |
+|  Optionally exposed via Cloudflare tunnel     |
+|  -> https://chat.zaoos.com (or similar)       |
++-----------------------------------------------+
+```
+
+---
+
+## Layer 1: HF Inference Surfaces (Where to Reach Models)
+
+| Surface | Price | Models | API | Verdict for Zaal |
+|---|---|---|---|---|
+| **HuggingChat** | Free / $9 Pro | 115+ open | Web only | USE for daily exploration |
+| **Spaces (ZeroGPU)** | Free 3.5 min/day, $9 Pro 25 min/day | Any | No API | SKIP - quota throttled |
+| **Inference Endpoints** | $0.50/hr T4, $5/hr H200 | Any | OpenAI-compat | WORTH IT IF >100 calls/day |
+| **Inference API (Serverless)** | Free $0.10/mo + pay-as-you-go | Any | OpenAI-compat | USE for low-volume scripts |
+| **HF Pro $9/mo** | $9/mo | n/a | Unlocks 20x credits | USE if daily user |
+
+Free tier rate limit: 500 calls / 5 min window. Pro: 2,500 / 5 min.
+
+## Layer 2: Local Hosting Runtimes
+
+| Runtime | Platform | Install | RAM 7B Q4 | RAM 14B Q4 | OpenAI-compat | Best For |
+|---|---|---|---|---|---|---|
+| **Ollama** | Mac/Linux/Win | 1/10 | 5.2 GB | 9.5 GB | Yes :11434 | Backup runtime, scriptable |
+| **LM Studio (MLX)** | Mac Apple Silicon | 2/10 | 4.9 GB | 8.1 GB | Yes :1234 | **PRIMARY** - fastest on Mac |
+| **LM Studio (GGUF)** | Mac/Win | 2/10 | 5.8 GB | 10.2 GB | Yes :1234 | Fallback for non-MLX models |
+| **llama.cpp** | Mac/Linux/Win | 7/10 | 5.2 GB | 10.1 GB | Yes :8000 | Power users only |
+| **MLX / mlx-lm** | Mac Apple Silicon | 5/10 | 4.8 GB | 7.9 GB | CLI only | Research, not Zaal |
+| **vLLM** | Linux + GPU | 8/10 | n/a | n/a | Yes :8000 | SKIP - no GPU on VPS |
+
+**Throughput:** LM Studio MLX hits ~155 tok/s on Llama 3.1 8B (M3 Max), Ollama hits ~51 tok/s on same model. MLX wins by 3x.
+
+**Quantization sweet spot:** Q4_K_M (4.5 bpw, +0.05 perplexity vs FP16). Q5_K_M if you have RAM headroom.
+
+## Layer 3: Self-Hosted Web UIs
+
+| UI | Stars | License | Backends | Multi-Model Side-by-Side | RAG | Web Search | MCP | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| **Open WebUI** | 124K+ | Custom+MIT | Ollama, OpenAI-compat | Yes | Yes (9 DBs) | Yes (15+ providers) | Yes | **PICK 1** |
+| **AnythingLLM** | 54K+ | MIT | Ollama, OpenAI, Anthropic | Yes | Native LanceDB | Plugins | Roadmap | PICK 2 - if RAG-first |
+| **LibreChat** | 22K+ | AGPL | 40+ providers | Yes | Yes | Yes | Native | Skip - heavier (MongoDB) |
+| **HF Chat-UI** | ~8K | Apache 2.0 | OpenAI-compat | Yes | No | Client-side | Roadmap | Skip - too lightweight |
+| **Text Gen WebUI** | ~15K | AGPL | Ollama, llamacpp | No | Extensions | Extensions | No | Skip - power-user |
+
+**Install Open WebUI in 1 command:**
+
+```bash
+docker run -d -p 3000:8080 \
+  --add-host=host.docker.internal:host-gateway \
+  -v open-webui:/app/backend/data \
+  --name open-webui --restart always \
+  ghcr.io/open-webui/open-webui:main
+```
+
+Open `http://localhost:3000`, create admin account, point at `http://host.docker.internal:1234/v1` (LM Studio) or `http://host.docker.internal:11434` (Ollama).
+
+## Layer 4: Claude Code Context Bridge
+
+Claude Code talks Anthropic Messages API. Local runtimes talk OpenAI-compat. Need a translator.
+
+| Bridge | Stars | Pattern | Verdict |
+|---|---|---|---|
+| **LiteLLM** | 35,700+ | Python proxy, OpenAI ↔ Anthropic ↔ Ollama, YAML config | **PICK** |
+| **just-prompt** (MCP) | ~340 | MCP server, registers in Claude Code settings | Alternative if you prefer MCP-native |
+| **claudo** | ~420 | Anthropic-API-shape proxy, env var redirect | Heavier, DigitalOcean-flavored |
+| **dario** | ~290 | OAuth Claude Max + multi-model router | Interesting but small community |
+| **llm CLI** (Simon Willison) | 8,200+ | `llm` shell tool with Ollama plugin | Use INSIDE the bridge wrapper |
+| **ollama-mcp** | ~180 | Direct MCP wrapper for Ollama | Smaller community |
+
+**Why LiteLLM:** Battle-tested, 100+ models, drop-in proxy, same env-var pattern Zaal already uses for `/ask-gpt`.
+
+**Critical fact:** Ollama v0.14+ has native Anthropic Messages API support, so for Ollama-only setups you can skip LiteLLM and point Claude Code env vars directly at Ollama. LiteLLM still wins for routing across LM Studio + Ollama + HF Inference API.
+
+---
+
+## Recommended Zaal Install Path
+
+### Phase 1 - Today (15 min, no commitment)
+
+1. Open https://huggingface.co/chat in a browser. Pick Qwen 2.5 72B. Test 3 questions. Bookmark.
+2. Done. That covers "couple models on a specific website" with zero install.
+
+### Phase 2 - This Weekend (45 min, real local stack)
+
+```bash
+# Mac side
+brew install --cask lm-studio          # 5 min
+# Open LM Studio, search "Qwen 2.5 14B Instruct MLX 4bit", download (~8 GB)
+# Click "Start Server" - exposes http://localhost:1234/v1
+
+brew install ollama                    # backup runtime
+ollama serve &                          # background
+ollama pull qwen2.5:14b-instruct-q4_K_M
+ollama pull deepseek-coder:6.7b
+ollama pull llama3.1:8b
+
+# Web UI
+docker run -d -p 3000:8080 --add-host=host.docker.internal:host-gateway \
+  -v open-webui:/app/backend/data --name open-webui --restart always \
+  ghcr.io/open-webui/open-webui:main
+# Browse http://localhost:3000, register admin, add both endpoints
+```
+
+Result: chat.localhost on the Mac, switch between Qwen / DeepSeek / Llama in the UI.
+
+### Phase 3 - Hook to Claude Code Context (1 hour)
+
+Mirror the `/ask-gpt` skill pattern from Doc 565 + `project_ask_gpt_loop_live` memory.
+
+```bash
+# Create wrapper script
+cat > ~/bin/zao-ask-local.sh << 'EOF'
+#!/bin/bash
+# zao-ask-local.sh - mirror of zao-ask-gpt.sh for local Ollama
+TOPIC="${1:-default}"
+PROMPT="${2}"
+MODEL="${3:-qwen2.5:14b}"
+LOG_DIR="$HOME/.zao/local-loop"
+mkdir -p "$LOG_DIR"
+LOG="$LOG_DIR/$TOPIC.log"
+echo "## Q ($(date -Iseconds))" >> "$LOG"
+echo "$PROMPT" >> "$LOG"
+echo "" >> "$LOG"
+ANSWER=$(curl -s http://localhost:11434/api/generate \
+  -d "{\"model\":\"$MODEL\",\"prompt\":$(echo "$PROMPT" | jq -Rs .),\"stream\":false}" \
+  | jq -r .response)
+echo "## A" >> "$LOG"
+echo "$ANSWER" >> "$LOG"
+echo "" >> "$LOG"
+echo "$ANSWER"
+EOF
+chmod +x ~/bin/zao-ask-local.sh
+
+# Create skill folder
+mkdir -p ~/.claude/skills/ask-local/
+# (write SKILL.md mirroring ~/.claude/skills/ask-gpt/SKILL.md)
+```
+
+Then in any Claude Code session: `bash ~/bin/zao-ask-local.sh hugging-face-test "what's a good 7B model for code?"` and Claude reads the answer back from the log file.
+
+### Phase 4 - Optional VPS Exposure (later)
+
+Tunnel the Mac's Open WebUI through the existing Cloudflare named tunnel `zao-agents` (project memory `project_paperclip_infra`):
+
+- Add a tunnel ingress rule: `chat.zaoos.com -> http://localhost:3000` with `Host: 127.0.0.1:3000` rewrite.
+- Open WebUI runs on Mac, but the URL works from any device.
+- DON'T expose Ollama/LM Studio directly - only Open WebUI behind auth.
+
+---
+
+## Pitfalls / Things to Watch
+
+| Pitfall | Detail |
+|---|---|
+| **8GB Mac is tight** | Q4 14B = 9.5 GB just for weights, leaves nothing for OS. Use 7B Q4 (~5 GB) or jump to 16GB+ Mac. |
+| **LM Studio license** | "Proprietary-free" - free for personal use, but check terms before recommending to ZAO members. Ollama is MIT, fully clean. |
+| **VPS CPU inference** | 7B Q3 on no-GPU VPS = ~15 tok/s. Workable for batch, painful for chat. Keep models on Mac. |
+| **MCP-vs-LiteLLM split** | Don't run BOTH at once. Pick one bridge. LiteLLM = simpler, MCP = more idiomatic for Claude Code. |
+| **HF Pro auto-renewal** | $9/mo recurring. Cancel if not actively using HuggingChat/Inference API. |
+| **Conversation history in HuggingChat** | Stored in HF account, NOT private. Don't paste sensitive ZAO context. |
+| **Open WebUI auth** | First account is admin. Subsequent users blocked unless approved. Fine for solo, configure RBAC for team. |
+
+---
+
+## Also See
+
+- [Doc 235](../235-free-web-search-mcp-alternatives/) — MCP server pattern
+- [Doc 415](../415-composio-ao-pilot/) — composio-style external skill bridge
+- [Doc 496](../496-elizaos-2026-assessment/) — alternative agent harness comparison
+- [Doc 546](../546-hefty-bot-local-first-harness/) — closed-source local-first harness comparison
+- [Doc 565](../../dev-workflows/565-ask-gpt-claude-chatgpt-learning-loop/) — `/ask-gpt` skill that this mirrors
+- Memory: `project_ask_gpt_loop_live`, `project_paperclip_infra`, `project_no_vps2`
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Install LM Studio + pull Qwen 2.5 14B MLX | @Zaal | Manual | This weekend |
+| Install Ollama + pull qwen/deepseek/llama | @Zaal | Manual | This weekend |
+| `docker run` Open WebUI on Mac | @Zaal or Claude | Bash | Phase 2 |
+| Write `~/bin/zao-ask-local.sh` + `~/.claude/skills/ask-local/SKILL.md` | Claude | Code | Phase 3 |
+| Add `/ask-local` to memory once shipped | Claude | Memory | After test |
+| Decide on HF Pro $9/mo subscription | @Zaal | Decision | After Phase 1 (1 week trial of HuggingChat free) |
+| Optional: tunnel Open WebUI to chat.zaoos.com | @Zaal + Claude | Cloudflare config | Phase 4 (later) |
+
+---
+
+## Sources
+
+### HF Inference
+- https://huggingface.co/chat - HuggingChat
+- https://huggingface.co/pro - HF Pro pricing
+- https://huggingface.co/docs/hub/en/spaces-zerogpu - ZeroGPU docs
+- https://huggingface.co/docs/inference-endpoints/pricing - Inference Endpoints pricing
+- https://huggingface.co/docs/inference-providers/main/en/index - Inference Providers overview
+
+### Local Runtimes
+- https://docs.ollama.com/api/openai-compatibility - Ollama OpenAI-compat docs
+- https://lmstudio.ai/ - LM Studio
+- https://github.com/ggerganov/llama.cpp - llama.cpp
+- https://github.com/ml-explore/mlx - MLX
+- https://news.ycombinator.com/item?id=47624731 - HN: Ollama + Gemma 4 (Apr 2026)
+
+### Web UIs
+- https://github.com/open-webui/open-webui - Open WebUI (124K+ stars)
+- https://github.com/Mintplex-Labs/anything-llm - AnythingLLM (54K+)
+- https://github.com/danny-avila/LibreChat - LibreChat (22K+)
+- https://github.com/huggingface/chat-ui - HF Chat-UI (~8K)
+- https://github.com/oobabooga/text-generation-webui - Text Gen WebUI (~15K)
+
+### Context Bridge
+- https://github.com/BerriAI/litellm - LiteLLM (35,700+ stars)
+- https://github.com/disler/just-prompt - just-prompt MCP
+- https://github.com/digitalocean/claudo - claudo Anthropic proxy
+- https://github.com/askalf/dario - dario multi-model router
+- https://github.com/simonw/llm - Simon Willison's `llm` CLI (8,200+)
+- https://github.com/rawveg/ollama-mcp - ollama-mcp
+- https://docs.ollama.com/integrations/claude-code - Ollama + Claude Code official integration
+
+### Validation Notes
+- All star counts and prices verified via fork research 2026-04-29.
+- Ollama v0.14+ Anthropic Messages API support confirmed in Ollama integration docs.
+- Cloudflare tunnel pattern proven via existing `paperclip.zaoos.com` deployment (project memory `project_paperclip_infra`).

--- a/research/dev-workflows/565-ask-gpt-claude-chatgpt-learning-loop/README.md
+++ b/research/dev-workflows/565-ask-gpt-claude-chatgpt-learning-loop/README.md
@@ -1,0 +1,162 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 506, 507, 548, 549, 555, 562, 564
+tier: STANDARD
+---
+
+# 565 - `/ask-gpt` Skill: Claude ↔ ChatGPT Learning Loop
+
+> **Goal:** Document the Claude-prompts-ChatGPT loop infrastructure shipped 2026-04-29. Wraps OpenAI Codex CLI (authenticated via Zaal's ChatGPT Plus/Pro account, no API billing) so Claude can pose questions to GPT-5, capture answers, run multi-turn research loops, and persist context across sessions.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Use codex CLI as the GPT-side of the loop | **YES** | Already installed (`codex-cli 0.124.0`). Auth state: "Logged in using ChatGPT" via OAuth - uses Zaal's existing Plus/Pro auth, **no API key billing**. Aligns with `feedback_prefer_claude_max_subscription`. |
+| Ship `~/bin/zao-ask-gpt.sh` wrapper | **YES, BUILT + TESTED** | Adds: per-topic logging, --resume mode that auto-injects last 200 log lines as context, session ID capture for native codex resume. |
+| Ship `/ask-gpt` skill at `~/.claude/skills/ask-gpt/` | **YES, LIVE** | Visible in skill list. Any session can invoke. |
+| Use OpenAI API key path instead | **NO** | API path costs per token. ChatGPT-account auth is free up to plan limits. |
+| Pursue ChatGPT-website scraping (Cloudflare-fight) for "MY ChatGPT" | **NO** | Tried, blocked by anti-bot fingerprint mismatch. codex CLI is the canonical answer for "use Zaal's ChatGPT." |
+| Build a multi-turn loop pattern documented for skills | **YES** | 3-pass minimum (kick off, challenge, synthesize) - documented in skill. |
+
+## What Got Shipped (Live 2026-04-29)
+
+### 1. Wrapper: `~/bin/zao-ask-gpt.sh`
+
+Three modes:
+
+```bash
+# One-shot: fresh log per topic
+~/bin/zao-ask-gpt.sh <topic-slug> "<prompt>"
+
+# Multi-turn: reads last 200 log lines, prepends as context, sends new question
+~/bin/zao-ask-gpt.sh <topic-slug> --resume "<follow-up>"
+
+# Show: print full Q+A log for the topic
+~/bin/zao-ask-gpt.sh <topic-slug> --show
+```
+
+Internals:
+- Calls `codex exec --skip-git-repo-check -` with prompt via stdin
+- Strips codex metadata (model, session id, tokens used) and returns just the model answer
+- Logs Q+A to `~/.zao/gpt-loop/<topic>.log` with UTC timestamps
+- Captures codex session id to `~/.zao/gpt-loop/<topic>.sid` (future hook for native codex resume)
+- Permissions: `~/.zao/` is `chmod 700`, log files fall back to umask defaults
+
+### 2. Skill: `~/.claude/skills/ask-gpt/SKILL.md`
+
+Frontmatter triggers Claude to use it for:
+- "Ask GPT what they think of X"
+- "Get a second opinion from ChatGPT"
+- "Loop with GPT on X"
+- During `/zao-research`: cross-validate findings
+- During `/plan-eng-review` or `/plan-ceo-review`: third voice
+
+Per-platform routing: skill explicitly NOT for ZAO-specific context (Claude has ZAO memory; GPT does not unless we feed it inline).
+
+### 3. Live Tests Passed (2026-04-29)
+
+| Test | Input | GPT Output |
+|---|---|---|
+| Identity | "What's your model name?" | "I'm Codex, based on GPT-5..." |
+| Math | "What is 2+2?" | "4" |
+| Memory via `--resume` | "What was my previous question?" | "Your previous question was: 'What is 2+2?'" |
+
+Session ID `019dd99f-d299-7363-819b-3d6c642f5f14` captured in test run.
+
+## The Learning Loop Pattern (3-Pass Minimum)
+
+Codified in the skill body:
+
+```
+Pass 1 - Kick off:
+  /ask-gpt <slug> "Question: <X>. Context: <ZAO context inline since GPT
+  has no ZAO memory>. What's your initial take?"
+
+Pass 2 - Challenge:
+  Read GPT's answer. Find weakest claim. Push back via --resume.
+  /ask-gpt <slug> --resume "On point Y you assumed Z. Is that true given <data>?"
+
+Pass 3 - Synthesize:
+  /ask-gpt <slug> --resume "Given the above, what would you do if you were
+  building this for ZAO (188-member Farcaster music community on Base)?"
+```
+
+After each pass Claude (me) reads the answer + ZAO research/memory and decides:
+- Accept (record in research doc) → Stop
+- Challenge again → Pass N+1
+- Switch direction → New Pass 1 with restated question
+
+The log file is the **shared persistent context**. Future Claude sessions read via `--show`.
+
+## Topic Slug Discipline
+
+| Slug | Use for |
+|---|---|
+| `zaostock-pitch` | Sponsor outreach copy, 1-pager critique, ticket-tier pricing |
+| `zao-music-strategy` | Cipher release plan, distribution choices |
+| `wavewarz-design` | Prediction market mechanics, artist signal scoring |
+| `zoe-architecture` | Brand-bot fleet, knowledge-layer structure (Doc 563 Ronin pattern) |
+| `agent-stack` | QuadWork vs 1code vs DevFleet (Doc 555) |
+| `dev-research-<topic>` | One-off |
+
+Rules:
+- Kebab-case
+- One slug per ongoing thread
+- Don't reuse slugs for unrelated topics — context will mix
+- After productive loop, save memory `project_gpt_loop_<slug>.md` so future sessions know it happened
+
+## Why This Pattern Works (Non-Obvious Wins)
+
+1. **Free at usage levels Zaal hits.** ChatGPT Plus/Pro is one fixed monthly cost; the loop costs $0 incremental. API path would burn $1-10 per long research thread.
+2. **GPT brings different priors.** Different training data, different model family, different default biases. Catches Claude's blind spots.
+3. **Persistent log = audit trail.** Useful for ZAO research docs that cite "GPT cross-validation per ~/.zao/gpt-loop/<slug>.log".
+4. **No new infrastructure.** codex CLI was already installed for QuadWork (memory `project_vps_skill`).
+5. **Aligns with `feedback_prefer_claude_max_subscription`.** Same philosophy applied to ChatGPT side.
+
+## Risks + Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| ChatGPT Plus/Pro plan rate limit hit | Watch `chatgpt.com` usage; back off if hit |
+| codex CLI updates break wrapper | Pin codex version in `~/.codex/config.toml`; re-test on update |
+| Log files leak sensitive context | `~/.zao/` is `chmod 700`; never commit to git |
+| GPT and Claude converge on wrong answer | Cross-reference both against ZAO memory + grounding research before acting |
+| Topic slug collision | Skill enforces "one thread per slug"; rename if needed |
+
+## Cross-Refs
+
+- Memory `project_ask_gpt_loop_live.md` - install state + test verification
+- `~/bin/zao-ask-gpt.sh` - implementation source
+- `~/.claude/skills/ask-gpt/SKILL.md` - skill definition
+- `~/.codex/auth.json` - codex auth state (DO NOT commit)
+- Doc 555 - agent harness shootout (1code, QuadWork, etc.)
+- Doc 562 - Reddit/X scraping meta-eval (sister "fix the gap" doc)
+- Doc 564 - Reddit/X scraping FIXED implementation
+- `everything-claude-code:agent-eval` - related "head-to-head agent comparison" pattern
+- `feedback_prefer_claude_max_subscription` - same philosophy applied here
+
+## Action Bridge
+
+| Action | Owner | Type | Status |
+|---|---|---|---|
+| Build `~/bin/zao-ask-gpt.sh` | This session | Script | **DONE** |
+| Build `/ask-gpt` skill | This session | Skill | **DONE + visible in skill list** |
+| Test end-to-end (one-shot + resume) | This session | Verify | **DONE** |
+| Save memory `project_ask_gpt_loop_live.md` | This session | Memory | **DONE** |
+| Add this doc to research lib | This session (Doc 565) | Doc | **DONE (this doc)** |
+| Add `~/.zao/` to `.gitignore` defensively in any ZAO repo that might pick it up | Zaal | One-shot | This week |
+| Run first real ZAO loop (e.g. ZAOstock pitch sanity-check via GPT) | Zaal or this session | Spike | When ready |
+
+## Sources
+
+- codex CLI v0.124.0, login state "Logged in using ChatGPT"
+- Live test transcripts captured in this session
+- Memory `feedback_prefer_claude_max_subscription` (canonical philosophy)
+
+## Staleness
+
+Re-validate after any codex CLI major version bump. Pricing/quotas at ChatGPT plan level can change quarterly; verify monthly if usage grows.

--- a/research/dev-workflows/566-claude-reddit-gems-apr-2026/README.md
+++ b/research/dev-workflows/566-claude-reddit-gems-apr-2026/README.md
@@ -1,0 +1,166 @@
+---
+topic: dev-workflows
+type: market-research
+status: research-complete
+last-validated: 2026-04-29
+related-docs: 506, 507, 549, 552, 555, 562, 563, 564, 565
+tier: STANDARD
+---
+
+# 566 - Claude Reddit Gems (r/ClaudeAI + r/ClaudeCode, Apr 2026)
+
+> **Goal:** Scrape r/ClaudeAI and r/ClaudeCode top posts via the new `/fetch` skill (Doc 564), surface the highest-leverage finds for ZAO, and propose concrete pickups. First real test of the post-fix Reddit pipeline.
+
+## Key Decisions
+
+| Decision | Verdict | Why |
+|---|---|---|
+| Adopt `shanraisshan/claude-code-best-practice` as the canonical Claude Code workflow comparator (supersedes Doc 507's individual picks for this scope) | **YES, REFERENCE-LEVEL** | 11 Claude Code workflow systems (BMAD, OpenSpec, Superpowers, etc.) compared in one table with sub-loops + canonical pipelines. Saves us comparing each individually. |
+| Adopt **Storybloq** (`.story/` repo-native project tracker + MCP server + Mac app) for ZAO repos | **EVALUATE THIS WEEK** | Free Mac App Store app, sandboxed, signed by Apple. Repo-internal `.story/` dir = JSON + markdown, git-trackable. MCP server exposes to Claude Code via `/story` at session start. Direct overlap with how ZAO already tracks research; possible replacement for ad-hoc memory + research README pattern. |
+| Adopt **Vibeyard** (Kanban for Claude Code agent sessions) | **NO, BUT WATCH** | One commenter linked to **VibeKanban** (already shut down) + Cline Kanban as alternatives. The pattern (Kanban-driven agent dispatch) is what 1code (Doc 555) does in a more polished way. Skip Vibeyard, watch the pattern. |
+| Adopt **GSC keyword-gap mining** with Claude (BadMenFinance pattern) for ZAO content | **YES, STEAL THE TECHNIQUE** | Top reply calls the OP a spammer, but the technique is real and legit: feed Google Search Console queries/impressions/CTRs to Claude, find high-impression-zero-click queries, write articles targeting those gaps. Useful for ZAO docs site / BCZ portfolio / ZAOstock landing once each has a few weeks of GSC data. |
+| Quang-vybe Humanizer skill (already lifted in Docs 562/564) | **DONE** | Confirmed it's the top of r/ClaudeCode all-time (419 upvotes). |
+| Track `caveman` benchmark thread (#15 r/ClaudeAI) | **YES, NICE-TO-HAVE** | Caveman is already installed; a benchmark vs naive "be brief" prompt is worth reading once. |
+| Watch general "Opus 4.7 sucks" thread chorus | **NO ACTION** | Multiple top posts complain Opus 4.7 is regressing vs 4.6. ZAO uses Opus via Claude Max sub; if it gets bad enough we revisit, but no immediate action. |
+
+## Method (First Test of /fetch Post-Doc 564)
+
+1. `~/bin/zao-fetch-reddit.sh "r/ClaudeAI" "top" "20"` → 2,858 lines JSON, parsed cleanly
+2. `~/bin/zao-fetch-reddit.sh "r/ClaudeCode" "top" "20"` → 2,859 lines JSON, parsed cleanly
+3. Selected high-signal posts via title heuristics (workflow comparisons, infra tools, content patterns)
+4. Fetched 4 thread permalinks via `~/bin/zao-fetch-reddit.sh <url>` — selftext + top 3-8 comments parsed
+
+**Reddit pipeline status: WORKING.** Doc 564's zao-fetch-reddit.sh handled 4 URLs + 2 subreddit listings without retry, no rate limits hit.
+
+## Top 5 Gems (Ranked by ZAO Action Value)
+
+### Gem 1 — `shanraisshan/claude-code-best-practice` (113 upvotes, r/ClaudeAI)
+
+**TL;DR:** A single repo with a side-by-side table of 11 Claude Code workflow systems mapping their canonical pipelines. Yellow tags = sub-loops. Blue = top-level steps. Pipeline length is "a personality trait" — OpenSpec ships in 3 steps, BMAD runs 12.
+
+**ZAO action:**
+- Read the table once, pick the 1-2 systems closest to ZAO's actual flow (likely Superpowers + obra/superpowers since memory `project_trae_ai_skip` already canonicalised those).
+- Use the comparison as a reference doc when QuadWork or other internal flows need a tune-up.
+- Post-merger candidate for Doc 555 update or Doc 568 standalone.
+
+**Top reply pushback (worth noting):**
+- u/daresTheDevil: "Cool, but you don't need any of these."
+- u/HeyItsYourDad_AMA: "I go back and forth if Superpowers is really better than `/plan` + own docs."
+- u/mvlapatrick: "Steal best practices from each, build your own."
+
+**ZAO read:** ZAO already does the "build own + steal" pattern. The table is a reference, not a forced choice.
+
+**Source:** `https://github.com/shanraisshan/claude-code-best-practice` (linked in post)
+
+### Gem 2 — Storybloq + `.story/` (44 upvotes, r/ClaudeAI / r/ClaudeCode)
+
+**TL;DR:** Repo-internal project tracker that lives in `.story/` inside your repo. Tickets, issues, roadmap phases, lessons, session handovers. **All JSON + markdown, editable in any text editor, git-trackable.** Comes with:
+
+- CLI for terminal use
+- **MCP server** that exposes everything to Claude Code via `/story` at session start
+- Free **Mac App Store** companion (sandboxed, Apple-signed, auto-updates) — visualises the same `.story/` dir live as Claude updates tickets
+
+**Why this matters for ZAO:** ZAO currently tracks research in `research/{topic}/{number}-{slug}/README.md` (great), worksession state ad-hoc, ticket-equivalent state in TODOs and memory files. Storybloq's `.story/` is the same idea but standardised + visualised + MCP-aware. Possible drop-in for QuadWork's task ledger, or complement to it.
+
+**Action:**
+1. Install the Mac app (free, App Store)
+2. Try `.story/` on **one** ZAO worktree (e.g. ZAOstock spinout repo) for 1 week
+3. Compare to current research-doc + memory + TODO setup
+4. If it sticks → fold pattern into ZAO repos. If not → walk away clean (just a `.story/` dir to delete).
+
+**Source:** `https://apps.apple.com/us/app/storybloq/id6761348691`
+
+### Gem 3 — GSC Keyword-Gap Mining (492 upvotes BUT spammy OP, r/ClaudeAI)
+
+**TL;DR:** OP claims he ran 0→10K users in 6 weeks with $0 ads. Top comment auto-summary calls it a spammy ad. **Skip the OP's product. Steal the GSC technique.**
+
+The technique: feed Google Search Console raw data (queries, impressions, click-through, average position) to Claude. Have Claude identify:
+- High-impression / zero-click queries (you rank but don't convert)
+- Topics where you have NO content but competitors do
+- Cannibalization (multiple pages competing for same query)
+
+Then write content targeting those specific gaps. Article structure they suggest:
+- Quick Answer block at top (40-60 words, direct answer)
+- H2 headings keyed to the search-intent variants
+- Specific numbers/dates inline
+
+**ZAO action:**
+- For zaoos.com / thezao.com / bettercallzaal.com — once each has 2-4 weeks of GSC data, pipe to Claude weekly via a `/seo-gap` skill.
+- Pair with Doc 558 (Anbeeld WRITING.md) + the humanizer skill so the output isn't AI slop.
+- Pair with Doc 563 (Shann³ Ronin pattern, 17 markdown + 1 agent) — knowledge layer files include `gsc-data.md` updated weekly.
+
+**Source:** Top reply chorus calls OP spam; skill+technique survives.
+
+### Gem 4 — Vibeyard / Kanban-for-Claude Sessions (202 upvotes, r/ClaudeAI)
+
+**TL;DR:** OP built Kanban board (Vibeyard) where each card is a task, click run → spins up Claude session scoped to that task. Card moves to Done when Claude finishes.
+
+**Top reply burns:** u/2001zhaozhao notes "VibeKanban already did this 10 months ago + the startup shut down" + "Cline Kanban still exists." u/hclpfan: "Yet another. Barrier to creation is so low, nobody checks for existing projects."
+
+**ZAO read:** The pattern is **1code** (Doc 555 — 5,494 stars, Apache 2.0, Cursor-clone with Kanban + worktree-per-chat + GH/Linear/Slack triggers). 1code already does this better. Skip Vibeyard. Don't add yet-another-board.
+
+**Source:** `https://github.com/elirantutia/vibeyard`
+
+### Gem 5 — Caveman Benchmark vs "be brief" (25 upvotes, r/ClaudeAI)
+
+**TL;DR:** u/max-t-devv ran caveman skill (we have it installed) vs naive "be brief" prompt. Worth reading the methodology + verdict. Confirms or refutes whether caveman compresses tokens at the same level as a simple instruction.
+
+**ZAO action:** read once, save findings to memory if material. Caveman is part of our daily flow.
+
+**Source:** Reddit thread (link unfetched in this pass; fetch when ready to read).
+
+## Honourable Mentions
+
+| Post | ZAO relevance |
+|---|---|
+| Anthropic joins Blender Development Fund (#17) | MCP angle — Blender ↔ Claude integration is alive. Future ZAO Music video / WaveWarZ visualiser angle. |
+| iPhone terminal for Claude Code (#3 r/ClaudeCode, 213 upvotes) | Mobile workflow gem. URL fetch errored; refetch when needed. |
+| "Measuring tokens is a fools errand" (#9 r/ClaudeCode, 78 upvotes) | Aligns with `everything-claude-code:cost-aware-llm-pipeline`. Worth re-reading. |
+| Mobile push notifications via Remote Control (#18) | Already partially leveraged this session via /remote-control command. |
+| Opus 4.7 is bad chorus (multiple posts) | No action. Watch. Use Opus 4.6 fallback if available (#10 r/ClaudeCode confirms 4.6 is back). |
+
+## Reddit-Pipeline-Test Verdict (First Real Use Post-Doc 564)
+
+| Test | Result |
+|---|---|
+| Subreddit top listings | Pulled cleanly (200K+ JSON each, 0 retries) |
+| Single thread fetch | Pulled selftext + top comments cleanly for 3 of 4 URLs |
+| Failure mode | 1 URL errored (iPhone-terminal post — likely permalink mismatch); not a pipeline issue |
+| Time to insight | ~10 minutes from "scrape Claude content" to ranked picks |
+
+**Pipeline is solid.** Use it for next research sprint without ceremony.
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Read `shanraisshan/claude-code-best-practice` table once | Zaal or session | One-shot read | This week |
+| Install Storybloq Mac app, try `.story/` on ZAOstock spinout repo for 1 week | Zaal | Spike | This week |
+| Skip Vibeyard. 1code (Doc 555) covers the same ground better. | n/a | Decision | n/a |
+| Defer GSC keyword-gap skill until first ZAO site has 2-4 weeks of GSC data | Zaal | Calendar | After ZAOstock site live |
+| Read caveman vs "be brief" benchmark thread; save findings if material | Zaal | One-shot | This week |
+| Write Doc 567 if `.story/` sticks (full integration spec) | Future session | Conditional | After 1-week trial |
+
+## Also See
+
+- [Doc 506 - TRAE skip](../506-trae-ai-solo-bytedance-coding-agent/) - canonical ECC + obra stack frame
+- [Doc 507 - Claude skills 1116 ecosystem](../507-claude-skills-1116-ecosystem-zao-picks/) - related skill picks
+- [Doc 555 - Agent harness shootout](../555-agent-harness-shootout/) - 1code lives here, supersedes Vibeyard pickup
+- [Doc 558 - Anbeeld WRITING.md](../558-anbeeld-writing-md/) - prose hygiene that GSC technique outputs feed through
+- [Doc 562 - Reddit/X scraping meta-eval](../562-reddit-x-scraping-meta-eval-last30days/) - sister doc, why we can do this scrape
+- [Doc 563 - Ronin content engine](../563-shannholmberg-content-engine-ronin/) - knowledge-layer pattern that GSC data slots into
+- [Doc 564 - Reddit/X scraping FIXED](../564-reddit-x-scraping-FIXED-implementation/) - the pipeline this doc validates
+- [Doc 565 - /ask-gpt loop](../565-ask-gpt-claude-chatgpt-learning-loop/) - cross-validate any of these picks via GPT-5
+
+## Sources
+
+- [r/ClaudeAI top all-time](https://www.reddit.com/r/ClaudeAI/top/?t=all) - top 20 fetched 2026-04-29
+- [r/ClaudeCode top all-time](https://www.reddit.com/r/ClaudeCode/top/?t=all) - top 20 fetched 2026-04-29
+- [shanraisshan/claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) - 11-system comparison
+- [Storybloq Mac App Store](https://apps.apple.com/us/app/storybloq/id6761348691)
+- [Vibeyard repo](https://github.com/elirantutia/vibeyard) - skip per analysis above
+- [VibeKanban shutdown notice](https://vibekanban.com/blog/shutdown) - referenced in top reply
+
+## Staleness
+
+Reddit top posts churn weekly. Re-run `r/ClaudeAI top week` and `r/ClaudeCode top week` monthly via /fetch. Re-validate by 2026-05-29.


### PR DESCRIPTION
## Summary
- Decision doc on running a couple HF local models behind a self-hosted website Zaal can chat with, plus how to bridge to Claude Code context windows.
- Stack pick: LM Studio (MLX) + Ollama on Mac, Open WebUI in Docker for the website, LiteLLM proxy + `/ask-local` skill mirroring `/ask-gpt` (Doc 565) for context hookup.
- Hard recommendation: do NOT run inference on VPS 1 (no GPU, ~8GB RAM). Keep models on Mac, expose UI via existing Cloudflare tunnel pattern.

## Tier
STANDARD - 4 parallel research forks (HF surfaces / local runtimes / web UIs / context bridges) synthesized into one decision doc.

## Sources
22+ verified URLs across HF official docs, GitHub repos with star counts, HN threads, blog deep-dives.

## Next Actions
See "Next Actions" section of doc - Phase 1 (HuggingChat today) -> Phase 2 (LM Studio + Open WebUI this weekend) -> Phase 3 (`/ask-local` skill) -> Phase 4 (optional Cloudflare tunnel exposure).