### PR TITLE
feat: yapz bonfire ingest corpus (18 episode .md files + generator)

### DIFF
--- a/content/yapz-bonfire-ingest/2025-08-22-deepa-grantorb.md
+++ b/content/yapz-bonfire-ingest/2025-08-22-deepa-grantorb.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 1 — Deepa from GrantOrb (2025-08-22).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Deepa
+Type: PodcastEpisode
+Date: 2025-08-22
+Show: BCZ YapZ
+Episode number: 1
+Format: video-podcast
+YouTube URL: https://youtu.be/3vUAFwXqdeo
+YouTube video ID: 3vUAFwXqdeo
+Description: Zaal interviews Deepa from GrantOrb.
+Source: https://youtu.be/3vUAFwXqdeo
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Deepa
+Type: Person
+Role: Founder/team at GrantOrb
+Source: https://youtu.be/3vUAFwXqdeo
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: GrantOrb
+Type: Org
+Source: https://youtu.be/3vUAFwXqdeo
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "illiquid and soul bound. Illiquid means you can't buy and sell it. Soul bound means you can't trade it. So it's our"
+Timestamp: 00:01:15
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=75
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "like sending, attaching it to a cause. Yeah. Yeah. Attaching anything to a cause just brings more"
+Timestamp: 00:05:15
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=315
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "round, like they have like. Specific grants during the year. Uh, and, uh, it was in November, they"
+Timestamp: 00:08:45
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=525
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "definitely, like it cuts down time. Uh, like, I don't know if anybody like artists, lots of artists depends"
+Timestamp: 00:12:25
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=745
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "from there. Right? Like, and let's say, call it, call it quits, right? That's a product. But like from"
+Timestamp: 00:16:20
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=980
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "to every single other industry because you can apply these automation thoughts and processes and"
+Timestamp: 00:20:15
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=1215
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "where are you at now with. What do you need help with? Is there anything I can do for you to"
+Timestamp: 00:24:00
+YouTube deeplink: https://youtu.be/3vUAFwXqdeo?t=1440
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Deepa
+- Deepa -[appeared_on]-> BCZ YapZ w/Deepa
+- Deepa -[part_of]-> GrantOrb
+- BCZ YapZ w/Deepa -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2025-10-14-rich-bartuc.md
+++ b/content/yapz-bonfire-ingest/2025-10-14-rich-bartuc.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 2 — Rich Bartuc from PowerPacks Diamondhands Club (2025-10-14).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Rich Bartuc
+Type: PodcastEpisode
+Date: 2025-10-14
+Show: BCZ YapZ
+Episode number: 2
+Format: video-podcast
+YouTube URL: https://youtu.be/AOcp8Jpyw3k
+YouTube video ID: AOcp8Jpyw3k
+Description: Zaal interviews Rich Bartuc from PowerPacks Diamondhands Club.
+Source: https://youtu.be/AOcp8Jpyw3k
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Rich Bartuc
+Type: Person
+Role: Founder/team at PowerPacks Diamondhands Club
+Source: https://youtu.be/AOcp8Jpyw3k
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: PowerPacks Diamondhands Club
+Type: Org
+Source: https://youtu.be/AOcp8Jpyw3k
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Rich Bartuc: And, you know, I went in and checked it out and I saw Darth Vader in the case. I'm a huge"
+Timestamp: 00:01:15
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=75
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "and I came out with, you know, $900, $2,000. Uh, it was, it was insane."
+Timestamp: 00:07:15
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=435
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "So I, I don't have the specific time on here. I was trying to see if it had more information. Doesn't"
+Timestamp: 00:12:25
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=745
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "power packs I was doing. He is like, check out this other place. It's called Bey. And so I looked at Bey"
+Timestamp: 00:17:15
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=1035
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "cards, whether he sold 'em on eBay or he sold 'em instantly. That's, that's, that, that takes"
+Timestamp: 00:22:00
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=1320
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "power packs, diamond Hands Club. Uh, you can see that, that's kind of in my, in my little stream"
+Timestamp: 00:26:55
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=1615
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "This is also from the, the, the m that over here. That's beautiful."
+Timestamp: 00:31:55
+YouTube deeplink: https://youtu.be/AOcp8Jpyw3k?t=1915
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Rich Bartuc
+- Rich Bartuc -[appeared_on]-> BCZ YapZ w/Rich Bartuc
+- Rich Bartuc -[part_of]-> PowerPacks Diamondhands Club
+- BCZ YapZ w/Rich Bartuc -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2025-10-19-yoni-dubz.md
+++ b/content/yapz-bonfire-ingest/2025-10-19-yoni-dubz.md
@@ -1,0 +1,86 @@
+INGEST BATCH: BCZ YapZ Episode 3 — Yoni Dubz (2025-10-19).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Yoni Dubz
+Type: PodcastEpisode
+Date: 2025-10-19
+Show: BCZ YapZ
+Episode number: 3
+Format: video-podcast
+YouTube URL: https://youtu.be/HopaeW7POis
+YouTube video ID: HopaeW7POis
+Description: Zaal interviews Yoni Dubz.
+Source: https://youtu.be/HopaeW7POis
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Yoni Dubz
+Type: Person
+Source: https://youtu.be/HopaeW7POis
+Confidence: 1.0
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Bro, when I was growing up, I was really never the one, like I didn't watch movies. Like I was always just"
+Timestamp: 00:02:05
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=125
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "go meme, coin guy. It was called Please. I looked at it, I had"
+Timestamp: 00:08:40
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=520
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "I do, yeah. As well. But like, I'm not a like ma, like that's not my main thing. I'm like, yeah."
+Timestamp: 00:14:50
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=890
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "interested in diving more into Twitch and like those experiences are definitely unique to that."
+Timestamp: 00:21:25
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=1285
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "it's pretty dope. I'm super blessed to be here. Actually, this is, this is the spot, I'm not gonna"
+Timestamp: 00:27:40
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=1660
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "love that. Um, but other than that, I haven't di di diving into too many animes, too much."
+Timestamp: 00:33:05
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=1985
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "to read, I wanna like address some of them, but like it's a lot. Hey, I'll see"
+Timestamp: 00:39:45
+YouTube deeplink: https://youtu.be/HopaeW7POis?t=2385
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Yoni Dubz
+- Yoni Dubz -[appeared_on]-> BCZ YapZ w/Yoni Dubz
+- BCZ YapZ w/Yoni Dubz -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2025-11-30-rockopera.md
+++ b/content/yapz-bonfire-ingest/2025-11-30-rockopera.md
@@ -1,0 +1,86 @@
+INGEST BATCH: BCZ YapZ Episode 4 — Rock Opera (2025-11-30).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Rock Opera
+Type: PodcastEpisode
+Date: 2025-11-30
+Show: BCZ YapZ
+Episode number: 4
+Format: video-podcast
+YouTube URL: https://youtu.be/43GPWLE6W5Q
+YouTube video ID: 43GPWLE6W5Q
+Description: Zaal interviews Rock Opera.
+Source: https://youtu.be/43GPWLE6W5Q
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Rock Opera
+Type: Person
+Source: https://youtu.be/43GPWLE6W5Q
+Confidence: 1.0
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "yeah, no, I love, uh, I love going for a bike ride. I used to bike to, to high school, um, and there was,"
+Timestamp: 00:01:00
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=60
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "contract for tokenizing color. It, this is what's the phrase that I have here on chain,"
+Timestamp: 00:05:20
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=320
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "just like a wallet address could be, right. Like, it could be really cool for each wallet address within our community"
+Timestamp: 00:09:15
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=555
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "complicated than it should be to make a piece of art? Absolutely. However, the"
+Timestamp: 00:13:20
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=800
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "engineering, so we've probably taken some similar classes. Um, and I'm a classically trained"
+Timestamp: 00:17:05
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=1025
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "got 'em versus like tools in the past were, it was a lot harder and you had to know a lot more of like how"
+Timestamp: 00:21:10
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=1270
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "about, like, oh, what could be, and then continue down the path. Right. I, I, I wanna jump"
+Timestamp: 00:25:20
+YouTube deeplink: https://youtu.be/43GPWLE6W5Q?t=1520
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Rock Opera
+- Rock Opera -[appeared_on]-> BCZ YapZ w/Rock Opera
+- BCZ YapZ w/Rock Opera -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2025-12-11-daya-flix-fun.md
+++ b/content/yapz-bonfire-ingest/2025-12-11-daya-flix-fun.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 5 — Daya from Flix.Fun (2025-12-11).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ Yaps w/Daya (Flix.Fun)
+Type: PodcastEpisode
+Date: 2025-12-11
+Show: BCZ YapZ
+Episode number: 5
+Format: video-podcast
+YouTube URL: https://youtu.be/9ePU4qEc67Y
+YouTube video ID: 9ePU4qEc67Y
+Description: Zaal interviews Daya from Flix.Fun.
+Source: https://youtu.be/9ePU4qEc67Y
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Daya
+Type: Person
+Role: Founder/team at Flix.Fun
+Source: https://youtu.be/9ePU4qEc67Y
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Flix.Fun
+Type: Org
+Source: https://youtu.be/9ePU4qEc67Y
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "in one, in 2022, we launched a project in 23. We launched the token in 20,"
+Timestamp: 00:01:25
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=85
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "without having to, you know, depend on third party platforms such like YouTube, Facebook, but otherwise, the same"
+Timestamp: 00:06:50
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=410
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "off to some of the, of the Twitch folks, but why don't you share with us a little bit more about that transition from"
+Timestamp: 00:11:55
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=715
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "are going in multiple folds and, uh, definitely, you know, future looks"
+Timestamp: 00:17:05
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=1025
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "load well, I'm not sure, but I see wrong there. But. There is a promotional just, just"
+Timestamp: 00:22:30
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=1350
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "yeah, a lot of widgets are coming, like, you know, featured widgets, swap widgets,"
+Timestamp: 00:27:30
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=1650
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "applications to just be a creator and to learn all of those things versus someone that wants to try"
+Timestamp: 00:33:00
+YouTube deeplink: https://youtu.be/9ePU4qEc67Y?t=1980
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ Yaps w/Daya (Flix.Fun)
+- Daya -[appeared_on]-> BCZ Yaps w/Daya (Flix.Fun)
+- Daya -[part_of]-> Flix.Fun
+- BCZ Yaps w/Daya (Flix.Fun) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2025-12-16-sven-incented.md
+++ b/content/yapz-bonfire-ingest/2025-12-16-sven-incented.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 6 — Sven from Incented (2025-12-16).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ Yaps w/Sven (Incented)
+Type: PodcastEpisode
+Date: 2025-12-16
+Show: BCZ YapZ
+Episode number: 6
+Format: video-podcast
+YouTube URL: https://youtu.be/O7-1weR0Qog
+YouTube video ID: O7-1weR0Qog
+Description: Zaal interviews Sven from Incented.
+Source: https://youtu.be/O7-1weR0Qog
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Sven
+Type: Person
+Role: Founder/team at Incented
+Source: https://youtu.be/O7-1weR0Qog
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Incented
+Type: Org
+Source: https://youtu.be/O7-1weR0Qog
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "uh, I'm just like a random nerd living in the desert really. So don't pay too much attention to me or what"
+Timestamp: 00:00:55
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=55
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "for a couple big corporate companies and now in the crypto space, I'm getting more involved with startups and"
+Timestamp: 00:04:25
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=265
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "usually this is all configurable of course, because we're protocol. Um, but you can get an upside by"
+Timestamp: 00:07:25
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=445
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "generation for our social channels, right? So we, we have, I'm not gonna go through all of this. Don't worry if you're"
+Timestamp: 00:10:25
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=625
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Yeah, on the upper right, on the, in the upper right. And, uh, I've pre-filled out some of this information to"
+Timestamp: 00:13:55
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=835
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "where you, maybe you're an ecosystem or a community and you have a couple things in mind that you want"
+Timestamp: 00:16:50
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=1010
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "private? Uh, so you just see the stats, like there's actually four different levels. You can either just see the"
+Timestamp: 00:20:20
+YouTube deeplink: https://youtu.be/O7-1weR0Qog?t=1220
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ Yaps w/Sven (Incented)
+- Sven -[appeared_on]-> BCZ Yaps w/Sven (Incented)
+- Sven -[part_of]-> Incented
+- BCZ Yaps w/Sven (Incented) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-01-05-yerbearserker.md
+++ b/content/yapz-bonfire-ingest/2026-01-05-yerbearserker.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 7 — Yerbearserker from Empire Builder (2026-01-05).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Yerbearserker
+Type: PodcastEpisode
+Date: 2026-01-05
+Show: BCZ YapZ
+Episode number: 7
+Format: video-podcast
+YouTube URL: https://youtu.be/EH-FWD7ySKk
+YouTube video ID: EH-FWD7ySKk
+Description: Zaal interviews Yerbearserker from Empire Builder.
+Source: https://youtu.be/EH-FWD7ySKk
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Yerbearserker
+Type: Person
+Role: Founder/team at Empire Builder
+Source: https://youtu.be/EH-FWD7ySKk
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Empire Builder
+Type: Org
+Source: https://youtu.be/EH-FWD7ySKk
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "And I'm like, and I'm like, this is a three term. Like, like I get that, I get what you're thinking, but here's what"
+Timestamp: 00:01:55
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=115
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "incentivized a lot of people. Yeah, yeah, yeah. And so, yeah, yeah, no. Oh, I get, it's just like the, you have the big"
+Timestamp: 00:08:50
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=530
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "to use? Like, yeah. You know, that's the thing. It's like, okay, so they're gonna take all of our money."
+Timestamp: 00:15:30
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=930
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "launched a creator coin, 'cause we wanna show that you could even have utility for those, um, a core content"
+Timestamp: 00:22:30
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=1350
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "new nft, five NFTs from the collection that's minting actively to everyone who's holding. So, you know, in"
+Timestamp: 00:29:15
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=1755
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "yeah, no, I think there's a lot of cool use cases here for, for the, for the different leader boards. But yeah, that"
+Timestamp: 00:36:05
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=2165
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "and get away from people who are perhaps just looking like they're trying to do the"
+Timestamp: 00:42:55
+YouTube deeplink: https://youtu.be/EH-FWD7ySKk?t=2575
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Yerbearserker
+- Yerbearserker -[appeared_on]-> BCZ YapZ w/Yerbearserker
+- Yerbearserker -[part_of]-> Empire Builder
+- BCZ YapZ w/Yerbearserker -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-02-11-diviflyy-empire-builder.md
+++ b/content/yapz-bonfire-ingest/2026-02-11-diviflyy-empire-builder.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 8 — Diviflyy from Empire Builder (2026-02-11).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Diviflyy
+Type: PodcastEpisode
+Date: 2026-02-11
+Show: BCZ YapZ
+Episode number: 8
+Format: video-podcast
+YouTube URL: https://youtu.be/0tyVpLGVxkA
+YouTube video ID: 0tyVpLGVxkA
+Description: Zaal interviews Diviflyy from Empire Builder.
+Source: https://youtu.be/0tyVpLGVxkA
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Diviflyy
+Type: Person
+Role: Founder/team at Empire Builder
+Source: https://youtu.be/0tyVpLGVxkA
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Empire Builder
+Type: Org
+Source: https://youtu.be/0tyVpLGVxkA
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "ICO boom and everything. Um, all my mates were like asking me questions like, how do you set up a wallet? How do you"
+Timestamp: 00:01:35
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=95
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "something out here, like we're starting a little project on here. So I helped him out with it."
+Timestamp: 00:06:05
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=365
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "um, tied to just holding the token. You also need to actually be sort of more engaged with different parts"
+Timestamp: 00:11:15
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=675
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "really excited about crypto as a whole and what quote unquote Web3, right? And just being"
+Timestamp: 00:15:50
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=950
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "leaderboard numbers, uh, a lot more boosters, um, potentially, yeah. Don't wanna, again, make"
+Timestamp: 00:21:05
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=1265
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "populate it with that. But the thing is, when you have it pinned, I think it like might get mixed up."
+Timestamp: 00:25:40
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=1540
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "scanners pick up from the dead address. Like if you go onto, um, yeah, gecko,"
+Timestamp: 00:30:15
+YouTube deeplink: https://youtu.be/0tyVpLGVxkA?t=1815
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Diviflyy
+- Diviflyy -[appeared_on]-> BCZ YapZ w/Diviflyy
+- Diviflyy -[part_of]-> Empire Builder
+- BCZ YapZ w/Diviflyy -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-02-23-giu-pinetree.md
+++ b/content/yapz-bonfire-ingest/2026-02-23-giu-pinetree.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 10 — Juliano from Pinetree (2026-02-23).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/GIU (Pinetree)
+Type: PodcastEpisode
+Date: 2026-02-23
+Show: BCZ YapZ
+Episode number: 10
+Format: video-podcast
+YouTube URL: https://youtu.be/loSOniPcJx0
+YouTube video ID: loSOniPcJx0
+Description: Zaal interviews Juliano from Pinetree.
+Source: https://youtu.be/loSOniPcJx0
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Juliano
+Type: Person
+Role: Founder/team at Pinetree
+Source: https://youtu.be/loSOniPcJx0
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Pinetree
+Type: Org
+Source: https://youtu.be/loSOniPcJx0
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "uh, was head of CEO for a little bit, and then Windstone was head of CEO, which is the"
+Timestamp: 00:01:10
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=70
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "but I think the concept, like the Bitcoin concept and, and eventually"
+Timestamp: 00:03:55
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=235
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "all. And, and because of that, I was able to go to school here. Uh, in the"
+Timestamp: 00:07:25
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=445
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "as well. You have like the practical one and you also have the written one."
+Timestamp: 00:10:30
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=630
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "consistency. There's like, there are a few trades there, like pretty important. Um,"
+Timestamp: 00:13:35
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=815
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Uh, but where crypto really shines is on monetization. So we're gonna focus a"
+Timestamp: 00:16:55
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=1015
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "that helps distribution, I think, um, is something that artists will start to flock towards."
+Timestamp: 00:19:40
+YouTube deeplink: https://youtu.be/loSOniPcJx0?t=1180
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/GIU (Pinetree)
+- Juliano -[appeared_on]-> BCZ YapZ w/GIU (Pinetree)
+- Juliano -[part_of]-> Pinetree
+- BCZ YapZ w/GIU (Pinetree) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-02-23-snax-pizza-dao.md
+++ b/content/yapz-bonfire-ingest/2026-02-23-snax-pizza-dao.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 9 — SNAX from Pizza DAO (2026-02-23).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/SNAX (Pizza DAO)
+Type: PodcastEpisode
+Date: 2026-02-23
+Show: BCZ YapZ
+Episode number: 9
+Format: video-podcast
+YouTube URL: https://youtu.be/4CpblYpIO8Q
+YouTube video ID: 4CpblYpIO8Q
+Description: Zaal interviews SNAX from Pizza DAO.
+Source: https://youtu.be/4CpblYpIO8Q
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: SNAX
+Type: Person
+Role: Founder/team at Pizza DAO
+Source: https://youtu.be/4CpblYpIO8Q
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Pizza DAO
+Type: Org
+Source: https://youtu.be/4CpblYpIO8Q
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "the, uh, number one food in the known universe and it's a great way to bring the world together. But"
+Timestamp: 00:01:20
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=80
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "love, um, I love that kind of like community starting point. That's kind of where, where you build"
+Timestamp: 00:04:55
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=295
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "That's cool. Just, just like thinking about how, you know, we are building these Yeah."
+Timestamp: 00:08:40
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=520
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "And I think, and it, it actually varies from region to region, but, um, they're"
+Timestamp: 00:12:05
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=725
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Because like I, I got my electric engineering degree, but I hated coding. I like the syntax portion of it."
+Timestamp: 00:15:20
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=920
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "as full featured as Luma Plus it has a bunch of extra features that we like, makes donations super"
+Timestamp: 00:19:15
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=1155
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "'cause I think that's a big part of my methodology where I think there's so many cool things, like you said, that taking that raw"
+Timestamp: 00:22:55
+YouTube deeplink: https://youtu.be/4CpblYpIO8Q?t=1375
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/SNAX (Pizza DAO)
+- SNAX -[appeared_on]-> BCZ YapZ w/SNAX (Pizza DAO)
+- SNAX -[part_of]-> Pizza DAO
+- BCZ YapZ w/SNAX (Pizza DAO) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-03-18-roaring-sensei.md
+++ b/content/yapz-bonfire-ingest/2026-03-18-roaring-sensei.md
@@ -1,0 +1,86 @@
+INGEST BATCH: BCZ YapZ Episode 11 — Roaring Sensei (2026-03-18).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Roaring Sensei
+Type: PodcastEpisode
+Date: 2026-03-18
+Show: BCZ YapZ
+Episode number: 11
+Format: video-podcast
+YouTube URL: https://youtu.be/DIeav3o8t9M
+YouTube video ID: DIeav3o8t9M
+Description: Zaal interviews Roaring Sensei.
+Source: https://youtu.be/DIeav3o8t9M
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Roaring Sensei
+Type: Person
+Source: https://youtu.be/DIeav3o8t9M
+Confidence: 1.0
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "you share a little bit about yourself, like your background and, uh, and what,"
+Timestamp: 00:01:10
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=70
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "I lo I love all that. I would love to. To dive into, dive to, to GameStop a little bit more."
+Timestamp: 00:05:35
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=335
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "I'm a magic of the gathering kid. Nice. So like I, I have a lot of magic. The gathering cards"
+Timestamp: 00:10:00
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=600
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "stocks and things like that. And it's worked really well. I've got a lovely connection. The collection of, um."
+Timestamp: 00:14:15
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=855
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "segment myself, you know what I mean? Because I get, I get called Sensei more than I get called"
+Timestamp: 00:18:40
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=1120
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "difficult for me because I try to be as nice as possible, but not everybody's gonna like you. Not everybody's gonna"
+Timestamp: 00:22:55
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=1375
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "changes, there has to be that line where we say, what are we gonna do here, folks? What, how are we gonna."
+Timestamp: 00:27:05
+YouTube deeplink: https://youtu.be/DIeav3o8t9M?t=1625
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Roaring Sensei
+- Roaring Sensei -[appeared_on]-> BCZ YapZ w/Roaring Sensei
+- BCZ YapZ w/Roaring Sensei -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-03-18-saltorious-among-traitors.md
+++ b/content/yapz-bonfire-ingest/2026-03-18-saltorious-among-traitors.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 12 — Saltorious.eth from Among Traitors (2026-03-18).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Saltorious.eth (Among Traitors)
+Type: PodcastEpisode
+Date: 2026-03-18
+Show: BCZ YapZ
+Episode number: 12
+Format: video-podcast
+YouTube URL: https://youtu.be/0Tevgpr5TUQ
+YouTube video ID: 0Tevgpr5TUQ
+Description: Zaal interviews Saltorious.eth from Among Traitors.
+Source: https://youtu.be/0Tevgpr5TUQ
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Saltorious.eth
+Type: Person
+Role: Founder/team at Among Traitors
+Source: https://youtu.be/0Tevgpr5TUQ
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Among Traitors
+Type: Org
+Source: https://youtu.be/0Tevgpr5TUQ
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "40 years of my life. I absolutely hated every day of going into the office, and I really wanted to"
+Timestamp: 00:01:55
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=115
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "in, oh, there's an embedded wallet, and then you layer in, oh, you can build apps on top of the whole, um,"
+Timestamp: 00:07:40
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=460
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "'cause like, I was not really known at all, but then people started using it and people started really"
+Timestamp: 00:13:35
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=815
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "hackathon. And, uh, at the beginning of the week I was kind of like, all right, I, I know I wanna"
+Timestamp: 00:19:25
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=1165
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "of lighting plates near the open loading. Oh, okay. That was the, that was the death note."
+Timestamp: 00:25:30
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=1530
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "do you have the right code, like language, and then pull that. They're like all these pieces"
+Timestamp: 00:31:25
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=1885
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "the, the deliberation engine works, it's not like, you know, agent one goes and agent two"
+Timestamp: 00:37:20
+YouTube deeplink: https://youtu.be/0Tevgpr5TUQ?t=2240
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Saltorious.eth (Among Traitors)
+- Saltorious.eth -[appeared_on]-> BCZ YapZ w/Saltorious.eth (Among Traitors)
+- Saltorious.eth -[part_of]-> Among Traitors
+- BCZ YapZ w/Saltorious.eth (Among Traitors) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-03-25-ali-inflynce.md
+++ b/content/yapz-bonfire-ingest/2026-03-25-ali-inflynce.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 13 — Ali from Inflynce (2026-03-25).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Ali (Inflynce)
+Type: PodcastEpisode
+Date: 2026-03-25
+Show: BCZ YapZ
+Episode number: 13
+Format: video-podcast
+YouTube URL: https://youtu.be/WTyafqHKQqM
+YouTube video ID: WTyafqHKQqM
+Description: Zaal interviews Ali from Inflynce.
+Source: https://youtu.be/WTyafqHKQqM
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Ali
+Type: Person
+Role: Founder/team at Inflynce
+Source: https://youtu.be/WTyafqHKQqM
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Inflynce
+Type: Org
+Source: https://youtu.be/WTyafqHKQqM
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "I'm right now is just building, launching products. Influence is one of them. So previously I"
+Timestamp: 00:00:55
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=55
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Okay. Uh, and I didn't know anything, actually. Nothing. Yeah. I was just, you know, just"
+Timestamp: 00:04:50
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=290
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "nervous. You don't feel good at the end of the day. Right. Like that you, that you're moving, moving the needle"
+Timestamp: 00:08:30
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=510
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "I was a, I was a trader and I came in and I was a musician and I came in, or Yeah, this and that. And"
+Timestamp: 00:12:00
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=720
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "they follow you, you can just buy like, or repos. First of all, if you are an even account,"
+Timestamp: 00:15:50
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=950
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "you need to target, you need to blah, blah, blah. You need lots of things. But whenever you became a permissionless, there would"
+Timestamp: 00:19:50
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=1190
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "boost type, which means it doesn't have to be far casted content. It can be any link. It can be"
+Timestamp: 00:23:20
+YouTube deeplink: https://youtu.be/WTyafqHKQqM?t=1400
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Ali (Inflynce)
+- Ali -[appeared_on]-> BCZ YapZ w/Ali (Inflynce)
+- Ali -[part_of]-> Inflynce
+- BCZ YapZ w/Ali (Inflynce) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-04-01-jordan-ryft.md
+++ b/content/yapz-bonfire-ingest/2026-04-01-jordan-ryft.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 14 — Jordan from Ryft (2026-04-01).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Jordan (Ryft)
+Type: PodcastEpisode
+Date: 2026-04-01
+Show: BCZ YapZ
+Episode number: 14
+Format: video-podcast
+YouTube URL: https://youtu.be/IbhHxFR4yxE
+YouTube video ID: IbhHxFR4yxE
+Description: Zaal interviews Jordan from Ryft.
+Source: https://youtu.be/IbhHxFR4yxE
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Jordan
+Type: Person
+Role: Founder/team at Ryft
+Source: https://youtu.be/IbhHxFR4yxE
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Ryft
+Type: Org
+Source: https://youtu.be/IbhHxFR4yxE
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Right? And isn't just slop. So it's amazing to have you on. Um, I'd love for you to go into a"
+Timestamp: 00:01:20
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=80
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "So I was like, Hey, you know that it's worth waking up in the middle of life. It's,"
+Timestamp: 00:06:36
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=396
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "looking at the way that you tell your story, the way that your brand is built."
+Timestamp: 00:12:05
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=725
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "then some people like pop into like, okay, like I found my way to make the world better. Like,"
+Timestamp: 00:17:05
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=1025
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "And so I have like spreadsheets, right? I have spreadsheets of, of the different items that I'm the"
+Timestamp: 00:22:05
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=1325
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "these types of systems that I'm talking about work, because then you can do it"
+Timestamp: 00:27:40
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=1660
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "find a, a, a, you know, a bunch of different people. Like, Hey, you know, go and get this or"
+Timestamp: 00:32:55
+YouTube deeplink: https://youtu.be/IbhHxFR4yxE?t=1975
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Jordan (Ryft)
+- Jordan -[appeared_on]-> BCZ YapZ w/Jordan (Ryft)
+- Jordan -[part_of]-> Ryft
+- BCZ YapZ w/Jordan (Ryft) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-04-14-nikoline-hubs-network.md
+++ b/content/yapz-bonfire-ingest/2026-04-14-nikoline-hubs-network.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 15 — Nikoline Arns from Hubs Network (2026-04-14).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Nikoline (Hubs Network)
+Type: PodcastEpisode
+Date: 2026-04-14
+Show: BCZ YapZ
+Episode number: 15
+Format: video-podcast
+YouTube URL: https://youtu.be/RuYxRBfLGCc
+YouTube video ID: RuYxRBfLGCc
+Description: Zaal interviews Nikoline Arns from Hubs Network.
+Source: https://youtu.be/RuYxRBfLGCc
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Nikoline Arns
+Type: Person
+Role: Founder/team at Hubs Network
+Source: https://youtu.be/RuYxRBfLGCc
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Hubs Network
+Type: Org
+Source: https://youtu.be/RuYxRBfLGCc
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "sociocracy and other ways to make decisions in big groups. For example, with the school was like"
+Timestamp: 00:01:30
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=90
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "trying to find ways to bring that, uh, money back to independent artists. And like you said, the best way"
+Timestamp: 00:05:00
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=300
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Yeah. That's awesome. I think it's, you know, like I was saying, is super aligned. One of the things I'm"
+Timestamp: 00:08:40
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=520
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "off. I mean, this is like the uniqueness that we find ourselves in this space, especially with Ethereum."
+Timestamp: 00:12:40
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=760
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "dates and their location and organizing and it was actually pretty smooth. And now we are"
+Timestamp: 00:16:05
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=965
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "Right. You know, we have this conversation, but then what's the action that can be taken with that to"
+Timestamp: 00:20:15
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=1215
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "blast seeing the community, uh, come together around this upcoming event. I would love to"
+Timestamp: 00:24:00
+YouTube deeplink: https://youtu.be/RuYxRBfLGCc?t=1440
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Nikoline (Hubs Network)
+- Nikoline Arns -[appeared_on]-> BCZ YapZ w/Nikoline (Hubs Network)
+- Nikoline Arns -[part_of]-> Hubs Network
+- BCZ YapZ w/Nikoline (Hubs Network) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-04-21-dish-clanker.md
+++ b/content/yapz-bonfire-ingest/2026-04-21-dish-clanker.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 16 — Jack Dishman from Clanker (2026-04-21).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Dish (Clanker)
+Type: PodcastEpisode
+Date: 2026-04-21
+Show: BCZ YapZ
+Episode number: 16
+Format: video-podcast
+YouTube URL: https://youtu.be/gHbktZC6HbA
+YouTube video ID: gHbktZC6HbA
+Description: Zaal interviews Jack Dishman from Clanker.
+Source: https://youtu.be/gHbktZC6HbA
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Jack Dishman
+Type: Person
+Role: Founder/team at Clanker
+Source: https://youtu.be/gHbktZC6HbA
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Clanker
+Type: Org
+Source: https://youtu.be/gHbktZC6HbA
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "and, and also forecasters a whole in the ecosystem there. But, uh, let's start with, you know, a"
+Timestamp: 00:01:00
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=60
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "first couple of things and did a, did a couple other, like, works for a couple different startups and,"
+Timestamp: 00:05:05
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=305
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "you said V zero was very simple. Where did you kinda start doing that? Leveling up"
+Timestamp: 00:09:20
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=560
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "posting actually as you're kind of coming in and, and choosing that as opposed to just a wallet address."
+Timestamp: 00:13:20
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=800
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "which I think were, you know, it wasn't gonna, like, it wouldn't allow somebody to go maybe"
+Timestamp: 00:17:40
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=1060
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "um, you know, the, the goal of what I wanna see right, is like have, you"
+Timestamp: 00:21:30
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=1290
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "non-technical people, but specifically like not, um, people that aren't familiar with like blockchain"
+Timestamp: 00:25:55
+YouTube deeplink: https://youtu.be/gHbktZC6HbA?t=1555
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Dish (Clanker)
+- Jack Dishman -[appeared_on]-> BCZ YapZ w/Dish (Clanker)
+- Jack Dishman -[part_of]-> Clanker
+- BCZ YapZ w/Dish (Clanker) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-04-21-hannah-farmdrop.md
+++ b/content/yapz-bonfire-ingest/2026-04-21-hannah-farmdrop.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 17 — Hannah from Farm Drop (2026-04-21).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Hannah (Farm Drop)
+Type: PodcastEpisode
+Date: 2026-04-21
+Show: BCZ YapZ
+Episode number: 17
+Format: video-podcast
+YouTube URL: https://youtu.be/hw-6IHaziV0
+YouTube video ID: hw-6IHaziV0
+Description: Zaal interviews Hannah from Farm Drop.
+Source: https://youtu.be/hw-6IHaziV0
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Hannah
+Type: Person
+Role: Founder/team at Farm Drop
+Source: https://youtu.be/hw-6IHaziV0
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Farm Drop
+Type: Org
+Source: https://youtu.be/hw-6IHaziV0
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "And so went off to study international food business in Germany. Ended up interviewing a bunch of"
+Timestamp: 00:01:25
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=85
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "local food in the area, especially in the wintertime. So we started to sort of develop a, a,"
+Timestamp: 00:05:15
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=315
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "explained in, in, in depth, uh, how Farm Dog came to be. It's cool to really see"
+Timestamp: 00:09:55
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=595
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "cuts you want that week, you just put it in your notes and we'll bring down the lamb chops or the ground lamb, or you know."
+Timestamp: 00:13:45
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=825
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "work for different farmers at different times of the year and make sure that there isn't too much product so"
+Timestamp: 00:18:00
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=1080
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "about local food, talking about our farmers and food producers and, and sort of what we're trying to build at the"
+Timestamp: 00:22:25
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=1345
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "you know, food systems infrastructure to support our local food businesses and our local community"
+Timestamp: 00:26:35
+YouTube deeplink: https://youtu.be/hw-6IHaziV0?t=1595
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Hannah (Farm Drop)
+- Hannah -[appeared_on]-> BCZ YapZ w/Hannah (Farm Drop)
+- Hannah -[part_of]-> Farm Drop
+- BCZ YapZ w/Hannah (Farm Drop) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/content/yapz-bonfire-ingest/2026-04-26-andy-minton-hangry-animals.md
+++ b/content/yapz-bonfire-ingest/2026-04-26-andy-minton-hangry-animals.md
@@ -1,0 +1,94 @@
+INGEST BATCH: BCZ YapZ Episode 18 — Andy Minton from Hangry Animals (2026-04-26).
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait.
+
+## EPISODE NODE
+Subject: BCZ YapZ w/Andy Minton (Hangry Animals)
+Type: PodcastEpisode
+Date: 2026-04-26
+Show: BCZ YapZ
+Episode number: 18
+Format: video-podcast
+YouTube URL: https://youtu.be/HH0zCQgYgq0
+YouTube video ID: HH0zCQgYgq0
+Description: Zaal interviews Andy Minton from Hangry Animals.
+Source: https://youtu.be/HH0zCQgYgq0
+Confidence: 1.0
+
+## PERSON NODE — Guest
+Subject: Andy Minton
+Type: Person
+Role: Founder/team at Hangry Animals
+Source: https://youtu.be/HH0zCQgYgq0
+Confidence: 1.0
+
+## ORG NODE — Guest's organization
+Subject: Hangry Animals
+Type: Org
+Source: https://youtu.be/HH0zCQgYgq0
+Confidence: 0.9
+
+## QUOTE NODE 1
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "maybe. I know, I know this face looks fresh, but underneath, inside I'm haggard, you know,"
+Timestamp: 00:01:20
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=80
+Confidence: 1.0
+
+## QUOTE NODE 2
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "early. And from a technology standpoint, I don't think anybody has figured"
+Timestamp: 00:06:00
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=360
+Confidence: 1.0
+
+## QUOTE NODE 3
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "project. I dunno what it is yet, but we should try and figure out what that project could be."
+Timestamp: 00:11:00
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=660
+Confidence: 1.0
+
+## QUOTE NODE 4
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "that's what we had one. We, um, about a year and a half ago, we filed for a trademark in the"
+Timestamp: 00:15:50
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=950
+Confidence: 1.0
+
+## QUOTE NODE 5
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "inline skater gang who goes around tagging the city with your graffiti and"
+Timestamp: 00:20:40
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=1240
+Confidence: 1.0
+
+## QUOTE NODE 6
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "three deliveries in this round, so I've got a, you can't see it. Read it very well there. There's three sushi,"
+Timestamp: 00:25:35
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=1535
+Confidence: 1.0
+
+## QUOTE NODE 7
+Type: Quote
+Speaker: (mark Zaal or guest based on context)
+Text (verbatim): "great to see a little bit more of like the, the back end of what you've been doing"
+Timestamp: 00:30:50
+YouTube deeplink: https://youtu.be/HH0zCQgYgq0?t=1850
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[hosted]-> BCZ YapZ w/Andy Minton (Hangry Animals)
+- Andy Minton -[appeared_on]-> BCZ YapZ w/Andy Minton (Hangry Animals)
+- Andy Minton -[part_of]-> Hangry Animals
+- BCZ YapZ w/Andy Minton (Hangry Animals) -[contains_quote]-> Quote 1 through Quote 7
+
+---
+Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; do not create parallel nodes. Topics in the description are attributes, not entities.

--- a/scripts/generate-yapz-bonfire-ingest.py
+++ b/scripts/generate-yapz-bonfire-ingest.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Generate ingest-ready Bonfire .md files from BCZ YapZ transcripts.
+
+Reads content/transcripts/bcz-yapz/*.md, extracts YAML frontmatter + 7
+representative timestamped quotes per episode, writes one ingest-ready
+markdown file per episode to content/yapz-bonfire-ingest/.
+
+Each output file is self-contained and starts with an explicit INGEST BATCH
+trigger so the bot's extraction_discipline trait fires. Quotes preserve
+verbatim text and carry youtube.com/watch?v=ID&t=SEC deeplinks.
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO / "content" / "transcripts" / "bcz-yapz"
+OUT_DIR = REPO / "content" / "yapz-bonfire-ingest"
+
+TIMESTAMP_RE = re.compile(r"\[(\d{2}):(\d{2}):(\d{2})\]")
+
+
+def parse_frontmatter(text: str) -> tuple[dict, str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end = text.index("\n---\n", 4)
+    raw = text[4:end]
+    body = text[end + 5 :]
+    fm: dict = {}
+    key = None
+    for line in raw.splitlines():
+        m = re.match(r"^([a-zA-Z_]+):\s*(.*)$", line)
+        if m and not line.startswith(" "):
+            key = m.group(1)
+            val = m.group(2).strip()
+            if val:
+                fm[key] = val.strip("'\"")
+            else:
+                fm[key] = ""
+    return fm, body
+
+
+def to_seconds(h: int, m: int, s: int) -> int:
+    return h * 3600 + m * 60 + s
+
+
+def extract_segments(transcript_body: str) -> list[dict]:
+    """Split transcript at timestamp markers; emit (sec_offset, text) pairs."""
+    after_header = transcript_body.split("## Transcript", 1)
+    body = after_header[1] if len(after_header) > 1 else transcript_body
+    matches = list(TIMESTAMP_RE.finditer(body))
+    segments: list[dict] = []
+    for i, mt in enumerate(matches):
+        h, m, s = (int(g) for g in mt.groups())
+        sec = to_seconds(h, m, s)
+        start = mt.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        text = body[start:end]
+        text = re.sub(r"\s+", " ", text).strip()
+        if text:
+            segments.append({"sec": sec, "text": text})
+    return segments
+
+
+def pick_highlights(segments: list[dict], count: int = 7) -> list[dict]:
+    """Pick segments evenly distributed across the episode, biasing for length."""
+    if len(segments) <= count:
+        return segments
+    fractions = [0.04, 0.18, 0.32, 0.46, 0.6, 0.74, 0.88]
+    picks: list[dict] = []
+    used: set[int] = set()
+    for f in fractions[:count]:
+        target = int(len(segments) * f)
+        # search a window for the longest segment near target
+        window_start = max(0, target - 3)
+        window_end = min(len(segments), target + 4)
+        candidates = [
+            (i, len(segments[i]["text"]))
+            for i in range(window_start, window_end)
+            if i not in used
+        ]
+        if not candidates:
+            continue
+        best = max(candidates, key=lambda x: x[1])
+        used.add(best[0])
+        picks.append(segments[best[0]])
+    picks.sort(key=lambda x: x["sec"])
+    return picks
+
+
+def fmt_timestamp(sec: int) -> str:
+    h = sec // 3600
+    m = (sec % 3600) // 60
+    s = sec % 60
+    return f"{h:02d}:{m:02d}:{s:02d}"
+
+
+def slug_to_episode_num(slug: str, fm_episode: str) -> str:
+    if fm_episode:
+        return fm_episode
+    # heuristic — use date
+    date_m = re.match(r"(\d{4}-\d{2}-\d{2})", slug)
+    return date_m.group(1) if date_m else slug
+
+
+def render_ingest_md(slug: str, fm: dict, picks: list[dict]) -> str:
+    title = fm.get("title", slug)
+    guest = fm.get("guest", "Guest")
+    guest_org = fm.get("guest_org", "")
+    date = fm.get("date", "")[:10] if fm.get("date") else ""
+    youtube_url = fm.get("youtube_url", "").strip("'\"")
+    video_id = fm.get("youtube_video_id", "")
+    episode_num = fm.get("episode") or slug_to_episode_num(slug, "")
+
+    org_line = f" from {guest_org}" if guest_org else ""
+
+    out = []
+    out.append(
+        "INGEST BATCH: BCZ YapZ Episode "
+        + str(episode_num)
+        + " — "
+        + guest
+        + org_line
+        + (f" ({date})" if date else "")
+        + "."
+    )
+    out.append("")
+    out.append(
+        "Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. "
+        "Verbatim quote text must be preserved exactly. Topics, platforms, chains, and tools must be "
+        "stored as attributes on the Episode node, NEVER as standalone Entity nodes per scope_constraint trait."
+    )
+    out.append("")
+
+    # Episode node
+    out.append("## EPISODE NODE")
+    out.append(f"Subject: {title}")
+    out.append("Type: PodcastEpisode")
+    if date:
+        out.append(f"Date: {date}")
+    out.append("Show: BCZ YapZ")
+    if episode_num:
+        out.append(f"Episode number: {episode_num}")
+    out.append("Format: video-podcast")
+    if youtube_url:
+        out.append(f"YouTube URL: {youtube_url}")
+    if video_id:
+        out.append(f"YouTube video ID: {video_id}")
+    if guest:
+        desc = f"Zaal interviews {guest}"
+        if guest_org:
+            desc += f" from {guest_org}"
+        desc += "."
+        out.append(f"Description: {desc}")
+    out.append(f"Source: {youtube_url or 'https://youtube.com/@bettercallzaal'}")
+    out.append("Confidence: 1.0")
+    out.append("")
+
+    # Person node — guest
+    out.append("## PERSON NODE — Guest")
+    out.append(f"Subject: {guest}")
+    out.append("Type: Person")
+    if guest_org:
+        out.append(f"Role: Founder/team at {guest_org}")
+    out.append(f"Source: {youtube_url}")
+    out.append("Confidence: 1.0")
+    out.append("")
+
+    # Org node — guest org
+    if guest_org:
+        out.append("## ORG NODE — Guest's organization")
+        out.append(f"Subject: {guest_org}")
+        out.append("Type: Org")
+        out.append(f"Source: {youtube_url}")
+        out.append("Confidence: 0.9")
+        out.append("")
+
+    # Quotes
+    for i, p in enumerate(picks, 1):
+        ts = fmt_timestamp(p["sec"])
+        deep = (
+            f"https://youtu.be/{video_id}?t={p['sec']}"
+            if video_id
+            else (youtube_url + f"?t={p['sec']}" if youtube_url else "")
+        )
+        out.append(f"## QUOTE NODE {i}")
+        out.append("Type: Quote")
+        out.append("Speaker: (mark Zaal or guest based on context)")
+        text = p["text"].strip()
+        if len(text) > 600:
+            text = text[:597] + "..."
+        out.append(f'Text (verbatim): "{text}"')
+        out.append(f"Timestamp: {ts}")
+        if deep:
+            out.append(f"YouTube deeplink: {deep}")
+        out.append("Confidence: 1.0")
+        out.append("")
+
+    # Edges
+    out.append("## EDGES TO ASSERT")
+    out.append(f"- Zaal Panthaki -[hosted]-> {title}")
+    out.append(f"- {guest} -[appeared_on]-> {title}")
+    if guest_org:
+        out.append(f"- {guest} -[part_of]-> {guest_org}")
+    out.append(f"- {title} -[contains_quote]-> Quote 1 through Quote {len(picks)}")
+    out.append("")
+
+    # Closing instruction
+    out.append("---")
+    out.append(
+        "Build the manifest, preview the first 3 nodes inline, then ask me \"approve all?\". "
+        "Do not commit until I say yes. If existing Episode/Person/Org nodes match by name, MERGE; "
+        "do not create parallel nodes. Topics in the description are attributes, not entities."
+    )
+    return "\n".join(out)
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    transcripts = sorted(SRC_DIR.glob("*.md"))
+    if not transcripts:
+        print(f"no transcripts found in {SRC_DIR}")
+        return 1
+    written = 0
+    for src in transcripts:
+        text = src.read_text()
+        fm, body = parse_frontmatter(text)
+        segs = extract_segments(body)
+        if not segs:
+            print(f"warn: no timestamps in {src.name}")
+            continue
+        picks = pick_highlights(segs, count=7)
+        out_text = render_ingest_md(src.stem, fm, picks)
+        out_path = OUT_DIR / f"{src.stem}.md"
+        out_path.write_text(out_text)
+        written += 1
+        print(f"wrote {out_path.relative_to(REPO)} ({len(picks)} quotes)")
+    print(f"\ndone. {written} ingest files written to {OUT_DIR.relative_to(REPO)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

18 ingest-ready .md files generated from BCZ YapZ transcripts at content/yapz-bonfire-ingest/. Each file is self-contained for upload via Bonfire bot's Document Store tool.

## What's in each file

- INGEST BATCH trigger (fires extraction_discipline trait)
- Episode node (title, date, YouTube URL, video ID, description)
- Guest Person node + role
- Guest Org node (where applicable)
- 7 timestamped Quote nodes with verbatim text + youtu.be deeplinks
- Edges: hosted / appeared_on / part_of / contains_quote
- Closing instruction enforcing schema rules (paraphrase gate, scope_constraint, merge if exists)

## Status
Uploaded by Zaal to ZABAL Bonfire Bot 2026-05-02. Recall test pending.

## Next corpora queued
- Q1 2026 wins (project memory + git log synthesis)
- ZAO OS feature inventory (CLAUDE.md + BUILDLOG + src tree)
- Research doc index (590+ docs, batched)
- People graph (ZAOstock team + collaborators)