### PR TITLE
fix(miniapp): allow iframe embedding by Farcaster clients

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,7 +98,10 @@ const nextConfig: NextConfig = {
   async headers() {
     const securityHeaders = [
       { key: 'X-Content-Type-Options', value: 'nosniff' },
-      { key: 'X-Frame-Options', value: 'DENY' },
+      // X-Frame-Options intentionally omitted. The Farcaster miniapp is
+      // embedded in client iframes (Warpcast, Base App, third-party readers).
+      // Frame embedding policy is controlled via CSP `frame-ancestors *`
+      // set in src/middleware.ts.
       { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
       { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
       { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -97,6 +97,11 @@ function buildCspHeader(nonce: string): string {
     "connect-src 'self' https: wss:",
     "font-src 'self' https:",
     "frame-src 'self' https://open.spotify.com https://www.youtube.com https://w.soundcloud.com https://embed.sound.xyz https://audius.co https://relay.farcaster.xyz https://app.neynar.com https://embed.tidal.com https://*.bandcamp.com https://embed.music.apple.com https://meet.jit.si https://nouns.build https://songjam.space https://www.songjam.space https://empirebuilder.world https://incented.co https://app.magnetiq.xyz https://clanker.world https://www.wavewarz.com https://wavewarz.com https://wavewarz-intelligence.vercel.app https://analytics-wave-warz.vercel.app https://player.twitch.tv https://embed.twitch.tv https://www.twitch.tv https://clips.twitch.tv",
+    // Allow any origin to embed our pages — the app is a Farcaster miniapp
+    // and we don't know every client iframe origin (Warpcast, Base App,
+    // Coinbase Wallet, third-party Farcaster clients). Replaces the legacy
+    // X-Frame-Options: DENY which was blocking the miniapp from rendering.
+    'frame-ancestors *',
     "worker-src 'self' blob:",
     "base-uri 'self'",
     "form-action 'self'",
@@ -104,13 +109,11 @@ function buildCspHeader(nonce: string): string {
   return directives.join('; ');
 }
 
-function addSecurityHeaders(response: NextResponse, nonce?: string, pathname?: string): NextResponse {
-  // Allow iframe embedding for the embeddable leaderboard endpoint
-  if (pathname?.startsWith('/api/respect/leaderboard/embed')) {
-    response.headers.set('X-Frame-Options', 'ALLOWALL');
-  } else {
-    response.headers.set('X-Frame-Options', 'DENY');
-  }
+function addSecurityHeaders(response: NextResponse, nonce?: string, _pathname?: string): NextResponse {
+  // Intentionally NOT setting X-Frame-Options. Modern browsers honor the CSP
+  // `frame-ancestors *` directive above, which allows the miniapp to be
+  // embedded by any Farcaster client iframe. Setting XFO would override the
+  // CSP and break embedding.
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');


### PR DESCRIPTION
## Summary
Real root cause of the stuck-splash bug. \`X-Frame-Options: DENY\` was on every response from \`next.config.ts\` and \`src/middleware.ts\` — that header tells browsers \"do not embed in any iframe.\" Farcaster opens the miniapp in an iframe, so the browser refused to render it. Users saw native Farcaster splash forever because the page literally never painted.

## Fix
- Drop \`X-Frame-Options\` from \`next.config.ts\` headers
- Drop \`X-Frame-Options\` from \`src/middleware.ts\` \`addSecurityHeaders\`
- Add \`frame-ancestors *\` to the CSP built in \`middleware.ts\` — modern browsers honor CSP over the legacy XFO header

## Test plan
- [ ] After deploy: \`curl -sI https://zaoos.com/miniapp | grep -iE 'frame-ancestors|x-frame'\` shows frame-ancestors but no X-Frame-Options
- [ ] Force-quit Farcaster, reopen, tap ZAO OS miniapp — splash dismisses, app renders
- [ ] Web users at zaoos.com still see the landing page normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)