### PR TITLE
feat(bot): /zsedit + persona + chat fallback (re-targeted to main)

### DIFF
--- a/bot/src/actions.ts
+++ b/bot/src/actions.ts
@@ -189,7 +189,11 @@ export async function executeFromText(
   const { action, persona: usedPersona } = await parseAction(userText, persona);
 
   if (action.kind === 'unknown') {
-    return { ok: false, reply: `I can't act on that yet. Reason: ${action.reason}\n\nTry /ask for a Q&A reply, or give me something concrete like "add a todo to call Bangor by Friday".` };
+    // No discrete action - this is conversation. Hermes replies in voice
+    // instead of bailing out. The LLM also gets to nudge the user toward the
+    // right slash command if they're describing a website edit (cost-gated)
+    // or a feedback log (free).
+    return await hermesChatReply(requester, userText, persona);
   }
 
   try {
@@ -424,5 +428,50 @@ export async function executeFromText(
     }
   } catch (err) {
     return { ok: false, reply: `Action failed: ${err instanceof Error ? err.message : 'unknown error'}` };
+  }
+}
+
+/**
+ * Free-form Hermes chat. Used when the user types something that isn't a
+ * discrete action - so the bot stays conversational rather than refusing.
+ *
+ * The system prompt explicitly tells Hermes:
+ *   - identify as Hermes (the ZAOstock team bot that ships code edits)
+ *   - if the message is /test feedback that should be logged: suggest /zsfb
+ *   - if it's an edit the user wants shipped: suggest /zsedit
+ *   - otherwise just chat (under 200 words)
+ *
+ * Cost: one LLM call per chat reply, same as /ask. No DB writes here - the
+ * /zsfb and /zsedit commands handle persistence when the user opts in.
+ */
+async function hermesChatReply(
+  requester: TeamMember,
+  userText: string,
+  persona: PersonaName,
+): Promise<ExecuteResult> {
+  const system = [
+    "You are Hermes, the ZAOstock team's Telegram bot.",
+    'You handle two jobs: team ops + shipping code edits to the ZAOstock /test landing page.',
+    `You are talking to ${requester.name} (role: ${requester.role}, scope: ${requester.scope}).`,
+    'Reply in under 200 words. No emojis. No em dashes - use hyphens. Lowercase sentence starts are fine.',
+    '',
+    'Routing rules:',
+    '- If the user is describing a change they want made to the /test ZAOstock site, end your reply with: "Want me to ship it? Reply with /zsedit <your edit>." Do NOT call any tool yourself; users opt in via /zsedit.',
+    '- If the user is describing /test feedback they want logged but not shipped, suggest: "Reply /zsfb <text> to log it for the daily digest."',
+    '- If they want a discrete action (add todo, log a sponsor, mark a milestone), tell them to phrase it as a direct command (e.g., "add a todo to call Bangor by Friday") and you will parse it.',
+    '- For festival state questions (status, blockers, your todos), point them at /status, /mytodos, /digest.',
+    '- Otherwise just chat conversationally. Be useful, be brief.',
+    '',
+    'Voice: brand caps stay (ZAO, ZAOstock, FarHack, WaveWarZ). No "no margin / no extraction" copy. No specific member counts (use 100+).',
+  ].join('\n');
+
+  try {
+    const reply = await ask(userText, system, persona);
+    return { ok: true, reply: reply.text.trim() };
+  } catch (err) {
+    return {
+      ok: false,
+      reply: `LLM unreachable: ${err instanceof Error ? err.message : 'unknown'}. Try /ask, /zsfb, or /zsedit directly.`,
+    };
   }
 }

--- a/bot/src/hermes/commands.ts
+++ b/bot/src/hermes/commands.ts
@@ -45,7 +45,7 @@ function isAdmin(ctx: Context, member: TeamMember | null): boolean {
  */
 export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<void> {
   if (!isAdmin(ctx, member)) {
-    await ctx.reply('Hermes /fix is admin-only for v1. Ask Zaal to add you to BOT_ADMIN_TELEGRAM_IDS.');
+    await ctx.reply('/fix is admin-only - it can target any repo. Team can use /zsedit (locked to zaostock, daily-capped) instead. Ping Zaal if you need /fix scope.');
     return;
   }
 
@@ -59,7 +59,7 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
       : await checkOnPath('claude');
   if (!claudeOnPath) {
     await ctx.reply(
-      "Hermes can't find the 'claude' CLI on PATH. Install Claude Code on the bot host (Max plan), or set HERMES_CLAUDE_BIN.",
+      "I can't find the 'claude' CLI on the bot host - my Coder loop runs through it. Install Claude Code on the host (Max plan) or set HERMES_CLAUDE_BIN. Pinging Zaal.",
     );
     return;
   }
@@ -77,7 +77,7 @@ export async function cmdFix(ctx: Context, member: TeamMember | null): Promise<v
     return;
   }
 
-  await ctx.reply(`Hermes starting against ${target}. Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.`);
+  await ctx.reply(`On it. Cloning ${target}, Coder will read + write a diff, Critic grades. You get a PR link if score >=70. Max 3 attempts.`);
 
   // Fire-and-forget: long-running, will report back via Telegram.
   void runAndReport(ctx, { triggered_by_telegram_id: fromId, triggered_in_chat_id: chatId, issue_text: text, target_repo: target });
@@ -94,22 +94,22 @@ async function runAndReport(
       const pingZaal = ZAAL_TG_ID && ZAAL_TG_ID !== input.triggered_by_telegram_id ? `\n\ncc @${ZAAL_TG_ID}` : '';
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes READY. PR ${r.pr_url}\nCritic score: ${r.critic_score}/100\nAttempts: ${r.fixer_attempts}\nCost: $${r.estimated_cost_usd ?? 'n/a'}${pingZaal}\n\nPush when good.`,
+        `READY. PR open: ${r.pr_url}\nCritic: ${r.critic_score}/100 in ${r.fixer_attempts} attempt(s). Cost $${r.estimated_cost_usd ?? 'n/a'}.${pingZaal}\n\nReview + merge when good.`,
       );
     } else if (result.kind === 'escalated') {
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes ESCALATED. Hit max ${r.fixer_max_attempts} attempts. Last feedback: ${result.reason}\nRun ID: ${r.id}`,
+        `ESCALATED after ${r.fixer_max_attempts} attempts. Last critic feedback: ${result.reason}\nRun ID: ${r.id}\n\nThis one needs a human. Either rephrase + retry or take it manually.`,
       );
     } else {
       await ctx.api.sendMessage(
         input.triggered_in_chat_id,
-        `Hermes FAILED. ${result.reason}\nRun ID: ${r.id}`,
+        `FAILED. ${result.reason}\nRun ID: ${r.id}`,
       );
     }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    await ctx.api.sendMessage(input.triggered_in_chat_id, `Hermes crashed outside the loop: ${msg}`);
+    await ctx.api.sendMessage(input.triggered_in_chat_id, `Coder loop crashed outside the run: ${msg}`);
   }
 }
 
@@ -169,12 +169,12 @@ function formatRun(r: { id: string; status: string; fixer_attempts: number; crit
  */
 export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promise<void> {
   if (!member) {
-    await ctx.reply('You need to be a registered team member to use /zsedit. Run /whoami to confirm or DM Zaal to get added.');
+    await ctx.reply('I only ship edits for registered team. Run /whoami to confirm, or DM Zaal to get added to the roster.');
     return;
   }
 
   if (process.env.ZSEDIT_DISABLED === '1') {
-    await ctx.reply('Team /zsedit is paused right now. /zsfb still works for logging feedback. Ping Zaal if it is urgent.');
+    await ctx.reply('Paused. /zsedit is off temporarily. /zsfb still works to log it for later. Ping Zaal if urgent.');
     return;
   }
 
@@ -182,14 +182,12 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   if (!text || text.length < 10) {
     await ctx.reply(
       [
-        'Usage: /zsedit <change you want on the /test ZAOstock site>',
+        'Tell me what to change on /test. I clone bettercallzaal/zaostock, write the diff, run a critic, open a PR if it scores >=70.',
         '',
         'Examples:',
         '  /zsedit drop the lineup TBA placeholders, keep the section header',
         '  /zsedit hero copy too long - cut the second sentence',
         '  /zsedit add a "lineup drops Aug 2026" pill near the top',
-        '',
-        'I clone bettercallzaal/zaostock, write the diff, run a critic, and open a PR if it passes 70/100. Max 3 attempts.',
       ].join('\n'),
     );
     return;
@@ -216,7 +214,7 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   }
   if (usedToday >= dailyCap) {
     await ctx.reply(
-      `Daily /zsedit cap reached (${usedToday}/${dailyCap}). Resets at UTC midnight. Use /zsfb to log feedback for tomorrow's batch, or ping Zaal if it is urgent.`,
+      `Hit your daily ship cap (${usedToday}/${dailyCap}). Resets at UTC midnight. Drop it in /zsfb so I batch it tomorrow, or ping Zaal if urgent.`,
     );
     return;
   }
@@ -226,14 +224,14 @@ export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promis
   const claudePath = process.env.HERMES_CLAUDE_BIN ?? '';
   const claudeOnPath = claudePath && existsSync(claudePath) ? true : await checkOnPath('claude');
   if (!claudeOnPath) {
-    await ctx.reply("Hermes can't find the 'claude' CLI on the bot host. Ping Zaal.");
+    await ctx.reply("Can't find the 'claude' CLI on my host - the Coder loop runs through it. Ping Zaal.");
     return;
   }
 
   await ctx.reply(
     [
-      `Hermes editing zaostock for ${member.name}. (${usedToday + 1}/${dailyCap} today.)`,
-      'Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.',
+      `On it, ${member.name}. Editing /test. (${usedToday + 1}/${dailyCap} today.)`,
+      'Coder writes the diff, Critic grades, you get a PR if score >=70. Max 3 attempts.',
     ].join('\n'),
   );
 

--- a/bot/src/hermes/commands.ts
+++ b/bot/src/hermes/commands.ts
@@ -1,6 +1,6 @@
 import type { Context } from 'grammy';
 import { dispatchHermesRun } from './runner';
-import { getRun, listOpenRuns } from './db';
+import { countRunsByTelegramIdToday, getRun, listOpenRuns } from './db';
 import type { HermesRepoTarget } from './types';
 import type { TeamMember } from '../auth';
 
@@ -150,4 +150,97 @@ function formatRun(r: { id: string; status: string; fixer_attempts: number; crit
   ]
     .filter(Boolean)
     .join('\n');
+}
+
+/**
+ * /zsedit <issue> - team-facing direct website edit on bettercallzaal/zaostock.
+ *
+ * How it differs from /fix:
+ *   - target_repo is HARDCODED to 'zaostock' (cannot be tricked into editing ZAO OS)
+ *   - Open to any active team member (no admin gate)
+ *   - Per-member daily cap (default 2/day, override via ZSEDIT_DAILY_PER_MEMBER)
+ *   - Kill switch: set ZSEDIT_DISABLED=1 to pause all team edits without redeploying
+ *
+ * Why a separate command vs opening /fix to all:
+ *   /fix can target any repo profile and is the admin's catch-all. /zsedit is
+ *   the safe, scoped, rate-limited surface for the team. If costs spike or
+ *   the team needs lockdown, flip ZSEDIT_DISABLED and /fix still works for
+ *   admins.
+ */
+export async function cmdZsEdit(ctx: Context, member: TeamMember | null): Promise<void> {
+  if (!member) {
+    await ctx.reply('You need to be a registered team member to use /zsedit. Run /whoami to confirm or DM Zaal to get added.');
+    return;
+  }
+
+  if (process.env.ZSEDIT_DISABLED === '1') {
+    await ctx.reply('Team /zsedit is paused right now. /zsfb still works for logging feedback. Ping Zaal if it is urgent.');
+    return;
+  }
+
+  const text = (ctx.message?.text ?? '').replace(/^\/zsedit(@\w+)?\s*/, '').trim();
+  if (!text || text.length < 10) {
+    await ctx.reply(
+      [
+        'Usage: /zsedit <change you want on the /test ZAOstock site>',
+        '',
+        'Examples:',
+        '  /zsedit drop the lineup TBA placeholders, keep the section header',
+        '  /zsedit hero copy too long - cut the second sentence',
+        '  /zsedit add a "lineup drops Aug 2026" pill near the top',
+        '',
+        'I clone bettercallzaal/zaostock, write the diff, run a critic, and open a PR if it passes 70/100. Max 3 attempts.',
+      ].join('\n'),
+    );
+    return;
+  }
+
+  const fromId = ctx.from?.id;
+  const chatId = ctx.chat?.id;
+  if (!fromId || !chatId) {
+    await ctx.reply('Cannot identify sender or chat.');
+    return;
+  }
+
+  // Per-member daily cap. Counts ALL runs by this telegram id today (including
+  // failed/escalated) so spend pressure is honored even on retries.
+  const dailyCap = Number(process.env.ZSEDIT_DAILY_PER_MEMBER ?? '2');
+  let usedToday = 0;
+  try {
+    usedToday = await countRunsByTelegramIdToday(fromId);
+  } catch (err) {
+    console.error('[zsedit] daily cap query failed', err);
+    // fail-open: if the count query breaks, still allow the run rather than
+    // hard-blocking the team. Spend is still gated by the fleet daily cap in
+    // runner.ts.
+  }
+  if (usedToday >= dailyCap) {
+    await ctx.reply(
+      `Daily /zsedit cap reached (${usedToday}/${dailyCap}). Resets at UTC midnight. Use /zsfb to log feedback for tomorrow's batch, or ping Zaal if it is urgent.`,
+    );
+    return;
+  }
+
+  // Reuse the same Claude CLI presence check /fix uses.
+  const { existsSync } = await import('node:fs');
+  const claudePath = process.env.HERMES_CLAUDE_BIN ?? '';
+  const claudeOnPath = claudePath && existsSync(claudePath) ? true : await checkOnPath('claude');
+  if (!claudeOnPath) {
+    await ctx.reply("Hermes can't find the 'claude' CLI on the bot host. Ping Zaal.");
+    return;
+  }
+
+  await ctx.reply(
+    [
+      `Hermes editing zaostock for ${member.name}. (${usedToday + 1}/${dailyCap} today.)`,
+      'Coder writes diff, Critic grades, you get a PR link if score >=70. Max 3 attempts.',
+    ].join('\n'),
+  );
+
+  void runAndReport(ctx, {
+    triggered_by_telegram_id: fromId,
+    triggered_in_chat_id: chatId,
+    issue_text: text,
+    target_repo: 'zaostock',
+  });
 }

--- a/bot/src/hermes/db.ts
+++ b/bot/src/hermes/db.ts
@@ -41,3 +41,21 @@ export async function listOpenRuns(limit = 20): Promise<HermesRun[]> {
   if (error) throw new Error(`listOpenRuns failed: ${error.message}`);
   return (data as HermesRun[]) ?? [];
 }
+
+/**
+ * How many Hermes runs has this telegram_id triggered since UTC midnight?
+ * Used by /zsedit to enforce per-member daily caps. Counts every run regardless
+ * of final status (so a failed/escalated run still counts toward the cap -
+ * spend was incurred either way).
+ */
+export async function countRunsByTelegramIdToday(telegramId: number): Promise<number> {
+  const todayUtcStart = new Date();
+  todayUtcStart.setUTCHours(0, 0, 0, 0);
+  const { count, error } = await db()
+    .from('hermes_runs')
+    .select('id', { count: 'exact', head: true })
+    .eq('triggered_by_telegram_id', telegramId)
+    .gte('created_at', todayUtcStart.toISOString());
+  if (error) throw new Error(`countRunsByTelegramIdToday failed: ${error.message}`);
+  return count ?? 0;
+}

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -18,7 +18,7 @@ import { scheduleAll } from './schedule';
 import { alertDevops, buildHealthReport } from './ops';
 import { morningDigest, eveningRecap, weekAheadDigest, fridayRetro } from './digest';
 import { cmdOp } from './onepagers';
-import { cmdFix, cmdFixStatus } from './hermes/commands';
+import { cmdFix, cmdFixStatus, cmdZsEdit } from './hermes/commands';
 import {
   cmdCircles,
   cmdJoin,
@@ -132,6 +132,7 @@ bot.command('help', async (ctx) => {
       '  /do <text> - I parse + update the board',
       '  /idea <text> - drop into the pool, Zaal sees daily',
       '  /zsfb <text> - feedback on the /test ZAOstock site (auto-tagged by section)',
+      '  /zsedit <text> - actually ship the edit to /test (Hermes opens a PR; capped per day)',
       '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
       '',
@@ -197,6 +198,14 @@ bot.command('fix', async (ctx) => {
 
 bot.command('fix_status', async (ctx) => {
   await cmdFixStatus(ctx);
+});
+
+// /zsedit - team-facing direct edit of bettercallzaal/zaostock /test site.
+// Open to all team members, target locked to zaostock, per-member daily cap,
+// kill switch via ZSEDIT_DISABLED env. See bot/src/hermes/commands.ts.
+bot.command('zsedit', async (ctx) => {
+  const member = await resolveMember(ctx.from?.id, ctx.from?.username);
+  await cmdZsEdit(ctx, member);
 });
 
 bot.command('press', async (ctx) => {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -88,16 +88,14 @@ bot.command('start', async (ctx) => {
   if (member) {
     await ctx.reply(
       [
-        `Hey ${member.name}. Dashboard is your hub: https://zaoos.com/stock/team`,
+        `Hey ${member.name}. Hermes here - I read, I write, I ship.`,
         '',
-        'Bot is backup. Useful for:',
-        '  /mytodos - what you are owning',
-        '  /do <text> - tell me what happened, I update the board',
-        '  /circles - the 8 circles, /join <slug> to grab one',
-        '  /op - 1-pagers (sponsor / partner / venue briefings)',
-        '  /digest morning - daily brief',
-        '  /ask - ask me anything',
-        '  /help - full list',
+        'I do two jobs:',
+        '  1) save you typing on team ops (/mytodos /do /idea /circles /op /digest)',
+        '  2) edit the ZAOstock site for you (/zsfb to log, /zsedit to actually ship a PR)',
+        '',
+        'Dashboard for full context: https://zaoos.com/stock/team',
+        'Type /help for the full surface.',
       ].join('\n'),
     );
     return;
@@ -105,7 +103,8 @@ bot.command('start', async (ctx) => {
   const u = ctx.from?.username ? `@${ctx.from.username}` : 'your account';
   await ctx.reply(
     [
-      `Hey - I'm the ZAOstock Team Bot. ZAO Festivals presents ZAOstock, Oct 3 in Ellsworth.`,
+      `Hey - Hermes here. I run the ZAOstock team ops + ship code edits to the site.`,
+      `ZAO Festivals presents ZAOstock, Oct 3 in Ellsworth.`,
       '',
       `Don't recognize ${u} on the roster yet. Ping Zaal to link you.`,
       '',
@@ -119,9 +118,15 @@ bot.command('help', async (ctx) => {
   const isGroup = ctx.chat?.type !== 'private';
   await ctx.reply(
     [
-      'ZAOstock Team Bot - I save you typing. Dashboard has the context.',
+      'Hermes - team ops + code edits. Dashboard has the full state.',
       '',
-      'Read:',
+      'Edit the ZAOstock site:',
+      '  /zsfb <text> - log feedback on /test, no PR (auto-tagged by section)',
+      '  /zsedit <text> - ship the edit. I clone, write, critique, open a PR. Capped per day.',
+      '  /fix [zaostock|zaoos] <issue> - admin: same loop, broader scope',
+      '  /fix_status [run_id] - check open code runs',
+      '',
+      'Read team state:',
       '  /status - festival snapshot, top blockers',
       '  /mytodos - what you are owning',
       '  /mytodos_all - everything open across the team (claimable)',
@@ -131,8 +136,6 @@ bot.command('help', async (ctx) => {
       'Tell me what happened:',
       '  /do <text> - I parse + update the board',
       '  /idea <text> - drop into the pool, Zaal sees daily',
-      '  /zsfb <text> - feedback on the /test ZAOstock site (auto-tagged by section)',
-      '  /zsedit <text> - actually ship the edit to /test (Hermes opens a PR; capped per day)',
       '  /note <text> - meeting note, goes to dashboard',
       '  /gemba <text> - quick standup log',
       '',
@@ -156,10 +159,6 @@ bot.command('help', async (ctx) => {
       '',
       'External (anyone, no link needed):',
       '  /press - press kit + contact info',
-      '',
-      'Hermes (admin only, runs via Claude Code CLI on Max plan):',
-      '  /fix <issue> - Coder writes diff, Critic grades, you get a PR if score >=70',
-      '  /fix_status [run_id] - check open Hermes runs',
       '',
       'Ops:',
       '  /chatinfo - chat + topic ids',
@@ -263,7 +262,7 @@ bot.command('ask', async (ctx) => {
   try {
     const reply = await ask(
       text,
-      `You are the ZAOstock Team Bot advisor. Answer briefly (under 300 words). If the user is asking about festival state, tell them to use /status or /mytodos.`,
+      `You are Hermes, the ZAOstock team bot. You handle team ops + ship code edits to the ZAOstock site. Answer briefly (under 300 words). If the user is asking about festival state, tell them to use /status or /mytodos. If they want to change the site, tell them /zsfb (log) or /zsedit (ship).`,
     );
     await ctx.reply(reply.text);
   } catch (err) {

--- a/bot/src/zsfb.ts
+++ b/bot/src/zsfb.ts
@@ -76,7 +76,7 @@ export async function addZsFb(member: TeamMember, text: string): Promise<string>
   });
 
   return [
-    `Logged (${section}). id ${data.id.slice(0, 8)}.`,
-    `Zaal sees the daily digest. He'll trigger Hermes if it's a clear ship.`,
+    `Got it - logged under ${section}. id ${data.id.slice(0, 8)}.`,
+    `I'll surface it in the daily digest. Want it shipped now? Run /zsedit with the same text.`,
   ].join('\n');
 }


### PR DESCRIPTION
## Summary

PR #447 was auto-closed by GitHub when its base branch got squash-merged via #446 - the three commits never actually landed on main. Re-cherry-picked onto a fresh branch off current main:

1. \`/zsedit <issue>\` - team-facing direct edit on bettercallzaal/zaostock with per-member daily cap and kill switch
2. Persona pass - bot speaks as Hermes across /start, /help, /ask system, /fix and /zsedit replies, /zsfb confirmation
3. Hermes chat fallback - plain text in DM (or @-mention in group) routes through executeFromText; if no action parses, Hermes replies conversationally + nudges toward /zsfb or /zsedit

This is what the team sees at /start after merge:

\`\`\`
Hey [name]. Hermes here - I read, I write, I ship.

I do two jobs:
  1) save you typing on team ops (/mytodos /do /idea /circles /op /digest)
  2) edit the ZAOstock site for you (/zsfb to log, /zsedit to actually ship a PR)
\`\`\`

## Test plan after merge + bot host pull/restart

- [ ] /start replies with the new Hermes intro
- [ ] /help lists "Edit the ZAOstock site" section first with /zsfb /zsedit /fix
- [ ] /zsfb hero copy too long - confirm reply parses section as 'hero'
- [ ] DM "the lineup section feels heavy" - confirm Hermes chat reply ending with "Want me to ship it? Reply /zsedit ..."
- [ ] /zsedit add a "lineup drops Aug 2026" pill near the top - confirm Hermes opens PR on bettercallzaal/zaostock
- [ ] Same member /zsedit 3rd time same day - cap kicks in
- [ ] ZSEDIT_DISABLED=1 env -> /zsedit replies "Paused"