### PR TITLE
feat(sopha): credit curators on quote-casts + fix /sopha share preview

### DIFF
--- a/src/app/sopha/opengraph-image.tsx
+++ b/src/app/sopha/opengraph-image.tsx
@@ -1,0 +1,79 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'edge';
+export const alt = 'Sopha x ZAO OS — Curated Farcaster, inside the music DAO';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function SophaOG() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          width: '100%',
+          height: '100%',
+          background: 'linear-gradient(135deg, #0a1628 0%, #0a1628 60%, #1a1f2e 100%)',
+          padding: '64px 72px',
+          fontFamily: 'sans-serif',
+          color: '#e5e7eb',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              padding: '8px 18px',
+              borderRadius: 999,
+              background: 'rgba(184, 150, 111, 0.12)',
+              border: '1px solid rgba(184, 150, 111, 0.35)',
+              color: '#B8966F',
+              fontSize: 22,
+              letterSpacing: 2,
+              textTransform: 'uppercase',
+            }}
+          >
+            Live integration
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div style={{ display: 'flex', alignItems: 'center', fontSize: 96, fontWeight: 700, letterSpacing: -2 }}>
+            <span
+              style={{
+                background: 'linear-gradient(90deg, #f5a623, #ffd700)',
+                backgroundClip: 'text',
+                color: 'transparent',
+              }}
+            >
+              Sopha
+            </span>
+            <span style={{ color: '#6b7280', margin: '0 24px' }}>x</span>
+            <span style={{ color: 'white' }}>ZAO OS</span>
+          </div>
+          <div style={{ display: 'flex', fontSize: 34, color: '#9ca3af', maxWidth: 1000, lineHeight: 1.3 }}>
+            Deep Social meets the Music DAO. Sopha curates the long-form, philosophy, and art end of Farcaster — ZAO OS pipes the signal into our gated chat.
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', fontSize: 22, color: '#6b7280' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span style={{ color: '#B8966F', fontSize: 20, letterSpacing: 1 }}>sopha.social</span>
+            <span style={{ color: '#f5a623', fontSize: 20, letterSpacing: 1 }}>zaoos.com/sopha</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
+            <span>50 casts / refresh</span>
+            <span style={{ color: '#374151' }}>·</span>
+            <span>Quality 65-85</span>
+            <span style={{ color: '#374151' }}>·</span>
+            <span>5min cache</span>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/sopha/page.tsx
+++ b/src/app/sopha/page.tsx
@@ -2,15 +2,6 @@ import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 
-const miniAppEmbed = JSON.stringify({
-  version: '1',
-  imageUrl: 'https://zaoos.com/og-sopha.png',
-  button: {
-    title: 'See the Trending feed',
-    action: { type: 'launch_miniapp', url: 'https://zaoos.com/sopha' },
-  },
-});
-
 export const metadata: Metadata = {
   title: 'Sopha x ZAO OS — Curated Farcaster, inside the music DAO',
   description:
@@ -26,7 +17,6 @@ export const metadata: Metadata = {
     title: 'Sopha x ZAO OS — Curated Farcaster',
     description: 'Deep Social meets the Music DAO. Sopha curates, ZAO governs.',
   },
-  other: { 'fc:miniapp': miniAppEmbed },
 };
 
 const STATS: { label: string; value: string }[] = [

--- a/src/components/chat/ComposeBar.tsx
+++ b/src/components/chat/ComposeBar.tsx
@@ -8,6 +8,14 @@ import { generateHashtags } from '@/lib/ai/textAnalysis';
 
 const ALL_CHANNELS = communityConfig.farcaster.channels.map((id) => ({ id, label: `#${id}` }));
 
+function buildSophaAttribution(quotedCast: QuotedCastData): string {
+  const curator = quotedCast._curators?.[0]?.username;
+  if (curator) {
+    return `\n\n— Curated by @${curator} on @sopha_social, shared via ZAOOS`;
+  }
+  return `\n\n— Curated by @sopha_social, shared via ZAOOS`;
+}
+
 export interface ReplyContext {
   hash: string;
   authorName: string;
@@ -131,8 +139,12 @@ export const ComposeBar = forwardRef<ComposeBarHandle, ComposeBarProps>(function
 
         const crossPost = crossPostChannels.size > 0 ? [...crossPostChannels] : undefined;
         const parentHash = replyTo?.hash || undefined;
+        const baseText = msg || ' ';
+        const outgoing = quotedCast?._source === 'sopha'
+          ? `${baseText}${buildSophaAttribution(quotedCast)}`
+          : baseText;
         await onSend(
-          msg || ' ',
+          outgoing,
           parentHash,
           quotedCast?.hash,
           crossPost,
@@ -360,6 +372,11 @@ export const ComposeBar = forwardRef<ComposeBarHandle, ComposeBarProps>(function
                 Quoting {quotedCast.author.display_name || quotedCast.author.username}
               </span>
               <p className="text-xs text-gray-400 mt-0.5 line-clamp-2">{quotedCast.text}</p>
+              {quotedCast._source === 'sopha' && (
+                <p className="text-[10px] text-[#B8966F] mt-1">
+                  Will append: {buildSophaAttribution(quotedCast).trim()}
+                </p>
+              )}
             </div>
             <button
               onClick={onClearQuote}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,15 @@ export interface QuotedCastData {
   text: string;
   timestamp: string;
   embeds?: { url?: string }[];
+  /** Origin of the cast inside ZAO OS — used to credit external curators on outgoing quote-casts. */
+  _source?: 'sopha' | 'neynar';
+  /** Curator attribution carried from the source feed. */
+  _curators?: {
+    fid?: number;
+    username: string;
+    display_name?: string;
+    pfp_url?: string;
+  }[];
 }
 
 export interface CastEmbed {


### PR DESCRIPTION
## Summary

Two fixes that round out the Sopha integration:

### 1. Quote-cast attribution

Today the Trending tab shows "Curated by @{curator}" inline, but when a ZAO member quote-casts that cast back to Farcaster, the credit doesn't travel — the cast looks like the member found it themselves.

Now: if the quoted cast came from Sopha, the outgoing cast text ends with

> — Curated by @{curator} on @sopha_social, shared via ZAOOS

(falls back to "@sopha_social" if no curator is named on the cast).

The compose preview chip also shows the suffix that will be appended, so the member sees the credit before they hit send.

Type-level change: `QuotedCastData` now optionally carries `_source` and `_curators`, threaded from `SophaCast` -> `TrendingCast` -> `Message` -> `ComposeBar`.

### 2. /sopha share preview

The page set `fc:miniapp` pointing at `/og-sopha.png` — neither asset existed and the page is a marketing surface, not a launchable miniapp. Removed `fc:miniapp` and added `src/app/sopha/opengraph-image.tsx` (Next.js edge-rendered ImageResponse) so Farcaster, X, and link unfurls all render a proper Sopha-x-ZAO OS card.

## Test plan
- [ ] Open Trending, quote a Sopha-sourced cast, see compose chip show the appended credit line
- [ ] Send the quote-cast and verify the outgoing Farcaster cast contains the suffix
- [ ] Quote a Neynar (non-Sopha) cast and verify NO suffix is appended
- [ ] Share `/sopha` URL on Farcaster and confirm the OG card renders