### PR TITLE
feat(bot): Hermes targets zaostock + /zsfb feedback intake

### DIFF
--- a/bot/src/hermes/coder.ts
+++ b/bot/src/hermes/coder.ts
@@ -5,7 +5,33 @@ import {
   HERMES_ROUTING_ENABLED,
 } from './claude-cli';
 import { listChangedFiles, runCmd } from './git';
-import { HERMES_FORBIDDEN_PATHS, type FixerInput, type FixerOutput } from './types';
+import { HERMES_FORBIDDEN_PATHS, type FixerInput, type FixerOutput, type HermesRepoTarget } from './types';
+
+/**
+ * Per-target system-prompt addendum. Surfaced as a small block inside the user
+ * prompt so the same FIXER_SYSTEM works across repos and we just inject the
+ * right repo-specific context. Add new targets here.
+ */
+function repoContextBlock(target: HermesRepoTarget): string {
+  if (target === 'zaostock') {
+    return [
+      '# Repo Context: zaostock',
+      'You are working on the standalone bettercallzaal/zaostock Next.js festival site.',
+      'Stack: Next.js 16 App Router, React 19, Tailwind v4, Supabase, iron-session.',
+      'Primary route: src/app/test/page.tsx (the staging /test landing the team is iterating on).',
+      'Live homepage: src/app/page.tsx. /donate, /sponsor, /apply, /team are also live.',
+      'Voice rules to keep: lowercase sentence starts, brand caps stay (ZAO, ZAOstock, FarHack, WaveWarZ).',
+      'No emojis, no em dashes - use hyphens. No "no margin / no extraction" or operator-margin language.',
+      'No specific member counts (use "100+"). No crypto/web3/onchain in body copy. Sponsors pay money, partners give time.',
+    ].join('\n');
+  }
+  return [
+    '# Repo Context: ZAO OS',
+    'You are working on the bettercallzaal/ZAOOS monorepo (Farcaster-native social platform + bot).',
+    'Stack: Next.js 16 App Router, React 19, Tailwind, Supabase, Neynar, iron-session, grammy bot.',
+    'Treat bot/ as its own subproject with its own package.json + lockfile.',
+  ].join('\n');
+}
 
 /**
  * Sprint 1 cost-routing (per doc 541): when HERMES_ROUTING=on, attempt 1
@@ -72,9 +98,12 @@ const FIXER_OUTPUT_SCHEMA = {
 } as const;
 
 export async function runFixer(input: FixerInput): Promise<FixerOutput> {
+  const target: HermesRepoTarget = input.targetRepo ?? 'zaoos';
   const userPrompt = [
     `# Issue (attempt ${input.attemptNumber} of 3)`,
     input.issueText,
+    '',
+    repoContextBlock(target),
     '',
     input.previousCriticFeedback
       ? `# Previous Critic Feedback (score < 70 - address this)\n${input.previousCriticFeedback}\n`

--- a/bot/src/hermes/commands.ts
+++ b/bot/src/hermes/commands.ts
@@ -1,7 +1,29 @@
 import type { Context } from 'grammy';
 import { dispatchHermesRun } from './runner';
 import { getRun, listOpenRuns } from './db';
+import type { HermesRepoTarget } from './types';
 import type { TeamMember } from '../auth';
+
+/**
+ * Parse `/fix [<target>] <issue text>` where <target> is an optional repo
+ * profile name. Returns the resolved target + the trimmed issue text.
+ *
+ * Examples:
+ *   /fix tighten the hero copy           -> { target: 'zaoos', text: 'tighten the hero copy' }
+ *   /fix zaostock drop the lineup TBA    -> { target: 'zaostock', text: 'drop the lineup TBA' }
+ *   /fix zaoos rename auth helper        -> { target: 'zaoos', text: 'rename auth helper' }
+ */
+function parseFixCommand(rawText: string): { target: HermesRepoTarget; text: string } {
+  const stripped = rawText.replace(/^\/fix(@\w+)?\s*/, '').trim();
+  const firstWord = stripped.split(/\s+/)[0]?.toLowerCase() ?? '';
+  if (firstWord === 'zaostock') {
+    return { target: 'zaostock', text: stripped.slice(firstWord.length).trim() };
+  }
+  if (firstWord === 'zaoos') {
+    return { target: 'zaoos', text: stripped.slice(firstWord.length).trim() };
+  }
+  return { target: 'zaoos', text: stripped };
+}
 
 const ZAAL_TG_ID = Number(process.env.ZAAL_TELEGRAM_ID ?? '0') || null;
 
@@ -42,9 +64,9 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
     return;
   }
 
-  const text = (ctx.message?.text ?? '').replace(/^\/fix(@\w+)?\s*/, '').trim();
+  const { target, text } = parseFixCommand(ctx.message?.text ?? '');
   if (!text || text.length < 10) {
-    await ctx.reply('Usage: /fix <issue> - describe the bug or feature in 1-3 sentences.');
+    await ctx.reply('Usage: /fix [zaostock|zaoos] <issue> - describe the bug or feature in 1-3 sentences. Default target is zaoos.');
     return;
   }
 
@@ -55,15 +77,15 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
     return;
   }
 
-  await ctx.reply('Hermes starting. Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.');
+  await ctx.reply(`Hermes starting against ${target}. Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.`);
 
   // Fire-and-forget: long-running, will report back via Telegram.
-  void runAndReport(ctx, { triggered_by_telegram_id: fromId, triggered_in_chat_id: chatId, issue_text: text });
+  void runAndReport(ctx, { triggered_by_telegram_id: fromId, triggered_in_chat_id: chatId, issue_text: text, target_repo: target });
 }
 
 async function runAndReport(
   ctx: Context,
-  input: { triggered_by_telegram_id: number; triggered_in_chat_id: number; issue_text: string },
+  input: { triggered_by_telegram_id: number; triggered_in_chat_id: number; issue_text: string; target_repo?: HermesRepoTarget },
 ): Promise<void> {
   try {
     const result = await dispatchHermesRun(input);

--- a/bot/src/hermes/git.ts
+++ b/bot/src/hermes/git.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { HermesRepoTarget } from './types';
 
 export interface GitRunResult {
   stdout: string;
@@ -59,18 +60,57 @@ export async function cleanupWorkdir(workdir: string): Promise<void> {
 }
 
 /**
- * Clone the ZAO OS repo into workdir as a fresh checkout from origin/main.
- * Uses HERMES_REPO_URL env (or falls back to bettercallzaal/ZAOOS over https).
+ * Repo profile = the configuration we need to clone, install, and pre-flight a
+ * given repo target. Adding a new target means adding a profile entry below
+ * (and a matching system-prompt context block in coder.ts).
+ *
+ * `installSubdirs`: extra directories that need their own `npm ci/install`
+ * after the root install. ZAO OS has bot/ with its own lockfile; zaostock has
+ * none today (single root package).
+ */
+export interface RepoProfile {
+  target: HermesRepoTarget;
+  url: string;
+  defaultBranch: string;
+  installSubdirs: string[];
+}
+
+const HERMES_REPO_PROFILES: Record<HermesRepoTarget, RepoProfile> = {
+  zaoos: {
+    target: 'zaoos',
+    url: process.env.HERMES_REPO_URL ?? 'https://github.com/bettercallzaal/ZAOOS.git',
+    defaultBranch: 'main',
+    installSubdirs: ['bot'],
+  },
+  zaostock: {
+    target: 'zaostock',
+    url: process.env.HERMES_ZAOSTOCK_REPO_URL ?? 'https://github.com/bettercallzaal/zaostock.git',
+    defaultBranch: 'main',
+    installSubdirs: [],
+  },
+};
+
+export function getRepoProfile(target: HermesRepoTarget): RepoProfile {
+  return HERMES_REPO_PROFILES[target];
+}
+
+/**
+ * Clone the target repo into workdir as a fresh checkout from origin/main.
+ * Default target is 'zaoos' (ZAO OS monorepo). Pass 'zaostock' to target the
+ * standalone festival site - same pre-flight + safety guarantees.
+ *
  * Authentication: relies on system git credentials (gh auth or SSH key).
+ * The same gh auth must have push access to whichever repo is targeted.
  */
 export async function cloneAndBranch(
   workdir: string,
   branchName: string,
+  target: HermesRepoTarget = 'zaoos',
 ): Promise<void> {
-  const repoUrl = process.env.HERMES_REPO_URL ?? 'https://github.com/bettercallzaal/ZAOOS.git';
-  const clone = await runCmd('git', ['clone', '--depth', '50', '--branch', 'main', repoUrl, workdir]);
+  const profile = getRepoProfile(target);
+  const clone = await runCmd('git', ['clone', '--depth', '50', '--branch', profile.defaultBranch, profile.url, workdir]);
   if (clone.exitCode !== 0) {
-    throw new Error(`git clone failed: ${clone.stderr.slice(0, 400)}`);
+    throw new Error(`git clone failed (${target}): ${clone.stderr.slice(0, 400)}`);
   }
   const checkout = await runCmd('git', ['checkout', '-b', branchName], workdir);
   if (checkout.exitCode !== 0) {
@@ -97,28 +137,21 @@ export async function cloneAndBranch(
     );
   }
 
-  // ALSO install bot/ deps. ZAO is not a real workspace (no pnpm-workspace
-  // entry for bot, has own package-lock.json) so root install doesn't pull
-  // grammy/supabase-js into bot/node_modules. Without this the bot-side
-  // typecheck fails with "Cannot find module 'grammy'".
-  const botLockExists = await fs
-    .access(`${workdir}/bot/package-lock.json`)
-    .then(() => true)
-    .catch(() => false);
-  const botPkgExists = await fs
-    .access(`${workdir}/bot/package.json`)
-    .then(() => true)
-    .catch(() => false);
-  if (botPkgExists) {
-    const botInstallCmd = botLockExists ? 'ci' : 'install';
-    const botInstall = await runCmd(
+  // Install deps in any extra subdirs the profile declares (e.g. ZAO OS bot/).
+  for (const subdir of profile.installSubdirs) {
+    const subPath = `${workdir}/${subdir}`;
+    const subLockExists = await fs.access(`${subPath}/package-lock.json`).then(() => true).catch(() => false);
+    const subPkgExists = await fs.access(`${subPath}/package.json`).then(() => true).catch(() => false);
+    if (!subPkgExists) continue;
+    const subCmd = subLockExists ? 'ci' : 'install';
+    const subInstall = await runCmd(
       'npm',
-      [botInstallCmd, '--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'],
-      `${workdir}/bot`,
+      [subCmd, '--ignore-scripts', '--no-audit', '--no-fund', '--prefer-offline'],
+      subPath,
     );
-    if (botInstall.exitCode !== 0) {
+    if (subInstall.exitCode !== 0) {
       console.error(
-        `[hermes/git] bot npm ${botInstallCmd} returned exit ${botInstall.exitCode}. Pre-flight may fail. stderr: ${botInstall.stderr.slice(0, 300)}`,
+        `[hermes/git] ${subdir} npm ${subCmd} returned exit ${subInstall.exitCode}. Pre-flight may fail. stderr: ${subInstall.stderr.slice(0, 300)}`,
       );
     }
   }

--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -8,6 +8,7 @@ import { createRun, updateRun } from './db';
 import {
   HERMES_DEFAULT_MAX_ATTEMPTS,
   HERMES_PASS_THRESHOLD,
+  type HermesRepoTarget,
   type HermesRun,
 } from './types';
 
@@ -53,6 +54,8 @@ export interface DispatchInput {
   triggered_by_telegram_id: number;
   triggered_in_chat_id: number;
   issue_text: string;
+  /** Which repo to clone + open the PR against. Default 'zaoos'. */
+  target_repo?: HermesRepoTarget;
 }
 
 /**
@@ -109,8 +112,10 @@ export async function dispatchHermesRun(
   let totalOut = 0;
   let lastFeedback: string | undefined;
 
+  const targetRepo: HermesRepoTarget = input.target_repo ?? 'zaoos';
+
   try {
-    await cloneAndBranch(workdir, branchName);
+    await cloneAndBranch(workdir, branchName, targetRepo);
 
     let attempt = 0;
     while (attempt < HERMES_DEFAULT_MAX_ATTEMPTS) {
@@ -126,6 +131,7 @@ export async function dispatchHermesRun(
           branchName,
           attemptNumber: attempt,
           previousCriticFeedback: lastFeedback,
+          targetRepo,
         });
       } catch (err) {
         // Coder's individual call failed (non-JSON output, CLI crash, etc).

--- a/bot/src/hermes/types.ts
+++ b/bot/src/hermes/types.ts
@@ -32,12 +32,27 @@ export interface HermesRun {
   completed_at: string | null;
 }
 
+/**
+ * Which repo Hermes is targeting. 'zaoos' is the default (the original ZAO OS
+ * monorepo where Hermes was built). 'zaostock' targets the standalone
+ * bettercallzaal/zaostock Next.js festival site so the team can drive /test
+ * iterations through the Telegram bot.
+ *
+ * Adding more targets: extend HERMES_REPO_PROFILES in git.ts and update the
+ * per-target system-prompt context in coder.ts.
+ */
+export type HermesRepoTarget = 'zaoos' | 'zaostock';
+
+export const HERMES_DEFAULT_TARGET: HermesRepoTarget = 'zaoos';
+
 export interface FixerInput {
   issueText: string;
   workTreePath: string;
   branchName: string;
   attemptNumber: number;
   previousCriticFeedback?: string;
+  /** Which repo profile to apply (system-prompt context, forbidden paths, etc). */
+  targetRepo?: HermesRepoTarget;
 }
 
 export interface FixerOutput {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './auth';
 import { buildStatus, buildMyTodos, buildMyContributions, buildAllOpenTodos, buildTeamRoster } from './status';
 import { addGemba, addIdea, addNote } from './capture';
+import { addZsFb } from './zsfb';
 import { executeFromText } from './actions';
 import { ask } from './llm';
 import { ensureChatRegistered, getChatRow, setChatMode, setPostDigests } from './group';
@@ -130,6 +131,7 @@ bot.command('help', async (ctx) => {
       'Tell me what happened:',
       '  /do <text> - I parse + update the board',
       '  /idea <text> - drop into the pool, Zaal sees daily',
+      '  /zsfb <text> - feedback on the /test ZAOstock site (auto-tagged by section)',
       '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
       '',
@@ -232,6 +234,15 @@ bot.command('note', async (ctx) => {
   const member = await requireMember(ctx);
   if (!member) return;
   await ctx.reply(await addNote(member, ctx.match));
+});
+
+// /zsfb <comment> - low-friction ZAOstock /test feedback (open to all team).
+// Saves to stock_suggestions with [zsfb:<section>] prefix for downstream
+// Hermes triage. Distinct from /idea so the /test backlog stays scoped.
+bot.command('zsfb', async (ctx) => {
+  const member = await requireMember(ctx);
+  if (!member) return;
+  await ctx.reply(await addZsFb(member, ctx.match ?? ''));
 });
 
 bot.command('ask', async (ctx) => {

--- a/bot/src/zsfb.ts
+++ b/bot/src/zsfb.ts
@@ -1,0 +1,82 @@
+// /zsfb <comment> - low-friction ZAOstock /test feedback intake
+//
+// Open to all team members (not admin-gated like /fix). Saves to
+// stock_suggestions with a [zsfb:<section>] prefix so the dashboard + Hermes
+// can filter for /test feedback specifically.
+//
+// Section auto-detected from keywords. If none match, tagged 'general'. The
+// section keyword is a hint for downstream triage, not a hard label - Hermes
+// always reads the full text.
+//
+// Why prefix vs new column: stock_suggestions schema is shared with /idea +
+// public submissions. Adding a column would require a migration and would
+// fragment the suggestion pool. Prefix is reversible, dashboard-friendly, and
+// keeps everything in one bucket.
+
+import { db } from './supabase';
+import { logBotActivity } from './activity';
+import type { TeamMember } from './auth';
+
+const SECTION_KEYWORDS: Array<{ section: string; pattern: RegExp }> = [
+  { section: 'hero', pattern: /\b(hero|top|first|opening|tagline)\b/i },
+  { section: 'lineup', pattern: /\b(lineup|artists?|band|dj|performer|set list)\b/i },
+  { section: 'sponsors', pattern: /\b(sponsor|sponsorship|partner with us|main stage sponsor|broadcast|year.round)\b/i },
+  { section: 'partners', pattern: /\b(partners?|fractured atlas|enteract|heart of ellsworth|town of ellsworth|poc)\b/i },
+  { section: 'vibes', pattern: /\b(vibe|photo|gallery|image|visual)\b/i },
+  { section: 'about', pattern: /\b(about|story|why|maine|acadia)\b/i },
+  { section: 'where', pattern: /\b(where|location|map|parklet|franklin street|ellsworth)\b/i },
+  { section: 'team', pattern: /\b(team|mosaic|members?|roster)\b/i },
+  { section: 'rsvp', pattern: /\b(rsvp|join|get on the list|volunteer|sign up)\b/i },
+  { section: 'lineage', pattern: /\b(lineage|past events?|paloo?za|chella|zaoville|history)\b/i },
+  { section: 'donate', pattern: /\b(donate|donation|paypal|giveth|crypto|fiat)\b/i },
+  { section: 'sticky', pattern: /\b(sticky|dock|floating|bottom bar)\b/i },
+];
+
+export function detectSection(text: string): string {
+  for (const { section, pattern } of SECTION_KEYWORDS) {
+    if (pattern.test(text)) return section;
+  }
+  return 'general';
+}
+
+export async function addZsFb(member: TeamMember, text: string): Promise<string> {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return [
+      'Say something after /zsfb - what should we change on /test?',
+      '',
+      'Examples:',
+      '  /zsfb hero copy too long, drop the second sentence',
+      '  /zsfb sponsors section feels short, add a one-liner about why we do tiers',
+      '  /zsfb lineage cards need more breathing room on mobile',
+    ].join('\n');
+  }
+
+  const section = detectSection(trimmed);
+  const tagged = `[zsfb:${section}] ${trimmed}`;
+
+  const { data, error } = await db()
+    .from('stock_suggestions')
+    .insert({
+      name: member.name,
+      contact: `tg:${member.id}`,
+      suggestion: tagged,
+    })
+    .select('id')
+    .single();
+
+  if (error) return `Could not save: ${error.message}`;
+
+  await logBotActivity({
+    actorId: member.id,
+    entityType: 'member',
+    entityId: member.id,
+    action: 'zsfb_add',
+    newValue: `[${section}] ${trimmed.slice(0, 180)}`,
+  });
+
+  return [
+    `Logged (${section}). id ${data.id.slice(0, 8)}.`,
+    `Zaal sees the daily digest. He'll trigger Hermes if it's a clear ship.`,
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Two upgrades to @ZAOstockTeamBot so the team can drive ZAOstock /test iterations through Telegram.

### Phase 1 - Hermes can target the zaostock repo

\`/fix\` now accepts an optional repo prefix:

\`\`\`
/fix <issue>            # -> ZAO OS (default, unchanged)
/fix zaostock <issue>   # -> bettercallzaal/zaostock
/fix zaoos <issue>      # -> ZAO OS (explicit)
\`\`\`

- New \`HermesRepoTarget\` type + repo profile registry in \`bot/src/hermes/git.ts\`. Adding a new target = one object entry.
- \`cloneAndBranch\` takes an optional \`target\` arg, defaults to \`zaoos\` so existing callers are unchanged.
- Per-target system-prompt context block injected into the user prompt (Coder gets the right repo facts: stack, voice rules, sponsors-vs-partners distinction, no emojis, etc.).
- \`gh pr create\` runs in the cloned workdir, so PRs land on the correct repo automatically - no extra wiring.

### Phase 2 - /zsfb feedback intake (open to all team)

New \`/zsfb <comment>\` command. Anyone on the team can drop /test feedback without admin perms or learning /fix syntax.

- Saves to \`stock_suggestions\` with \`[zsfb:<section>]\` prefix.
- Section auto-detected (hero, lineup, sponsors, partners, vibes, about, where, team, rsvp, lineage, donate, sticky, general).
- Activity log entry tagged \`zsfb_add\` so digest can pull a daily backlog.
- Help text updated to surface the command to the team.

### Workflow this enables

1. Team chats: \`/zsfb hero copy too long, drop the second sentence\`
2. Bot replies: \`Logged (hero). id 4f23a1c8.\`
3. Zaal sees the daily digest, picks the ones ready to ship.
4. Zaal types: \`/fix zaostock hero copy too long, drop the second sentence\`
5. Hermes Coder + Critic loop runs against bettercallzaal/zaostock and opens a PR if the score >=70.

Phase 3 (auto-batch \`/zstriage\` + nightly cluster runs) layers on top without changing the team-facing surface.

## Test plan

- [ ] DM bot \`/help\` and confirm /zsfb is listed under "Tell me what happened"
- [ ] Send \`/zsfb test from <name>\` and confirm reply matches \`Logged (general). id ...\`
- [ ] Check \`stock_suggestions\` table - row appears with \`[zsfb:general] test from <name>\`
- [ ] Send \`/zsfb hero feels short\` -> section parsed as \`hero\`
- [ ] Admin sends \`/fix zaostock add a test comment to /test page hero\` - confirm Hermes clones bettercallzaal/zaostock, opens PR there (not on ZAOOS)
- [ ] Admin sends \`/fix tighten error message in some ZAO OS file\` (no prefix) - confirm Hermes still defaults to ZAOOS, no regression
- [ ] \`fix_status\` reports the correct PR URL + score for both targets