### PR TITLE
fix(miniapp): unstick native splash on /miniapp entry

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,5 +1,5 @@
 // ZAO OS Service Worker — offline support + caching
-const CACHE_NAME = 'zaoos-v1';
+const CACHE_NAME = 'zaoos-v2';
 const OFFLINE_URL = '/offline';
 
 // Cap on cached page navigations + dynamically-cached assets so the SW
@@ -111,11 +111,14 @@ self.addEventListener('fetch', (event) => {
 
   // Page navigations — network first, offline fallback
   if (request.mode === 'navigate') {
+    // Never cache the miniapp entry — stale HTML here means users get stuck
+    // on the native Farcaster splash because ready() lives in the new bundle.
+    const isMiniAppEntry = url.pathname === '/miniapp' || url.pathname.startsWith('/miniapp/');
+
     event.respondWith(
       fetch(request)
         .then((response) => {
-          // Cache successful page loads, then trim oldest if over cap
-          if (response.ok) {
+          if (response.ok && !isMiniAppEntry) {
             const clone = response.clone();
             caches.open(CACHE_NAME).then((cache) => {
               cache.put(request, clone).then(() =>
@@ -126,6 +129,7 @@ self.addEventListener('fetch', (event) => {
           return response;
         })
         .catch(() => {
+          if (isMiniAppEntry) return caches.match(OFFLINE_URL);
           return caches.match(request).then((cached) => {
             return cached || caches.match(OFFLINE_URL);
           });

--- a/src/app/miniapp/layout.tsx
+++ b/src/app/miniapp/layout.tsx
@@ -23,6 +23,12 @@ export const metadata: Metadata = {
   },
 };
 
+// Never cache the miniapp entry HTML — Farcaster client + SW were serving
+// stale builds where sdk.actions.ready() never fired, leaving users stuck on
+// the native splash screen.
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export default function MiniAppLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/miniapp/page.tsx
+++ b/src/app/miniapp/page.tsx
@@ -29,16 +29,18 @@ export default function MiniAppPage() {
     async function init() {
       try {
         const { sdk } = await import('@farcaster/miniapp-sdk');
+
+        // Dismiss native splash IMMEDIATELY, before anything else can fail.
+        // If the splash hangs because ready() was blocked behind isInMiniApp /
+        // context / auth, the user just sees the Farcaster icon forever.
+        sdk.actions.ready().catch(() => {});
+
         const inMiniApp = await sdk.isInMiniApp();
 
         if (!inMiniApp) {
-          // Not in a mini app context — redirect to web landing
           window.location.href = '/';
           return;
         }
-
-        // Immediately dismiss the native splash screen
-        await sdk.actions.ready();
         if (cancelled) return;
 
         // Silent auth: read FID from miniapp context (no SIWF signature prompt).


### PR DESCRIPTION
## Summary
Users were getting stuck on the native Farcaster splash (just the ZAO logo, no spinner, no page paint) when opening the miniapp. Three things were stacking:

1. **SW caching** — `public/sw.js` cached `/miniapp` navigation HTML. Old builds without `ready()` were being served. Skip caching for `/miniapp*` navigations and bump `CACHE_NAME` to `zaoos-v2` to evict v1.
2. **Static page caching** — `/miniapp` was being statically rendered. Set `dynamic = 'force-dynamic'` and `revalidate = 0` in `src/app/miniapp/layout.tsx`.
3. **Late ready() call** — `sdk.actions.ready()` was awaited behind `sdk.isInMiniApp()`. If anything hung first, splash never dismissed. Now fired fire-and-forget as the very first SDK call.

## Test plan
- [ ] Force-quit Farcaster, reopen, tap ZAO OS miniapp. Splash dismisses fast and the app renders.
- [ ] Hard reload zaoos.com/miniapp in browser, confirm no SW caches the HTML (DevTools → Application → Service Workers → check no `/miniapp` entry under Cache).
- [ ] `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)