### PR TITLE
feat(empire-builder): iteration-2 cross-product slot dashboard + voting tab + booster proposal

### DIFF
--- a/research/business/586-zabal-booster-network-effect-proposal/README.md
+++ b/research/business/586-zabal-booster-network-effect-proposal/README.md
@@ -1,0 +1,94 @@
+---
+topic: business
+type: decision
+status: review-pending
+last-validated: 2026-05-02
+related-docs: 582, 583, 584, 585
+tier: STANDARD
+---
+
+# 586 - ZABAL Empire Network-Effect Booster Proposal (Telegram-Ready)
+
+> **Goal:** A drop-in proposal Zaal can paste into Telegram to Adrian (`@glankerempire`) requesting that 5 network-effect ERC-20 boosters be added to the ZABAL Empire on Empire Builder V3. Closes issue EB-18 (#433).
+
+---
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| Send timing | SEND before Sunday 2026-05-04 official V3 announcement window. Adrian is bug-bashing in the open this week, low-friction time to ask for empire config changes. |
+| Tone | PEER. Adrian is a top ZABAL holder himself (rank 3 as `diviflyy`). Frame as "we're building EB into ZAOOS, here is the booster set we want; mirrors your own glonkybot config". |
+| Scope | 5 boosters in this round. Don't over-ask. Each is a top-20 empire token by `total_distributed` or `rank` (doc 584). |
+| Multiplier values | 5x for the strongest fits (CLANKER, GLANKER), 3x for the rest. Mirrors glonkybot's scheme but slightly more conservative. |
+| Threshold values | Use `10000000000000000000000000` = 10M tokens with 18 decimals (the same threshold glonkybot uses on every ERC-20 booster). Keeps onboarding consistent across empires. |
+
+---
+
+## The Proposal (paste this to Telegram)
+
+> Hey Adrian - GM. Diving into V3 on the ZABAL side and wanted to flag one config ask. We are building Empire Builder native into ZAO OS so members can see ZABAL leaderboard / boosters / distributions inline (PRs #412 + #429). Pulled the data and noticed our boosters set is light (LOANZ, zaal, SANG, ZAAL) compared to glonkybot's 17-token cross-promotion strategy.
+>
+> Want to mirror your network-effect approach with 5 boosters, all ERC-20 on Base, threshold 10M tokens (matches your glonkybot threshold):
+>
+> 1. **CLANKER** `0x1bc0c42215582d5a085795f4badbac3ff36d1bcb` - 5x
+> 2. **GLANKER** `0x33ac788bc9ccb27e9ec558fb2bde79950a6b9d5b` - 5x
+> 3. **ARTBABY** `0x09f3f0ee2cf938f56bc664ce85152209a7457b07` - 3x
+> 4. **BB (BizarreBeasts)** `0x0520bf1d3cee163407ada79109333ab1599b4004` - 3x
+> 5. **PUSH (Keep Pushing)** `0x620468c62ad229a110365495dd0d7b7b802fab81` - 3x
+>
+> Rationale per token:
+> - **CLANKER** is the launchpad ZABAL was deployed through. Holders are aligned with the whole Farcaster token economy.
+> - **GLANKER** is your bot's native token. Reciprocates - we list yours, your members get a boost in ours, and the loop closes.
+> - **ARTBABY** is the top distributor in V3 ($10.7K lifetime). Pulls in a creator audience.
+> - **BB** has the highest burn ratio in the top 10 (368M burned for $3.8K distributed). Disciplined community.
+> - **PUSH** is a daily-cadence motivational community - high engagement profile, good cross-rewards.
+>
+> Once these are live we will surface them in our /zabal channel inside ZAO OS so members can see qualification status. Happy to Zoom for 15 to walk through the rest of the questions doc 582 / 583 / 584 surfaced (especially `farToken` semantics, the `api` leaderboard write path, and the QUOTIENT booster source).
+
+---
+
+## Why these 5 (full reasoning)
+
+| Booster | Why it fits ZABAL | Empire stats (doc 584) | Multiplier |
+|---------|-------------------|------------------------|------------|
+| CLANKER | ZABAL was launched via Clanker. Adrian's Glonkybot has it at 1.5x at a low threshold. Low cost, high signal. | Now Farcaster-owned launchpad. Network-foundational. | 5x |
+| GLANKER | Adrian's empire token. ZAO honoring his network-effect strategy by including it. Reciprocity. | Highest rank score in top-20 (9.34). | 5x |
+| ARTBABY | Top USD distributor in V3. Holders are creators, ZAO's natural audience. | $10,797 distributed lifetime, 5.6B burned. | 3x |
+| BB | BizarreBeasts community. Highest burn-to-distribute ratio in top 10. Disciplined / loyal. | $3,854 distributed, 368M burned. | 3x |
+| PUSH | "Keep Pushing" daily-greeting community. Active engagement profile, complements ZAO's GM patterns. | $4,066 distributed, 1.04B burned, owner `push-`. | 3x |
+
+## What we are not asking for (yet)
+
+- DICKBUTT, SAUSAGE, CLANKERMON, etc. - cultural fit unclear for ZAO right now.
+- LUM, REAPS, SPARTAN, MTDV, hmbt - smaller empires, secondary.
+- Any NFT booster - ZAO does not run an NFT collection at the scale ArtBaby does. Skip the NFT-collector archetype for ZABAL.
+
+## Open Questions Bundle (separate Telegram message)
+
+1. CORS for `zaoos.com` calling `empirebuilder.world/api/*` direct (we proxy server-side currently).
+2. Rate limits per IP / per token / per endpoint.
+3. `farToken` vs `tokenHolders` - what is the engagement signal in farToken?
+4. `api` leaderboard - how does ZAOOS submit votes to a slot like the Zabal Voting Miniapp?
+5. QUOTIENT booster - source of truth (Quotient API)?
+6. `total_distributed` denomination - USD always, or token sometimes?
+7. Write API timeline (distribute / burn / airdrop) and whitelisting process.
+8. Webhooks (push) vs polling (current) for distribute / burn / airdrop events.
+
+## Sources
+
+- [Doc 584 — top creator playbooks](../584-empire-builder-farcaster-creator-playbooks/) - the data behind the 5 picks
+- [Doc 583 — idea surface](../583-empire-builder-zao-os-integration-ideas/) - issue mapping
+- [Empire Builder API top-empires](https://empirebuilder.world/api/top-empires?page=1&limit=20)
+- [Empire Builder API glonkybot boosters](https://empirebuilder.world/api/boosters/0x33ac788bc9ccb27e9ec558fb2bde79950a6b9d5b)
+- Internal: PR #412 (MVP), PR #429 (hotfix), PR #430 (doc 585), Issues #413-#433
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Paste the proposal text into Telegram to @glankerempire | @Zaal | DM | Before Sunday 2026-05-04 |
+| Send the open-questions bundle as a follow-up Telegram message | @Zaal | DM | Same window |
+| Once boosters land in Adrian's config, refresh `/api/boosters/<ZABAL>` and confirm in EmpirePanel Boosters tab | @Claude (next session) | Verify | After Adrian confirms |
+| If Adrian asks for a 15-min Zoom, schedule via Zaal's calendar | @Zaal | Calendar | After he replies |
+| Close issue EB-18 (#433) once proposal is sent and add a link comment to the issue with the Telegram timestamp | @Zaal | Issue close | After send |

--- a/src/components/chat/EmpirePanel.tsx
+++ b/src/components/chat/EmpirePanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useEscapeClose } from '@/hooks/useEscapeClose';
 import type {
   AddressStatsResponse,
@@ -12,17 +12,24 @@ import type {
 import { LEADERBOARD_TYPE_LABELS } from '@/lib/empire-builder/types';
 import { ZABAL_OWNER } from '@/lib/empire-builder/config';
 
-type Tab = 'leaderboard' | 'you' | 'boosters';
+type Tab = 'leaderboard' | 'you' | 'boosters' | 'voting';
 
 interface EmpirePanelProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
+interface SlotInfo {
+  index: number;
+  id: string;
+  name?: string;
+  type?: string;
+}
+
 interface LeaderboardApiResponse {
   success: boolean;
   data?: {
-    slots: Array<{ index: number; id: string; name?: string; type?: string }>;
+    slots: SlotInfo[];
     active: { index: number; id: string };
     leaderboard: LeaderboardResponse | null;
   };
@@ -40,6 +47,30 @@ interface MeApiResponse {
   error?: string;
 }
 
+type GroupId = 'holders' | 'farcaster' | 'songjam' | 'respect' | 'voting' | 'other';
+
+const GROUP_ORDER: Array<{ id: GroupId; label: string }> = [
+  { id: 'holders', label: 'Holders' },
+  { id: 'farcaster', label: 'Farcaster' },
+  { id: 'songjam', label: 'SongJam' },
+  { id: 'respect', label: 'Respect' },
+  { id: 'voting', label: 'Voting' },
+  { id: 'other', label: 'Other' },
+];
+
+function groupOf(slot: SlotInfo): GroupId {
+  if (slot.type === 'tokenHolders') return 'holders';
+  if (slot.type === 'farToken') return 'farcaster';
+  if (slot.type === 'api') return 'voting';
+  const name = (slot.name ?? '').toLowerCase();
+  if (name.includes('songjam')) return 'songjam';
+  if (name.includes('respect')) return 'respect';
+  return 'other';
+}
+
+const SLOT_STORAGE_KEY = 'eb-empire-panel-slot';
+const TAB_STORAGE_KEY = 'eb-empire-panel-tab';
+
 function formatNumber(value: number): string {
   if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
   if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
@@ -56,7 +87,7 @@ function shortAddress(addr: string): string {
 
 export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
   const [tab, setTab] = useState<Tab>('leaderboard');
-  const [slots, setSlots] = useState<Array<{ index: number; id: string; name?: string; type?: string }>>([]);
+  const [slots, setSlots] = useState<SlotInfo[]>([]);
   const [activeSlot, setActiveSlot] = useState<number>(0);
   const [board, setBoard] = useState<LeaderboardResponse | null>(null);
   const [me, setMe] = useState<MeApiResponse['data'] | null>(null);
@@ -64,6 +95,21 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
   const [error, setError] = useState<string | null>(null);
   useEscapeClose(onClose, isOpen);
 
+  // Restore persisted slot + tab on first open
+  useEffect(() => {
+    if (!isOpen) return;
+    const savedSlot = typeof window !== 'undefined' ? window.localStorage.getItem(SLOT_STORAGE_KEY) : null;
+    if (savedSlot !== null) {
+      const idx = Number(savedSlot);
+      if (Number.isFinite(idx) && idx >= 0) setActiveSlot(idx);
+    }
+    const savedTab = typeof window !== 'undefined' ? window.localStorage.getItem(TAB_STORAGE_KEY) : null;
+    if (savedTab && ['leaderboard', 'you', 'boosters', 'voting'].includes(savedTab)) {
+      setTab(savedTab as Tab);
+    }
+  }, [isOpen]);
+
+  // Fetch on slot change while open
   useEffect(() => {
     if (!isOpen) return;
     let cancelled = false;
@@ -100,10 +146,56 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
     };
   }, [isOpen, activeSlot]);
 
+  const groupedSlots = useMemo(() => {
+    const map = new Map<GroupId, SlotInfo[]>();
+    for (const slot of slots) {
+      const id = groupOf(slot);
+      const list = map.get(id) ?? [];
+      list.push(slot);
+      map.set(id, list);
+    }
+    return map;
+  }, [slots]);
+
+  const activeSlotInfo = slots.find((s) => s.index === activeSlot) ?? slots[0] ?? null;
+  const activeGroup: GroupId = activeSlotInfo ? groupOf(activeSlotInfo) : 'holders';
+  const activeGroupSlots = groupedSlots.get(activeGroup) ?? [];
+  const isApiSlot = activeSlotInfo?.type === 'api';
+
+  // Snap voting tab back to leaderboard when leaving an api slot
+  useEffect(() => {
+    if (!isApiSlot && tab === 'voting') setTab('leaderboard');
+  }, [isApiSlot, tab]);
+
+  const handleSlotSelect = (index: number) => {
+    setActiveSlot(index);
+    if (typeof window !== 'undefined') window.localStorage.setItem(SLOT_STORAGE_KEY, String(index));
+  };
+
+  const handleGroupSelect = (groupId: GroupId) => {
+    const groupSlots = groupedSlots.get(groupId);
+    if (!groupSlots || groupSlots.length === 0) return;
+    handleSlotSelect(groupSlots[0].index);
+  };
+
+  const handleTabSelect = (next: Tab) => {
+    setTab(next);
+    if (typeof window !== 'undefined') window.localStorage.setItem(TAB_STORAGE_KEY, next);
+  };
+
   if (!isOpen) return null;
 
   const entries = board?.entries ?? [];
-  const activeSlotInfo: LeaderboardSlot | null = board?.leaderboard ?? null;
+  const slotInfo: LeaderboardSlot | null = board?.leaderboard ?? null;
+
+  const visibleGroups = GROUP_ORDER.filter((g) => (groupedSlots.get(g.id)?.length ?? 0) > 0);
+
+  const tabDefs: Array<{ id: Tab; label: string; show: boolean }> = [
+    { id: 'leaderboard', label: isApiSlot ? 'Voters' : 'Leaderboard', show: true },
+    { id: 'you', label: 'You', show: true },
+    { id: 'boosters', label: 'Boosters', show: !isApiSlot },
+    { id: 'voting', label: 'How it works', show: isApiSlot },
+  ];
 
   return (
     <>
@@ -122,8 +214,8 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
           </button>
           <div className="flex-1 min-w-0">
             <h2 className="font-semibold text-sm text-gray-300">ZABAL Empire</h2>
-            <p className="text-[10px] text-gray-500">
-              Empire Builder V3 - {activeSlotInfo?.name ?? 'Leaderboard'}
+            <p className="text-[10px] text-gray-500 truncate">
+              Empire Builder V3 - {slotInfo?.name ?? 'Leaderboard'}
             </p>
           </div>
           <a
@@ -136,53 +228,79 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
           </a>
         </div>
 
-        {/* Tabs */}
-        <div className="flex gap-1 px-3 py-2 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0">
-          {(
-            [
-              { id: 'leaderboard' as const, label: 'Leaderboard' },
-              { id: 'you' as const, label: 'You' },
-              { id: 'boosters' as const, label: 'Boosters' },
-            ]
-          ).map((t) => (
-            <button
-              key={t.id}
-              onClick={() => setTab(t.id)}
-              className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-                tab === t.id
-                  ? 'bg-[#f5a623] text-[#0a1628]'
-                  : 'text-gray-400 hover:bg-white/5 hover:text-white'
-              }`}
-            >
-              {t.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Slot selector */}
-        {slots.length > 1 && (
+        {/* Group tabs */}
+        {visibleGroups.length > 1 && (
           <div className="flex gap-1 px-3 py-2 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0 overflow-x-auto">
-            {slots.map((s) => {
-              const typeLabel = s.type ? LEADERBOARD_TYPE_LABELS[s.type] ?? s.type : null;
+            {visibleGroups.map((g) => {
+              const count = groupedSlots.get(g.id)?.length ?? 0;
+              const isActive = g.id === activeGroup;
               return (
                 <button
-                  key={s.id}
-                  onClick={() => setActiveSlot(s.index)}
-                  className={`flex-shrink-0 px-3 py-1 rounded-full text-[10px] font-medium transition-colors whitespace-nowrap flex items-center gap-1.5 ${
-                    s.index === activeSlot
+                  key={g.id}
+                  onClick={() => handleGroupSelect(g.id)}
+                  className={`flex-shrink-0 px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap flex items-center gap-1.5 ${
+                    isActive
                       ? 'bg-[#f5a623]/15 text-[#f5a623] border border-[#f5a623]/30'
                       : 'bg-[#1a2a3a] text-gray-400 hover:text-white'
                   }`}
                 >
-                  <span>{s.name ?? s.type ?? `Slot ${s.index + 1}`}</span>
-                  {typeLabel && (
-                    <span className="text-[8px] opacity-60 uppercase tracking-wider">
-                      {typeLabel}
-                    </span>
+                  <span>{g.label}</span>
+                  {count > 1 && (
+                    <span className="text-[9px] opacity-70">{count}</span>
                   )}
                 </button>
               );
             })}
+          </div>
+        )}
+
+        {/* Sub-pills (only when current group has multiple slots) */}
+        {activeGroupSlots.length > 1 && (
+          <div className="flex gap-1 px-3 py-1.5 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0 overflow-x-auto">
+            {activeGroupSlots.map((s) => (
+              <button
+                key={s.id}
+                onClick={() => handleSlotSelect(s.index)}
+                className={`flex-shrink-0 px-2.5 py-0.5 rounded-full text-[10px] font-medium transition-colors whitespace-nowrap ${
+                  s.index === activeSlot
+                    ? 'bg-[#f5a623] text-[#0a1628]'
+                    : 'bg-white/5 text-gray-400 hover:text-white'
+                }`}
+              >
+                {s.name ?? `Slot ${s.index + 1}`}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Function tabs */}
+        <div className="flex gap-1 px-3 py-2 border-b border-white/[0.08] bg-[#0d1b2a] flex-shrink-0">
+          {tabDefs
+            .filter((t) => t.show)
+            .map((t) => (
+              <button
+                key={t.id}
+                onClick={() => handleTabSelect(t.id)}
+                className={`flex-1 px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  tab === t.id
+                    ? 'bg-[#f5a623] text-[#0a1628]'
+                    : 'text-gray-400 hover:bg-white/5 hover:text-white'
+                }`}
+              >
+                {t.label}
+              </button>
+            ))}
+        </div>
+
+        {/* Slot type explainer */}
+        {activeSlotInfo?.type && (
+          <div className="px-4 py-2 border-b border-white/[0.05] bg-[#0a1628] flex-shrink-0">
+            <p className="text-[10px] text-gray-500">
+              <span className="text-[#f5a623]/70 uppercase tracking-wider mr-1">
+                {LEADERBOARD_TYPE_LABELS[activeSlotInfo.type] ?? activeSlotInfo.type}
+              </span>
+              <span>{slotTypeBlurb(activeSlotInfo.type)}</span>
+            </p>
           </div>
         )}
 
@@ -193,11 +311,17 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
           ) : error ? (
             <ErrorState message={error} />
           ) : tab === 'leaderboard' ? (
-            <LeaderboardTab entries={entries} myWallet={me?.wallet ?? null} />
+            <LeaderboardTab
+              entries={entries}
+              myWallet={me?.wallet ?? null}
+              isApiSlot={isApiSlot}
+            />
           ) : tab === 'you' ? (
-            <YouTab data={me ?? null} />
-          ) : (
+            <YouTab data={me ?? null} isApiSlot={isApiSlot} />
+          ) : tab === 'boosters' ? (
             <BoostersTab boosters={me?.boosters ?? []} />
+          ) : (
+            <VotingTab slotName={activeSlotInfo?.name ?? 'this voting slot'} />
           )}
 
           <p className="text-[10px] text-gray-600 text-center pt-2">
@@ -207,6 +331,21 @@ export function EmpirePanel({ isOpen, onClose }: EmpirePanelProps) {
       </div>
     </>
   );
+}
+
+function slotTypeBlurb(type: string): string {
+  switch (type) {
+    case 'tokenHolders':
+      return 'Ranked by your $ZABAL balance plus boosters.';
+    case 'farToken':
+      return 'Farcaster-native ranking. Engagement-weighted, not just balance.';
+    case 'api':
+      return 'Externally-fed leaderboard. Score updates from a custom source like a voting miniapp.';
+    case 'nft':
+      return 'Ranked by qualifying NFT holdings.';
+    default:
+      return 'Custom leaderboard.';
+  }
 }
 
 function LoadingState() {
@@ -232,9 +371,11 @@ function ErrorState({ message }: { message: string }) {
 function LeaderboardTab({
   entries,
   myWallet,
+  isApiSlot,
 }: {
   entries: LeaderboardEntry[];
   myWallet: string | null;
+  isApiSlot: boolean;
 }) {
   if (entries.length === 0) {
     return (
@@ -245,12 +386,14 @@ function LeaderboardTab({
   }
 
   const myAddr = myWallet?.toLowerCase() ?? null;
+  const valueLabel = isApiSlot ? 'votes' : 'points';
 
   return (
     <div className="space-y-2">
       {entries.slice(0, 50).map((entry) => {
         const isMe = myAddr && entry.address.toLowerCase() === myAddr;
         const isOwner = entry.address.toLowerCase() === ZABAL_OWNER.toLowerCase();
+        const value = entry.points ?? entry.score ?? 0;
         return (
           <div
             key={entry.address}
@@ -283,11 +426,13 @@ function LeaderboardTab({
             </div>
             <div className="text-right">
               <p className={`text-sm font-bold ${isMe ? 'text-[#f5a623]' : 'text-white'}`}>
-                {formatNumber(entry.points ?? entry.score ?? 0)}
+                {isApiSlot ? value.toLocaleString() : formatNumber(value)}
               </p>
               <p className="text-[10px] text-gray-500">
                 {entry.totalRewards
                   ? formatUsd(entry.totalRewards)
+                  : isApiSlot
+                  ? valueLabel
                   : entry.score && entry.points
                   ? `${(entry.points / Math.max(entry.score, 1)).toFixed(2)}x boost`
                   : 'no rewards yet'}
@@ -300,7 +445,13 @@ function LeaderboardTab({
   );
 }
 
-function YouTab({ data }: { data: MeApiResponse['data'] | null }) {
+function YouTab({
+  data,
+  isApiSlot,
+}: {
+  data: MeApiResponse['data'] | null;
+  isApiSlot: boolean;
+}) {
   if (!data || !data.wallet) {
     return (
       <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08] text-center">
@@ -323,7 +474,7 @@ function YouTab({ data }: { data: MeApiResponse['data'] | null }) {
           rel="noopener noreferrer"
           className="text-[10px] text-[#f5a623] hover:text-[#ffd700] mt-3 inline-block"
         >
-          Stake or hold ZABAL to qualify
+          {isApiSlot ? 'Cast a vote on Empire Builder' : 'Stake or hold ZABAL to qualify'}
         </a>
       </div>
     );
@@ -333,16 +484,21 @@ function YouTab({ data }: { data: MeApiResponse['data'] | null }) {
   const score = entry.score ?? 0;
   const points = entry.points ?? 0;
   const boost = score > 0 ? points / score : 0;
+  const headerLabel = isApiSlot ? 'Your Voting Rank' : 'Your ZABAL Empire';
 
   return (
     <div className="space-y-4">
       <div className="bg-gradient-to-r from-[#f5a623]/10 to-[#ffd700]/5 rounded-xl p-5 border border-[#f5a623]/30">
-        <p className="text-xs text-[#f5a623] uppercase tracking-wider mb-3">Your ZABAL Empire</p>
+        <p className="text-xs text-[#f5a623] uppercase tracking-wider mb-3">{headerLabel}</p>
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-3xl font-bold text-white">{formatNumber(points)}</p>
+            <p className="text-3xl font-bold text-white">
+              {isApiSlot ? points.toLocaleString() : formatNumber(points)}
+            </p>
             <p className="text-xs text-gray-400 mt-1">
-              {formatNumber(score)} score, {boost.toFixed(2)}x boost
+              {isApiSlot
+                ? `${score.toLocaleString()} votes cast`
+                : `${formatNumber(score)} score, ${boost.toFixed(2)}x boost`}
             </p>
           </div>
           <div className="text-right">
@@ -377,40 +533,79 @@ function BoostersTab({ boosters }: { boosters: Booster[] }) {
 
   return (
     <div className="space-y-2">
-      {boosters.map((b, i) => (
-        <div
-          key={`${b.contractAddress ?? 'booster'}-${i}`}
-          className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
-            b.qualified
-              ? 'bg-[#f5a623]/5 border-[#f5a623]/30'
-              : 'bg-[#0d1b2a] border-white/[0.08]'
-          }`}
-        >
-          <div className="w-9 h-9 rounded-lg bg-[#1a2a3a] flex items-center justify-center flex-shrink-0">
-            <span className="text-xs font-bold text-[#f5a623]">
-              {b.multiplier ? `${b.multiplier}x` : b.type.slice(0, 3)}
-            </span>
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-white truncate">
-              {b.token_symbol ?? b.type}
-              <span className="ml-2 text-[10px] text-gray-500 uppercase">{b.type}</span>
-            </p>
-            {b.contractAddress && (
-              <p className="text-[10px] text-gray-500 truncate">{shortAddress(b.contractAddress)}</p>
-            )}
-          </div>
-          <span
-            className={`text-[10px] font-medium px-2 py-1 rounded-full ${
+      {boosters.map((b, i) => {
+        const isQuotient = b.type === 'QUOTIENT';
+        const typeLabel = isQuotient ? 'Reputation' : b.type;
+        return (
+          <div
+            key={`${b.contractAddress ?? 'booster'}-${i}`}
+            className={`flex items-center gap-3 px-4 py-3 rounded-xl border ${
               b.qualified
-                ? 'bg-[#f5a623]/15 text-[#f5a623]'
-                : 'bg-white/5 text-gray-500'
+                ? 'bg-[#f5a623]/5 border-[#f5a623]/30'
+                : 'bg-[#0d1b2a] border-white/[0.08]'
             }`}
           >
-            {b.qualified ? 'qualified' : 'locked'}
-          </span>
-        </div>
-      ))}
+            <div className="w-9 h-9 rounded-lg bg-[#1a2a3a] flex items-center justify-center flex-shrink-0">
+              <span className="text-xs font-bold text-[#f5a623]">
+                {b.multiplier ? `${b.multiplier}x` : b.type.slice(0, 3)}
+              </span>
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium text-white truncate">
+                {b.token_symbol ?? typeLabel}
+                <span className="ml-2 text-[10px] text-gray-500 uppercase">{typeLabel}</span>
+              </p>
+              {b.contractAddress && !isQuotient && (
+                <p className="text-[10px] text-gray-500 truncate">{shortAddress(b.contractAddress)}</p>
+              )}
+              {isQuotient && (
+                <p className="text-[10px] text-gray-500 truncate">Social-graph reputation booster</p>
+              )}
+            </div>
+            <span
+              className={`text-[10px] font-medium px-2 py-1 rounded-full ${
+                b.qualified
+                  ? 'bg-[#f5a623]/15 text-[#f5a623]'
+                  : 'bg-white/5 text-gray-500'
+              }`}
+            >
+              {b.qualified ? 'qualified' : 'locked'}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function VotingTab({ slotName }: { slotName: string }) {
+  return (
+    <div className="space-y-4">
+      <div className="bg-[#0d1b2a] rounded-xl p-5 border border-white/[0.08]">
+        <p className="text-xs text-[#f5a623] uppercase tracking-wider mb-3">How {slotName} works</p>
+        <ul className="space-y-2 text-sm text-gray-300">
+          <li className="flex gap-2">
+            <span className="text-[#f5a623] flex-shrink-0">1.</span>
+            <span>This is an <strong className="text-white">API-fed</strong> leaderboard. Score is not your token balance - it is votes counted by an external miniapp.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#f5a623] flex-shrink-0">2.</span>
+            <span>Votes feed back into ZABAL Empire scoring, so they affect distribution share too.</span>
+          </li>
+          <li className="flex gap-2">
+            <span className="text-[#f5a623] flex-shrink-0">3.</span>
+            <span>The native vote-cast surface inside ZAO OS is on the iteration-2 roadmap (issue EB-17). For now use Empire Builder directly.</span>
+          </li>
+        </ul>
+      </div>
+      <a
+        href="https://www.empirebuilder.world/"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full text-center px-4 py-3 rounded-xl bg-[#f5a623] text-[#0a1628] font-semibold text-sm hover:bg-[#ffd700] transition-colors"
+      >
+        Cast a vote on Empire Builder
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Stacked on PR #429 (which is stacked on PR #412).

Closes #431 (EB-16), #432 (EB-17 read-side), #433 (EB-18).

## What ships

- **EB-16 grouped slot dashboard** in EmpirePanel: 2-tier nav (group tabs + sub-pills). ZABAL's 7 slots render as Holders / Farcaster / SongJam (3 seasons collapsed) / Respect / Voting. localStorage persistence for slot + tab.
- **EB-17 voting tab (read)**: api-type slots get relabelled tabs (Voters + How it works) and a new VotingTab explainer. Hides Boosters tab on api slots (irrelevant). Cast-a-vote surface inside ZAO OS still TBD pending Adrian's write-API spec; this PR links out to Empire Builder for now.
- **EB-18 booster proposal doc** at \`research/business/586-zabal-booster-network-effect-proposal/README.md\`. Telegram-ready text Zaal pastes to @glankerempire (5 boosters: CLANKER + GLANKER + ARTBABY + BB + PUSH) plus open-questions bundle for Sunday.
- Slot type explainer below tabs ("Holders - Ranked by your \$ZABAL balance plus boosters", etc) for the LEADERBOARD_TYPE values discovered in doc 584.
- QUOTIENT booster type now renders as "Reputation" with social-graph blurb.

## Stack
- PR #412 (MVP) -> PR #429 (hotfix multi-type) -> PR #430 (this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)