### PR TITLE
feat(bot): /zsedit - team-facing direct website edits with daily cap

### DIFF
--- a/bot/src/actions.ts
+++ b/bot/src/actions.ts
@@ -189,7 +189,11 @@ export async function executeFromText(
   const { action, persona: usedPersona } = await parseAction(userText, persona);
 
   if (action.kind === 'unknown') {
-    return { ok: false, reply: `I can't act on that yet. Reason: ${action.reason}\n\nTry /ask for a Q&A reply, or give me something concrete like "add a todo to call Bangor by Friday".` };
+    // No discrete action - this is conversation. Hermes replies in voice
+    // instead of bailing out. The LLM also gets to nudge the user toward the
+    // right slash command if they're describing a website edit (cost-gated)
+    // or a feedback log (free).
+    return await hermesChatReply(requester, userText, persona);
   }
 
   try {
@@ -424,5 +428,50 @@ export async function executeFromText(
     }
   } catch (err) {
     return { ok: false, reply: `Action failed: ${err instanceof Error ? err.message : 'unknown error'}` };
+  }
+}
+
+/**
+ * Free-form Hermes chat. Used when the user types something that isn't a
+ * discrete action - so the bot stays conversational rather than refusing.
+ *
+ * The system prompt explicitly tells Hermes:
+ *   - identify as Hermes (the ZAOstock team bot that ships code edits)
+ *   - if the message is /test feedback that should be logged: suggest /zsfb
+ *   - if it's an edit the user wants shipped: suggest /zsedit
+ *   - otherwise just chat (under 200 words)
+ *
+ * Cost: one LLM call per chat reply, same as /ask. No DB writes here - the
+ * /zsfb and /zsedit commands handle persistence when the user opts in.
+ */
+async function hermesChatReply(
+  requester: TeamMember,
+  userText: string,
+  persona: PersonaName,
+): Promise<ExecuteResult> {
+  const system = [
+    "You are Hermes, the ZAOstock team's Telegram bot.",
+    'You handle two jobs: team ops + shipping code edits to the ZAOstock /test landing page.',
+    `You are talking to ${requester.name} (role: ${requester.role}, scope: ${requester.scope}).`,
+    'Reply in under 200 words. No emojis. No em dashes - use hyphens. Lowercase sentence starts are fine.',
+    '',
+    'Routing rules:',
+    '- If the user is describing a change they want made to the /test ZAOstock site, end your reply with: "Want me to ship it? Reply with /zsedit <your edit>." Do NOT call any tool yourself; users opt in via /zsedit.',
+    '- If the user is describing /test feedback they want logged but not shipped, suggest: "Reply /zsfb <text> to log it for the daily digest."',
+    '- If they want a discrete action (add todo, log a sponsor, mark a milestone), tell them to phrase it as a direct command (e.g., "add a todo to call Bangor by Friday") and you will parse it.',
+    '- For festival state questions (status, blockers, your todos), point them at /status, /mytodos, /digest.',
+    '- Otherwise just chat conversationally. Be useful, be brief.',
+    '',
+    'Voice: brand caps stay (ZAO, ZAOstock, FarHack, WaveWarZ). No "no margin / no extraction" copy. No specific member counts (use 100+).',
+  ].join('\n');
+
+  try {
+    const reply = await ask(userText, system, persona);
+    return { ok: true, reply: reply.text.trim() };
+  } catch (err) {
+    return {
+      ok: false,
+      reply: `LLM unreachable: ${err instanceof Error ? err.message : 'unknown'}. Try /ask, /zsfb, or /zsedit directly.`,
+    };
   }
 }

--- a/bot/src/hermes/commands.ts
+++ b/bot/src/hermes/commands.ts
@@ -45,7 +45,7 @@ function isAdmin(ctx: Context, member: TeamMember | null): boolean {
  */
 export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<void> {
   if (!isAdmin(ctx, member)) {
-    await ctx.reply('Hermes /fix is admin-only for v1. Ask Zaal to add you to BOT_ADMIN_TELEGRAM_IDS.');
+    await ctx.reply('/fix is admin-only - it can target any repo. Team can use /zsedit (locked to zaostock, daily-capped) instead. Ping Zaal if you need /fix scope.');
     return;
   }
 
@@ -59,7 +59,7 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
       : await checkOnPath('claude');
   if (!claudeOnPath) {
     await ctx.reply(
-      "Hermes can't find the 'claude' CLI on PATH. Install Claude Code on the bot host (Max plan), or set HERMES_CLAUDE_BIN.",
+      "I can't find the 'claude' CLI on the bot host - my Coder loop runs through it. Install Claude Code on the host (Max plan) or set HERMES_CLAUDE_BIN. Pinging Zaal.",
     );
     return;
   }
@@ -77,7 +77,7 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
     return;
   }
 
-  await ctx.reply(`Hermes starting against ${target}. Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.`);
+  await ctx.reply(`On it. Cloning ${target}, Coder will read + write a diff, Critic grades. You get a PR link if score >=70. Max 3 attempts.`);
 
   // Fire-and-forget: long-running, will report back via Telegram.
   void runAndReport(ctx, { triggered_by_telegram_id: fromId, triggered_in_chat_id: chatId, issue_text: text, target_repo: target });
@@ -94,22 +94,22 @@ async function runAndReport(
       const pingZaal = ZAAL_TG_ID && ZAAL_TG_ID !== input.triggered_by_telegram_id ? `\n\ncc @${ZAAL_TG_ID}` : '';
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes READY. PR ${r.pr_url}\nCritic score: ${r.critic_score}/100\nAttempts: ${r.fixer_attempts}\nCost: $${r.estimated_cost_usd ?? 'n/a'}${pingZaal}\n\nPush when good.`,
+        `READY. PR open: ${r.pr_url}\nCritic: ${r.critic_score}/100 in ${r.fixer_attempts} attempt(s). Cost $${r.estimated_cost_usd ?? 'n/a'}.${pingZaal}\n\nReview + merge when good.`,
       );
     } else if (result.kind === 'escalated') {
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes ESCALATED. Hit max ${r.fixer_max_attempts} attempts. Last feedback: ${result.reason}\nRun ID: ${r.id}`,
+        `ESCALATED after ${r.fixer_max_attempts} attempts. Last critic feedback: ${result.reason}\nRun ID: ${r.id}\n\nThis one needs a human. Either rephrase + retry or take it manually.`,
       );
     } else {
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes FAILED. ${result.reason}\nRun ID: ${r.id}`,
+        `FAILED. ${result.reason}\nRun ID: ${r.id}`,
       );
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    await ctx.api.sendMessage(input.triggered_in_chat_id, `Hermes crashed outside the loop: ${msg}`);
+    await ctx.api.sendMessage(input.triggered_in_chat_id, `Coder loop crashed outside the run: ${msg}`);
   }
 }
 
@@ -169,12 +169,12 @@ function formatRun(r: { id: string; status: string; fixer_attempts: number; crit
  */
 export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promise<void> {
   if (!member) {
-    await ctx.reply('You need to be a registered team member to use /zsedit. Run /whoami to confirm or DM Zaal to get added.');
+    await ctx.reply('I only ship edits for registered team. Run /whoami to confirm, or DM Zaal to get added to the roster.');
     return;
   }
 
   if (process.env.ZSEDIT_DISABLED === '1') {
-    await ctx.reply('Team /zsedit is paused right now. /zsfb still works for logging feedback. Ping Zaal if it is urgent.');
+    await ctx.reply('Paused. /zsedit is off temporarily. /zsfb still works to log it for later. Ping Zaal if urgent.');
     return;
   }
 
@@ -182,14 +182,12 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   if (!text || text.length < 10) {
     await ctx.reply(
       [
-        'Usage: /zsedit <change you want on the /test ZAOstock site>',
+        'Tell me what to change on /test. I clone bettercallzaal/zaostock, write the diff, run a critic, open a PR if it scores >=70.',
         '',
         'Examples:',
         '  /zsedit drop the lineup TBA placeholders, keep the section header',
         '  /zsedit hero copy too long - cut the second sentence',
         '  /zsedit add a "lineup drops Aug 2026" pill near the top',
-        '',
-        'I clone bettercallzaal/zaostock, write the diff, run a critic, and open a PR if it passes 70/100. Max 3 attempts.',
       ].join('\n'),
     );
     return;
@@ -216,7 +214,7 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   }
   if (usedToday >= dailyCap) {
     await ctx.reply(
-      `Daily /zsedit cap reached (${usedToday}/${dailyCap}). Resets at UTC midnight. Use /zsfb to log feedback for tomorrow's batch, or ping Zaal if it is urgent.`,
+      `Hit your daily ship cap (${usedToday}/${dailyCap}). Resets at UTC midnight. Drop it in /zsfb so I batch it tomorrow, or ping Zaal if urgent.`,
     );
     return;
   }
@@ -226,14 +224,14 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   const claudePath = process.env.HERMES_CLAUDE_BIN ?? '';
   const claudeOnPath = claudePath && existsSync(claudePath) ? true : await checkOnPath('claude');
   if (!claudeOnPath) {
-    await ctx.reply("Hermes can't find the 'claude' CLI on the bot host. Ping Zaal.");
+    await ctx.reply("Can't find the 'claude' CLI on my host - the Coder loop runs through it. Ping Zaal.");
     return;
   }
 
   await ctx.reply(
     [
-      `Hermes editing zaostock for ${member.name}. (${usedToday + 1}/${dailyCap} today.)`,
-      'Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.',
+      `On it, ${member.name}. Editing /test. (${usedToday + 1}/${dailyCap} today.)`,
+      'Coder writes the diff, Critic grades, you get a PR if score >=70. Max 3 attempts.',
     ].join('\n'),
   );
 

--- a/bot/src/hermes/commands.ts
+++ b/bot/src/hermes/commands.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'grammy';
 import { dispatchHermesRun } from './runner';
-import { getRun, listOpenRuns } from './db';
+import { countRunsByTelegramIdToday, getRun, listOpenRuns } from './db';
 import type { HermesRepoTarget } from './types';
 import type { TeamMember } from '../auth';
 
@@ -150,4 +150,97 @@ function formatRun(r: { id: string; status: string; fixer_attempts: number; crit
   ]
     .filter(Boolean)
     .join('\n');
+}
+
+/**
+ * /zsedit <issue> - team-facing direct website edit on bettercallzaal/zaostock.
+ *
+ * How it differs from /fix:
+ *   - target_repo is HARDCODED to 'zaostock' (cannot be tricked into editing ZAO OS)
+ *   - Open to any active team member (no admin gate)
+ *   - Per-member daily cap (default 2/day, override via ZSEDIT_DAILY_PER_MEMBER)
+ *   - Kill switch: set ZSEDIT_DISABLED=1 to pause all team edits without redeploying
+ *
+ * Why a separate command vs opening /fix to all:
+ *   /fix can target any repo profile and is the admin's catch-all. /zsedit is
+ *   the safe, scoped, rate-limited surface for the team. If costs spike or
+ *   the team needs lockdown, flip ZSEDIT_DISABLED and /fix still works for
+ *   admins.
+ */
+export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promise<void> {
+  if (!member) {
+    await ctx.reply('You need to be a registered team member to use /zsedit. Run /whoami to confirm or DM Zaal to get added.');
+    return;
+  }
+
+  if (process.env.ZSEDIT_DISABLED === '1') {
+    await ctx.reply('Team /zsedit is paused right now. /zsfb still works for logging feedback. Ping Zaal if it is urgent.');
+    return;
+  }
+
+  const text = (ctx.message?.text ?? '').replace(/^\/zsedit(@\w+)?\s*/, '').trim();
+  if (!text || text.length < 10) {
+    await ctx.reply(
+      [
+        'Usage: /zsedit <change you want on the /test ZAOstock site>',
+        '',
+        'Examples:',
+        '  /zsedit drop the lineup TBA placeholders, keep the section header',
+        '  /zsedit hero copy too long - cut the second sentence',
+        '  /zsedit add a "lineup drops Aug 2026" pill near the top',
+        '',
+        'I clone bettercallzaal/zaostock, write the diff, run a critic, and open a PR if it passes 70/100. Max 3 attempts.',
+      ].join('\n'),
+    );
+    return;
+  }
+
+  const fromId = ctx.from?.id;
+  const chatId = ctx.chat?.id;
+  if (!fromId || !chatId) {
+    await ctx.reply('Cannot identify sender or chat.');
+    return;
+  }
+
+  // Per-member daily cap. Counts ALL runs by this telegram id today (including
+  // failed/escalated) so spend pressure is honored even on retries.
+  const dailyCap = Number(process.env.ZSEDIT_DAILY_PER_MEMBER ?? '2');
+  let usedToday = 0;
+  try {
+    usedToday = await countRunsByTelegramIdToday(fromId);
+  } catch (err) {
+    console.error('[zsedit] daily cap query failed', err);
+    // fail-open: if the count query breaks, still allow the run rather than
+    // hard-blocking the team. Spend is still gated by the fleet daily cap in
+    // runner.ts.
+  }
+  if (usedToday >= dailyCap) {
+    await ctx.reply(
+      `Daily /zsedit cap reached (${usedToday}/${dailyCap}). Resets at UTC midnight. Use /zsfb to log feedback for tomorrow's batch, or ping Zaal if it is urgent.`,
+    );
+    return;
+  }
+
+  // Reuse the same Claude CLI presence check /fix uses.
+  const { existsSync } = await import('node:fs');
+  const claudePath = process.env.HERMES_CLAUDE_BIN ?? '';
+  const claudeOnPath = claudePath && existsSync(claudePath) ? true : await checkOnPath('claude');
+  if (!claudeOnPath) {
+    await ctx.reply("Hermes can't find the 'claude' CLI on the bot host. Ping Zaal.");
+    return;
+  }
+
+  await ctx.reply(
+    [
+      `Hermes editing zaostock for ${member.name}. (${usedToday + 1}/${dailyCap} today.)`,
+      'Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.',
+    ].join('\n'),
+  );
+
+  void runAndReport(ctx, {
+    triggered_by_telegram_id: fromId,
+    triggered_in_chat_id: chatId,
+    issue_text: text,
+    target_repo: 'zaostock',
+  });
 }

--- a/bot/src/hermes/db.ts
+++ b/bot/src/hermes/db.ts
@@ -41,3 +41,21 @@ export async function listOpenRuns(limit = 20): Promise<HermesRun[]> {
   if (error) throw new Error(`listOpenRuns failed: ${error.message}`);
   return (data as HermesRun[]) ?? [];
 }
+
+/**
+ * How many Hermes runs has this telegram_id triggered since UTC midnight?
+ * Used by /zsedit to enforce per-member daily caps. Counts every run regardless
+ * of final status (so a failed/escalated run still counts toward the cap -
+ * spend was incurred either way).
+ */
+export async function countRunsByTelegramIdToday(telegramId: number): Promise<number> {
+  const todayUtcStart = new Date();
+  todayUtcStart.setUTCHours(0, 0, 0, 0);
+  const { count, error } = await db()
+    .from('hermes_runs')
+    .select('id', { count: 'exact', head: true })
+    .eq('triggered_by_telegram_id', telegramId)
+    .gte('created_at', todayUtcStart.toISOString());
+  if (error) throw new Error(`countRunsByTelegramIdToday failed: ${error.message}`);
+  return count ?? 0;
+}

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -18,7 +18,7 @@ import { scheduleAll } from './schedule';
 import { alertDevops, buildHealthReport } from './ops';
 import { morningDigest, eveningRecap, weekAheadDigest, fridayRetro } from './digest';
 import { cmdOp } from './onepagers';
-import { cmdFix, cmdFixStatus } from './hermes/commands';
+import { cmdFix, cmdFixStatus, cmdZsEdit } from './hermes/commands';
 import {
   cmdCircles,
   cmdJoin,
@@ -132,6 +132,7 @@ bot.command('help', async (ctx) => {
       '  /do <text> - I parse + update the board',
       '  /idea <text> - drop into the pool, Zaal sees daily',
       '  /zsfb <text> - feedback on the /test ZAOstock site (auto-tagged by section)',
+      '  /zsedit <text> - actually ship the edit to /test (Hermes opens a PR; capped per day)',
       '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
       '',
@@ -197,6 +198,14 @@ bot.command('fix', async (ctx) => {
 
 bot.command('fix_status', async (ctx) => {
   await cmdFixStatus(ctx);
+});
+
+// /zsedit - team-facing direct edit of bettercallzaal/zaostock /test site.
+// Open to all team members, target locked to zaostock, per-member daily cap,
+// kill switch via ZSEDIT_DISABLED env. See bot/src/hermes/commands.ts.
+bot.command('zsedit', async (ctx) => {
+  const member = await resolveMember(ctx.from?.id, ctx.from?.username);
+  await cmdZsEdit(ctx, member);
 });
 
 bot.command('press', async (ctx) => {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -88,16 +88,14 @@ bot.command('start', async (ctx) => {
   if (member) {
     await ctx.reply(
       [
-        `Hey ${member.name}. Dashboard is your hub: https://zaoos.com/stock/team`,
+        `Hey ${member.name}. Hermes here - I read, I write, I ship.`,
         '',
-        'Bot is backup. Useful for:',
-        '  /mytodos - what you are owning',
-        '  /do <text> - tell me what happened, I update the board',
-        '  /circles - the 8 circles, /join <slug> to grab one',
-        '  /op - 1-pagers (sponsor / partner / venue briefings)',
-        '  /digest morning - daily brief',
-        '  /ask - ask me anything',
-        '  /help - full list',
+        'I do two jobs:',
+        '  1) save you typing on team ops (/mytodos /do /idea /circles /op /digest)',
+        '  2) edit the ZAOstock site for you (/zsfb to log, /zsedit to actually ship a PR)',
+        '',
+        'Dashboard for full context: https://zaoos.com/stock/team',
+        'Type /help for the full surface.',
       ].join('\n'),
     );
     return;
@@ -105,7 +103,8 @@ bot.command('start', async (ctx) => {
   const u = ctx.from?.username ? `@${ctx.from.username}` : 'your account';
   await ctx.reply(
     [
-      `Hey - I'm the ZAOstock Team Bot. ZAO Festivals presents ZAOstock, Oct 3 in Ellsworth.`,
+      `Hey - Hermes here. I run the ZAOstock team ops + ship code edits to the site.`,
+      `ZAO Festivals presents ZAOstock, Oct 3 in Ellsworth.`,
       '',
       `Don't recognize ${u} on the roster yet. Ping Zaal to link you.`,
       '',
@@ -119,9 +118,15 @@ bot.command('help', async (ctx) => {
   const isGroup = ctx.chat?.type !== 'private';
   await ctx.reply(
     [
-      'ZAOstock Team Bot - I save you typing. Dashboard has the context.',
+      'Hermes - team ops + code edits. Dashboard has the full state.',
       '',
-      'Read:',
+      'Edit the ZAOstock site:',
+      '  /zsfb <text> - log feedback on /test, no PR (auto-tagged by section)',
+      '  /zsedit <text> - ship the edit. I clone, write, critique, open a PR. Capped per day.',
+      '  /fix [zaostock|zaoos] <issue> - admin: same loop, broader scope',
+      '  /fix_status [run_id] - check open code runs',
+      '',
+      'Read team state:',
       '  /status - festival snapshot, top blockers',
       '  /mytodos - what you are owning',
       '  /mytodos_all - everything open across the team (claimable)',
@@ -131,8 +136,6 @@ bot.command('help', async (ctx) => {
       'Tell me what happened:',
       '  /do <text> - I parse + update the board',
       '  /idea <text> - drop into the pool, Zaal sees daily',
-      '  /zsfb <text> - feedback on the /test ZAOstock site (auto-tagged by section)',
-      '  /zsedit <text> - actually ship the edit to /test (Hermes opens a PR; capped per day)',
       '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
       '',
@@ -156,10 +159,6 @@ bot.command('help', async (ctx) => {
       '',
       'External (anyone, no link needed):',
       '  /press - press kit + contact info',
-      '',
-      'Hermes (admin only, runs via Claude Code CLI on Max plan):',
-      '  /fix <issue> - Coder writes diff, Critic grades, you get a PR if score >=70',
-      '  /fix_status [run_id] - check open Hermes runs',
       '',
       'Ops:',
       '  /chatinfo - chat + topic ids',
@@ -263,7 +262,7 @@ bot.command('ask', async (ctx) => {
   try {
     const reply = await ask(
       text,
-      `You are the ZAOstock Team Bot advisor. Answer briefly (under 300 words). If the user is asking about festival state, tell them to use /status or /mytodos.`,
+      `You are Hermes, the ZAOstock team bot. You handle team ops + ship code edits to the ZAOstock site. Answer briefly (under 300 words). If the user is asking about festival state, tell them to use /status or /mytodos. If they want to change the site, tell them /zsfb (log) or /zsedit (ship).`,
     );
     await ctx.reply(reply.text);
   } catch (err) {

--- a/bot/src/zsfb.ts
+++ b/bot/src/zsfb.ts
@@ -76,7 +76,7 @@ export async function addZsFb(member: TeamMember, text: string): Promise<string>
   });
 
   return [
-    `Logged (${section}). id ${data.id.slice(0, 8)}.`,
-    `Zaal sees the daily digest. He'll trigger Hermes if it's a clear ship.`,
+    `Got it - logged under ${section}. id ${data.id.slice(0, 8)}.`,
+    `I'll surface it in the daily digest. Want it shipped now? Run /zsedit with the same text.`,
   ].join('\n');
 }

--- a/content/bonfire-ingest/people-graph.md
+++ b/content/bonfire-ingest/people-graph.md
@@ -1,0 +1,542 @@
+INGEST BATCH: ZAO People Graph (45+ named people in Zaal's web3 + Ellsworth orbit).
+
+Build a manifest of Person nodes, Org nodes, and relationship edges, preview the first 3 nodes, then ask me to approve. If a Person node already exists with matching name, MERGE attributes; do not create parallel Person nodes. Topics + platforms + tools must be attributes only, never standalone Entity nodes per scope_constraint trait.
+
+## SECTION 1 — ZAOSTOCK TEAM (CO-FOUNDERS + KEY ROLES)
+
+### FACT 1
+Subject: Cassie
+Type: Person
+Role: ZAOstock strategic advisor
+Description: Strategic validator for ZAOstock direction. On 2026-04-28 confirmed the ZAOstock infrastructure IS the product, festival is proof. Anti-pivot stance.
+Source: internal://memory/project_zaostock_master_strategy.md
+Confidence: 1.0
+
+### FACT 2
+Subject: Steve Peer
+Type: Person
+Role: ZAOstock co-curator (proposed)
+Description: Ellsworth-based drummer since 1989. Plays in Crown Vics. Hosts 430 Bayside house concerts. ZAO Stock co-curator candidate, not yet pitched on full role.
+Source: internal://memory/project_steve_peer.md
+Confidence: 1.0
+
+### FACT 3
+Subject: Roddy Ehrlenbach
+Type: Person
+Role: City of Ellsworth Parks/Rec
+Description: Venue contact for Franklin Street Parklet, ZAOstock 2026 location. First in-person meeting 2026-04-28 at City Hall. Confirmed October 3 2026 date and location.
+Source: internal://memory/project_roddy_parklet_contact.md
+Confidence: 1.0
+
+### FACT 4
+Subject: Tyler
+Type: Person
+Role: ZAOstock team member
+Description: Listed in ZAOstock corrected team roster (memory project_zao_stock_team.md).
+Source: internal://memory/project_zao_stock_team.md
+Confidence: 0.9
+
+### FACT 5
+Subject: Hannah
+Type: Person
+Role: Farm Drop
+Description: Founder/team at Farm Drop. Appeared on BCZ YapZ 2026-04-21. ZAOstock team contact for Ellsworth ecosystem.
+Source: internal://content/yapz-bonfire-ingest/2026-04-21-hannah-farmdrop.md
+Confidence: 1.0
+
+### FACT 6
+Subject: Kenny
+Type: Person
+Role: POIDH community lead
+Description: Reviewed POIDH ZAO clip-up bounty pre-launch (2026-04-27). Trusted reviewer for bounty wording + format pivot.
+Source: internal://memory/project_poidh_bounty_live.md
+Confidence: 1.0
+
+## SECTION 2 — BCZ YAPZ GUESTS (Q1 2026)
+
+### FACT 7
+Subject: Yerbearserker
+Type: Person
+Role: Empire Builder team
+Description: BCZ YapZ Ep 7 guest 2026-01-05. Empire Builder ecosystem contributor. Top voter in ZABAL Empire Voting tab as of 2026-05-02.
+Source: internal://content/yapz-bonfire-ingest/2026-01-05-yerbearserker.md
+Confidence: 1.0
+
+### FACT 8
+Subject: Diviflyy
+Type: Person
+Role: Empire Builder team
+Description: BCZ YapZ Ep 8 guest 2026-02-11. Empire Builder ecosystem contributor. Holders top 3 in ZABAL Empire as of 2026-05-02.
+Source: internal://content/yapz-bonfire-ingest/2026-02-11-diviflyy-empire-builder.md
+Confidence: 1.0
+
+### FACT 9
+Subject: Juliano
+Type: Person
+Role: Pinetree
+Description: BCZ YapZ Ep 9 guest 2026-02-23 (also known as GIU). Pinetree project founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-02-23-giu-pinetree.md
+Confidence: 1.0
+
+### FACT 10
+Subject: SNAX
+Type: Person
+Role: Pizza DAO
+Description: BCZ YapZ Ep 10 guest 2026-02-23. Pizza DAO contributor.
+Source: internal://content/yapz-bonfire-ingest/2026-02-23-snax-pizza-dao.md
+Confidence: 1.0
+
+### FACT 11
+Subject: Roaring Sensei
+Type: Person
+Role: Web3 builder
+Description: BCZ YapZ Ep 11 guest 2026-03-18.
+Source: internal://content/yapz-bonfire-ingest/2026-03-18-roaring-sensei.md
+Confidence: 1.0
+
+### FACT 12
+Subject: Saltorious.eth
+Type: Person
+Role: Among Traitors
+Description: BCZ YapZ Ep 12 guest 2026-03-18. Among Traitors project founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-03-18-saltorious-among-traitors.md
+Confidence: 1.0
+
+### FACT 13
+Subject: Ali
+Type: Person
+Role: Inflynce
+Description: BCZ YapZ Ep 13 guest 2026-03-25. Inflynce project founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-03-25-ali-inflynce.md
+Confidence: 1.0
+
+### FACT 14
+Subject: Jordan
+Type: Person
+Role: Ryft
+Description: BCZ YapZ Ep 14 guest 2026-04-01. Ryft project founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-04-01-jordan-ryft.md
+Confidence: 1.0
+
+### FACT 15
+Subject: Nikoline Arns
+Type: Person
+Role: Hubs Network
+Description: BCZ YapZ Ep 15 guest 2026-04-14. Hubs Network founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-04-14-nikoline-hubs-network.md
+Confidence: 1.0
+
+### FACT 16
+Subject: Jack Dishman
+Type: Person
+Role: Clanker
+Description: BCZ YapZ Ep 16 guest 2026-04-21 (also known as Dish). Clanker founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-04-21-dish-clanker.md
+Confidence: 1.0
+
+### FACT 17
+Subject: Andy Minton
+Type: Person
+Role: Hangry Animals
+Description: BCZ YapZ Ep 18 guest 2026-04-26. Hangry Animals project founder/team.
+Source: internal://content/yapz-bonfire-ingest/2026-04-26-andy-minton-hangry-animals.md
+Confidence: 1.0
+
+## SECTION 3 — BCZ YAPZ GUESTS (2025)
+
+### FACT 18
+Subject: Deepa
+Type: Person
+Role: GrantOrb founder
+Description: BCZ YapZ Ep 1 guest 2025-08-22. Founded GrantOrb after seeing skills gap in grant writing communication. Nonprofit + web3 background. Entered web3 via Polygon COVID relief campaign 2021.
+Source: internal://content/yapz-bonfire-ingest/2025-08-22-deepa-grantorb.md
+Confidence: 1.0
+
+### FACT 19
+Subject: Rich Bartuc
+Type: Person
+Role: PowerPacks Diamondhands Club
+Description: BCZ YapZ Ep 2 guest 2025-10-14. PowerPacks Diamondhands Club founder.
+Source: internal://content/yapz-bonfire-ingest/2025-10-14-rich-bartuc.md
+Confidence: 1.0
+
+### FACT 20
+Subject: Yoni Dubz
+Type: Person
+Role: Web3 builder
+Description: BCZ YapZ Ep 3 guest 2025-10-19.
+Source: internal://content/yapz-bonfire-ingest/2025-10-19-yoni-dubz.md
+Confidence: 1.0
+
+### FACT 21
+Subject: Rock Opera
+Type: Person
+Role: Web3 music artist
+Description: BCZ YapZ Ep 4 guest 2025-11-30.
+Source: internal://content/yapz-bonfire-ingest/2025-11-30-rockopera.md
+Confidence: 1.0
+
+### FACT 22
+Subject: Daya
+Type: Person
+Role: Flix.Fun
+Description: BCZ YapZ Ep 5 guest 2025-12-11. Flix.Fun founder/team.
+Source: internal://content/yapz-bonfire-ingest/2025-12-11-daya-flix-fun.md
+Confidence: 1.0
+
+### FACT 23
+Subject: Sven
+Type: Person
+Role: Incented
+Description: BCZ YapZ Ep 6 guest 2025-12-16. Incented founder/team.
+Source: internal://content/yapz-bonfire-ingest/2025-12-16-sven-incented.md
+Confidence: 1.0
+
+## SECTION 4 — PARTNERS + EXTERNAL FOUNDERS
+
+### FACT 24
+Subject: Joshua.eth
+Type: Person
+Role: Bonfires.ai founder
+Description: Founder of Bonfires.ai (parent company Delve). ZABAL Bonfire Bot deployed on Genesis tier. Outstanding open questions: programmatic graph wipe, MCP server roadmap, ERC-8004 alignment, batch payload max.
+Source: internal://research/identity/581
+Confidence: 1.0
+
+### FACT 25
+Subject: Matteo Tambussi
+Type: Person
+Role: Livepeer OG, ETHTurin/SpaghettETH founder
+Description: ZAO Italy bridge candidate. Doc 419 + Maceo intro 2026-04-17. Potential live-streaming + Italy ecosystem partnerships.
+Source: internal://memory/project_matteo_tambussi_italy_bridge.md
+Confidence: 1.0
+
+### FACT 26
+Subject: Maceo
+Type: Person
+Role: Connector
+Description: Made Mat Tambussi intro to Zaal 2026-04-17.
+Source: internal://memory/project_matteo_tambussi_italy_bridge.md
+Confidence: 0.9
+
+### FACT 27
+Subject: nickysap
+Type: Person
+Role: Juke audio Farcaster client founder
+Description: Building Juke (Farcaster audio client). Partnership with ZAO post-FISHBOWLZ-pause 2026-04-16. Replaces FISHBOWLZ standalone audio rooms strategy.
+Source: internal://memory/project_fishbowlz_deprecated.md
+Confidence: 1.0
+
+### FACT 28
+Subject: Ohnahji
+Type: Person
+Role: LTAW3 cohost
+Description: Co-host of "Let's Talk About Web3" weekly Twitch livestream with Zaal + EZinCrypto. Top Holder + Top Farcaster on ZABAL Empire Builder leaderboard 2026-05-02 (score 699M Farcaster, 433M Holders rank 2).
+Source: internal://research/identity/580
+Confidence: 1.0
+
+### FACT 29
+Subject: EZinCrypto
+Type: Person
+Role: LTAW3 cohost
+Description: Co-host of "Let's Talk About Web3" with Zaal + Ohnahji. Concert-impact organizer per Deepa YapZ episode. Bridges music + impact crypto.
+Source: internal://research/identity/580
+Confidence: 1.0
+
+### FACT 30
+Subject: ticweb3
+Type: Person
+Role: ZABAL ecosystem contributor
+Description: Top Holders rank in ZABAL Empire Builder leaderboard 2026-05-02 (score 433M, lifetime $8.26).
+Source: internal://memory/project_empire_builder_zabal_integration.md
+Confidence: 0.9
+
+### FACT 31
+Subject: candytoybox
+Type: Person
+Role: ZABAL Farcaster contributor
+Description: Top 3 Farcaster engagement rank in ZABAL Empire Builder leaderboard 2026-05-02.
+Source: internal://memory/project_empire_builder_zabal_integration.md
+Confidence: 0.9
+
+## SECTION 5 — ZAO FRACTALS CORE
+
+### FACT 32
+Subject: Dan
+Type: Person
+Role: ZAO Fractals core
+Description: Core relationship in ZAO Fractals weekly process. 90+ weeks running as of Apr 2026. Mondays 6pm EST. Discord Python bot.
+Source: internal://memory/project_fractal_process.md
+Confidence: 1.0
+
+### FACT 33
+Subject: Tadas
+Type: Person
+Role: ZAO Fractals core
+Description: Core relationship in ZAO Fractals. Frapps submission and OG/ZOR Respect distribution context.
+Source: internal://memory/project_fractal_process.md
+Confidence: 1.0
+
+## SECTION 6 — ZAO ECOSYSTEM ARTISTS + COMMUNITY
+
+### FACT 34
+Subject: Hurric4n3ike
+Type: Person
+Role: ZAO ecosystem artist
+Description: WaveWarZ battler. Featured in WaveWarZ LIVE Rematch at ZAO-CHELLA Miami 2024-12-06 vs JANGO UU.
+Source: internal://research/identity/580 + zaofestivals.com
+Confidence: 1.0
+
+### FACT 35
+Subject: JANGO UU
+Type: Person
+Role: ZAO ecosystem artist
+Description: WaveWarZ battler. Featured in WaveWarZ LIVE Rematch at ZAO-CHELLA Miami 2024-12-06 vs Hurric4n3ike.
+Source: internal://research/identity/580 + zaofestivals.com
+Confidence: 1.0
+
+### FACT 36
+Subject: AttaBotty
+Type: Person
+Role: ZAO co-founder + artist
+Description: Co-founder of The ZAO and ecosystem artist. Long-time collaborator.
+Source: internal://research/identity/580
+Confidence: 0.9
+
+### FACT 37
+Subject: Losi
+Type: Person
+Role: Web3 music artist (Colombia)
+Description: Colombia-based web3 music pioneer. ZAO ecosystem artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 38
+Subject: Mr.Darius
+Type: Person
+Role: Musician + community builder
+Description: ZAO ecosystem musician + community builder.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 39
+Subject: Jadyn Violet
+Type: Person
+Role: ZAO ecosystem musician
+Description: Notable ZAO artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 40
+Subject: Maxwell Aden
+Type: Person
+Role: ZAO ecosystem musician
+Description: Notable ZAO artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 41
+Subject: NessytheRilla
+Type: Person
+Role: ZAO ecosystem musician
+Description: Notable ZAO artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 42
+Subject: Songs of Eden
+Type: Person
+Role: ZAO ecosystem musician
+Description: Notable ZAO artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+### FACT 43
+Subject: Clejan
+Type: Person
+Role: ZAO ecosystem musician
+Description: Notable ZAO artist.
+Source: internal://research/identity/580
+Confidence: 0.8
+
+## SECTION 7 — ORGS + PROJECTS LINKED TO PEOPLE ABOVE
+
+### FACT 44
+Subject: GrantOrb
+Type: Org
+Description: Web3 grant-writing tool using AI to convert short keyword input into full grant proposals. First tested on Gitcoin in 2023. Founded by Deepa.
+Source: internal://content/yapz-bonfire-ingest/2025-08-22-deepa-grantorb.md
+Confidence: 1.0
+
+### FACT 45
+Subject: Empire Builder
+Type: Org
+Description: Empire Builder V3 leaderboard / distribution / multiplier engine. Integrated with ZABAL via the EmpirePanel drawer in ZAO OS. Yerbearserker, Diviflyy active contributors.
+Source: internal://memory/project_empire_builder_zabal_integration.md
+Confidence: 1.0
+
+### FACT 46
+Subject: Hubs Network
+Type: Org
+Description: Web3 community + hub-network platform. Founded by Nikoline Arns. BCZ YapZ Ep 15.
+Source: internal://content/yapz-bonfire-ingest/2026-04-14-nikoline-hubs-network.md
+Confidence: 1.0
+
+### FACT 47
+Subject: Clanker
+Type: Org
+Description: Token launchpad. Founded by Jack Dishman. BCZ YapZ Ep 16.
+Source: internal://content/yapz-bonfire-ingest/2026-04-21-dish-clanker.md
+Confidence: 1.0
+
+### FACT 48
+Subject: Farm Drop
+Type: Org
+Description: Ellsworth/Maine ecosystem partner. Hannah on BCZ YapZ Ep 17.
+Source: internal://content/yapz-bonfire-ingest/2026-04-21-hannah-farmdrop.md
+Confidence: 1.0
+
+### FACT 49
+Subject: Hangry Animals
+Type: Org
+Description: Andy Minton's project. BCZ YapZ Ep 18.
+Source: internal://content/yapz-bonfire-ingest/2026-04-26-andy-minton-hangry-animals.md
+Confidence: 1.0
+
+### FACT 50
+Subject: Pizza DAO
+Type: Org
+Description: SNAX is contributor. BCZ YapZ Ep 10.
+Source: internal://content/yapz-bonfire-ingest/2026-02-23-snax-pizza-dao.md
+Confidence: 1.0
+
+### FACT 51
+Subject: Pinetree
+Type: Org
+Description: Juliano (GIU) is founder/team. BCZ YapZ Ep 9.
+Source: internal://content/yapz-bonfire-ingest/2026-02-23-giu-pinetree.md
+Confidence: 1.0
+
+### FACT 52
+Subject: Among Traitors
+Type: Org
+Description: Saltorious.eth is founder/team. BCZ YapZ Ep 12.
+Source: internal://content/yapz-bonfire-ingest/2026-03-18-saltorious-among-traitors.md
+Confidence: 1.0
+
+### FACT 53
+Subject: Inflynce
+Type: Org
+Description: Ali is founder/team. BCZ YapZ Ep 13.
+Source: internal://content/yapz-bonfire-ingest/2026-03-25-ali-inflynce.md
+Confidence: 1.0
+
+### FACT 54
+Subject: Ryft
+Type: Org
+Description: Jordan is founder/team. BCZ YapZ Ep 14.
+Source: internal://content/yapz-bonfire-ingest/2026-04-01-jordan-ryft.md
+Confidence: 1.0
+
+### FACT 55
+Subject: Flix.Fun
+Type: Org
+Description: Daya is founder/team. BCZ YapZ Ep 5.
+Source: internal://content/yapz-bonfire-ingest/2025-12-11-daya-flix-fun.md
+Confidence: 1.0
+
+### FACT 56
+Subject: Incented
+Type: Org
+Description: Sven is founder/team. BCZ YapZ Ep 6.
+Source: internal://content/yapz-bonfire-ingest/2025-12-16-sven-incented.md
+Confidence: 1.0
+
+### FACT 57
+Subject: PowerPacks Diamondhands Club
+Type: Org
+Description: Rich Bartuc is founder. BCZ YapZ Ep 2.
+Source: internal://content/yapz-bonfire-ingest/2025-10-14-rich-bartuc.md
+Confidence: 1.0
+
+### FACT 58
+Subject: Crown Vics
+Type: Org
+Description: Ellsworth-area band. Steve Peer is drummer. Active on Maine local music scene.
+Source: internal://memory/project_steve_peer.md
+Confidence: 1.0
+
+### FACT 59
+Subject: 430 Bayside
+Type: Venue
+Description: Steve Peer's Ellsworth house concert venue. Local infrastructure for ZAO Stock partnerships.
+Source: internal://memory/project_steve_peer.md
+Confidence: 0.9
+
+### FACT 60
+Subject: Bonfires.ai (Delve)
+Type: Org
+Description: Knowledge graph platform. Joshua.eth founder. Parent company Delve. ZAO is Genesis tier customer. Telegram-native bots, kEngrams, Cross-Bonfire Search, Document Store, Firecrawl + Fireflies + Twitter integrations.
+Source: internal://research/identity/542
+Confidence: 1.0
+
+## EDGES TO ASSERT
+
+- Cassie -[advises]-> ZAOstock 2026
+- Steve Peer -[curates_with]-> ZAOstock 2026
+- Steve Peer -[plays_in]-> Crown Vics
+- Steve Peer -[hosts_at]-> 430 Bayside
+- Roddy Ehrlenbach -[provides_venue_for]-> ZAOstock 2026
+- Tyler -[part_of]-> ZAOstock team
+- Hannah -[part_of]-> ZAOstock team
+- Hannah -[founded]-> Farm Drop
+- Kenny -[reviewed]-> POIDH bounty 1151
+- Yerbearserker -[appeared_on]-> BCZ YapZ Ep 7
+- Yerbearserker -[part_of]-> Empire Builder
+- Diviflyy -[appeared_on]-> BCZ YapZ Ep 8
+- Diviflyy -[part_of]-> Empire Builder
+- Juliano -[appeared_on]-> BCZ YapZ Ep 9
+- Juliano -[founded]-> Pinetree
+- SNAX -[appeared_on]-> BCZ YapZ Ep 10
+- SNAX -[part_of]-> Pizza DAO
+- Roaring Sensei -[appeared_on]-> BCZ YapZ Ep 11
+- Saltorious.eth -[appeared_on]-> BCZ YapZ Ep 12
+- Saltorious.eth -[founded]-> Among Traitors
+- Ali -[appeared_on]-> BCZ YapZ Ep 13
+- Ali -[founded]-> Inflynce
+- Jordan -[appeared_on]-> BCZ YapZ Ep 14
+- Jordan -[founded]-> Ryft
+- Nikoline Arns -[appeared_on]-> BCZ YapZ Ep 15
+- Nikoline Arns -[founded]-> Hubs Network
+- Jack Dishman -[appeared_on]-> BCZ YapZ Ep 16
+- Jack Dishman -[founded]-> Clanker
+- Andy Minton -[appeared_on]-> BCZ YapZ Ep 18
+- Andy Minton -[founded]-> Hangry Animals
+- Deepa -[appeared_on]-> BCZ YapZ Ep 1
+- Deepa -[founded]-> GrantOrb
+- Rich Bartuc -[appeared_on]-> BCZ YapZ Ep 2
+- Rich Bartuc -[founded]-> PowerPacks Diamondhands Club
+- Yoni Dubz -[appeared_on]-> BCZ YapZ Ep 3
+- Rock Opera -[appeared_on]-> BCZ YapZ Ep 4
+- Daya -[appeared_on]-> BCZ YapZ Ep 5
+- Daya -[founded]-> Flix.Fun
+- Sven -[appeared_on]-> BCZ YapZ Ep 6
+- Sven -[part_of]-> Incented
+- Joshua.eth -[founded]-> Bonfires.ai (Delve)
+- Joshua.eth -[provides]-> ZABAL Bonfire Bot
+- Matteo Tambussi -[bridges_to]-> ZAO Italy
+- Matteo Tambussi -[part_of]-> Livepeer
+- Maceo -[introduced]-> Matteo Tambussi to Zaal Panthaki
+- nickysap -[founded]-> Juke audio Farcaster client
+- Ohnahji -[cohosts]-> Let's Talk About Web3
+- EZinCrypto -[cohosts]-> Let's Talk About Web3
+- Zaal Panthaki -[cohosts]-> Let's Talk About Web3
+- Dan -[part_of]-> ZAO Fractals
+- Tadas -[part_of]-> ZAO Fractals
+- Hurric4n3ike -[battled_in]-> WaveWarZ at ZAO-CHELLA 2024
+- JANGO UU -[battled_in]-> WaveWarZ at ZAO-CHELLA 2024
+- AttaBotty -[cofounded]-> The ZAO
+- Zaal Panthaki -[knows]-> [each Person above]
+
+---
+
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Total ~60 facts (45 Persons + 15 Orgs/Venues) plus ~50 edges. Do not commit until I say yes. If existing Person or Org nodes match by name, MERGE; do not create parallel nodes.

--- a/content/bonfire-ingest/research-index-agents.md
+++ b/content/bonfire-ingest/research-index-agents.md
@@ -1,0 +1,883 @@
+INGEST BATCH: ZAO Research Library Index — agents (1 topic folder).
+
+Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. Each ResearchDoc has Topic + Doc number + Description as attributes. Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes.
+
+## SECTION — agents (87 docs)
+
+### FACT 1
+Subject: Research Doc 026: Hindsight: Agent Memory System (vectorize-io/hindsight)
+Type: ResearchDoc
+Topic: agents
+Doc number: 026
+Description: Hindsight: Agent Memory System (vectorize-io/hindsight)
+Source: internal://research/agents/026-hindsight-agent-memory/
+Confidence: 1.0
+
+
+### FACT 2
+Subject: Research Doc 070: Sub-agents vs Agent Teams + Claude Architect Patterns for ZAO OS
+Type: ResearchDoc
+Topic: agents
+Doc number: 070
+Description: Sub-agents vs Agent Teams + Claude Architect Patterns for ZAO OS
+Source: internal://research/agents/070-subagents-vs-agent-teams/
+Confidence: 1.0
+
+
+### FACT 3
+Subject: Research Doc 071: Research 71: Paperclip AI Rate Limiting & Multi-Agent API Key Management
+Type: ResearchDoc
+Topic: agents
+Doc number: 071
+Description: Research 71: Paperclip AI Rate Limiting & Multi-Agent API Key Management
+Source: internal://research/agents/071-paperclip-rate-limits-multi-agent/
+Confidence: 1.0
+
+
+### FACT 4
+Subject: Research Doc 084: Farcaster AI Agents Landscape (March 2026)
+Type: ResearchDoc
+Topic: agents
+Doc number: 084
+Description: Farcaster AI Agents Landscape (March 2026)
+Source: internal://research/agents/084-farcaster-ai-agents-landscape/
+Confidence: 1.0
+
+
+### FACT 5
+Subject: Research Doc 085: Building and Deploying a Farcaster AI Agent with Neynar
+Type: ResearchDoc
+Topic: agents
+Doc number: 085
+Description: Building and Deploying a Farcaster AI Agent with Neynar
+Source: internal://research/agents/085-farcaster-agent-technical-setup/
+Confidence: 1.0
+
+
+### FACT 6
+Subject: Research Doc 090: AI-Run Community: Self-Improving Agent OS for ZAO
+Type: ResearchDoc
+Topic: agents
+Doc number: 090
+Description: AI-Run Community: Self-Improving Agent OS for ZAO
+Source: internal://research/agents/090-ai-run-community-agent-os/
+Confidence: 1.0
+
+
+### FACT 7
+Subject: Research Doc 161: Agent Harness Engineering: LangChain DeepAgents, Virtual Filesystems & the Ralph Loop
+Type: ResearchDoc
+Topic: agents
+Doc number: 161
+Description: Agent Harness Engineering: LangChain DeepAgents, Virtual Filesystems & the Ralph Loop
+Source: internal://research/agents/161-agent-harness-engineering-langchain/
+Confidence: 1.0
+
+
+### FACT 8
+Subject: Research Doc 171: Council of High Intelligence: Multi-Agent Deliberation for ZAO OS
+Type: ResearchDoc
+Topic: agents
+Doc number: 171
+Description: Council of High Intelligence: Multi-Agent Deliberation for ZAO OS
+Source: internal://research/agents/171-council-high-intelligence-multi-agent-deliberation/
+Confidence: 1.0
+
+
+### FACT 9
+Subject: Research Doc 202: Multi-Agent Orchestration: OpenClaw Supervising Paperclip + Human-as-Agent
+Type: ResearchDoc
+Topic: agents
+Doc number: 202
+Description: Multi-Agent Orchestration: OpenClaw Supervising Paperclip + Human-as-Agent
+Source: internal://research/agents/202-multi-agent-orchestration-openclaw-paperclip/
+Confidence: 1.0
+
+
+### FACT 10
+Subject: Research Doc 205: OpenClaw + Paperclip + ElizaOS: Full Agent Stack Deployment Plan
+Type: ResearchDoc
+Topic: agents
+Doc number: 205
+Description: OpenClaw + Paperclip + ElizaOS: Full Agent Stack Deployment Plan
+Source: internal://research/agents/205-openclaw-paperclip-elizaos-deployment-plan/
+Confidence: 1.0
+
+
+### FACT 11
+Subject: Research Doc 206: LobsterAI Agent Architecture Analysis
+Type: ResearchDoc
+Topic: agents
+Doc number: 206
+Description: LobsterAI Agent Architecture Analysis
+Source: internal://research/agents/206-lobsterai-agent-architecture/
+Confidence: 1.0
+
+
+### FACT 12
+Subject: Research Doc 208: Paperclip Plugins: Ecosystem Update & ZAO Integration Plan
+Type: ResearchDoc
+Topic: agents
+Doc number: 208
+Description: Paperclip Plugins: Ecosystem Update & ZAO Integration Plan
+Source: internal://research/agents/208-paperclip-plugins-ecosystem-update/
+Confidence: 1.0
+
+
+### FACT 13
+Subject: Research Doc 227: Agentic Workflows in 2026: Frameworks, Patterns & Music/Web3 Applications
+Type: ResearchDoc
+Topic: agents
+Doc number: 227
+Description: Agentic Workflows in 2026: Frameworks, Patterns & Music/Web3 Applications
+Source: internal://research/agents/227-agentic-workflows-2026/
+Confidence: 1.0
+
+
+### FACT 14
+Subject: Research Doc 234: OpenClaw Comprehensive Guide: Agent Memory, Knowledge Graphs, MCP Servers & Context Management
+Type: ResearchDoc
+Topic: agents
+Doc number: 234
+Description: OpenClaw Comprehensive Guide: Agent Memory, Knowledge Graphs, MCP Servers & Context Management
+Source: internal://research/agents/234-openclaw-comprehensive-guide/
+Confidence: 1.0
+
+
+### FACT 15
+Subject: Research Doc 235: Free Web Search MCP Alternatives for AI Agents
+Type: ResearchDoc
+Topic: agents
+Doc number: 235
+Description: Free Web Search MCP Alternatives for AI Agents
+Source: internal://research/agents/235-free-web-search-mcp-alternatives/
+Confidence: 1.0
+
+
+### FACT 16
+Subject: Research Doc 236: - Autonomous OpenClaw Operator Pattern: 3-Layer Memory, Heartbeats, Delegation & Nightly Consolidation
+Type: ResearchDoc
+Topic: agents
+Doc number: 236
+Description: - Autonomous OpenClaw Operator Pattern: 3-Layer Memory, Heartbeats, Delegation & Nightly Consolidation
+Source: internal://research/agents/236-autonomous-openclaw-operator-pattern/
+Confidence: 1.0
+
+
+### FACT 17
+Subject: Research Doc 237: USV Agents, Tasklet, Malleable Software & The "Build Something You Want" Era
+Type: ResearchDoc
+Topic: agents
+Doc number: 237
+Description: USV Agents, Tasklet, Malleable Software & The "Build Something You Want" Era
+Source: internal://research/agents/237-usv-agents-tasklet-malleable-software/
+Confidence: 1.0
+
+
+### FACT 18
+Subject: Research Doc 239: Agent Frameworks & Infrastructure Evaluation for ZAO OS
+Type: ResearchDoc
+Topic: agents
+Doc number: 239
+Description: Agent Frameworks & Infrastructure Evaluation for ZAO OS
+Source: internal://research/agents/239-agent-frameworks-infrastructure-evaluation/
+Confidence: 1.0
+
+
+### FACT 19
+Subject: Research Doc 245: ZOE Upgrade: Autonomous Workflow, Telegram Patterns, Neynar API & Founder Agent Playbook
+Type: ResearchDoc
+Topic: agents
+Doc number: 245
+Description: ZOE Upgrade: Autonomous Workflow, Telegram Patterns, Neynar API & Founder Agent Playbook
+Source: internal://research/agents/245-zoe-upgrade-autonomous-workflow-2026/
+Confidence: 1.0
+
+
+### FACT 20
+Subject: Research Doc 246: Neynar API: Creative Agent Uses for ZOE
+Type: ResearchDoc
+Topic: agents
+Doc number: 246
+Description: Neynar API: Creative Agent Uses for ZOE
+Source: internal://research/agents/246-neynar-api-creative-agent-uses/
+Confidence: 1.0
+
+
+### FACT 21
+Subject: Research Doc 247: Top 50 Local AI Models for Privacy + Best Outputs (2026)
+Type: ResearchDoc
+Topic: agents
+Doc number: 247
+Description: Top 50 Local AI Models for Privacy + Best Outputs (2026)
+Source: internal://research/agents/247-top-50-local-ai-models-2026/
+Confidence: 1.0
+
+
+### FACT 22
+Subject: Research Doc 251: HuggingFace Platform Deep Dive: What ZAO Can Do With a Write Token
+Type: ResearchDoc
+Topic: agents
+Doc number: 251
+Description: HuggingFace Platform Deep Dive: What ZAO Can Do With a Write Token
+Source: internal://research/agents/251-huggingface-platform-deep-dive/
+Confidence: 1.0
+
+
+### FACT 23
+Subject: Research Doc 253: AutoAgent: Self-Optimizing Agent Harnesses (Kevin Gu / ThirdLayer)
+Type: ResearchDoc
+Topic: agents
+Doc number: 253
+Description: AutoAgent: Self-Optimizing Agent Harnesses (Kevin Gu / ThirdLayer)
+Source: internal://research/agents/253-autoagent-self-optimizing-agents/
+Confidence: 1.0
+
+
+### FACT 24
+Subject: Research Doc 256: ZOE Agent Factory: The Vision
+Type: ResearchDoc
+Topic: agents
+Doc number: 256
+Description: ZOE Agent Factory: The Vision
+Source: internal://research/agents/256-zoe-agent-factory-vision/
+Confidence: 1.0
+
+
+### FACT 25
+Subject: Research Doc 259: Agent Self-Optimization: AutoAgent + Claude Code Hooks
+Type: ResearchDoc
+Topic: agents
+Doc number: 259
+Description: Agent Self-Optimization: AutoAgent + Claude Code Hooks
+Source: internal://research/agents/259-agent-self-optimization/
+Confidence: 1.0
+
+
+### FACT 26
+Subject: Research Doc 262: Virtuals Protocol: Agent Payment Rail
+Type: ResearchDoc
+Topic: agents
+Doc number: 262
+Description: Virtuals Protocol: Agent Payment Rail
+Source: internal://research/agents/262-virtuals-protocol-agent-rail/
+Confidence: 1.0
+
+
+### FACT 27
+Subject: Research Doc 266: Mission Control v2: Open-Source AI Agent Orchestration
+Type: ResearchDoc
+Topic: agents
+Doc number: 266
+Description: Mission Control v2: Open-Source AI Agent Orchestration
+Source: internal://research/agents/266-mission-control-v2/
+Confidence: 1.0
+
+
+### FACT 28
+Subject: Research Doc 267: OpenClaw Skills & Capabilities Reference
+Type: ResearchDoc
+Topic: agents
+Doc number: 267
+Description: OpenClaw Skills & Capabilities Reference
+Source: internal://research/agents/267-openclaw-skills-capabilities/
+Confidence: 1.0
+
+
+### FACT 29
+Subject: Research Doc 268: Milady AI: ElizaOS Evolution for Desktop-First AI Agents
+Type: ResearchDoc
+Topic: agents
+Doc number: 268
+Description: Milady AI: ElizaOS Evolution for Desktop-First AI Agents
+Source: internal://research/agents/268-milady-ai-elizaos-evolution/
+Confidence: 1.0
+
+
+### FACT 30
+Subject: Research Doc 278: Farcaster Agentic Bootcamp vs ZAO Agent Squad: Gap Analysis & Upgrade Plan
+Type: ResearchDoc
+Topic: agents
+Doc number: 278
+Description: Farcaster Agentic Bootcamp vs ZAO Agent Squad: Gap Analysis & Upgrade Plan
+Source: internal://research/agents/278-agentic-bootcamp-zao-agent-squad/
+Confidence: 1.0
+
+
+### FACT 31
+Subject: Research Doc 288: Multi-Agent Dashboard Visual Research: UI Patterns for Agent Squad Monitoring
+Type: ResearchDoc
+Topic: agents
+Doc number: 288
+Description: Multi-Agent Dashboard Visual Research: UI Patterns for Agent Squad Monitoring
+Source: internal://research/agents/288-multi-agent-dashboard-visual-research/
+Confidence: 1.0
+
+
+### FACT 32
+Subject: Research Doc 290: FISHBOWLZ Agentic Participants: AI Agents as Live Room Members
+Type: ResearchDoc
+Topic: agents
+Doc number: 290
+Description: FISHBOWLZ Agentic Participants: AI Agents as Live Room Members
+Source: internal://research/agents/290-fishbowlz-agentic-participants/
+Confidence: 1.0
+
+
+### FACT 33
+Subject: Research Doc 291: Farcaster Agentic Bootcamp Days 3-5: Agents, Memory, Identity
+Type: ResearchDoc
+Topic: agents
+Doc number: 291
+Description: Farcaster Agentic Bootcamp Days 3-5: Agents, Memory, Identity
+Source: internal://research/agents/291-farcaster-agentic-bootcamp-days-3-5/
+Confidence: 1.0
+
+
+### FACT 34
+Subject: Research Doc 292: Pixel Agents Dashboard Customization for ZAO OS
+Type: ResearchDoc
+Topic: agents
+Doc number: 292
+Description: Pixel Agents Dashboard Customization for ZAO OS
+Source: internal://research/agents/292-pixel-agents-dashboard-customization/
+Confidence: 1.0
+
+
+### FACT 35
+Subject: Research Doc 293: Multi-Agent Orchestration Tools, GitNexus Knowledge Graphs & High-Impact Agent Prompts
+Type: ResearchDoc
+Topic: agents
+Doc number: 293
+Description: Multi-Agent Orchestration Tools, GitNexus Knowledge Graphs & High-Impact Agent Prompts
+Source: internal://research/agents/293-multi-agent-tools-gitnexus-prompts/
+Confidence: 1.0
+
+
+### FACT 36
+Subject: Research Doc 296: Agentic Workflow Optimization: Powerful Center + Cheap Edge Operating Model
+Type: ResearchDoc
+Topic: agents
+Doc number: 296
+Description: Agentic Workflow Optimization: Powerful Center + Cheap Edge Operating Model
+Source: internal://research/agents/296-agentic-workflow-optimization/
+Confidence: 1.0
+
+
+### FACT 37
+Subject: Research Doc 307: The Great Convergence: Agent Harness Architecture
+Type: ResearchDoc
+Topic: agents
+Doc number: 307
+Description: The Great Convergence: Agent Harness Architecture
+Source: internal://research/agents/307-great-convergence-agent-harness-architecture/
+Confidence: 1.0
+
+
+### FACT 38
+Subject: Research Doc 318: Multi-Agent Coordination: Cassie Heart's Agentic Bootcamp Session 10
+Type: ResearchDoc
+Topic: agents
+Doc number: 318
+Description: Multi-Agent Coordination: Cassie Heart's Agentic Bootcamp Session 10
+Source: internal://research/agents/318-cassie-multi-agent-coordination-bootcamp/
+Confidence: 1.0
+
+
+### FACT 39
+Subject: Research Doc 325: - ZABAL Agent Swarm Economy: 3 Brand Agents Trading, Buying & Building Volume
+Type: ResearchDoc
+Topic: agents
+Doc number: 325
+Description: - ZABAL Agent Swarm Economy: 3 Brand Agents Trading, Buying & Building Volume
+Source: internal://research/agents/325-zabal-agent-swarm-economy/
+Confidence: 1.0
+
+
+### FACT 40
+Subject: Research Doc 325: ElevenLabs Agents: Voice AI Platform for ZAO OS
+Type: ResearchDoc
+Topic: agents
+Doc number: 325
+Description: ElevenLabs Agents: Voice AI Platform for ZAO OS
+Source: internal://research/agents/325-elevenlabs-agents-voice-ai-platform/
+Confidence: 1.0
+
+
+### FACT 41
+Subject: Research Doc 339: - Austin Griffith, CLAWD Agent, ETHSkills & Patterns to Steal for VAULT/BANKER/DEALER
+Type: ResearchDoc
+Topic: agents
+Doc number: 339
+Description: - Austin Griffith, CLAWD Agent, ETHSkills & Patterns to Steal for VAULT/BANKER/DEALER
+Source: internal://research/agents/339-austin-griffith-clawd-ethskills-agent-patterns/
+Confidence: 1.0
+
+
+### FACT 42
+Subject: Research Doc 340: - CLAWD Deep Dive: 4 Systems to Fork for ZABAL Agent Swarm
+Type: ResearchDoc
+Topic: agents
+Doc number: 340
+Description: - CLAWD Deep Dive: 4 Systems to Fork for ZABAL Agent Swarm
+Source: internal://research/agents/340-clawd-patterns-deep-dive-4-systems/
+Confidence: 1.0
+
+
+### FACT 43
+Subject: Research Doc 344: - Bankr Bot: AI Trading Agent + Skills Marketplace for ZABAL Swarm
+Type: ResearchDoc
+Topic: agents
+Doc number: 344
+Description: - Bankr Bot: AI Trading Agent + Skills Marketplace for ZABAL Swarm
+Source: internal://research/agents/344-bankr-bot-agent-trading-skills/
+Confidence: 1.0
+
+
+### FACT 44
+Subject: Research Doc 345: - ZABAL Agent Swarm: Master Blueprint (CANONICAL)
+Type: ResearchDoc
+Topic: agents
+Doc number: 345
+Description: - ZABAL Agent Swarm: Master Blueprint (CANONICAL)
+Source: internal://research/agents/345-zabal-agent-swarm-master-blueprint/
+Confidence: 1.0
+
+
+### FACT 45
+Subject: Research Doc 351: - ZABAL Agent Swarm Activation Checklist: How It SHOULD Work vs How It COULD Work
+Type: ResearchDoc
+Topic: agents
+Doc number: 351
+Description: - ZABAL Agent Swarm Activation Checklist: How It SHOULD Work vs How It COULD Work
+Source: internal://research/agents/351-zabal-swarm-activation-checklist/
+Confidence: 1.0
+
+
+### FACT 46
+Subject: Research Doc 353: - Autonomous Agent Trading: Beyond Fixed Schedules
+Type: ResearchDoc
+Topic: agents
+Doc number: 353
+Description: - Autonomous Agent Trading: Beyond Fixed Schedules
+Source: internal://research/agents/353-autonomous-trading-beyond-schedules/
+Confidence: 1.0
+
+
+### FACT 47
+Subject: Research Doc 360: - Profit Agent: Hot Wallet Money-Making Strategy
+Type: ResearchDoc
+Topic: agents
+Doc number: 360
+Description: - Profit Agent: Hot Wallet Money-Making Strategy
+Source: internal://research/agents/360-profit-agent-hot-wallet-strategy/
+Confidence: 1.0
+
+
+### FACT 48
+Subject: Research Doc 363: - Darwinian Agent Evolution: Die, Mutate, Respawn, Iterate
+Type: ResearchDoc
+Topic: agents
+Doc number: 363
+Description: - Darwinian Agent Evolution: Die, Mutate, Respawn, Iterate
+Source: internal://research/agents/363-darwinian-agent-evolution/
+Confidence: 1.0
+
+
+### FACT 49
+Subject: Research Doc 364: - Multi-Harness Agent Orchestration: OpenClaw + Hermes + Tournament Model
+Type: ResearchDoc
+Topic: agents
+Doc number: 364
+Description: - Multi-Harness Agent Orchestration: OpenClaw + Hermes + Tournament Model
+Source: internal://research/agents/364-multi-harness-agent-orchestration/
+Confidence: 1.0
+
+
+### FACT 50
+Subject: Research Doc 420: HyperFrames: HTML-as-Video for AI Agents
+Type: ResearchDoc
+Topic: agents
+Doc number: 420
+Description: HyperFrames: HTML-as-Video for AI Agents
+Source: internal://research/agents/420-hyperframes-html-video-agents/
+Confidence: 1.0
+
+
+### FACT 51
+Subject: Research Doc 433: Agent Outbound Phone Calls: Ring-a-Ding vs DIY Twilio + OpenAI Realtime
+Type: ResearchDoc
+Topic: agents
+Doc number: 433
+Description: Agent Outbound Phone Calls: Ring-a-Ding vs DIY Twilio + OpenAI Realtime
+Source: internal://research/agents/433-agent-outbound-phone-calls-ringading-twilio/
+Confidence: 1.0
+
+
+### FACT 52
+Subject: Research Doc 435: ZOE Effectiveness v2: Proactive, Context-Aware, Safe Playbook
+Type: ResearchDoc
+Topic: agents
+Doc number: 435
+Description: ZOE Effectiveness v2: Proactive, Context-Aware, Safe Playbook
+Source: internal://research/agents/435-zoe-effectiveness-v2-playbook/
+Confidence: 1.0
+
+
+### FACT 53
+Subject: Research Doc 447: Agent Stack 7-Day Improvement Sprint
+Type: ResearchDoc
+Topic: agents
+Doc number: 447
+Description: Agent Stack 7-Day Improvement Sprint
+Source: internal://research/agents/447-agent-stack-week-improvement-sprint/
+Confidence: 1.0
+
+
+### FACT 54
+Subject: Research Doc 451: AO Claude Code Dialog Block Forensics - Doc 451
+Type: ResearchDoc
+Topic: agents
+Doc number: 451
+Description: AO Claude Code Dialog Block Forensics - Doc 451
+Source: internal://research/agents/451-ao-claude-code-dialog-block-forensics/
+Confidence: 1.0
+
+
+### FACT 55
+Subject: Research Doc 452: AO Sidebar Counter Filter Fix
+Type: ResearchDoc
+Topic: agents
+Doc number: 452
+Description: AO Sidebar Counter Filter Fix
+Source: internal://research/agents/452-ao-sidebar-counter-filter-fix/
+Confidence: 1.0
+
+
+### FACT 56
+Subject: Research Doc 453: AO Offline Banner - WebSocket Diagnosis
+Type: ResearchDoc
+Topic: agents
+Doc number: 453
+Description: AO Offline Banner - WebSocket Diagnosis
+Source: internal://research/agents/453-ao-offline-banner-websocket-diagnosis/
+Confidence: 1.0
+
+
+### FACT 57
+Subject: Research Doc 454: Agent Stack Reliability Hardening (Apr 20)
+Type: ResearchDoc
+Topic: agents
+Doc number: 454
+Description: Agent Stack Reliability Hardening (Apr 20)
+Source: internal://research/agents/454-agent-stack-reliability-hardening-apr20/
+Confidence: 1.0
+
+
+### FACT 58
+Subject: Research Doc 457: Status:** Hunt complete, fixes pending
+Type: ResearchDoc
+Topic: agents
+Doc number: 457
+Description: Status:** Hunt complete, fixes pending
+Source: internal://research/agents/457-silent-failure-hunt-ecc/
+Confidence: 1.0
+
+
+### FACT 59
+Subject: Research Doc 460: Status:** Research complete
+Type: ResearchDoc
+Topic: agents
+Doc number: 460
+Description: Status:** Research complete
+Source: internal://research/agents/460-zao-agentic-stack-end-to-end-design/
+Confidence: 1.0
+
+
+### FACT 60
+Subject: Research Doc 464: ZOE Telegram: Reply-Context Bug, Capability Matrix, Ship-PR Loop
+Type: ResearchDoc
+Topic: agents
+Doc number: 464
+Description: ZOE Telegram: Reply-Context Bug, Capability Matrix, Ship-PR Loop
+Source: internal://research/agents/464-zoe-telegram-reply-context-ship-pr/
+Confidence: 1.0
+
+
+### FACT 61
+Subject: Research Doc 465: ZOE Observability + Dispatch Hardening (post-messaging-fix)
+Type: ResearchDoc
+Topic: agents
+Doc number: 465
+Description: ZOE Observability + Dispatch Hardening (post-messaging-fix)
+Source: internal://research/agents/465-zoe-observability-dispatch-hardening/
+Confidence: 1.0
+
+
+### FACT 62
+Subject: Research Doc 466: AO UI Button Audit - Root Cause Analysis
+Type: ResearchDoc
+Topic: agents
+Doc number: 466
+Description: AO UI Button Audit - Root Cause Analysis
+Source: internal://research/agents/466-ao-ui-button-audit-apr21/
+Confidence: 1.0
+
+
+### FACT 63
+Subject: Research Doc 467: ZAO Branded Bot Fleet Design, Telegram hub (Magnetiq / WaveWarZ / ZAO Stock / ZAO Devz / Research)
+Type: ResearchDoc
+Topic: agents
+Doc number: 467
+Description: ZAO Branded Bot Fleet Design, Telegram hub (Magnetiq / WaveWarZ / ZAO Stock / ZAO Devz / Research)
+Source: internal://research/agents/467-zao-bot-fleet-design-magnetiq/
+Confidence: 1.0
+
+
+### FACT 64
+Subject: Research Doc 468: ZAO Farcaster Hub: POIDH bot, HyperSub bot, and dual-hub (Telegram + Farcaster) design
+Type: ResearchDoc
+Topic: agents
+Doc number: 468
+Description: ZAO Farcaster Hub: POIDH bot, HyperSub bot, and dual-hub (Telegram + Farcaster) design
+Source: internal://research/agents/468-zao-farcaster-hub-poidh-hypersub-dual-hub/
+Confidence: 1.0
+
+
+### FACT 65
+Subject: Research Doc 473: clawdbotatg Apr 21 Update: Patterns to Steal for ZOE / OpenClaw / Agent Squad
+Type: ResearchDoc
+Topic: agents
+Doc number: 473
+Description: clawdbotatg Apr 21 Update: Patterns to Steal for ZOE / OpenClaw / Agent Squad
+Source: internal://research/agents/473-clawdbotatg-apr21-updates-zoe-openclaw/
+Confidence: 1.0
+
+
+### FACT 66
+Subject: Research Doc 474: BCZ 101 Bot + Transcript RAG Best Practices
+Type: ResearchDoc
+Topic: agents
+Doc number: 474
+Description: BCZ 101 Bot + Transcript RAG Best Practices
+Source: internal://research/agents/474-bcz101-bot-transcript-rag/
+Confidence: 1.0
+
+
+### FACT 67
+Subject: Research Doc 479: Walden Yan (Cognition) — What's Actually Working in Multi-Agent Systems
+Type: ResearchDoc
+Topic: agents
+Doc number: 479
+Description: Walden Yan (Cognition) — What's Actually Working in Multi-Agent Systems
+Source: internal://research/agents/479-walden-multi-agent-patterns-cognition/
+Confidence: 1.0
+
+
+### FACT 68
+Subject: Research Doc 483: r/hermesagent — Nous Research Hermes as a Local-First Agent Framework
+Type: ResearchDoc
+Topic: agents
+Doc number: 483
+Description: r/hermesagent — Nous Research Hermes as a Local-First Agent Framework
+Source: internal://research/agents/483-hermes-agent-local-llm-framework/
+Confidence: 1.0
+
+
+### FACT 69
+Subject: Research Doc 484: Matricula — Autonomous Self-Improving Farcaster Agent (@matricula)
+Type: ResearchDoc
+Topic: agents
+Doc number: 484
+Description: Matricula — Autonomous Self-Improving Farcaster Agent (@matricula)
+Source: internal://research/agents/484-matricula-autonomous-farcaster-agent/
+Confidence: 1.0
+
+
+### FACT 70
+Subject: Research Doc 487: QuadWork — 4-Agent Coding Team (Head + Dev + 2 Reviewers)
+Type: ResearchDoc
+Topic: agents
+Doc number: 487
+Description: QuadWork — 4-Agent Coding Team (Head + Dev + 2 Reviewers)
+Source: internal://research/agents/487-quadwork-four-agent-dev-team/
+Confidence: 1.0
+
+
+### FACT 71
+Subject: Research Doc 488: CORTEX — Synthetic Cognition Memory Architecture (Rezzyman / ATERNA.AI)
+Type: ResearchDoc
+Topic: agents
+Doc number: 488
+Description: CORTEX — Synthetic Cognition Memory Architecture (Rezzyman / ATERNA.AI)
+Source: internal://research/agents/488-cortex-synthetic-cognition-memory/
+Confidence: 1.0
+
+
+### FACT 72
+Subject: Research Doc 491: Install QuadWork for the 3-Repo Split (zao-research / zao-chat / zao-brain)
+Type: ResearchDoc
+Topic: agents
+Doc number: 491
+Description: Install QuadWork for the 3-Repo Split (zao-research / zao-chat / zao-brain)
+Source: internal://research/agents/491-quadwork-install-three-repo-split/
+Confidence: 1.0
+
+
+### FACT 73
+Subject: Research Doc 495: Team Telegram Bot 2026 Patterns — v1.5 Architecture Call
+Type: ResearchDoc
+Topic: agents
+Doc number: 495
+Description: Team Telegram Bot 2026 Patterns — v1.5 Architecture Call
+Source: internal://research/agents/495-team-telegram-bot-2026-patterns/
+Confidence: 1.0
+
+
+### FACT 74
+Subject: Research Doc 496: ElizaOS 2026 Assessment: For ZAOstock Bot Decision
+Type: ResearchDoc
+Topic: agents
+Doc number: 496
+Description: ElizaOS 2026 Assessment: For ZAOstock Bot Decision
+Source: internal://research/agents/496-elizaos-2026-assessment/
+Confidence: 1.0
+
+
+### FACT 75
+Subject: Research Doc 497: Quad / QuadWork Workflow Deep Dive
+Type: ResearchDoc
+Topic: agents
+Doc number: 497
+Description: Quad / QuadWork Workflow Deep Dive
+Source: internal://research/agents/497-quad-workflow-deep-dive/
+Confidence: 1.0
+
+
+### FACT 76
+Subject: Research Doc 523: ZAO Agentic Systems Full Audit + Fix-PR Pipeline + Hermes Dual-Bot Architecture
+Type: ResearchDoc
+Topic: agents
+Doc number: 523
+Description: ZAO Agentic Systems Full Audit + Fix-PR Pipeline + Hermes Dual-Bot Architecture
+Source: internal://research/agents/523-zao-agentic-systems-full-audit-fix-pr-pipeline/
+Confidence: 1.0
+
+
+### FACT 77
+Subject: Research Doc 524: ZAO Agentic Systems - Everything Map (LIVE / STARTED / PLANNED / ARCHIVED)
+Type: ResearchDoc
+Topic: agents
+Doc number: 524
+Description: ZAO Agentic Systems - Everything Map (LIVE / STARTED / PLANNED / ARCHIVED)
+Source: internal://research/agents/524-zao-agentic-everything-live-archived-started-planned/
+Confidence: 1.0
+
+
+### FACT 78
+Subject: Research Doc 527: Multi-Bot Telegram Coordination - The Best-Practice Playbook for ZAO
+Type: ResearchDoc
+Topic: agents
+Doc number: 527
+Description: Multi-Bot Telegram Coordination - The Best-Practice Playbook for ZAO
+Source: internal://research/agents/527-multi-bot-telegram-coordination-best-practices/
+Confidence: 1.0
+
+
+### FACT 79
+Subject: Research Doc 529: Hermes Quality Pipeline - Pre-Critic Gates + Conflict Policy
+Type: ResearchDoc
+Topic: agents
+Doc number: 529
+Description: Hermes Quality Pipeline - Pre-Critic Gates + Conflict Policy
+Source: internal://research/agents/529-hermes-quality-pipeline-pre-critic-gates/
+Confidence: 1.0
+
+
+### FACT 80
+Subject: Research Doc 531: Hermes Honest Audit - Pivot or Persist
+Type: ResearchDoc
+Topic: agents
+Doc number: 531
+Description: Hermes Honest Audit - Pivot or Persist
+Source: internal://research/agents/531-hermes-honest-audit-pivot-or-persist/
+Confidence: 1.0
+
+
+### FACT 81
+Subject: Research Doc 541: Hermes Gaps vs Industry Best Practices (Apr 27 2026)
+Type: ResearchDoc
+Topic: agents
+Doc number: 541
+Description: Hermes Gaps vs Industry Best Practices (Apr 27 2026)
+Source: internal://research/agents/541-hermes-gaps-vs-industry-best-practices/
+Confidence: 1.0
+
+
+### FACT 82
+Subject: Research Doc 546: Hefty.bot: Local-First Personal AI Harness (Slava / Based Rooms tip)
+Type: ResearchDoc
+Topic: agents
+Doc number: 546
+Description: Hefty.bot: Local-First Personal AI Harness (Slava / Based Rooms tip)
+Source: internal://research/agents/546-hefty-bot-local-first-harness/
+Confidence: 1.0
+
+
+### FACT 83
+Subject: Research Doc 547: Multi-Agent Coordination: Bonfire, ZOE, Hermes (Apr 28 2026)
+Type: ResearchDoc
+Topic: agents
+Doc number: 547
+Description: Multi-Agent Coordination: Bonfire, ZOE, Hermes (Apr 28 2026)
+Source: internal://research/agents/547-multi-agent-coordination-bonfire-zoe-hermes/
+Confidence: 1.0
+
+
+### FACT 84
+Subject: Research Doc 559: Wetware (`ww`): P2P OS for Autonomous Agents
+Type: ResearchDoc
+Topic: agents
+Doc number: 559
+Description: Wetware (`ww`): P2P OS for Autonomous Agents
+Source: internal://research/agents/559-wetware-ww-p2p-agent-os/
+Confidence: 1.0
+
+
+### FACT 85
+Subject: Research Doc 567: Hugging Face Local Models + Web UI + Claude Code Context Bridge
+Type: ResearchDoc
+Topic: agents
+Doc number: 567
+Description: Hugging Face Local Models + Web UI + Claude Code Context Bridge
+Source: internal://research/agents/567-hugging-face-local-models-context-bridge/
+Confidence: 1.0
+
+
+### FACT 86
+Subject: Research Doc 568: Doc 568: Aware Brain - Local-First Knowledge Graph Chat for ZAO
+Type: ResearchDoc
+Topic: agents
+Doc number: 568
+Description: Doc 568: Aware Brain - Local-First Knowledge Graph Chat for ZAO
+Source: internal://research/agents/568-aware-brain-local-memory-knowledge-graph/
+Confidence: 1.0
+
+
+### FACT 87
+Subject: Research Doc 574: Inbox Batch Apr 30: Agent Commerce, Alignment Skills, Local Stack Update
+Type: ResearchDoc
+Topic: agents
+Doc number: 574
+Description: Inbox Batch Apr 30: Agent Commerce, Alignment Skills, Local Stack Update
+Source: internal://research/agents/574-inbox-apr30-agent-commerce-skills-stack/
+Confidence: 1.0
+
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[authored]-> [each ResearchDoc above]
+- The ZAO -[has_research_doc]-> [each ResearchDoc]
+- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)
+
+---
+Build the manifest, preview the first 3 nodes, then ask me "approve all?". Total 87 ResearchDoc nodes in this batch. Do not commit until I say yes. If a Doc number already exists in graph, MERGE; do not create duplicate.

--- a/content/bonfire-ingest/research-index-dev-workflows.md
+++ b/content/bonfire-ingest/research-index-dev-workflows.md
@@ -1,0 +1,1013 @@
+INGEST BATCH: ZAO Research Library Index — dev / workflows (1 topic folder).
+
+Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. Each ResearchDoc has Topic + Doc number + Description as attributes. Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes.
+
+## SECTION — dev-workflows (100 docs)
+
+### FACT 1
+Subject: Research Doc 030: bettercallzaal GitHub Projects Inventory
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 030
+Description: bettercallzaal GitHub Projects Inventory
+Source: internal://research/dev-workflows/030-bettercallzaal-github/
+Confidence: 1.0
+
+
+### FACT 2
+Subject: Research Doc 038: AI Code Audit, Cleanup Agents & Codebase Efficiency
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 038
+Description: AI Code Audit, Cleanup Agents & Codebase Efficiency
+Source: internal://research/dev-workflows/038-ai-code-audit-cleanup/
+Confidence: 1.0
+
+
+### FACT 3
+Subject: Research Doc 039: GitHub Documentation, Presentation & Research Display
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 039
+Description: GitHub Documentation, Presentation & Research Display
+Source: internal://research/dev-workflows/039-github-documentation-presentation/
+Confidence: 1.0
+
+
+### FACT 4
+Subject: Research Doc 045: Research Organization Patterns: How Others Do It
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 045
+Description: Research Organization Patterns: How Others Do It
+Source: internal://research/dev-workflows/045-research-organization-patterns/
+Confidence: 1.0
+
+
+### FACT 5
+Subject: Research Doc 054: Superpowers: Agentic Skills Framework for Claude Code
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 054
+Description: Superpowers: Agentic Skills Framework for Claude Code
+Source: internal://research/dev-workflows/054-superpowers-agentic-skills/
+Confidence: 1.0
+
+
+### FACT 6
+Subject: Research Doc 063: Autoresearch Deep Dive: Implementations & ZAO OS Applications
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 063
+Description: Autoresearch Deep Dive: Implementations & ZAO OS Applications
+Source: internal://research/dev-workflows/063-autoresearch-deep-dive-zao-applications/
+Confidence: 1.0
+
+
+### FACT 7
+Subject: Research Doc 066: Backend Testing Strategy for ZAO OS
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 066
+Description: Backend Testing Strategy for ZAO OS
+Source: internal://research/dev-workflows/066-backend-testing-strategy/
+Confidence: 1.0
+
+
+### FACT 8
+Subject: Research Doc 076: Git Branching Strategy for ZAO OS + Paperclip Agents
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 076
+Description: Git Branching Strategy for ZAO OS + Paperclip Agents
+Source: internal://research/dev-workflows/076-git-branching-ai-agents/
+Confidence: 1.0
+
+
+### FACT 9
+Subject: Research Doc 089: Paperclip + gstack + Autoresearch: The AI Company Stack
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 089
+Description: Paperclip + gstack + Autoresearch: The AI Company Stack
+Source: internal://research/dev-workflows/089-paperclip-gstack-autoresearch-stack/
+Confidence: 1.0
+
+
+### FACT 10
+Subject: Research Doc 137: Skills Audit, Cleanup & Security Best Practices
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 137
+Description: Skills Audit, Cleanup & Security Best Practices
+Source: internal://research/dev-workflows/137-skills-audit-security-practices/
+Confidence: 1.0
+
+
+### FACT 11
+Subject: Research Doc 154: Skills & Commands Master Reference
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 154
+Description: Skills & Commands Master Reference
+Source: internal://research/dev-workflows/154-skills-commands-master-reference/
+Confidence: 1.0
+
+
+### FACT 12
+Subject: Research Doc 157: Cross-Project Asset Audit: Reusable Code from Sibling ZAO Projects
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 157
+Description: Cross-Project Asset Audit: Reusable Code from Sibling ZAO Projects
+Source: internal://research/dev-workflows/157-cross-project-asset-audit/
+Confidence: 1.0
+
+
+### FACT 13
+Subject: Research Doc 159: ZAO OS Feature Inventory & QA Checklist
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 159
+Description: ZAO OS Feature Inventory & QA Checklist
+Source: internal://research/dev-workflows/159-feature-inventory-qa-checklist/
+Confidence: 1.0
+
+
+### FACT 14
+Subject: Research Doc 162: Open Source Projects Directory for ZAO OS
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 162
+Description: Open Source Projects Directory for ZAO OS
+Source: internal://research/dev-workflows/162-open-source-projects-directory/
+Confidence: 1.0
+
+
+### FACT 15
+Subject: Research Doc 164: Skills, Research Workflow & Autoresearch Improvements
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 164
+Description: Skills, Research Workflow & Autoresearch Improvements
+Source: internal://research/dev-workflows/164-skills-research-workflow-improvements/
+Confidence: 1.0
+
+
+### FACT 16
+Subject: Research Doc 165: Doc 165 — Claude Code Multi-Session Management
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 165
+Description: Doc 165 — Claude Code Multi-Session Management
+Source: internal://research/dev-workflows/165-claude-code-multi-session-management/
+Confidence: 1.0
+
+
+### FACT 17
+Subject: Research Doc 166: ZAO OS Developer Workflow Improvements
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 166
+Description: ZAO OS Developer Workflow Improvements
+Source: internal://research/dev-workflows/166-dev-workflow-improvements/
+Confidence: 1.0
+
+
+### FACT 18
+Subject: Research Doc 168: Claude Code Community Innovations: Autoresearch 10x, Council of High Intelligence, Learn Vibe Build
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 168
+Description: Claude Code Community Innovations: Autoresearch 10x, Council of High Intelligence, Learn Vibe Build
+Source: internal://research/dev-workflows/168-claude-code-community-innovations-march2026/
+Confidence: 1.0
+
+
+### FACT 19
+Subject: Research Doc 170: Autoresearch 10x: Binary Eval Checklists for ZAO OS Skills
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 170
+Description: Autoresearch 10x: Binary Eval Checklists for ZAO OS Skills
+Source: internal://research/dev-workflows/170-autoresearch-10x-eval-checklists-zao-skills/
+Confidence: 1.0
+
+
+### FACT 20
+Subject: Research Doc 172: Solo Founder AI-Powered Development: The ZAO OS Case Study
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 172
+Description: Solo Founder AI-Powered Development: The ZAO OS Case Study
+Source: internal://research/dev-workflows/172-solo-founder-ai-dev-workflow/
+Confidence: 1.0
+
+
+### FACT 21
+Subject: Research Doc 196: Doc 170 — Solo Developer + AI Coding Landscape 2026
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 196
+Description: Doc 170 — Solo Developer + AI Coding Landscape 2026
+Source: internal://research/dev-workflows/196-solo-dev-ai-coding-landscape-2026/
+Confidence: 1.0
+
+
+### FACT 22
+Subject: Research Doc 212: Vercel Integrations, Airtable & Custom Integration Console for ZAO OS
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 212
+Description: Vercel Integrations, Airtable & Custom Integration Console for ZAO OS
+Source: internal://research/dev-workflows/212-vercel-integrations-airtable/
+Confidence: 1.0
+
+
+### FACT 23
+Subject: Research Doc 225: Doc 225: Fork-Friendly Open-Source Patterns
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 225
+Description: Doc 225: Fork-Friendly Open-Source Patterns
+Source: internal://research/dev-workflows/225-fork-friendly-open-source-patterns/
+Confidence: 1.0
+
+
+### FACT 24
+Subject: Research Doc 232: MCP Server Development Guide
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 232
+Description: MCP Server Development Guide
+Source: internal://research/dev-workflows/232-mcp-server-development-guide/
+Confidence: 1.0
+
+
+### FACT 25
+Subject: Research Doc 238: Claude Tools Top 50 Evaluation for ZAO OS
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 238
+Description: Claude Tools Top 50 Evaluation for ZAO OS
+Source: internal://research/dev-workflows/238-claude-tools-top50-evaluation/
+Confidence: 1.0
+
+
+### FACT 26
+Subject: Research Doc 242: Claude 20 Underused Features: ZAO Power User Audit
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 242
+Description: Claude 20 Underused Features: ZAO Power User Audit
+Source: internal://research/dev-workflows/242-claude-20-underused-features-power-user/
+Confidence: 1.0
+
+
+### FACT 27
+Subject: Research Doc 243: Claude Intermediate Guide (AI Edge): Cowork, Skills 2.0, Dispatch & Prompting
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 243
+Description: Claude Intermediate Guide (AI Edge): Cowork, Skills 2.0, Dispatch & Prompting
+Source: internal://research/dev-workflows/243-claude-intermediate-guide-aiedge-cowork-skills2/
+Confidence: 1.0
+
+
+### FACT 28
+Subject: Research Doc 248: Network Tab Debugging Guide for ZAO OS
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 248
+Description: Network Tab Debugging Guide for ZAO OS
+Source: internal://research/dev-workflows/248-network-tab-debugging-guide/
+Confidence: 1.0
+
+
+### FACT 29
+Subject: Research Doc 276: HowiAI: Gridley's AI Habit Workflows for Daily Operations
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 276
+Description: HowiAI: Gridley's AI Habit Workflows for Daily Operations
+Source: internal://research/dev-workflows/276-howiai-gridley-ai-habit-workflows/
+Confidence: 1.0
+
+
+### FACT 30
+Subject: Research Doc 279: Research Library Audit & Reorganization
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 279
+Description: Research Library Audit & Reorganization
+Source: internal://research/dev-workflows/279-research-library-audit-reorganization/
+Confidence: 1.0
+
+
+### FACT 31
+Subject: Research Doc 282: Awesome Design MD: AI-Readable Design Systems
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 282
+Description: Awesome Design MD: AI-Readable Design Systems
+Source: internal://research/dev-workflows/282-awesome-design-md-system/
+Confidence: 1.0
+
+
+### FACT 32
+Subject: Research Doc 297: Graphify: Knowledge Graph for Codebases & Research
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 297
+Description: Graphify: Knowledge Graph for Codebases & Research
+Source: internal://research/dev-workflows/297-graphify-knowledge-graph-codebase/
+Confidence: 1.0
+
+
+### FACT 33
+Subject: Research Doc 298: Claude Token Optimization Strategies for ZAO OS Development
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 298
+Description: Claude Token Optimization Strategies for ZAO OS Development
+Source: internal://research/dev-workflows/298-claude-token-optimization-strategies/
+Confidence: 1.0
+
+
+### FACT 34
+Subject: Research Doc 299: LLM Knowledge Bases & Personal Wiki Systems
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 299
+Description: LLM Knowledge Bases & Personal Wiki Systems
+Source: internal://research/dev-workflows/299-llm-knowledge-bases-wiki-systems/
+Confidence: 1.0
+
+
+### FACT 35
+Subject: Research Doc 300: AI Memory & Agent Infrastructure Tools
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 300
+Description: AI Memory & Agent Infrastructure Tools
+Source: internal://research/dev-workflows/300-ai-memory-agent-infrastructure/
+Confidence: 1.0
+
+
+### FACT 36
+Subject: Research Doc 301: Developer Tooling Roundup: Agent-Era Tools (April 2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 301
+Description: Developer Tooling Roundup: Agent-Era Tools (April 2026)
+Source: internal://research/dev-workflows/301-developer-tooling-roundup-2026/
+Confidence: 1.0
+
+
+### FACT 37
+Subject: Research Doc 302: AI Content Engine & SEO Automation Patterns
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 302
+Description: AI Content Engine & SEO Automation Patterns
+Source: internal://research/dev-workflows/302-ai-content-engine-automation-patterns/
+Confidence: 1.0
+
+
+### FACT 38
+Subject: Research Doc 303: Daily AI Skill Building Curriculum
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 303
+Description: Daily AI Skill Building Curriculum
+Source: internal://research/dev-workflows/303-daily-ai-skill-building-curriculum/
+Confidence: 1.0
+
+
+### FACT 39
+Subject: Research Doc 305: Pocket Assistant: ZOE as Flow State Support, Not Dashboard
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 305
+Description: Pocket Assistant: ZOE as Flow State Support, Not Dashboard
+Source: internal://research/dev-workflows/305-pocket-assistant-flow-state-workflow/
+Confidence: 1.0
+
+
+### FACT 40
+Subject: Research Doc 306: Web Scraping for AI Agents: Reading X Posts, Articles, and Any URL
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 306
+Description: Web Scraping for AI Agents: Reading X Posts, Articles, and Any URL
+Source: internal://research/dev-workflows/306-web-scraping-ai-agents/
+Confidence: 1.0
+
+
+### FACT 41
+Subject: Research Doc 319: X/Twitter Scraping Tools That Work in April 2026
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 319
+Description: X/Twitter Scraping Tools That Work in April 2026
+Source: internal://research/dev-workflows/319-x-twitter-scraping-tools-2026/
+Confidence: 1.0
+
+
+### FACT 42
+Subject: Research Doc 321: WorktreeHQ + Git Worktree Branching Strategy
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 321
+Description: WorktreeHQ + Git Worktree Branching Strategy
+Source: internal://research/dev-workflows/321-worktreehq-git-branching-strategy/
+Confidence: 1.0
+
+
+### FACT 43
+Subject: Research Doc 353: Claude Code Token Optimization v2: What's Actually Working (and What Isn't)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 353
+Description: Claude Code Token Optimization v2: What's Actually Working (and What Isn't)
+Source: internal://research/dev-workflows/353-claude-code-token-optimization-v2/
+Confidence: 1.0
+
+
+### FACT 44
+Subject: Research Doc 354: Local LLM Coding Alternatives: Hermes, Ollama, and Stretching Token Limits
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 354
+Description: Local LLM Coding Alternatives: Hermes, Ollama, and Stretching Token Limits
+Source: internal://research/dev-workflows/354-local-llm-coding-alternatives-hermes/
+Confidence: 1.0
+
+
+### FACT 45
+Subject: Research Doc 355: Harness Engineering: CREAO's AI-First Workflow (Peter Pang)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 355
+Description: Harness Engineering: CREAO's AI-First Workflow (Peter Pang)
+Source: internal://research/dev-workflows/355-harness-engineering-creao-ai-first/
+Confidence: 1.0
+
+
+### FACT 46
+Subject: Research Doc 356: Karpathy's LLM Wiki Pattern: Persistent Compounding Knowledge Bases
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 356
+Description: Karpathy's LLM Wiki Pattern: Persistent Compounding Knowledge Bases
+Source: internal://research/dev-workflows/356-karpathy-llm-wiki-pattern/
+Confidence: 1.0
+
+
+### FACT 47
+Subject: Research Doc 357: Caveman: Token Compression Skill for Claude Code
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 357
+Description: Caveman: Token Compression Skill for Claude Code
+Source: internal://research/dev-workflows/357-caveman-token-compression-skill/
+Confidence: 1.0
+
+
+### FACT 48
+Subject: Research Doc 359: Web Scraping & Data Extraction for AI Tools: Best Practices
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 359
+Description: Web Scraping & Data Extraction for AI Tools: Best Practices
+Source: internal://research/dev-workflows/359-web-scraping-ai-tools-best-practices/
+Confidence: 1.0
+
+
+### FACT 49
+Subject: Research Doc 362: Doc 362: Caveman Mode Token Savings Analysis
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 362
+Description: Doc 362: Caveman Mode Token Savings Analysis
+Source: internal://research/dev-workflows/362-caveman-token-savings-analysis/
+Confidence: 1.0
+
+
+### FACT 50
+Subject: Research Doc 365: Recoupable Monorepo Architecture & Best Practices for ZAO
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 365
+Description: Recoupable Monorepo Architecture & Best Practices for ZAO
+Source: internal://research/dev-workflows/365-recoupable-monorepo-best-practices/
+Confidence: 1.0
+
+
+### FACT 51
+Subject: Research Doc 366: AGENTS.md & AI-Assisted Monorepo Best Practices (2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 366
+Description: AGENTS.md & AI-Assisted Monorepo Best Practices (2026)
+Source: internal://research/dev-workflows/366-agents-md-monorepo-best-practices-2026/
+Confidence: 1.0
+
+
+### FACT 52
+Subject: Research Doc 367: Biome Migration, Microservice Decomposition, Keyboard UX & Shared UI Patterns
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 367
+Description: Biome Migration, Microservice Decomposition, Keyboard UX & Shared UI Patterns
+Source: internal://research/dev-workflows/367-biome-microservices-keyboard-shared-ui/
+Confidence: 1.0
+
+
+### FACT 53
+Subject: Research Doc 405: - ZAO OS Monorepo Migration Plan
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 405
+Description: - ZAO OS Monorepo Migration Plan
+Source: internal://research/dev-workflows/405-monorepo-migration/
+Confidence: 1.0
+
+
+### FACT 54
+Subject: Research Doc 408: Claude Code 1M Context Window Session Management
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 408
+Description: Claude Code 1M Context Window Session Management
+Source: internal://research/dev-workflows/408-claude-code-1m-context-session-management/
+Confidence: 1.0
+
+
+### FACT 55
+Subject: Research Doc 409: Claude Skills: Anthropic Engineers Barry & Mahesh Explain
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 409
+Description: Claude Skills: Anthropic Engineers Barry & Mahesh Explain
+Source: internal://research/dev-workflows/409-claude-skills-anthropic-engineers-guide/
+Confidence: 1.0
+
+
+### FACT 56
+Subject: Research Doc 411: AI-Native Engineering Team: CREAO's 99% AI-Written Code
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 411
+Description: AI-Native Engineering Team: CREAO's 99% AI-Written Code
+Source: internal://research/dev-workflows/411-ai-native-eng-team-creao-99pct-ai-code/
+Confidence: 1.0
+
+
+### FACT 57
+Subject: Research Doc 412: AI Dev Tools Roundup: Conductor, Replicas, AO Agents
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 412
+Description: AI Dev Tools Roundup: Conductor, Replicas, AO Agents
+Source: internal://research/dev-workflows/412-ai-dev-tools-roundup-conductor-replicas-aoagents/
+Confidence: 1.0
+
+
+### FACT 58
+Subject: Research Doc 414: AI-Native Documentation Patterns for Monorepos (2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 414
+Description: AI-Native Documentation Patterns for Monorepos (2026)
+Source: internal://research/dev-workflows/414-ai-native-documentation-patterns/
+Confidence: 1.0
+
+
+### FACT 59
+Subject: Research Doc 415: Composio Agent Orchestrator (AO)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 415
+Description: Composio Agent Orchestrator (AO)
+Source: internal://research/dev-workflows/415-composio-agent-orchestrator/
+Confidence: 1.0
+
+
+### FACT 60
+Subject: Research Doc 422: Claude Routines: ZAO Automation Stack
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 422
+Description: Claude Routines: ZAO Automation Stack
+Source: internal://research/dev-workflows/422-claude-routines-zao-automation-stack/
+Confidence: 1.0
+
+
+### FACT 61
+Subject: Research Doc 424: Nested CLAUDE.md + Claudesidian + /wrap Pattern
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 424
+Description: Nested CLAUDE.md + Claudesidian + /wrap Pattern
+Source: internal://research/dev-workflows/424-nested-claudemd-claudesidian-wrap-pattern/
+Confidence: 1.0
+
+
+### FACT 62
+Subject: Research Doc 426: diagram-design Skill (Cathryn Lavery)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 426
+Description: diagram-design Skill (Cathryn Lavery)
+Source: internal://research/dev-workflows/426-diagram-design-skill-cathryn-lavery/
+Confidence: 1.0
+
+
+### FACT 63
+Subject: Research Doc 429: Claude Code Skills Deep Dive
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 429
+Description: Claude Code Skills Deep Dive
+Source: internal://research/dev-workflows/429-claude-code-skills-deep-dive/
+Confidence: 1.0
+
+
+### FACT 64
+Subject: Research Doc 434: Claude Code Aux Model Routing: What Actually Exists vs the Hermes 8-Slot Myth
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 434
+Description: Claude Code Aux Model Routing: What Actually Exists vs the Hermes 8-Slot Myth
+Source: internal://research/dev-workflows/434-claude-code-aux-model-routing/
+Confidence: 1.0
+
+
+### FACT 65
+Subject: Research Doc 440: Claude Code + Process Level-Up (meta review)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 440
+Description: Claude Code + Process Level-Up (meta review)
+Source: internal://research/dev-workflows/440-claude-code-process-level-up/
+Confidence: 1.0
+
+
+### FACT 66
+Subject: Research Doc 441: Status:** Research complete
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 441
+Description: Status:** Research complete
+Source: internal://research/dev-workflows/441-everything-claude-code-integration/
+Confidence: 1.0
+
+
+### FACT 67
+Subject: Research Doc 448: Project config scan
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 448
+Description: Project config scan
+Source: internal://research/dev-workflows/448-ecc-skills-teaching-guide/
+Confidence: 1.0
+
+
+### FACT 68
+Subject: Research Doc 459: Spawn a fresh Claude Code session in an isolated worktree off ZAO OS V1.
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 459
+Description: Spawn a fresh Claude Code session in an isolated worktree off ZAO OS V1.
+Source: internal://research/dev-workflows/459-parallel-workspace-isolation-zao-os/
+Confidence: 1.0
+
+
+### FACT 69
+Subject: Research Doc 461: Block git pushes that would land on main or on a branch whose PR is already merged.
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 461
+Description: Block git pushes that would land on main or on a branch whose PR is already merged.
+Source: internal://research/dev-workflows/461-push-to-merged-pr-failure-fix/
+Confidence: 1.0
+
+
+### FACT 70
+Subject: Research Doc 469: InfraNodus: Text Network Analysis + Knowledge Graph for ZAO Discourse
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 469
+Description: InfraNodus: Text Network Analysis + Knowledge Graph for ZAO Discourse
+Source: internal://research/dev-workflows/469-infranodus-text-network-knowledge-graph/
+Confidence: 1.0
+
+
+### FACT 71
+Subject: Research Doc 472: AI Tooling + Ecosystem Roundup 2026-04-21
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 472
+Description: AI Tooling + Ecosystem Roundup 2026-04-21
+Source: internal://research/dev-workflows/472-ai-tooling-roundup-apr21/
+Confidence: 1.0
+
+
+### FACT 72
+Subject: Research Doc 477: BCZ YapZ YouTube Description + Timestamp Template
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 477
+Description: BCZ YapZ YouTube Description + Timestamp Template
+Source: internal://research/dev-workflows/477-youtube-seo-bcz-yapz/
+Confidence: 1.0
+
+
+### FACT 73
+Subject: Research Doc 478: Obsidian + Claude Code as Personal AI Brain (JARVIS / Cowork Pattern)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 478
+Description: Obsidian + Claude Code as Personal AI Brain (JARVIS / Cowork Pattern)
+Source: internal://research/dev-workflows/478-obsidian-claude-jarvis-ai-brain/
+Confidence: 1.0
+
+
+### FACT 74
+Subject: Research Doc 480: Khairallah's 35 Claude Code Commands & Workflows (April 2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 480
+Description: Khairallah's 35 Claude Code Commands & Workflows (April 2026)
+Source: internal://research/dev-workflows/480-claude-code-35-commands-khairallah/
+Confidence: 1.0
+
+
+### FACT 75
+Subject: Research Doc 490: BCZ YapZ Archive Page (/bcz-yapz)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 490
+Description: BCZ YapZ Archive Page (/bcz-yapz)
+Source: internal://research/dev-workflows/490-bcz-yapz-archive-page/
+Confidence: 1.0
+
+
+### FACT 76
+Subject: Research Doc 493: /zao-research Skill v2 Redesign (Audit + Community-Source Mandate)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 493
+Description: /zao-research Skill v2 Redesign (Audit + Community-Source Mandate)
+Source: internal://research/dev-workflows/493-zao-research-skill-v2-redesign/
+Confidence: 1.0
+
+
+### FACT 77
+Subject: Research Doc 506: TRAE AI + SOLO Mode (ByteDance)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 506
+Description: TRAE AI + SOLO Mode (ByteDance)
+Source: internal://research/dev-workflows/506-trae-ai-solo-bytedance-coding-agent/
+Confidence: 1.0
+
+
+### FACT 78
+Subject: Research Doc 507: Claude Skills 1,116 Ecosystem - ZAO Curated Picks
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 507
+Description: Claude Skills 1,116 Ecosystem - ZAO Curated Picks
+Source: internal://research/dev-workflows/507-claude-skills-1116-ecosystem-zao-picks/
+Confidence: 1.0
+
+
+### FACT 79
+Subject: Research Doc 508: Creator Infra + Mini Apps + Token Burn Signal Brief (Apr 25 2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 508
+Description: Creator Infra + Mini Apps + Token Burn Signal Brief (Apr 25 2026)
+Source: internal://research/dev-workflows/508-creator-infra-mini-apps-token-burn-signals-apr25/
+Confidence: 1.0
+
+
+### FACT 80
+Subject: Research Doc 528: pi.dev Coding Agent (Mario Zechner / @badlogic)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 528
+Description: pi.dev Coding Agent (Mario Zechner / @badlogic)
+Source: internal://research/dev-workflows/528-pi-dev-coding-agent-mario-zechner/
+Confidence: 1.0
+
+
+### FACT 81
+Subject: Research Doc 536: Claude.md Best Practices (darkzodchi, X post)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 536
+Description: Claude.md Best Practices (darkzodchi, X post)
+Source: internal://research/dev-workflows/536-claude-dot-md-best-practices/
+Confidence: 1.0
+
+
+### FACT 82
+Subject: Research Doc 537: Shann's Superpowers Planning Framework for Project Execution
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 537
+Description: Shann's Superpowers Planning Framework for Project Execution
+Source: internal://research/dev-workflows/537-shann-superpowers-planning-framework/
+Confidence: 1.0
+
+
+### FACT 83
+Subject: Research Doc 539: "Grill Me" Claude Skill - Specs-to-Code Interrogation Pattern
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 539
+Description: "Grill Me" Claude Skill - Specs-to-Code Interrogation Pattern
+Source: internal://research/dev-workflows/539-grill-me-claude-skill-specs-to-code/
+Confidence: 1.0
+
+
+### FACT 84
+Subject: Research Doc 545: MitcheIl's 6-Agent Viral X Content Pipeline (Apr 2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 545
+Description: MitcheIl's 6-Agent Viral X Content Pipeline (Apr 2026)
+Source: internal://research/dev-workflows/545-mitcheil-6agent-viral-x-content-pipeline/
+Confidence: 1.0
+
+
+### FACT 85
+Subject: Research Doc 549: 21st.dev Hub: Component Platform + Magic MCP + 1code
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 549
+Description: 21st.dev Hub: Component Platform + Magic MCP + 1code
+Source: internal://research/dev-workflows/549-21st-dev-component-platform/
+Confidence: 1.0
+
+
+### FACT 86
+Subject: Research Doc 550: GitPitcher Evaluation (gitpitcher.com)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 550
+Description: GitPitcher Evaluation (gitpitcher.com)
+Source: internal://research/dev-workflows/550-gitpitcher-evaluation/
+Confidence: 1.0
+
+
+### FACT 87
+Subject: Research Doc 551: Research Roadmap + Library Audit (573 docs, audit + next 30 days)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 551
+Description: Research Roadmap + Library Audit (573 docs, audit + next 30 days)
+Source: internal://research/dev-workflows/551-research-roadmap-library-audit/
+Confidence: 1.0
+
+
+### FACT 88
+Subject: Research Doc 552: ZAO Skill Library Audit
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 552
+Description: ZAO Skill Library Audit
+Source: internal://research/dev-workflows/552-zao-skill-library-audit/
+Confidence: 1.0
+
+
+### FACT 89
+Subject: Research Doc 553: Memory File Health Audit
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 553
+Description: Memory File Health Audit
+Source: internal://research/dev-workflows/553-memory-file-health-audit/
+Confidence: 1.0
+
+
+### FACT 90
+Subject: Research Doc 554: Worktree Collision Postmortem (2026-04-29)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 554
+Description: Worktree Collision Postmortem (2026-04-29)
+Source: internal://research/dev-workflows/554-worktree-collision-postmortem/
+Confidence: 1.0
+
+
+### FACT 91
+Subject: Research Doc 555: Agent Harness Shootout: 1code vs QuadWork vs DevFleet vs ECC vs obra/superpowers vs Lazer
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 555
+Description: Agent Harness Shootout: 1code vs QuadWork vs DevFleet vs ECC vs obra/superpowers vs Lazer
+Source: internal://research/dev-workflows/555-agent-harness-shootout/
+Confidence: 1.0
+
+
+### FACT 92
+Subject: Research Doc 556: Gasless Onboarding Stack for ZAOstock RSVP + ZABAL First-Stake + Cipher Mint
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 556
+Description: Gasless Onboarding Stack for ZAOstock RSVP + ZABAL First-Stake + Cipher Mint
+Source: internal://research/dev-workflows/556-gasless-onboarding-stack-zaostock/
+Confidence: 1.0
+
+
+### FACT 93
+Subject: Research Doc 557: Onchain Festival Ticketing for ZAOstock Oct 3 2026
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 557
+Description: Onchain Festival Ticketing for ZAOstock Oct 3 2026
+Source: internal://research/dev-workflows/557-onchain-festival-ticketing-zaostock/
+Confidence: 1.0
+
+
+### FACT 94
+Subject: Research Doc 558: Anbeeld WRITING.md (AI-Prose Diagnostic Toolkit)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 558
+Description: Anbeeld WRITING.md (AI-Prose Diagnostic Toolkit)
+Source: internal://research/dev-workflows/558-anbeeld-writing-md/
+Confidence: 1.0
+
+
+### FACT 95
+Subject: Research Doc 560: OpenWhisp: Local Speech-to-Text for ZAO Content + Voice Notes
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 560
+Description: OpenWhisp: Local Speech-to-Text for ZAO Content + Voice Notes
+Source: internal://research/dev-workflows/560-openwhisp-local-speech-to-text/
+Confidence: 1.0
+
+
+### FACT 96
+Subject: Research Doc 562: Reddit/X Scraping Capability + r/ClaudeCode Top Skill (Humanizer) + last30days-skill
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 562
+Description: Reddit/X Scraping Capability + r/ClaudeCode Top Skill (Humanizer) + last30days-skill
+Source: internal://research/dev-workflows/562-reddit-x-scraping-meta-eval-last30days/
+Confidence: 1.0
+
+
+### FACT 97
+Subject: Research Doc 563: Shann³ (@shannholmberg) Content-Engine Pattern: 17 Markdown Files + 1 Agent = 10 Social Accounts
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 563
+Description: Shann³ (@shannholmberg) Content-Engine Pattern: 17 Markdown Files + 1 Agent = 10 Social Accounts
+Source: internal://research/dev-workflows/563-shannholmberg-content-engine-ronin/
+Confidence: 1.0
+
+
+### FACT 98
+Subject: Research Doc 564: Reddit/X Scraping FIXED (Implementation Doc)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 564
+Description: Reddit/X Scraping FIXED (Implementation Doc)
+Source: internal://research/dev-workflows/564-reddit-x-scraping-FIXED-implementation/
+Confidence: 1.0
+
+
+### FACT 99
+Subject: Research Doc 565: `/ask-gpt` Skill: Claude ↔ ChatGPT Learning Loop
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 565
+Description: `/ask-gpt` Skill: Claude ↔ ChatGPT Learning Loop
+Source: internal://research/dev-workflows/565-ask-gpt-claude-chatgpt-learning-loop/
+Confidence: 1.0
+
+
+### FACT 100
+Subject: Research Doc 566: Claude Reddit Gems (r/ClaudeAI + r/ClaudeCode, Apr 2026)
+Type: ResearchDoc
+Topic: dev-workflows
+Doc number: 566
+Description: Claude Reddit Gems (r/ClaudeAI + r/ClaudeCode, Apr 2026)
+Source: internal://research/dev-workflows/566-claude-reddit-gems-apr-2026/
+Confidence: 1.0
+
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[authored]-> [each ResearchDoc above]
+- The ZAO -[has_research_doc]-> [each ResearchDoc]
+- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)
+
+---
+Build the manifest, preview the first 3 nodes, then ask me "approve all?". Total 100 ResearchDoc nodes in this batch. Do not commit until I say yes. If a Doc number already exists in graph, MERGE; do not create duplicate.

--- a/content/bonfire-ingest/research-index-governance-community-identity.md
+++ b/content/bonfire-ingest/research-index-governance-community-identity.md
@@ -1,0 +1,1203 @@
+INGEST BATCH: ZAO Research Library Index — governance / community / identity (7 topic folders).
+
+Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. Each ResearchDoc has Topic + Doc number + Description as attributes. Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes.
+
+## SECTION — governance (31 docs)
+
+### FACT 1
+Subject: Research Doc 056: ORDAO & Respect Game System -- Research
+Type: ResearchDoc
+Topic: governance
+Doc number: 056
+Description: ORDAO & Respect Game System -- Research
+Source: internal://research/governance/056-ordao-respect-system/
+Confidence: 1.0
+
+
+### FACT 2
+Subject: Research Doc 058: Respect System Deep Dive: Scoring Math, On-Chain State & ORDAO Integration
+Type: ResearchDoc
+Topic: governance
+Doc number: 058
+Description: Respect System Deep Dive: Scoring Math, On-Chain State & ORDAO Integration
+Source: internal://research/governance/058-respect-deep-dive/
+Confidence: 1.0
+
+
+### FACT 3
+Subject: Research Doc 059: ZAO Hats Tree: On-Chain State & ZAO OS Integration Plan
+Type: ResearchDoc
+Topic: governance
+Doc number: 059
+Description: ZAO Hats Tree: On-Chain State & ZAO OS Integration Plan
+Source: internal://research/governance/059-hats-tree-integration/
+Confidence: 1.0
+
+
+### FACT 4
+Subject: Research Doc 075: Hats Protocol V2 Updates & New Tooling
+Type: ResearchDoc
+Topic: governance
+Doc number: 075
+Description: Hats Protocol V2 Updates & New Tooling
+Source: internal://research/governance/075-hats-protocol-v2-updates/
+Confidence: 1.0
+
+
+### FACT 5
+Subject: Research Doc 102: Fractals Page: frapps, ORDAO, and ZAO Fractal Governance
+Type: ResearchDoc
+Topic: governance
+Doc number: 102
+Description: Fractals Page: frapps, ORDAO, and ZAO Fractal Governance
+Source: internal://research/governance/102-fractals-frapps-ordao-page/
+Confidence: 1.0
+
+
+### FACT 6
+Subject: Research Doc 103: Fractal Governance Ecosystem Deep Dive (March 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 103
+Description: Fractal Governance Ecosystem Deep Dive (March 2026)
+Source: internal://research/governance/103-fractal-governance-ecosystem/
+Confidence: 1.0
+
+
+### FACT 7
+Subject: Research Doc 104: Complete Fractal Communities Directory (March 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 104
+Description: Complete Fractal Communities Directory (March 2026)
+Source: internal://research/governance/104-fractal-communities-directory/
+Confidence: 1.0
+
+
+### FACT 8
+Subject: Research Doc 109: Research 109: Optimystics Tooling Ecosystem — ZAO OS Integration Guide
+Type: ResearchDoc
+Topic: governance
+Doc number: 109
+Description: Research 109: Optimystics Tooling Ecosystem — ZAO OS Integration Guide
+Source: internal://research/governance/109-optimystics-tooling-ecosystem/
+Confidence: 1.0
+
+
+### FACT 9
+Subject: Research Doc 111: Proposal UI Best Practices for ZAO OS
+Type: ResearchDoc
+Topic: governance
+Doc number: 111
+Description: Proposal UI Best Practices for ZAO OS
+Source: internal://research/governance/111-proposal-ui-best-practices/
+Confidence: 1.0
+
+
+### FACT 10
+Subject: Research Doc 114: ZAO Fractal Live Infrastructure + Bot Data Flow (March 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 114
+Description: ZAO Fractal Live Infrastructure + Bot Data Flow (March 2026)
+Source: internal://research/governance/114-zao-fractal-live-infrastructure/
+Confidence: 1.0
+
+
+### FACT 11
+Subject: Research Doc 115: ZAO Respect Data Reconciliation Plan (March 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 115
+Description: ZAO Respect Data Reconciliation Plan (March 2026)
+Source: internal://research/governance/115-zao-data-reconciliation/
+Confidence: 1.0
+
+
+### FACT 12
+Subject: Research Doc 132: Snapshot Weekly Priority Polls for ZAO OS
+Type: ResearchDoc
+Topic: governance
+Doc number: 132
+Description: Snapshot Weekly Priority Polls for ZAO OS
+Source: internal://research/governance/132-snapshot-weekly-polls/
+Confidence: 1.0
+
+
+### FACT 13
+Subject: Research Doc 133: Governance System: Complete Audit
+Type: ResearchDoc
+Topic: governance
+Doc number: 133
+Description: Governance System: Complete Audit
+Source: internal://research/governance/133-governance-system-audit/
+Confidence: 1.0
+
+
+### FACT 14
+Subject: Research Doc 140: BuilderOSS: The Complete Nouns Builder Protocol Ecosystem
+Type: ResearchDoc
+Topic: governance
+Doc number: 140
+Description: BuilderOSS: The Complete Nouns Builder Protocol Ecosystem
+Source: internal://research/governance/140-buildeross-nouns-protocol-ecosystem/
+Confidence: 1.0
+
+
+### FACT 15
+Subject: Research Doc 149: BuilderOSS Deep Dive: Everything ZAO Can Use
+Type: ResearchDoc
+Topic: governance
+Doc number: 149
+Description: BuilderOSS Deep Dive: Everything ZAO Can Use
+Source: internal://research/governance/149-buildeross-deep-dive-everything/
+Confidence: 1.0
+
+
+### FACT 16
+Subject: Research Doc 184: Superchain ORDAO & Cross-Chain Fractal Governance
+Type: ResearchDoc
+Topic: governance
+Doc number: 184
+Description: Superchain ORDAO & Cross-Chain Fractal Governance
+Source: internal://research/governance/184-superchain-ordao-crosschain-fractal/
+Confidence: 1.0
+
+
+### FACT 17
+Subject: Research Doc 188: ZAO Fractal Bot + Process Deep Dive (March 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 188
+Description: ZAO Fractal Bot + Process Deep Dive (March 2026)
+Source: internal://research/governance/188-zao-fractal-bot-process/
+Confidence: 1.0
+
+
+### FACT 18
+Subject: Research Doc 285: ORDAO & ORFrapps Updated Documentation (April 2026)
+Type: ResearchDoc
+Topic: governance
+Doc number: 285
+Description: ORDAO & ORFrapps Updated Documentation (April 2026)
+Source: internal://research/governance/285-ordao-orfrapps-updated-docs/
+Confidence: 1.0
+
+
+### FACT 19
+Subject: Research Doc 299: Nouns DAO Ecosystem & Snap Integration
+Type: ResearchDoc
+Topic: governance
+Doc number: 299
+Description: Nouns DAO Ecosystem & Snap Integration
+Source: internal://research/governance/299-nouns-dao-ecosystem-snap-integration/
+Confidence: 1.0
+
+
+### FACT 20
+Subject: Research Doc 306: Eden Fractal & Optimism Fractal: Complete History, Philosophy & Architecture
+Type: ResearchDoc
+Topic: governance
+Doc number: 306
+Description: Eden Fractal & Optimism Fractal: Complete History, Philosophy & Architecture
+Source: internal://research/governance/306-eden-fractal-op-fractal-deep-history/
+Confidence: 1.0
+
+
+### FACT 21
+Subject: Research Doc 346: - IYKYK DAO + Fractal Nouns: Inter-DAO Governance & Community Dashboard for ZOUNZ
+Type: ResearchDoc
+Topic: governance
+Doc number: 346
+Description: - IYKYK DAO + Fractal Nouns: Inter-DAO Governance & Community Dashboard for ZOUNZ
+Source: internal://research/governance/346-iykyk-fractal-nouns-inter-dao-governance/
+Confidence: 1.0
+
+
+### FACT 22
+Subject: Research Doc 347: - ZAO Oracle: Verifying Real Outcomes for ZABAL Rewards
+Type: ResearchDoc
+Topic: governance
+Doc number: 347
+Description: - ZAO Oracle: Verifying Real Outcomes for ZABAL Rewards
+Source: internal://research/governance/347-zao-oracle-outcome-verification/
+Confidence: 1.0
+
+
+### FACT 23
+Subject: Research Doc 349: - ZABAL Staking: Simple Contracts + Farcaster Mini App Options
+Type: ResearchDoc
+Topic: governance
+Doc number: 349
+Description: - ZABAL Staking: Simple Contracts + Farcaster Mini App Options
+Source: internal://research/governance/349-zabal-staking-miniapp-options/
+Confidence: 1.0
+
+
+### FACT 24
+Subject: Research Doc 444: ZAO Fractal Submission: April 20, 2026
+Type: ResearchDoc
+Topic: governance
+Doc number: 444
+Description: ZAO Fractal Submission: April 20, 2026
+Source: internal://research/governance/444-fractal-submission-apr20-2026/
+Confidence: 1.0
+
+
+### FACT 25
+Subject: Research Doc 450: Pre-Fractal Discord Talking Points: Apr 20 2026 5pm EST
+Type: ResearchDoc
+Topic: governance
+Doc number: 450
+Description: Pre-Fractal Discord Talking Points: Apr 20 2026 5pm EST
+Source: internal://research/governance/450-pre-fractal-discord-talking-points-apr20/
+Confidence: 1.0
+
+
+### FACT 26
+Subject: Research Doc 497: Sociocracy & Circles for Small Teams: ZAOstock Implementation Guide
+Type: ResearchDoc
+Topic: governance
+Doc number: 497
+Description: Sociocracy & Circles for Small Teams: ZAOstock Implementation Guide
+Source: internal://research/governance/497-sociocracy-circles-small-teams/
+Confidence: 1.0
+
+
+### FACT 27
+Subject: Research Doc 498: ZAOstock Fractal Adaptation: Festival Team Governance Model
+Type: ResearchDoc
+Topic: governance
+Doc number: 498
+Description: ZAOstock Fractal Adaptation: Festival Team Governance Model
+Source: internal://research/governance/498-zao-fractal-adapted-for-zaostock/
+Confidence: 1.0
+
+
+### FACT 28
+Subject: Research Doc 500: DAO Event Coordination Patterns - Real-World Mechanics
+Type: ResearchDoc
+Topic: governance
+Doc number: 500
+Description: DAO Event Coordination Patterns - Real-World Mechanics
+Source: internal://research/governance/500-dao-event-coordination-patterns/
+Confidence: 1.0
+
+
+### FACT 29
+Subject: Research Doc 501: Flat-Org Onboarding UX: From First Day to Invisible Structure
+Type: ResearchDoc
+Topic: governance
+Doc number: 501
+Description: Flat-Org Onboarding UX: From First Day to Invisible Structure
+Source: internal://research/governance/501-flat-org-onboarding-ux/
+Confidence: 1.0
+
+
+### FACT 30
+Subject: Research Doc 502: ZAOstock Circles v1 Spec
+Type: ResearchDoc
+Topic: governance
+Doc number: 502
+Description: ZAOstock Circles v1 Spec
+Source: internal://research/governance/502-zaostock-circles-v1-spec/
+Confidence: 1.0
+
+
+### FACT 31
+Subject: Research Doc 567: Nouns DAO Deep Dive: Mechanism Lore + ZAO Angles
+Type: ResearchDoc
+Topic: governance
+Doc number: 567
+Description: Nouns DAO Deep Dive: Mechanism Lore + ZAO Angles
+Source: internal://research/governance/567-nouns-dao-deep-zao-angles/
+Confidence: 1.0
+
+
+## SECTION — community (32 docs)
+
+### FACT 32
+Subject: Research Doc 023: Austin Griffith, Scaffold-ETH & the ETH Skills Ecosystem
+Type: ResearchDoc
+Topic: community
+Doc number: 023
+Description: Austin Griffith, Scaffold-ETH & the ETH Skills Ecosystem
+Source: internal://research/community/023-austin-griffith-eth-skills/
+Confidence: 1.0
+
+
+### FACT 33
+Subject: Research Doc 050: The ZAO: Complete Guide
+Type: ResearchDoc
+Topic: community
+Doc number: 050
+Description: The ZAO: Complete Guide
+Source: internal://research/community/050-the-zao-complete-guide/
+Confidence: 1.0
+
+
+### FACT 34
+Subject: Research Doc 051: The ZAO — 2026 Whitepaper
+Type: ResearchDoc
+Topic: community
+Doc number: 051
+Description: The ZAO — 2026 Whitepaper
+Source: internal://research/community/051-zao-whitepaper-2026/
+Confidence: 1.0
+
+
+### FACT 35
+Subject: Research Doc 060: Vitalik's Ethereum Philosophy & EF Mandate: ZAO Alignment Analysis
+Type: ResearchDoc
+Topic: community
+Doc number: 060
+Description: Vitalik's Ethereum Philosophy & EF Mandate: ZAO Alignment Analysis
+Source: internal://research/community/060-vitalik-ethereum-philosophy/
+Confidence: 1.0
+
+
+### FACT 36
+Subject: Research Doc 061: Ethereum Alignment Opportunities: ZK Credentials, Curation Markets, Community Notes, Cross-Community Fractals & Grants
+Type: ResearchDoc
+Topic: community
+Doc number: 061
+Description: Ethereum Alignment Opportunities: ZK Credentials, Curation Markets, Community Notes, Cross-Community Fractals & Grants
+Source: internal://research/community/061-ethereum-alignment-opportunities/
+Confidence: 1.0
+
+
+### FACT 37
+Subject: Research Doc 065: ZABAL Partner Ecosystem: MAGNETIQ, SongJam, Empire Builder, Clanker
+Type: ResearchDoc
+Topic: community
+Doc number: 065
+Description: ZABAL Partner Ecosystem: MAGNETIQ, SongJam, Empire Builder, Clanker
+Source: internal://research/community/065-zabal-partner-ecosystem/
+Confidence: 1.0
+
+
+### FACT 38
+Subject: Research Doc 094: Content Moderation, Onboarding UX & Community Analytics
+Type: ResearchDoc
+Topic: community
+Doc number: 094
+Description: Content Moderation, Onboarding UX & Community Analytics
+Source: internal://research/community/094-moderation-onboarding-analytics/
+Confidence: 1.0
+
+
+### FACT 39
+Subject: Research Doc 105: Research Doc 105: Key People in the Fractal Governance Ecosystem
+Type: ResearchDoc
+Topic: community
+Doc number: 105
+Description: Research Doc 105: Key People in the Fractal Governance Ecosystem
+Source: internal://research/community/105-fractal-key-people/
+Confidence: 1.0
+
+
+### FACT 40
+Subject: Research Doc 106: Research Doc 106: Dan SingJoy & Eden Fractal Deep Dive
+Type: ResearchDoc
+Topic: community
+Doc number: 106
+Description: Research Doc 106: Dan SingJoy & Eden Fractal Deep Dive
+Source: internal://research/community/106-dan-singjoy-eden-fractal-deep-dive/
+Confidence: 1.0
+
+
+### FACT 41
+Subject: Research Doc 110: Community Directory & CRM for ZAO OS
+Type: ResearchDoc
+Topic: community
+Doc number: 110
+Description: Community Directory & CRM for ZAO OS
+Source: internal://research/community/110-community-directory-crm/
+Confidence: 1.0
+
+
+### FACT 42
+Subject: Research Doc 169: AI Education for Music Creators: Landscape Gap & ZAO Opportunity
+Type: ResearchDoc
+Topic: community
+Doc number: 169
+Description: AI Education for Music Creators: Landscape Gap & ZAO Opportunity
+Source: internal://research/community/169-ai-education-music-creators-landscape/
+Confidence: 1.0
+
+
+### FACT 43
+Subject: Research Doc 200: The Definitive Community OS: AI Agents, Platform Architecture & Vision
+Type: ResearchDoc
+Topic: community
+Doc number: 200
+Description: The Definitive Community OS: AI Agents, Platform Architecture & Vision
+Source: internal://research/community/200-community-os-ai-agents-platform-vision/
+Confidence: 1.0
+
+
+### FACT 44
+Subject: Research Doc 229: ZAO Member Profiles
+Type: ResearchDoc
+Topic: community
+Doc number: 229
+Description: ZAO Member Profiles
+Source: internal://research/community/229-zao-member-profiles/
+Confidence: 1.0
+
+
+### FACT 45
+Subject: Research Doc 249: Incented Deep Dive, New Campaign Ideas & ClawDown Challenge for ZOE
+Type: ResearchDoc
+Topic: community
+Doc number: 249
+Description: Incented Deep Dive, New Campaign Ideas & ClawDown Challenge for ZOE
+Source: internal://research/community/249-incented-deep-dive-new-campaigns-clawdown/
+Confidence: 1.0
+
+
+### FACT 46
+Subject: Research Doc 272: ZAO Task Forces & Team Structure: 6-Month Roadmap
+Type: ResearchDoc
+Topic: community
+Doc number: 272
+Description: ZAO Task Forces & Team Structure: 6-Month Roadmap
+Source: internal://research/community/272-zao-task-forces-2026/
+Confidence: 1.0
+
+
+### FACT 47
+Subject: Research Doc 287: ZAO FAQ + Word Wall: Community-Driven Web3 Glossary
+Type: ResearchDoc
+Topic: community
+Doc number: 287
+Description: ZAO FAQ + Word Wall: Community-Driven Web3 Glossary
+Source: internal://research/community/287-zao-faq-word-wall-glossary/
+Confidence: 1.0
+
+
+### FACT 48
+Subject: Research Doc 289: ZAO Tool Box
+Type: ResearchDoc
+Topic: community
+Doc number: 289
+Description: ZAO Tool Box
+Source: internal://research/community/289-zao-tool-box/
+Confidence: 1.0
+
+
+### FACT 49
+Subject: Research Doc 348: - SongJam Points System Deep Dive: Scoring, Multipliers & ZABAL Oracle Integration
+Type: ResearchDoc
+Topic: community
+Doc number: 348
+Description: - SongJam Points System Deep Dive: Scoring, Multipliers & ZABAL Oracle Integration
+Source: internal://research/community/348-songjam-points-system-deep-dive/
+Confidence: 1.0
+
+
+### FACT 50
+Subject: Research Doc 352: COC Concertz Full Context: Show History, Artist Profiles, and Content Automation
+Type: ResearchDoc
+Topic: community
+Doc number: 352
+Description: COC Concertz Full Context: Show History, Artist Profiles, and Content Automation
+Source: internal://research/community/352-coc-concertz-full-context-artist-profiles/
+Confidence: 1.0
+
+
+### FACT 51
+Subject: Research Doc 358: BetterCallZaal Brand Voice Analysis
+Type: ResearchDoc
+Topic: community
+Doc number: 358
+Description: BetterCallZaal Brand Voice Analysis
+Source: internal://research/community/358-bettercallzaal-brand-voice-analysis/
+Confidence: 1.0
+
+
+### FACT 52
+Subject: Research Doc 363: ZAOstock People + Brands: Comprehensive Profile Index
+Type: ResearchDoc
+Topic: community
+Doc number: 363
+Description: ZAOstock People + Brands: Comprehensive Profile Index
+Source: internal://research/community/363-zao-stock-people-brands-2026/
+Confidence: 1.0
+
+
+### FACT 53
+Subject: Research Doc 415: POIDH Bounties: Deep Dive for The ZAO + WaveWarZ
+Type: ResearchDoc
+Topic: community
+Doc number: 415
+Description: POIDH Bounties: Deep Dive for The ZAO + WaveWarZ
+Source: internal://research/community/415-poidh-bounties-zao-wavewarz/
+Confidence: 1.0
+
+
+### FACT 54
+Subject: Research Doc 419: Maceo Call: Matteo Tambussi + Italy Web3 Music Ecosystem
+Type: ResearchDoc
+Topic: community
+Doc number: 419
+Description: Maceo Call: Matteo Tambussi + Italy Web3 Music Ecosystem
+Source: internal://research/community/419-maceo-call-matteo-tambussi-italy-web3-music/
+Confidence: 1.0
+
+
+### FACT 55
+Subject: Research Doc 427: UVR (Underground Violet Rave) & Jadyn Violet — Brand Brief for Discord Intro Bot
+Type: ResearchDoc
+Topic: community
+Doc number: 427
+Description: UVR (Underground Violet Rave) & Jadyn Violet — Brand Brief for Discord Intro Bot
+Source: internal://research/community/427-uvr-jadyn-violet-brand-intro-bot/
+Confidence: 1.0
+
+
+### FACT 56
+Subject: Research Doc 432: ZAO Master Context: Tricky Buddha Space Recap
+Type: ResearchDoc
+Topic: community
+Doc number: 432
+Description: ZAO Master Context: Tricky Buddha Space Recap
+Source: internal://research/community/432-zao-master-context-tricky-buddha/
+Confidence: 1.0
+
+
+### FACT 57
+Subject: Research Doc 449: Matteo Tambussi Italy-Bridge Follow-Up
+Type: ResearchDoc
+Topic: community
+Doc number: 449
+Description: Matteo Tambussi Italy-Bridge Follow-Up
+Source: internal://research/community/449-matteo-tambussi-followup/
+Confidence: 1.0
+
+
+### FACT 58
+Subject: Research Doc 458: ZAO Contribution Circles
+Type: ResearchDoc
+Topic: community
+Doc number: 458
+Description: ZAO Contribution Circles
+Source: internal://research/community/458-zao-contribution-circles/
+Confidence: 1.0
+
+
+### FACT 59
+Subject: Research Doc 530: ZOUNZ Artist Trait + Wordmark Brief
+Type: ResearchDoc
+Topic: community
+Doc number: 530
+Description: ZOUNZ Artist Trait + Wordmark Brief
+Source: internal://research/community/530-zounz-artist-trait-brief/
+Confidence: 1.0
+
+
+### FACT 60
+Subject: Research Doc 533: POIDH Clip-Up Bounty: BCZ YapZ Ep 17 (Hannah / Farm Drop)
+Type: ResearchDoc
+Topic: community
+Doc number: 533
+Description: POIDH Clip-Up Bounty: BCZ YapZ Ep 17 (Hannah / Farm Drop)
+Source: internal://research/community/533-poidh-clipup-bounty-bcz-yapz-hannah/
+Confidence: 1.0
+
+
+### FACT 61
+Subject: Research Doc 538: Monteux School & Music Festival: Hancock, Maine
+Type: ResearchDoc
+Topic: community
+Doc number: 538
+Description: Monteux School & Music Festival: Hancock, Maine
+Source: internal://research/community/538-monteux-school-music-festival-hancock-me/
+Confidence: 1.0
+
+
+### FACT 62
+Subject: Research Doc 547: Cassie advisor session: AI-augmented community coordination as the bigger play
+Type: ResearchDoc
+Topic: community
+Doc number: 547
+Description: Cassie advisor session: AI-augmented community coordination as the bigger play
+Source: internal://research/community/547-cassie-advisor-ai-human-coordination-validation/
+Confidence: 1.0
+
+
+### FACT 63
+Subject: Research Doc 577: Viral X Thread Patterns: Humble Milestone Posts (Birthday, Hackathon, Launch)
+Type: ResearchDoc
+Topic: community
+Doc number: 577
+Description: Viral X Thread Patterns: Humble Milestone Posts (Birthday, Hackathon, Launch)
+Source: internal://research/community/577-viral-x-thread-patterns-humble-milestone-posts/
+Confidence: 1.0
+
+
+## SECTION — identity (18 docs)
+
+### FACT 64
+Subject: Research Doc 005: ZIDs — ZAO Decentralized Identity
+Type: ResearchDoc
+Topic: identity
+Doc number: 005
+Description: ZIDs — ZAO Decentralized Identity
+Source: internal://research/identity/005-zao-identity/
+Confidence: 1.0
+
+
+### FACT 65
+Subject: Research Doc 134: External Reputation Signals — Comprehensive Inventory
+Type: ResearchDoc
+Topic: identity
+Doc number: 134
+Description: External Reputation Signals — Comprehensive Inventory
+Source: internal://research/identity/134-external-reputation-signals-comprehensive/
+Confidence: 1.0
+
+
+### FACT 66
+Subject: Research Doc 135: Exhaustive Profile Enrichment Signals
+Type: ResearchDoc
+Topic: identity
+Doc number: 135
+Description: Exhaustive Profile Enrichment Signals
+Source: internal://research/identity/135-exhaustive-profile-enrichment-signals/
+Confidence: 1.0
+
+
+### FACT 67
+Subject: Research Doc 158: ZAO Member Naming: ENS Subnames vs Basenames vs Custom
+Type: ResearchDoc
+Topic: identity
+Doc number: 158
+Description: ZAO Member Naming: ENS Subnames vs Basenames vs Custom
+Source: internal://research/identity/158-zao-member-naming-ens-basenames/
+Confidence: 1.0
+
+
+### FACT 68
+Subject: Research Doc 191: Reputation Scoring Systems for ZAO OS
+Type: ResearchDoc
+Topic: identity
+Doc number: 191
+Description: Reputation Scoring Systems for ZAO OS
+Source: internal://research/identity/191-reputation-scoring-systems/
+Confidence: 1.0
+
+
+### FACT 69
+Subject: Research Doc 203: NFT Gallery on Member Profiles via Alchemy NFT API
+Type: ResearchDoc
+Topic: identity
+Doc number: 203
+Description: NFT Gallery on Member Profiles via Alchemy NFT API
+Source: internal://research/identity/203-nft-gallery-alchemy-integration/
+Confidence: 1.0
+
+
+### FACT 70
+Subject: Research Doc 271: ZAO Knowledge Graph: Member Identity & Relationship Mapping
+Type: ResearchDoc
+Topic: identity
+Doc number: 271
+Description: ZAO Knowledge Graph: Member Identity & Relationship Mapping
+Source: internal://research/identity/271-zao-knowledge-graph/
+Confidence: 1.0
+
+
+### FACT 71
+Subject: Research Doc 525: Guild.xyz + Token-Gating Platform Evaluation for ZAO OS
+Type: ResearchDoc
+Topic: identity
+Doc number: 525
+Description: Guild.xyz + Token-Gating Platform Evaluation for ZAO OS
+Source: internal://research/identity/525-guild-xyz-token-gating-platforms-evaluation/
+Confidence: 1.0
+
+
+### FACT 72
+Subject: Research Doc 542: Bonfires.ai Knowledge Graph for BCZ Strategies + ZAO Ecosystem
+Type: ResearchDoc
+Topic: identity
+Doc number: 542
+Description: Bonfires.ai Knowledge Graph for BCZ Strategies + ZAO Ecosystem
+Source: internal://research/identity/542-bonfires-ai-knowledge-graph-bcz-strategies/
+Confidence: 1.0
+
+
+### FACT 73
+Subject: Research Doc 543: Bonfires Bot Shipping Questions (Round 2, Operational Deep Dive)
+Type: ResearchDoc
+Topic: identity
+Doc number: 543
+Description: Bonfires Bot Shipping Questions (Round 2, Operational Deep Dive)
+Source: internal://research/identity/543-bonfires-bot-shipping-questions/
+Confidence: 1.0
+
+
+### FACT 74
+Subject: Research Doc 544: Bonfires SDK + Notion Config Map for ZAO Wiring
+Type: ResearchDoc
+Topic: identity
+Doc number: 544
+Description: Bonfires SDK + Notion Config Map for ZAO Wiring
+Source: internal://research/identity/544-bonfires-sdk-zao-wiring/
+Confidence: 1.0
+
+
+### FACT 75
+Subject: Research Doc 545: ZABAL Knowledge-Graph Ontology v1
+Type: ResearchDoc
+Topic: identity
+Doc number: 545
+Description: ZABAL Knowledge-Graph Ontology v1
+Source: internal://research/identity/545-zabal-knowledge-graph-ontology/
+Confidence: 1.0
+
+
+### FACT 76
+Subject: Research Doc 546: Bonfires.ai Real-World Deployments + Patterns to Adopt/Avoid
+Type: ResearchDoc
+Topic: identity
+Doc number: 546
+Description: Bonfires.ai Real-World Deployments + Patterns to Adopt/Avoid
+Source: internal://research/identity/546-bonfires-real-world-deployments/
+Confidence: 1.0
+
+
+### FACT 77
+Subject: Research Doc 548: Bonfire First-Week Context Teaching Playbook
+Type: ResearchDoc
+Topic: identity
+Doc number: 548
+Description: Bonfire First-Week Context Teaching Playbook
+Source: internal://research/identity/548-bonfire-first-week-context-teaching/
+Confidence: 1.0
+
+
+### FACT 78
+Subject: Research Doc 549: Bonfire as Zaal's Personal Second Brain (Obsidian Alternative)
+Type: ResearchDoc
+Topic: identity
+Doc number: 549
+Description: Bonfire as Zaal's Personal Second Brain (Obsidian Alternative)
+Source: internal://research/identity/549-bonfire-personal-second-brain/
+Confidence: 1.0
+
+
+### FACT 79
+Subject: Research Doc 569: YapZ Bonfire Ingestion Strategy
+Type: ResearchDoc
+Topic: identity
+Doc number: 569
+Description: YapZ Bonfire Ingestion Strategy
+Source: internal://research/identity/569-yapz-bonfire-ingestion-strategy/
+Confidence: 1.0
+
+
+### FACT 80
+Subject: Research Doc 570: Zaal's Personal Knowledge Graph for Agentic Memory
+Type: ResearchDoc
+Topic: identity
+Doc number: 570
+Description: Zaal's Personal Knowledge Graph for Agentic Memory
+Source: internal://research/identity/570-zaal-personal-kg-agentic-memory/
+Confidence: 1.0
+
+
+### FACT 81
+Subject: Research Doc 581: Bonfire Graph Wipe + Bot Hygiene (Post-Mortem)
+Type: ResearchDoc
+Topic: identity
+Doc number: 581
+Description: Bonfire Graph Wipe + Bot Hygiene (Post-Mortem)
+Source: internal://research/identity/581-bonfire-graph-wipe-bot-hygiene/
+Confidence: 1.0
+
+
+## SECTION — cross-platform (14 docs)
+
+### FACT 82
+Subject: Research Doc 077: Bluesky Cross-Posting Integration for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 077
+Description: Bluesky Cross-Posting Integration for ZAO OS
+Source: internal://research/cross-platform/077-bluesky-cross-posting-integration/
+Confidence: 1.0
+
+
+### FACT 83
+Subject: Research Doc 096: Cross-Post API Deep Dive: Platform-by-Platform Integration Guide
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 096
+Description: Cross-Post API Deep Dive: Platform-by-Platform Integration Guide
+Source: internal://research/cross-platform/096-cross-post-api-deep-dive/
+Confidence: 1.0
+
+
+### FACT 84
+Subject: Research Doc 097: Nostr Cross-Posting Integration for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 097
+Description: Nostr Cross-Posting Integration for ZAO OS
+Source: internal://research/cross-platform/097-nostr-cross-posting-integration/
+Confidence: 1.0
+
+
+### FACT 85
+Subject: Research Doc 117: Lens V3 Integration (Consolidated)
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 117
+Description: Lens V3 Integration (Consolidated)
+Source: internal://research/cross-platform/117-lens-v3-integration/
+Confidence: 1.0
+
+
+### FACT 86
+Subject: Research Doc 177: Mastodon + Threads Cross-Posting Integration for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 177
+Description: Mastodon + Threads Cross-Posting Integration for ZAO OS
+Source: internal://research/cross-platform/177-mastodon-threads-cross-posting/
+Confidence: 1.0
+
+
+### FACT 87
+Subject: Research Doc 179: Reddit Cross-Posting Integration for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 179
+Description: Reddit Cross-Posting Integration for ZAO OS
+Source: internal://research/cross-platform/179-reddit-cross-posting-integration/
+Confidence: 1.0
+
+
+### FACT 88
+Subject: Research Doc 183: Social Connections & X Integration for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 183
+Description: Social Connections & X Integration for ZAO OS
+Source: internal://research/cross-platform/183-social-connections-x-integration/
+Confidence: 1.0
+
+
+### FACT 89
+Subject: Research Doc 214: Twitch API Deep Integration: Comprehensive Feature Map for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 214
+Description: Twitch API Deep Integration: Comprehensive Feature Map for ZAO OS
+Source: internal://research/cross-platform/214-twitch-api-deep-integration/
+Confidence: 1.0
+
+
+### FACT 90
+Subject: Research Doc 228: Meta Developer Platform: APIs, Models & Integration Opportunities for ZAO OS
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 228
+Description: Meta Developer Platform: APIs, Models & Integration Opportunities for ZAO OS
+Source: internal://research/cross-platform/228-meta-developer-platform/
+Confidence: 1.0
+
+
+### FACT 91
+Subject: Research Doc 351: YouTube Description SEO & Transcript-to-Description Workflow for COC Concertz
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 351
+Description: YouTube Description SEO & Transcript-to-Description Workflow for COC Concertz
+Source: internal://research/cross-platform/351-youtube-description-seo-concert-transcripts/
+Confidence: 1.0
+
+
+### FACT 92
+Subject: Research Doc 353: YouTube Content Pipeline Automation for COC Concertz
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 353
+Description: YouTube Content Pipeline Automation for COC Concertz
+Source: internal://research/cross-platform/353-youtube-content-pipeline-automation/
+Confidence: 1.0
+
+
+### FACT 93
+Subject: Research Doc 354: - Cross-Posting Infrastructure Audit: What Exists for Agent Teaser Distribution
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 354
+Description: - Cross-Posting Infrastructure Audit: What Exists for Agent Teaser Distribution
+Source: internal://research/cross-platform/354-cross-posting-infrastructure-audit/
+Confidence: 1.0
+
+
+### FACT 94
+Subject: Research Doc 355: - Autonomous Social Distribution 2026: What Works, What's Noise, What to Steal
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 355
+Description: - Autonomous Social Distribution 2026: What Works, What's Noise, What to Steal
+Source: internal://research/cross-platform/355-autonomous-social-distribution-2026/
+Confidence: 1.0
+
+
+### FACT 95
+Subject: Research Doc 486: Reddit Reply Bot for ZAO + JustMakingMusic as a Distribution Vertical
+Type: ResearchDoc
+Topic: cross-platform
+Doc number: 486
+Description: Reddit Reply Bot for ZAO + JustMakingMusic as a Distribution Vertical
+Source: internal://research/cross-platform/486-reddit-zao-reply-bot-justmakingmusic-vertical/
+Confidence: 1.0
+
+
+## SECTION — security (7 docs)
+
+### FACT 96
+Subject: Research Doc 040: Codebase Audit Guide: Step-by-Step
+Type: ResearchDoc
+Topic: security
+Doc number: 040
+Description: Codebase Audit Guide: Step-by-Step
+Source: internal://research/security/040-codebase-audit-guide/
+Confidence: 1.0
+
+
+### FACT 97
+Subject: Research Doc 057: Codebase Security Audit (March 17, 2026)
+Type: ResearchDoc
+Topic: security
+Doc number: 057
+Description: Codebase Security Audit (March 17, 2026)
+Source: internal://research/security/057-codebase-security-audit-march-2026/
+Confidence: 1.0
+
+
+### FACT 98
+Subject: Research Doc 136: API Status Verification — March 2026
+Type: ResearchDoc
+Topic: security
+Doc number: 136
+Description: API Status Verification — March 2026
+Source: internal://research/security/136-api-status-verification-march-2026/
+Confidence: 1.0
+
+
+### FACT 99
+Subject: Research Doc 343: - Agent Wallet Security: Securing VAULT/BANKER/DEALER Beyond Env Vars
+Type: ResearchDoc
+Topic: security
+Doc number: 343
+Description: - Agent Wallet Security: Securing VAULT/BANKER/DEALER Beyond Env Vars
+Source: internal://research/security/343-agent-wallet-security-zabal-swarm/
+Confidence: 1.0
+
+
+### FACT 100
+Subject: Research Doc 463: Status:** Audit complete, fixes in progress
+Type: ResearchDoc
+Topic: security
+Doc number: 463
+Description: Status:** Audit complete, fixes in progress
+Source: internal://research/security/463-portal-ao-audit-10-batch/
+Confidence: 1.0
+
+
+### FACT 101
+Subject: Research Doc 471: Vercel OAuth Supply Chain Breach April 2026 - ZAO Action Checklist
+Type: ResearchDoc
+Topic: security
+Doc number: 471
+Description: Vercel OAuth Supply Chain Breach April 2026 - ZAO Action Checklist
+Source: internal://research/security/471-vercel-oauth-breach-apr2026/
+Confidence: 1.0
+
+
+### FACT 102
+Subject: Research Doc 494: Vps Secrets Ai Coding Agent
+Type: ResearchDoc
+Topic: security
+Doc number: 494
+Description: Vps Secrets Ai Coding Agent
+Source: internal://research/security/494-vps-secrets-ai-coding-agent/
+Confidence: 1.0
+
+
+## SECTION — wavewarz (5 docs)
+
+### FACT 103
+Subject: Research Doc 099: Prediction Market Music Battles for ZAO OS
+Type: ResearchDoc
+Topic: wavewarz
+Doc number: 099
+Description: Prediction Market Music Battles for ZAO OS
+Source: internal://research/wavewarz/099-prediction-market-music-battles/
+Confidence: 1.0
+
+
+### FACT 104
+Subject: Research Doc 100: Reading Solana PDA Data from Next.js (WaveWarZ Battle Vaults)
+Type: ResearchDoc
+Topic: wavewarz
+Doc number: 100
+Description: Reading Solana PDA Data from Next.js (WaveWarZ Battle Vaults)
+Source: internal://research/wavewarz/100-solana-pda-reading-nextjs/
+Confidence: 1.0
+
+
+### FACT 105
+Subject: Research Doc 101: WaveWarZ × ZAO OS: Integration Whitepaper
+Type: ResearchDoc
+Topic: wavewarz
+Doc number: 101
+Description: WaveWarZ × ZAO OS: Integration Whitepaper
+Source: internal://research/wavewarz/101-wavewarz-zao-whitepaper/
+Confidence: 1.0
+
+
+### FACT 106
+Subject: Research Doc 180: WaveWarZ Artist Discovery Pipeline for ZAO OS
+Type: ResearchDoc
+Topic: wavewarz
+Doc number: 180
+Description: WaveWarZ Artist Discovery Pipeline for ZAO OS
+Source: internal://research/wavewarz/180-wavewarz-integration-blueprints/
+Confidence: 1.0
+
+
+### FACT 107
+Subject: Research Doc 421: Quotient's Anti-Cucktrading Manifesto: AI Superforecaster Design for WaveWarZ
+Type: ResearchDoc
+Topic: wavewarz
+Doc number: 421
+Description: Quotient's Anti-Cucktrading Manifesto: AI Superforecaster Design for WaveWarZ
+Source: internal://research/wavewarz/421-quotient-anti-cucktrading-ai-superforecaster/
+Confidence: 1.0
+
+
+## SECTION — legacy top-level docs (12 docs)
+
+### FACT 108
+Subject: Research Doc 280: FID Registration & x402 Deep Dive: How to Give ZAO Agents a Farcaster Identity
+Type: ResearchDoc
+Topic: misc
+Doc number: 280
+Description: FID Registration & x402 Deep Dive: How to Give ZAO Agents a Farcaster Identity
+Source: internal://research/280-fid-registration-x402-deep-dive/
+Confidence: 1.0
+
+### FACT 109
+Subject: Research Doc 281: Farcaster Agents Landscape & Registration Paths: The Complete Picture
+Type: ResearchDoc
+Topic: misc
+Doc number: 281
+Description: Farcaster Agents Landscape & Registration Paths: The Complete Picture
+Source: internal://research/281-farcaster-agents-landscape-registration/
+Confidence: 1.0
+
+### FACT 110
+Subject: Research Doc 282: Privy Auth Integration for FISHBOWLZ
+Type: ResearchDoc
+Topic: misc
+Doc number: 282
+Description: Privy Auth Integration for FISHBOWLZ
+Source: internal://research/282-privy-auth-fishbowlz-integration/
+Confidence: 1.0
+
+### FACT 111
+Subject: Research Doc 283: Privy Embedded Wallets & Smart Wallets for FISHBOWLZ Token Mechanics on Base
+Type: ResearchDoc
+Topic: misc
+Doc number: 283
+Description: Privy Embedded Wallets & Smart Wallets for FISHBOWLZ Token Mechanics on Base
+Source: internal://research/283-privy-embedded-wallets-fishbowlz-token-mechanics/
+Confidence: 1.0
+
+### FACT 112
+Subject: Research Doc 284: Privy Full Feature Set for FISHBOWLZ
+Type: ResearchDoc
+Topic: misc
+Doc number: 284
+Description: Privy Full Feature Set for FISHBOWLZ
+Source: internal://research/284-privy-full-feature-set-fishbowlz/
+Confidence: 1.0
+
+### FACT 113
+Subject: Research Doc 288: Doc 288 — Agent Squad Monitoring & Visualization Dashboards
+Type: ResearchDoc
+Topic: misc
+Doc number: 288
+Description: Doc 288 — Agent Squad Monitoring & Visualization Dashboards
+Source: internal://research/288-agent-squad-monitoring-dashboards/
+Confidence: 1.0
+
+### FACT 114
+Subject: Research Doc 289: Doc 289 — ZOE Dashboard: Chat-Based Command Center UX Patterns
+Type: ResearchDoc
+Topic: misc
+Doc number: 289
+Description: Doc 289 — ZOE Dashboard: Chat-Based Command Center UX Patterns
+Source: internal://research/289-zoe-dashboard-chat-ux-patterns/
+Confidence: 1.0
+
+### FACT 115
+Subject: Research Doc 309: Karpathy's LLM Wiki: Codebase-to-Wiki Compiler for Token Optimization
+Type: ResearchDoc
+Topic: misc
+Doc number: 309
+Description: Karpathy's LLM Wiki: Codebase-to-Wiki Compiler for Token Optimization
+Source: internal://research/309-karpathy-llm-wiki-codebase-compiler/
+Confidence: 1.0
+
+### FACT 116
+Subject: Research Doc 310: Meta TRIBE v2: Brain Prediction Model for Content Optimization
+Type: ResearchDoc
+Topic: misc
+Doc number: 310
+Description: Meta TRIBE v2: Brain Prediction Model for Content Optimization
+Source: internal://research/310-meta-tribe-v2-brain-prediction-content/
+Confidence: 1.0
+
+### FACT 117
+Subject: Research Doc 311: Vibe-Coded Apps: $800K/yr Marketing Playbook
+Type: ResearchDoc
+Topic: misc
+Doc number: 311
+Description: Vibe-Coded Apps: $800K/yr Marketing Playbook
+Source: internal://research/311-vibe-coded-apps-marketing-playbook/
+Confidence: 1.0
+
+### FACT 118
+Subject: Research Doc 312: Claude Skills Marketplace & Ecosystem (Apr 2026)
+Type: ResearchDoc
+Topic: misc
+Doc number: 312
+Description: Claude Skills Marketplace & Ecosystem (Apr 2026)
+Source: internal://research/312-claude-skills-marketplace-ecosystem/
+Confidence: 1.0
+
+### FACT 119
+Subject: Research Doc 314: Doc 314 - Music Metadata, ISRC Codes & AI-Generated Music Distribution (2026)
+Type: ResearchDoc
+Topic: misc
+Doc number: 314
+Description: Doc 314 - Music Metadata, ISRC Codes & AI-Generated Music Distribution (2026)
+Source: internal://research/314-music-metadata-isrc-ai-distribution/
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[authored]-> [each ResearchDoc above]
+- The ZAO -[has_research_doc]-> [each ResearchDoc]
+- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)
+
+---
+Build the manifest, preview the first 3 nodes, then ask me "approve all?". Total 119 ResearchDoc nodes in this batch. Do not commit until I say yes. If a Doc number already exists in graph, MERGE; do not create duplicate.

--- a/content/bonfire-ingest/research-index-infra-business-events.md
+++ b/content/bonfire-ingest/research-index-infra-business-events.md
@@ -1,0 +1,1177 @@
+INGEST BATCH: ZAO Research Library Index — infra / business / events (3 topic folders).
+
+Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. Each ResearchDoc has Topic + Doc number + Description as attributes. Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes.
+
+## SECTION — infrastructure (45 docs)
+
+### FACT 1
+Subject: Research Doc 012: Gating Access to ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 012
+Description: Gating Access to ZAO OS
+Source: internal://research/infrastructure/012-gating/
+Confidence: 1.0
+
+
+### FACT 2
+Subject: Research Doc 016: UI Reference — CG / Commonwealth
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 016
+Description: UI Reference — CG / Commonwealth
+Source: internal://research/infrastructure/016-ui-reference/
+Confidence: 1.0
+
+
+### FACT 3
+Subject: Research Doc 035: Notifications: Complete Implementation Guide
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 035
+Description: Notifications: Complete Implementation Guide
+Source: internal://research/infrastructure/035-notifications-complete-guide/
+Confidence: 1.0
+
+
+### FACT 4
+Subject: Research Doc 041: Next.js 16 + React 19 Deep Dive
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 041
+Description: Next.js 16 + React 19 Deep Dive
+Source: internal://research/infrastructure/041-nextjs16-react19-deep-dive/
+Confidence: 1.0
+
+
+### FACT 5
+Subject: Research Doc 092: Public APIs 2026 Update: Best Free APIs for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 092
+Description: Public APIs 2026 Update: Best Free APIs for ZAO OS
+Source: internal://research/infrastructure/092-public-apis-2026-update/
+Confidence: 1.0
+
+
+### FACT 6
+Subject: Research Doc 093: Missing Infrastructure: Testing, CI/CD, Monitoring, Design System, PWA
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 093
+Description: Missing Infrastructure: Testing, CI/CD, Monitoring, Design System, PWA
+Source: internal://research/infrastructure/093-missing-infrastructure-gaps/
+Confidence: 1.0
+
+
+### FACT 7
+Subject: Research Doc 098: Supabase Database Optimizations for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 098
+Description: Supabase Database Optimizations for ZAO OS
+Source: internal://research/infrastructure/098-supabase-database-optimizations/
+Confidence: 1.0
+
+
+### FACT 8
+Subject: Research Doc 116: Doc 116 — Discord Integration Research for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 116
+Description: Doc 116 — Discord Integration Research for ZAO OS
+Source: internal://research/infrastructure/116-discord-integration-research/
+Confidence: 1.0
+
+
+### FACT 9
+Subject: Research Doc 118: Settings Page Redesign
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 118
+Description: Settings Page Redesign
+Source: internal://research/infrastructure/118-settings-page-redesign/
+Confidence: 1.0
+
+
+### FACT 10
+Subject: Research Doc 122: SongJam Screen Share PR: Stream Video SDK Integration
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 122
+Description: SongJam Screen Share PR: Stream Video SDK Integration
+Source: internal://research/infrastructure/122-songjam-screen-share-pr/
+Confidence: 1.0
+
+
+### FACT 11
+Subject: Research Doc 129: Alchemy APIs Deep Integration for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 129
+Description: Alchemy APIs Deep Integration for ZAO OS
+Source: internal://research/infrastructure/129-alchemy-apis-deep-integration/
+Confidence: 1.0
+
+
+### FACT 12
+Subject: Research Doc 176: Supabase Scaling & Optimization for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 176
+Description: Supabase Scaling & Optimization for ZAO OS
+Source: internal://research/infrastructure/176-supabase-scaling-optimization/
+Confidence: 1.0
+
+
+### FACT 13
+Subject: Research Doc 182: Home Screen / Dashboard Design for Music Community Platforms
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 182
+Description: Home Screen / Dashboard Design for Music Community Platforms
+Source: internal://research/infrastructure/182-home-screen-dashboard-design/
+Confidence: 1.0
+
+
+### FACT 14
+Subject: Research Doc 192: Multi-Platform Streaming from ZAO OS Audio Rooms (RTMP Out)
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 192
+Description: Multi-Platform Streaming from ZAO OS Audio Rooms (RTMP Out)
+Source: internal://research/infrastructure/192-multiplatform-streaming-rtmp/
+Confidence: 1.0
+
+
+### FACT 15
+Subject: Research Doc 215: OBS + Restream + StreamYard Feature Analysis: What ZAO OS Spaces Should Have
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 215
+Description: OBS + Restream + StreamYard Feature Analysis: What ZAO OS Spaces Should Have
+Source: internal://research/infrastructure/215-obs-restream-streamyard-feature-analysis/
+Confidence: 1.0
+
+
+### FACT 16
+Subject: Research Doc 217: - Audio/Video Quality Optimization for Live Streaming
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 217
+Description: - Audio/Video Quality Optimization for Live Streaming
+Source: internal://research/infrastructure/217-av-quality-optimization-live-streaming/
+Confidence: 1.0
+
+
+### FACT 17
+Subject: Research Doc 218: Mobile App Strategy: PWA, Capacitor, React Native, Expo, Tauri, TWA
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 218
+Description: Mobile App Strategy: PWA, Capacitor, React Native, Expo, Tauri, TWA
+Source: internal://research/infrastructure/218-mobile-app-strategy-pwa-native/
+Confidence: 1.0
+
+
+### FACT 18
+Subject: Research Doc 221: Admin Dashboard Best Practices for Web3 Community Apps
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 221
+Description: Admin Dashboard Best Practices for Web3 Community Apps
+Source: internal://research/infrastructure/221-admin-dashboard-best-practices/
+Confidence: 1.0
+
+
+### FACT 19
+Subject: Research Doc 223: - Smart Contract Development Guide for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 223
+Description: - Smart Contract Development Guide for ZAO OS
+Source: internal://research/infrastructure/223-smart-contract-development-guide/
+Confidence: 1.0
+
+
+### FACT 20
+Subject: Research Doc 233: Spaces & Streaming Full Codebase Audit
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 233
+Description: Spaces & Streaming Full Codebase Audit
+Source: internal://research/infrastructure/233-spaces-streaming-full-audit/
+Confidence: 1.0
+
+
+### FACT 21
+Subject: Research Doc 275: - Stream.io Video SDK Dashboard Configuration
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 275
+Description: - Stream.io Video SDK Dashboard Configuration
+Source: internal://research/infrastructure/275-stream-video-sdk-dashboard-configuration/
+Confidence: 1.0
+
+
+### FACT 22
+Subject: Research Doc 283: Vercel + Next.js 16 Performance Optimization Guide
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 283
+Description: Vercel + Next.js 16 Performance Optimization Guide
+Source: internal://research/infrastructure/283-vercel-nextjs16-performance-optimization/
+Confidence: 1.0
+
+
+### FACT 23
+Subject: Research Doc 286: Claude Cowork SEO Workflow & ZAO OS SEO Audit
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 286
+Description: Claude Cowork SEO Workflow & ZAO OS SEO Audit
+Source: internal://research/infrastructure/286-claude-cowork-seo-workflow/
+Confidence: 1.0
+
+
+### FACT 24
+Subject: Research Doc 313: Metaverse & 3D Virtual World for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 313
+Description: Metaverse & 3D Virtual World for ZAO OS
+Source: internal://research/infrastructure/313-metaverse-3d-virtual-world-zao/
+Confidence: 1.0
+
+
+### FACT 25
+Subject: Research Doc 314: Quilibrium Network: Comprehensive Deep Dive
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 314
+Description: Quilibrium Network: Comprehensive Deep Dive
+Source: internal://research/infrastructure/314-quilibrium-network-comprehensive-deep-dive/
+Confidence: 1.0
+
+
+### FACT 26
+Subject: Research Doc 315: 3D Metaverse Codebase Integration & Onboarding Map
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 315
+Description: 3D Metaverse Codebase Integration & Onboarding Map
+Source: internal://research/infrastructure/315-metaverse-codebase-integration-onboarding/
+Confidence: 1.0
+
+
+### FACT 27
+Subject: Research Doc 319: Lightweight 3D Portal Hub for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 319
+Description: Lightweight 3D Portal Hub for ZAO OS
+Source: internal://research/infrastructure/319-lightweight-3d-portal-hub/
+Confidence: 1.0
+
+
+### FACT 28
+Subject: Research Doc 368: Notion vs. Custom Dashboard for ZAOstock Festival Planning
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 368
+Description: Notion vs. Custom Dashboard for ZAOstock Festival Planning
+Source: internal://research/infrastructure/368-notion-vs-custom-festival-planning/
+Confidence: 1.0
+
+
+### FACT 29
+Subject: Research Doc 413: ZAOstock Dashboard as Notion Replacement
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 413
+Description: ZAOstock Dashboard as Notion Replacement
+Source: internal://research/infrastructure/413-zaostock-dashboard-notion-replacement/
+Confidence: 1.0
+
+
+### FACT 30
+Subject: Research Doc 415: Composable OS-Style Architecture for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 415
+Description: Composable OS-Style Architecture for ZAO OS
+Source: internal://research/infrastructure/415-composable-os-architecture/
+Confidence: 1.0
+
+
+### FACT 31
+Subject: Research Doc 416: Native App Distribution: TestFlight + Play Store for ZAO OS
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 416
+Description: Native App Distribution: TestFlight + Play Store for ZAO OS
+Source: internal://research/infrastructure/416-native-app-testflight-playstore/
+Confidence: 1.0
+
+
+### FACT 32
+Subject: Research Doc 417: Agent Tools Remote Access: Making Everything Reachable from zaoos.com
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 417
+Description: Agent Tools Remote Access: Making Everything Reachable from zaoos.com
+Source: internal://research/infrastructure/417-agent-tools-remote-access/
+Confidence: 1.0
+
+
+### FACT 33
+Subject: Research Doc 428: Unified Agent Portal + ao.zaoos.com + Phone Claude Code
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 428
+Description: Unified Agent Portal + ao.zaoos.com + Phone Claude Code
+Source: internal://research/infrastructure/428-unified-agent-portal-ao-phone-access/
+Confidence: 1.0
+
+
+### FACT 34
+Subject: Research Doc 430: Portal Stack Improvements + Prioritized Build Order
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 430
+Description: Portal Stack Improvements + Prioritized Build Order
+Source: internal://research/infrastructure/430-portal-stack-improvements-plan/
+Confidence: 1.0
+
+
+### FACT 35
+Subject: Research Doc 431: Portal v2: Universal Nav + Version-Control + Backlog
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 431
+Description: Portal v2: Universal Nav + Version-Control + Backlog
+Source: internal://research/infrastructure/431-portal-universal-nav-v2-improvements/
+Confidence: 1.0
+
+
+### FACT 36
+Subject: Research Doc 433: Portal v3: Todos Brain Dump + Universal Nav + infra/portal Versioned
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 433
+Description: Portal v3: Todos Brain Dump + Universal Nav + infra/portal Versioned
+Source: internal://research/infrastructure/433-portal-todos-brain-dump-universal-nav/
+Confidence: 1.0
+
+
+### FACT 37
+Subject: Research Doc 436: Phone Agentic Stack Playbook + Health Check
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 436
+Description: Phone Agentic Stack Playbook + Health Check
+Source: internal://research/infrastructure/436-phone-agentic-stack-playbook-health/
+Confidence: 1.0
+
+
+### FACT 38
+Subject: Research Doc 478: ICP + Caffeine: Simple NFT Purchase App
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 478
+Description: ICP + Caffeine: Simple NFT Purchase App
+Source: internal://research/infrastructure/478-icp-caffeine-nft-purchase/
+Confidence: 1.0
+
+
+### FACT 39
+Subject: Research Doc 503: Loomio vs Native: Consensus Voting for ZAOstock Circles v1
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 503
+Description: Loomio vs Native: Consensus Voting for ZAOstock Circles v1
+Source: internal://research/infrastructure/503-loomio-integration-feasibility/
+Confidence: 1.0
+
+
+### FACT 40
+Subject: Research Doc 532: Restream Developer API Deep Dive
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 532
+Description: Restream Developer API Deep Dive
+Source: internal://research/infrastructure/532-restream-developer-api-deep-dive/
+Confidence: 1.0
+
+
+### FACT 41
+Subject: Research Doc 543: Vercel Fluid Active CPU Cap on bettercallzaals-projects (40+ Projects, 1 Free Team)
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 543
+Description: Vercel Fluid Active CPU Cap on bettercallzaals-projects (40+ Projects, 1 Free Team)
+Source: internal://research/infrastructure/543-vercel-fluid-active-cpu-cap-bcz-team/
+Confidence: 1.0
+
+
+### FACT 42
+Subject: Research Doc 544: Livepeer Streaming for ZAO OS Spaces + Broadcast
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 544
+Description: Livepeer Streaming for ZAO OS Spaces + Broadcast
+Source: internal://research/infrastructure/544-livepeer-streaming-zao-os/
+Confidence: 1.0
+
+
+### FACT 43
+Subject: Research Doc 570: ZAOstock Landing Redesign: Godly + Festival Patterns
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 570
+Description: ZAOstock Landing Redesign: Godly + Festival Patterns
+Source: internal://research/infrastructure/570-zaostock-landing-redesign-godly-festival-patterns/
+Confidence: 1.0
+
+
+### FACT 44
+Subject: Research Doc 572: Godly Third Pass + Festival Microsites Overnight Iteration
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 572
+Description: Godly Third Pass + Festival Microsites Overnight Iteration
+Source: internal://research/infrastructure/572-godly-third-pass-zaostock-overnight-iteration/
+Confidence: 1.0
+
+
+### FACT 45
+Subject: Research Doc 576: Godly Fourth Pass: Content Richness + 2-Path Donate + Birthday R3F Patterns
+Type: ResearchDoc
+Topic: infrastructure
+Doc number: 576
+Description: Godly Fourth Pass: Content Richness + 2-Path Donate + Birthday R3F Patterns
+Source: internal://research/infrastructure/576-godly-fourth-pass-zaostock-richness-donate-birthday/
+Confidence: 1.0
+
+
+## SECTION — business (39 docs)
+
+### FACT 46
+Subject: Research Doc 029: Artist Revenue, IP Rights & the ZAO Revenue Model
+Type: ResearchDoc
+Topic: business
+Doc number: 029
+Description: Artist Revenue, IP Rights & the ZAO Revenue Model
+Source: internal://research/business/029-artist-revenue-ip-rights/
+Confidence: 1.0
+
+
+### FACT 47
+Subject: Research Doc 037: Platform Bridges, Competitor Deep Dives, Monetization & SEO
+Type: ResearchDoc
+Topic: business
+Doc number: 037
+Description: Platform Bridges, Competitor Deep Dives, Monetization & SEO
+Source: internal://research/business/037-bridges-competitors-monetization/
+Confidence: 1.0
+
+
+### FACT 48
+Subject: Research Doc 125: Coinflow Fiat Checkout for ZAO OS
+Type: ResearchDoc
+Topic: business
+Doc number: 125
+Description: Coinflow Fiat Checkout for ZAO OS
+Source: internal://research/business/125-coinflow-fiat-checkout/
+Confidence: 1.0
+
+
+### FACT 49
+Subject: Research Doc 139: Trustware SDK: Secure Crypto Payments & Asset Infrastructure
+Type: ResearchDoc
+Topic: business
+Doc number: 139
+Description: Trustware SDK: Secure Crypto Payments & Asset Infrastructure
+Source: internal://research/business/139-trustware-sdk-deep-dive/
+Confidence: 1.0
+
+
+### FACT 50
+Subject: Research Doc 222: Payment Infrastructure: Stripe, Coinbase Commerce, Coinflow, 0xSplits
+Type: ResearchDoc
+Topic: business
+Doc number: 222
+Description: Payment Infrastructure: Stripe, Coinbase Commerce, Coinflow, 0xSplits
+Source: internal://research/business/222-payment-infrastructure-stripe-coinbase/
+Confidence: 1.0
+
+
+### FACT 51
+Subject: Research Doc 244: Polymarket Trading as ZOUNZ Treasury Revenue: Claude API + Open-Source Toolkit
+Type: ResearchDoc
+Topic: business
+Doc number: 244
+Description: Polymarket Trading as ZOUNZ Treasury Revenue: Claude API + Open-Source Toolkit
+Source: internal://research/business/244-polymarket-claude-api-trading-analysis/
+Confidence: 1.0
+
+
+### FACT 52
+Subject: Research Doc 252: Publish.new: Paragraph's AI-Native Marketplace for Digital Goods
+Type: ResearchDoc
+Topic: business
+Doc number: 252
+Description: Publish.new: Paragraph's AI-Native Marketplace for Digital Goods
+Source: internal://research/business/252-publish-new-agent-marketplace/
+Confidence: 1.0
+
+
+### FACT 53
+Subject: Research Doc 258: ZABAL + SANG Research + FISHBOWLZ Buyback
+Type: ResearchDoc
+Topic: business
+Doc number: 258
+Description: ZABAL + SANG Research + FISHBOWLZ Buyback
+Source: internal://research/business/258-zabal-sang-buyback/
+Confidence: 1.0
+
+
+### FACT 54
+Subject: Research Doc 263: Obsidian's Lean Team Model: $350M Valuation, 9 Employees, 3 Engineers
+Type: ResearchDoc
+Topic: business
+Doc number: 263
+Description: Obsidian's Lean Team Model: $350M Valuation, 9 Employees, 3 Engineers
+Source: internal://research/business/263-obsidian-lean-team-model/
+Confidence: 1.0
+
+
+### FACT 55
+Subject: Research Doc 264: Doc 264: LinkedIn Build-in-Public Playbook for Web3 Builders
+Type: ResearchDoc
+Topic: business
+Doc number: 264
+Description: Doc 264: LinkedIn Build-in-Public Playbook for Web3 Builders
+Source: internal://research/business/264-linkedin-build-in-public-playbook/
+Confidence: 1.0
+
+
+### FACT 56
+Subject: Research Doc 298: FISHBOWLZ Tokenization: Token Design, Fee Splits, and ZABAL Auto-Buyback
+Type: ResearchDoc
+Topic: business
+Doc number: 298
+Description: FISHBOWLZ Tokenization: Token Design, Fee Splits, and ZABAL Auto-Buyback
+Source: internal://research/business/298-fishbowlz-tokenization/
+Confidence: 1.0
+
+
+### FACT 57
+Subject: Research Doc 299: Audio Room Best Practices: UX, Retention, Moderation, and Accessibility for FISHBOWLZ
+Type: ResearchDoc
+Topic: business
+Doc number: 299
+Description: Audio Room Best Practices: UX, Retention, Moderation, and Accessibility for FISHBOWLZ
+Source: internal://research/business/299-audio-room-best-practices/
+Confidence: 1.0
+
+
+### FACT 58
+Subject: Research Doc 307: App Monetization: Ernesto Lopez Framework vs ZAO OS Reality
+Type: ResearchDoc
+Topic: business
+Doc number: 307
+Description: App Monetization: Ernesto Lopez Framework vs ZAO OS Reality
+Source: internal://research/business/307-app-monetization-ernesto-lopez-framework/
+Confidence: 1.0
+
+
+### FACT 59
+Subject: Research Doc 322: Paragraph + Publish.new: Newsletter Platform, Agent Commerce & COC Concertz Integration
+Type: ResearchDoc
+Topic: business
+Doc number: 322
+Description: Paragraph + Publish.new: Newsletter Platform, Agent Commerce & COC Concertz Integration
+Source: internal://research/business/322-paragraph-publishnew-newsletter-agent-commerce/
+Confidence: 1.0
+
+
+### FACT 60
+Subject: Research Doc 324: - ZABAL/SANG Wallet Agent System: Tokenomics, Autonomous Swaps & Promoter Incentives
+Type: ResearchDoc
+Topic: business
+Doc number: 324
+Description: - ZABAL/SANG Wallet Agent System: Tokenomics, Autonomous Swaps & Promoter Incentives
+Source: internal://research/business/324-zabal-sang-wallet-agent-tokenomics/
+Confidence: 1.0
+
+
+### FACT 61
+Subject: Research Doc 333: Doc 333 - AI Music Licensing, Sync Placement & Building an AI Music Label (2026)
+Type: ResearchDoc
+Topic: business
+Doc number: 333
+Description: Doc 333 - AI Music Licensing, Sync Placement & Building an AI Music Label (2026)
+Source: internal://research/business/333-ai-music-licensing-sync-label-deep-dive/
+Confidence: 1.0
+
+
+### FACT 62
+Subject: Research Doc 350: Anatomy of Viral Engagement Bait: Claude Shortcuts + Quant Trading Posts
+Type: ResearchDoc
+Topic: business
+Doc number: 350
+Description: Anatomy of Viral Engagement Bait: Claude Shortcuts + Quant Trading Posts
+Source: internal://research/business/350-viral-engagement-bait-anatomy/
+Confidence: 1.0
+
+
+### FACT 63
+Subject: Research Doc 352: - Paragraph + x402 Agent Content Commerce: Implementation Guide
+Type: ResearchDoc
+Topic: business
+Doc number: 352
+Description: - Paragraph + x402 Agent Content Commerce: Implementation Guide
+Source: internal://research/business/352-paragraph-x402-agent-implementation/
+Confidence: 1.0
+
+
+### FACT 64
+Subject: Research Doc 361: Empire Builder Deep Dive: V3 Features, Distribution, and ZAO Integration Strategy
+Type: ResearchDoc
+Topic: business
+Doc number: 361
+Description: Empire Builder Deep Dive: V3 Features, Distribution, and ZAO Integration Strategy
+Source: internal://research/business/361-empire-builder-deep-dive-v3-integration/
+Confidence: 1.0
+
+
+### FACT 65
+Subject: Research Doc 362: Lean Six Sigma for ZAO Festival Operations
+Type: ResearchDoc
+Topic: business
+Doc number: 362
+Description: Lean Six Sigma for ZAO Festival Operations
+Source: internal://research/business/362-lean-six-sigma-festival-operations/
+Confidence: 1.0
+
+
+### FACT 66
+Subject: Research Doc 406: Coinflow ISV Deep Dive: WaveWarZ + ZAO Integration
+Type: ResearchDoc
+Topic: business
+Doc number: 406
+Description: Coinflow ISV Deep Dive: WaveWarZ + ZAO Integration
+Source: internal://research/business/406-coinflow-isv-deep-dive-wavewarz-zao/
+Confidence: 1.0
+
+
+### FACT 67
+Subject: Research Doc 410: Polymarket Trading Bot via Claude: $11,400 Profit in 19 Days
+Type: ResearchDoc
+Topic: business
+Doc number: 410
+Description: Polymarket Trading Bot via Claude: $11,400 Profit in 19 Days
+Source: internal://research/business/410-polymarket-bot-claude-11k-profit-19-days/
+Confidence: 1.0
+
+
+### FACT 68
+Subject: Research Doc 429: Paragraph Agents Launch (Apr 17 2026): Skills, Micropaywalls, Archive Listing
+Type: ResearchDoc
+Topic: business
+Doc number: 429
+Description: Paragraph Agents Launch (Apr 17 2026): Skills, Micropaywalls, Archive Listing
+Source: internal://research/business/429-paragraph-agents-launch-apr2026/
+Confidence: 1.0
+
+
+### FACT 69
+Subject: Research Doc 455: BCZ Maine Clients: Stephen Coston (Stay Bar Harbor) + Cameron (Riverside Group)
+Type: ResearchDoc
+Topic: business
+Doc number: 455
+Description: BCZ Maine Clients: Stephen Coston (Stay Bar Harbor) + Cameron (Riverside Group)
+Source: internal://research/business/455-bcz-maine-clients-stephen-cameron/
+Confidence: 1.0
+
+
+### FACT 70
+Subject: Research Doc 470: Behavioral Intervention > Financial Literacy: ZAO Playbook
+Type: ResearchDoc
+Topic: business
+Doc number: 470
+Description: Behavioral Intervention > Financial Literacy: ZAO Playbook
+Source: internal://research/business/470-behavioral-intervention-vs-financial-literacy-zao/
+Confidence: 1.0
+
+
+### FACT 71
+Subject: Research Doc 474: Foundercheck BLOCK (3.95): ICP Resolution + Distribution Wedge
+Type: ResearchDoc
+Topic: business
+Doc number: 474
+Description: Foundercheck BLOCK (3.95): ICP Resolution + Distribution Wedge
+Source: internal://research/business/474-foundercheck-block-icp-resolution/
+Confidence: 1.0
+
+
+### FACT 72
+Subject: Research Doc 481: kompreni / Quotient — Anti-"Cucktrading" AI Superforecaster
+Type: ResearchDoc
+Topic: business
+Doc number: 481
+Description: kompreni / Quotient — Anti-"Cucktrading" AI Superforecaster
+Source: internal://research/business/481-kompreni-quotient-anti-cucktrading-superforecaster/
+Confidence: 1.0
+
+
+### FACT 73
+Subject: Research Doc 482: DigiHold's 7 Money Rules (Founder Finance After Losing $1.5M)
+Type: ResearchDoc
+Topic: business
+Doc number: 482
+Description: DigiHold's 7 Money Rules (Founder Finance After Losing $1.5M)
+Source: internal://research/business/482-digihold-seven-money-rules-founder-finance/
+Confidence: 1.0
+
+
+### FACT 74
+Subject: Research Doc 485: Distribution Is Hard V3 (jlcolton) — GTM Field Guide for Builders
+Type: ResearchDoc
+Topic: business
+Doc number: 485
+Description: Distribution Is Hard V3 (jlcolton) — GTM Field Guide for Builders
+Source: internal://research/business/485-distribution-is-hard-v3-jlcolton/
+Confidence: 1.0
+
+
+### FACT 75
+Subject: Research Doc 498: Zlank: Unified Agent-Native SDK (Clanker + Empire Builder + Farcaster Graph)
+Type: ResearchDoc
+Topic: business
+Doc number: 498
+Description: Zlank: Unified Agent-Native SDK (Clanker + Empire Builder + Farcaster Graph)
+Source: internal://research/business/498-zlank-unified-sdk-concept/
+Confidence: 1.0
+
+
+### FACT 76
+Subject: Research Doc 526: Distribution Is Hard V3, Applied: Per-Entity Playbooks for the ZAO Stack
+Type: ResearchDoc
+Topic: business
+Doc number: 526
+Description: Distribution Is Hard V3, Applied: Per-Entity Playbooks for the ZAO Stack
+Source: internal://research/business/526-distribution-v3-zao-entity-playbooks/
+Confidence: 1.0
+
+
+### FACT 77
+Subject: Research Doc 547: BCard / B Foundation / Black Flag Collective: ZAO Partnership Opportunity
+Type: ResearchDoc
+Topic: business
+Doc number: 547
+Description: BCard / B Foundation / Black Flag Collective: ZAO Partnership Opportunity
+Source: internal://research/business/547-bcard-bfoundation-black-flag-collective/
+Confidence: 1.0
+
+
+### FACT 78
+Subject: Research Doc 572: $ZABAL Chain: Avalanche L1, L2, or Stay on Base?
+Type: ResearchDoc
+Topic: business
+Doc number: 572
+Description: $ZABAL Chain: Avalanche L1, L2, or Stay on Base?
+Source: internal://research/business/572-zabal-avalanche-l1-l2-gas-token/
+Confidence: 1.0
+
+
+### FACT 79
+Subject: Research Doc 573: Where AVAX Ecosystem Helps $ZABAL: The Arena, Music Royalties, Retro9000
+Type: ResearchDoc
+Topic: business
+Doc number: 573
+Description: Where AVAX Ecosystem Helps $ZABAL: The Arena, Music Royalties, Retro9000
+Source: internal://research/business/573-zabal-avax-surfaces-arena-music/
+Confidence: 1.0
+
+
+### FACT 80
+Subject: Research Doc 581: Whop Platform + Top Whop Creators Deep Dive (DISPATCH)
+Type: ResearchDoc
+Topic: business
+Doc number: 581
+Description: Whop Platform + Top Whop Creators Deep Dive (DISPATCH)
+Source: internal://research/business/581-whop-creator-deep-dive/
+Confidence: 1.0
+
+
+### FACT 81
+Subject: Research Doc 582: Empire Builder V3 Live (Soft Launch) + New Public API
+Type: ResearchDoc
+Topic: business
+Doc number: 582
+Description: Empire Builder V3 Live (Soft Launch) + New Public API
+Source: internal://research/business/582-empire-builder-v3-live-launch/
+Confidence: 1.0
+
+
+### FACT 82
+Subject: Research Doc 583: Empire Builder x ZAO OS: Integration Idea Surface
+Type: ResearchDoc
+Topic: business
+Doc number: 583
+Description: Empire Builder x ZAO OS: Integration Idea Surface
+Source: internal://research/business/583-empire-builder-zao-os-integration-ideas/
+Confidence: 1.0
+
+
+### FACT 83
+Subject: Research Doc 584: Empire Builder x Farcaster: Top-Creator Playbooks + Live ZABAL Data
+Type: ResearchDoc
+Topic: business
+Doc number: 584
+Description: Empire Builder x Farcaster: Top-Creator Playbooks + Live ZABAL Data
+Source: internal://research/business/584-empire-builder-farcaster-creator-playbooks/
+Confidence: 1.0
+
+
+### FACT 84
+Subject: Research Doc 585: Empire Builder x ZAO OS: Test-Loop Findings + Iteration-2 Idea Surface
+Type: ResearchDoc
+Topic: business
+Doc number: 585
+Description: Empire Builder x ZAO OS: Test-Loop Findings + Iteration-2 Idea Surface
+Source: internal://research/business/585-empire-builder-test-loop-ideas-iteration-2/
+Confidence: 1.0
+
+
+## SECTION — events (32 docs)
+
+### FACT 85
+Subject: Research Doc 201: AI, Creator Economy & Web3 Landscape: March 2026
+Type: ResearchDoc
+Topic: events
+Doc number: 201
+Description: AI, Creator Economy & Web3 Landscape: March 2026
+Source: internal://research/events/201-ai-creator-economy-landscape-march-2026/
+Confidence: 1.0
+
+
+### FACT 86
+Subject: Research Doc 207: ZAO VPS Agent Stack: Full Session Log & Architecture
+Type: ResearchDoc
+Topic: events
+Doc number: 207
+Description: ZAO VPS Agent Stack: Full Session Log & Architecture
+Source: internal://research/events/207-zao-vps-agent-stack-session-log/
+Confidence: 1.0
+
+
+### FACT 87
+Subject: Research Doc 240: Farcaster Agentic Bootcamp (Builders Garden)
+Type: ResearchDoc
+Topic: events
+Doc number: 240
+Description: Farcaster Agentic Bootcamp (Builders Garden)
+Source: internal://research/events/240-farcaster-agentic-bootcamp-builders-garden/
+Confidence: 1.0
+
+
+### FACT 88
+Subject: Research Doc 241: Q1 2026 Big Wins: The ZAO
+Type: ResearchDoc
+Topic: events
+Doc number: 241
+Description: Q1 2026 Big Wins: The ZAO
+Source: internal://research/events/241-q1-2026-big-wins/
+Confidence: 1.0
+
+
+### FACT 89
+Subject: Research Doc 254: ZOE Agent Ecosystem Status (Apr 3 2026)
+Type: ResearchDoc
+Topic: events
+Doc number: 254
+Description: ZOE Agent Ecosystem Status (Apr 3 2026)
+Source: internal://research/events/254-zoe-agent-ecosystem-status/
+Confidence: 1.0
+
+
+### FACT 90
+Subject: Research Doc 257: ZOE Ship Log: Apr 3 2026
+Type: ResearchDoc
+Topic: events
+Doc number: 257
+Description: ZOE Ship Log: Apr 3 2026
+Source: internal://research/events/257-zoe-ship-log-apr-3-2026/
+Confidence: 1.0
+
+
+### FACT 91
+Subject: Research Doc 265: ClawDown Poker Agent (ZOE)
+Type: ResearchDoc
+Topic: events
+Doc number: 265
+Description: ClawDown Poker Agent (ZOE)
+Source: internal://research/events/265-clawdown-poker-agent/
+Confidence: 1.0
+
+
+### FACT 92
+Subject: Research Doc 270: ZAO Stock: Planning & Knowledge Base
+Type: ResearchDoc
+Topic: events
+Doc number: 270
+Description: ZAO Stock: Planning & Knowledge Base
+Source: internal://research/events/270-zao-stock-planning/
+Confidence: 1.0
+
+
+### FACT 93
+Subject: Research Doc 274: ZAO Stock Team: Deep Profiles
+Type: ResearchDoc
+Topic: events
+Doc number: 274
+Description: ZAO Stock Team: Deep Profiles
+Source: internal://research/events/274-zao-stock-team-deep-profiles/
+Confidence: 1.0
+
+
+### FACT 94
+Subject: Research Doc 294: Research Doc 294 - Event Coordinator AI Agents
+Type: ResearchDoc
+Topic: events
+Doc number: 294
+Description: Research Doc 294 - Event Coordinator AI Agents
+Source: internal://research/events/294-event-coordinator-ai-agents/
+Confidence: 1.0
+
+
+### FACT 95
+Subject: Research Doc 316: Farcaster Agentic Bootcamp Week 2: Budget-Friendly Agent Dev Stack
+Type: ResearchDoc
+Topic: events
+Doc number: 316
+Description: Farcaster Agentic Bootcamp Week 2: Budget-Friendly Agent Dev Stack
+Source: internal://research/events/316-farcaster-agentic-bootcamp-week2-deep-dive/
+Confidence: 1.0
+
+
+### FACT 96
+Subject: Research Doc 317: Farcaster Agentic Bootcamp Week 1: Session Transcripts & Extracted Insights
+Type: ResearchDoc
+Topic: events
+Doc number: 317
+Description: Farcaster Agentic Bootcamp Week 1: Session Transcripts & Extracted Insights
+Source: internal://research/events/317-farcaster-agentic-bootcamp-week1-transcripts/
+Confidence: 1.0
+
+
+### FACT 97
+Subject: Research Doc 326: - Farcaster Agentic Bootcamp: Complete Session Guide & ZABAL Agent Swarm Extraction
+Type: ResearchDoc
+Topic: events
+Doc number: 326
+Description: - Farcaster Agentic Bootcamp: Complete Session Guide & ZABAL Agent Swarm Extraction
+Source: internal://research/events/326-agentic-bootcamp-complete-session-guide/
+Confidence: 1.0
+
+
+### FACT 98
+Subject: Research Doc 364: ZAO Festivals Deep Research: Everything for the Pitch
+Type: ResearchDoc
+Topic: events
+Doc number: 364
+Description: ZAO Festivals Deep Research: Everything for the Pitch
+Source: internal://research/events/364-zao-festivals-deep-research/
+Confidence: 1.0
+
+
+### FACT 99
+Subject: Research Doc 369: DreamEvent.ai Framework: What ZAOstock Is Missing
+Type: ResearchDoc
+Topic: events
+Doc number: 369
+Description: DreamEvent.ai Framework: What ZAOstock Is Missing
+Source: internal://research/events/369-dreamevent-framework-gap-analysis/
+Confidence: 1.0
+
+
+### FACT 100
+Subject: Research Doc 418: Birding Man Festival (Ramble On Farm) — Lessons for ZAOstock
+Type: ResearchDoc
+Topic: events
+Doc number: 418
+Description: Birding Man Festival (Ramble On Farm) — Lessons for ZAOstock
+Source: internal://research/events/418-birding-man-festival-analysis/
+Confidence: 1.0
+
+
+### FACT 101
+Subject: Research Doc 423: Music x Crypto Connect Sesh — Apr 17 2026 (WaveWarZ × BCZ Strategies)
+Type: ResearchDoc
+Topic: events
+Doc number: 423
+Description: Music x Crypto Connect Sesh — Apr 17 2026 (WaveWarZ × BCZ Strategies)
+Source: internal://research/events/423-music-x-crypto-connect-sesh-apr17/
+Confidence: 1.0
+
+
+### FACT 102
+Subject: Research Doc 425: ZAOstock Dashboard UI: Six Sigma + Modern PM Tool Patterns
+Type: ResearchDoc
+Topic: events
+Doc number: 425
+Description: ZAOstock Dashboard UI: Six Sigma + Modern PM Tool Patterns
+Source: internal://research/events/425-zaostock-dashboard-ui-lean-kanban-patterns/
+Confidence: 1.0
+
+
+### FACT 103
+Subject: Research Doc 428: ZAOstock Run-of-Show Program (Oct 3, 2026)
+Type: ResearchDoc
+Topic: events
+Doc number: 428
+Description: ZAOstock Run-of-Show Program (Oct 3, 2026)
+Source: internal://research/events/428-zaostock-run-of-show-program/
+Confidence: 1.0
+
+
+### FACT 104
+Subject: Research Doc 433: ZAO Media Capture Pipeline Spec
+Type: ResearchDoc
+Topic: events
+Doc number: 433
+Description: ZAO Media Capture Pipeline Spec
+Source: internal://research/events/433-zao-media-capture-pipeline-spec/
+Confidence: 1.0
+
+
+### FACT 105
+Subject: Research Doc 442: WaveWarZ Sunday Battle Recap Socials — Apr 20 2026
+Type: ResearchDoc
+Topic: events
+Doc number: 442
+Description: WaveWarZ Sunday Battle Recap Socials — Apr 20 2026
+Source: internal://research/events/442-wavewarz-sunday-battle-recap-socials/
+Confidence: 1.0
+
+
+### FACT 106
+Subject: Research Doc 443: ZAOstock Sponsor Pitch Drafts (Oct 3, 2026)
+Type: ResearchDoc
+Topic: events
+Doc number: 443
+Description: ZAOstock Sponsor Pitch Drafts (Oct 3, 2026)
+Source: internal://research/events/443-zao-stock-sponsor-pitch-drafts/
+Confidence: 1.0
+
+
+### FACT 107
+Subject: Research Doc 445: ZAOstock Monday Progress Report (Apr 20, 2026)
+Type: ResearchDoc
+Topic: events
+Doc number: 445
+Description: ZAOstock Monday Progress Report (Apr 20, 2026)
+Source: internal://research/events/445-zao-stock-monday-apr20-report/
+Confidence: 1.0
+
+
+### FACT 108
+Subject: Research Doc 456: FarmDrop x SoulBenders May 24 Benefit + Hannah Semler BCZ Yapz Interview Prep
+Type: ResearchDoc
+Topic: events
+Doc number: 456
+Description: FarmDrop x SoulBenders May 24 Benefit + Hannah Semler BCZ Yapz Interview Prep
+Source: internal://research/events/456-farmdrop-soulbenders-may24-hannah-interview/
+Confidence: 1.0
+
+
+### FACT 109
+Subject: Research Doc 457: FarmDrop: Hannah Voice Memo Deep Brief + May 24 Event Full Run-of-Show
+Type: ResearchDoc
+Topic: events
+Doc number: 457
+Description: FarmDrop: Hannah Voice Memo Deep Brief + May 24 Event Full Run-of-Show
+Source: internal://research/events/457-farmdrop-hannah-voice-memo-event-brief/
+Confidence: 1.0
+
+
+### FACT 110
+Subject: Research Doc 458: FarmDrop Statewide Expansion + Sam Lardner & Barcelona Collab + Maine Follow-Up Todos
+Type: ResearchDoc
+Topic: events
+Doc number: 458
+Description: FarmDrop Statewide Expansion + Sam Lardner & Barcelona Collab + Maine Follow-Up Todos
+Source: internal://research/events/458-farmdrop-statewide-expansion-sam-lardner-collab/
+Confidence: 1.0
+
+
+### FACT 111
+Subject: Research Doc 472: ZAOstock Artist Lockin Timeline (Internal Proposal)
+Type: ResearchDoc
+Topic: events
+Doc number: 472
+Description: ZAOstock Artist Lockin Timeline (Internal Proposal)
+Source: internal://research/events/472-zaostock-artist-lockin-timeline/
+Confidence: 1.0
+
+
+### FACT 112
+Subject: Research Doc 473: Road to ZAOstock: Magnetic Portal Spec
+Type: ResearchDoc
+Topic: events
+Doc number: 473
+Description: Road to ZAOstock: Magnetic Portal Spec
+Source: internal://research/events/473-road-to-zaostock-magnetic-portal/
+Confidence: 1.0
+
+
+### FACT 113
+Subject: Research Doc 476: ZAOstock Apr 22 Team Recap (Internal)
+Type: ResearchDoc
+Topic: events
+Doc number: 476
+Description: ZAOstock Apr 22 Team Recap (Internal)
+Source: internal://research/events/476-zaostock-apr22-team-recap/
+Confidence: 1.0
+
+
+### FACT 114
+Subject: Research Doc 477: ZAOstock Dashboard: Replace Notion Completely (170-Day Build)
+Type: ResearchDoc
+Topic: events
+Doc number: 477
+Description: ZAOstock Dashboard: Replace Notion Completely (170-Day Build)
+Source: internal://research/events/477-zaostock-dashboard-notion-replacement/
+Confidence: 1.0
+
+
+### FACT 115
+Subject: Research Doc 499: Music Festival & Artist Collective Governance: Real-World Models for Flat Teams
+Type: ResearchDoc
+Topic: events
+Doc number: 499
+Description: Music Festival & Artist Collective Governance: Real-World Models for Flat Teams
+Source: internal://research/events/499-music-festival-collective-governance/
+Confidence: 1.0
+
+
+### FACT 116
+Subject: Research Doc 504: ZAOstock Aug 15 2026 Mini-Festival Dry Run
+Type: ResearchDoc
+Topic: events
+Doc number: 504
+Description: ZAOstock Aug 15 2026 Mini-Festival Dry Run
+Source: internal://research/events/504-aug15-dryrun-planning/
+Confidence: 1.0
+
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[authored]-> [each ResearchDoc above]
+- The ZAO -[has_research_doc]-> [each ResearchDoc]
+- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)
+
+---
+Build the manifest, preview the first 3 nodes, then ask me "approve all?". Total 116 ResearchDoc nodes in this batch. Do not commit until I say yes. If a Doc number already exists in graph, MERGE; do not create duplicate.

--- a/content/bonfire-ingest/research-index-music-farcaster.md
+++ b/content/bonfire-ingest/research-index-music-farcaster.md
@@ -1,0 +1,1115 @@
+INGEST BATCH: ZAO Research Library Index — music / farcaster (2 topic folders).
+
+Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. Each ResearchDoc has Topic + Doc number + Description as attributes. Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes.
+
+## SECTION — music (80 docs)
+
+### FACT 1
+Subject: Research Doc 079: SongJam Ecosystem & Music Player Research
+Type: ResearchDoc
+Topic: music
+Doc number: 079
+Description: SongJam Ecosystem & Music Player Research
+Source: internal://research/music/079-songjam-music-player-research/
+Confidence: 1.0
+
+
+### FACT 2
+Subject: Research Doc 082: Music-First Social Platform Redesign Research
+Type: ResearchDoc
+Topic: music
+Doc number: 082
+Description: Music-First Social Platform Redesign Research
+Source: internal://research/music/082-music-social-platform-redesign/
+Confidence: 1.0
+
+
+### FACT 3
+Subject: Research Doc 107: Music Page Layout & Design for ZAO OS
+Type: ResearchDoc
+Topic: music
+Doc number: 107
+Description: Music Page Layout & Design for ZAO OS
+Source: internal://research/music/107-music-page-layout-design/
+Confidence: 1.0
+
+
+### FACT 4
+Subject: Research Doc 112: Audius API Deep Dive for ZAO OS Integration
+Type: ResearchDoc
+Topic: music
+Doc number: 112
+Description: Audius API Deep Dive for ZAO OS Integration
+Source: internal://research/music/112-audius-api-deep-dive/
+Confidence: 1.0
+
+
+### FACT 5
+Subject: Research Doc 113: Top 10 Music Fixes for ZAO OS
+Type: ResearchDoc
+Topic: music
+Doc number: 113
+Description: Top 10 Music Fixes for ZAO OS
+Source: internal://research/music/113-top-10-music-fixes/
+Confidence: 1.0
+
+
+### FACT 6
+Subject: Research Doc 130: Next Music Integrations: Deep Research + Implementation Plan
+Type: ResearchDoc
+Topic: music
+Doc number: 130
+Description: Next Music Integrations: Deep Research + Implementation Plan
+Source: internal://research/music/130-next-music-integrations/
+Confidence: 1.0
+
+
+### FACT 7
+Subject: Research Doc 138: Do Plays on ZAO OS Count? Stream Attribution Deep Dive
+Type: ResearchDoc
+Topic: music
+Doc number: 138
+Description: Do Plays on ZAO OS Count? Stream Attribution Deep Dive
+Source: internal://research/music/138-play-counting-stream-attribution/
+Confidence: 1.0
+
+
+### FACT 8
+Subject: Research Doc 141: On-Chain Music Distribution Landscape 2026
+Type: ResearchDoc
+Topic: music
+Doc number: 141
+Description: On-Chain Music Distribution Landscape 2026
+Source: internal://research/music/141-onchain-music-distribution-landscape/
+Confidence: 1.0
+
+
+### FACT 9
+Subject: Research Doc 143: 0xSplits: Automated Revenue Distribution for ZAO Artists
+Type: ResearchDoc
+Topic: music
+Doc number: 143
+Description: 0xSplits: Automated Revenue Distribution for ZAO Artists
+Source: internal://research/music/143-0xsplits-revenue-distribution/
+Confidence: 1.0
+
+
+### FACT 10
+Subject: Research Doc 144: ZOUNZ + Music NFTs: Unified DAO-Powered Music Distribution
+Type: ResearchDoc
+Topic: music
+Doc number: 144
+Description: ZOUNZ + Music NFTs: Unified DAO-Powered Music Distribution
+Source: internal://research/music/144-zounz-music-nft-unified-distribution/
+Confidence: 1.0
+
+
+### FACT 11
+Subject: Research Doc 145: Simple NFT Platform Design: Music Collectibles for ZAO Members
+Type: ResearchDoc
+Topic: music
+Doc number: 145
+Description: Simple NFT Platform Design: Music Collectibles for ZAO Members
+Source: internal://research/music/145-simple-nft-platform-design/
+Confidence: 1.0
+
+
+### FACT 12
+Subject: Research Doc 146: Open Contracts: Multi-Artist Distribution via Forkable Smart Contracts
+Type: ResearchDoc
+Topic: music
+Doc number: 146
+Description: Open Contracts: Multi-Artist Distribution via Forkable Smart Contracts
+Source: internal://research/music/146-open-contracts-multi-artist-distribution/
+Confidence: 1.0
+
+
+### FACT 13
+Subject: Research Doc 148: Master Integration Plan: ZAO On-Chain Music Distribution Service
+Type: ResearchDoc
+Topic: music
+Doc number: 148
+Description: Master Integration Plan: ZAO On-Chain Music Distribution Service
+Source: internal://research/music/148-master-integration-plan-onchain-distribution/
+Confidence: 1.0
+
+
+### FACT 14
+Subject: Research Doc 151: ZOUNZ Music Distribution Without Zora: Arweave + Thirdweb + 0xSplits
+Type: ResearchDoc
+Topic: music
+Doc number: 151
+Description: ZOUNZ Music Distribution Without Zora: Arweave + Thirdweb + 0xSplits
+Source: internal://research/music/151-zounz-distribution-without-zora/
+Confidence: 1.0
+
+
+### FACT 15
+Subject: Research Doc 152: Arweave Ecosystem Deep Dive: Building a Full Music Layer on the Permaweb
+Type: ResearchDoc
+Topic: music
+Doc number: 152
+Description: Arweave Ecosystem Deep Dive: Building a Full Music Layer on the Permaweb
+Source: internal://research/music/152-arweave-ecosystem-deep-dive/
+Confidence: 1.0
+
+
+### FACT 16
+Subject: Research Doc 153: BazAR & Atomic Assets: Arweave-Native Music Distribution for ZAO
+Type: ResearchDoc
+Topic: music
+Doc number: 153
+Description: BazAR & Atomic Assets: Arweave-Native Music Distribution for ZAO
+Source: internal://research/music/153-bazar-arweave-atomic-assets-music/
+Confidence: 1.0
+
+
+### FACT 17
+Subject: Research Doc 155: End-to-End Music NFT: Upload → Mint → Buy (Implementation Plan)
+Type: ResearchDoc
+Topic: music
+Doc number: 155
+Description: End-to-End Music NFT: Upload → Mint → Buy (Implementation Plan)
+Source: internal://research/music/155-music-nft-end-to-end-implementation/
+Confidence: 1.0
+
+
+### FACT 18
+Subject: Research Doc 156: Pods.media & Podcast Tokenization: Can ZAO Clone It on Arweave?
+Type: ResearchDoc
+Topic: music
+Doc number: 156
+Description: Pods.media & Podcast Tokenization: Can ZAO Clone It on Arweave?
+Source: internal://research/music/156-pods-media-podcast-tokenization/
+Confidence: 1.0
+
+
+### FACT 19
+Subject: Research Doc 160: Audio Spaces Landscape: Farcaster Apps, X Spaces Competitors & Provider Comparison
+Type: ResearchDoc
+Topic: music
+Doc number: 160
+Description: Audio Spaces Landscape: Farcaster Apps, X Spaces Competitors & Provider Comparison
+Source: internal://research/music/160-audio-spaces-landscape-comparison/
+Confidence: 1.0
+
+
+### FACT 20
+Subject: Research Doc 167: Audio APIs, Music Players & Display Patterns
+Type: ResearchDoc
+Topic: music
+Doc number: 167
+Description: Audio APIs, Music Players & Display Patterns
+Source: internal://research/music/167-audio-apis-music-players-displays/
+Confidence: 1.0
+
+
+### FACT 21
+Subject: Research Doc 185: Synchronized Listening Rooms & Collaborative Music Experiences
+Type: ResearchDoc
+Topic: music
+Doc number: 185
+Description: Synchronized Listening Rooms & Collaborative Music Experiences
+Source: internal://research/music/185-synchronized-listening-rooms/
+Confidence: 1.0
+
+
+### FACT 22
+Subject: Research Doc 186: Music Discovery Feed — Research & Implementation Plan
+Type: ResearchDoc
+Topic: music
+Doc number: 186
+Description: Music Discovery Feed — Research & Implementation Plan
+Source: internal://research/music/186-music-discovery-feeds/
+Confidence: 1.0
+
+
+### FACT 23
+Subject: Research Doc 187: Songlink/Odesli API for Universal Music Links
+Type: ResearchDoc
+Topic: music
+Doc number: 187
+Description: Songlink/Odesli API for Universal Music Links
+Source: internal://research/music/187-songlink-odesli-api/
+Confidence: 1.0
+
+
+### FACT 24
+Subject: Research Doc 189: Mobile Music Player Optimization & Advanced Features
+Type: ResearchDoc
+Topic: music
+Doc number: 189
+Description: Mobile Music Player Optimization & Advanced Features
+Source: internal://research/music/189-mobile-player-optimization/
+Confidence: 1.0
+
+
+### FACT 25
+Subject: Research Doc 190: ZAO OS Music Player: Complete Audit & Future Roadmap
+Type: ResearchDoc
+Topic: music
+Doc number: 190
+Description: ZAO OS Music Player: Complete Audit & Future Roadmap
+Source: internal://research/music/190-music-player-complete-audit/
+Confidence: 1.0
+
+
+### FACT 26
+Subject: Research Doc 209: AI Video Generation Tools for ZAO OS
+Type: ResearchDoc
+Topic: music
+Doc number: 209
+Description: AI Video Generation Tools for ZAO OS
+Source: internal://research/music/209-ai-video-generation-tools/
+Confidence: 1.0
+
+
+### FACT 27
+Subject: Research Doc 211: Music Player UI Best Practices & Feature Research
+Type: ResearchDoc
+Topic: music
+Doc number: 211
+Description: Music Player UI Best Practices & Feature Research
+Source: internal://research/music/211-music-player-ui-best-practices/
+Confidence: 1.0
+
+
+### FACT 28
+Subject: Research Doc 216: Doc 216 — AI Features for ZAO OS Live Rooms & Music
+Type: ResearchDoc
+Topic: music
+Doc number: 216
+Description: Doc 216 — AI Features for ZAO OS Live Rooms & Music
+Source: internal://research/music/216-ai-features-live-rooms-music/
+Confidence: 1.0
+
+
+### FACT 29
+Subject: Research Doc 220: Mobile-First Music App UX Patterns for ZAO OS
+Type: ResearchDoc
+Topic: music
+Doc number: 220
+Description: Mobile-First Music App UX Patterns for ZAO OS
+Source: internal://research/music/220-mobile-first-music-ux-patterns/
+Confidence: 1.0
+
+
+### FACT 30
+Subject: Research Doc 255: FISHBOWLZ: Persistent Async Audio Spaces
+Type: ResearchDoc
+Topic: music
+Doc number: 255
+Description: FISHBOWLZ: Persistent Async Audio Spaces
+Source: internal://research/music/255-fishbowlz-spec/
+Confidence: 1.0
+
+
+### FACT 31
+Subject: Research Doc 261: AI Agent Music Pipeline
+Type: ResearchDoc
+Topic: music
+Doc number: 261
+Description: AI Agent Music Pipeline
+Source: internal://research/music/261-ai-agent-music-pipeline/
+Confidence: 1.0
+
+
+### FACT 32
+Subject: Research Doc 273: Web3 Streaming Features: Wallet Tipping, Token-Gated Rooms, NFT Tickets
+Type: ResearchDoc
+Topic: music
+Doc number: 273
+Description: Web3 Streaming Features: Wallet Tipping, Token-Gated Rooms, NFT Tickets
+Source: internal://research/music/273-web3-streaming-features-tipping-gating-tickets/
+Confidence: 1.0
+
+
+### FACT 33
+Subject: Research Doc 277: FISHBOWLZ Audio Providers & Architecture
+Type: ResearchDoc
+Topic: music
+Doc number: 277
+Description: FISHBOWLZ Audio Providers & Architecture
+Source: internal://research/music/277-fishbowlz-audio-providers/
+Confidence: 1.0
+
+
+### FACT 34
+Subject: Research Doc 280: FISHBOWLZ: MVP to SaaS-Ready Roadmap
+Type: ResearchDoc
+Topic: music
+Doc number: 280
+Description: FISHBOWLZ: MVP to SaaS-Ready Roadmap
+Source: internal://research/music/280-fishbowlz-mvp-to-saas-roadmap/
+Confidence: 1.0
+
+
+### FACT 35
+Subject: Research Doc 281: Audio Room Competitive Landscape 2026
+Type: ResearchDoc
+Topic: music
+Doc number: 281
+Description: Audio Room Competitive Landscape 2026
+Source: internal://research/music/281-audio-room-competitive-landscape/
+Confidence: 1.0
+
+
+### FACT 36
+Subject: Research Doc 313: Doc 313 - ElevenLabs Voice Changer for Music Production
+Type: ResearchDoc
+Topic: music
+Doc number: 313
+Description: Doc 313 - ElevenLabs Voice Changer for Music Production
+Source: internal://research/music/313-elevenlabs-voice-changer-music-production/
+Confidence: 1.0
+
+
+### FACT 37
+Subject: Research Doc 313: Doc 313: TikTok, Reels & Shorts Marketing for AI-Assisted Musicians (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 313
+Description: Doc 313: TikTok, Reels & Shorts Marketing for AI-Assisted Musicians (2026)
+Source: internal://research/music/313-tiktok-reels-ai-music-marketing/
+Confidence: 1.0
+
+
+### FACT 38
+Subject: Research Doc 313: Doc 313 - ElevenLabs Scribe v2 Speech-to-Text for Community Transcription
+Type: ResearchDoc
+Topic: music
+Doc number: 313
+Description: Doc 313 - ElevenLabs Scribe v2 Speech-to-Text for Community Transcription
+Source: internal://research/music/313-elevenlabs-scribe-v2-speech-to-text/
+Confidence: 1.0
+
+
+### FACT 39
+Subject: Research Doc 313: Doc 313 - AI Music Production Workflows 2026: Complete Pipeline Guide
+Type: ResearchDoc
+Topic: music
+Doc number: 313
+Description: Doc 313 - AI Music Production Workflows 2026: Complete Pipeline Guide
+Source: internal://research/music/313-ai-music-production-workflows-2026/
+Confidence: 1.0
+
+
+### FACT 40
+Subject: Research Doc 314: Doc 314 - Music Metadata, ISRC Codes & AI-Generated Music Distribution (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 314
+Description: Doc 314 - Music Metadata, ISRC Codes & AI-Generated Music Distribution (2026)
+Source: internal://research/music/314-music-metadata-isrc-ai-distribution/
+Confidence: 1.0
+
+
+### FACT 41
+Subject: Research Doc 315: Doc 315: Revenue Stacking - Monetizing a Single AI-Generated Song (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 315
+Description: Doc 315: Revenue Stacking - Monetizing a Single AI-Generated Song (2026)
+Source: internal://research/music/315-ai-song-revenue-stacking/
+Confidence: 1.0
+
+
+### FACT 42
+Subject: Research Doc 319: AI Music Creation Platforms: Multi-Output Song Production
+Type: ResearchDoc
+Topic: music
+Doc number: 319
+Description: AI Music Creation Platforms: Multi-Output Song Production
+Source: internal://research/music/319-ai-music-creation-platforms-multi-output/
+Confidence: 1.0
+
+
+### FACT 43
+Subject: Research Doc 320: Doc 320: AI-Generated Music for Games, Interactive Media & Roblox (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 320
+Description: Doc 320: AI-Generated Music for Games, Interactive Media & Roblox (2026)
+Source: internal://research/music/320-ai-music-games-interactive-media/
+Confidence: 1.0
+
+
+### FACT 44
+Subject: Research Doc 320: Doc 320 - ElevenLabs Music API Deep Dive (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 320
+Description: Doc 320 - ElevenLabs Music API Deep Dive (2026)
+Source: internal://research/music/320-elevenlabs-music-api-deep-dive/
+Confidence: 1.0
+
+
+### FACT 45
+Subject: Research Doc 320: Anatomy of a Viral Summer Song: Making "The Summer of 26"
+Type: ResearchDoc
+Topic: music
+Doc number: 320
+Description: Anatomy of a Viral Summer Song: Making "The Summer of 26"
+Source: internal://research/music/320-anatomy-viral-summer-songs/
+Confidence: 1.0
+
+
+### FACT 46
+Subject: Research Doc 321: Doc 321: Suno AI Music Platform - Deep Dive (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 321
+Description: Doc 321: Suno AI Music Platform - Deep Dive (April 2026)
+Source: internal://research/music/321-suno-ai-music-platform-2026/
+Confidence: 1.0
+
+
+### FACT 47
+Subject: Research Doc 322: Doc 322: AI Music Distribution & Marketing for Independent Artists (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 322
+Description: Doc 322: AI Music Distribution & Marketing for Independent Artists (2026)
+Source: internal://research/music/322-ai-music-distribution-marketing-2026/
+Confidence: 1.0
+
+
+### FACT 48
+Subject: Research Doc 322: Doc 322: Kits.AI - Singing Voice Conversion Platform
+Type: ResearchDoc
+Topic: music
+Doc number: 322
+Description: Doc 322: Kits.AI - Singing Voice Conversion Platform
+Source: internal://research/music/322-kits-ai-singing-voice-conversion/
+Confidence: 1.0
+
+
+### FACT 49
+Subject: Research Doc 323: Doc 323: Mixing & Mastering AI-Generated Music in a DAW (2026 Guide)
+Type: ResearchDoc
+Topic: music
+Doc number: 323
+Description: Doc 323: Mixing & Mastering AI-Generated Music in a DAW (2026 Guide)
+Source: internal://research/music/323-mixing-mastering-ai-music-daw-guide/
+Confidence: 1.0
+
+
+### FACT 50
+Subject: Research Doc 323: ElevenLabs API: Full Capabilities & What We Can Build
+Type: ResearchDoc
+Topic: music
+Doc number: 323
+Description: ElevenLabs API: Full Capabilities & What We Can Build
+Source: internal://research/music/323-elevenlabs-api-full-capabilities/
+Confidence: 1.0
+
+
+### FACT 51
+Subject: Research Doc 323: Doc 323 - ElevenLabs Music Dubbing & Song Translation (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 323
+Description: Doc 323 - ElevenLabs Music Dubbing & Song Translation (2026)
+Source: internal://research/music/323-elevenlabs-music-dubbing-translation/
+Confidence: 1.0
+
+
+### FACT 52
+Subject: Research Doc 324: ACE-Step Deep Dive: Getting the Most Out of AI Music Generation
+Type: ResearchDoc
+Topic: music
+Doc number: 324
+Description: ACE-Step Deep Dive: Getting the Most Out of AI Music Generation
+Source: internal://research/music/324-ace-step-deep-dive/
+Confidence: 1.0
+
+
+### FACT 53
+Subject: Research Doc 326: AI Songwriting Collaborator Guide: Writing "The Summer of 26"
+Type: ResearchDoc
+Topic: music
+Doc number: 326
+Description: AI Songwriting Collaborator Guide: Writing "The Summer of 26"
+Source: internal://research/music/326-ai-songwriting-collaborator-guide/
+Confidence: 1.0
+
+
+### FACT 54
+Subject: Research Doc 327: Doc 327 - AI-Generated Music: Viral Hits & Commercial Success Case Studies
+Type: ResearchDoc
+Topic: music
+Doc number: 327
+Description: Doc 327 - AI-Generated Music: Viral Hits & Commercial Success Case Studies
+Source: internal://research/music/327-ai-music-viral-commercial-success-case-studies/
+Confidence: 1.0
+
+
+### FACT 55
+Subject: Research Doc 327: Doc 327 - Open Source Speech-to-Text: Whisper & Alternatives Deep Dive
+Type: ResearchDoc
+Topic: music
+Doc number: 327
+Description: Doc 327 - Open Source Speech-to-Text: Whisper & Alternatives Deep Dive
+Source: internal://research/music/327-open-source-speech-to-text-whisper-alternatives/
+Confidence: 1.0
+
+
+### FACT 56
+Subject: Research Doc 328: Doc 328 - Open Source Singing Voice Synthesis & Conversion Tools (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 328
+Description: Doc 328 - Open Source Singing Voice Synthesis & Conversion Tools (April 2026)
+Source: internal://research/music/328-open-source-singing-voice-synthesis-tools/
+Confidence: 1.0
+
+
+### FACT 57
+Subject: Research Doc 328: Open Source Music Generation Landscape 2026: Complete Model Directory
+Type: ResearchDoc
+Topic: music
+Doc number: 328
+Description: Open Source Music Generation Landscape 2026: Complete Model Directory
+Source: internal://research/music/328-open-source-music-generation-landscape-2026/
+Confidence: 1.0
+
+
+### FACT 58
+Subject: Research Doc 329: Doc 329 - Open Source Text-to-Speech: ElevenLabs Alternatives (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 329
+Description: Doc 329 - Open Source Text-to-Speech: ElevenLabs Alternatives (April 2026)
+Source: internal://research/music/329-open-source-tts-elevenlabs-alternatives/
+Confidence: 1.0
+
+
+### FACT 59
+Subject: Research Doc 329: The $0 Music Production Stack: Idea to Distributed Song (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 329
+Description: The $0 Music Production Stack: Idea to Distributed Song (April 2026)
+Source: internal://research/music/329-zero-dollar-music-production-stack/
+Confidence: 1.0
+
+
+### FACT 60
+Subject: Research Doc 330: Doc 330 - Open Source Stem Separation Tools 2026: Deep Dive
+Type: ResearchDoc
+Topic: music
+Doc number: 330
+Description: Doc 330 - Open Source Stem Separation Tools 2026: Deep Dive
+Source: internal://research/music/330-open-source-stem-separation-tools-2026/
+Confidence: 1.0
+
+
+### FACT 61
+Subject: Research Doc 331: AI Music Video Generation Tools Deep Dive (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 331
+Description: AI Music Video Generation Tools Deep Dive (April 2026)
+Source: internal://research/music/331-ai-music-video-generation-deep-dive-2026/
+Confidence: 1.0
+
+
+### FACT 62
+Subject: Research Doc 332: Music Distribution Infrastructure on Farcaster & Web3 (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 332
+Description: Music Distribution Infrastructure on Farcaster & Web3 (April 2026)
+Source: internal://research/music/332-farcaster-music-distribution-infrastructure-2026/
+Confidence: 1.0
+
+
+### FACT 63
+Subject: Research Doc 333: Doc 333: AI Music Practitioners, Creators & Educators (April 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 333
+Description: Doc 333: AI Music Practitioners, Creators & Educators (April 2026)
+Source: internal://research/music/333-ai-music-practitioners-creators-educators-2026/
+Confidence: 1.0
+
+
+### FACT 64
+Subject: Research Doc 334: Doc 334: AI Music Prompt Engineering Masterclass
+Type: ResearchDoc
+Topic: music
+Doc number: 334
+Description: Doc 334: AI Music Prompt Engineering Masterclass
+Source: internal://research/music/334-ai-music-prompt-engineering-masterclass/
+Confidence: 1.0
+
+
+### FACT 65
+Subject: Research Doc 335: Doc 335: Live AI Music Performance & Festival Guide (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 335
+Description: Doc 335: Live AI Music Performance & Festival Guide (2026)
+Source: internal://research/music/335-live-ai-music-performance-festival-guide/
+Confidence: 1.0
+
+
+### FACT 66
+Subject: Research Doc 336: Doc 336: Spatial Audio & Dolby Atmos for AI-Generated Music
+Type: ResearchDoc
+Topic: music
+Doc number: 336
+Description: Doc 336: Spatial Audio & Dolby Atmos for AI-Generated Music
+Source: internal://research/music/336-spatial-audio-dolby-atmos-ai-music/
+Confidence: 1.0
+
+
+### FACT 67
+Subject: Research Doc 336: Doc 336: Sound Design & SFX for AI-Generated Music Production (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 336
+Description: Doc 336: Sound Design & SFX for AI-Generated Music Production (2026)
+Source: internal://research/music/336-sound-design-sfx-ai-music-production/
+Confidence: 1.0
+
+
+### FACT 68
+Subject: Research Doc 336: Doc 336: AI Mastering & Mixing Tools Deep Dive (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 336
+Description: Doc 336: AI Mastering & Mixing Tools Deep Dive (2026)
+Source: internal://research/music/336-ai-mastering-mixing-tools-deep-dive-2026/
+Confidence: 1.0
+
+
+### FACT 69
+Subject: Research Doc 337: Doc 337: Microphone & Recording Setup for AI Voice Cloning + Music Production
+Type: ResearchDoc
+Topic: music
+Doc number: 337
+Description: Doc 337: Microphone & Recording Setup for AI Voice Cloning + Music Production
+Source: internal://research/music/337-microphone-recording-setup-voice-cloning/
+Confidence: 1.0
+
+
+### FACT 70
+Subject: Research Doc 337: Doc 337: Spotify Playlist Placement & Streaming Optimization for AI-Generated Music (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 337
+Description: Doc 337: Spotify Playlist Placement & Streaming Optimization for AI-Generated Music (2026)
+Source: internal://research/music/337-spotify-playlist-placement-streaming-optimization-2026/
+Confidence: 1.0
+
+
+### FACT 71
+Subject: Research Doc 338: Doc 338: Selling AI-Generated Beats & Sample Packs - Revenue Guide (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 338
+Description: Doc 338: Selling AI-Generated Beats & Sample Packs - Revenue Guide (2026)
+Source: internal://research/music/338-ai-beats-sample-packs-revenue-guide/
+Confidence: 1.0
+
+
+### FACT 72
+Subject: Research Doc 338: AI-Generated Music for Podcasts, Radio Shows & Audio Content (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 338
+Description: AI-Generated Music for Podcasts, Radio Shows & Audio Content (2026)
+Source: internal://research/music/338-ai-music-podcasts-radio-shows-2026/
+Confidence: 1.0
+
+
+### FACT 73
+Subject: Research Doc 340: Doc 340 - Remote Collaboration Tools for AI Music Production (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 340
+Description: Doc 340 - Remote Collaboration Tools for AI Music Production (2026)
+Source: internal://research/music/340-remote-collaboration-tools-ai-music-2026/
+Confidence: 1.0
+
+
+### FACT 74
+Subject: Research Doc 341: Doc 341: Music Theory for AI Music Generation Prompts
+Type: ResearchDoc
+Topic: music
+Doc number: 341
+Description: Doc 341: Music Theory for AI Music Generation Prompts
+Source: internal://research/music/341-music-theory-ai-prompting/
+Confidence: 1.0
+
+
+### FACT 75
+Subject: Research Doc 342: Doc 342: AI Hip-Hop Production Deep Dive - Complete Guide for Rappers (2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 342
+Description: Doc 342: AI Hip-Hop Production Deep Dive - Complete Guide for Rappers (2026)
+Source: internal://research/music/342-ai-hip-hop-production-deep-dive-2026/
+Confidence: 1.0
+
+
+### FACT 76
+Subject: Research Doc 407: Music NFT Sales via Coinflow: Fiat-to-Mint on Base
+Type: ResearchDoc
+Topic: music
+Doc number: 407
+Description: Music NFT Sales via Coinflow: Fiat-to-Mint on Base
+Source: internal://research/music/407-music-nft-coinflow-fiat-mint/
+Confidence: 1.0
+
+
+### FACT 77
+Subject: Research Doc 446: Doc 446: Crown Vics Artist Outreach - ZAO Stock Oct 3 Music Programming
+Type: ResearchDoc
+Topic: music
+Doc number: 446
+Description: Doc 446: Crown Vics Artist Outreach - ZAO Stock Oct 3 Music Programming
+Source: internal://research/music/446-crown-vics-artist-outreach/
+Confidence: 1.0
+
+
+### FACT 78
+Subject: Research Doc 475: ZAO Music Entity: Web3 Artist Support Collective
+Type: ResearchDoc
+Topic: music
+Doc number: 475
+Description: ZAO Music Entity: Web3 Artist Support Collective
+Source: internal://research/music/475-zao-music-entity/
+Confidence: 1.0
+
+
+### FACT 79
+Subject: Research Doc 535: AnyTwoCardzz: Web3 Music Producer + NFT Collector
+Type: ResearchDoc
+Topic: music
+Doc number: 535
+Description: AnyTwoCardzz: Web3 Music Producer + NFT Collector
+Source: internal://research/music/535-anytwocardzz-web3-music-producer-post/
+Confidence: 1.0
+
+
+### FACT 80
+Subject: Research Doc 561: djOS™ AI DJ Co-Pilot (Mainstream Entertainment Group, Apr 27 2026)
+Type: ResearchDoc
+Topic: music
+Doc number: 561
+Description: djOS™ AI DJ Co-Pilot (Mainstream Entertainment Group, Apr 27 2026)
+Source: internal://research/music/561-djos-ai-dj-copilot-mainstream/
+Confidence: 1.0
+
+
+## SECTION — farcaster (30 docs)
+
+### FACT 81
+Subject: Research Doc 002: Farcaster Hub API
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 002
+Description: Farcaster Hub API
+Source: internal://research/farcaster/002-farcaster-hub-api/
+Confidence: 1.0
+
+
+### FACT 82
+Subject: Research Doc 017: Neynar FID Registration & Managed Signers
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 017
+Description: Neynar FID Registration & Managed Signers
+Source: internal://research/farcaster/017-neynar-onboarding/
+Confidence: 1.0
+
+
+### FACT 83
+Subject: Research Doc 020: Followers / Following Feed (Sortable, Filterable)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 020
+Description: Followers / Following Feed (Sortable, Filterable)
+Source: internal://research/farcaster/020-followers-following-feed/
+Confidence: 1.0
+
+
+### FACT 84
+Subject: Research Doc 073: Farcaster Ecosystem Update (March 2026)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 073
+Description: Farcaster Ecosystem Update (March 2026)
+Source: internal://research/farcaster/073-farcaster-ecosystem-2026-update/
+Confidence: 1.0
+
+
+### FACT 85
+Subject: Research Doc 074: XMTP V3 Browser SDK & MLS Encryption
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 074
+Description: XMTP V3 Browser SDK & MLS Encryption
+Source: internal://research/farcaster/074-xmtp-v4-mls-encryption/
+Confidence: 1.0
+
+
+### FACT 86
+Subject: Research Doc 081: Farcaster Social Graph APIs & Social Sharing Features
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 081
+Description: Farcaster Social Graph APIs & Social Sharing Features
+Source: internal://research/farcaster/081-farcaster-social-graph-sharing/
+Confidence: 1.0
+
+
+### FACT 87
+Subject: Research Doc 123: DFOS (Dark Forest Operating System)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 123
+Description: DFOS (Dark Forest Operating System)
+Source: internal://research/farcaster/123-dfos-dark-forest-protocol/
+Confidence: 1.0
+
+
+### FACT 88
+Subject: Research Doc 124: Sopha: Deep Social on Farcaster (Curation Client)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 124
+Description: Sopha: Deep Social on Farcaster (Curation Client)
+Source: internal://research/farcaster/124-sopha-deep-social-farcaster/
+Confidence: 1.0
+
+
+### FACT 89
+Subject: Research Doc 173: Farcaster Mini Apps Integration for ZAO OS
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 173
+Description: Farcaster Mini Apps Integration for ZAO OS
+Source: internal://research/farcaster/173-farcaster-miniapps-integration/
+Confidence: 1.0
+
+
+### FACT 90
+Subject: Research Doc 199: Advanced Social Graph Features: Visualization, Growth Tracking, Influence Mapping
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 199
+Description: Advanced Social Graph Features: Visualization, Growth Tracking, Influence Mapping
+Source: internal://research/farcaster/199-advanced-social-graph-features/
+Confidence: 1.0
+
+
+### FACT 91
+Subject: Research Doc 250: Farcaster Mini Apps llms.txt Deep Dive (April 2026)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 250
+Description: Farcaster Mini Apps llms.txt Deep Dive (April 2026)
+Source: internal://research/farcaster/250-farcaster-miniapps-llms-txt-2026/
+Confidence: 1.0
+
+
+### FACT 92
+Subject: Research Doc 260: BREAKING: Neynar Acquires Far caster (April 3, 2026)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 260
+Description: BREAKING: Neynar Acquires Far caster (April 3, 2026)
+Source: internal://research/farcaster/260-neynar-acquires-farcaster/
+Confidence: 1.0
+
+
+### FACT 93
+Subject: Research Doc 293: Sopha External Feed API Integration
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 293
+Description: Sopha External Feed API Integration
+Source: internal://research/farcaster/293-sopha-api-integration/
+Confidence: 1.0
+
+
+### FACT 94
+Subject: Research Doc 295: Farcaster Snaps
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 295
+Description: Farcaster Snaps
+Source: internal://research/farcaster/295-farcaster-snaps/
+Confidence: 1.0
+
+
+### FACT 95
+Subject: Research Doc 304: Quilibrium, Hypersnap, and Free Neynar API via haatz.quilibrium.com
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 304
+Description: Quilibrium, Hypersnap, and Free Neynar API via haatz.quilibrium.com
+Source: internal://research/farcaster/304-quilibrium-hypersnap-free-neynar-api/
+Confidence: 1.0
+
+
+### FACT 96
+Subject: Research Doc 305: Farcaster Channel Moderation & Community Management
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 305
+Description: Farcaster Channel Moderation & Community Management
+Source: internal://research/farcaster/305-channel-moderation-community-management/
+Confidence: 1.0
+
+
+### FACT 97
+Subject: Research Doc 306: Farcaster Protocol Features Gap Analysis for ZAO OS
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 306
+Description: Farcaster Protocol Features Gap Analysis for ZAO OS
+Source: internal://research/farcaster/306-farcaster-protocol-features-gap-analysis/
+Confidence: 1.0
+
+
+### FACT 98
+Subject: Research Doc 308: Farcaster Ecosystem Spring 2026: Snaps, Neynar Stewardship, FarCon Rome
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 308
+Description: Farcaster Ecosystem Spring 2026: Snaps, Neynar Stewardship, FarCon Rome
+Source: internal://research/farcaster/308-farcaster-ecosystem-spring-2026/
+Confidence: 1.0
+
+
+### FACT 99
+Subject: Research Doc 309: Snapchain vs Hypersnap: Protocol Architecture Deep Dive
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 309
+Description: Snapchain vs Hypersnap: Protocol Architecture Deep Dive
+Source: internal://research/farcaster/309-snapchain-hypersnap-protocol-deep-dive/
+Confidence: 1.0
+
+
+### FACT 100
+Subject: Research Doc 489: Hypersnap + Cass on Mars — Run a Farcaster Snapchain Node
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 489
+Description: Hypersnap + Cass on Mars — Run a Farcaster Snapchain Node
+Source: internal://research/farcaster/489-hypersnap-farcaster-node-cassonmars/
+Confidence: 1.0
+
+
+### FACT 101
+Subject: Research Doc 505: Zlank.online Builder Spec (synthesized from 4-agent research)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 505
+Description: Zlank.online Builder Spec (synthesized from 4-agent research)
+Source: internal://research/farcaster/505-zlank-online-builder-spec/
+Confidence: 1.0
+
+
+### FACT 102
+Subject: Research Doc 527: Zlank Next: Top 3 Builds Post-FarHack
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 527
+Description: Zlank Next: Top 3 Builds Post-FarHack
+Source: internal://research/farcaster/527-zlank-next-3-builds/
+Confidence: 1.0
+
+
+### FACT 103
+Subject: Research Doc 534: Snap Best Practices From The Wild
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 534
+Description: Snap Best Practices From The Wild
+Source: internal://research/farcaster/534-snap-best-practices-from-the-wild/
+Confidence: 1.0
+
+
+### FACT 104
+Subject: Research Doc 548: Lazer Mini Apps CLI Evaluation (miniapps.lazer.tools)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 548
+Description: Lazer Mini Apps CLI Evaluation (miniapps.lazer.tools)
+Source: internal://research/farcaster/548-lazer-miniapps-cli-evaluation/
+Confidence: 1.0
+
+
+### FACT 105
+Subject: Research Doc 571: Intori SCIS + Tuum Tech: Donald Bullers Meeting + ZAO Integration Path
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 571
+Description: Intori SCIS + Tuum Tech: Donald Bullers Meeting + ZAO Integration Path
+Source: internal://research/farcaster/571-intori-scis-tuum-tech-db-meeting/
+Confidence: 1.0
+
+
+### FACT 106
+Subject: Research Doc 575: Mini App Splash Stuck: Postmortem + Best Practices
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 575
+Description: Mini App Splash Stuck: Postmortem + Best Practices
+Source: internal://research/farcaster/575-miniapp-splash-best-practices/
+Confidence: 1.0
+
+
+### FACT 107
+Subject: Research Doc 586: Hypersnap Node Install Playbook (VPS Purchase Decision + Step-by-Step)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 586
+Description: Hypersnap Node Install Playbook (VPS Purchase Decision + Step-by-Step)
+Source: internal://research/farcaster/586-hypersnap-node-vps-install-playbook/
+Confidence: 1.0
+
+
+### FACT 108
+Subject: Research Doc 587: Hypersnap + Quilibrium + farcasterorg Ecosystem (May 2026 Status)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 587
+Description: Hypersnap + Quilibrium + farcasterorg Ecosystem (May 2026 Status)
+Source: internal://research/farcaster/587-hypersnap-quilibrium-farcasterorg-ecosystem-may2026/
+Confidence: 1.0
+
+
+### FACT 109
+Subject: Research Doc 588: Cassie Heart (CassOnMars) GitHub Deep Profile
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 588
+Description: Cassie Heart (CassOnMars) GitHub Deep Profile
+Source: internal://research/farcaster/588-cassie-heart-github-deep-profile/
+Confidence: 1.0
+
+
+### FACT 110
+Subject: Research Doc 589: haatz.quilibrium.com Coverage Audit + Cassie Cast Intel (May 2026)
+Type: ResearchDoc
+Topic: farcaster
+Doc number: 589
+Description: haatz.quilibrium.com Coverage Audit + Cassie Cast Intel (May 2026)
+Source: internal://research/farcaster/589-haatz-coverage-cassie-casts-may2026/
+Confidence: 1.0
+
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[authored]-> [each ResearchDoc above]
+- The ZAO -[has_research_doc]-> [each ResearchDoc]
+- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)
+
+---
+Build the manifest, preview the first 3 nodes, then ask me "approve all?". Total 110 ResearchDoc nodes in this batch. Do not commit until I say yes. If a Doc number already exists in graph, MERGE; do not create duplicate.

--- a/scripts/generate-research-index-ingest.py
+++ b/scripts/generate-research-index-ingest.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Generate ingest-ready Bonfire .md files for the ZAO research library.
+
+Reads research/<folder>/<num>-<slug>/README.md across the repo and emits
+five thematic ingest files at content/bonfire-ingest/research-index-*.md.
+Each file holds one fact per research doc with a one-line summary pulled
+from the doc's first H1 or first non-empty narrative line.
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "research"
+OUT = REPO / "content" / "bonfire-ingest"
+
+GROUPS: dict[str, list[str]] = {
+    "agents": ["agents"],
+    "dev-workflows": ["dev-workflows"],
+    "music-farcaster": ["music", "farcaster"],
+    "infra-business-events": ["infrastructure", "business", "events"],
+    "governance-community-identity": [
+        "governance",
+        "community",
+        "identity",
+        "cross-platform",
+        "security",
+        "wavewarz",
+        "inspiration",
+    ],
+}
+
+
+def first_h1_or_summary(readme: Path) -> str:
+    """Pull a one-line summary from the README — first H1, then first prose line."""
+    try:
+        text = readme.read_text(errors="replace")
+    except Exception:
+        return ""
+    lines = text.splitlines()
+    # try H1
+    for line in lines:
+        if line.startswith("# "):
+            return line[2:].strip()
+    # try first quote line ("> ...")
+    for line in lines:
+        if line.startswith("> "):
+            return line[2:].strip().strip("*_")
+    # try first prose line that isn't frontmatter or table
+    in_frontmatter = False
+    for line in lines:
+        s = line.strip()
+        if not s:
+            continue
+        if s == "---":
+            in_frontmatter = not in_frontmatter
+            continue
+        if in_frontmatter:
+            continue
+        if s.startswith(("|", "##", "```", "- ")):
+            continue
+        return s[:200]
+    return ""
+
+
+def slug_from_path(p: Path) -> tuple[str, str]:
+    """Extract numeric ID + slug from research/<topic>/<num>-<slug>/."""
+    name = p.name
+    m = re.match(r"(\d+)-(.+)", name)
+    if m:
+        return m.group(1), m.group(2)
+    return name, name
+
+
+def find_top_level_legacy_docs() -> list[Path]:
+    """Find legacy top-level research/<num>-<slug>/README.md (pre-folder era)."""
+    docs = []
+    for d in SRC.iterdir():
+        if not d.is_dir():
+            continue
+        if d.name.startswith("_") or d.name == "newfiles":
+            continue
+        # skip topic folders
+        if d.name in {
+            "agents",
+            "music",
+            "dev-workflows",
+            "infrastructure",
+            "governance",
+            "community",
+            "cross-platform",
+            "farcaster",
+            "identity",
+            "business",
+            "events",
+            "wavewarz",
+            "security",
+            "inspiration",
+        }:
+            continue
+        if re.match(r"\d+-", d.name):
+            readme = d / "README.md"
+            if readme.exists():
+                docs.append(d)
+    return docs
+
+
+def render_fact(idx: int, topic: str, doc_dir: Path) -> str:
+    num, slug = slug_from_path(doc_dir)
+    readme = doc_dir / "README.md"
+    title = first_h1_or_summary(readme) or slug.replace("-", " ").title()
+    title_clean = title.lstrip("#").strip()
+    title_clean = re.sub(r"^\d+\s*[-—]\s*", "", title_clean)
+    short = title_clean[:160]
+    return (
+        f"### FACT {idx}\n"
+        f"Subject: Research Doc {num}: {short}\n"
+        f"Type: ResearchDoc\n"
+        f"Topic: {topic}\n"
+        f"Doc number: {num}\n"
+        f"Description: {short}\n"
+        f"Source: internal://research/{topic}/{doc_dir.name}/\n"
+        f"Confidence: 1.0\n"
+    )
+
+
+def render_file(group_name: str, topics: list[str]) -> str:
+    out: list[str] = []
+    out.append(
+        f"INGEST BATCH: ZAO Research Library Index — "
+        f"{group_name.replace('-', ' / ')} ({len(topics)} topic folder{'s' if len(topics) > 1 else ''})."
+    )
+    out.append("")
+    out.append(
+        "Build a manifest of ResearchDoc nodes, preview the first 3, then ask me to approve. "
+        "Each ResearchDoc has Topic + Doc number + Description as attributes. "
+        "Topics, platforms, tools, and dates must be attributes only, NEVER standalone Entity nodes per scope_constraint trait. "
+        "If existing ResearchDoc nodes match by Doc number, MERGE; do not create parallel nodes."
+    )
+    out.append("")
+
+    idx = 1
+    total_docs = 0
+    for topic in topics:
+        topic_dir = SRC / topic
+        if not topic_dir.exists():
+            continue
+        docs = sorted(
+            [d for d in topic_dir.iterdir() if d.is_dir() and re.match(r"\d+-", d.name)],
+            key=lambda p: int(re.match(r"(\d+)-", p.name).group(1)),
+        )
+        if not docs:
+            continue
+        out.append(f"## SECTION — {topic} ({len(docs)} docs)")
+        out.append("")
+        for d in docs:
+            out.append(render_fact(idx, topic, d))
+            out.append("")
+            idx += 1
+        total_docs += len(docs)
+
+    # legacy top-level docs go into the "governance-community-identity" file as misc
+    if group_name == "governance-community-identity":
+        legacy = find_top_level_legacy_docs()
+        if legacy:
+            out.append(f"## SECTION — legacy top-level docs ({len(legacy)} docs)")
+            out.append("")
+            for d in sorted(legacy, key=lambda p: int(re.match(r"(\d+)-", p.name).group(1))):
+                num, slug = slug_from_path(d)
+                title = first_h1_or_summary(d / "README.md") or slug.replace(
+                    "-", " "
+                ).title()
+                title_clean = re.sub(r"^\d+\s*[-—]\s*", "", title.lstrip("#").strip())[
+                    :160
+                ]
+                out.append(f"### FACT {idx}")
+                out.append(f"Subject: Research Doc {num}: {title_clean}")
+                out.append(f"Type: ResearchDoc")
+                out.append(f"Topic: misc")
+                out.append(f"Doc number: {num}")
+                out.append(f"Description: {title_clean}")
+                out.append(f"Source: internal://research/{d.name}/")
+                out.append(f"Confidence: 1.0")
+                out.append("")
+                idx += 1
+            total_docs += len(legacy)
+
+    out.append("## EDGES TO ASSERT")
+    out.append("- Zaal Panthaki -[authored]-> [each ResearchDoc above]")
+    out.append("- The ZAO -[has_research_doc]-> [each ResearchDoc]")
+    out.append(
+        "- ResearchDoc -[has_topic]-> Topic (as attribute, do NOT create Topic Entity nodes)"
+    )
+    out.append("")
+    out.append("---")
+    out.append(
+        f'Build the manifest, preview the first 3 nodes, then ask me "approve all?". '
+        f"Total {total_docs} ResearchDoc nodes in this batch. "
+        f"Do not commit until I say yes. If a Doc number already exists in graph, MERGE; "
+        f"do not create duplicate."
+    )
+    return "\n".join(out)
+
+
+def main() -> int:
+    OUT.mkdir(parents=True, exist_ok=True)
+    summary = []
+    for group, topics in GROUPS.items():
+        text = render_file(group, topics)
+        path = OUT / f"research-index-{group}.md"
+        path.write_text(text)
+        # count facts
+        count = text.count("\n### FACT ")
+        summary.append((group, count, path))
+        print(f"wrote {path.relative_to(REPO)} ({count} facts)")
+    print("\n--- summary ---")
+    total = sum(c for _, c, _ in summary)
+    print(f"total ResearchDoc facts across 5 files: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stacks on #446. Closes the gap between \`/zsfb\` (log feedback) and \`/fix\` (admin-only) by adding a team-facing edit lever with a per-member daily cap and a kill switch.

## What lands

- New \`/zsedit <issue>\` command. Open to any active team member resolved via /whoami.
- target_repo HARDCODED to \`zaostock\`. Cannot be tricked into editing ZAO OS via prefix games.
- Per-member daily cap: \`ZSEDIT_DAILY_PER_MEMBER\` (default 2/day, counts every triggered run today regardless of final status).
- Kill switch: \`ZSEDIT_DISABLED=1\` pauses team /zsedit without touching admin /fix.
- Same Coder + Critic loop. Same fleet daily $20 cap. Same PR-watcher alerts.
- Help text updated to surface /zsedit alongside /zsfb.

## How team uses it

\`\`\`
/zsedit drop the lineup TBA placeholders, keep the section header
/zsedit hero copy too long - cut the second sentence
/zsedit add a "lineup drops Aug 2026" pill near the top
\`\`\`

Bot replies optimistically, then reports back PR + critic score (or escalation reason) once the loop finishes.

## Why a separate command vs opening /fix to all

- \`/fix\` can target any repo profile and is the admin's catch-all.
- \`/zsedit\` is the safe, scoped, rate-limited surface for the team.
- If costs spike, \`ZSEDIT_DISABLED=1\` pauses team-wide while admin /fix keeps working.
- Different reply copy makes it obvious to a non-admin which command to use.

## DB

New \`countRunsByTelegramIdToday(telegramId)\` helper in \`bot/src/hermes/db.ts\`. Uses existing \`idx_hermes_runs_triggered_by\` index, no schema change.

## Test plan

- [ ] Bot \`/help\` shows /zsedit under "Tell me what happened"
- [ ] Non-admin team member sends \`/zsedit add a test comment to /test page\`
- [ ] Bot replies with attempts counter \`(1/2 today)\` and "Hermes editing zaostock for <name>"
- [ ] PR appears on bettercallzaal/zaostock (NOT ZAOOS) within ~3 min
- [ ] Same member triggers a 3rd time same day - bot replies "Daily /zsedit cap reached (2/2)"
- [ ] Set \`ZSEDIT_DISABLED=1\` env and restart bot - any /zsedit replies "Team /zsedit is paused right now"
- [ ] Admin /fix still works for both zaoos and zaostock targets, ignores ZSEDIT_DISABLED