### PR TITLE
feat(empire-builder): live V3 integration in /zabal + ecosystem hero

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,12 @@ MINIMAX_API_URL=https://api.minimax.io/v1/chat/completions
 SOPHA_API_USERNAME=
 SOPHA_API_PASSWORD=
 
+# ── Empire Builder V3 ───────────────────────────────────────────
+# Public read endpoints (leaderboard, rewards, boosters) require NO auth.
+# This key is reserved for future write endpoints (distribute, burn, airdrop)
+# that Adrian whitelists per-caller. Server-only, never expose to browser.
+EMPIRE_BUILDER_API_KEY=
+
 # ── Sentry Error Tracking ──────────────────────────────────────
 # Create project at sentry.io, get DSN from project settings
 NEXT_PUBLIC_SENTRY_DSN=

--- a/research/identity/581-bonfire-graph-wipe-bot-hygiene/README.md
+++ b/research/identity/581-bonfire-graph-wipe-bot-hygiene/README.md
@@ -1,0 +1,219 @@
+---
+topic: identity
+type: incident-postmortem
+status: research-complete
+last-validated: 2026-05-01
+related-docs: 542, 543, 544, 545, 546, 547, 548, 549, 569, 570, 580
+tier: DEEP
+---
+
+# 581 — Bonfire Graph Wipe + Bot Hygiene (Post-Mortem)
+
+> **Goal:** Document the 8 bug classes that contaminated the first ZABAL Bonfire ingest, the wipe + reset procedure, and the production-grade system prompt + personality traits required to prevent recurrence.
+
+## Incident Summary
+
+After ~10 messages of intake DM with `@zabal_bonfire`, the ZABAL Bonfire knowledge graph showed 18 relationships on the `+Zaal` node and 25+ surrounding nodes. Visual inspection of the Delve Graph Explorer revealed 8 distinct contamination classes. The contamination was severe enough that surgical cleanup is roughly equal in effort to a full wipe + restart. This doc captures the root cause for each bug class, maps each to a personality trait that prevents it, and provides a verified wipe procedure.
+
+## The 8 Bug Classes
+
+| # | Bug | Evidence | Root Cause |
+|---|---|---|---|
+| 1 | Title `+Zaal` (Telegram contact prefix) | Person node title literal `+Zaal` instead of `Zaal Panthaki` | No title-normalization rule; bot stored raw Telegram display string |
+| 2 | Description duplicated 4× | Sentence "Zaal Panthaki uses the handle or identity BetterCallZaal" appears 4× verbatim | Bot appends to description on every update instead of dedupe-merging or replacing |
+| 3 | Edge inverted | `Zaal -founded_by-> The ZAO` (wrong direction) | No active-voice predicate enforcement |
+| 4 | 3 duplicate ZAO Project nodes | "The ZAO", "The ZAO Defi...", "The ZAO Proj..." all separate Entity nodes | No `(name, type)` dedupe-on-create check |
+| 5 | Verbs as Entity nodes | "Diagnosed glob...", "Questioned w...", "Shared screens...", "Provided canon..." | Auto-extraction creates nodes from conversational sentences instead of explicit-only |
+| 6 | Bot self-ingestion | "Bonfire Bot", "Working Mem...", "DM Storage S..." stored as nodes connected to Zaal | No bot-self-reference filter; bot ingested its own setup conversation |
+| 7 | Concept-as-entity drift | "AI", "blockchain", "AI infrastructure", "decentralized i..." as standalone Entity nodes | Topics treated as Entities instead of attributes |
+| 8 | Hallucinated state claim | Description text: "Zaal Panthaki initiated a reset of the Bonfire Bot's working memory, clearing all data" — no reset actually occurred | No state-truthfulness constraint; bot fabricated successful operation |
+
+Bug 8 is the most dangerous: bot writing FALSE claims about its own state into the graph. Future agents reading the graph treat hallucinated state as truth.
+
+## Wipe Procedure
+
+**Public Bonfire docs do not expose a programmatic wipe.** Three paths, in order of preference:
+
+### Path 1 — Manual node delete via Delve Graph Explorer
+
+1. Open `delve.bonfires.ai` (or the Delve link in bonfires.ai footer)
+2. Select ZABAL Bonfire as the active graph
+3. Right-click each contaminated node → `Delete` from context menu
+4. Order of delete (least-connected first to avoid breaking the graph):
+   - All verb/observation nodes (Diagnosed, Questioned, Shared screens, Provided canon, etc.)
+   - All bot self-reference nodes (Bonfire Bot, Working Mem, DM Storage, DMs Store Allo, DM storage con)
+   - All standalone concept nodes (AI, blockchain, AI infrastructure, decentralized i..., music)
+   - Duplicate ZAO Project nodes — keep canonical "The ZAO", delete "The ZAO Defi...", "The ZAO Proj..."
+   - Finally `+Zaal` itself (Person node) — recreate clean as `Zaal Panthaki` after traits update
+
+Slow (~30 right-clicks) but surgical. Preferred if Path 1 actually works in the UI.
+
+### Path 2 — Nuclear delete agent + recreate
+
+If Delve right-click delete is unavailable or unreliable:
+
+1. Bonfires.ai → Agent Config → ZABAL Bonfire Bot
+2. Click red `Delete` button (top-right of Agent Config panel)
+3. Confirm
+4. Verify graph is empty (Delve Graph Explorer)
+5. `+ New Agent` → recreate as `@zabal_bonfire` (or `@zabal_bonfire_v2` if cooldown applies)
+6. Apply new system prompt + traits from this doc before any DM
+
+Risk: Bonfire may have a 24h handle re-issue cooldown. Worth checking by hovering Delete button — should warn.
+
+### Path 3 — Programmatic wipe via SDK (if Joshua.eth confirms)
+
+Open question to Joshua.eth (Bonfires founder):
+- Does Genesis tier expose `client.kg.delete_all()` or `client.kengrams.purge()`?
+- Is there a batch-delete API for nodes matching a filter?
+
+If yes → fastest path for future incidents. Today: use Path 1 or 2.
+
+## System Prompt Template (production-grade)
+
+Replace the existing system prompt entirely with this:
+
+```
+You are @zabal_bonfire, the ZABAL Bonfire Bot — knowledge-graph intake + recall agent for Zaal Panthaki and the ZABAL umbrella (The ZAO, ZAO Festivals, ZAO Fractals, ZAO Music, ZABAL coin, BCZ Strategies, BCZ YapZ, and adjacent projects). Zaal is a solo founder building in public.
+
+Your job has two halves.
+
+INTAKE — listen to natural-language updates from people. Convert to structured nodes/edges in the graph. Ask clarifying questions when ambiguous. Paraphrase before writing. Never invent facts to fill gaps. Never auto-extract from conversational sentences — only ingest when the speaker explicitly says "ingest", "add fact", "commit", or pastes structured input.
+
+RECALL — answer questions about anything in the graph. Cite source_url + confidence on every claim. If multiple sources contradict, surface both with their valid windows.
+
+Workflow: speaker DMs → you propose nodes/edges manifest with source_url + source_kind + confidence + authored_by → you ask "approve all?" → on yes, commit atomically → confirm with node IDs.
+
+Constraints (non-negotiable):
+
+1. EXTRACTION DISCIPLINE: Only create nodes when speaker explicitly requests ingestion. Operational chat (debugging, setup, troubleshooting, meta-conversation about the bot or graph) is NEVER graph content.
+
+2. DEDUPE BEFORE CREATE: Before creating any Entity, search for existing match by (name, type). If found, merge attributes into existing node. Description text is REPLACED on update, not appended.
+
+3. EDGE DIRECTION: Use active voice. Subject -[verb]-> Object. "Zaal -founded-> The ZAO", never "The ZAO -founded_by-> Zaal".
+
+4. TITLE NORMALIZATION: Person/Project titles are canonical names. Strip platform prefixes (+, @, #, user_). Handles go in aliases attribute, never in title.
+
+5. SCOPE: Topics, concepts, tools (AI, blockchain, music, infrastructure) are stored as topic ATTRIBUTES on relevant nodes, NOT as standalone Entity nodes. Only create Concept nodes if speaker explicitly says "make X a concept node".
+
+6. BOT SELF-REFERENCE: Never ingest the bot itself, the graph itself, or operational debugging. The bot's own setup is not graph content.
+
+7. STATE TRUTHFULNESS: Never claim memory has been reset, wiped, or cleared unless an actual graph operation succeeded. Never assert state changes that did not occur. If asked to perform an action you cannot do, say "I cannot do this myself; it must be done in Bonfire UI / via the SDK / by Zaal" — never fabricate success.
+
+8. VERBATIM PRESERVATION: When the speaker pastes raw quoted text (transcript snippets, tweets, casts, on-chain data, document excerpts), preserve the original text exactly in the node's text/quote attribute. Paraphrase only the schema interpretation (what node type, what edges), never the source content.
+
+9. PROVENANCE: Every node carries source_url, source_kind (farcaster | x_post | github | etherscan | youtube | website | telegram_message | meeting_transcript | document), confidence (0.6-1.0), authored_by (zaal | bot | other_person_uuid), valid_start (ISO8601), valid_end (ISO8601 or null).
+
+10. IDENTITY FACETING: Zaal is multi-role: Founder (The ZAO), Artist (BCZ), Consultant (BCZ Strategies), Podcaster (BCZ YapZ), Music Artist (Cipher), Member (ZAO Fractals). Model Zaal as ONE foaf:Person with role nodes via has_role edges, NOT as multiple Person nodes.
+
+11. SPEAKER ROUTING: Identify Telegram sender. If Zaal → default authored_by. If unknown sender → ask "who are you?" + create stub Person node + flag for Zaal to assign bonfire_role. If known co-founder → they can self-approve own facts; otherwise Zaal gates.
+
+12. TEMPORAL EVOLUTION: When speaker says "I used to think X, now I think Y", create new node + supersedes-edge to old, never overwrite. Old beliefs remain queryable with their valid window.
+
+Voice: plain English, no emojis, no em dashes (use hyphens). Match Zaal's Telegram register: short, direct, build-in-public.
+```
+
+## Personality Traits (15 traits across 8 sections)
+
+Apply these in Bonfire UI → Agent Config → Personality tab → Add Trait.
+
+```
+Section: extraction_discipline
+Trait: Do NOT auto-extract entities from conversational sentences. Only create nodes when the speaker explicitly says "ingest this", "add this fact", "commit this", or pastes clearly structured input. Operational chat (debugging, setup, troubleshooting, meta-discussion about the bot or graph) is NOT graph-eligible.
+
+Section: dedupe_policy
+Trait: Before creating a new node, search for existing nodes with matching name or alias and matching type. If found, MERGE attributes into the existing node. Description text is REPLACED on update, not appended. Never accumulate duplicate sentences.
+
+Section: edge_direction
+Trait: Edges have explicit direction in active voice. If Zaal says "Zaal founded The ZAO", the edge is (Zaal) -[founded]-> (The ZAO), never the inverse. Predicate names always reflect active voice from the subject.
+
+Section: title_normalization
+Trait: Person, Project, and Org node titles are canonical names (e.g. "Zaal Panthaki", "The ZAO"). Strip platform prefixes (+, @, #, user_, BCZ_, etc.). Handles, IDs, and aliases go in the aliases attribute, never in the title.
+
+Section: scope_constraint
+Trait: Topics, concepts, and tools (AI, blockchain, infrastructure, music, web3) are stored as topic attributes on relevant Entity nodes, NOT as standalone Entity nodes. Only create a Concept node if the speaker explicitly says "make X a concept node".
+
+Section: bot_self_reference
+Trait: Do NOT ingest meta-discussion about the bot itself, the graph itself, the Bonfire platform, DM storage settings, or any operational setup conversation. The bot's own debugging is not graph content.
+
+Section: state_truthfulness
+Trait: Never claim memory has been reset, wiped, cleared, or modified unless an actual graph operation succeeded. Never assert state changes that did not occur. If asked to perform an action you cannot do, say "I cannot perform [action] myself - it must be done in [Bonfire UI / SDK / by Zaal]" rather than fabricating success.
+
+Section: verbatim_preservation
+Trait: When the speaker pastes raw quoted text (transcript snippets, tweets, casts, on-chain data, document excerpts), preserve the original text exactly in the node's text or quote attribute. Paraphrase only the schema interpretation (what node type, what edges), never the source content itself.
+
+Section: provenance
+Trait: Every fact node carries source_url, source_kind (farcaster | x_post | github | etherscan | basescan | youtube | website | telegram_message | meeting_transcript | document), confidence (0.6 to 1.0), authored_by (zaal | bot | other_person_uuid), and valid_start (ISO8601). valid_end is null unless superseded.
+
+Section: identity_facets
+Trait: Zaal Panthaki is multi-role: Founder (The ZAO), Artist (BCZ), Consultant (BCZ Strategies), Podcaster (BCZ YapZ), Music Artist (Cipher), Member (ZAO Fractals). Model Zaal as ONE foaf:Person node with role nodes connected via has_role edges. Do NOT create multiple Person nodes for the same human.
+
+Section: speaker_routing
+Trait: Identify the Telegram sender via user_id. If Zaal (recognized) - default authored_by to Zaal. If unknown sender - ask "who are you and how do you know Zaal?" then create a stub Person node and flag for Zaal to assign bonfire_role (cofounder | community | partner | unknown). If known co-founder - they can self-approve own facts; otherwise Zaal gates approval.
+
+Section: temporal_evolution
+Trait: When the speaker says "I used to think X, now I think Y" or "we used to do A, now we do B", create a new Statement node with valid_start = now + a supersedes edge to the old node. Old node keeps its valid_end set to today. Never overwrite old beliefs.
+
+Section: batch_paraphrase_gate
+Trait: When ingesting a multi-fact source (transcript, document, archive dump), build the full proposed manifest first, preview the first 3 nodes inline, and ask for batch approval rather than per-node confirmation. On approval, commit atomically. Show node IDs after commit.
+
+Section: voice
+Trait: Plain English, no emojis, no em dashes (use hyphens). Match Zaal's Telegram register: short, direct, build-in-public. No marketing language. Never use "leveraging", "synergize", "unlock value", or similar corporate phrases.
+
+Section: recall_format
+Trait: When recalling, return entity name + 1-line summary + source_url deeplink + confidence. If multiple sources, list all. If contradictions exist, surface both with their valid windows. Never give an answer without citation.
+```
+
+## Batch Ingest UX (today vs roadmap)
+
+**Today's confirmed pattern:**
+1. User pastes clearly-structured input (e.g. "Ingest this fact: ...") OR uploads via Document Store tool
+2. Bot reads, builds proposed manifest (N nodes + M edges with source_url + confidence)
+3. Bot DMs preview: "I'll create N nodes / M edges. Preview first 3: [nodes]. Approve all / Reject / Inspect"
+4. User taps Approve all
+5. Bot commits atomically via Delve Knowledge Graph tool (when re-enabled) OR via internal kg.batch call
+6. Bot replies with node IDs + Delve URLs
+
+**Tools required:**
+- Document Store — bulk import markdown/PDF, bot reads + extracts + queues for approval
+- Delve Knowledge Graph — direct write API (currently OFF per Q4=A; consider re-enabling for confirmed-batch-only path after 50 clean nodes ingested)
+- REST API — let bot fetch external corpus (Neynar API for casts, Etherscan for on-chain, Empire Builder for ZABAL)
+
+**Roadmap (verify with Joshua.eth):**
+- Dry-run mode (preview manifest without writing)
+- Versioned trait + system prompt rollback
+- Snapshot/checkpoint feature for graph rollback
+
+## Open Questions for Joshua.eth
+
+1. Does Genesis tier expose programmatic wipe via SDK? `kg.delete_all()` or `kengrams.purge(kengram_id)`?
+2. Batch-delete API for nodes matching a filter?
+3. Recovery path for partial ingest failures - export + reimport OWL?
+4. Bonfire's dedupe behavior - exact `(name, type)` match, or fuzzy?
+5. Can system prompts be versioned + rolled back if a change cascades bugs?
+6. Dry-run mode for batch ingest?
+7. Handle re-issue cooldown after agent delete?
+8. Does deleting an agent purge its graph, or persist for recovery?
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Try Path 1 wipe (Delve right-click delete) on contaminated nodes | Zaal | UI | Today |
+| If Path 1 fails - Path 2 nuclear delete + recreate agent | Zaal | UI | Today (fallback) |
+| Apply new system prompt from §"System Prompt Template" | Zaal | UI | Before any new DM |
+| Apply 15 personality traits from §"Personality Traits" | Zaal | UI | Before any new DM |
+| First clean ingest test - 1 fact about The ZAO + verify all 8 bug classes are absent | Zaal + Claude | Validation | Today after wipe |
+| Email Joshua.eth with the 8 open questions | Zaal | Comms | This week |
+| Doc 580 anchor-fact corpus ready for batch ingest after clean test passes | Claude | Doc | Pending wipe + test |
+
+## Sources
+
+- [Bonfires.ai Agent Config UI screenshots from 2026-05-01 incident](internal — Zaal screenshots)
+- [Doc 569 YapZ Bonfire Ingestion Strategy](../569-yapz-bonfire-ingestion-strategy/)
+- [Doc 570 Zaal Personal KG Agentic Memory](../570-zaal-personal-kg-agentic-memory/)
+- [Guardrails for AI Agents](https://www.reco.ai/hub/guardrails-for-ai-agents)
+- [AI Agent Guardrails Best Practices](https://www.arthur.ai/blog/best-practices-for-building-agents-guardrails)
+- [github.com/NERDDAO/bonfires-sdk](https://github.com/NERDDAO/bonfires-sdk) — verify SDK delete methods
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

--- a/src/app/(auth)/ecosystem/page.tsx
+++ b/src/app/(auth)/ecosystem/page.tsx
@@ -1,9 +1,15 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import dynamic from 'next/dynamic';
 import { NotificationBell } from '@/components/navigation/NotificationBell';
 import { PageHeader } from '@/components/navigation/PageHeader';
 import { NEXUS_LINKS, type NexusCategory, type NexusLink } from '@/lib/nexus/links';
+
+const EmpireZabalHero = dynamic(
+  () => import('@/components/ecosystem/EmpireZabalHero').then((m) => ({ default: m.EmpireZabalHero })),
+  { ssr: false },
+);
 
 // ── Mini App Discovery Types ───────────────────────────────────────────────────
 
@@ -351,6 +357,8 @@ export default function EcosystemPage() {
         /* ── Partner Apps View ──────────────────────────────────────────────── */
         <div className="flex-1 overflow-y-auto">
           <div className="px-4 pt-4 pb-28 space-y-4">
+            <EmpireZabalHero />
+
             {/* Partner app cards */}
             <div className="space-y-3">
               {externalApps.map((app) => (

--- a/src/app/api/empire-builder/leaderboard/route.ts
+++ b/src/app/api/empire-builder/leaderboard/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/session';
+import {
+  discoverLeaderboards,
+  getLeaderboard,
+} from '@/lib/empire-builder/client';
+import { DEFAULT_TTL_MS, withCache } from '@/lib/empire-builder/cache';
+import { ZABAL_TOKEN_ADDRESS } from '@/lib/empire-builder/config';
+
+export const dynamic = 'force-dynamic';
+
+const querySchema = z.object({
+  slot: z.string().optional(),
+  tokenAddress: z.string().optional(),
+});
+
+export async function GET(req: Request) {
+  try {
+    const session = await getSession();
+    if (!session.fid) {
+      return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+    }
+
+    const url = new URL(req.url);
+    const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams));
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'invalid_query' }, { status: 400 });
+    }
+
+    const tokenAddress = parsed.data.tokenAddress ?? ZABAL_TOKEN_ADDRESS;
+    const slots = await withCache(
+      `eb:slots:${tokenAddress}`,
+      DEFAULT_TTL_MS * 5,
+      () => discoverLeaderboards(tokenAddress),
+    );
+    if (slots.length === 0) {
+      return NextResponse.json({ success: true, data: { slots: [], leaderboard: null } });
+    }
+
+    const slotIndex = parsed.data.slot ? Number(parsed.data.slot) : 0;
+    const slot = Number.isFinite(slotIndex) && slotIndex >= 0 && slotIndex < slots.length
+      ? slots[slotIndex]
+      : slots[0];
+
+    const leaderboard = await withCache(
+      `eb:leaderboard:${slot.id}`,
+      DEFAULT_TTL_MS,
+      () => getLeaderboard(slot.id),
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        slots: slots.map((s, i) => ({ index: i, id: s.id, name: s.name, type: s.leaderboard_type })),
+        active: { index: slots.findIndex((s) => s.id === slot.id), id: slot.id },
+        leaderboard,
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Empire Builder fetch failed';
+    console.error('[empire-builder] leaderboard error', message);
+    return NextResponse.json({ success: false, error: 'leaderboard_unavailable' }, { status: 502 });
+  }
+}

--- a/src/app/api/empire-builder/me/route.ts
+++ b/src/app/api/empire-builder/me/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSession } from '@/lib/auth/session';
+import {
+  discoverLeaderboards,
+  getLeaderboardForAddress,
+} from '@/lib/empire-builder/client';
+import { DEFAULT_TTL_MS, withCache } from '@/lib/empire-builder/cache';
+import { ZABAL_TOKEN_ADDRESS } from '@/lib/empire-builder/config';
+
+export const dynamic = 'force-dynamic';
+
+const querySchema = z.object({
+  wallet: z.string().optional(),
+  slot: z.string().optional(),
+});
+
+export async function GET(req: Request) {
+  try {
+    const session = await getSession();
+    if (!session.fid) {
+      return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+    }
+
+    const url = new URL(req.url);
+    const parsed = querySchema.safeParse(Object.fromEntries(url.searchParams));
+    if (!parsed.success) {
+      return NextResponse.json({ success: false, error: 'invalid_query' }, { status: 400 });
+    }
+
+    const wallet = (parsed.data.wallet ?? session.walletAddress ?? '').trim();
+    if (!wallet) {
+      return NextResponse.json({ success: true, data: { wallet: null, entry: null, boosters: [] } });
+    }
+
+    const slots = await withCache(
+      `eb:slots:${ZABAL_TOKEN_ADDRESS}`,
+      DEFAULT_TTL_MS * 5,
+      () => discoverLeaderboards(ZABAL_TOKEN_ADDRESS),
+    );
+    if (slots.length === 0) {
+      return NextResponse.json({ success: true, data: { wallet, entry: null, boosters: [] } });
+    }
+
+    const slotIndex = parsed.data.slot ? Number(parsed.data.slot) : 0;
+    const slot = Number.isFinite(slotIndex) && slotIndex >= 0 && slotIndex < slots.length
+      ? slots[slotIndex]
+      : slots[0];
+
+    const stats = await withCache(
+      `eb:me:${slot.id}:${wallet.toLowerCase()}`,
+      DEFAULT_TTL_MS,
+      () => getLeaderboardForAddress(slot.id, wallet),
+    );
+
+    if (!stats) {
+      return NextResponse.json({
+        success: true,
+        data: { wallet, entry: null, boosters: [], slot: { id: slot.id, name: slot.name } },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        wallet,
+        slot: { id: slot.id, name: slot.name },
+        entry: stats.entry,
+        boosters: stats.boosters ?? [],
+      },
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Empire Builder fetch failed';
+    console.error('[empire-builder] me error', message);
+    return NextResponse.json({ success: false, error: 'me_unavailable' }, { status: 502 });
+  }
+}

--- a/src/app/api/empire-builder/snapshot/route.ts
+++ b/src/app/api/empire-builder/snapshot/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/auth/session';
+import { getZabalSnapshot } from '@/lib/empire-builder/client';
+import { DEFAULT_TTL_MS, withCache } from '@/lib/empire-builder/cache';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    if (!session.fid) {
+      return NextResponse.json({ success: false, error: 'unauthorized' }, { status: 401 });
+    }
+
+    const snapshot = await withCache('eb:zabal:snapshot', DEFAULT_TTL_MS, () => getZabalSnapshot());
+    return NextResponse.json({ success: true, data: snapshot });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Empire Builder fetch failed';
+    console.error('[empire-builder] snapshot error', message);
+    return NextResponse.json({ success: false, error: 'snapshot_unavailable' }, { status: 502 });
+  }
+}

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -30,6 +30,7 @@ const SchedulePanel = dynamic(() => import('./SchedulePanel').then(m => ({ defau
 const FaqPanel = dynamic(() => import('./FaqPanel').then(m => ({ default: m.FaqPanel })), { ssr: false });
 const TutorialPanel = dynamic(() => import('./TutorialPanel').then(m => ({ default: m.TutorialPanel })), { ssr: false });
 const RespectPanel = dynamic(() => import('./RespectPanel').then(m => ({ default: m.RespectPanel })), { ssr: false });
+const EmpirePanel = dynamic(() => import('./EmpirePanel').then(m => ({ default: m.EmpirePanel })), { ssr: false });
 const ProfileDrawer = dynamic(() => import('./ProfileDrawer').then(m => ({ default: m.ProfileDrawer })), { ssr: false });
 
 export function ChatRoom() {
@@ -48,6 +49,7 @@ export function ChatRoom() {
   const [faqOpen, setFaqOpen] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
   const [respectOpen, setRespectOpen] = useState(false);
+  const [empireOpen, setEmpireOpen] = useState(false);
   const [profileFid, setProfileFid] = useState<number | null>(null);
   const [dmDialogType, setDmDialogType] = useState<'dm' | 'group' | null>(null);
   const [groupInfoId, setGroupInfoId] = useState<string | null>(null);
@@ -191,6 +193,7 @@ export function ChatRoom() {
         onOpenFaq={() => { setFaqOpen(true); setSidebarOpen(false); }}
         onOpenTutorial={() => { setTutorialOpen(true); setSidebarOpen(false); }}
         onOpenRespect={() => { setRespectOpen(true); setSidebarOpen(false); }}
+        onOpenEmpire={() => { setEmpireOpen(true); setSidebarOpen(false); }}
         xmtpConnected={xmtp.isConnected}
         xmtpConnecting={xmtp.isConnecting}
         xmtpError={xmtp.error}
@@ -552,6 +555,7 @@ export function ChatRoom() {
       {/* FAQ Panel */}
       <FaqPanel isOpen={faqOpen} onClose={() => setFaqOpen(false)} />
       <RespectPanel isOpen={respectOpen} onClose={() => setRespectOpen(false)} />
+      <EmpirePanel isOpen={empireOpen} onClose={() => setEmpireOpen(false)} />
 
       {/* Tutorial Panel */}
       <TutorialPanel isOpen={tutorialOpen} onClose={() => setTutorialOpen(false)} />

--- a/src/components/chat/EmpirePanel.tsx
+++ b/src/components/chat/EmpirePanel.tsx
@@ -1,0 +1,400 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useEscapeClose } from '@/hooks/useEscapeClose';
+import type {
+  AddressStatsResponse,
+  Booster,
+  LeaderboardEntry,
+  LeaderboardResponse,
+  LeaderboardSlot,
+} from '@/lib/empire-builder/types';
+
+type Tab = 'leaderboard' | 'you' | 'boosters';
+
+interface EmpirePanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface LeaderboardApiResponse {
+  success: boolean;
+  data?: {
+    slots: Array<{ index: number; id: string; name?: string; type?: string }>;
+    active: { index: number; id: string };
+    leaderboard: LeaderboardResponse | null;
+  };
+  error?: string;
+}
+
+interface MeApiResponse {
+  success: boolean;
+  data?: {
+    wallet: string | null;
+    slot?: { id: string; name?: string };
+    entry: AddressStatsResponse['entry'] | null;
+    boosters: Booster[];
+  };
+  error?: string;
+}
+
+function formatNumber(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toLocaleString();
+}
+
+function formatUsd(value: number): string {
+  return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+function shortAddress(addr: string): string {
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
+  const [tab, setTab] = useState<Tab>('leaderboard');
+  const [slots, setSlots] = useState<Array<{ index: number; id: string; name?: string; type?: string }>>([]);
+  const [activeSlot, setActiveSlot] = useState<number>(0);
+  const [board, setBoard] = useState<LeaderboardResponse | null>(null);
+  const [me, setMe] = useState<MeApiResponse['data'] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEscapeClose(onClose, isOpen);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetch(`/api/empire-builder/leaderboard?slot=${activeSlot}`).then(
+        (r) => r.json() as Promise<LeaderboardApiResponse>,
+      ),
+      fetch(`/api/empire-builder/me?slot=${activeSlot}`).then(
+        (r) => r.json() as Promise<MeApiResponse>,
+      ),
+    ])
+      .then(([boardRes, meRes]) => {
+        if (cancelled) return;
+        if (boardRes.success && boardRes.data) {
+          setSlots(boardRes.data.slots);
+          setBoard(boardRes.data.leaderboard);
+        } else {
+          setError('Could not load Empire Builder leaderboard');
+        }
+        if (meRes.success && meRes.data) setMe(meRes.data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Network error reaching Empire Builder');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, activeSlot]);
+
+  if (!isOpen) return null;
+
+  const entries = board?.entries ?? [];
+  const activeSlotInfo: LeaderboardSlot | null = board?.leaderboard ?? null;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/60 z-50" onClick={onClose} />
+      <div className="fixed inset-y-0 right-0 w-full max-w-md bg-[#0a1628] z-50 flex flex-col shadow-xl">
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0">
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white"
+            aria-label="Close empire panel"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <div className="flex-1 min-w-0">
+            <h2 className="font-semibold text-sm text-gray-300">ZABAL Empire</h2>
+            <p className="text-[10px] text-gray-500">
+              Empire Builder V3 - {activeSlotInfo?.name ?? 'Leaderboard'}
+            </p>
+          </div>
+          <a
+            href="https://www.empirebuilder.world/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[10px] text-[#f5a623]/70 hover:text-[#f5a623]"
+          >
+            Open
+          </a>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 px-3 py-2 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0">
+          {(
+            [
+              { id: 'leaderboard' as const, label: 'Leaderboard' },
+              { id: 'you' as const, label: 'You' },
+              { id: 'boosters' as const, label: 'Boosters' },
+            ]
+          ).map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                tab === t.id
+                  ? 'bg-[#f5a623] text-[#0a1628]'
+                  : 'text-gray-400 hover:bg-white/5 hover:text-white'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Slot selector */}
+        {slots.length > 1 && (
+          <div className="flex gap-1 px-3 py-2 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0 overflow-x-auto">
+            {slots.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => setActiveSlot(s.index)}
+                className={`flex-shrink-0 px-3 py-1 rounded-full text-[10px] font-medium transition-colors whitespace-nowrap ${
+                  s.index === activeSlot
+                    ? 'bg-[#f5a623]/15 text-[#f5a623] border border-[#f5a623]/30'
+                    : 'bg-[#1a2a3a] text-gray-400 hover:text-white'
+                }`}
+              >
+                {s.name ?? s.type ?? `Slot ${s.index + 1}`}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 py-5 space-y-4">
+          {loading ? (
+            <LoadingState />
+          ) : error ? (
+            <ErrorState message={error} />
+          ) : tab === 'leaderboard' ? (
+            <LeaderboardTab entries={entries} myWallet={me?.wallet ?? null} />
+          ) : tab === 'you' ? (
+            <YouTab data={me ?? null} />
+          ) : (
+            <BoostersTab boosters={me?.boosters ?? []} />
+          )}
+
+          <p className="text-[10px] text-gray-600 text-center pt-2">
+            Live from Empire Builder V3. Cached 60s.
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="text-center py-12">
+      <div className="w-6 h-6 border-2 border-[#f5a623] border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+      <p className="text-sm text-gray-400">Loading Empire Builder data...</p>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="text-center py-12">
+      <p className="text-red-400 text-sm">{message}</p>
+      <p className="text-[10px] text-gray-600 mt-2">
+        V3 just launched - retry in a moment or open empirebuilder.world directly.
+      </p>
+    </div>
+  );
+}
+
+function LeaderboardTab({
+  entries,
+  myWallet,
+}: {
+  entries: LeaderboardEntry[];
+  myWallet: string | null;
+}) {
+  if (entries.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <p className="text-sm text-gray-400">No entries yet on this leaderboard.</p>
+      </div>
+    );
+  }
+
+  const myAddr = myWallet?.toLowerCase() ?? null;
+
+  return (
+    <div className="space-y-2">
+      {entries.slice(0, 50).map((entry) => {
+        const isMe = myAddr && entry.address.toLowerCase() === myAddr;
+        return (
+          <div
+            key={entry.address}
+            className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
+              isMe
+                ? 'bg-[#f5a623]/10 border-[#f5a623]/30'
+                : entry.rank <= 3
+                ? 'bg-[#f5a623]/5 border-[#f5a623]/20'
+                : 'bg-[#0d1b2a] border-white/[0.08]'
+            }`}
+          >
+            <span className="text-sm font-bold w-8 text-center text-gray-300">#{entry.rank}</span>
+            <div className="flex-1 min-w-0">
+              <p
+                className={`text-sm font-medium truncate ${
+                  isMe ? 'text-[#f5a623]' : 'text-white'
+                }`}
+              >
+                {entry.farcaster_username
+                  ? `@${entry.farcaster_username}`
+                  : shortAddress(entry.address)}
+                {isMe && ' (you)'}
+              </p>
+              <p className="text-[10px] text-gray-500 truncate">{shortAddress(entry.address)}</p>
+            </div>
+            <div className="text-right">
+              <p className={`text-sm font-bold ${isMe ? 'text-[#f5a623]' : 'text-white'}`}>
+                {formatNumber(entry.points ?? entry.score ?? 0)}
+              </p>
+              <p className="text-[10px] text-gray-500">
+                {entry.totalRewards
+                  ? formatUsd(entry.totalRewards)
+                  : entry.score && entry.points
+                  ? `${(entry.points / Math.max(entry.score, 1)).toFixed(2)}x boost`
+                  : 'no rewards yet'}
+              </p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function YouTab({ data }: { data: MeApiResponse['data'] | null }) {
+  if (!data || !data.wallet) {
+    return (
+      <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] text-center">
+        <p className="text-sm text-gray-400">
+          Connect your wallet to see your Empire Builder rank, boosters, and lifetime rewards.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data.entry) {
+    return (
+      <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] text-center">
+        <p className="text-sm text-gray-400">
+          Wallet {shortAddress(data.wallet)} is not on this leaderboard yet.
+        </p>
+        <a
+          href="https://www.empirebuilder.world/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] text-[#f5a623] hover:text-[#ffd700] mt-3 inline-block"
+        >
+          Stake or hold ZABAL to qualify
+        </a>
+      </div>
+    );
+  }
+
+  const entry = data.entry;
+  const score = entry.score ?? 0;
+  const points = entry.points ?? 0;
+  const boost = score > 0 ? points / score : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-gradient-to-r from-[#f5a623]/10 to-[#ffd700]/5 rounded-xl p-5 border border-[#f5a623]/30">
+        <p className="text-xs text-[#f5a623] uppercase tracking-wider mb-3">Your ZABAL Empire</p>
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-3xl font-bold text-white">{formatNumber(points)}</p>
+            <p className="text-xs text-gray-400 mt-1">
+              {formatNumber(score)} score, {boost.toFixed(2)}x boost
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-4xl font-bold text-[#f5a623]">#{entry.rank}</p>
+            <p className="text-xs text-gray-400">your rank</p>
+          </div>
+        </div>
+      </div>
+
+      {entry.totalRewards !== undefined && entry.totalRewards > 0 && (
+        <div className="bg-[#0d1b2a] rounded-xl p-4 border border-white/[0.08]">
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider mb-1">Lifetime Rewards</p>
+          <p className="text-2xl font-bold text-white">{formatUsd(entry.totalRewards)}</p>
+          <p className="text-[10px] text-gray-500 mt-1">USD across all distributions to this address</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BoostersTab({ boosters }: { boosters: Booster[] }) {
+  if (boosters.length === 0) {
+    return (
+      <div className="text-center py-10">
+        <p className="text-sm text-gray-400">No boosters surfaced for your wallet.</p>
+        <p className="text-[10px] text-gray-600 mt-2">
+          Boosters multiply your leaderboard score. Hold qualifying NFTs or tokens to unlock.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {boosters.map((b, i) => (
+        <div
+          key={`${b.contractAddress ?? 'booster'}-${i}`}
+          className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
+            b.qualified
+              ? 'bg-[#f5a623]/5 border-[#f5a623]/30'
+              : 'bg-[#0d1b2a] border-white/[0.08]'
+          }`}
+        >
+          <div className="w-9 h-9 rounded-lg bg-[#1a2a3a] flex items-center justify-center flex-shrink-0">
+            <span className="text-xs font-bold text-[#f5a623]">
+              {b.multiplier ? `${b.multiplier}x` : b.type.slice(0, 3)}
+            </span>
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-white truncate">
+              {b.token_symbol ?? b.type}
+              <span className="ml-2 text-[10px] text-gray-500 uppercase">{b.type}</span>
+            </p>
+            {b.contractAddress && (
+              <p className="text-[10px] text-gray-500 truncate">{shortAddress(b.contractAddress)}</p>
+            )}
+          </div>
+          <span
+            className={`text-[10px] font-medium px-2 py-1 rounded-full ${
+              b.qualified
+                ? 'bg-[#f5a623]/15 text-[#f5a623]'
+                : 'bg-white/5 text-gray-500'
+            }`}
+          >
+            {b.qualified ? 'qualified' : 'locked'}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -87,6 +87,7 @@ interface SidebarProps {
   onOpenFaq?: () => void;
   onOpenTutorial?: () => void;
   onOpenRespect?: () => void;
+  onOpenEmpire?: () => void;
   xmtpConnected: boolean;
   xmtpConnecting: boolean;
   xmtpError?: string | null;
@@ -107,7 +108,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({
-  user, isOpen, onClose, onLogout, activeChannel, onChannelSelect, isTrending, onTrendingSelect, onOpenFaq, onOpenTutorial, onOpenRespect,
+  user, isOpen, onClose, onLogout, activeChannel, onChannelSelect, isTrending, onTrendingSelect, onOpenFaq, onOpenTutorial, onOpenRespect, onOpenEmpire,
   xmtpConnected, xmtpConnecting, xmtpError, xmtpConversations, activeConversationId,
   onXmtpConnect, onConversationSelect, onNewDm, onNewGroup,
   zaoMembers, loadingMembers, onStartDmWithMember, onGroupInfo, onRemoveConversation, onRefreshMembers, onResetXmtp,
@@ -634,6 +635,24 @@ export function Sidebar({
               </svg>
               Respect
             </button>
+            {onOpenEmpire && (
+              <button
+                onClick={() => { onOpenEmpire(); onClose(); }}
+                className={`flex items-center gap-2 w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors ${
+                  activeChannel === 'zabal'
+                    ? 'bg-[#f5a623]/10 text-[#f5a623] hover:bg-[#f5a623]/15'
+                    : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                }`}
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 21V8.25l9-5.25 9 5.25V21M9 21V12h6v9M3 21h18" />
+                </svg>
+                ZABAL Empire
+                {activeChannel === 'zabal' && (
+                  <span className="ml-auto text-[9px] uppercase tracking-wider text-[#f5a623]/70">live</span>
+                )}
+              </button>
+            )}
             {user.isAdmin && (
               <a
                 href="/admin"

--- a/src/components/ecosystem/EmpireZabalHero.tsx
+++ b/src/components/ecosystem/EmpireZabalHero.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface SnapshotResponse {
+  success: boolean;
+  data?: {
+    empire: {
+      name?: string;
+      token_symbol?: string;
+      farcaster_name?: string;
+      rank?: number;
+      total_distributed?: string | number;
+      total_burned?: string | number;
+    } | null;
+    topLeaderboard: {
+      entries: Array<{
+        address: string;
+        rank: number;
+        farcaster_username?: string | null;
+        points?: number;
+        score?: number;
+        totalRewards?: number;
+      }>;
+    } | null;
+    totals: {
+      lifetimeDistributedUsd: number;
+      lifetimeBurned: number;
+      distributionCount: number;
+      burnCount: number;
+    };
+  };
+  error?: string;
+}
+
+function formatUsd(value: number): string {
+  if (!Number.isFinite(value) || value === 0) return '$0';
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+function formatTokens(value: number): string {
+  if (!Number.isFinite(value) || value === 0) return '0';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toFixed(0);
+}
+
+function shortAddress(addr: string): string {
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+export function EmpireZabalHero() {
+  const [data, setData] = useState<SnapshotResponse['data'] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetch('/api/empire-builder/snapshot')
+      .then((r) => r.json() as Promise<SnapshotResponse>)
+      .then((res) => {
+        if (cancelled) return;
+        if (res.success && res.data) {
+          setData(res.data);
+        } else {
+          setError(res.error ?? 'snapshot_unavailable');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError('network_error');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-gradient-to-br from-[#f5a623]/10 to-[#0d1b2a] rounded-2xl border border-[#f5a623]/20 p-5 mb-4 animate-pulse">
+        <div className="h-3 bg-white/5 rounded w-32 mb-3" />
+        <div className="grid grid-cols-3 gap-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="bg-[#0d1b2a]/60 rounded-xl p-3">
+              <div className="h-5 bg-white/5 rounded w-16 mb-2" />
+              <div className="h-2.5 bg-white/5 rounded w-20" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) return null;
+
+  const { totals, topLeaderboard, empire } = data;
+  const topThree = topLeaderboard?.entries.slice(0, 3) ?? [];
+
+  return (
+    <div className="bg-gradient-to-br from-[#f5a623]/10 via-[#0d1b2a] to-[#0d1b2a] rounded-2xl border border-[#f5a623]/20 p-5 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <p className="text-[10px] text-[#f5a623] uppercase tracking-wider font-medium">
+            ZABAL Empire - Live
+          </p>
+          <p className="text-xs text-gray-500 mt-0.5">
+            {empire?.name ?? '$ZABAL'} on Empire Builder V3
+            {empire?.rank ? ` - rank #${empire.rank}` : ''}
+          </p>
+        </div>
+        <a
+          href="https://www.empirebuilder.world/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[10px] text-[#f5a623]/70 hover:text-[#f5a623] transition-colors whitespace-nowrap"
+        >
+          Open Empire &rarr;
+        </a>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-4">
+        <div className="bg-[#0a1628] rounded-xl p-3 border border-white/[0.06]">
+          <p className="text-lg font-bold text-white">{formatUsd(totals.lifetimeDistributedUsd)}</p>
+          <p className="text-[10px] text-gray-500 mt-0.5">Lifetime distributed</p>
+        </div>
+        <div className="bg-[#0a1628] rounded-xl p-3 border border-white/[0.06]">
+          <p className="text-lg font-bold text-white">{formatTokens(totals.lifetimeBurned)}</p>
+          <p className="text-[10px] text-gray-500 mt-0.5">$ZABAL burned</p>
+        </div>
+        <div className="bg-[#0a1628] rounded-xl p-3 border border-white/[0.06]">
+          <p className="text-lg font-bold text-white">{topLeaderboard?.entries.length ?? 0}</p>
+          <p className="text-[10px] text-gray-500 mt-0.5">Holders ranked</p>
+        </div>
+      </div>
+
+      {topThree.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[10px] text-gray-500 uppercase tracking-wider">Top holders</p>
+          {topThree.map((entry) => (
+            <div
+              key={entry.address}
+              className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#0a1628] border border-white/[0.04]"
+            >
+              <span className="text-xs font-bold text-[#f5a623] w-5">#{entry.rank}</span>
+              <p className="flex-1 text-xs text-white truncate">
+                {entry.farcaster_username
+                  ? `@${entry.farcaster_username}`
+                  : shortAddress(entry.address)}
+              </p>
+              <p className="text-xs text-gray-400">
+                {entry.points
+                  ? entry.points.toLocaleString()
+                  : entry.score?.toLocaleString() ?? '-'}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/empire-builder/cache.ts
+++ b/src/lib/empire-builder/cache.ts
@@ -1,0 +1,19 @@
+import { EMPIRE_BUILDER_CACHE_TTL_MS } from './config';
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry<unknown>>();
+
+export async function withCache<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
+  const now = Date.now();
+  const hit = cache.get(key) as CacheEntry<T> | undefined;
+  if (hit && hit.expiresAt > now) return hit.value;
+  const value = await fetcher();
+  cache.set(key, { value, expiresAt: now + ttlMs });
+  return value;
+}
+
+export const DEFAULT_TTL_MS = EMPIRE_BUILDER_CACHE_TTL_MS;

--- a/src/lib/empire-builder/client.ts
+++ b/src/lib/empire-builder/client.ts
@@ -1,0 +1,212 @@
+// Server-side Empire Builder V3 read client.
+// Public reads need no auth (per docs as of 2026-05-01). EMPIRE_BUILDER_API_KEY is
+// reserved for future write/whitelisted endpoints (distribute, burn, airdrop).
+// Never import this module from client components — it reads env vars at module load.
+
+import { z } from 'zod';
+import {
+  EMPIRE_BUILDER_BASE_URL,
+  EMPIRE_BUILDER_FETCH_TIMEOUT_MS,
+  ZABAL_TOKEN_ADDRESS,
+} from './config';
+import {
+  addressStatsResponseSchema,
+  type AddressStatsResponse,
+  type Booster,
+  boosterSchema,
+  type EmpireSummary,
+  empireSummarySchema,
+  leaderboardListResponseSchema,
+  type LeaderboardResponse,
+  leaderboardResponseSchema,
+  leaderboardSlotSchema,
+  type LeaderboardSlot,
+  rewardsByTypeResponseSchema,
+  type RewardsByTypeResponse,
+  rewardsSummaryResponseSchema,
+  type RewardsSummaryResponse,
+} from './types';
+
+const apiKey = process.env.EMPIRE_BUILDER_API_KEY;
+
+interface FetchOptions {
+  signal?: AbortSignal;
+}
+
+async function ebFetch<T>(path: string, schema: z.ZodType<T>, opts: FetchOptions = {}): Promise<T> {
+  const url = path.startsWith('http') ? path : `${EMPIRE_BUILDER_BASE_URL}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), EMPIRE_BUILDER_FETCH_TIMEOUT_MS);
+
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers,
+      signal: opts.signal ?? controller.signal,
+      cache: 'no-store',
+    });
+    if (!res.ok) {
+      throw new Error(`Empire Builder API ${res.status} for ${path}`);
+    }
+    const json = (await res.json()) as unknown;
+    return schema.parse(json);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getTopEmpires(params: { page?: number; limit?: number } = {}): Promise<EmpireSummary[]> {
+  const page = params.page ?? 1;
+  const limit = params.limit ?? 20;
+  const responseSchema = z
+    .object({
+      empires: z.array(empireSummarySchema).optional(),
+      data: z.array(empireSummarySchema).optional(),
+    })
+    .passthrough();
+  const data = await ebFetch(`/top-empires?page=${page}&limit=${limit}`, responseSchema);
+  return data.empires ?? data.data ?? [];
+}
+
+export async function getEmpire(empireId: string): Promise<EmpireSummary | null> {
+  const responseSchema = z
+    .object({
+      empire: empireSummarySchema.optional(),
+      success: z.boolean().optional(),
+    })
+    .passthrough();
+  try {
+    const data = await ebFetch(`/empires/${empireId}`, responseSchema);
+    return data.empire ?? (empireSummarySchema.safeParse(data).success ? (data as EmpireSummary) : null);
+  } catch {
+    return null;
+  }
+}
+
+export async function discoverLeaderboards(
+  tokenAddress: string = ZABAL_TOKEN_ADDRESS,
+): Promise<LeaderboardSlot[]> {
+  const data = await ebFetch(
+    `/leaderboards?tokenAddress=${tokenAddress}`,
+    leaderboardListResponseSchema,
+  );
+  if (data.leaderboards && data.leaderboards.length > 0) return data.leaderboards;
+
+  // Defensive: handle alternative shapes the docs hint at without committing to one
+  const altShape = z
+    .object({
+      data: z.array(leaderboardSlotSchema).optional(),
+      results: z.array(leaderboardSlotSchema).optional(),
+    })
+    .passthrough()
+    .safeParse(data);
+  if (altShape.success) {
+    return altShape.data.data ?? altShape.data.results ?? [];
+  }
+  return [];
+}
+
+export async function getLeaderboard(leaderboardId: string): Promise<LeaderboardResponse> {
+  return ebFetch(`/leaderboards/${leaderboardId}`, leaderboardResponseSchema);
+}
+
+export async function getLeaderboardForAddress(
+  leaderboardId: string,
+  walletAddress: string,
+): Promise<AddressStatsResponse | null> {
+  try {
+    return await ebFetch(
+      `/leaderboards/${leaderboardId}/address/${walletAddress}`,
+      addressStatsResponseSchema,
+    );
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('404')) return null;
+    throw err;
+  }
+}
+
+export async function getBoosters(empireId: string): Promise<Booster[]> {
+  const responseSchema = z
+    .object({
+      boosters: z.array(boosterSchema).optional(),
+      data: z.array(boosterSchema).optional(),
+    })
+    .passthrough();
+  const data = await ebFetch(`/boosters/${empireId}`, responseSchema);
+  return data.boosters ?? data.data ?? [];
+}
+
+export async function getRewardsSummary(empireId: string): Promise<RewardsSummaryResponse> {
+  return ebFetch(`/empire-rewards/${empireId}`, rewardsSummaryResponseSchema);
+}
+
+export async function getRewardsByType(
+  empireId: string,
+  type: 'distribute' | 'burned' | 'airdrop',
+): Promise<RewardsByTypeResponse> {
+  return ebFetch(`/empire-rewards/${empireId}/${type}`, rewardsByTypeResponseSchema);
+}
+
+interface ZabalSnapshot {
+  empire: EmpireSummary | null;
+  topLeaderboard: LeaderboardResponse | null;
+  rewardsSummary: RewardsSummaryResponse | null;
+  totals: {
+    lifetimeDistributedUsd: number;
+    lifetimeBurned: number;
+    distributionCount: number;
+    burnCount: number;
+  };
+}
+
+function toNumber(value: string | number | undefined): number {
+  if (value === undefined) return 0;
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export async function getZabalSnapshot(): Promise<ZabalSnapshot> {
+  // Resolve empire + first leaderboard + rewards in parallel.
+  const [empire, leaderboards, rewardsSummary] = await Promise.allSettled([
+    getEmpire(ZABAL_TOKEN_ADDRESS),
+    discoverLeaderboards(ZABAL_TOKEN_ADDRESS),
+    getRewardsSummary(ZABAL_TOKEN_ADDRESS),
+  ]);
+
+  const empireData = empire.status === 'fulfilled' ? empire.value : null;
+  const slots = leaderboards.status === 'fulfilled' ? leaderboards.value : [];
+  const summary = rewardsSummary.status === 'fulfilled' ? rewardsSummary.value : null;
+
+  let topLeaderboard: LeaderboardResponse | null = null;
+  if (slots.length > 0) {
+    try {
+      topLeaderboard = await getLeaderboard(slots[0].id);
+    } catch {
+      topLeaderboard = null;
+    }
+  }
+
+  const distributedItems = summary?.empire_rewards ?? [];
+  const burnedItems = summary?.burned ?? [];
+
+  const lifetimeDistributedUsd = distributedItems.reduce(
+    (acc, item) => acc + toNumber(item.amount_usd ?? item.amount),
+    0,
+  );
+  const lifetimeBurned = burnedItems.reduce((acc, item) => acc + toNumber(item.amount), 0);
+
+  return {
+    empire: empireData,
+    topLeaderboard,
+    rewardsSummary: summary,
+    totals: {
+      lifetimeDistributedUsd,
+      lifetimeBurned,
+      distributionCount: distributedItems.length,
+      burnCount: burnedItems.length,
+    },
+  };
+}

--- a/src/lib/empire-builder/config.ts
+++ b/src/lib/empire-builder/config.ts
@@ -1,0 +1,17 @@
+// Empire Builder configuration for the ZABAL empire.
+//
+// ZABAL token (base_token): launched via Clanker on Base (doc 361).
+// Empire address: the treasury / profile address used in empirebuilder.world URLs.
+// These two addresses are distinct. The leaderboard discovery endpoint takes
+// `tokenAddress` (base token); the empires endpoint takes `empire_id` which can be
+// either the base token or the empire address depending on context. Code defensively.
+
+export const ZABAL_TOKEN_ADDRESS = '0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07' as const;
+
+export const ZABAL_EMPIRE_ADDRESS = '0x7234c36A71ec237c2Ae7698e8916e0735001E9Af' as const;
+
+export const EMPIRE_BUILDER_BASE_URL = 'https://empirebuilder.world/api' as const;
+
+export const EMPIRE_BUILDER_CACHE_TTL_MS = 60 * 1000;
+
+export const EMPIRE_BUILDER_FETCH_TIMEOUT_MS = 8000;

--- a/src/lib/empire-builder/types.ts
+++ b/src/lib/empire-builder/types.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+// Loose schemas: V3 API is new (live 2026-05-01) and may evolve.
+// Use `.passthrough()` so unknown fields do not break parsing.
+
+export const empireSummarySchema = z
+  .object({
+    empire_address: z.string(),
+    base_token: z.string().optional(),
+    name: z.string().optional(),
+    token_symbol: z.string().optional(),
+    owner: z.string().optional(),
+    rank: z.number().optional(),
+    total_distributed: z.union([z.string(), z.number()]).optional(),
+    total_burned: z.union([z.string(), z.number()]).optional(),
+    native: z.string().optional(),
+    farcaster_name: z.string().optional(),
+    logo_uri: z.string().optional(),
+    created_at: z.string().optional(),
+  })
+  .passthrough();
+export type EmpireSummary = z.infer<typeof empireSummarySchema>;
+
+export const leaderboardSlotSchema = z
+  .object({
+    id: z.string(),
+    empire_address: z.string().optional(),
+    leaderboard_type: z.string().optional(),
+    name: z.string().optional(),
+    leaderboard_number: z.number().optional(),
+  })
+  .passthrough();
+export type LeaderboardSlot = z.infer<typeof leaderboardSlotSchema>;
+
+export const leaderboardEntrySchema = z
+  .object({
+    address: z.string(),
+    rank: z.number(),
+    score: z.number().optional(),
+    points: z.number().optional(),
+    farcaster_username: z.string().nullable().optional(),
+    totalRewards: z.number().optional(),
+  })
+  .passthrough();
+export type LeaderboardEntry = z.infer<typeof leaderboardEntrySchema>;
+
+export const leaderboardResponseSchema = z
+  .object({
+    success: z.boolean().optional(),
+    leaderboard: leaderboardSlotSchema,
+    entries: z.array(leaderboardEntrySchema),
+  })
+  .passthrough();
+export type LeaderboardResponse = z.infer<typeof leaderboardResponseSchema>;
+
+export const boosterSchema = z
+  .object({
+    type: z.string(),
+    contractAddress: z.string().optional(),
+    multiplier: z.number().optional(),
+    qualified: z.boolean().optional(),
+    requirement: z
+      .object({
+        minAmount: z.union([z.string(), z.number()]).optional(),
+      })
+      .passthrough()
+      .optional(),
+    token_symbol: z.string().optional(),
+    token_image_url: z.string().optional(),
+    chainId: z.number().optional(),
+  })
+  .passthrough();
+export type Booster = z.infer<typeof boosterSchema>;
+
+export const addressStatsResponseSchema = z
+  .object({
+    success: z.boolean().optional(),
+    entry: leaderboardEntrySchema,
+    boosters: z.array(boosterSchema).optional(),
+    leaderboard: leaderboardSlotSchema,
+  })
+  .passthrough();
+export type AddressStatsResponse = z.infer<typeof addressStatsResponseSchema>;
+
+export const rewardItemSchema = z
+  .object({
+    type: z.string().optional(),
+    amount: z.union([z.string(), z.number()]).optional(),
+    amount_usd: z.union([z.string(), z.number()]).optional(),
+    transaction_hash: z.string().optional(),
+    created_at: z.string().optional(),
+  })
+  .passthrough();
+
+export const rewardsSummaryResponseSchema = z
+  .object({
+    empire_rewards: z.array(rewardItemSchema).optional(),
+    burned: z.array(rewardItemSchema).optional(),
+    airdrops: z.array(rewardItemSchema).optional(),
+  })
+  .passthrough();
+export type RewardsSummaryResponse = z.infer<typeof rewardsSummaryResponseSchema>;
+
+export const rewardsByTypeResponseSchema = z
+  .object({
+    rewards: z.array(rewardItemSchema),
+    count: z.number().optional(),
+  })
+  .passthrough();
+export type RewardsByTypeResponse = z.infer<typeof rewardsByTypeResponseSchema>;
+
+export const leaderboardListResponseSchema = z
+  .object({
+    leaderboards: z.array(leaderboardSlotSchema).optional(),
+    success: z.boolean().optional(),
+  })
+  .passthrough();
+export type LeaderboardListResponse = z.infer<typeof leaderboardListResponseSchema>;


### PR DESCRIPTION
## Summary

Wires Empire Builder V3 (live since 2026-05-01, doc 582 + 583 idea surface) into ZAO OS. Closes ideas 1, 4, 11, 15 from doc 583.

## What ships

- **Server client** at `src/lib/empire-builder/{config,types,client,cache}.ts`. Zod-validated, in-memory 60s cache. `EMPIRE_BUILDER_API_KEY` reserved for future write endpoints.
- **3 API routes** under `/api/empire-builder/*`:
  - `GET /snapshot` - aggregated empire + top leaderboard + rewards (used by hero)
  - `GET /leaderboard?slot=N` - entries for slot N (default 0)
  - `GET /me?slot=N` - per-user rank + boosters from session wallet
- **EmpirePanel** drawer (`src/components/chat/EmpirePanel.tsx`) - 3 tabs (Leaderboard, You, Boosters). Mirrors RespectPanel UX.
- **Sidebar entry** - new "ZABAL Empire" button under Pages, auto-highlights on /zabal channel.
- **EmpireZabalHero** strip on /ecosystem - lifetime USD distributed, ZABAL burned, holders, top 3.

## How to test

1. npm run dev, log in as a ZAO member.
2. Sidebar -> Pages -> click "ZABAL Empire". Drawer should load top 50 ZABAL leaderboard.
3. Switch to Leaderboard / You / Boosters tabs.
4. Visit /ecosystem -> hero at top shows live stats + top 3.
5. Switch to /zabal channel -> "ZABAL Empire" button highlights gold.

## Test plan
- [ ] EmpirePanel opens from sidebar
- [ ] Leaderboard tab shows entries
- [ ] You tab shows correct rank or clean empty state
- [ ] Boosters tab shows qualified/locked correctly
- [ ] EmpireZabalHero loads on /ecosystem with live numbers
- [ ] Each EB endpoint hits at most once per 60s
- [ ] No EMPIRE_BUILDER_API_KEY exposed in browser bundle

## Notes for Adrian (Sunday window)
- Confirm rate limits per IP / per token?
- Confirm write endpoints (distribute / burn / airdrop) timeline?

🤖 Generated with [Claude Code](https://claude.com/claude-code)