### PR TITLE
fix(miniapp): revert force-dynamic, simpler SDK import

### DIFF
--- a/src/app/miniapp/layout.tsx
+++ b/src/app/miniapp/layout.tsx
@@ -23,12 +23,6 @@ export const metadata: Metadata = {
   },
 };
 
-// Never cache the miniapp entry HTML — Farcaster client + SW were serving
-// stale builds where sdk.actions.ready() never fired, leaving users stuck on
-// the native splash screen.
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
-
 export default function MiniAppLayout({ children }: { children: React.ReactNode }) {
   return children;
 }

--- a/src/app/miniapp/page.tsx
+++ b/src/app/miniapp/page.tsx
@@ -27,14 +27,15 @@ export default function MiniAppPage() {
     let cancelled = false;
 
     async function init() {
-      let sdk: typeof import('@farcaster/miniapp-sdk').sdk | undefined;
+      let sdkModule: typeof import('@farcaster/miniapp-sdk');
       try {
-        ({ sdk } = await import('@farcaster/miniapp-sdk'));
+        sdkModule = await import('@farcaster/miniapp-sdk');
       } catch {
         // SDK package failed to load — only happens off-Farcaster
         window.location.href = '/';
         return;
       }
+      const { sdk } = sdkModule;
 
       // Dismiss native splash IMMEDIATELY, before anything else can fail.
       sdk.actions.ready().catch(() => {});


### PR DESCRIPTION
## Summary
After PR #439 fixed XFO and the page started rendering inside Farcaster, the iframe started showing \"This page couldn't load.\" Likely cause: \`dynamic = 'force-dynamic'\` + \`revalidate = 0\` (added in #437 to bust caches while debugging) emit \`cache-control: no-store\` and stream the response in a way Farcaster's iframe wrapper doesn't like.

## Fix
- Drop the \`dynamic\` and \`revalidate\` exports from \`src/app/miniapp/layout.tsx\`. The cache-bust they were doing isn't needed once XFO is gone — Farcaster reloads the iframe on each launch anyway.
- Simpler SDK import: bind \`sdkModule\` to the dynamic import result, then destructure \`sdk\`. The previous \`let sdk: typeof import(...).sdk\` form occasionally trips Turbopack.

## Test plan
- [ ] Curl shows normal cache headers, not \`no-store\`: \`curl -sI https://zaoos.com/miniapp | grep -i cache\`
- [ ] Force-quit Farcaster, reopen, tap miniapp — iframe loads without \"couldn't load\" error
- [ ] If allowlisted: lands on /home; if not: denied screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)