### PR TITLE
feat(miniapp): silent auto-signin via context FID, kill SIWF prompt

### DIFF
--- a/src/app/api/miniapp/auth-context/route.ts
+++ b/src/app/api/miniapp/auth-context/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Miniapp context-based auth — silent (no SIWF signature prompt).
+ *
+ * Reads FID from request body (provided by client via sdk.context.user.fid).
+ * Trust model: the FID claim is UNSIGNED. A non-Farcaster caller could POST
+ * any allowlisted FID and obtain a session for that user. Acceptable for
+ * gating an invite-only community where the alternative is a SIWF prompt
+ * every miniapp launch. For sensitive ops, keep using /api/miniapp/auth
+ * (QuickAuth/JWT-verified).
+ */
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { checkAllowlist } from '@/lib/gates/allowlist';
+import { getUserByFid } from '@/lib/farcaster/neynar';
+import { saveSession } from '@/lib/auth/session';
+import { logger } from '@/lib/logger';
+
+const BodySchema = z.object({
+  fid: z.number().int().positive(),
+});
+
+export async function POST(req: NextRequest) {
+  try {
+    const json = await req.json().catch(() => null);
+    const parsed = BodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+    }
+    const { fid } = parsed.data;
+
+    const neynarUser = await getUserByFid(fid);
+    if (!neynarUser) {
+      return NextResponse.json({ error: 'FID not found' }, { status: 404 });
+    }
+
+    const gate = await checkAllowlist(fid);
+    let hasAccess = gate.allowed;
+
+    if (!hasAccess && neynarUser.verified_addresses?.eth_addresses) {
+      for (const addr of neynarUser.verified_addresses.eth_addresses) {
+        const walletCheck = await checkAllowlist(undefined, addr);
+        if (walletCheck.allowed) {
+          hasAccess = true;
+          break;
+        }
+      }
+    }
+
+    if (hasAccess) {
+      await saveSession({
+        fid,
+        username: neynarUser.username || '',
+        displayName: neynarUser.display_name || '',
+        pfpUrl: neynarUser.pfp_url || '',
+      });
+    }
+
+    return NextResponse.json({
+      fid,
+      hasAccess,
+      username: neynarUser.username || '',
+      displayName: neynarUser.display_name || '',
+      pfpUrl: neynarUser.pfp_url || '',
+    });
+  } catch (error: unknown) {
+    logger.error('Miniapp context auth error:', error);
+    return NextResponse.json({ error: 'Auth failed' }, { status: 500 });
+  }
+}

--- a/src/app/miniapp/page.tsx
+++ b/src/app/miniapp/page.tsx
@@ -41,16 +41,28 @@ export default function MiniAppPage() {
         await sdk.actions.ready();
         if (cancelled) return;
 
-        // Check allowlist via QuickAuth
+        // Silent auth: read FID from miniapp context (no SIWF signature prompt).
+        // Falls back to QuickAuth if context FID is missing.
         try {
-          const response = await sdk.quickAuth.fetch('/api/miniapp/auth');
+          const ctx = await sdk.context;
+          const ctxFid = ctx?.user?.fid;
+
+          let response: Response;
+          if (ctxFid) {
+            response = await fetch('/api/miniapp/auth-context', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ fid: ctxFid }),
+            });
+          } else {
+            response = await sdk.quickAuth.fetch('/api/miniapp/auth');
+          }
           if (cancelled) return;
 
           if (response.ok) {
             const data = await response.json();
             if (data.hasAccess) {
               setAuthState('allowed');
-              // Redirect to main app
               window.location.href = '/home';
             } else {
               setUsername(data.username || '');

--- a/src/components/miniapp/MiniAppGate.tsx
+++ b/src/components/miniapp/MiniAppGate.tsx
@@ -53,9 +53,19 @@ export function MiniAppGate({ children }: MiniAppGateProps) {
         // in 'authing' if the API hangs.
         setState('authing');
         try {
-          const authPromise = sdk.quickAuth.fetch('/api/miniapp/auth');
+          // Silent auth via miniapp context FID (no SIWF prompt).
+          // Falls back to QuickAuth if context FID missing.
+          const ctx = await sdk.context;
+          const ctxFid = ctx?.user?.fid;
+          const authPromise: Promise<Response> = ctxFid
+            ? fetch('/api/miniapp/auth-context', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ fid: ctxFid }),
+              })
+            : sdk.quickAuth.fetch('/api/miniapp/auth');
           const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error('quickauth-timeout')), 5000),
+            setTimeout(() => reject(new Error('miniapp-auth-timeout')), 5000),
           );
           const response = await Promise.race([authPromise, timeoutPromise]);
           if (cancelled) return;


### PR DESCRIPTION
## Summary
- Miniapp now auto-signs-in using `sdk.context.user.fid` from Farcaster runtime — no more SIWF signature prompt on launch.
- New endpoint `/api/miniapp/auth-context` Neynar-verifies the FID, checks allowlist (FID + verified wallets), creates session.
- Falls back to QuickAuth (`/api/miniapp/auth`) if context FID missing (non-Farcaster web users).
- Touches `src/app/miniapp/page.tsx` and `src/components/miniapp/MiniAppGate.tsx`.

## Tradeoff
The new endpoint trusts an unsigned FID claim. Anyone who knows an allowlisted FID could call it directly with curl and obtain a session. Acceptable for allowlist gating where the alternative is a signature prompt every launch. Sensitive ops should keep using the signed `/api/miniapp/auth` route.

## Test plan
- [ ] Open zaoos.com miniapp inside Warpcast/Farcaster client. No SIWF prompt. Splash dismisses, redirect to `/home`.
- [ ] Non-allowlisted FID sees "denied" screen.
- [ ] Open `https://zaoos.com/` on web (no miniapp context). Still shows LoginButton, AuthKit signin works.
- [ ] `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)