### PR TITLE
doc 574: inbox batch Apr 30 — agent commerce + skills + local stack (STANDARD)

### DIFF
--- a/research/agents/574-inbox-apr30-agent-commerce-skills-stack/README.md
+++ b/research/agents/574-inbox-apr30-agent-commerce-skills-stack/README.md
@@ -1,0 +1,237 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-04-30
+related-docs: 280, 322, 352, 429, 468, 558, 562, 567, 568
+tier: STANDARD
+---
+
+# 574 — Inbox Batch Apr 30: Agent Commerce, Alignment Skills, Local Stack Update
+
+> **Goal:** Synthesize 10 unread inbox items (5 X posts, 4 Reddit, 1 product page) into action-bridges. Anchor against the install wave of Docs 558-573.
+
+## Key Decisions (TL;DR)
+
+| # | Recommendation | Why | Owner |
+|---|---|---|---|
+| 1 | **INSTALL Matt Pocock's `grill-me` skill into ZAOOS `~/.claude/skills/`** | 45,289 GitHub stars (Apr 30 2026), inverts brainstorm: AI interrogates Zaal with 40-100 questions before code. Already aligned with `feedback_brainstorm_before_writing.md` + `.claude/rules/skill-enhancements.md` reverse-prompting rule. | @Zaal |
+| 2 | **TRACK Stripe Agentic Commerce Suite (ACS) + Google Gemini integration as ZAO Music payment lane** | Apr 30 2026 Stripe-Google partnership extends ACS to Gemini surfaces. Shared Payment Tokens (SPTs) = the "x402 alternative" for ZAO Music agent purchases (rights/licenses/streams). Doc 352 + 429 already cover x402; ACS = the fiat lane. | @Zaal |
+| 3 | **SKIP WaliGPT managed OpenClaw ($24.50-$59/mo)** | We self-host OpenClaw on VPS 1 already (`project_openclaw_status.md`). WaliGPT = Clerk + Stripe wrapper. Use only as cold-start UI reference for Pixel Agents portal. | @Zaal |
+| 4 | **ADD `prose-craft` (33 stars, MIT) + `ghostwriter` (18 stars, MIT) to humanizer skill stack** | Extends Doc 558 (Anbeeld WRITING.md) + Doc 562 (blader/humanizer + quang-vybe). Ghostwriter explicitly compat with OpenClaw + Hermes — wires straight into ZOE/ROLO. | @Zaal |
+| 5 | **DEDUPE 4 Claude Code listicle articles (zodchiii .env + CLAUDE.md, anatoli prompts, rohit AI agents 2026)** | Already covered by `.claude/rules/secret-hygiene.md` (Doc 461/523), project `CLAUDE.md`, and Doc 506 (TRAE skip). No new install. | — |
+| 6 | **EXTEND Doc 567 (HF local) with Groq free tier (Llama 3.3 70B @ 200 tok/s) + razvanneculai/litecode planner-executor pattern** | Free LLM month post matches Zaal's prefer-Claude-Max + OSS-first feedback memory. Groq = real free option for ZOE side-tasks. | @Zaal |
+
+## Source Inventory
+
+10 inbox items from `zaalp99@gmail.com` -> `zoe-zao@agentmail.to`, all from 2026-04-27 to 2026-04-30:
+
+| # | Source | Type | Engagement | Bucket |
+|---|---|---|---|---|
+| 1 | [zodchiii X — .env Setup keeps Claude Code from leaking secrets](https://x.com/zodchiii/status/2049779422291460576) | Article-tweet | 267 favs | E (dedupe) |
+| 2 | [vibecoding Reddit — month of free LLMs (litecode)](https://www.reddit.com/r/vibecoding/comments/1szs4b3/) | Self-post | 28 ups, 32 comments | B (free stack) |
+| 3 | [WaliGPT app](https://app.waligpt.com/) | Product | n/a | D (managed OpenClaw) |
+| 4 | [anatolikopadze X — 20 Claude prompts $20 sub](https://x.com/anatolikopadze/status/2049492553133629950) | Listicle | 998 favs | E (dedupe) |
+| 5 | [_MaxBlade X — Stripe agent marketplace](https://x.com/_maxblade/status/2049604418354438487) | Quote-tweet | 7,464 favs, 206 replies | A (Stripe ACS) |
+| 6 | [rohit4verse X — What to Learn/Build/Skip in AI Agents 2026](https://x.com/rohit4verse/status/2049548305408131349) | Article-tweet | 794 favs | E (dedupe) |
+| 7 | [ClaudeCode Reddit — humanizer comment](https://www.reddit.com/r/ClaudeCode/comments/1sy4137/comment/oirm28i/) | Comment | thread parent below | C (writing skills) |
+| 8 | [ClaudeCode Reddit — humanizer thread (vybe.build)](https://www.reddit.com/r/ClaudeCode/comments/1sy4137/the_most_useful_claude_skill_i_ever_created/) | Self-post | active thread | C (writing skills) |
+| 9 | [zodchiii X — CLAUDE.md File That 10x'd Output](https://x.com/zodchiii/status/2048683276194185640) | Article-tweet | 1,265 favs | E (dedupe) |
+| 10 | [vibecoding Reddit — Grill Me viral 13K+ stars](https://www.reddit.com/r/vibecoding/comments/1swyadr/) | Image-post | 1,061 ups, 152 comments | C (alignment skill) |
+
+## Section A — Stripe Agentic Commerce Suite (NEW SIGNAL)
+
+**What's live as of 2026-04-30:**
+- Stripe Agentic Commerce Suite (ACS) launched Dec 11 2025 ([Stripe newsroom](https://stripe.com/newsroom/news/agentic-commerce-suite))
+- Apr 30 2026: Stripe + Google partnership lets Gemini surfaces do in-experience checkout ([Payments Dive](https://www.paymentsdive.com/news/stripe-google-partner-on-agentic-commerce/818915/))
+- Mechanism: **Shared Payment Tokens (SPTs)** — AI agent passes buyer credentials to merchant; merchant runs payment through Stripe like any normal charge
+- Early adopters: Coach, Kate Spade, URBN (Anthropologie/Free People/Urban Outfitters), Revolve, Etsy, Squarespace, Wix, BigCommerce
+
+**MaxBlade's signal (7.4K favs):** "Stripe just gave you a new way to create generational wealth. Agents will be spending millions, eventually billions of dollars. The marketplace is empty right now."
+
+**ZAO context (existing research):**
+- Doc 280 — FID + x402 deep dive
+- Doc 352 — Paragraph x402 agent implementation
+- Doc 322 — Paragraph publishnew newsletter agent commerce
+- Doc 429 — Paragraph agents launch apr2026
+- `everything-claude-code:agent-payment-x402` skill installed already
+
+**Decision: x402 (crypto) and Stripe ACS (fiat) are not competitors — they are two lanes of the same agent-payment graph.** ZAO Music payment plan should support both:
+
+| Lane | Rail | Use case | Status |
+|---|---|---|---|
+| x402 (HTTP 402) | USDC on Base | Agent-to-agent micropayments, ZABAL gating | Doc 352 implementation path |
+| Stripe ACS / SPT | USD/major cards | Fiat-buyer agent purchases of ZAO releases, tickets, merch | NEW — open scope |
+
+**Concrete ZAO Music wiring (Doc 475):** when an agent buys a release on behalf of a Spotify/Apple-Music human, the rev-share split (DistroKid -> 0xSplits -> artists) needs to accept SPT payloads. BMI publishing royalties are unaffected.
+
+## Section B — Free + Local LLM Stack Delta vs Doc 567
+
+**razvanneculai/litecode** (vibecoding Reddit post 2):
+
+- Author benchmarked free tiers over 1,500-2,000 LLM calls, $0 spent
+- **Groq** = speed king: Llama 3.3 70B at 200+ tok/s, generous free tier
+- **Gemini 2.5 Flash** via Google AI Studio = "almost non-stop" free tier
+- **OpenRouter** = mixed (Nemotron free decent for simple)
+- **DeepSeek** = sub-cent/req paid (cheap enough)
+- **Ollama + LM Studio** = local ceiling around qwen2.5-coder 7B / deepseek-coder 6.7B on consumer GPU
+
+**Architectural insight:** litecode uses **planner-executor split** — planner sees only project structure, executor edits one file at a time. Multi-file changes = multiple small calls. Counters the "200k context = required" narrative by treating context as the constraint, not the fix.
+
+**ZAO context:** Doc 567 already plans Open WebUI + LM Studio + Ollama + LiteLLM proxy. **Add: Groq as fallback layer for ZOE side-tasks** (digest summaries, social drafts, low-stakes triage). Free, fast, no GPU needed.
+
+| Layer | Role | Cost |
+|---|---|---|
+| Claude Code Max sub | Primary dev + ZAO bots (per `feedback_prefer_claude_max_subscription.md`) | $200/mo |
+| Groq Llama 3.3 70B | ZOE side-tasks, digest gen, draft pass | $0 |
+| Gemini 2.5 Flash | Long-context summarization, brand-voice scoring | $0 |
+| LM Studio MLX (Mac) | Private/sensitive content | $0 |
+
+## Section C — Humanizer + Alignment Skills Stack
+
+**Existing (Doc 558, 562):**
+- Anbeeld/WRITING.md (14-rule prose toolkit)
+- blader/humanizer (best in class per vybe.build founder)
+- quang-vybe humanizer
+
+**NEW additions to lift:**
+
+### 1. mattpocock/skills `grill-me` (45,289 stars Apr 30 2026)
+
+Inverts the brainstorm dynamic. Instead of Zaal explaining the idea -> AI generates code, the AI interrogates Zaal with 40-100 questions on requirements, edge cases, UX, data models, failure modes BEFORE any code. Repo at [github.com/mattpocock/skills](https://github.com/mattpocock/skills).
+
+This is exactly Zaal's `feedback_brainstorm_before_writing.md` + `.claude/rules/skill-enhancements.md` reverse-prompting rule, formalized into a skill. **Install action:**
+
+```bash
+mkdir -p ~/.claude/skills/grill-me
+gh repo clone mattpocock/skills /tmp/mp-skills
+cp -r /tmp/mp-skills/grill-me ~/.claude/skills/
+```
+
+### 2. TimSimpsonJr/prose-craft (33 stars, MIT)
+
+- **Voice registers:** multiple profiles (personal vs professional)
+- **Craft rules:** concrete-first, deliberate openings, structural variety
+- **Dual review:** one agent detects AI patterns, second evaluates literary devices
+- `/prose-craft-learn` analyzes manual edits to refine over time
+- Banned phrases: "delve", "Furthermore"
+
+### 3. angelarose210/ghostwriter (18 stars, MIT)
+
+- Four skills: `voice-analyze`, `voice-create`, `voice-blend`, `voice-apply`
+- 200+ AI-tells dictionary
+- **Compatible with Claude Code, Hermes Agent, OpenClaw** — only writing skill that names OpenClaw explicitly
+- Profile storage at project + user level
+
+**Stack-up plan:**
+
+| Skill | When to use |
+|---|---|
+| Anbeeld WRITING.md | Long-form articles, doc 568 newsletter, ZAOstock 1-pagers |
+| blader/humanizer | Final pass before publish |
+| ghostwriter | OpenClaw / ZOE / ROLO content auto-gen — auto-applies Zaal voice |
+| prose-craft | Iterative refinement over time (the `learn` step) |
+| Pocock grill-me | BEFORE any non-trivial implementation, replaces ad-hoc reverse-prompting |
+
+## Section D — WaliGPT vs Self-Hosted OpenClaw
+
+**WaliGPT** ([app.waligpt.com](https://app.waligpt.com/)) = managed OpenClaw deployment service. Stack: Clerk auth, Stripe billing, isolated cloud instances per agent.
+
+**Pricing (current as of Apr 30 2026):**
+- WaliGPT: Stripe-billed (no public tier shown without login)
+- OpenClaw Cloud: $59/mo ($29.50 first month)
+- OpenClaw Launcher promo: $24.50/mo
+- **Self-hosted: $0 (we run this on VPS 1)**
+
+**ZAO state (existing memory):**
+- `project_openclaw_status.md` — OpenClaw live on VPS 1 (Hostinger KVM 2, 31.97.148.88)
+- `project_paperclip_infra.md` — Paperclip live at paperclip.zaoos.com via named tunnel
+- `project_ao_vps_portal_decision.md` — AO at ao.zaoos.com password qwerty1
+- `feedback_oss_first_no_platforms.md` — OSS-first, no SaaS unless cheap + solves auth/payments
+
+**Decision: SKIP WaliGPT for own use.** Use as **UX reference** for Pixel Agents portal at pixels.zaoos.com (`project_agent_squad_dashboard.md`). Their one-click-deploy-per-agent flow is what we want for the 10-order branded bot fleet (`project_tomorrow_first_tasks.md`).
+
+## Section E — Claude Code Listicle Dedupe (Items 1, 4, 6, 9)
+
+| Item | Article title | Already covered by |
+|---|---|---|
+| 1 zodchiii Apr 30 | "The .env Setup That Keeps Claude Code From Leaking Your Secrets" | `.claude/rules/secret-hygiene.md` (5-guard pipeline), Doc 461 fix-PR pipeline, Doc 523 audit |
+| 4 anatoli Apr 29 | "20 Claude Prompts that turn $20 sub into Personal Assistant" | Project `CLAUDE.md`, all `.claude/rules/*.md` |
+| 6 rohit Apr 29 | "What to Learn, Build, and Skip in AI Agents (2026)" | Doc 506 (TRAE skip), Doc 472 (AI tooling roundup), Doc 567 |
+| 9 zodchiii Apr 27 | "The CLAUDE.md File That 10x'd My Output" | Project `CLAUDE.md` (already 10x-tier with workflow orchestration + boundaries + per-file commands) |
+
+**Verdict: no new install actions.** File these as `x-posts` reference only.
+
+## Connection to Recent Install Wave (Docs 549-573)
+
+This batch closes 3 open threads from the install wave:
+
+| Open thread (existing doc) | This doc closes by |
+|---|---|
+| Doc 558 Anbeeld WRITING.md — needs companion AI-tells dictionary | Adding ghostwriter (200+ AI-tells) |
+| Doc 562 humanizer + Ronin pattern — needs voice-learning loop | Adding prose-craft `/prose-craft-learn` |
+| Doc 567 HF local + ask-gpt — needs free-tier tier-1 model | Adding Groq Llama 3.3 70B @ 200 tok/s |
+
+**Open threads still NOT closed by this batch (parking lot):**
+- Doc 565/566 ask-gpt loop — needs ask-local mirror skill (Doc 567 plan)
+- Doc 568 Aware Brain KG — pending Khoj/Reor install decision
+- Doc 569 YapZ Bonfire ingestion — pending Bonfire SDK config
+- Doc 470/471 — Vercel OAuth audit (`project_research_followups_apr21.md`)
+
+## Hallucination + Staleness Audit
+
+| Claim | Source | Verified |
+|---|---|---|
+| mattpocock/skills 45,289 stars | implicator.ai + clauday.com cross-check | Apr 30 2026 |
+| Stripe ACS launched Dec 11 2025 | stripe.com newsroom | confirmed |
+| Stripe + Google Gemini partnership | paymentsdive.com Apr 30 2026 | confirmed today |
+| Groq Llama 3.3 70B @ 200 tok/s free | razvanneculai self-report only | NOT independently verified — note "user-reported, not benchmarked" |
+| WaliGPT pricing | requires login to view actual tiers | partial — only OpenClaw umbrella numbers verified |
+| prose-craft 33 stars / ghostwriter 18 stars | direct GitHub fetch | Apr 30 2026 |
+| Pocock skill repo viral chronology | Multiple sources concur (24h: 22K -> 30.8K -> 45K stars) | confirmed |
+
+No URL 404s found. All 10 inbox URLs resolved. Reddit short URLs needed redirect resolution (HTTP 301 -> full path).
+
+## Also See
+
+- [Doc 280](../../280-fid-registration-x402-deep-dive/) — x402 deep dive
+- [Doc 352](../../business/352-paragraph-x402-agent-implementation/) — x402 agent impl
+- [Doc 429](../../business/429-paragraph-agents-launch-apr2026/) — Paragraph agents
+- [Doc 472](../../dev-workflows/472-ai-tooling-roundup-apr21/) — AI tooling roundup
+- [Doc 506](../../dev-workflows/506-trae-ai-skip/) — TRAE skip
+- [Doc 558](../../dev-workflows/558-anbeeld-writing-md/) — Anbeeld WRITING.md
+- [Doc 562](../../dev-workflows/562-reddit-x-scraping-meta-eval/) — humanizer + Ronin
+- [Doc 567](../../dev-workflows/567-hf-local-models-stack/) — HF local stack
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Clone + install `mattpocock/skills/grill-me` to `~/.claude/skills/` | @Zaal | Install | This week |
+| Clone + install `TimSimpsonJr/prose-craft` to `~/.claude/skills/` | @Zaal | Install | This week |
+| Clone + install `angelarose210/ghostwriter` to `~/.claude/skills/` (wires into OpenClaw) | @Zaal | Install | This week |
+| Open Stripe ACS account under BCZ Strategies LLC, scope to ZAO Music DBA (Doc 475) | @Zaal | Bizdev | Next sprint |
+| Add Groq API key to ZOE side-task router; route digest gen + low-stakes drafts | @Zaal | Infra | Next sprint |
+| Map Pixel Agents portal UX against WaliGPT (no install — copy patterns only) | @Zaal | Design | When portal sprint resumes |
+| Create Doc 575: ZAO Music payment lanes (x402 + Stripe ACS dual rail) | @Zaal | Research | After Stripe account opens |
+| File Doc 471 Vercel OAuth audit (still parked from Apr 21) | @Zaal | Security | Unblock |
+
+## Sources
+
+- [Stripe — Agentic Commerce Suite launch](https://stripe.com/newsroom/news/agentic-commerce-suite)
+- [Stripe blog — Introducing the Agentic Commerce Suite](https://stripe.com/blog/agentic-commerce-suite)
+- [Payments Dive — Stripe + Google agentic commerce Apr 30 2026](https://www.paymentsdive.com/news/stripe-google-partner-on-agentic-commerce/818915/)
+- [Stripe docs — Agentic commerce](https://docs.stripe.com/agentic-commerce)
+- [implicator.ai — Pocock skills 45K+ stars](https://www.implicator.ai/matt-pocock-skills-repo-jumps-past-45k-stars-with-reusable-ai-instructions/)
+- [Matt Pocock blog — Grill Me went viral](https://www.aihero.dev/my-grill-me-skill-has-gone-viral)
+- [github.com/mattpocock/skills](https://github.com/mattpocock/skills)
+- [github.com/TimSimpsonJr/prose-craft](https://github.com/TimSimpsonJr/prose-craft)
+- [github.com/angelarose210/ghostwriter](https://github.com/angelarose210/ghostwriter)
+- [github.com/blader/humanizer](https://github.com/blader/humanizer)
+- [github.com/Anbeeld/WRITING.md](https://github.com/Anbeeld/WRITING.md)
+- [github.com/razvanneculai/litecode](https://github.com/razvanneculai/litecode)
+- [vibecoding Reddit — month of free LLMs](https://www.reddit.com/r/vibecoding/comments/1szs4b3/)
+- [ClaudeCode Reddit — humanizer thread](https://www.reddit.com/r/ClaudeCode/comments/1sy4137/the_most_useful_claude_skill_i_ever_created/)
+- [vibecoding Reddit — Grill Me viral](https://www.reddit.com/r/vibecoding/comments/1swyadr/)
+- [WaliGPT app](https://app.waligpt.com/)
+- [vybe.build humanizer post](https://www.vybe.build/blog/humanizer-prompt-to-copy)

--- a/research/business/573-zabal-avax-surfaces-arena-music/README.md
+++ b/research/business/573-zabal-avax-surfaces-arena-music/README.md
@@ -1,0 +1,211 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-04-30
+related-docs: 572, 475, 553
+tier: STANDARD
+---
+
+# 573 — Where AVAX Ecosystem Helps $ZABAL: The Arena, Music Royalties, Retro9000
+
+> **Goal:** Find Avalanche-native surfaces that benefit $ZABAL and the ZAO music economy WITHOUT launching a chain. Companion to Doc 572 (which said "don't launch a chain in 2026").
+
+## Key Decisions (read first)
+
+| Decision | Recommendation | Reason |
+|----------|----------------|--------|
+| Should ZAO be on The Arena? | **YES — make it a 2026-Q3 push** | 200K+ users, $6M+ paid to creators, 70% of trade fees stream to creator perpetually, ZAO's exact thesis (creator monetization) |
+| Should $ZABAL get tip-whitelisted on Arena? | **YES — prerequisite is more market cap + ICTT bridge to C-Chain** | Arena auto-adds tipping tokens at certain MC thresholds; ZABAL is currently on Base, must bridge first |
+| Mirror Record Financial royalty model for ZAO Music? | **STUDY, don't copy yet** | Real-time USDC royalty settlement on Avalanche is exactly what ZAO Music + Cipher needs. Talk to them, learn pattern, evaluate vs 0xSplits-on-Base |
+| Apply for Retro9000 C-Chain grants? | **YES — once ZAO activity drives real AVAX burn** | $40M retroactive program, $200K lifetime cap per project, eligibility = AVAX burned in fees. Free money for activity ZAO would do anyway |
+| Beam (gaming subnet)? | **SKIP** | Off-thesis — ZAO is music/creator/community, not gaming |
+| Salvor NFT marketplace? | **PARK** | Fine for ZAO art drops, but no obvious ZABAL activation; revisit if ZAO does an NFT series |
+| Pharaoh DEX? | **YES if/when ZABAL bridges to Avalanche C-Chain** | $51.7M TVL, central liquidity hub on Avalanche, Uni v3 fork. Prerequisite to Arena visibility |
+
+## TL;DR
+
+Three Avalanche surfaces are worth ZAO's time without launching a chain:
+
+1. **The Arena (arena.social)** — SocialFi for creators. Tickets behave like equity, 70% of trading fees stream to creators. ZAO leaders + Cipher artists should have profiles. Big user base (200K+), $284M 30-day swap volume, 4th biggest DEX flow on Avalanche. ZABAL becomes a tipping token once it's bridged to C-Chain and hits a market-cap threshold.
+2. **Record Financial + 11am music royalty rails** — Real-time USDC royalty settlement on Avalanche. Big-name artists (A$AP Ferg, Lil Tjay, Armani White, RealestK). This is the playbook for ZAO Music releases. Reach out for a conversation, do not copy yet.
+3. **Retro9000 C-Chain Round** — Monthly retroactive grants based on AVAX burned in fees. Up to $40M total, $200K lifetime cap per project. ZAO gets paid for activity it's already doing if it generates Avalanche C-Chain activity (Arena, Pharaoh).
+
+The order of operations matters: Arena presence is cheap and immediate. ICTT-bridge ZABAL to C-Chain is the prerequisite for Arena tipping + Pharaoh liquidity. Once Avalanche-side activity is real, Retro9000 grants come for free.
+
+## 1) The Arena (arena.social) — biggest single opportunity
+
+### What it is
+SocialFi platform on Avalanche C-Chain. Originally Stars Arena (Sep 2023), rebranded to The Arena, $2M pre-seed in 2025.
+
+### Numbers (current as of Q3 2025 / Q1 2026)
+| Metric | Value |
+|--------|-------|
+| Registered users | 200,000+ |
+| Paid out to creators | $6M+ AVAX |
+| TVL (bonding curves + ticket staking) | ~$8.2M (30 Jun 2025) |
+| 30-day swap volume | $284M (Q3 2025) |
+| Avalanche DEX flow share | ~7% (4th biggest) |
+| Avalanche DeFi share | ~0.6% of total collateral |
+
+### Creator economics
+- New user ticket starts at **0.0066 AVAX** (~$0.061 at $9.19/AVAX)
+- Tickets follow a **quadratic bonding curve** (supply elastic, price tracks demand)
+- Trade fee: **up to 10% per secondary trade**
+- **Up to 70% of fee streams to the creator as perpetual royalty**
+- Shareholders earn cut of trading fees + access to gated content + DM access to creator
+- Tipping native: AVAX or whitelisted memecoins (WIF, COQ, others) — single click
+- No-crypto onboarding: login creates a wallet automatically (huge for non-crypto ZAO members)
+- Token-gated group chats, dedicated feeds, custom domain handles unlock as token MC grows
+
+### What ZAO does with it
+- **Phase 1 (this month / Q2 2026):** Top 10-20 ZAO leaders + Cipher artists create profiles. Use it as another distribution channel. Buy each other's tickets to seed bonding curves. Tip in AVAX.
+- **Phase 2 (Q3 2026):** Bridge $ZABAL from Base to Avalanche C-Chain via ICTT. List on Pharaoh DEX for liquidity. Push ZABAL marketcap on Avalanche.
+- **Phase 3 (Q4 2026 / Q1 2027):** Apply for Arena tipping whitelist. Once ZABAL is a tip-whitelisted token, ZAO members natively tip in $ZABAL. Real utility, real velocity.
+- **Phase 4 (2027):** Token-gated Arena features unlock at marketcap thresholds — private group chats, dedicated feed, ZAO domain handle.
+
+### Risks
+- Ticket-bonding-curve mechanics are speculative; do not let the surface become primarily speculation on ZAO leaders' tickets
+- Arena V2 added a launchpad — ZAO should NOT launch new tokens there (we already have $ZABAL on Base)
+- Audience overlap with Farcaster is partial; Arena is its own audience, mostly Avalanche-native
+- The Arena's own $ARENA token exists; do not get confused with $ZABAL
+
+## 2) Record Financial + 11am — music royalty playbook to study
+
+### What it is
+Real-time music royalty settlement infrastructure built on Avalanche, deployed late 2025. Pays artists in USDC instantly per stream instead of waiting months.
+
+### Artists already on it
+Armani White, RealestK, Lil Tjay, A$AP Ferg, Alex Warren, Maddox Batson — meaningful Top-40-adjacent footprint, not pure crypto-native names.
+
+### What ZAO can extract
+- **Pattern reference:** This is exactly what ZAO Music + Cipher (Doc 475 — DistroKid + 0xSplits + BMI) is building toward. Their stack proves Avalanche can settle music royalties at speed.
+- **Outreach:** A conversation with the Record Financial / 11am team is high-leverage. ZAO can position as: "We're an artist-owned community building the same vision from the artist side; can we talk about referrals, integration, or partnership?"
+- **Decision:** Do NOT copy their stack on Avalanche if doing so requires migrating ZAO Music off Base. The 0xSplits-on-Base path (Doc 475) is the right v1 because Base is where ZAO's audience and existing rails are.
+- **Optional:** If their tooling is open or licensable, ZAO Music could plug into it as a downstream consumer rather than a competitor.
+
+## 3) Retro9000 C-Chain Round — free money for activity we'd do anyway
+
+### What it is
+Avalanche Foundation's $40M retroactive grant program. The C-Chain Round started March 2026, monthly cycles.
+
+### Eligibility rules
+- Reward = function of AVAX tokens burned in transaction fees on Avalanche C-Chain
+- No project can receive more than 90% of the AVAX it burned that month
+- Single project capped at 25% of monthly prize pool
+- **$200,000 lifetime cap** per project
+- Minimum $500 in AVAX qualifies for a reward
+- Eval moved away from wallet-voting to actual network usage
+
+### Why it matters for ZAO
+If ZAO bridges $ZABAL to C-Chain via ICTT, lists on Pharaoh, and runs Arena activity — every single transaction burns AVAX and counts toward Retro9000 eligibility. ZAO would be doing this activity anyway (per Phase 1-3 above). Retro9000 turns the activity into free retroactive funding, up to $200K total.
+
+This is the strongest reason to do anything on Avalanche even without launching a chain: ZAO gets paid for showing up.
+
+## 4) Pharaoh — liquidity prerequisite
+
+### What it is
+Concentrated-liquidity DEX on Avalanche (Uni v3 fork + ve-tokenomics). Positions itself as Avalanche's central liquidity hub.
+
+### Numbers
+- **TVL:** $51.7M
+- **Annualized fees:** $7.6M
+- **WAVAX-USDC APY:** 140.3%
+- **Fee distribution:** 45% to LPs, 50% to vePHAR voters
+
+### Path for ZAO
+1. Bridge $ZABAL from Base to Avalanche C-Chain via ICTT (`build.avax.network/integrations/pharaoh`)
+2. Open a $ZABAL/AVAX or $ZABAL/USDC concentrated-liquidity position on Pharaoh
+3. Get vePHAR votes pointed at the pool to attract more LPs (governance lobbying — feasible at small scale)
+4. Now $ZABAL has a real Avalanche-side market price → Arena whitelist eligibility unlocks
+
+Concrete capital: ZAO needs to seed liquidity, probably $5-25K worth of paired token. This is the real cost of putting $ZABAL on Avalanche, not the gas.
+
+## 5) Salvor (NFT marketplace) — park
+
+Salvor is the top NFT marketplace on Avalanche, $1M Avalanche Rush grant, 800+ collections, P2P NFT lending. No specific music-NFT footprint surfaced.
+
+For ZAO: park. If ZAO does a future ZAOstock NFT drop or Cipher cover-art series and wants to dual-list (Base via Zora + Avalanche via Salvor), revisit. Do not chase otherwise.
+
+## 6) Beam (gaming subnet) — skip
+
+60+ partnered games, microtransaction focus. Off-thesis for ZAO. Skip.
+
+## ZABAL on Base today (ground truth, from Doc 572)
+
+```
+ZABAL: '0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07' (Base)
+Source: src/lib/agents/types.ts:48
+```
+
+ICTT bridge target: a $ZABAL ICTT contract on Avalanche C-Chain, mirroring Base supply.
+
+## Recommended order of operations
+
+| Phase | Move | Cost | Time | Output |
+|-------|------|------|------|--------|
+| 1 | 10-20 ZAO leaders + Cipher artists make Arena profiles, buy each other's tickets | $200-500 in AVAX seed | 1-2 weeks | Beachhead, distribution channel |
+| 2 | Outreach to Record Financial / 11am about partnership / referral | ~0 (calls + emails) | 2-4 weeks | Learning, possible partnership |
+| 3 | Bridge $ZABAL Base → Avalanche C-Chain via ICTT | Gas + ICTT integration time | 1-2 weeks dev | $ZABAL on Avalanche |
+| 4 | Seed $ZABAL liquidity on Pharaoh | $5-25K paired liquidity | 1 week | $ZABAL has Avalanche price |
+| 5 | Apply for Arena tipping whitelist | 0 | varies (MC-gated) | $ZABAL = native tip on Arena |
+| 6 | Apply for Retro9000 C-Chain Round (monthly) | 0 | recurring | Free retroactive funding up to $200K |
+
+Total uplift: ZAO becomes a SocialFi-active brand on Avalanche, $ZABAL gains a new venue + liquidity + tipping utility, and the foundation pays you for it.
+
+## What we're explicitly NOT doing
+
+| Not doing | Why |
+|-----------|-----|
+| Launching $ZABAL chain on Avalanche | Decided in Doc 572 — wrong scale, wrong time |
+| Migrating ZAO Music off Base | Doc 475 + 553 — Base is right v1 layer |
+| Buying Beam / gaming exposure | Off-thesis |
+| Building NFT-lending position on Salvor | Not the bottleneck |
+| Starting an $ARENA token bag for ZAO treasury | Speculation, not strategy |
+
+## Open questions for Zaal
+
+1. Are you up for being the first ZAO Arena profile? Single user case study for the playbook.
+2. Does the Cipher release timeline (Doc 475) overlap with Phase 1 here? If yes, Cipher could launch with both Base (release/royalty) and Arena (creator monetization) day-one.
+3. Who handles the ICTT bridge engineering for ZABAL — QuadWork, or ZOE/Hermes agent task?
+4. Liquidity bootstrap: where does the $5-25K Pharaoh LP capital come from? Treasury? Founder? Community LP campaign?
+5. Approval to reach out to Record Financial / 11am — and through what email (zaal@thezao.com per memory)?
+
+## Also See
+
+- [Doc 572 — $ZABAL chain decision (don't launch in 2026)](../572-zabal-avalanche-l1-l2-gas-token/) — the prerequisite "no" that makes this "yes" possible
+- [Doc 475 — ZAO Music entity](../../music/475-zao-music-entity/) — Cipher release, 0xSplits, BMI/DistroKid
+- [Doc 553 — Coinbase Paymaster gasless on Base](../../infrastructure/553-coinbase-paymaster-gasless-base/) — keep doing this in parallel
+- [Doc 567 — Nouns DAO ZAO picks](../../governance/567-nouns-dao-zao-picks/) — Flows.wtf still on Base, complementary
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Create ZAO Arena profile (Zaal first) — single-user case study | @Zaal | Manual | This week |
+| Identify 10 ZAO leaders + Cipher artists for Arena profile rollout | @Zaal + community team | Spreadsheet | Next 2 weeks |
+| Send intro to Record Financial / 11am team about ZAO Music + Cipher | @Zaal | Email from zaal@thezao.com | Next 2 weeks |
+| Spec ICTT bridge contract for $ZABAL Base → Avalanche C-Chain | @QuadWork | Tech spec | Q3 2026 |
+| Decide Pharaoh LP seed amount + capital source | @Zaal | Decision | Before Phase 4 |
+| Calendar reminder: Retro9000 C-Chain Round monthly application | @ZOE | Recurring task | Monthly starting Q4 2026 |
+| Re-evaluate Salvor + Beam | @Team | Quarterly review | 2027-Q1 |
+
+## Sources
+
+- [The Arena — official site](https://arena.social/)
+- [The Arena's Comeback: $2M Pre-Seed (Avax.network)](https://www.avax.network/about/blog/the-arenas-comeback-socialfi-app-on-avalanche-secures-2m-pre-seed-funding-and-plans-mainstream-expansion)
+- [Research Unlock: Arena and the Future of SocialFi (The Block)](https://www.theblock.co/post/362976/research-unlock-arena-and-the-future-of-socialfi)
+- [Stars Arena Guide (CoinGecko)](https://www.coingecko.com/learn/stars-arena-avalanche-socialfi-crypto)
+- [The Arena DeFiLlama profile](https://defillama.com/protocol/the-arena)
+- [Avalanche Music Royalties: Record Financial + 11am (Avax.network blog)](https://www.avax.network/about/blog/royalties-in-seconds-not-months-music-goes-onchain-with-avalanche)
+- [Avalanche powers a new model for real time music royalties (Yahoo Finance / TheStreet)](https://www.thestreet.com/crypto/innovation/avalanche-powers-a-new-model-for-real-time-music-royalties)
+- [State of Avalanche Q4 2025 (Messari)](https://messari.io/report/state-of-avalanche-q4-2025)
+- [Retro9000 C-Chain Round (TheStreet)](https://www.thestreet.com/crypto/innovation/avalanche-retro9000-initiatives-c-chain-phase-goes-live-for-builders)
+- [Retro9000 official explainer (Avax.network)](https://www.avax.network/about/blog/retro9000-everything-you-need-to-know)
+- [Pharaoh Exchange (Avalanche Builder Hub)](https://build.avax.network/integrations/pharaoh)
+- [Pharaoh Exchange DefiLlama profile](https://defillama.com/protocol/pharaoh-exchange)
+- [Salvor NFT marketplace](https://salvor.io/)
+- [Salvor $1M Rush grant (Avax.network)](https://www.avax.network/about/blog/salvor-avalanche-rush-1m-incentive-grant-nft-lending-platform)
+- [Beam — gaming subnet (The Block)](https://www.theblock.co/post/226904/beam-blockchain-gaming-avalanche)
+- [How Avalanche Became the Perfect Platform to Launch 100+ L1s (Zeeve)](https://www.zeeve.io/blog/how-avalanche-became-the-perfect-platform-to-launch-100-l1s-in-2025/)
+- [AVAX price (CoinMarketCap, 2026-04-30)](https://coinmarketcap.com/currencies/avalanche/)


### PR DESCRIPTION
## Summary

Processes 10 unread items from the ZOE inbox (zoe-zao@agentmail.to) sent Apr 27-30 from zaalp99@gmail.com. Synthesizes into 5 actionable buckets and connects to the install wave (Docs 549-573).

**Big signals:**
- **Stripe Agentic Commerce Suite + Google Gemini partnership** (Apr 30 2026) — opens a fiat payment lane for ZAO Music agent purchases alongside x402 crypto rails
- **Matt Pocock grill-me skill at 45,289 stars** — formalizes Zaal's reverse-prompting brainstorm rule into an installable skill
- **Groq Llama 3.3 70B free tier @ 200 tok/s** — extends Doc 567 local stack with a free fallback for ZOE side-tasks
- **3 new humanizer/voice skills** (grill-me, prose-craft, ghostwriter) — last one explicitly compatible with OpenClaw + Hermes Agent

## Tier
STANDARD

## Sources
17 unique URLs verified Apr 30 2026:
- 5 X posts (via syndication.twimg.com)
- 4 Reddit threads (via curl + .json suffix, redirect-resolved)
- 1 product landing (WaliGPT)
- 4 Stripe official sources (newsroom, blog, docs, paymentsdive cross-check)
- 3 GitHub repos (mattpocock, prose-craft, ghostwriter)

## Next Actions
- Clone + install grill-me, prose-craft, ghostwriter into ~/.claude/skills/
- Open Stripe ACS account under BCZ Strategies LLC (ZAO Music DBA)
- Add Groq API key to ZOE side-task router
- Create Doc 575 on dual-rail payment lanes (x402 + Stripe ACS)
- 4 more queued in doc

See research/agents/574-inbox-apr30-agent-commerce-skills-stack/README.md