### PR TITLE
doc 573: where AVAX ecosystem helps $ZABAL — Arena, music rails, Retro9000

### DIFF
--- a/research/business/573-zabal-avax-surfaces-arena-music/README.md
+++ b/research/business/573-zabal-avax-surfaces-arena-music/README.md
@@ -1,0 +1,211 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-04-30
+related-docs: 572, 475, 553
+tier: STANDARD
+---
+
+# 573 — Where AVAX Ecosystem Helps $ZABAL: The Arena, Music Royalties, Retro9000
+
+> **Goal:** Find Avalanche-native surfaces that benefit $ZABAL and the ZAO music economy WITHOUT launching a chain. Companion to Doc 572 (which said "don't launch a chain in 2026").
+
+## Key Decisions (read first)
+
+| Decision | Recommendation | Reason |
+|----------|----------------|--------|
+| Should ZAO be on The Arena? | **YES — make it a 2026-Q3 push** | 200K+ users, $6M+ paid to creators, 70% of trade fees stream to creator perpetually, ZAO's exact thesis (creator monetization) |
+| Should $ZABAL get tip-whitelisted on Arena? | **YES — prerequisite is more market cap + ICTT bridge to C-Chain** | Arena auto-adds tipping tokens at certain MC thresholds; ZABAL is currently on Base, must bridge first |
+| Mirror Record Financial royalty model for ZAO Music? | **STUDY, don't copy yet** | Real-time USDC royalty settlement on Avalanche is exactly what ZAO Music + Cipher needs. Talk to them, learn pattern, evaluate vs 0xSplits-on-Base |
+| Apply for Retro9000 C-Chain grants? | **YES — once ZAO activity drives real AVAX burn** | $40M retroactive program, $200K lifetime cap per project, eligibility = AVAX burned in fees. Free money for activity ZAO would do anyway |
+| Beam (gaming subnet)? | **SKIP** | Off-thesis — ZAO is music/creator/community, not gaming |
+| Salvor NFT marketplace? | **PARK** | Fine for ZAO art drops, but no obvious ZABAL activation; revisit if ZAO does an NFT series |
+| Pharaoh DEX? | **YES if/when ZABAL bridges to Avalanche C-Chain** | $51.7M TVL, central liquidity hub on Avalanche, Uni v3 fork. Prerequisite to Arena visibility |
+
+## TL;DR
+
+Three Avalanche surfaces are worth ZAO's time without launching a chain:
+
+1. **The Arena (arena.social)** — SocialFi for creators. Tickets behave like equity, 70% of trading fees stream to creators. ZAO leaders + Cipher artists should have profiles. Big user base (200K+), $284M 30-day swap volume, 4th biggest DEX flow on Avalanche. ZABAL becomes a tipping token once it's bridged to C-Chain and hits a market-cap threshold.
+2. **Record Financial + 11am music royalty rails** — Real-time USDC royalty settlement on Avalanche. Big-name artists (A$AP Ferg, Lil Tjay, Armani White, RealestK). This is the playbook for ZAO Music releases. Reach out for a conversation, do not copy yet.
+3. **Retro9000 C-Chain Round** — Monthly retroactive grants based on AVAX burned in fees. Up to $40M total, $200K lifetime cap per project. ZAO gets paid for activity it's already doing if it generates Avalanche C-Chain activity (Arena, Pharaoh).
+
+The order of operations matters: Arena presence is cheap and immediate. ICTT-bridge ZABAL to C-Chain is the prerequisite for Arena tipping + Pharaoh liquidity. Once Avalanche-side activity is real, Retro9000 grants come for free.
+
+## 1) The Arena (arena.social) — biggest single opportunity
+
+### What it is
+SocialFi platform on Avalanche C-Chain. Originally Stars Arena (Sep 2023), rebranded to The Arena, $2M pre-seed in 2025.
+
+### Numbers (current as of Q3 2025 / Q1 2026)
+| Metric | Value |
+|--------|-------|
+| Registered users | 200,000+ |
+| Paid out to creators | $6M+ AVAX |
+| TVL (bonding curves + ticket staking) | ~$8.2M (30 Jun 2025) |
+| 30-day swap volume | $284M (Q3 2025) |
+| Avalanche DEX flow share | ~7% (4th biggest) |
+| Avalanche DeFi share | ~0.6% of total collateral |
+
+### Creator economics
+- New user ticket starts at **0.0066 AVAX** (~$0.061 at $9.19/AVAX)
+- Tickets follow a **quadratic bonding curve** (supply elastic, price tracks demand)
+- Trade fee: **up to 10% per secondary trade**
+- **Up to 70% of fee streams to the creator as perpetual royalty**
+- Shareholders earn cut of trading fees + access to gated content + DM access to creator
+- Tipping native: AVAX or whitelisted memecoins (WIF, COQ, others) — single click
+- No-crypto onboarding: login creates a wallet automatically (huge for non-crypto ZAO members)
+- Token-gated group chats, dedicated feeds, custom domain handles unlock as token MC grows
+
+### What ZAO does with it
+- **Phase 1 (this month / Q2 2026):** Top 10-20 ZAO leaders + Cipher artists create profiles. Use it as another distribution channel. Buy each other's tickets to seed bonding curves. Tip in AVAX.
+- **Phase 2 (Q3 2026):** Bridge $ZABAL from Base to Avalanche C-Chain via ICTT. List on Pharaoh DEX for liquidity. Push ZABAL marketcap on Avalanche.
+- **Phase 3 (Q4 2026 / Q1 2027):** Apply for Arena tipping whitelist. Once ZABAL is a tip-whitelisted token, ZAO members natively tip in $ZABAL. Real utility, real velocity.
+- **Phase 4 (2027):** Token-gated Arena features unlock at marketcap thresholds — private group chats, dedicated feed, ZAO domain handle.
+
+### Risks
+- Ticket-bonding-curve mechanics are speculative; do not let the surface become primarily speculation on ZAO leaders' tickets
+- Arena V2 added a launchpad — ZAO should NOT launch new tokens there (we already have $ZABAL on Base)
+- Audience overlap with Farcaster is partial; Arena is its own audience, mostly Avalanche-native
+- The Arena's own $ARENA token exists; do not get confused with $ZABAL
+
+## 2) Record Financial + 11am — music royalty playbook to study
+
+### What it is
+Real-time music royalty settlement infrastructure built on Avalanche, deployed late 2025. Pays artists in USDC instantly per stream instead of waiting months.
+
+### Artists already on it
+Armani White, RealestK, Lil Tjay, A$AP Ferg, Alex Warren, Maddox Batson — meaningful Top-40-adjacent footprint, not pure crypto-native names.
+
+### What ZAO can extract
+- **Pattern reference:** This is exactly what ZAO Music + Cipher (Doc 475 — DistroKid + 0xSplits + BMI) is building toward. Their stack proves Avalanche can settle music royalties at speed.
+- **Outreach:** A conversation with the Record Financial / 11am team is high-leverage. ZAO can position as: "We're an artist-owned community building the same vision from the artist side; can we talk about referrals, integration, or partnership?"
+- **Decision:** Do NOT copy their stack on Avalanche if doing so requires migrating ZAO Music off Base. The 0xSplits-on-Base path (Doc 475) is the right v1 because Base is where ZAO's audience and existing rails are.
+- **Optional:** If their tooling is open or licensable, ZAO Music could plug into it as a downstream consumer rather than a competitor.
+
+## 3) Retro9000 C-Chain Round — free money for activity we'd do anyway
+
+### What it is
+Avalanche Foundation's $40M retroactive grant program. The C-Chain Round started March 2026, monthly cycles.
+
+### Eligibility rules
+- Reward = function of AVAX tokens burned in transaction fees on Avalanche C-Chain
+- No project can receive more than 90% of the AVAX it burned that month
+- Single project capped at 25% of monthly prize pool
+- **$200,000 lifetime cap** per project
+- Minimum $500 in AVAX qualifies for a reward
+- Eval moved away from wallet-voting to actual network usage
+
+### Why it matters for ZAO
+If ZAO bridges $ZABAL to C-Chain via ICTT, lists on Pharaoh, and runs Arena activity — every single transaction burns AVAX and counts toward Retro9000 eligibility. ZAO would be doing this activity anyway (per Phase 1-3 above). Retro9000 turns the activity into free retroactive funding, up to $200K total.
+
+This is the strongest reason to do anything on Avalanche even without launching a chain: ZAO gets paid for showing up.
+
+## 4) Pharaoh — liquidity prerequisite
+
+### What it is
+Concentrated-liquidity DEX on Avalanche (Uni v3 fork + ve-tokenomics). Positions itself as Avalanche's central liquidity hub.
+
+### Numbers
+- **TVL:** $51.7M
+- **Annualized fees:** $7.6M
+- **WAVAX-USDC APY:** 140.3%
+- **Fee distribution:** 45% to LPs, 50% to vePHAR voters
+
+### Path for ZAO
+1. Bridge $ZABAL from Base to Avalanche C-Chain via ICTT (`build.avax.network/integrations/pharaoh`)
+2. Open a $ZABAL/AVAX or $ZABAL/USDC concentrated-liquidity position on Pharaoh
+3. Get vePHAR votes pointed at the pool to attract more LPs (governance lobbying — feasible at small scale)
+4. Now $ZABAL has a real Avalanche-side market price → Arena whitelist eligibility unlocks
+
+Concrete capital: ZAO needs to seed liquidity, probably $5-25K worth of paired token. This is the real cost of putting $ZABAL on Avalanche, not the gas.
+
+## 5) Salvor (NFT marketplace) — park
+
+Salvor is the top NFT marketplace on Avalanche, $1M Avalanche Rush grant, 800+ collections, P2P NFT lending. No specific music-NFT footprint surfaced.
+
+For ZAO: park. If ZAO does a future ZAOstock NFT drop or Cipher cover-art series and wants to dual-list (Base via Zora + Avalanche via Salvor), revisit. Do not chase otherwise.
+
+## 6) Beam (gaming subnet) — skip
+
+60+ partnered games, microtransaction focus. Off-thesis for ZAO. Skip.
+
+## ZABAL on Base today (ground truth, from Doc 572)
+
+```
+ZABAL: '0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07' (Base)
+Source: src/lib/agents/types.ts:48
+```
+
+ICTT bridge target: a $ZABAL ICTT contract on Avalanche C-Chain, mirroring Base supply.
+
+## Recommended order of operations
+
+| Phase | Move | Cost | Time | Output |
+|-------|------|------|------|--------|
+| 1 | 10-20 ZAO leaders + Cipher artists make Arena profiles, buy each other's tickets | $200-500 in AVAX seed | 1-2 weeks | Beachhead, distribution channel |
+| 2 | Outreach to Record Financial / 11am about partnership / referral | ~0 (calls + emails) | 2-4 weeks | Learning, possible partnership |
+| 3 | Bridge $ZABAL Base → Avalanche C-Chain via ICTT | Gas + ICTT integration time | 1-2 weeks dev | $ZABAL on Avalanche |
+| 4 | Seed $ZABAL liquidity on Pharaoh | $5-25K paired liquidity | 1 week | $ZABAL has Avalanche price |
+| 5 | Apply for Arena tipping whitelist | 0 | varies (MC-gated) | $ZABAL = native tip on Arena |
+| 6 | Apply for Retro9000 C-Chain Round (monthly) | 0 | recurring | Free retroactive funding up to $200K |
+
+Total uplift: ZAO becomes a SocialFi-active brand on Avalanche, $ZABAL gains a new venue + liquidity + tipping utility, and the foundation pays you for it.
+
+## What we're explicitly NOT doing
+
+| Not doing | Why |
+|-----------|-----|
+| Launching $ZABAL chain on Avalanche | Decided in Doc 572 — wrong scale, wrong time |
+| Migrating ZAO Music off Base | Doc 475 + 553 — Base is right v1 layer |
+| Buying Beam / gaming exposure | Off-thesis |
+| Building NFT-lending position on Salvor | Not the bottleneck |
+| Starting an $ARENA token bag for ZAO treasury | Speculation, not strategy |
+
+## Open questions for Zaal
+
+1. Are you up for being the first ZAO Arena profile? Single user case study for the playbook.
+2. Does the Cipher release timeline (Doc 475) overlap with Phase 1 here? If yes, Cipher could launch with both Base (release/royalty) and Arena (creator monetization) day-one.
+3. Who handles the ICTT bridge engineering for ZABAL — QuadWork, or ZOE/Hermes agent task?
+4. Liquidity bootstrap: where does the $5-25K Pharaoh LP capital come from? Treasury? Founder? Community LP campaign?
+5. Approval to reach out to Record Financial / 11am — and through what email (zaal@thezao.com per memory)?
+
+## Also See
+
+- [Doc 572 — $ZABAL chain decision (don't launch in 2026)](../572-zabal-avalanche-l1-l2-gas-token/) — the prerequisite "no" that makes this "yes" possible
+- [Doc 475 — ZAO Music entity](../../music/475-zao-music-entity/) — Cipher release, 0xSplits, BMI/DistroKid
+- [Doc 553 — Coinbase Paymaster gasless on Base](../../infrastructure/553-coinbase-paymaster-gasless-base/) — keep doing this in parallel
+- [Doc 567 — Nouns DAO ZAO picks](../../governance/567-nouns-dao-zao-picks/) — Flows.wtf still on Base, complementary
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Create ZAO Arena profile (Zaal first) — single-user case study | @Zaal | Manual | This week |
+| Identify 10 ZAO leaders + Cipher artists for Arena profile rollout | @Zaal + community team | Spreadsheet | Next 2 weeks |
+| Send intro to Record Financial / 11am team about ZAO Music + Cipher | @Zaal | Email from zaal@thezao.com | Next 2 weeks |
+| Spec ICTT bridge contract for $ZABAL Base → Avalanche C-Chain | @QuadWork | Tech spec | Q3 2026 |
+| Decide Pharaoh LP seed amount + capital source | @Zaal | Decision | Before Phase 4 |
+| Calendar reminder: Retro9000 C-Chain Round monthly application | @ZOE | Recurring task | Monthly starting Q4 2026 |
+| Re-evaluate Salvor + Beam | @Team | Quarterly review | 2027-Q1 |
+
+## Sources
+
+- [The Arena — official site](https://arena.social/)
+- [The Arena's Comeback: $2M Pre-Seed (Avax.network)](https://www.avax.network/about/blog/the-arenas-comeback-socialfi-app-on-avalanche-secures-2m-pre-seed-funding-and-plans-mainstream-expansion)
+- [Research Unlock: Arena and the Future of SocialFi (The Block)](https://www.theblock.co/post/362976/research-unlock-arena-and-the-future-of-socialfi)
+- [Stars Arena Guide (CoinGecko)](https://www.coingecko.com/learn/stars-arena-avalanche-socialfi-crypto)
+- [The Arena DeFiLlama profile](https://defillama.com/protocol/the-arena)
+- [Avalanche Music Royalties: Record Financial + 11am (Avax.network blog)](https://www.avax.network/about/blog/royalties-in-seconds-not-months-music-goes-onchain-with-avalanche)
+- [Avalanche powers a new model for real time music royalties (Yahoo Finance / TheStreet)](https://www.thestreet.com/crypto/innovation/avalanche-powers-a-new-model-for-real-time-music-royalties)
+- [State of Avalanche Q4 2025 (Messari)](https://messari.io/report/state-of-avalanche-q4-2025)
+- [Retro9000 C-Chain Round (TheStreet)](https://www.thestreet.com/crypto/innovation/avalanche-retro9000-initiatives-c-chain-phase-goes-live-for-builders)
+- [Retro9000 official explainer (Avax.network)](https://www.avax.network/about/blog/retro9000-everything-you-need-to-know)
+- [Pharaoh Exchange (Avalanche Builder Hub)](https://build.avax.network/integrations/pharaoh)
+- [Pharaoh Exchange DefiLlama profile](https://defillama.com/protocol/pharaoh-exchange)
+- [Salvor NFT marketplace](https://salvor.io/)
+- [Salvor $1M Rush grant (Avax.network)](https://www.avax.network/about/blog/salvor-avalanche-rush-1m-incentive-grant-nft-lending-platform)
+- [Beam — gaming subnet (The Block)](https://www.theblock.co/post/226904/beam-blockchain-gaming-avalanche)
+- [How Avalanche Became the Perfect Platform to Launch 100+ L1s (Zeeve)](https://www.zeeve.io/blog/how-avalanche-became-the-perfect-platform-to-launch-100-l1s-in-2025/)
+- [AVAX price (CoinMarketCap, 2026-04-30)](https://coinmarketcap.com/currencies/avalanche/)


### PR DESCRIPTION
## Summary

Companion to Doc 572 (which said "don't launch a chain in 2026"). Tactical playbook for using Avalanche surfaces to help $ZABAL and ZAO Music WITHOUT launching a chain.

**Top picks:**
- **The Arena (arena.social)** — 200K+ users, 70% of trade fees stream to creators, $284M 30-day swap vol, 4th biggest DEX flow on Avalanche. ZAO leaders + Cipher artists should have profiles. ZABAL becomes a tipping token after bridging to C-Chain + market-cap threshold.
- **Record Financial + 11am** — real-time USDC music royalty rails on Avalanche; A$AP Ferg, Lil Tjay, Armani White already on it. Outreach for partnership / referral, study the pattern for ZAO Music + Cipher (Doc 475).
- **Retro9000 C-Chain Round** — $40M retroactive grant program, $200K lifetime cap per project, eligibility = AVAX burned. ZAO gets paid for activity it would do anyway.
- **Pharaoh DEX** ($51.7M TVL) — prerequisite for $ZABAL liquidity on Avalanche after ICTT bridge.
- **Skip:** Beam (gaming, off-thesis), Salvor (park — revisit if ZAO does NFT drop).

**Order of operations:** Arena profiles -> Record Financial outreach -> ICTT bridge ZABAL Base->C-Chain -> seed Pharaoh LP -> Arena tip whitelist -> Retro9000 monthly grants.

## Tier
STANDARD (16 sources, comparison table with 6 surfaces, 6-phase action plan)

## Sources
The Arena official + The Block + CoinGecko + DeFiLlama, Avax.network blogs (3), Messari Q4 2025, Pharaoh + Salvor + Beam refs, Retro9000 official, AVAX price snapshot.

## Next Actions
See [Next Actions table](research/business/573-zabal-avax-surfaces-arena-music/README.md#next-actions) — Zaal's first Arena profile, Cipher-artist rollout, Record Financial intro email, ICTT bridge spec, Pharaoh LP capital decision, ZOE recurring Retro9000 task.