### PR TITLE
feat(stock): redirect /stock/* to zaostock.com after spinout

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -124,6 +124,16 @@ function addSecurityHeaders(response: NextResponse, nonce?: string, pathname?: s
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
+  // ZAOstock spinout: redirect /stock/* and /api/stock/* to zaostock.com
+  // Project graduated 2026-04-29. Live at https://zaostock.com.
+  if (pathname === '/stock' || pathname.startsWith('/stock/') || pathname.startsWith('/api/stock/')) {
+    const newPath = pathname
+      .replace(/^\/api\/stock/, '/api')
+      .replace(/^\/stock/, '');
+    const target = `https://zaostock.com${newPath || '/'}${request.nextUrl.search}`;
+    return NextResponse.redirect(target, 301);
+  }
+
   // Fast path for page routes — skip rate limiting entirely, just add headers
   if (!pathname.startsWith('/api/')) {
     const nonce = generateNonce();


### PR DESCRIPTION
## Summary

ZAOstock graduated from ZAOOS to its own repo + Supabase + Vercel deploy on 2026-04-29. Live at https://zaostock.com.

This PR adds a 301 redirect in middleware so any bookmark or external link to `/stock/*` or `/api/stock/*` lands on the new domain.

## Migration status

- New repo: bettercallzaal/zaostock
- New Supabase: yjrlaxpjusmrfylumban (22 tables, 210 rows migrated)
- New Vercel deploy: zaostock.com live
- Redirect: this PR

## What this preserves

- Bookmarked `/stock/team` -> https://zaostock.com/team
- `/stock/sponsor` -> https://zaostock.com/sponsor
- `/stock/onepagers/overview` -> https://zaostock.com/onepagers/overview
- API paths under `/api/stock/*` -> `https://zaostock.com/api/*`

## What this does NOT affect

- The Telegram bot reads Supabase directly (not via /api/stock), so no bot changes needed
- All other ZAOOS routes (chat, music, governance) untouched

## Next (after this merges)

- 48h verification window to confirm zaostock.com handles all traffic
- Then delete `src/app/stock/`, `src/app/api/stock/`, `src/lib/stock/`, `src/lib/auth/stock-team-session.ts` from ZAOOS

## Test plan

- [ ] Visit /stock on zaoos.com -> should 301 to https://zaostock.com/
- [ ] Visit /stock/team on zaoos.com -> should 301 to https://zaostock.com/team
- [ ] All other ZAOOS routes still work