### PR TITLE
fix(auth): SameSite=None session cookie for Farcaster iframe

### DIFF
--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -19,13 +19,20 @@ export interface SessionPayload {
   isAdmin?: boolean;
 }
 
+// SameSite=None is REQUIRED for the session cookie to be sent in third-party
+// iframe contexts — Farcaster client embeds zaoos.com in an iframe, and
+// SameSite=Lax cookies are dropped on cross-site iframe navigations. Without
+// None, /api/miniapp/auth-context sets a cookie that the browser then
+// refuses to send on the /home redirect, and the server sees no session.
+// SameSite=None requires Secure=true, so dev (http://localhost) keeps Lax.
+const isProd = process.env.NODE_ENV === 'production';
 const sessionOptions = {
   password: ENV.SESSION_SECRET,
   cookieName: 'zaoos_session',
   cookieOptions: {
-    secure: process.env.NODE_ENV === 'production',
+    secure: isProd,
     httpOnly: true,
-    sameSite: 'lax' as const,
+    sameSite: (isProd ? 'none' : 'lax') as 'none' | 'lax',
     maxAge: 7 * 24 * 60 * 60, // 7 days
   },
 };


### PR DESCRIPTION
## Summary
Even after PRs #436/#439/#441/#444, the miniapp dropped users on the public Sign In page after auto-signin. Cause: \`sameSite: 'lax'\` on the session cookie. zaoos.com inside Farcaster's iframe is a third-party context — browsers refuse to send Lax cookies on cross-site iframe navigations, so:

1. \`/miniapp\` POSTs to \`/api/miniapp/auth-context\` → server sets \`zaoos_session\` cookie
2. Browser drops/withholds the cookie because Lax + iframe
3. \`window.location.href = '/home'\` → server-side \`getSessionData()\` returns null → redirect to \`/\`
4. User sees LoginButton

## Fix
\`SameSite=None\` in production. Requires Secure (already set conditionally on NODE_ENV=production). Dev stays Lax because Chrome rejects None on non-Secure cookies over http.

## Test plan
- [ ] After deploy: \`curl -sI -X POST https://zaoos.com/api/miniapp/auth-context -H 'content-type: application/json' -d '{"fid":1}' | grep -i set-cookie\` shows \`SameSite=None\`
- [ ] Force-quit Farcaster, reopen, tap miniapp — lands on \`/home\` directly, no Sign In page
- [ ] Web zaoos.com still works for non-iframe users

🤖 Generated with [Claude Code](https://claude.com/claude-code)