### PR TITLE
feat(bot): /regen - self-serve dashboard login code mint

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -19,6 +19,7 @@ import { alertDevops, buildHealthReport } from './ops';
 import { morningDigest, eveningRecap, weekAheadDigest, fridayRetro } from './digest';
 import { cmdOp } from './onepagers';
 import { cmdFix, cmdFixStatus, cmdZsEdit } from './hermes/commands';
+import { cmdRegenSelf, cmdRegenForName } from './regen';
 import {
   cmdCircles,
   cmdJoin,
@@ -142,6 +143,7 @@ bot.command('help', async (ctx) => {
       'Ask me anything:',
       '  /ask <question> - LLM reply, no DB write',
       '  /whoami - confirm who I think you are',
+      '  /regen - DM me to get a fresh dashboard login code (1/day; admin /regen <Name> to regen for someone else)',
       '',
       'Circles:',
       '  /circles - all 8 + who coordinates',
@@ -251,6 +253,19 @@ bot.command('zsfb', async (ctx) => {
   const member = await requireMember(ctx);
   if (!member) return;
   await ctx.reply(await addZsFb(member, ctx.match ?? ''));
+});
+
+// /regen - mint a new dashboard login code.
+// No arg + DM -> regen own code (any team member, daily-capped).
+// With <Name> arg -> admin-only regen for someone else (DMs target if linked).
+bot.command('regen', async (ctx) => {
+  const member = await resolveMember(ctx.from?.id, ctx.from?.username);
+  const arg = (ctx.match ?? '').toString().trim();
+  if (arg) {
+    await cmdRegenForName(ctx, member);
+  } else {
+    await cmdRegenSelf(ctx, member);
+  }
 });
 
 bot.command('ask', async (ctx) => {

--- a/bot/src/regen.ts
+++ b/bot/src/regen.ts
@@ -1,0 +1,232 @@
+// /regen - generate a new 4-character dashboard login code
+//
+// Two surfaces:
+//   - Self-serve (any team member): /regen in DM only, mints + writes own code,
+//     replies privately with plaintext.
+//   - Admin override: /regen <Name>, regen anyone, DMs target if linked, falls
+//     back to replying to the admin so they can relay.
+//
+// Why this exists:
+//   - Codes are scrypt-hashed in DB; if a member loses theirs, only a fresh
+//     mint can restore login. The legacy path was: SQL UPDATE pasted into
+//     Supabase by Zaal. This automates it via Telegram so Zaal isn't a
+//     bottleneck and team members can self-service.
+//   - Two tables in the same Supabase project hold member rows:
+//       team_members        - what the dashboard login route reads
+//       stock_team_members  - what the bot's auth + roster commands read
+//     Out-of-band sync exists between them (name as the join key). /regen
+//     writes the new password_hash to BOTH so login + roster stay coherent.
+//
+// Safety:
+//   - DM-only for self-regen (codes leak risk in groups)
+//   - Daily cap (REGEN_DAILY_PER_MEMBER, default 1/day) prevents abuse
+//   - Admin override checks BOT_ADMIN_TELEGRAM_IDS env (same gate as /fix)
+//   - All regens log to stock_activity_log for audit
+
+import type { Context } from 'grammy';
+import { scryptSync, randomBytes } from 'node:crypto';
+import { db } from './supabase';
+import { logBotActivity } from './activity';
+import {
+  findMemberByTelegramId,
+  findMemberByUsername,
+  type TeamMember,
+} from './auth';
+
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+function generateCode(): string {
+  let out = '';
+  for (let i = 0; i < 4; i++) out += ALPHABET[randomBytes(1)[0] % ALPHABET.length];
+  return out;
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+function isAdmin(ctx: Context): boolean {
+  const adminIds = (process.env.BOT_ADMIN_TELEGRAM_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromId = ctx.from?.id;
+  if (!fromId) return false;
+  return adminIds.includes(String(fromId));
+}
+
+async function countRegensForMemberToday(memberId: string): Promise<number> {
+  const todayUtcStart = new Date();
+  todayUtcStart.setUTCHours(0, 0, 0, 0);
+  const { count, error } = await db()
+    .from('stock_activity_log')
+    .select('id', { count: 'exact', head: true })
+    .eq('actor_id', memberId)
+    .eq('action', 'code_regen')
+    .gte('created_at', todayUtcStart.toISOString());
+  if (error) {
+    console.error('[regen] count query failed', error.message);
+    return 0; // fail-open; daily cap is a courtesy not a security boundary
+  }
+  return count ?? 0;
+}
+
+/**
+ * Mint a new code for `member`, write to both team_members (dashboard login)
+ * and stock_team_members (bot roster), log the activity.
+ *
+ * Returns the plaintext code so the caller can DM it to the right person.
+ * NEVER write the plaintext anywhere persistent - only the salt:hash.
+ */
+async function mintAndWrite(member: TeamMember): Promise<{ ok: true; code: string } | { ok: false; reply: string }> {
+  const code = generateCode();
+  const passwordHash = hashPassword(code);
+
+  // Dashboard login table (read by /api/team/login in zaostock). Match by
+  // name since stock_team_members and team_members share name as join key.
+  const dash = await db()
+    .from('team_members')
+    .update({ password_hash: passwordHash, active: true })
+    .eq('name', member.name);
+
+  // Bot roster table - keep the hash in sync so any future bot reader sees
+  // the same value. ID match is exact for this table (we resolved from it).
+  const bot = await db()
+    .from('stock_team_members')
+    .update({ password_hash: passwordHash })
+    .eq('id', member.id);
+
+  if (dash.error && bot.error) {
+    return { ok: false, reply: `Could not write to either table. dashboard=${dash.error.message}. bot=${bot.error.message}` };
+  }
+  if (dash.error) {
+    // Bot table got it but dashboard didn't - login won't work. Surface loudly.
+    return {
+      ok: false,
+      reply: `Wrote to bot roster but dashboard update failed: ${dash.error.message}. Login won't change. Ping Zaal to fix the team_members row by name='${member.name}'.`,
+    };
+  }
+  // bot.error alone is fine - dashboard is the user-visible one.
+  if (bot.error) {
+    console.error(`[regen] stock_team_members update warning: ${bot.error.message}`);
+  }
+
+  await logBotActivity({
+    actorId: member.id,
+    entityType: 'member',
+    entityId: member.id,
+    action: 'code_regen',
+    newValue: 'mint',
+  });
+
+  return { ok: true, code };
+}
+
+/**
+ * /regen self-serve. Open to any registered team member, DM only.
+ */
+export async function cmdRegenSelf(ctx: Context, member: TeamMember | null): Promise<void> {
+  if (!member) {
+    await ctx.reply('I only regen codes for registered team. Run /whoami to confirm, or DM Zaal to get added.');
+    return;
+  }
+
+  const chatType = ctx.chat?.type;
+  if (chatType !== 'private') {
+    await ctx.reply('DM me directly for /regen - I never paste a login code into a group. Open a DM and try again.');
+    return;
+  }
+
+  const dailyCap = Number(process.env.REGEN_DAILY_PER_MEMBER ?? '1');
+  const usedToday = await countRegensForMemberToday(member.id);
+  if (usedToday >= dailyCap) {
+    await ctx.reply(
+      `You already regenerated today (${usedToday}/${dailyCap}). Resets at UTC midnight. Ping Zaal if you've genuinely lost it twice.`,
+    );
+    return;
+  }
+
+  const result = await mintAndWrite(member);
+  if (!result.ok) {
+    await ctx.reply(result.reply);
+    return;
+  }
+
+  await ctx.reply(
+    [
+      `New code: ${result.code}`,
+      '',
+      `Use it at https://zaostock.com/team to log into the dashboard.`,
+      `Case-insensitive. (${usedToday + 1}/${dailyCap} regens today.)`,
+    ].join('\n'),
+  );
+}
+
+/**
+ * /regen <Name> admin override. Mints a fresh code for a different team member
+ * and either DMs it to them (if their telegram_id is linked) or hands it back
+ * to the admin to relay.
+ */
+export async function cmdRegenForName(ctx: Context, callerMember: TeamMember | null): Promise<void> {
+  if (!isAdmin(ctx)) {
+    await ctx.reply('Admin-only when targeting someone else. Use /regen with no argument to regen your own code.');
+    return;
+  }
+
+  const text = (ctx.message?.text ?? '').replace(/^\/regen(@\w+)?\s*/, '').trim();
+  if (!text) {
+    // Caller wants their own code, which is the self-serve path. Route there.
+    await cmdRegenSelf(ctx, callerMember);
+    return;
+  }
+
+  // Find target by name. Try normalized lookups against stock_team_members.
+  const { data: target } = await db()
+    .from('stock_team_members')
+    .select('id, name, scope, role, telegram_id, telegram_username, active')
+    .ilike('name', text)
+    .neq('active', false)
+    .maybeSingle();
+
+  if (!target) {
+    await ctx.reply(`Couldn't find a team member matching "${text}". Try the exact name from the roster.`);
+    return;
+  }
+
+  const result = await mintAndWrite(target as TeamMember);
+  if (!result.ok) {
+    await ctx.reply(result.reply);
+    return;
+  }
+
+  // Try to DM the target privately if their telegram_id is linked.
+  const targetTgId = (target as TeamMember).telegram_id;
+  if (targetTgId) {
+    try {
+      await ctx.api.sendMessage(
+        targetTgId,
+        [
+          `Hermes here - your dashboard code was reset by admin.`,
+          '',
+          `New code: ${result.code}`,
+          `Use it at https://zaostock.com/team`,
+        ].join('\n'),
+      );
+      await ctx.reply(`Reset done. New code DM'd to ${target.name} privately. Activity logged.`);
+      return;
+    } catch (err) {
+      // Fall through to hand the code to the admin if the DM bounces.
+      console.error(`[regen] DM to target ${target.name} failed`, err);
+    }
+  }
+
+  await ctx.reply(
+    [
+      `Reset done for ${target.name}.`,
+      `Their telegram is not linked (or DM blocked), so I can't deliver privately.`,
+      `Relay this to them yourself: ${result.code}`,
+    ].join('\n'),
+  );
+}

--- a/content/bonfire-ingest/chatgpt-archive-keepers-non-zao-1.md
+++ b/content/bonfire-ingest/chatgpt-archive-keepers-non-zao-1.md
@@ -1,0 +1,814 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-keepers-non-zao-1 (73 conversations).
+
+ChatGPT non-ZAO-tagged keepers (long threads 20+ msgs / decisions / writing / person mentions). Part 1 of 2 — older half.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: ZWealth
+Type: Conversation
+Date: 2023-08-02
+Bucket: KEEP_WRITING
+Message count: 14
+Prompt (verbatim, opening): "Z wealth club has the following vision. create some podcast ideas to talk about "Our vision is to create a community of empowered young Zoroastrians in North America who confidently make personal financial decisions. We are committed to providing younger individuals with acces..."
+Conclusion (verbatim, closing): "Certainly! Here's a meeting review for your session on 8/16: --- **Z Wealth Club Meeting Review - 8/16** 🌟 **Main Highlights:** 1. **Ethics & Integrity in Business – The Zoroastrian Method**: Farzad shared a LinkedIn post which was insightful and provided a perspective on inte..."
+Source: https://chatgpt.com/c/eed56b23-c02d-4eee-a938-d6e1e60015b1
+Confidence: 1.0
+
+### FACT 2
+Subject: Collaborators Monthly Newsletter!
+Type: Conversation
+Date: 2023-08-17
+Bucket: KEEP_WRITING
+Message count: 73
+Prompt (verbatim, opening): "I want to create a ZTalent Agency dao (decentralized autoaumous org) where the governance coin gets multiplied by the amount of years you have been there. What are all the prompts you would need to make a detailed 1 year plan 6 months to pre launch and 6 months to post launch"
+Conclusion (verbatim, closing): "### Welcome to the ZTalent Collaborators' Monthly Pulse Hello Visionaries, I'm ecstatic to present you with the first issue of our monthly newsletter, curated especially for the ZTalent Collaborators—the cornerstone of our burgeoning community. This initiative aims to keep us ..."
+Source: https://chatgpt.com/c/a94a34d1-e2f1-4e51-bcde-7e414b7b0159
+Confidence: 1.0
+
+### FACT 3
+Subject: ZTalent Tunes (RM)
+Type: Conversation
+Date: 2023-08-25
+Bucket: KEEP_LONG_THREAD
+Message count: 28
+Prompt (verbatim, opening): "quick summary Welcome, artists & builders. Each week, we navigate music’s future together. Today, I’m getting into the default mode of music release strategies & get into a great example of 2 artists trying something new. Inside Issue #18 💡 Context: Challenge the default 🤔 Tha..."
+Conclusion (verbatim, closing): "### ZTalent Tunes: The Future of Decentralized Music Streaming --- #### Slide 1: Introduction **Slide Content:** - Welcome to ZTalent Tunes - The Future of Decentralized Music Streaming **Talking Points:** - Welcome to the unveiling of ZTalent Tunes, the future of decentralize..."
+Source: https://chatgpt.com/c/8e9164ba-cc5d-4a43-94fc-dcd26344f820
+Confidence: 1.0
+
+### FACT 4
+Subject: DAO Vision & Advisory (RM)
+Type: Conversation
+Date: 2023-08-27
+Bucket: KEEP_LONG_THREAD
+Message count: 84
+Prompt (verbatim, opening): "I want to make a DAO for Ztalent look through this list and tell me what you think https://101blockchains.com/pros-and-cons-of-dao/ also look through my website and give me feedback on what i can do to change it so that in 3 months I can launch my dao publicly here is my backg..."
+Conclusion (verbatim, closing): "Great! Proceeding with this comprehensive roadmap will set Jamie Richards on a transformative journey in the Web3 space. It will not only empower him as an artist but also educate and onboard his existing fanbase into the crypto world. The roadmap provides a structured approac..."
+Source: https://chatgpt.com/c/124c1165-3555-4886-9cf4-c000d4ffd175
+Confidence: 1.0
+
+### FACT 5
+Subject: ZTalent Newsletter
+Type: Conversation
+Date: 2023-08-29
+Bucket: KEEP_WRITING
+Message count: 57
+Prompt (verbatim, opening): "remember my plans for the DAO I want to make a newsletter for communication between members of the DAO I want to send an intro newsletter that covers most of the basics of a newsletter give me good prompts to set up my newsletter"
+Conclusion (verbatim, closing): "Absolutely, Zaal! Here are three vibrant options for your second ZTalent Newsletter: ### Option 1: --- # ZTalent Newsletter: Issue #2 ## Subject Line: "ZTalent: Your Backstage Pass to the Future of Music and Tech 🎵" --- ## Introduction Hey there, Future Rockstars! 🌟 I'm back, ..."
+Source: https://chatgpt.com/c/4f30ba5e-823c-4dc6-8fbe-8a22ab229df4
+Confidence: 1.0
+
+### FACT 6
+Subject: GameStop: Investment and Vision
+Type: Conversation
+Date: 2023-09-06
+Bucket: KEEP_WRITING
+Message count: 7
+Prompt (verbatim, opening): "Do some research online and write me a blog post about why GameStop is a good investment and try to explain a history of the gamestop stock from late 2020 to present Here is background on gamestop Pitchbook data (~25k/year data source) showing company going private through mer..."
+Conclusion (verbatim, closing): "Absolutely, Zaal. I can see how this topic would resonate with your interests in the evolving landscape of technology and business. Let's craft a blog post that mirrors your visionary approach to the world of Web3 and decentralized platforms. Here we go: --- # GameStop: A Beac..."
+Source: https://chatgpt.com/c/183857cd-26f3-49ad-8d83-d202a2507909
+Confidence: 1.0
+
+### FACT 7
+Subject: ZTalent Newsletter #5
+Type: Conversation
+Date: 2023-09-14
+Bucket: KEEP_DECISION
+Message count: 110
+Prompt (verbatim, opening): "write me a newsletter # 2 for ztalent use these as the 3 main sections Rhythm & Tech Digest: A weekly roundup of how technology is reshaping the music landscape. PlugIn Pulse: A weekly spotlight on a tool or plugin that can redefine your music creation process. ZTalent Vibes: ..."
+Conclusion (verbatim, closing): "Absolutely! Here's a sign-off that encapsulates the ZTalent vibe: --- With vibes as electric as a killer guitar solo and a vision as expansive as the blockchain, we're just getting started. Keep those dreams big and those spirits high, Future Rockstars! 🎸🌟 Until next time, let..."
+Source: https://chatgpt.com/c/2706c7c6-f169-4b52-b81e-5f6cc2dc7d36
+Confidence: 1.0
+
+### FACT 8
+Subject: ZTalent Roadmap
+Type: Conversation
+Date: 2023-10-01
+Bucket: KEEP_LONG_THREAD
+Message count: 25
+Prompt (verbatim, opening): "I am going to feed you a bunch of information about a startup idea called ZTalent that is focused on demystifying emmerging tech for musicians I want you to build out a full roadmap, a presentation and business proposal for a vc to look at that does not know about web 3 techno..."
+Conclusion (verbatim, closing): "Certainly, let's dive deeper into each section of the ZTalent Roadmap. --- ### ZTalent Roadmap #### Introduction ##### Brief Overview of ZTalent ZTalent aims to revolutionize the music streaming industry by leveraging blockchain technology to create a decentralized platform th..."
+Source: https://chatgpt.com/c/f5b7cc87-664f-464c-bd25-f5837691bb10
+Confidence: 1.0
+
+### FACT 9
+Subject: Hats Protocol into ZTalen
+Type: Conversation
+Date: 2023-10-01
+Bucket: KEEP_WRITING
+Message count: 18
+Prompt (verbatim, opening): "Integrating Hats Protocol into ZTalent's Community Structure The Hats Protocol can be a game-changer for ZTalent, especially given your focus on artist empowerment and demystifying emerging tech. Here's how: Initial Setup: Start by defining the core Hats that align with ZTalen..."
+Conclusion (verbatim, closing): "Certainly! Here"
+Source: https://chatgpt.com/c/d01eb400-c772-4933-8858-114816c3bdc3
+Confidence: 1.0
+
+### FACT 10
+Subject: newsletter #6
+Type: Conversation
+Date: 2023-10-20
+Bucket: KEEP_WRITING
+Message count: 58
+Prompt (verbatim, opening): "https://paragraph.xyz/@ztalent/zaalnewsletter0 https://paragraph.xyz/@ztalent/ztalent-newsletter-1 https://paragraph.xyz/@ztalent/ztalent-2-unlocking-new-realms-in-music,-tech,-and-community https://paragraph.xyz/@ztalent/ztalent-newsletter-3 https://paragraph.xyz/@ztalent/zta..."
+Conclusion (verbatim, closing): "Certainly, let's condense the tweet to fit within Twitter's 280-character limit. Here's a revised version: --- 🚀 Just dropped ZTalent Newsletter #6! Excited to feature @CandyToyBoxYT1 from @Web3AcademyDAO. Explore #Farcaster's impact on musicians in #Web3 & don't miss Candy's ..."
+Source: https://chatgpt.com/c/4799bca7-60ad-440c-8ae1-413f283a7828
+Confidence: 1.0
+
+### FACT 11
+Subject: ZTalent newsletter 7
+Type: Conversation
+Date: 2023-10-24
+Bucket: KEEP_PERSON
+Message count: 74
+Prompt (verbatim, opening): "https://cryptonews.net/news/nft/27712067/ https://blockster.com/jadyn-violet-presents-raver-realm-where-music-meets-collectible-pfp-artistry research raver realm and write an article about everything Jadyn violet is doing to revolutionize the music industry in web 3"
+Conclusion (verbatim, closing): "Certainly, here's a more official-sounding version of the Twitter thread for ZTalent Newsletter #7: --- **Tweet 1:** ZTalent Newsletter Issue #7 is now available. This edition delves into the transformative projects ‘Raver Realm’ and ‘Manifold Studio’. Don't miss these groundb..."
+Source: https://chatgpt.com/c/c577af25-746b-47ed-99c4-5f6e5a1c48cb
+Confidence: 1.0
+
+### FACT 12
+Subject: why blockchain matter meeting Agenda
+Type: Conversation
+Date: 2023-10-30
+Bucket: KEEP_LONG_THREAD
+Message count: 102
+Prompt (verbatim, opening): "Hello, I want to set up an event called Crypto History for Musicians by Zeek Talent featuring Onagi University and Biohazard."
+Conclusion (verbatim, closing): "The agenda you've outlined for your meeting looks comprehensive and well-structured. It covers all the essential elements you need to address for an effective and productive session. Here's the agenda in a clean format for your convenience: --- ### Meeting Agenda: Review & Pra..."
+Source: https://chatgpt.com/c/67310433-8477-4a08-87c9-b15ed9451345
+Confidence: 1.0
+
+### FACT 13
+Subject: Newsletter (jon) threads
+Type: Conversation
+Date: 2023-11-03
+Bucket: KEEP_WRITING
+Message count: 91
+Prompt (verbatim, opening): "here is newsletter 8 🌟 Hello Future Rockstars! 🌟 Welcome to the 7th official edition of the ZTalent newsletter! We're thrilled to have you on this incredible journey where music, technology, and entrepreneurship collide. Buckle up, because this edition is packed with groundbre..."
+Conclusion (verbatim, closing): "Here's a detailed Twitter thread based on the ZTalent Newsletter Edition #14: 1. **Introduction** - "Hello Future Rockstars! 🌟 Welcome to the special edition of the ZTalent newsletter as we wrap up 2023 with inspiring stories from the world of music and technology." 2. **Spotl..."
+Source: https://chatgpt.com/c/edef3723-8991-47e9-a1b8-53ab37422781
+Confidence: 1.0
+
+### FACT 14
+Subject: Smoke Cover Test
+Type: Conversation
+Date: 2023-11-07
+Bucket: KEEP_LONG_THREAD
+Message count: 57
+Prompt (verbatim, opening): "using dalle3 can I input images"
+Conclusion (verbatim, closing): "Unfortunately, I'm not able to retrieve or display past images generated in our conversation. However, I can create a new image for you based on the description you provided. Please let me know the details you'd like to include, and I'll be happy to generate a new image for you."
+Source: https://chatgpt.com/c/4531283f-0a68-41f7-aa00-42fb237fbf74
+Confidence: 1.0
+
+### FACT 15
+Subject: newsletter 9 (CWC test)
+Type: Conversation
+Date: 2023-11-11
+Bucket: KEEP_WRITING
+Message count: 17
+Prompt (verbatim, opening): "i wanna write the ztalent newsletter 9 here are the previous ones 🌟 Hello Future Rockstars! 🌟 Welcome to the 8th official edition of the ZTalent newsletter! In this edition, we're delving deep into the realms of technology, music, and entrepreneurship, with a special focus on ..."
+Conclusion (verbatim, closing): "🎵 **Next on ZTalent: Blockchain's beat in music & Boomy's AI-driven composition! Tune in Nov 18th for industry-changing insights. 🚀 #ZTalent #MusicTech**"
+Source: https://chatgpt.com/c/f24d97a6-c7b5-409e-b6ca-71e14511db39
+Confidence: 1.0
+
+### FACT 16
+Subject: Nfts 4 event create
+Type: Conversation
+Date: 2023-11-16
+Bucket: KEEP_PERSON
+Message count: 25
+Prompt (verbatim, opening): "i am working on an event Opening Remarks by Host Zaal (5 min): "Hello and welcome, everyone! I'm Zaal from ZTalent Agency, your host for today's event, 'Why Blockchain Matters for Musicians.' We have a fantastic lineup and a compelling agenda ahead of us. Please feel free to r..."
+Conclusion (verbatim, closing): "Title: **ZTalent Event #1 Participant** Description: "Embrace your journey into the innovative world of music and blockchain with the 'ZTalent Event #1 Participant' NFT. This token commemorates your active participation in the 'Why Blockchain Matters 4 Musicians' event, symbol..."
+Source: https://chatgpt.com/c/9b3805bf-0a7b-4077-b037-eb47153b1973
+Confidence: 1.0
+
+### FACT 17
+Subject: ZTalent Newsletter #11
+Type: Conversation
+Date: 2023-11-24
+Bucket: KEEP_WRITING
+Message count: 24
+Prompt (verbatim, opening): "using the following two website urls as a format start to build the ztalent newsletter #11 https://paragraph.xyz/@ztalent/ztalentnewsletter9 https://paragraph.xyz/@ztalent/ztalentnewsletter10 Here's What to Expect from Each Newsletter Rhythm & Tech Digest: A weekly roundup of ..."
+Conclusion (verbatim, closing): "Understood! Here are two outro options for the ZTalent Newsletter #11, ending with a note of thanks: --- **Outro Option 1:** Thank you for joining us on this exciting journey through the latest in music and technology. Your enthusiasm and engagement are what make our community..."
+Source: https://chatgpt.com/c/5e7e7397-93b6-4c28-9c84-c449b40c915c
+Confidence: 1.0
+
+### FACT 18
+Subject: Art Basel 2023 Recap
+Type: Conversation
+Date: 2023-12-17
+Bucket: KEEP_WRITING
+Message count: 36
+Prompt (verbatim, opening): "i am writign the 13th newsletter https://learnweb3.io/ lets make the Rhythm & Tech Digest: A weekly roundup of how technology is reshaping the music landscape. about art basel 2023 as you may have notice this weeks edition is a week late. thats because the ztalent team went to..."
+Conclusion (verbatim, closing): "--- As we wrap up this edition, a huge thank you to our ZTalent family. Your creativity and drive are the heartbeats of our community. Here's to more innovation, artistry, and shared success in the journey ahead. Stay tuned, stay inspired! Warmly, The ZTalent Team --- This sho..."
+Source: https://chatgpt.com/c/bf3764ce-c9a3-4074-8153-2056df1ecc99
+Confidence: 1.0
+
+### FACT 19
+Subject: Morning Tiktok Captions
+Type: Conversation
+Date: 2023-12-18
+Bucket: KEEP_LONG_THREAD
+Message count: 29
+Prompt (verbatim, opening): "3. Let Go of the Idea that Gentle, Relaxed People Can't Be Superachievers One of the major reasons so many of us remain hurried, frightened, and competitive, and continue to live life as if it were one giant emergency, is our fear that if we were to become more peaceful and lo..."
+Conclusion (verbatim, closing): ""Good Morning everyone! 💖💝😍 Let's start the day with this beautiful thought: 'A flower cannot blossom without sunshine, and man cannot live without love.' A warm welcome to Timi Wale from Nigeria, our newest member in the Discord community! 🎶🌟 An artist and music producer who ..."
+Source: https://chatgpt.com/c/9e582f0d-8c2d-43f1-a6ec-68f9bdb835b0
+Confidence: 1.0
+
+### FACT 20
+Subject: Blockchain Music Revolution Speech
+Type: Conversation
+Date: 2023-12-19
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "PROJECT DESCRIPTION Writing a Speech with Purpose This project addresses topic selection strategies, how to define the purpose of your speech, and methods for producing a well-organized speech. Purpose: The purpose of this project is to learn or review basic methods for writin..."
+Conclusion (verbatim, closing): ""Step into the future of music with our latest Toastmasters presentation, 'Harmony in Disruption: How Blockchain Composes the Future of Music'. In this eye-opening speech, we delve into how blockchain is poised to transform the music industry from the ground up. Discover the p..."
+Source: https://chatgpt.com/c/95246bf2-150e-4765-bdc6-2db3940ca8ce
+Confidence: 1.0
+
+### FACT 21
+Subject: DS Pipeline Study Insights
+Type: Conversation
+Date: 2023-12-20
+Bucket: KEEP_LONG_THREAD
+Message count: 42
+Prompt (verbatim, opening): "Act as a student and take the given paper and wait for my questions about it, the question will ask you to aummarize and preform other tasks on the given paper"
+Conclusion (verbatim, closing): "Based on the abstract of "The Art and Practice of Data Science Pipelines," it can be said that the abstract is informative and reflects the body of the paper well. The key elements that support this assessment are: 1. **Overview of Scope and Purpose**: The abstract concisely o..."
+Source: https://chatgpt.com/c/487e421e-5d5b-49ef-a387-ef6eb2850d35
+Confidence: 1.0
+
+### FACT 22
+Subject: Newsletter 12 Summary Title
+Type: Conversation
+Date: 2023-12-29
+Bucket: KEEP_WRITING
+Message count: 10
+Prompt (verbatim, opening): "read through the last 3. newsletters and make the newsletter 14 https://paragraph.xyz/@ztalent/ztalentnewsletter11 https://paragraph.xyz/@ztalent/ztalentnewsletter12 https://paragraph.xyz/@ztalent/ztalentnewsletter13 Rhythm & Tech Digest: A weekly roundup of how technology is ..."
+Conclusion (verbatim, closing): "I can provide a concise summary of the newsletter's content, but I'm unable to reproduce the full text verbatim. The newsletter includes an interview with a music professional discussing their background, collaboration within the ZTalent community, and their views on Web3 tech..."
+Source: https://chatgpt.com/c/8ee8467d-7065-4fad-ac6d-8fb0495911e6
+Confidence: 1.0
+
+### FACT 23
+Subject: ERC-20 vs NFTs & Smart Contracts
+Type: Conversation
+Date: 2024-01-07
+Bucket: KEEP_DECISION
+Message count: 4
+Prompt (verbatim, opening): "whats the erc 20 standard vs other nfts and smart conctracts"
+Conclusion (verbatim, closing): "The ERC-20 standard, other types of NFTs (Non-Fungible Tokens), and smart contracts are all concepts related to the Ethereum blockchain, but they serve different purposes and have distinct characteristics. ### ERC-20 Standard 1. **Definition**: ERC-20 is a technical standard u..."
+Source: https://chatgpt.com/c/25c5ee4d-ff67-4b35-8c5f-6197a1a507e7
+Confidence: 1.0
+
+### FACT 24
+Subject: New chat
+Type: Conversation
+Date: 2024-01-22
+Bucket: KEEP_WRITING
+Message count: 4
+Prompt (verbatim, opening): "https://www.globenewswire.com/en/news-release/2023/02/21/2612378/0/en/OKX-Named-Top-Sponsor-of-ETHDenver-World-s-Largest-Web3-Hackathon.html research this"
+Conclusion (verbatim, closing): ""
+Source: https://chatgpt.com/c/79939403-6dbd-467d-ba37-3cb64fab9251
+Confidence: 1.0
+
+### FACT 25
+Subject: ETHDenver 2023 Sponsor Information
+Type: Conversation
+Date: 2024-01-22
+Bucket: KEEP_WRITING
+Message count: 16
+Prompt (verbatim, opening): "https://www.globenewswire.com/en/news-release/2023/02/21/2612378/0/en/OKX-Named-Top-Sponsor-of-ETHDenver-World-s-Largest-Web3-Hackathon.html i am look ing for you to make me an example spreadsheet for a list of sponsor opportunities for a musician /event curator for eth denver..."
+Conclusion (verbatim, closing): "To manually search through the Ethereum Denver Twitter page for mentions of sponsors for ETHDenver 2023, you can follow these steps: 1. **Go to the Ethereum Denver Twitter Page:** - Visit [Ethereum Denver Twitter](https://twitter.com/ethereumdenver?lang=en). 2. **Navigate to t..."
+Source: https://chatgpt.com/c/f11ba159-0a8f-4cdd-9017-08a2c7dd8cf2
+Confidence: 1.0
+
+### FACT 26
+Subject: Access SEC Comment Letter
+Type: Conversation
+Date: 2024-02-02
+Bucket: KEEP_WRITING
+Message count: 6
+Prompt (verbatim, opening): "https://www.sec.gov/comments/s7-11-23/s71123-typec.pdf Research this article"
+Conclusion (verbatim, closing): "I couldn't directly access the document. However, you can view the SEC comment letter by following the link and downloading the PDF for a detailed read. These documents usually contain comments on proposed rule changes or other regulatory matters, and can provide insights into..."
+Source: https://chatgpt.com/c/a354e8df-0737-47df-9d22-9974b68baa45
+Confidence: 1.0
+
+### FACT 27
+Subject: Java programming assignment help.
+Type: Conversation
+Date: 2024-02-24
+Bucket: KEEP_LONG_THREAD
+Message count: 467
+Prompt (verbatim, opening): "act as a java programmer and help me program sections marked for: //TODO: BONUS implement this for Programming Assignment 2 - Part 1 in the given code reccurrentneuralnetworks.java"
+Conclusion (verbatim, closing): "Yes, integrating the methods for updating the weights and biases based on gradients calculated during backpropagation is crucial for your neural network to learn and adapt based on the loss gradient derived from the training data. This process directly addresses the optimizati..."
+Source: https://chatgpt.com/c/3014345e-42d6-4f7d-a095-fecf263bab64
+Confidence: 1.0
+
+### FACT 28
+Subject: 2k followeres
+Type: Conversation
+Date: 2024-03-09
+Bucket: KEEP_LONG_THREAD
+Message count: 73
+Prompt (verbatim, opening): "Heyo, I'm trying to make a Twitter post for 2,000 followers as well, I was giving an introduction to myself as I've never said that. I also..."
+Conclusion (verbatim, closing): "on this journey; be part of the melody that shapes the future. Every tweet, every interaction, is a note in our shared symphony. 🎶 #SharedSymphony #FutureMelody [Graphic of a musical journey] 20/ Let’s forge ahead, making history with every beat, in a world where music and tec..."
+Source: https://chatgpt.com/c/c950c1ea-5887-4cef-a730-f763822b711a
+Confidence: 1.0
+
+### FACT 29
+Subject: Explore Stops: La Pine to Bend
+Type: Conversation
+Date: 2024-04-12
+Bucket: KEEP_LONG_THREAD
+Message count: 25
+Prompt (verbatim, opening): "From la pine Oregon to bend Oregon what cool stops are on the way with less than a 15 min detour"
+Conclusion (verbatim, closing): "Here are ten short winter hikes in the Bend, Oregon area that are"
+Source: https://chatgpt.com/c/7aa9f0bd-ae21-403c-ac65-f737baef809c
+Confidence: 1.0
+
+### FACT 30
+Subject: Deploy Smart Contract Hardhat
+Type: Conversation
+Date: 2024-06-20
+Bucket: KEEP_DECISION
+Message count: 5
+Prompt (verbatim, opening): "i want to deploy a smart contract in vs code using hard hat please give me all the steps listed out like I am a 10 year old"
+Conclusion (verbatim, closing): "Deploying a smart contract in VS Code using Hardhat can be broken down into simple, easy-to-follow steps. Here’s how to do it: ### Step 1: Install Node.js 1. Go to the [Node.js website](https://nodejs.org/). 2. Download and install the LTS version (it’s the recommended one). #..."
+Source: https://chatgpt.com/c/90abdbc1-a60e-4dd9-96f2-081dcee897a6
+Confidence: 1.0
+
+### FACT 31
+Subject: Using Farcaster Directory
+Type: Conversation
+Date: 2024-10-25
+Bucket: KEEP_WRITING
+Message count: 35
+Prompt (verbatim, opening): "https://github.com/YashKarthik/farcaster-directory how do i use this github"
+Conclusion (verbatim, closing): "It seems this project requires several environment variables to run. Here’s how to set them up: ### Step 1: Create a `.env.local` File In the project’s root directory (the `farcaster-directory` folder), create a file named `.env.local`: ```bash touch .env.local ``` ### Step 2:..."
+Source: https://chatgpt.com/c/671b89a9-1c8c-8000-88dd-8c1c9e013851
+Confidence: 1.0
+
+### FACT 32
+Subject: Tipsy (hurricane idea)
+Type: Conversation
+Date: 2024-12-05
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "i want to create a wallet to wallet messaging app for crypto and I want to include only paid messages on this playfrom I was thinking a pwa but now i relized you cant get notifications wiht a pwa i know there is a protocol for message but can we create this what are our option..."
+Conclusion (verbatim, closing): "Got it—your media player will be a *centerpiece* of the curator tool. If we want people to vibe with playlists and come back often, the player should feel **premium, fast, and immersive**. Here are a few key features we can lock in: --- ### 🎧 **High-Quality Media Player – Must..."
+Source: https://chatgpt.com/c/67527e6b-3658-8000-9a08-63abe86d2df1
+Confidence: 1.0
+
+### FACT 33
+Subject: Omi vs Omi Dev Kit
+Type: Conversation
+Date: 2025-02-13
+Bucket: KEEP_DECISION
+Message count: 8
+Prompt (verbatim, opening): "whats omi vs omi dev kit 2"
+Conclusion (verbatim, closing): "Alright, let's break it down. Omi is an AI-powered wearable device designed to be your personal assistant, summarizing conversations, creating to-do lists, and helping schedule meetings. The standard Omi device, priced at $89, is set to ship in Q2 2025. This version is us..."
+Source: https://chatgpt.com/c/67ae3da0-4068-8000-b267-7c26f9077d92
+Confidence: 1.0
+
+### FACT 34
+Subject: Display link in Spatial
+Type: Conversation
+Date: 2025-03-13
+Bucket: KEEP_LONG_THREAD
+Message count: 48
+Prompt (verbatim, opening): "https://toolkit.spatial.io/docs/installation can u figure out how to display a link on the world"
+Conclusion (verbatim, closing): "You can absolutely display a clickable link in your Spatial world—but you’ll need to build it yourself as an interactive object. Here’s the straightforward (and slightly cheeky) lowdown: 1. **Create the Visual:** In Unity, add a UI element (like a TextMeshPro or even a simple ..."
+Source: https://chatgpt.com/c/67d365b4-cc40-8000-8bd5-3b7511dd0f8b
+Confidence: 1.0
+
+### FACT 35
+Subject: Embed Bitcoin vs M2 Chart
+Type: Conversation
+Date: 2025-03-17
+Bucket: KEEP_DECISION
+Message count: 16
+Prompt (verbatim, opening): "can i create an embed code for a chart for bitcoin vs global m2 money supply"
+Conclusion (verbatim, closing): "Below is an end-to-end example you can embed on your Webflow site. This example uses Chart.js to plot Bitcoin prices (fetched from CoinGecko, which doesn’t require an API key) and U.S. M2 money supply (fetched from FRED, which does require an API key). > **Important:** > - **C..."
+Source: https://chatgpt.com/c/67d8261c-0378-8000-808c-aa467253f69c
+Confidence: 1.0
+
+### FACT 36
+Subject: Conversation summary request
+Type: Conversation
+Date: 2025-03-23
+Bucket: KEEP_LONG_THREAD
+Message count: 117
+Prompt (verbatim, opening): "Full details"
+Conclusion (verbatim, closing): "In 2020, NFTs opened new doors for artists, transforming MP3s into collectibles and promising creative control and new revenue streams. However, by 2022, the landscape shifted as tools broke and communities scattered, with many projects becoming quick cash grabs. Influenc..."
+Source: https://chatgpt.com/c/67e04c12-a444-8000-aabd-a61b4a23f32e
+Confidence: 1.0
+
+### FACT 37
+Subject: Social Media Dashboard Automation
+Type: Conversation
+Date: 2025-03-25
+Bucket: KEEP_LONG_THREAD
+Message count: 42
+Prompt (verbatim, opening): "i want to have a page that automatically has all of my social media links and follow counts on it so I can use that as a dashboard for my content and improving my following. is there a way I can automatically search on Instagram and twitter how many followers an account has fr..."
+Conclusion (verbatim, closing): "Since Webflow is a visual web design platform that doesn’t let you run server-side code directly, you’ll need a little “bridge” to talk to Farcaster’s gRPC API. Here’s a simple, non-dev-friendly roadmap to achieve this: --- ## 1. Create a Serverless Function as a Bridge Becaus..."
+Source: https://chatgpt.com/c/67e2e6c7-60b4-8000-b8a6-b635e12ec076
+Confidence: 1.0
+
+### FACT 38
+Subject: Cleaning Glasses Journal
+Type: Conversation
+Date: 2025-04-02
+Bucket: KEEP_LONG_THREAD
+Message count: 26
+Prompt (verbatim, opening): "I'm working on improving my morning and night routine and modulating my use of canabis for it to be helpful to me. Let's focus on the canabis use first and create a sort of journal before I partake that I fill out"
+Conclusion (verbatim, closing): "Great instinct. To make your form **super easy and effective** for fast, repeatable daily use — especially if you’re high or tired — we want to: ### ✅ Design Priorities: 1. **Reduce friction** — minimal typing, mostly tap/select. 2. **Keep it short** — 3–5 total taps max. 3. *..."
+Source: https://chatgpt.com/c/67ed3bae-0840-8000-a1a8-85f2d8a68d5f
+Confidence: 1.0
+
+### FACT 39
+Subject: Grocery List Meal Ideas
+Type: Conversation
+Date: 2025-04-08
+Bucket: KEEP_LONG_THREAD
+Message count: 24
+Prompt (verbatim, opening): "I want to start having a list of meals that I like and the raw ingredients it takes so that I can prepare for my groceriy list each week here are some of the things i buy, lets make a list of potenital grocery items Groceries List Bread C4 Mayo Detergent Shampoo Febreeze Waffl..."
+Conclusion (verbatim, closing): "Here’s your first recipe document for the week: **Beef Bulgogi** — complete with ingredients and step-by-step instructions. 👉 [Download the docx file here](sandbox:/mnt/data/Transitional_Food_Week_1_Beef_Bulgogi.docx) Ready when you are for the next recipe!"
+Source: https://chatgpt.com/c/67f53294-0820-8000-ab6d-8078d9f2ef63
+Confidence: 1.0
+
+### FACT 40
+Subject: GME Stock Deep Dive
+Type: Conversation
+Date: 2025-04-13
+Bucket: KEEP_LONG_THREAD
+Message count: 21
+Prompt (verbatim, opening): "I want you to do a full deep dive on the gme stock and the financial markets and macro economics Also look into directly registering shares Lookst everything that has happened since Jan 2020 to now and make a timeline Use this subreddit for research initially and go from links..."
+Conclusion (verbatim, closing): "Below is a complete Word‑document version of the report (in a .doc file) that includes all of the text and citations inline. You can download it and then open it using any word processor. (If you need additional formatting or have any issues, let me know!) Click the link below..."
+Source: https://chatgpt.com/c/67fb930f-52ec-8000-8877-89f4662e066a
+Confidence: 1.0
+
+### FACT 41
+Subject: How to Send Bulk DMs
+Type: Conversation
+Date: 2025-04-17
+Bucket: KEEP_WRITING
+Message count: 8
+Prompt (verbatim, opening): "https://getpercs.crisp.help/en/article/how-to-send-bulk-direct-casts-on-warpcast-1a2z0d4/ research this and explain it to me"
+Conclusion (verbatim, closing): "To send bulk direct messages (called "direct casts") on Warpcast using Percs, follow these steps: --- ### 1. **Connect Your Warpcast Profile to Percs** Begin by integrating your Warpcast account with Percs: - In the Percs admin panel, navigate to the **Settings** tab. ..."
+Source: https://chatgpt.com/c/6800d7d8-2288-8000-8d9b-12ceee5fafc3
+Confidence: 1.0
+
+### FACT 42
+Subject: Web3 Episode Breakdown
+Type: Conversation
+Date: 2025-04-22
+Bucket: KEEP_WRITING
+Message count: 23
+Prompt (verbatim, opening): "Let’s talk about web 3 EP 1 Sections lets split this up and explain in the youtube description the different sections of the video. 1. normie.tech 2. Crypto.com (CRO token) 3. Credit cards / ways to off board in the space 4. In process 5. Farcaster 6. Deso /vibecoding 7. Daily..."
+Conclusion (verbatim, closing): "Absolutely — let's correct the information about Rodeo and provide an updated **YouTube description** and **caption** for **Let’s Talk About Web3 – Episode 2**, reflecting the accurate details and the 44-minute runtime. --- ### **Let’s Talk About Web3 – Episode 2** Welcome to ..."
+Source: https://chatgpt.com/c/68076db8-d34c-8000-a4b4-11b9f5fd6abe
+Confidence: 1.0
+
+### FACT 43
+Subject: Airdrop
+Type: Conversation
+Date: 2025-04-29
+Bucket: KEEP_LONG_THREAD
+Message count: 29
+Prompt (verbatim, opening): "0x7990d756acf4e12afc41f995130a33925fb868ee 2,523 2651 0x7234c36A71ec237c2Ae7698e8916e0735001E9Af 2,394 2642 0xfAb9a3D37999E12252b47468D2FFD4BE15936012 1,454 1676 0x8D43A3fC2fed663BF6B82Ea4792C0e5239D5eE66 1,474 1542 0x29F5DeE65E1Fb856B816EaB4f0B702c10e5Eaa34 1,262 1372 0xbC660..."
+Conclusion (verbatim, closing): "Here is your final airdrop list formatted with just the **address** and the **difference (as quantity)**, ready to use for distribution or uploads. Would you like me to export this as a downloadable CSV file now?"
+Source: https://chatgpt.com/c/6811013d-5a7c-8000-ad30-5456852af8af
+Confidence: 1.0
+
+### FACT 44
+Subject: Address List Comparison
+Type: Conversation
+Date: 2025-04-29
+Bucket: KEEP_PERSON
+Message count: 8
+Prompt (verbatim, opening): "<!-- Hidden Address Data Block --> <div style="display: none;"> <script id="addressData" type="application/json"> { "0x7234c36A71ec237c2Ae7698e8916e0735001E9Af": { "name": "Zaal", "url": "" }, "0x7990d756acf4e12afc41f995130a33925fb868ee": { "name": "Attabotty", "url": "" }, "0..."
+Conclusion (verbatim, closing): "Perfect — let’s do it! You want to **properly add** `Shawn` and `Stonies` into the list, using the correct addresses you provided. Here’s the **full addition ready** to be merged into your hidden block: ```json { "0x547f8B793362df477a23aF6ee05F8e4e291a2Ee4": { "name": "Shawn",..."
+Source: https://chatgpt.com/c/68110ecb-6648-8000-8ab8-bf6c1e57c519
+Confidence: 1.0
+
+### FACT 45
+Subject: (redo)(tues) IFS Session Simulation
+Type: Conversation
+Date: 2025-05-06
+Bucket: KEEP_LONG_THREAD
+Message count: 30
+Prompt (verbatim, opening): "believe that you are the best ifs therapy trainer in the world lets go through a session"
+Conclusion (verbatim, closing): "Let’s go — Session 2, fresh slate. --- ### **IFS Session #2 – Check-In and Invitation** We’ll start with the same grounding. Take a breath. Settle in. Let’s drop back in with this: > **“What part of me wants my attention right now?”** It might be a different one than before — ..."
+Source: https://chatgpt.com/c/681a142b-b2dc-8000-8ea7-f8b4bdcbef7d
+Confidence: 1.0
+
+### FACT 46
+Subject: Name Correction Request
+Type: Conversation
+Date: 2025-05-12
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "make sure it says Ohanhji B instead of Ohnahj ii B"
+Conclusion (verbatim, closing): "{ "referenced_image_ids": ["file-XfGvNrauXW4PQDLpGTopLu"], "prompt": "Keep everything exactly the same as the image, but correct the text under the leftmost avatar from 'Ohnahj ii B' to 'Ohanhji B'. Use the same font, size, color, and positioning.", "size": "1024x1024" }"
+Source: https://chatgpt.com/c/6822523b-0e2c-8000-9e7d-3dd059cde389
+Confidence: 1.0
+
+### FACT 47
+Subject: Acadia DAO Logo Design
+Type: Conversation
+Date: 2025-05-14
+Bucket: KEEP_LONG_THREAD
+Message count: 24
+Prompt (verbatim, opening): "Can we make an Acadia DAO logo Do research on Acadia and make the mascot a lobster with other Maine stuff around him"
+Conclusion (verbatim, closing): "{ "prompt": "A cheerful red lobster mascot wearing a beige fisherman's hat stands proudly in the center of a circular logo. Behind it are scenic elements representing Acadia National Park, including a lighthouse by the ocean, evergreen trees, mountains, and a setting sun. The ..."
+Source: https://chatgpt.com/c/68246ef8-7b58-8000-833d-5cd33216ffc9
+Confidence: 1.0
+
+### FACT 48
+Subject: Pizza Party Announcement Thread
+Type: Conversation
+Date: 2025-05-14
+Bucket: KEEP_WRITING
+Message count: 35
+Prompt (verbatim, opening): "i want to work on my posts as annoucements for the pizza party coming up ID Status Name City Organization Crews Specialties Telegram Notes 42 Expert Enzo Pepperoni Philadelphia PizzaDAO Events, Real Estate, Governance, Comms, Tech, Video, Biz Dev Spreadsheets, organization, SQ..."
+Conclusion (verbatim, closing): "Your setup is solid — you’re 90% of the way there. The budget, timing, and engagement objective all make sense for your local event. That said, here are **3 smart tweaks** I recommend before you hit "Launch" to optimize this for *local turnout and relevance*: --- ## ✅ WHAT LOO..."
+Source: https://chatgpt.com/c/68247423-4d40-8000-91c1-31da1185dc7c
+Confidence: 1.0
+
+### FACT 49
+Subject: Podcast 3 Caption Idea
+Type: Conversation
+Date: 2025-05-19
+Bucket: KEEP_DECISION
+Message count: 10
+Prompt (verbatim, opening): "Podcast 3 - Intro (0:00 - Gratitude(1:13 - Farcon experience (2:14 - IRL experience (10:49) - ANON Vs DOXXED (26:02 - Farcaster Protocol (38:38) - Frame to Mini-apps (47:35 - Outro(54:41) - can we make a caption for ep 3 please"
+Conclusion (verbatim, closing): "Perfect — based on the formatting of Episodes 1 and 2, here’s the full caption for **Let’s Talk About Web3 – Episode 3**: --- **Let’s Talk About Web3 – Episode 3** Welcome to Episode 3 of *Let’s Talk About Web3* — a weekly livestream where we break down what’s happening across..."
+Source: https://chatgpt.com/c/682b0687-cc08-8000-bcb3-4db166df166e
+Confidence: 1.0
+
+### FACT 50
+Subject: Pizza Party Essentials
+Type: Conversation
+Date: 2025-05-22
+Bucket: KEEP_DECISION
+Message count: 6
+Prompt (verbatim, opening): "I'm throwing a pizza partty what kinda stuff at Walmart should I get I'm getting soda plastic cups and plates"
+Conclusion (verbatim, closing): "Sounds like a good time! Here’s a simple Walmart shopping list to make your pizza party smooth, fun, and well-stocked: ### **Essentials (besides pizza, soda, cups, and plates):** - **Napkins** (pizza can be greasy) - **Plastic cutlery** (forks/knives in case people want them) ..."
+Source: https://chatgpt.com/c/682f6912-8d30-8000-9e69-cdeb48f26a5e
+Confidence: 1.0
+
+### FACT 51
+Subject: Lil Nouns Proposal Guide
+Type: Conversation
+Date: 2025-05-26
+Bucket: KEEP_LONG_THREAD
+Message count: 49
+Prompt (verbatim, opening): "i want to do a proposal with lil nouns lets do as much research on what makes a proposal get accepted https://lilnouns.notion.site/Explore-Lil-Nouns-db990658e6ab4cf19121b22642645032 https://lilnouns.wtf/vote here are resources to look at using the vote tab look at proposals th..."
+Conclusion (verbatim, closing): "```markdown # Lil LiveStreamZ @ NFT NYC ### Bringing Lil Nouns ⌐◨-◨ to Times Square **Sponsor:** `@NounerHandle` (holder of Lil Noun #1234) --- ## TL;DR - One-day Nounish streaming house + “road-trip” content during NFT NYC - **Ask:** 6 ETH to hit 50 k viewers, mint 500 souven..."
+Source: https://chatgpt.com/c/6834f98d-d350-8000-a5c1-2ca842dae951
+Confidence: 1.0
+
+### FACT 52
+Subject: LTAW3 Ep 4 Summary
+Type: Conversation
+Date: 2025-05-27
+Bucket: KEEP_WRITING
+Message count: 12
+Prompt (verbatim, opening): "using the above transcript and the below titles can we make a caption for the youtube video for lets talk about web 3 ep 4 LTAW3 EP 4 1. Intro / gratitudes 2. BTC pizza day 1. S/O Fellenz 3. Unlock protocol 4. Where to get started 1. s/o raven 5. Tips to be conservative with y..."
+Conclusion (verbatim, closing): "Absolutely — here’s the **Episode 4** caption for *Let’s Talk About Web3* in the same structure and tone as Episode 3: --- ## Let’s Talk About Web3 – Episode 4 Welcome to Episode 4 of *Let’s Talk About Web3* — the weekly livestream where we explore onchain culture, creator too..."
+Source: https://chatgpt.com/c/6835e847-c704-8000-9e59-1184b5c87ea8
+Confidence: 1.0
+
+### FACT 53
+Subject: Resize Image to 512x512
+Type: Conversation
+Date: 2025-06-04
+Bucket: KEEP_LONG_THREAD
+Message count: 65
+Prompt (verbatim, opening): "can we change this to 512x 512 without removing anything"
+Conclusion (verbatim, closing): "I can’t fulfill that request because it violates our content policies. However, I can create a new square graphic inspired by your upload with “EP. 3” in the top right corner. If you’d like me to generate that, just confirm the content you'd like included (e.g., same hosts, ti..."
+Source: https://chatgpt.com/c/6840a894-801c-8000-a55a-858b29fae707
+Confidence: 1.0
+
+### FACT 54
+Subject: Remove Ep 6 Request
+Type: Conversation
+Date: 2025-06-04
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "can we get rid of the ep. 6"
+Conclusion (verbatim, closing): "Here’s the improved version of your image, resized to 1400x300 pixels while preserving the design and layout: [Download Improved 1400x300 Image](sandbox:/mnt/data/resized_image_1400x300_padded.png)"
+Source: https://chatgpt.com/c/6840ab27-08d4-8000-98ed-5dad984d45fd
+Confidence: 1.0
+
+### FACT 55
+Subject: Battle-Day Schedule Update
+Type: Conversation
+Date: 2025-06-04
+Bucket: KEEP_LONG_THREAD
+Message count: 149
+Prompt (verbatim, opening): "ok i want to change this to be more one battle each day wednesday thursday and friday instead of all on one day"
+Conclusion (verbatim, closing): "Great—that means the checklist covers every open loop and your draft is already in solid shape. 🎯 **Next options if you’d like them:** 1. **Rapid-fire implementation help** • I can drop the exact replacement paragraphs and budget block here for quick copy-paste. • Or I can giv..."
+Source: https://chatgpt.com/c/6840f739-3144-8000-9f93-c19113c56942
+Confidence: 1.0
+
+### FACT 56
+Subject: Proposal Improvement Feedback
+Type: Conversation
+Date: 2025-06-04
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "ok look through our files and see if we can make improvements to our proposal Here is a visual of our people too"
+Conclusion (verbatim, closing): "Below is a punch-list of the highest-impact edits you can make before sharing **Lil WaveWarZ @ NFT NYC** with the Lil Nouns community. I’ve grouped the notes by section so you (or a designer) can jump in quickly. --- ### 1. Add a crisp Executive Summary (1/3/1 format) * **1 se..."
+Source: https://chatgpt.com/c/6841102a-8edc-8000-8759-6a6d0efc23df
+Confidence: 1.0
+
+### FACT 57
+Subject: Hosting images in Markdown
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_LONG_THREAD
+Message count: 24
+Prompt (verbatim, opening): "how do i host an image so that i can paste it into markdown"
+Conclusion (verbatim, closing): "Sure thing—here’s the quickest way to get an image up on GitHub and grab a stable URL you can drop into Markdown. --- ## Option A: Web-only (“no git installed”) 1. **Create a new repo** *Log in → `+` → **New repository** → give it a name (e.g., `zao-assets`) → **Create reposit..."
+Source: https://chatgpt.com/c/6841cac5-0c64-8000-af6a-5d01557d85a7
+Confidence: 1.0
+
+### FACT 58
+Subject: Content Distribution Cleanup
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_WRITING
+Message count: 8
+Prompt (verbatim, opening): "## Content & Distribution ![5](https://hackmd.io/_uploads/HydwtfzXll.jpg) # Content, Marketing, & Distribution **Live Broadcast Channels:** - X - YouTube - Twitch - TikTok - Farcaster mini-app - HyperFi metaverse **Post-Event Clips:** - TikTok - YouTube Shorts - ZORA - Farcast..."
+Conclusion (verbatim, closing): "Here’s your cleaned-up `.md` version: ```markdown ## Content, Marketing, & Distribution ![5](https://hackmd.io/_uploads/HydwtfzXll.jpg) **Live Broadcast Channels:** X, YouTube, Twitch, TikTok, Farcaster mini-app, HyperFi metaverse **Post-Event Clips:** TikTok, YouTube Shorts, ..."
+Source: https://chatgpt.com/c/6844e5b7-87e4-8000-a527-908f3702809d
+Confidence: 1.0
+
+### FACT 59
+Subject: EP 7 Banner Creation
+Type: Conversation
+Date: 2025-06-11
+Bucket: KEEP_LONG_THREAD
+Message count: 21
+Prompt (verbatim, opening): "can we make the ep 7 banner"
+Conclusion (verbatim, closing): "{ "prompt": "A promotional podcast banner for Episode 7 of 'LET'S TALK ABOUT WEB3'. The design should match the style of the provided image: dark blue background, bold yellow title text 'THE ZAO PRESENTS LET'S TALK ABOUT WEB3' in all caps, with small music and Web3-themed icon..."
+Source: https://chatgpt.com/c/684a341e-fdd8-8000-9b5e-942090e399b2
+Confidence: 1.0
+
+### FACT 60
+Subject: Formatting and Directions Assistance
+Type: Conversation
+Date: 2025-06-20
+Bucket: KEEP_LONG_THREAD
+Message count: 26
+Prompt (verbatim, opening): "can u help me with this request Great job on this!! Thank you … I made a couple of minor formatting changes, not knowing how many hands are going to touch this before it reaches the person who will make the changes, looking to ensure it’s crystal clear what we need. I simply t..."
+Conclusion (verbatim, closing): "Based on the updated PDF, here’s what you’re sending to David — and the email revised for clarity and direct action: --- **Subject:** Website Directory – Final Structure for Eliances Profiles Hi David, Attached is the finalized Website Directory that should guide how member pr..."
+Source: https://chatgpt.com/c/685574a0-0c88-8000-94e4-ed60d8edfc6a
+Confidence: 1.0
+
+### FACT 61
+Subject: Allostatic Load Recovery
+Type: Conversation
+Date: 2025-06-26
+Bucket: KEEP_LONG_THREAD
+Message count: 28
+Prompt (verbatim, opening): "It’s 11am. You’ve already been hit with ten Slack pings, five emails, a call you didn’t want to take, and a calendar reminder you forgot to snooze. You’re wired and tired—buzzed on caffeine but already struggling to get anything meaningful done, and it’s not even lunchtime. Or..."
+Conclusion (verbatim, closing): "Below is a **breath-first, food-optional** roadmap you can start tomorrow. Every step is built around the same principle: **short sympathetic “push” → deliberate parasympathetic “pull.”** The only thing you *must* track is your breath cadence and perceived energy (1-5). Food t..."
+Source: https://chatgpt.com/c/685d59c8-d1c0-8000-a438-53719caa43a8
+Confidence: 1.0
+
+### FACT 62
+Subject: MiNTunes MVP Plan
+Type: Conversation
+Date: 2025-06-27
+Bucket: KEEP_WRITING
+Message count: 72
+Prompt (verbatim, opening): "# **MiNTunes MVP — Product & Implementation Plan** A minimal Farcaster Mini-App (inspired by **Tortoise**) for minting and collecting **music NFTs**. All media + metadata is stored on **Arweave** via Bundlr, and the user pays the exact storage cost. --- ## 1. Research Insights..."
+Conclusion (verbatim, closing): "``` Design a Farcaster Mini-App UI called **“ZoundZ”** that lets artists mint and listeners collect music NFTs. **Tech stack & conventions** - React (Next.js 14 with App Router) - Tailwind CSS + shadcn/ui components - lucide-react for icons - Framer Motion for subtle animation..."
+Source: https://chatgpt.com/c/685ea136-bcd8-8000-a4ff-da44846f2a34
+Confidence: 1.0
+
+### FACT 63
+Subject: Album Cover Design
+Type: Conversation
+Date: 2025-06-27
+Bucket: KEEP_LONG_THREAD
+Message count: 51
+Prompt (verbatim, opening): "create a hip hop album cover for the artist named SMOKE WAVY for a single called SKY HIGH, use psychedlic illustrated visuals for the cover"
+Conclusion (verbatim, closing): "{ "prompt": "A psychedelic album cover for a hip hop single titled 'Sky High' by artist Smoke Wavy. The scene is filled with vibrant swirling clouds, rainbow-colored waves, cannabis leaves, a groovy 1960s sun and moon, and colorful patterns. There is no central figure or anima..."
+Source: https://chatgpt.com/c/685ef120-45e4-8000-b9c7-0064f82df15f
+Confidence: 1.0
+
+### FACT 64
+Subject: NFT Captions (photos) (vibe)
+Type: Conversation
+Date: 2025-06-28
+Bucket: KEEP_LONG_THREAD
+Message count: 87
+Prompt (verbatim, opening): "i want to make a basic caption for a picture i took in the blue grotto in capri on a trip with my family tto eruope during high school, it was one of the first photos i have taken that i have always looked in awe"
+Conclusion (verbatim, closing): "**Cape Cod – 4/21/2014** Captured this during a family walk on the Cape Cod Sunshine Pathway. It was calm, quiet, and the light felt perfect—simple shot of the shoreline that still holds the feeling of that day."
+Source: https://chatgpt.com/c/6860a1bc-ec54-8000-bf9f-34a0b511cd19
+Confidence: 1.0
+
+### FACT 65
+Subject: Dispersion vs Focus
+Type: Conversation
+Date: 2025-07-03
+Bucket: KEEP_DECISION
+Message count: 9
+Prompt (verbatim, opening): "After I moved to the US, I had my American dream moment. I arrived almost broke — just $1,300 in my bank account — and within about 20 months, I was leading a team of 60 people, running a company generating over $15 million a year. Whenever people asked how we pulled this off,..."
+Conclusion (verbatim, closing): "### Let’s Laser-Focus the ZAO Think of ZAO right now as a Swiss-army knife with 27 blades open at once. Cool, but you can’t **slice** anything. We’re going to snap 26 of those blades shut so the last one can cut cleanly. --- ## 1. Re-state the **North Star** > **THE ZAO demyst..."
+Source: https://chatgpt.com/c/6866681c-d710-8000-970a-3eef98b7251e
+Confidence: 1.0
+
+### FACT 66
+Subject: Change episode number
+Type: Conversation
+Date: 2025-07-12
+Bucket: KEEP_LONG_THREAD
+Message count: 64
+Prompt (verbatim, opening): "can we change the words from ep.9 to ep.10"
+Conclusion (verbatim, closing): "It’s already been updated — the current image shows **EP. 11** in the top right corner. Let me know if you'd like any other edits!"
+Source: https://chatgpt.com/c/68725185-10e4-8000-873f-482572ffead2
+Confidence: 1.0
+
+### FACT 67
+Subject: Budget Import
+Type: Conversation
+Date: 2025-07-31
+Bucket: KEEP_LONG_THREAD
+Message count: 349
+Prompt (verbatim, opening): "this is my past budget I want to improve the categories now that I have a home and am with my girlfriend i want to make it super easy so i can paste my simplifi transactions in and can immediatly categorize them or honestly have them auto categorize first i also attached the s..."
+Conclusion (verbatim, closing): "Short answer: **yes — but with one important clarification** before we do it the *right* way. Google Sheets has **two layers**: - **Apps Script** → automation, menus, mutations - **Sheet formulas (QUERY / TEXT / FILTER)** → live analytics If we try to force *everything* into A..."
+Source: https://chatgpt.com/c/688b9a08-b628-8329-b267-5de0b8b67831
+Confidence: 1.0
+
+### FACT 68
+Subject: Square image conversion
+Type: Conversation
+Date: 2025-08-13
+Bucket: KEEP_LONG_THREAD
+Message count: 53
+Prompt (verbatim, opening): "can we make 8 a square"
+Conclusion (verbatim, closing): "{"prompt":"A square promotional graphic for Episode 9 of 'Let's Talk About Web3,' presented by The ZAO. Same design as the provided Episode 10 image, with the same dark navy background, bold yellow title text, and illustrated hosts: Ohnahji B, EZinCrypto, and BetterCallZaal. U..."
+Source: https://chatgpt.com/c/689cf9d6-4f94-8326-85b0-158b9c82dd58
+Confidence: 1.0
+
+### FACT 69
+Subject: Mindful moments and beauty
+Type: Conversation
+Date: 2025-08-18
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "### Twitter (X) “Put beauty into your life.” Shared last week by @fellenz, still hitting today. Progress without beauty burns you out. A plant. A song. A walk. A person. What’s in your space that keeps you going? https://paragraph.com/@thezao/year-of-the-zao-day-231 --- ### Tw..."
+Source: https://chatgpt.com/c/68a37bef-9270-8324-9f9f-aaa5d07f36ca
+Confidence: 1.0
+
+### FACT 70
+Subject: flow for claw
+Type: Conversation
+Date: 2025-08-19
+Bucket: KEEP_LONG_THREAD
+Message count: 70
+Prompt (verbatim, opening): "Just back from getting a fairly gnarly health treatment at a cutting-edge clinic in Switzerland. Despite it knocking me out pretty hard in the days after, there’s one key weekly ritual I never, ever miss (even when semi-incapacitated). You see, every Sunday morning, I sit with..."
+Conclusion (verbatim, closing): "Good call. This is you **choosing signal over noise**. I’m fully aligned with this setup. Coach reflection first, then we lock it. --- ## What you just did (important) You didn’t add “more.” You **clarified what actually matters** for *this* season. For early February, your pr..."
+Source: https://chatgpt.com/c/68a4cf5b-3998-8329-bf96-b28d9a948970
+Confidence: 1.0
+
+### FACT 71
+Subject: Refuse emotional poison
+Type: Conversation
+Date: 2025-08-21
+Bucket: KEEP_LONG_THREAD
+Message count: 28
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Got it — here’s the updated set with the **link included in Telegram and Discord too**: --- ### Twitter (X) Flywheels are starting. Paired my @paragraph post with a Zora creator coin. Lesson of the day: don’t eat emotional poison. Refuse the bait, keep your energy. https://par..."
+Source: https://chatgpt.com/c/68a706f6-4784-832b-a6e6-01e3f214760c
+Confidence: 1.0
+
+### FACT 72
+Subject: Change to ep 12
+Type: Conversation
+Date: 2025-08-26
+Bucket: KEEP_LONG_THREAD
+Message count: 21
+Prompt (verbatim, opening): "can we change this to say ep. 12"
+Conclusion (verbatim, closing): "{"prompt":"Update the image text so that it says 'Ep. 14' instead of 'Ep. 13'.","referenced_image_ids":["file_00000000080c61fd88ddb2245107c723"]}"
+Source: https://chatgpt.com/c/68ae05ed-7a80-8333-8719-402102d61561
+Confidence: 1.0
+
+### FACT 73
+Subject: Image use confirmation
+Type: Conversation
+Date: 2025-08-26
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "can we use the second image for Rich Bartuc"
+Conclusion (verbatim, closing): "Done. Let me know if you want the glow, crop, or color grade tweaked to match the original even tighter."
+Source: https://chatgpt.com/c/68ae0732-d1e8-832e-83ba-a0bb26035a80
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 73 Conversation nodes. Merge on Subject+Date match.

--- a/content/bonfire-ingest/chatgpt-archive-keepers-non-zao-2.md
+++ b/content/bonfire-ingest/chatgpt-archive-keepers-non-zao-2.md
@@ -1,0 +1,814 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-keepers-non-zao-2 (73 conversations).
+
+ChatGPT non-ZAO-tagged keepers. Part 2 of 2 — newer half.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: Next.js project setup
+Type: Conversation
+Date: 2025-09-02
+Bucket: KEEP_LONG_THREAD
+Message count: 62
+Prompt (verbatim, opening): "This is a Next.js project bootstrapped with create-next-app. Getting Started First, run the development server: npm run dev # or yarn dev # or pnpm dev # or bun dev Open http://localhost:3000 with your browser to see the result. You can start editing the page by modifying app/..."
+Conclusion (verbatim, closing): "Awesome—let’s wire **Wert Sandbox** into your site’s **backend** properly so you can (1) create signed widget sessions server-side and (2) receive webhook events for simulated transactions. I’ll assume **Next.js on Vercel**. If you’re using Express or something else, the logic..."
+Source: https://chatgpt.com/c/68b75054-c4c0-832c-a7e0-ddbaafc8b813
+Confidence: 1.0
+
+### FACT 2
+Subject: Image and name update
+Type: Conversation
+Date: 2025-09-03
+Bucket: KEEP_LONG_THREAD
+Message count: 120
+Prompt (verbatim, opening): "Can we change pichi's image to this and can we make the name HURRIC4N3IKE"
+Conclusion (verbatim, closing): "Added the bottom line: “with special guest HURRIC4N3IKE” Download the updated promo: [EP.16 with special guest](sandbox:/mnt/data/LTAW3_EP16_with_special_guest.png) Want me to do square and story crops with the same footer?"
+Source: https://chatgpt.com/c/68b89035-d2d8-8333-be9a-851540fd5f40
+Confidence: 1.0
+
+### FACT 3
+Subject: Web 3 Ep.15 rollout
+Type: Conversation
+Date: 2025-09-03
+Bucket: KEEP_PERSON
+Message count: 18
+Prompt (verbatim, opening): "You are a social content generator for the **let's talk about web 3** project. ## Input: - **Core Content**: {Paste the file name, lesson title, or link here} - **Tone**: Casual, conversational, and culturally aware - website: twitch.tv/ohnahji ## Instructions: Generate platfo..."
+Conclusion (verbatim, closing): "Perfect — here’s the **updated ZM rollout** for **Let’s Talk About Web 3 Ep.15**, now including that it’s **also live on Pump.fun** alongside Twitch: --- ### Twitter (X) ZM Let’s Talk About Web 3 Ep.15 live w/ohnahji, ezincrypto, bettercallzaal and special guest HURRIC4N3IKE. ..."
+Source: https://chatgpt.com/c/68b8b398-82f0-8323-9dbf-e99687a14c9d
+Confidence: 1.0
+
+### FACT 4
+Subject: Styled Ep 15
+Type: Conversation
+Date: 2025-09-04
+Bucket: KEEP_LONG_THREAD
+Message count: 37
+Prompt (verbatim, opening): "can we make this styled one for Ep. 15"
+Conclusion (verbatim, closing): "{"prompt":"A promotional digital graphic for 'The ZAO Presents: Let's Talk About Web3' with bold yellow text on a dark navy background. The top right corner should display 'EP.15' instead of EP.16. Illustrations of the three hosts labeled OhNahji B, EZinCrypto, and BetterCallZ..."
+Source: https://chatgpt.com/c/68b9ac33-9f78-8329-89f2-3658afcaec4d
+Confidence: 1.0
+
+### FACT 5
+Subject: Change number value
+Type: Conversation
+Date: 2025-09-05
+Bucket: KEEP_LONG_THREAD
+Message count: 73
+Prompt (verbatim, opening): "change 14 to 16"
+Conclusion (verbatim, closing): "Got it — you want **all the versions styled like this reference**: - Bold yellow header - Dark navy background - Flat, clean illustrations for avatars - Names directly under each avatar - Subtle accent icons (cube, molecules, headphones, notes) - Footer info in the same typogr..."
+Source: https://chatgpt.com/c/68bb00a6-c68c-8320-afd5-98780cd8a44a
+Confidence: 1.0
+
+### FACT 6
+Subject: Balancing pain and wonder
+Type: Conversation
+Date: 2025-09-06
+Bucket: KEEP_LONG_THREAD
+Message count: 30
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Got it — you want the actual **newsletter link** used directly in the posts. Here’s the cleaned set of platform-specific posts, each starting with **ZM** and pointing to your URL: --- **Twitter (X)** ZM Life holds both pain and wonder. A community member reminded us: the sky, ..."
+Source: https://chatgpt.com/c/68bc35fb-4c78-8327-88e7-61c874ca5778
+Confidence: 1.0
+
+### FACT 7
+Subject: Boston sports DAO ideation
+Type: Conversation
+Date: 2025-09-08
+Bucket: KEEP_WRITING
+Message count: 98
+Prompt (verbatim, opening): "You said: https://farcaster.xyz/zaal/0xc1dd7cf6 Learn more about clanker and what I can do and start to ideate a Boston sports DAO based in betting on Boston sports and going to games and getting tickets for the community. Let's ideate about how we can grow this ChatGPT said: ..."
+Conclusion (verbatim, closing): "Here’s a suggested plan for filling out the Clanker v4 deployment form to launch **Boston Sports DAO ($BSD)**. Each field corresponds to an option in the Clanker interface you shared: | Field | Recommendation | Notes | |---|---|---| | **Network** | **Base** | Clanker v4 is mos..."
+Source: https://chatgpt.com/c/68be9a86-fb50-832b-ac81-d6c1b43fadd7
+Confidence: 1.0
+
+### FACT 8
+Subject: Boston teams logo design
+Type: Conversation
+Date: 2025-09-12
+Bucket: KEEP_LONG_THREAD
+Message count: 46
+Prompt (verbatim, opening): "Can we use the logos of the 4 BOSTON TEAMS so this looks cohestice"
+Conclusion (verbatim, closing): "{"prompt":"A refined 'Boston Sports DAO' logo featuring the mascot combining Boston's four major sports teams. Keep the Patriots hat, Celtics shamrock vest, Bruins 'B' emblem, and improve the Red Sox representation so the socks look bold, classic, and stylized in the same clea..."
+Source: https://chatgpt.com/c/68c473c9-7634-832e-9b7b-4b792cb5baf3
+Confidence: 1.0
+
+### FACT 9
+Subject: Boston Sports DAO plan
+Type: Conversation
+Date: 2025-09-12
+Bucket: KEEP_WRITING
+Message count: 29
+Prompt (verbatim, opening): "You said: You said: https://farcaster.xyz/zaal/0xc1dd7cf6 Learn more about clanker and what I can do and start to ideate a Boston sports DAO based in betting on Boston sports and going to games and getting tickets for the community. Let's ideate about how we can grow this Chat..."
+Conclusion (verbatim, closing): "I opened the file—here’s the situation: - **128 addresses** in your airdrop list. - Every address is set to receive **2.5 billion tokens each**. - That means you’d be giving away: **128 × 2.5B = 320 billion tokens total.** If your supply is anywhere near standard Clanker setup..."
+Source: https://chatgpt.com/c/68c485f3-94dc-832e-80d6-da15f727a765
+Confidence: 1.0
+
+### FACT 10
+Subject: Branch · Venv activation command
+Type: Conversation
+Date: 2025-09-25
+Bucket: KEEP_LONG_THREAD
+Message count: 563
+Prompt (verbatim, opening): "whats the terminical venv command it starts like source"
+Conclusion (verbatim, closing): "Got it — I can absolutely do that. Here’s what to do: just start a **new chat window** (click *“+ New Chat”* at the top left in ChatGPT), and send your next message there saying something like: > “Let’s continue the Dreamster frontend/backend debugging from the previous chat.”..."
+Source: https://chatgpt.com/c/68d58a78-71ec-8320-9067-465ca08c9787
+Confidence: 1.0
+
+### FACT 11
+Subject: Change request
+Type: Conversation
+Date: 2025-09-29
+Bucket: KEEP_LONG_THREAD
+Message count: 74
+Prompt (verbatim, opening): "can we change 9 to 10"
+Conclusion (verbatim, closing): "{"prompt":"Change only the number in the image from EP.17 to EP.18, and keep the name exactly as EZinCrypto. Do not change anything else.","referenced_image_ids":["3d6c68b6-df9f-4eb8-8678-8de600c2d4a8"]}"
+Source: https://chatgpt.com/c/68dacf46-34a4-8321-b54a-1a607cb4fe4e
+Confidence: 1.0
+
+### FACT 12
+Subject: Make square and retain info
+Type: Conversation
+Date: 2025-09-29
+Bucket: KEEP_LONG_THREAD
+Message count: 24
+Prompt (verbatim, opening): "lets make this a square but keep all the content"
+Conclusion (verbatim, closing): "{"prompt":"Update the episode number from EP.16 to EP.17 while keeping the rest of the design unchanged.","size":"1024x1024","referenced_image_ids":["file_00000000d4446230b098c7beb40cc065"],"n":1}"
+Source: https://chatgpt.com/c/68daddf9-b180-8324-9504-113e00f097a5
+Confidence: 1.0
+
+### FACT 13
+Subject: Branch · Branch · Vercel login error fix
+Type: Conversation
+Date: 2025-10-06
+Bucket: KEEP_LONG_THREAD
+Message count: 365
+Prompt (verbatim, opening): "I am trying to fix a vercel login error on this app I am creating, please point me in the right direction of what is going wrong in my deployments"
+Conclusion (verbatim, closing): "Yes — in your Dreamster backend structure, uploaded earlier, the file that handles **track uploads** is located here: ``` app/routes/musician/tracks/tracks.py ``` That’s the canonical endpoint for musician-related track management — including **upload**, **update**, **delete**..."
+Source: https://chatgpt.com/c/68e40efd-4338-8330-9c89-134017d78ff8
+Confidence: 1.0
+
+### FACT 14
+Subject: Image editing request
+Type: Conversation
+Date: 2025-10-14
+Bucket: KEEP_LONG_THREAD
+Message count: 28
+Prompt (verbatim, opening): "can we edit this image to be more like Zaal's pfp in the second image"
+Conclusion (verbatim, closing): "{"size":"1792x1024","n":1,"referenced_image_ids":["8c2b7bd7-f896-462f-b67d-0e4adfda2017"],"prompt":"Keep everything exactly the same in the horizontal image featuring BetterCallZaal and Yoni Dubz, but correct the shirt text from 'TheeZAO' to 'The ZAO' without changing any colo..."
+Source: https://chatgpt.com/c/68eea0e7-10c0-832a-afee-79698b6eee86
+Confidence: 1.0
+
+### FACT 15
+Subject: Prompt for episode banner
+Type: Conversation
+Date: 2025-10-14
+Bucket: KEEP_LONG_THREAD
+Message count: 41
+Prompt (verbatim, opening): "Can we make a prompt for a Ep 1 banner with guests from Minted Merch"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"referenced_image_ids":["file_00000000c60061f5832f395ba6047f69"],"prompt":"edit the image text to correct the spelling so it reads 'SEASON 3 EP 1' instead of 'SEASR 3 EP 1'. Keep the same bold 2D vector art style, layout, and color palette consistent ..."
+Source: https://chatgpt.com/c/68eede13-3bac-832e-b974-d94a4730eb2a
+Confidence: 1.0
+
+### FACT 16
+Subject: Resize for YouTube
+Type: Conversation
+Date: 2025-10-17
+Bucket: KEEP_LONG_THREAD
+Message count: 29
+Prompt (verbatim, opening): "dont change anything but resize this for a youtube video"
+Conclusion (verbatim, closing): "{"size":"1280x720","n":1,"referenced_image_ids":["7fdfc2c7-62a2-424f-9e63-a068c0d2bc1d"],"prompt":"Place the circular logo design centered on a solid black background sized for a YouTube thumbnail (1280x720). Maintain full clarity and proportions of the logo without cropping o..."
+Source: https://chatgpt.com/c/68f2d09b-d068-8329-a55c-c9357da54fc7
+Confidence: 1.0
+
+### FACT 17
+Subject: DAOs Research
+Type: Conversation
+Date: 2025-10-24
+Bucket: KEEP_LONG_THREAD
+Message count: 31
+Prompt (verbatim, opening): "https://docs.google.com/spreadsheets/d/16IDgIyPcfwJGG-zmXeMAenYbePQVHkc2P6WCwKEZgpk/edit?gid=0#gid=0 can u see this"
+Conclusion (verbatim, closing): "# DAO Ecosystem Status Update (Late 2025) ## Overview of the DAO Landscape (2021–2025) Decentralized Autonomous Organizations (DAOs) have proliferated across many domains since 2021. By early 2024, nearly 20,000 DAOs and sub-DAOs were tracked, collectively holding over $47 bil..."
+Source: https://chatgpt.com/c/68fb5a80-d404-8328-94f0-37571bd81a71
+Confidence: 1.0
+
+### FACT 18
+Subject: Fix API base URL
+Type: Conversation
+Date: 2025-10-26
+Bucket: KEEP_LONG_THREAD
+Message count: 224
+Prompt (verbatim, opening): "“Continue Dreamster frontend debugging from October 26 (registration 404 + 500 errors), I went to my deployment where the prcing page loaded and compared the two, here are the urls, they may point to different parts of the loading process but they should still give us proper i..."
+Conclusion (verbatim, closing): "✅ Perfect move — that’s a clean way to reset before continuing debugging. Here’s the **safe and exact way** to revert your local branch back to commit `ebbc5c0` and make sure Vercel rebuilds from it cleanly: --- ### 🧭 Step-by-Step Git Revert Process 1. **Fetch the latest remot..."
+Source: https://chatgpt.com/c/68fe79fa-58a0-8323-8751-51a613278973
+Confidence: 1.0
+
+### FACT 19
+Subject: Vision and mission statement
+Type: Conversation
+Date: 2025-10-27
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "lets build a vision and mission statement for lets talk about web 3 based around onboarding and teaching new people about blockchain the depths of the weird tech and tokenomics stuff"
+Conclusion (verbatim, closing): "Exactly — you’re thinking about this like a *content system*, not just a podcast. Let’s break it into two parts: --- ## **Part 1: Using Your Mission & Vision to Shape Episodes** Your **mission and vision** are your *north star*. Every episode can tie back to one of three ancho..."
+Source: https://chatgpt.com/c/68ffe414-ecbc-8331-baba-41c418f0afc3
+Confidence: 1.0
+
+### FACT 20
+Subject: Job search plan for Zaal
+Type: Conversation
+Date: 2025-10-29
+Bucket: KEEP_LONG_THREAD
+Message count: 90
+Prompt (verbatim, opening): "https://cryptojobslist.com/ i want to use this website to find a fulltime job for zaal"
+Conclusion (verbatim, closing): "# The ZAO Ecosystem & Zaal Panthaki (BetterCallZaal) ## GitHub Repositories - **Agent2** (TypeScript) – A testing framework for AI agents【74†L139-L140】. - **eliza1** (TypeScript) – Autonomous AI agents framework (“autonomous agents for everyone”【71†L154-L158】). - **Newsletterb..."
+Source: https://chatgpt.com/c/6901eb4d-29d0-8328-845d-27a2bd675812
+Confidence: 1.0
+
+### FACT 21
+Subject: Background composite request
+Type: Conversation
+Date: 2025-11-01
+Bucket: KEEP_LONG_THREAD
+Message count: 32
+Prompt (verbatim, opening): "i wanna put all 4 of these guys on a backgorund i will send the background next"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"referenced_image_ids":["file_00000000787c71f7a3fc697fc8b0a6eb","file_00000000060471f5959da031510aa3a1","file_00000000390471f78fd9a81c83c80512","file_0000000062d871f793c41083ce6f0bee","file_000000001dac71f59ee47c9dd9f01bc7"],"prompt":"create a digital..."
+Source: https://chatgpt.com/c/69069d30-b038-832f-8aa8-2be1f5b8e362
+Confidence: 1.0
+
+### FACT 22
+Subject: Revert GitHub commit
+Type: Conversation
+Date: 2025-11-02
+Bucket: KEEP_LONG_THREAD
+Message count: 96
+Prompt (verbatim, opening): "revert my github to a previous commit"
+Conclusion (verbatim, closing): "Perfect — here are clean, **SEO-optimized meta descriptions** for each of those core policy pages on **minsitryofsilks.com**, written to sound professional, trustworthy, and aligned with a luxury saree brand while still ranking well on Google. --- ### 💰 **Refund Policy — Meta ..."
+Source: https://chatgpt.com/c/6906d842-9d88-8323-b51a-d16a587860b4
+Confidence: 1.0
+
+### FACT 23
+Subject: Summarize newsletters content
+Type: Conversation
+Date: 2025-11-04
+Bucket: KEEP_WRITING
+Message count: 24
+Prompt (verbatim, opening): "https://paragraph.com/@artivism look at the 3 newsletters here and grab the content"
+Conclusion (verbatim, closing): "Perfect — here’s a refreshed set built around that tone: grounded, community-first, and emphasizing that The ZAO loves showing up for local art with purpose. --- ### **Twitter (X)** ZM we love supporting local art that moves with purpose. this week, all eyes on the Freedom & J..."
+Source: https://chatgpt.com/c/6909d8fc-ffa8-832b-a064-e7120f0b8402
+Confidence: 1.0
+
+### FACT 24
+Subject: Logo styling request
+Type: Conversation
+Date: 2025-11-04
+Bucket: KEEP_LONG_THREAD
+Message count: 63
+Prompt (verbatim, opening): "Can we style the logo like the second one But lets say Ep. 2 instead of Ep.1 and FT. We Them Media instead of minted merch"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"referenced_image_ids":["file_00000000776071f585fc3887a071c8d4"],"prompt":"Final corrected logo for 'The ZAO Presents: Let's Talk About Web 3 Season 3 Ep 2 ft. We Them Media'. Keep same design, characters, and colors (gold and black circular badge wit..."
+Source: https://chatgpt.com/c/690a3150-3574-8326-8a8f-7348461282cb
+Confidence: 1.0
+
+### FACT 25
+Subject: Research on Gardnr tool
+Type: Conversation
+Date: 2025-11-08
+Bucket: KEEP_LONG_THREAD
+Message count: 21
+Prompt (verbatim, opening): "ok i want to do research on a new tool https://gardnr.hatsprotocol.xyz/"
+Conclusion (verbatim, closing): "Absolutely — here’s a **tight, scroll-stopping version** of your Gardnr drop for Discord or Farcaster. It hits the key idea, skips the fluff, and keeps rhythm for fast reading: --- **🧠 Tool Drop: Gardnr (by Hats Protocol)** Gardnr introduces **Trust Zones** — smart containers ..."
+Source: https://chatgpt.com/c/690fefbb-b248-832e-8648-2267479f77f8
+Confidence: 1.0
+
+### FACT 26
+Subject: Episode 4 logo creation
+Type: Conversation
+Date: 2025-11-12
+Bucket: KEEP_LONG_THREAD
+Message count: 26
+Prompt (verbatim, opening): "can we make an episode 4 logo"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"referenced_image_ids":["file_00000000272871fd8b74cfde7bdeb6ab"],"prompt":"Create a new version of this logo that says 'EPISODE 7' instead of 'EPISODE 6' while keeping the same style, layout, and colors as the original Let's Talk About Web3 Season 3 d..."
+Source: https://chatgpt.com/c/69146ecd-a4bc-8330-bc1e-f0af6c7df5ff
+Confidence: 1.0
+
+### FACT 27
+Subject: Change number value
+Type: Conversation
+Date: 2025-11-12
+Bucket: KEEP_LONG_THREAD
+Message count: 25
+Prompt (verbatim, opening): "Lets change the 2 to a 4"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"referenced_image_ids":["3018a8f0-aee0-49fa-a013-a61228eb921c"],"prompt":"Change the text 'EPISODE 5' to 'EPISODE 6' while keeping the same style, font, and layout."}"
+Source: https://chatgpt.com/c/69149247-255c-832d-b1b8-c09df9773c3f
+Confidence: 1.0
+
+### FACT 28
+Subject: Change episode number
+Type: Conversation
+Date: 2025-11-12
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "can we make sure to change the episode number to 4 the only change between the two photos above is one number the episode number and i want to make sure that that is the only thing that cahnges"
+Conclusion (verbatim, closing): "Yeah, that’s frustrating — what’s happening is the image model can’t perfectly preserve *text accuracy*. It “redraws” text as part of the art, not as editable text layers, so it sometimes invents slight misspellings like “ABOOUT” when regenerating. To fix this *exactly*, here’..."
+Source: https://chatgpt.com/c/6914f4e1-e1b4-8328-923d-0dd8bf3be16e
+Confidence: 1.0
+
+### FACT 29
+Subject: OmniFlix brand change
+Type: Conversation
+Date: 2025-11-13
+Bucket: KEEP_LONG_THREAD
+Message count: 32
+Prompt (verbatim, opening): "do research on omniflix and their brand change to flix dot fun"
+Conclusion (verbatim, closing): "Here’s a **Farcaster Group Chat** version — tight, conversational, and aligned with the flow of the newsletter. --- **Farcaster Group Chat Post:** ZM going live at 11:30am EST with @0xCosmician to walk through the new FLIX.fun creator dashboard. Clean tool, big potential. Pull..."
+Source: https://chatgpt.com/c/6915b276-2614-8326-80bd-b83f42d25c75
+Confidence: 1.0
+
+### FACT 30
+Subject: Optical illusion logo design
+Type: Conversation
+Date: 2025-11-14
+Bucket: KEEP_LONG_THREAD
+Message count: 73
+Prompt (verbatim, opening): "make this olde temple optical illusion sharper with details and present it as a logo"
+Conclusion (verbatim, closing): "Here is the refined version you requested — **closer to the exact illusion from the sculpture**, using the second image as the base: ### ✔ Both animals outlined only (no interior fill) ### ✔ Unnecessary internal striping removed ### ✔ The **shared-head illusion** is preserved ..."
+Source: https://chatgpt.com/c/6916dcb2-4f4c-8323-bafe-d7abe1938f28
+Confidence: 1.0
+
+### FACT 31
+Subject: season 3 transcript to desctipon
+Type: Conversation
+Date: 2025-11-18
+Bucket: KEEP_LONG_THREAD
+Message count: 59
+Prompt (verbatim, opening): "ok lets make a let's talk about web 3 ep 4 Caption / description"
+Conclusion (verbatim, closing): "Perfect — here is your full, polished **YouTube Description + SEO-optimized breakdown** for: # **Let’s Talk About Web 3 — Season 3, Episode 9 w/ Tyler McNair** This matches the exact professional tone, formatting, and structure of Episodes 3–8 and is fully grounded in the tran..."
+Source: https://chatgpt.com/c/691cd378-8f40-832d-81c2-3cdd10f97de8
+Confidence: 1.0
+
+### FACT 32
+Subject: Testnet URL access
+Type: Conversation
+Date: 2025-11-19
+Bucket: KEEP_LONG_THREAD
+Message count: 629
+Prompt (verbatim, opening): "I have sent test ar tokens to a test wallet via AR.io and I want to access the testnet using my website application, how do I find the testnet url and port"
+Conclusion (verbatim, closing): "Good news: **your IRYS approval flow is now working** — that means the backend, upload, and route fixes are correct. But the new problem: # 🛑 **Every link you click redirects you back to the Admin Dashboard.** This has nothing to do with IRYS. This is a **client-side auth guar..."
+Source: https://chatgpt.com/c/691d79da-90e0-8320-9887-dd63ea7e759a
+Confidence: 1.0
+
+### FACT 33
+Subject: Track approval issue troubleshooting
+Type: Conversation
+Date: 2025-11-23
+Bucket: KEEP_LONG_THREAD
+Message count: 409
+Prompt (verbatim, opening): "I have got through to the track approval process but my problem is that the track still shows as rejected when i get redirected to the track management page after approval and it doesn't show up under music either"
+Conclusion (verbatim, closing): "That error is simple and harmless — TypeScript is just yelling because **that function argument was never typed**. You’re inside `useTrackPayments.ts`, and you have something like: ```ts const startBuy = useCallback( async ({ trackId, trackTitle, quantity = 1, priceUsd, succes..."
+Source: https://chatgpt.com/c/69234f72-4580-8323-b9ca-17c3962208e7
+Confidence: 1.0
+
+### FACT 34
+Subject: Fireside Farcaster agency article
+Type: Conversation
+Date: 2025-11-26
+Bucket: KEEP_WRITING
+Message count: 40
+Prompt (verbatim, opening): "ok i want to do a article about fireside and farcaster and the agency learn more about them online and then ask me questions"
+Conclusion (verbatim, closing): "Got you — here’s a **full long-form X post**, written in your deep, reflective Farcaster tone, with **Fireside as the main topic** and Farcaster + The Agency woven into the structure. This is the style of long X posts you see from serious builders — calm, intentional, and conc..."
+Source: https://chatgpt.com/c/6927735a-2ad0-8327-9a49-61b4c460b800
+Confidence: 1.0
+
+### FACT 35
+Subject: Wert Track Player Integration
+Type: Conversation
+Date: 2025-11-27
+Bucket: KEEP_LONG_THREAD
+Message count: 551
+Prompt (verbatim, opening): ""We are working on Dreamster FE. Continue context ONLY for the Wert + Track Player work.""
+Conclusion (verbatim, closing): "Perfect — that address checks out 👍 Now we can stop guessing and **close the loop cleanly**. --- ## ✅ What to do *right now* ### 1️⃣ Update your NFT config Replace the zero address **everywhere** with the Sepolia V2 router: ```python UNISWAP_V2_ROUTER = "0xeE567Fe1712Faf6149d8..."
+Source: https://chatgpt.com/c/6928022c-fa50-8322-810e-445dc69b80a4
+Confidence: 1.0
+
+### FACT 36
+Subject: Fix frontend whitespace
+Type: Conversation
+Date: 2025-11-30
+Bucket: KEEP_LONG_THREAD
+Message count: 94
+Prompt (verbatim, opening): "Lets fix the frontend of my dreamster to match frontend things, for example in the Dreamster website there is a common whitespace with ; on all my pages"
+Conclusion (verbatim, closing): "Here’s the *real answer*, no fluff: **Windsurf does NOT support macOS Catalina (10.15).** Your OS is too old for the current build. ### ✅ Verified System Requirements Windsurf requires: - **macOS 13 (Ventura) or later** - Apple Silicon **or** Intel CPU - 8GB RAM recommended Ca..."
+Source: https://chatgpt.com/c/692c4337-19cc-8331-ae46-6c9a4d57fea8
+Confidence: 1.0
+
+### FACT 37
+Subject: Build resume website
+Type: Conversation
+Date: 2025-11-30
+Bucket: KEEP_LONG_THREAD
+Message count: 22
+Prompt (verbatim, opening): "looking to buiLda resume website for zaal # Complete Website Content - Professional Consulting Portfolio **All content, copy, and information for the enhanced website** --- ## 🎯 **Hero Section Content** ### **Main Headlines** ``` Primary: "Zaal Panthaki" Secondary: "Web3 Engin..."
+Conclusion (verbatim, closing): "# The ZAO: Empowering Artists with Web3 – An Ecosystem Overview 【35†embed_image】 **The ZAO Mission and Vision:** The **Ztalent Artist Organization (ZAO)** is a community-driven hub where musicians, artists, and technologists unite to unlock the potential of Web3 and emerging t..."
+Source: https://chatgpt.com/c/692c7bfe-2fe0-8326-919e-b2860b4e0fea
+Confidence: 1.0
+
+### FACT 38
+Subject: Offer letter reconstruction
+Type: Conversation
+Date: 2025-12-09
+Bucket: KEEP_WRITING
+Message count: 11
+Prompt (verbatim, opening): "do you remember when you drafted an offer letter for my job with the title: data engineer & full stack developer?"
+Conclusion (verbatim, closing): "Alright, this is straightforward — and you’re in a *great* position because everything you do at Dreamster sits squarely inside the Data Science umbrella. You just need to articulate it in the right, clean, employer-friendly way. Here’s a **sharp, immigration-safe, HR-friendly..."
+Source: https://chatgpt.com/c/69386f74-3694-832f-95b9-1649af1aaa1c
+Confidence: 1.0
+
+### FACT 39
+Subject: Image load issue fix
+Type: Conversation
+Date: 2025-12-10
+Bucket: KEEP_LONG_THREAD
+Message count: 262
+Prompt (verbatim, opening): "in the dreamster website I currently have a image issue where the image does not pop up, and I get a failed to load image error, when the actual track and music contents work from the amazon s3 but not the image as seen in this screenshot:"
+Conclusion (verbatim, closing): "You’re right to call out the “double `/api`” thing — **your screenshot shows only one `/api`** and I shouldn’t have pushed that theory without evidence. That was sloppy. Now, **what your screenshot *does* show is the real problem**: ## What I see in your screenshot - The faili..."
+Source: https://chatgpt.com/c/6939aeac-eb34-832f-bf0e-498c5ef57b9d
+Confidence: 1.0
+
+### FACT 40
+Subject: Replace with rabbit caricature
+Type: Conversation
+Date: 2025-12-14
+Bucket: KEEP_LONG_THREAD
+Message count: 22
+Prompt (verbatim, opening): "can we replace the person on the right with a caricature of a rabbit"
+Conclusion (verbatim, closing): "{"prompt":"Promotional artwork for the show BCZ YAPS in the established BCZ Yaps style. A dark blue to purple gradient background with bold white text at the top reading “BCZ YAPS.” On the left is a cartoon caricature of BetterCallZaal wearing pixelated sunglasses, a backwards..."
+Source: https://chatgpt.com/c/693f578c-26d0-8327-8175-26bb3e1fb0fc
+Confidence: 1.0
+
+### FACT 41
+Subject: Meeting notes summary
+Type: Conversation
+Date: 2025-12-17
+Bucket: KEEP_PERSON
+Message count: 7
+Prompt (verbatim, opening): "Ltaw3 notes from 12/16 meeting lets creat Emails for let's talk about web 3 for an sop for inviting a guest Design work on ohnahji w/ bayo Graphics and animations if possible Zaal make TikTok account for ltaw3 Zaal focus on farcaster and monetization Maceo - focus on curating ..."
+Conclusion (verbatim, closing): "Here are the **clean, no-nonsense meeting notes** from the **12/16 LTaw3 meeting**, tightened up and ready to drop into Notion, Docs, or a follow-up email: --- ### **Let’s Talk About Web3 – 12/16 Meeting Notes** - Create **guest invitation emails** for *Let’s Talk About Web3* ..."
+Source: https://chatgpt.com/c/6942b220-8434-832c-a573-38731070824f
+Confidence: 1.0
+
+### FACT 42
+Subject: Plan for Clanker Team
+Type: Conversation
+Date: 2025-12-19
+Bucket: KEEP_WRITING
+Message count: 14
+Prompt (verbatim, opening): "https://farcaster.xyz/zaal/0x122171f9 can we look through all of these casts and replys and start to build a plan to get this Infront of the clanker team"
+Conclusion (verbatim, closing): "Here’s a **clean, no-BS list of next steps**, ordered by impact. This is the exact path I’d run if I were you. --- ## Phase 1 — Generate undeniable proof (Days 1–7) **1. Ship something visible every day** - Miniapp progress - ZABAL stream clip - Open-source commit - Tool demo ..."
+Source: https://chatgpt.com/c/694552dc-5b00-832d-9980-52ffccd32e81
+Confidence: 1.0
+
+### FACT 43
+Subject: Prompt creation help
+Type: Conversation
+Date: 2025-12-21
+Bucket: KEEP_LONG_THREAD
+Message count: 26
+Prompt (verbatim, opening): "help me with a good prompt"
+Conclusion (verbatim, closing): "Yep — here’s a **clean, precise image-edit prompt** to make that exact tweak **without touching anything else**. --- ## IMAGE EDIT PROMPT (MINIMAL CHANGE) **Prompt:** > Edit the provided illustration to **remove the star icon** in the bottom right corner. > > Keep the **“1/1” ..."
+Source: https://chatgpt.com/c/6947e6a0-46dc-8332-8068-22a6a4035c82
+Confidence: 1.0
+
+### FACT 44
+Subject: Budget creation overview
+Type: Conversation
+Date: 2025-12-22
+Bucket: KEEP_LONG_THREAD
+Message count: 261
+Prompt (verbatim, opening): "ok lets just create a budget with the numbers we have simple for the whiteboard so we can edit it each day lets start with 65$ for wifi 150$ for electricity i make 1.8 per paycheck after tax she makes partner 1.3 k after paycheck our morgage is 2.3k"
+Conclusion (verbatim, closing): "Yeah — fixing this *at the source* in Simplifi is the move. If Simplifi exports are consistently categorized, your CSV → budget pipeline becomes basically “import and report,” not “import and babysit.” Here’s what you can do in Simplifi to make the data dramatically cleaner be..."
+Source: https://chatgpt.com/c/694946a3-30fc-8327-9e18-2f5d1712eebd
+Confidence: 1.0
+
+### FACT 45
+Subject: Zaal Speaking Segments
+Type: Conversation
+Date: 2025-12-26
+Bucket: KEEP_LONG_THREAD
+Message count: 24
+Prompt (verbatim, opening): "lets look for when zaal talked for periods of time and find the timestamp for that"
+Conclusion (verbatim, closing): "Perfect — here are **clean, whitepaper-ready speaking points**, distilled directly from what *you said* in the Space. These are phrased as **context anchors**, not marketing copy, so you can expand, formalize, or footnote them however you want. --- ## **ZABAL — CORE SPEAKING P..."
+Source: https://chatgpt.com/c/694f1794-9790-8325-a31d-6e6d46174b9f
+Confidence: 1.0
+
+### FACT 46
+Subject: Travel Points
+Type: Conversation
+Date: 2025-12-28
+Bucket: KEEP_LONG_THREAD
+Message count: 26
+Prompt (verbatim, opening): "can i use this to redeem to cash or pay off the credit card i ahve with ti t"
+Conclusion (verbatim, closing): "Perfect — that actually makes your setup **cleaner**, not harder. Let’s lock this into a **Boston/Bangor operating system** and stop thinking about it every time you book. --- ## PART 1 — Your home-base logic (set once, reuse forever) ### Primary airport: **Bangor (BGR)** - 30..."
+Source: https://chatgpt.com/c/6951988e-e388-8325-ab18-b6e57a17adab
+Confidence: 1.0
+
+### FACT 47
+Subject: Web3 Creator Tools
+Type: Conversation
+Date: 2025-12-31
+Bucket: KEEP_LONG_THREAD
+Message count: 29
+Prompt (verbatim, opening): "ROLE You are a professional YouTube content editor and transcript analyst. TASK I will upload a full transcript of a video. Your job is to turn it into a YouTube video description with accurate timestamps that help viewers navigate the conversation. OUTPUT REQUIREMENTS Create ..."
+Conclusion (verbatim, closing): "{"prompt":"YouTube Thumbnail — Guaranteed 16:9, No Black Bars\n\nCreate a high-impact YouTube thumbnail for a Web3 tutorial video titled:\n\n“Dappable Demo / Tutorial”\n\nCanvas & Aspect Ratio (STRICT)\n- True 16:9 horizontal canvas (1280×720)\n- Full-bleed image with NO borde..."
+Source: https://chatgpt.com/c/6955a70b-121c-832d-9ed1-57d738bd5e03
+Confidence: 1.0
+
+### FACT 48
+Subject: YouTube Description & Timestamps
+Type: Conversation
+Date: 2026-01-02
+Bucket: KEEP_LONG_THREAD
+Message count: 33
+Prompt (verbatim, opening): "stream 1 transcript is above I am going to post this to youtube so lets add a nunhc of description and then timestamps for this youtube video description"
+Conclusion (verbatim, closing): "{"prompt":"Create a bold, high-impact YouTube thumbnail for a Web3 livestream titled “Year of the ZABAL: Day 1 — Launching ZABAL Live.” True 16:9 horizontal canvas, full-bleed edge-to-edge with no borders or padding. Use the provided PFP avatar as the primary subject, framed c..."
+Source: https://chatgpt.com/c/6957fc26-7780-832c-bb22-d86093f6c43d
+Confidence: 1.0
+
+### FACT 49
+Subject: Tiny Intern Description
+Type: Conversation
+Date: 2026-01-03
+Bucket: KEEP_WRITING
+Message count: 48
+Prompt (verbatim, opening): "Deploy an AI assistant with its own personality traits to serve as your Empire's dedicated intern on Farcaster. Anyone can simply tag your Tiny Intern to ask for comprehensive details of your Empire's leaderboards, boosters, treasury holdings, and reward distributions. Intern ..."
+Conclusion (verbatim, closing): "Got it — clean, comma-separated, no extra words. **Topics (comma-separated):** ZABAL, Empire Builder, leaderboards, boosters, multipliers, treasury tracking, token distributions, on-chain transparency, ERC-20 tokens, NFTs, wallet lookups, Base ecosystem"
+Source: https://chatgpt.com/c/6959ab10-f7c4-832e-807e-5c2e1eb34a17
+Confidence: 1.0
+
+### FACT 50
+Subject: Boulder Castle Quest
+Type: Conversation
+Date: 2026-02-03
+Bucket: KEEP_WRITING
+Message count: 24
+Prompt (verbatim, opening): "ok i won this quest for a stay in denver lets prepare as much context and content around this trip and what i am committing to so that we can really show Boulder Castle Quest : Win Your Stay at Carrot Castle Boulder Win a room at Carrot Castle for Boulder Week 2026!* — Sponsor..."
+Conclusion (verbatim, closing): "Got it. This is the right moment to **slow down, interrogate the edges, and over-prepare** so execution feels light when you’re on the ground. I’m going to do two things in this response: 1. **Ask the next layer of questions** that actually matter for the trip, the activations..."
+Source: https://chatgpt.com/c/698263b9-86d0-83a4-8f38-7c31038a2acb
+Confidence: 1.0
+
+### FACT 51
+Subject: EF Comms Role Alignment
+Type: Conversation
+Date: 2026-02-06
+Bucket: KEEP_LONG_THREAD
+Message count: 76
+Prompt (verbatim, opening): "IconIcon You said: ok i have the job i want to apply for here lets start to surface all the knoweldege about zaal Name Type here... Email hello@example.com... Resume No file chosen Upload File or drag and drop here Where are you based? If you are a digital nomad, please indica..."
+Conclusion (verbatim, closing): "Perfect. Here’s a **final polish pass**—same content, same humble tone, just tighter rhythm, cleaner flow, and slightly stronger clarity. This is ready to ship. You can copy-paste this directly over what you have. --- # **ZAAL PANTHAKI** Bar Harbor, ME (Remote) GitHub: github...."
+Source: https://chatgpt.com/c/6986baef-0cb0-83a6-941b-62ef5067d886
+Confidence: 1.0
+
+### FACT 52
+Subject: LTAE
+Type: Conversation
+Date: 2026-02-09
+Bucket: KEEP_WRITING
+Message count: 13
+Prompt (verbatim, opening): "lets start to prep our next brand lets talk about eth i want to make a 30 min stream agenda for us to introduce the concept here is some more info from maceo DOCUMENT 1: PODCAST GUEST NOTES ✅ CONFIRMED (4): 1. Peth (Croatia) Email: [Need] Focus: Ethereum storyteller, DAO docum..."
+Conclusion (verbatim, closing): "image_group{"aspect_ratio":"16:9","query":["Ethereum global builders","Ethereum ecosystem world map","Ethereum developers conference audience","Ethereum emerging markets builders"]} Below is a **clean, bullet-point Episode 0 agenda** — no scripts, no fluff, just speaking no..."
+Source: https://chatgpt.com/c/6989ebb2-c2d4-83aa-bd3f-ee18c35181ae
+Confidence: 1.0
+
+### FACT 53
+Subject: DAF and Fiscal Sponsor Planning
+Type: Conversation
+Date: 2026-02-10
+Bucket: KEEP_WRITING
+Message count: 9
+Prompt (verbatim, opening): "DAF and fiscal sponsor planning I am going to the heart of ellsworth today and i want to confirm they can help with the accounting and being a DAF"
+Conclusion (verbatim, closing): "Nice — this is exactly the right convo to have *early*, not after money shows up. Here’s a **tight, no-fluff game plan** you can walk in with today. --- ## What you’re actually trying to confirm (plain English) You want to know if **The Heart of Ellsworth** can function as one..."
+Source: https://chatgpt.com/c/698b8d2e-2d6c-83a8-9a35-04fe3a397e8f
+Confidence: 1.0
+
+### FACT 54
+Subject: ETH Boulder Bio Draft
+Type: Conversation
+Date: 2026-02-13
+Bucket: KEEP_WRITING
+Message count: 12
+Prompt (verbatim, opening): "can we write this out for our eth boulder bio and make sure it sounds like what we are building"
+Conclusion (verbatim, closing): "Perfect — we’ll keep it builder-forward, ETH-native, and grounded in infrastructure. Here’s a clean version for both fields: --- ### **Bio** Engineer and Web3 founder building ownership infrastructure for the creator economy. Founder of The ZAO — a decentralized impact network..."
+Source: https://chatgpt.com/c/698f6628-d3f0-83a8-8b96-3618d3dfbce6
+Confidence: 1.0
+
+### FACT 55
+Subject: ETH BOULDER RECAP
+Type: Conversation
+Date: 2026-02-15
+Bucket: KEEP_WRITING
+Message count: 146
+Prompt (verbatim, opening): "Day 2 Joel chat with morning before leave and grabbed telegram Missed Event with Todd - https://nou-techne.github.io/techne-artizen/ - Presentation - Accelerating boulder with tech Met with homie again in morning He got a farcaster so go follow him up Loved the fishbowl discus..."
+Conclusion (verbatim, closing): "Yes. And you’re right to ask that. Your voice is not clean academic analysis. It’s not startup bro hype either. When you’re authentic, you: • Think out loud • Move between personal and structural • Ask questions mid-flow • Tie everything back to artists • Say “this is interest..."
+Source: https://chatgpt.com/c/699215ef-b970-83a8-9ef6-49502b1801b9
+Confidence: 1.0
+
+### FACT 56
+Subject: Onchain Creator Rally Submission
+Type: Conversation
+Date: 2026-02-15
+Bucket: KEEP_LONG_THREAD
+Message count: 20
+Prompt (verbatim, opening): "Submit Application Upload Banner Image Upload a banner image for your application, or we will dynamically generate one. This is the title 0x7234c36A71ec237c2Ae7698e8916e0735001E9Af Paragraph A Links Add link AI/ML Communication Community Content DAOs DeFi Design Education Ente..."
+Conclusion (verbatim, closing): "Perfect. Let’s tighten it up and remove anything soft. --- # Builders in Motion — ETH Boulder **Submitted by:** 0x7234c36A71ec237c2Ae7698e8916e0735001E9Af This is a short video documenting the people I met at ETH Boulder. It captures builders, creators, and conversations happe..."
+Source: https://chatgpt.com/c/69929472-9be4-83a9-8a54-fd2ab4cd167e
+Confidence: 1.0
+
+### FACT 57
+Subject: OpenClaw Install
+Type: Conversation
+Date: 2026-02-18
+Bucket: KEEP_LONG_THREAD
+Message count: 403
+Prompt (verbatim, opening): "https://vercel.com/kb/guide/running-openclaw-in-vercel-sandbox help me"
+Conclusion (verbatim, closing): "Good. We finally have the real problem in the logs. Two separate issues are happening. --- # 🔴 Problem 1 — Telegram Command Explosion This is the first red flag: ``` Telegram limits bots to 100 commands. 240 configured telegram setMyCommands failed (BOT_COMMANDS_TOO_MUCH) ``` ..."
+Source: https://chatgpt.com/c/6996660c-8520-83a5-8e64-4c397284e8aa
+Confidence: 1.0
+
+### FACT 58
+Subject: Weekly Twitter Thread Guide
+Type: Conversation
+Date: 2026-02-23
+Bucket: KEEP_WRITING
+Message count: 9
+Prompt (verbatim, opening): "I want to create a nested Twitter/X thread sharing my weekly contributions. Here's the structure I use: Format: • Main thread that introduces the week and points to sub-threads • Sub-threads for each category (Newsletter, GitHub Code, YouTube Videos) • Each sub-thread has an i..."
+Conclusion (verbatim, closing): "Here’s your fully structured nested thread — clean, personal, under 280 each, and actually saying something. --- **MAIN THREAD — Post 1** This week I pushed. Less talking. More shipping. Code. Campaigns. Conversations. Here’s the breakdown: • Newsletter thread below • GitHub c..."
+Source: https://chatgpt.com/c/699cc8e6-9fd4-8326-a934-1ae7feff0631
+Confidence: 1.0
+
+### FACT 59
+Subject: Artizen
+Type: Conversation
+Date: 2026-02-26
+Bucket: KEEP_LONG_THREAD
+Message count: 46
+Prompt (verbatim, opening): "1 American Season Yuval Shapira 33,939 votes | Submitted 2 Gaian Temple NAOBA 26,794 votes | Submitted 3 International Artists Project International Artists Project 22,882 votes | Submitted 4 DreamStarter.xyz Arun Philips 15,055 votes | Submitted 5 HOPE JED XO 14,058 votes | S..."
+Conclusion (verbatim, closing): "Here they are cleaned up and matched stylistically so they read like a pair: **Accepted** Accepted into the ZAO Fund for Emerging Culture on 3/6/26 after 4,983 $ZAO Respect tokens voted YES in the ZAO Discord. **Not Accepted** Not accepted into the ZAO Fund for Emerging Cultur..."
+Source: https://chatgpt.com/c/69a0ded5-6650-832f-8d3c-d2a38a4cff6e
+Confidence: 1.0
+
+### FACT 60
+Subject: Thermostat Replacement Guidance
+Type: Conversation
+Date: 2026-03-01
+Bucket: KEEP_LONG_THREAD
+Message count: 44
+Prompt (verbatim, opening): "I am replacing an old thermostat is this unsafe it's 2 wires idk what to do about the mercury and where do I put the two wires"
+Conclusion (verbatim, closing): "Nice — now we watch what happens. This is the “did everything actually work” moment. --- # 🧪 What Should Happen Next (Timeline) ### ⏱️ Within ~10–30 seconds: - You *might* hear a faint click - That’s the **zone valve starting to open** ### ⏱️ Within ~30–90 seconds: - Boiler sh..."
+Source: https://chatgpt.com/c/69a4efb8-6cbc-8333-82e2-1b74d49f8b51
+Confidence: 1.0
+
+### FACT 61
+Subject: Hypersub ERC-721 NFT
+Type: Conversation
+Date: 2026-03-01
+Bucket: KEEP_LONG_THREAD
+Message count: 50
+Prompt (verbatim, opening): "is hypersub an erc 20 or 1155 or 721 nft that i can use for holders"
+Conclusion (verbatim, closing): "That’s a **very good mechanic** because it ties together your three layers: **ZOLs → Core contributors** **$ZABAL / $ZAO holders → aligned supporters** **Hypersub → recurring culture layer** Hypersub supports **discounts and grants**, so this structure works well. --- # ZABAL ..."
+Source: https://chatgpt.com/c/69a4f8db-155c-8325-b0b0-0b19e0a0f6af
+Confidence: 1.0
+
+### FACT 62
+Subject: Obsidian Vaults and Sync
+Type: Conversation
+Date: 2026-03-04
+Bucket: KEEP_LONG_THREAD
+Message count: 21
+Prompt (verbatim, opening): "teach me about obsidian.md and how the vaults work and how to have multiple device login"
+Conclusion (verbatim, closing): "Perfect. Let’s build a **free / near-free “AI second brain” system** using **entity["software","Obsidian","knowledge management software"] + entity["software","Git","version control system"] + entity["company","GitHub","software hosting platform"]** that works with yo..."
+Source: https://chatgpt.com/c/69a814a0-f0b0-8332-8e8d-e5306ede74c5
+Confidence: 1.0
+
+### FACT 63
+Subject: Let’s Talk About ETH
+Type: Conversation
+Date: 2026-03-05
+Bucket: KEEP_LONG_THREAD
+Message count: 34
+Prompt (verbatim, opening): "ROLE You are a professional YouTube content editor and transcript analyst. TASK I will upload a full transcript of a video. Your job is to turn it into a YouTube video description with accurate timestamps that help viewers navigate the conversation. OUTPUT REQUIREMENTS Create ..."
+Conclusion (verbatim, closing): "Here is the **full clean copy-paste YouTube description** with your updated Season line included and formatted properly for the YouTube description field. --- Bitcoin promised peer-to-peer cash. Ethereum promised a world computer. People around the world are using both to buil..."
+Source: https://chatgpt.com/c/69a97f03-eb88-832b-a565-e8a3be990294
+Confidence: 1.0
+
+### FACT 64
+Subject: Caption Style Suggestions
+Type: Conversation
+Date: 2026-03-08
+Bucket: KEEP_LONG_THREAD
+Message count: 22
+Prompt (verbatim, opening): "reserach descrtipt and help me write. aogod duscstom tittle for the Add captions with blue text color #141e27 and a solid yellow background color #e0ddaa"
+Conclusion (verbatim, closing): "Use blue text **(#141e27)** with a solid yellow background **(#e0ddaa)** for captions. Keep them **bottom-centered with a very small margin from the bottom edge**, smaller font (~30px), and highlight words as they are spoken in a karaoke-style read."
+Source: https://chatgpt.com/c/69adad09-b328-832e-93e5-e2bdfb96957c
+Confidence: 1.0
+
+### FACT 65
+Subject: Caption correction request
+Type: Conversation
+Date: 2026-03-10
+Bucket: KEEP_LONG_THREAD
+Message count: 28
+Prompt (verbatim, opening): "i want to make an edit to lyrics on descript tell me what to say to the underlord to get this change from inccorrect lyrics to changing the correct lyrics but not changing any of the video only changing the captions/ lyrics 📍 Where you at, where you've been Paradise? With all ..."
+Conclusion (verbatim, closing): "From the screenshot you sent, you're **right-clicking in the transcript**, which won’t show the timing tools. The control you need is **in the top app menu**, not the right-click menu. Follow this path: ### Step-by-step 1. **Click anywhere in the transcript** so the script is ..."
+Source: https://chatgpt.com/c/69b07567-e278-8331-8e3a-00f57dc3e0f6
+Confidence: 1.0
+
+### FACT 66
+Subject: video editing tool
+Type: Conversation
+Date: 2026-03-10
+Bucket: KEEP_LONG_THREAD
+Message count: 64
+Prompt (verbatim, opening): "Use blue text #141e27 with a solid yellow background #e0ddaa. Captions should be bottom-centered with a very small margin from the bottom edge. Font size should be around 34–38px so it remains readable but not oversized. Display captions in a karaoke-style read, highlighting w..."
+Conclusion (verbatim, closing): "Here’s a clean summary you can send Ohnahji: We’re thinking about building a local-first video processing tool for our conversation-style content instead of relying on Descript for the full workflow. The idea is not to make a giant all-in-one editor, but a focused tool built a..."
+Source: https://chatgpt.com/c/69b09130-048c-832a-9340-f9afce6bb41a
+Confidence: 1.0
+
+### FACT 67
+Subject: Subaru Outback Wiper Issue
+Type: Conversation
+Date: 2026-03-17
+Bucket: KEEP_LONG_THREAD
+Message count: 44
+Prompt (verbatim, opening): "Having issues with my Subaru outback 2016 windshield wipers it only works on the top speed and none others I think It might the motors speed control module according to the internet can u help me confirm and order the psrt"
+Conclusion (verbatim, closing): "Perfect — you already found a solid OEM source. I pulled a **clean list of legit places** selling the exact same part (**86511AL02A**) so you can compare price, shipping, and trust level without digging. --- # 🧩 ✅ Your reference part - OEM Subaru Wiper Motor - **Part #: 86511A..."
+Source: https://chatgpt.com/c/69b953f6-d6c4-8327-83ee-a7e98049e059
+Confidence: 1.0
+
+### FACT 68
+Subject: Tax Deductions Explanation
+Type: Conversation
+Date: 2026-03-22
+Bucket: KEEP_LONG_THREAD
+Message count: 54
+Prompt (verbatim, opening): "why would i be filling this out whats it for"
+Conclusion (verbatim, closing): "Alright—here’s the **real number straight from your data**: # 💸 Total you spent in 2025 👉 **~$271,334** --- ## 🧠 What that actually means That number includes **everything**: - Bills - Credit card payments - Transfers between accounts - Mortgage - Daily spending - Travel - Foo..."
+Source: https://chatgpt.com/c/69c021be-e130-8325-b0e8-9ff130e1ab94
+Confidence: 1.0
+
+### FACT 69
+Subject: Concerts and Viral Tunes
+Type: Conversation
+Date: 2026-03-24
+Bucket: KEEP_LONG_THREAD
+Message count: 23
+Prompt (verbatim, opening): "Hi Zaal, Katina and I are back on the scene. I wish I had remembered to tell you about The Shitty Rolling Stones on Tuesday night at Black Moon. It was a massive event and total pandemonium. We don't see many nights like that in Ellsworth, Maine. The City Concert Series is pre..."
+Conclusion (verbatim, closing): "Hey thank you so much for taking a peek at the music. DUO Do are amazing. They’re actually from Argentina but traveling to Rome for a conference and part of our event was helping them crowdfund their trip out there in May. Great to hear the summer concert series is all booked ..."
+Source: https://chatgpt.com/c/69c2a158-8330-8333-a1a9-5323b16fdeb3
+Confidence: 1.0
+
+### FACT 70
+Subject: Nouns Proposal Best Practices
+Type: Conversation
+Date: 2026-03-25
+Bucket: KEEP_WRITING
+Message count: 16
+Prompt (verbatim, opening): "IconIcon About Dashboard Explore Playground Docs Bridge Base Base 0x7234c36A71ec237c2Ae7698e8916e0735001E9Af ZOUNZ avatar ZOUNZ Write Proposal How to create a proposal? Tips for writing great proposals First time creating a proposal? Start with the written proposal, then add t..."
+Conclusion (verbatim, closing): "Good call—tight, minimal, no future obligations. This is exactly how you avoid overengineering early governance. Here’s a clean, **no-strings-attached** version you can paste: --- # 🏗️ **ZOUNDZ Proposal: Pin ZABAL as Treasury Asset** ## **Title** **Pin ZABAL Token as a Treasur..."
+Source: https://chatgpt.com/c/69c3ab73-c760-832b-8f89-d2996a6cc53a
+Confidence: 1.0
+
+### FACT 71
+Subject: Farcaster and Decentralized Social
+Type: Conversation
+Date: 2026-04-23
+Bucket: KEEP_WRITING
+Message count: 83
+Prompt (verbatim, opening): "i want to write around a 1250 word article about farcaster and the power of decentrilized social media in the new age of creators and why its helpful and the power of being able to use a social graph when you create apps. it is the best place to find your first 100 users to go..."
+Conclusion (verbatim, closing): "Yeah—this is already **way better**, but here’s the honest take: You’re like **80% there structurally**… and still missing the *soul* of Farcaster. Right now it feels like: > “Clean Web3 product deck inspired by Farcaster” But what you actually need is: > “This could only exis..."
+Source: https://chatgpt.com/c/69ea06e3-ecc0-83ea-b265-1826c34cbfe5
+Confidence: 1.0
+
+### FACT 72
+Subject: Web3 Editorial Illustration Design
+Type: Conversation
+Date: 2026-04-24
+Bucket: KEEP_WRITING
+Message count: 10
+Prompt (verbatim, opening): "Editorial hero illustration for a Web3 article about portable social graphs, one creator identity connected across multiple app surfaces, social feed, mini app, creator dashboard, notification inbox, dark indigo background, lavender and violet accents, premium product illustra..."
+Conclusion (verbatim, closing): ""
+Source: https://chatgpt.com/c/69eb74b2-1668-83ea-95fd-40954a7fcae2
+Confidence: 1.0
+
+### FACT 73
+Subject: Farcaster Editorial Illustration
+Type: Conversation
+Date: 2026-04-24
+Bucket: KEEP_WRITING
+Message count: 29
+Prompt (verbatim, opening): "Create a high-resolution editorial hero illustration for a Web3 essay about Farcaster. Use a dark-mode product aesthetic inspired by official Farcaster docs: deep indigo and graphite background, soft violet and cool blue accents, restrained glow, rounded cards, no tacky neon c..."
+Conclusion (verbatim, closing): ""
+Source: https://chatgpt.com/c/69ebabd9-9e8c-83ea-9c41-4411745bd83b
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 73 Conversation nodes. Merge on Subject+Date match.

--- a/content/bonfire-ingest/chatgpt-archive-zao-2023-2024.md
+++ b/content/bonfire-ingest/chatgpt-archive-zao-2023-2024.md
@@ -1,0 +1,55 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-zao-2023-2024 (4 conversations).
+
+ChatGPT ZAO-tagged conversations 2023-07-18 through 2024-12-31.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: Employment Confirmation for Daniel Obuté
+Type: Conversation
+Date: 2024-05-13
+Bucket: KEEP_ZAO
+Message count: 5
+Prompt (verbatim, opening): "create a document saying that daniel obute is employed by zao music LLC and he has been on the team for the past 6 + months"
+Conclusion (verbatim, closing): "Here is a draft document for the employment confirmation of Daniel Obuté: --- **Zao Music LLC** 123 Harmony Lane, Music City, MC 56789 **Date:** May 13, 2024 **To Whom It May Concern,** This letter is to confirm that Mr. Daniel Obuté is currently employed with Zao Music LLC. H..."
+Source: https://chatgpt.com/c/c2d0eef4-1c9f-4dda-9ed4-b053a5c96e96
+Confidence: 1.0
+
+### FACT 2
+Subject: Discord Bot (check back)
+Type: Conversation
+Date: 2024-09-16
+Bucket: KEEP_ZAO
+Message count: 62
+Prompt (verbatim, opening): "i want to create a discord bot We have weekly consensus meetings on who is contributing the most to the ZAO Vision. With this I have everyone join one voice channel at the beginning for the presentation and then split folks up into rooms of max 6! I want a way where I can send..."
+Conclusion (verbatim, closing): "If the `/startmeeting` command isn’t working as expected, there are a few steps to troubleshoot and resolve the issue: ### 1. **Check Command Registration** Ensure that the bot is properly registering the `/startmeeting` command. Sometimes, the issue may be due to the command ..."
+Source: https://chatgpt.com/c/66e8198c-d79c-8000-89fb-344e529fc19d
+Confidence: 1.0
+
+### FACT 3
+Subject: OREC
+Type: Conversation
+Date: 2024-11-10
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "give me evertyhting you know about the zao fractal"
+Conclusion (verbatim, closing): "Integrating the **Optimistic Respect-based Executive Contract (OREC)** model could enhance the ZAO Fractal's governance by creating a streamlined, secure, and adaptive process for executing on-chain transactions, with these potential applications for the ZAO: ### 1. **Decentra..."
+Source: https://chatgpt.com/c/67312dfe-7ef0-8000-b7c9-5ba6614551d2
+Confidence: 1.0
+
+### FACT 4
+Subject: Thank You Notes ZAO-CHELLA
+Type: Conversation
+Date: 2024-12-19
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "Thank-You Note (From Zaal, the ZAO-CHELLA Events Team, and the ZAO Community) Dear [Vendor Name], On behalf of myself, the entire ZAO-CHELLA events team, and the amazing ZAO community, I want to express our deepest gratitude for your participation in this year’s event at Miami..."
+Conclusion (verbatim, closing): "**For the Firefly Team** Hey Firefly Team, Thank you so much for being part of ZAO-CHELLA during Miami Art Basel! Your contribution truly helped make the event shine, and we’re so grateful for your support and energy. We’d love to stay connected—let us know what we can do for ..."
+Source: https://chatgpt.com/c/67641e16-70a0-8000-92ca-b93e36d1aa5c
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 4 Conversation nodes. Merge on Subject+Date match.

--- a/content/bonfire-ingest/chatgpt-archive-zao-2025-h1.md
+++ b/content/bonfire-ingest/chatgpt-archive-zao-2025-h1.md
@@ -1,0 +1,1595 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-zao-2025-h1 (144 conversations).
+
+ChatGPT ZAO-tagged conversations 2025-01-01 through 2025-06-30.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: ZAO Cohort Proposal
+Type: Conversation
+Date: 2025-01-16
+Bucket: KEEP_ZAO
+Message count: 96
+Prompt (verbatim, opening): "I want to make a proposal for a song contest. Anyone who signs up for the contest can be part of the ZAO MUSIC COHORT #1 starting in March to June the requirements are to join the charmverse and share the song in the forums section. There will be 3 prizes 350,150,50$ for the t..."
+Conclusion (verbatim, closing): "### **ZAO Cohorts: Organized Timeline and Features** The **ZAO Cohorts** will run from **March to July 2025**, with two interconnected tracks: 1. **Musician Accelerator**: Focused on developing and empowering musicians. 2. **Creator Support Cohort**: Designed to support musici..."
+Source: https://chatgpt.com/c/6788ffbd-5218-8000-8f98-8e71a4d04aaf
+Confidence: 1.0
+
+### FACT 2
+Subject: ZAO Daily Content Strategy
+Type: Conversation
+Date: 2025-01-24
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You're an experienced digital strategist specializing in newsletters and social media content. We're creating the daily ‘Year of the ZAO: Day (X)’ content. Ask me the following setup questions as one block, then wait for my response before proceeding to the next step. Ensure t..."
+Conclusion (verbatim, closing): "Great! Now that the newsletter is live, I’ll proceed to Step 4: Social Media Adaptation. ### Social Media Posts: Year of the ZAO - Day 24 --- **Twitter (X):** Good morning, happy floral Fri-yay in the Year of the ZAO: Day 24. Today, we’re celebrating Desultor, a ZAO member wit..."
+Source: https://chatgpt.com/c/67939fcc-ed48-8000-a7c6-eaa62b469593
+Confidence: 1.0
+
+### FACT 3
+Subject: ZAO Daily Content Setup
+Type: Conversation
+Date: 2025-01-29
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You're an experienced digital strategist specializing in newsletters and social media content. We're creating the daily ‘Year of the ZAO: Day (29) content. Ask me the following setup questions as one block, then wait for my response before proceeding to the next step. Ensure t..."
+Conclusion (verbatim, closing): "### **Year of the ZAO - Day 29** **Your Best is Always Evolving** **Good morning, happy Wavy Wednesday in the Year of the ZAO: Day 29.** Your best is not a fixed point—it’s always shifting, adapting, and evolving. Some days, you’re full of energy, ready to take on the world. O..."
+Source: https://chatgpt.com/c/679a530f-59e8-8000-83e8-b2962cec322a
+Confidence: 1.0
+
+### FACT 4
+Subject: ZAO GrantZ Initiative
+Type: Conversation
+Date: 2025-01-30
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "lets make a proposal for the ZAO lets call it ZAO GrantZ lets ask for people who want to be on the grant finding team, grant writing team, event organizers/ musicians that are looking for funding to get funding in the ZAO, after the success of the the Lil Eternal Rhythms Perfo..."
+Conclusion (verbatim, closing): "### **Summary of Your Updated ZAO GrantZ Vision** You're proposing an evolution of the **ZAO GrantZ** initiative to include a **low-cost, opt-in subscription model**. This would create a more structured and sustainable way to support artists while also rewarding early adopters..."
+Source: https://chatgpt.com/c/679bbdd5-9130-8000-9264-084bc2d48283
+Confidence: 1.0
+
+### FACT 5
+Subject: Resume Optimization for Fundraising
+Type: Conversation
+Date: 2025-02-05
+Bucket: KEEP_ZAO
+Message count: 30
+Prompt (verbatim, opening): "# Zaal Panthaki Bar Harbor, ME | (781) 414-2359 | zaalp99@gmail.com LinkedIn: [linkedin.com/in/zaalp](https://www.linkedin.com/in/zaalp) | Website: [thezao.com](https://thezao.com) --- ## Professional Summary Innovative engineer and community leader with a proven track record ..."
+Conclusion (verbatim, closing): "Below is an updated **two-page** LaTeX template with **slightly larger headings** (using `\large`) and a bit more vertical spacing. It remains set at **10pt** font and **0.6-inch margins** so it should come closer to filling two pages (instead of just 1.5). Of course, the exac..."
+Source: https://chatgpt.com/c/67a3868f-3ca4-8000-b79b-85166b71a432
+Confidence: 1.0
+
+### FACT 6
+Subject: onchain
+Type: Conversation
+Date: 2025-02-12
+Bucket: KEEP_ZAO
+Message count: 125
+Prompt (verbatim, opening): "Node.js v23.3.0 /Users/zaalpanthaki/Desktop/CodingAI/Loanz2/eliza/agent: ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL @elizaos/agent@0.25.6-alpha.1 start: `node --loader ts-node/esm src/index.ts "--isRoot" "--character=characters/loanzofficer.character.json"` Exit status 7 ELIFECYCLE Com..."
+Conclusion (verbatim, closing): "Yo, it looks like your setup is still trying to update the character secrets from a file that doesn't exist—`studentloanzagent-seed.txt`. If you want to keep your seed in an env variable, you'll need to modify the secret-loading logic so it pulls from the env instead of attemp..."
+Source: https://chatgpt.com/c/67ac9ac9-1d3c-8000-9b50-1b144ae59b9b
+Confidence: 1.0
+
+### FACT 7
+Subject: Resume Enhancement Tips
+Type: Conversation
+Date: 2025-02-12
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "# Zaal Panthaki Bar Harbor, ME | (781) 414-2359 | zaalp99@gmail.com LinkedIn: [linkedin.com/in/zaalp](https://www.linkedin.com/in/zaalp) | Website: [thezao.com](https://thezao.com) --- ## Professional Summary Innovative engineer and community leader with a proven track record ..."
+Conclusion (verbatim, closing): "```latex \documentclass[11pt]{article} \usepackage[margin=1in]{geometry} \usepackage{setspace} \usepackage{hyperref} % for clickable links \begin{document} \pagestyle{plain} \setlength{\parindent}{0pt} \raggedright %------------------------------------------- % NAME & CONTACT ..."
+Source: https://chatgpt.com/c/67acbd95-2f40-8000-8bb4-06cb1a2836cc
+Confidence: 1.0
+
+### FACT 8
+Subject: Resume Writing Assistance
+Type: Conversation
+Date: 2025-02-13
+Bucket: KEEP_ZAO
+Message count: 28
+Prompt (verbatim, opening): "\documentclass[11pt]{article} \usepackage[margin=1in]{geometry} \usepackage{setspace} \usepackage{hyperref} % for clickable links \begin{document} \pagestyle{plain} \setlength{\parindent}{0pt} \raggedright %------------------------------------------- % NAME & CONTACT %--------..."
+Conclusion (verbatim, closing): "Below is a simple `.docx` file content encoded in Base64. Follow these steps: 1. **Copy** everything between the `-----BEGIN DOCX-----` and `-----END DOCX-----` lines (inclusive). 2. **Paste** into a text editor and **save** the file with a `.docx` extension (for example, `Cov..."
+Source: https://chatgpt.com/c/67ae4b68-e420-8000-9392-835aca23c08a
+Confidence: 1.0
+
+### FACT 9
+Subject: Resume Formatting Assistance
+Type: Conversation
+Date: 2025-02-18
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "\documentclass[11pt]{article} \usepackage[margin=1in]{geometry} \usepackage{setspace} \usepackage{hyperref} % for clickable links \begin{document} \pagestyle{plain} \setlength{\parindent}{0pt} \raggedright %------------------------------------------- % NAME & CONTACT %--------..."
+Conclusion (verbatim, closing): "```latex \documentclass[11pt]{article} \usepackage[margin=1in]{geometry} \usepackage{setspace} \usepackage{hyperref} % for clickable links \begin{document} \pagestyle{plain} \setlength{\parindent}{0pt} \raggedright %------------------------------------------- % NAME & CONTACT ..."
+Source: https://chatgpt.com/c/67b47db4-bf00-8000-8f27-ebb62ebfb263
+Confidence: 1.0
+
+### FACT 10
+Subject: ZAO Onboarding Guide
+Type: Conversation
+Date: 2025-02-20
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "I want to create an omboarding for the ZAO Welcome to the ZAO Verse! or Zverse ZAO casa, sui casa. 🖤 You are welcome here. Come in and make yourself comfortable. Your Gateway to ZAO & Web3 The ZAO is more than a movement—it’s an ecosystem for creators, artists, and communities..."
+Conclusion (verbatim, closing): "Below is a comprehensive summary that lists and organizes all the information you’ve provided—from the initial onboarding and ecosystem details to the most recent additions about the tech startup process. --- ## I. Onboarding & Introduction - **Welcome Message & Environment:**..."
+Source: https://chatgpt.com/c/67b71224-02fc-8000-b6d2-536c27ad2edc
+Confidence: 1.0
+
+### FACT 11
+Subject: Polkadot Music Project
+Type: Conversation
+Date: 2025-02-26
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "polka dot blockchain, i want to build something for the zao for music"
+Conclusion (verbatim, closing): "# Building an NFT Music Ownership Platform on Polkadot ## Introduction NFTs (Non-Fungible Tokens) are transforming music ownership by enabling unique digital assets that represent songs, albums, or related rights. An NFT music ownership platform allows artists to mint their mu..."
+Source: https://chatgpt.com/c/67bef914-c38c-8000-880e-54c3d63622a6
+Confidence: 1.0
+
+### FACT 12
+Subject: AI Agent Project Plan
+Type: Conversation
+Date: 2025-02-28
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "can you do a deep dive on eliza OS as an ai agent software I would like to make an ai agent for a project I am working ON help me make a plan for creating the best ai agent for this project Ultimate Meme Movement with Real Impact 🎓 From Meme to Movement: Making Student Loan De..."
+Conclusion (verbatim, closing): "# Expanding the Eliza OS AI Agent for Web3 Community Engagement Building on **Eliza OS**, an agentic AI framework, we can enhance the agent to operate across multiple platforms, generate memes, integrate with Web3, and manage social media. Eliza OS already supports connecting ..."
+Source: https://chatgpt.com/c/67c1f3e9-ffdc-8000-ba29-c842b6178fa0
+Confidence: 1.0
+
+### FACT 13
+Subject: ZAO Whitepaper Outline
+Type: Conversation
+Date: 2025-03-02
+Bucket: KEEP_ZAO
+Message count: 228
+Prompt (verbatim, opening): "Untitled Page I. Onboarding & Introduction • Welcome Message & Environment: ○ “Welcome to the ZAO Verse! or Zverse” ○ “ZAO casa, sui casa. 🖤” ○ Invitation to come in, get comfortable, and explore. • Onboarding Paths: ○ Intro to Blockchain (For Beginners): – Click “Blockchain 1..."
+Conclusion (verbatim, closing): "…you’ll want to surface learning and set the stage for next steps. Common closing prompts include: - **What’s your most important takeaway?** - **What action will you commit to?** - **What questions remain?** By pairing each question with the right format—whether in pairs, tri..."
+Source: https://chatgpt.com/c/67c4d65e-2960-8000-8ab6-f20656a8fbcf
+Confidence: 1.0
+
+### FACT 14
+Subject: Reimagining Token Mining
+Type: Conversation
+Date: 2025-03-05
+Bucket: KEEP_ZAO
+Message count: 7
+Prompt (verbatim, opening): "https://app.charmverse.io/the-zao/the-zao-whitepaper-draft-1-8386827677309043 research the ZAO adn the value and ideals and see if this makes sense for something we can build We should bring back mining — but not in the way you think: The industry today is overwhelmed with tok..."
+Conclusion (verbatim, closing): "Below is an overview of the core ideas behind the ZAO whitepaper draft and an analysis of its feasibility as a project: --- ### 1. Core Concept: Re-imagining Mining as Community-Driven Value Creation **Key Principles:** - **Moving Beyond Lazy Capital:** The draft criticizes “l..."
+Source: https://chatgpt.com/c/67c84c50-d6d0-8000-a839-4b60827c794a
+Confidence: 1.0
+
+### FACT 15
+Subject: Map Embed with Pins
+Type: Conversation
+Date: 2025-03-05
+Bucket: KEEP_ZAO
+Message count: 58
+Prompt (verbatim, opening): "ok i want to create embed code to have pins of people on a map. set it up so that I can have a name of someone with a link to something and a location. include for example Zaal, Bar harbor, Maine, thezao.com"
+Conclusion (verbatim, closing): "Below is an updated version that includes some mobile-friendly improvements. In this version: - **Responsive Layout:** The CSS uses a media query to switch to a vertical layout on smaller screens (mobile devices). On mobile, the sidebar appears on top (or can be made collapsib..."
+Source: https://chatgpt.com/c/67c89942-c27c-8000-ac41-46c40b31da73
+Confidence: 1.0
+
+### FACT 16
+Subject: COC ConcertZ Collaboration Proposal
+Type: Conversation
+Date: 2025-03-06
+Bucket: KEEP_ZAO
+Message count: 26
+Prompt (verbatim, opening): "​i wnat to make a proposal to ask for people to help as we partner with the COC to make some metaverse events. Looking for more folks to organize or have visual artists have their artwork displayed in the metaverse for the event COC ConcertZ: A Metaverse Musical Experience ​Jo..."
+Conclusion (verbatim, closing): "```markdown # Calling All ZAO Collaborators – Join Us for COC ConcertZ! Hello ZAO Family, We’re thrilled to announce an exciting opportunity to collaborate on a groundbreaking metaverse event. We are partnering with the Community of Communities (COC) to bring the inaugural COC..."
+Source: https://chatgpt.com/c/67ca2da2-95b0-8000-a43e-d797c9aaf7b4
+Confidence: 1.0
+
+### FACT 17
+Subject: ZAO Whitepaper Twitter Thread
+Type: Conversation
+Date: 2025-03-14
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "Ok I want to make a banging twitter thread about the ZAO can you help me by researching the ZAO HERES a link for more research https://app.charmverse.io/the-zao/the-zao-whitepaper-draft-1-8386827677309043 Let's do some research on this topic and how we can post a great twitter..."
+Conclusion (verbatim, closing): "# ZAO Whitepaper Insights – Twitter Thread 🧵 **Tweet 1:** 🎧 *Imagine a world where artists and creators call the shots.* The **ZAO** (ZTalent Artist Organization) whitepaper lays out a vision to make this real. Why should musicians care about blockchain and Web3? Because it mi..."
+Source: https://chatgpt.com/c/67d41cc0-aa04-8000-905f-b6c33fa28b6d
+Confidence: 1.0
+
+### FACT 18
+Subject: Interview Questions for ZAO
+Type: Conversation
+Date: 2025-03-15
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "i need to create interview questrions for someone can you help me https://x.com/sigueinventando research and see what questions to add we want to pertain to this https://x.com/sigueinventando/status/1900305931210285108 https://x.com/sigueinventando/status/1900254225315303749 h..."
+Conclusion (verbatim, closing): "Below is an updated press release draft that weaves in the latest details gleaned from our research: --- **Intro** In a celebration where raw creativity meets cutting-edge tech, Gabe stands as the creative force behind the ZAO community’s unforgettable moments. Back in April 2..."
+Source: https://chatgpt.com/c/67d600c5-41d8-8000-a484-ce881b73cad6
+Confidence: 1.0
+
+### FACT 19
+Subject: Social Media Data Tracker
+Type: Conversation
+Date: 2025-03-19
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "i wnat to make soemmthign that automatically stores the data of all my followers on a spcefici social media so I can have all my BettercallZAal account usernames listed for twitter Instagram youtube and twitch and tiktok but then I also want a section so that I can add the ZAO..."
+Conclusion (verbatim, closing): "Here's a layout idea that makes the x-axis your social media platforms (with the platform name included) and the y-axis your brands: ### Spreadsheet Structure **Columns (X-Axis):** Each column represents a social media platform's follower count. You might also include the acco..."
+Source: https://chatgpt.com/c/67da99f3-3b6c-8000-8015-2ddfb2876c77
+Confidence: 1.0
+
+### FACT 20
+Subject: MIDI-ZAO-NKZ Collaboration Proposal
+Type: Conversation
+Date: 2025-03-20
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "I want to create a proposal lets name the proposal MIDI-ZAO-NKZ tell people we are colaborating with the midipunks on a ZAO V Midipunks song where the hook will be the same but we will get ZAO folks on the ZAO song and miudipunks on the midipunks song with the goal to get the ..."
+Conclusion (verbatim, closing): "```markdown # Proposal: MIDI-ZAO-NKZ ## Overview Introducing **MIDI-ZAO-NKZ**, our groundbreaking collaboration that merges the best of both worlds—ZAO and MidiPunkz. We're blending our creative energies to craft a dual-version hit where the hook remains the same, but the magi..."
+Source: https://chatgpt.com/c/67dc005e-62a4-8000-91db-10e061b0dd47
+Confidence: 1.0
+
+### FACT 21
+Subject: ZAO Family Structure Plan
+Type: Conversation
+Date: 2025-03-23
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "I want to make this for the ZAO and organize it like big little in frats. I want 4 family lines under me. I want it to be like the big brother onboards the person to the ZAO and their family trees culture. I want it to be set up as good as it can be and organized as possible. ..."
+Conclusion (verbatim, closing): "Here’s a full **ZAO Family Tree Summary** in markdown, ready to drop into a doc, Notion page, or website: --- ```markdown # 🌳 The ZAO Family Tree ## Overview The **ZAO Family Tree** is an exclusive onboarding and cultural lineage system inspired by Big-Little structures found ..."
+Source: https://chatgpt.com/c/67e0610f-56c4-8000-91a7-0597b874099b
+Confidence: 1.0
+
+### FACT 22
+Subject: ZAO CARDS
+Type: Conversation
+Date: 2025-03-23
+Bucket: KEEP_ZAO
+Message count: 28
+Prompt (verbatim, opening): "ZAO CARDS MASHUP BATTLE REMIXING YUO USE A PART OF THE CARD TO IMPROVE THE SONG. MORE YOU HAVE COLLECTED FAMILIAR ENOUGH WITH A ARTIST to know what songs to play TEAM BATTLES 2v2 gonna make a game with web 3 avalanche lets splice up a song from the event you can play those ste..."
+Conclusion (verbatim, closing): "```markdown # ZAO Cards: Game Overview Imagine a game where music meets strategic card battles—a platform where every card is a musical element, and every battle is a remix session. This overview is meant to introduce you to the core concept, mechanics, and technical intricaci..."
+Source: https://chatgpt.com/c/67e0a43e-1e00-8000-b2d7-2a27ea519765
+Confidence: 1.0
+
+### FACT 23
+Subject: ZAO Marketing Funnel Plan
+Type: Conversation
+Date: 2025-03-24
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "i want to work on the produce asention ladder of the zao The ZAO (ZTalent Artist Organization): A Decentralized Impact Network for the Creator Economy Executive Summary Community Overview (Company Overview):The ZAO is a community-driven guild that challenges centralized system..."
+Conclusion (verbatim, closing): "Below is an extensive list of product ideas—ranging from free, entry-level offerings to high-tier, elite experiences—that could form a robust product ascension ladder for The ZAO. These options aim to engage creators at every stage of their journey, encouraging both artistic g..."
+Source: https://chatgpt.com/c/67e1cd30-8fa8-8000-90fe-a25ac7e4dcd5
+Confidence: 1.0
+
+### FACT 24
+Subject: Cypher
+Type: Conversation
+Date: 2025-03-26
+Bucket: KEEP_ZAO
+Message count: 69
+Prompt (verbatim, opening): "<!DOCTYPE html> <html lang="en"> <head> <meta charset="UTF-8" /> <meta name="viewport" content="width=device-width, initial-scale=1.0"> <title>Customizable ZAO-CHELLA Cypher Visualizer</title> <!-- Wavesurfer.js from CDN --> <script src="https://unpkg.com/wavesurfer.js"></scri..."
+Conclusion (verbatim, closing): "Here’s a bird’s-eye walkthrough of what your embedded ZAO-CHELLA Cypher Visualizer is doing, step by step: --- ## 1. Head Section - **Libraries Loaded** - **Wavesurfer.js** for the audio waveform UI. - **Web3.js** for Ethereum/Optimism token gating. - **Global Styles & Utility..."
+Source: https://chatgpt.com/c/67e42da5-9ec8-8000-90f7-e5f16aaad18f
+Confidence: 1.0
+
+### FACT 25
+Subject: ZAO Fest Documentary Outline
+Type: Conversation
+Date: 2025-03-27
+Bucket: KEEP_ZAO
+Message count: 26
+Prompt (verbatim, opening): "what do you know about everything for ZAO-CHELLA and ZAO FESTIVIALS I want to make a documentary like the fire festival documentary but showcase chaos turning into an amazing web 3 event help me with an outline"
+Conclusion (verbatim, closing): "```markdown # 🎤 ZAO-CHELLA Documentary Interview Questions A breakdown of questions for participants, staff, musicians, and community members — crafted for strong emotional sound bites, behind-the-scenes stories, and big-picture reflections based on the “Chaos to Crypto Carniv..."
+Source: https://chatgpt.com/c/67e57b18-7010-8000-baab-f23a67210a44
+Confidence: 1.0
+
+### FACT 26
+Subject: Let's Talk about Web 3 Logo
+Type: Conversation
+Date: 2025-03-29
+Bucket: KEEP_ZAO
+Message count: 212
+Prompt (verbatim, opening): "Can you give me an image for a logo with The Today Show w/bettercallzaal"
+Conclusion (verbatim, closing): "{"prompt":"A promotional banner for a Web3 podcast titled 'The ZAO Presents: Let's Talk About Web3' featuring Episode 6. The design uses a dark blue background with bold yellow graffiti-style text. The three cartoon-style hosts—Ohanji B, EZinCrypto, and BetterCallZaal—are illu..."
+Source: https://chatgpt.com/c/67e8a248-ec94-8000-97bb-22f22e3ecb5d
+Confidence: 1.0
+
+### FACT 27
+Subject: ZAO NEXUS
+Type: Conversation
+Date: 2025-03-31
+Bucket: KEEP_ZAO
+Message count: 363
+Prompt (verbatim, opening): "OK I have a links page for my website called the nexus Here is the code I currently Have <!-- EMBED #1: Styling & Layout (Improved Spacing) --> <style> :root { /* Branding Colors - Light Mode (default) */ --bg-color: #141e27; /* Deep blue background */ --text-color: #e0ddaa; /..."
+Conclusion (verbatim, closing): "### What works best inside a Webflow **Embed** element Webflow’s “Embed” widget simply pipes the raw markup you paste straight into the page. A few practical guidelines will spare you broken layouts and console errors. | ✅ Do | ❌ Don’t | |------|---------| | Treat the snippet ..."
+Source: https://chatgpt.com/c/67ea9ad4-0d18-8000-9674-907ced20141d
+Confidence: 1.0
+
+### FACT 28
+Subject: Web3 Podcast Run of Show
+Type: Conversation
+Date: 2025-04-11
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "Let’s Talk About Web3 with EZ, Ohnahji, and BetterCallZaal Duration: 60 minutes Platform: Huddle Meeting (public link, open participation) Streamed to: Twitch (EZ, Ohnahji, Zaal) Run of Show (Short Version) 0:00 – 5:00 — Opening Gratitudes Each host shares one thing they’re gr..."
+Conclusion (verbatim, closing): "```markdown Let’s Talk About Web3 is a community podcast exploring breakthrough Web3 tech and onchain culture through real-time discussions. ```"
+Source: https://chatgpt.com/c/67f903d0-331c-8000-8991-aef4ceda3c5f
+Confidence: 1.0
+
+### FACT 29
+Subject: ZAO Wikipedia Page Guidelines
+Type: Conversation
+Date: 2025-04-11
+Bucket: KEEP_ZAO
+Message count: 38
+Prompt (verbatim, opening): "ok i want to add a ZAO Wikipedia Page Wikipedia Article Wizard Referencing and notability Your article will be declined if the topic is not notable, violates copyright, or is not referenced properly. Notability The topic of an article must already be covered in reliable source..."
+Conclusion (verbatim, closing): "Below is a more polished, in‐depth Wikipedia draft that draws on the internal documentation available at nexus.thezao.com as well as the independent, secondary sources you provided. (Remember that while primary sources such as nexus.thezao.com can help clarify technical detail..."
+Source: https://chatgpt.com/c/67f90904-f7a0-8000-b75d-9e15f49b21f4
+Confidence: 1.0
+
+### FACT 30
+Subject: ZAO Wikipedia Research Plan
+Type: Conversation
+Date: 2025-04-11
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "Deep Research Prompt for ZAO Wikipedia Article Objective: Gather multiple independent, in-depth, and reliable secondary sources on ZAO (ZTalent Artist Organization) that can be used to support a Wikipedia article. The sources must be published by reputable media outlets, acade..."
+Conclusion (verbatim, closing): "## 1. Lindsey McConaghy – *Token for Your Thoughts* podcast (April 1, 2025), “How The ZAO Is Helping Artists Keep Their Music, Data, and Dollars.” **Podcast interview with ZAO founder Zaal Panthaki.** This source provides a comprehensive overview of ZAO’s mission and innovatio..."
+Source: https://chatgpt.com/c/67f950cc-ad04-8000-9b02-ce9fbaaf706a
+Confidence: 1.0
+
+### FACT 31
+Subject: ZAO Daily Workflow
+Type: Conversation
+Date: 2025-04-13
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "# 🌀 Year of the ZAO: Daily Content Workflow ### Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that become powerful, on-brand newsletters and social content for the enti..."
+Conclusion (verbatim, closing): "This is incredibly tight. The system is structured, responsive, and fully aligned with your daily execution flow. It captures the vibe of **BetterCallZaal** and **ZAO** perfectly—organized yet personal, ritualistic yet scalable. Here"
+Source: https://chatgpt.com/c/67fbadc6-86e8-8000-b6e6-9e1d55c8f3c0
+Confidence: 1.0
+
+### FACT 32
+Subject: ZAO Workflow Optimization
+Type: Conversation
+Date: 2025-04-13
+Bucket: KEEP_ZAO
+Message count: 34
+Prompt (verbatim, opening): "# 🌀 Year of the ZAO: Daily Content Workflow ### Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that become powerful, on-brand newsletters and social content for the enti..."
+Conclusion (verbatim, closing): "Perfect. Here's your **platform-specific social content** for **Year of the ZAO – Day 104** 👇 --- ## 📱 Social Media Posts – April 14, 2025 (Day 104) --- ### **1. Twitter (X)** **Good morning, happy Monday – April 14, 2025 in the Year of the ZAO: Day 104.** ZAO vs. MidiPunkz: W..."
+Source: https://chatgpt.com/c/67fbadd3-eb94-8000-ace6-4013c419ec19
+Confidence: 1.0
+
+### FACT 33
+Subject: ZAO Prompt update
+Type: Conversation
+Date: 2025-04-14
+Bucket: KEEP_ZAO
+Message count: 33
+Prompt (verbatim, opening): "can we update this prompt please # 🌀 Year of the ZAO: Daily Content Workflow ### Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that become powerful, on-brand newsletter..."
+Conclusion (verbatim, closing): "# 🌀 Year of the ZAO: Daily Content Workflow ### Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal’s reflections become polished, on‑brand newsletters and social content for two distinct audie..."
+Source: https://chatgpt.com/c/67fd3504-f208-8000-b473-7deabc2a9193
+Confidence: 1.0
+
+### FACT 34
+Subject: ZAO Daily Workflow
+Type: Conversation
+Date: 2025-04-15
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that become powerful, on-brand newsletters and social content for the entire ecosy..."
+Conclusion (verbatim, closing): "Understood — here’s the revised **Day 105 social content** with the word *“struggle”* removed and replaced with more aligned, empowering language. --- ## 🐦 Twitter (X) Day 105 of the Year of the ZAO 🌪️ What if your challenges weren’t setbacks… but teachers? Today’s reflection,..."
+Source: https://chatgpt.com/c/67fe3b70-3a60-8000-bce3-06956c50be8b
+Confidence: 1.0
+
+### FACT 35
+Subject: ZAO Daily Workflow Summary
+Type: Conversation
+Date: 2025-04-16
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that become powerful, on-brand newsletters and social content for the entire ecosy..."
+Conclusion (verbatim, closing): "Got it — here’s the **clean, text-only version** of the ZAO social captions for today's post promoting the stream: --- ### 📣 ZAO Social Captions (Text-Only) — April 16, 2025 (Day 106) **1. Twitter (X) – ZAO Account** Let’s Talk About Web 3 is live tonight at 6 PM EST. Would lo..."
+Source: https://chatgpt.com/c/67ff8d4d-7744-8000-a519-8433dec532f0
+Confidence: 1.0
+
+### FACT 36
+Subject: Welcome Messages for ZAO
+Type: Conversation
+Date: 2025-04-17
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "​To send bulk direct messages (called "direct casts") on Warpcast using Percs, follow these steps:​ PERCS | Onchain marketing solutions +2 PERCS +2 PERCS +2 1. Connect Your Warpcast Profile to Percs Begin by integrating your Warpcast account with Percs:​ In the Percs admin pan..."
+Conclusion (verbatim, closing): "Got it — to create and send a **mass DM (direct cast)** to all your Warpcast subscribers using **Percs**, follow this step-by-step guide now that you're ready to compose the message: --- ### ✅ How to Create a Mass DM in **Percs** (Warpcast) #### 🔹 Step 1: Go to Messaging - In ..."
+Source: https://chatgpt.com/c/6800d87f-5bec-8000-992e-3e20b69332bb
+Confidence: 1.0
+
+### FACT 37
+Subject: ZAO Content Workflow
+Type: Conversation
+Date: 2025-04-17
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal shares reflections that are transformed into powerful, on-brand newsletters and social content for th..."
+Conclusion (verbatim, closing): "Perfect call. Here’s the revised set of ZAO social posts for **Day 107**, now with a strong CTA to support the broader **Fractal ecosystem** on Gitcoin—where ZAO plays an active role. --- ### 📣 ZAO Social Media Posts – Day 107 (with Gitcoin Grant CTA) **1. Twitter (X):** Day 1..."
+Source: https://chatgpt.com/c/6800ec76-381c-8000-bafd-44197974f74b
+Confidence: 1.0
+
+### FACT 38
+Subject: ZAO Tap Mini App Plan
+Type: Conversation
+Date: 2025-04-18
+Bucket: KEEP_ZAO
+Message count: 42
+Prompt (verbatim, opening): "i am building with ohara for a farcaster mini-app help me prompt the ohara llm to create this mini-app here is the summary of what i want to do. ZAO Tap to Earn Mini App Summary I'm creating a fun, engaging mini app for Farcaster that promotes ZAO governance through a simple y..."
+Conclusion (verbatim, closing): "Absolutely! Here's a comprehensive prompt you can provide to Ohana to generate the **ZAO Tap to Earn** mini-app in a single shot: --- **Project Title**: ZAO Tap to Earn – Farcaster Mini-App **Objective**: Develop a gamified mini-app integrated with Farcaster to promote dai..."
+Source: https://chatgpt.com/c/68025cbe-54f8-8000-acc4-ad984a254204
+Confidence: 1.0
+
+### FACT 39
+Subject: Add Twitch Zao Branding
+Type: Conversation
+Date: 2025-04-20
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "can we add twitch to this and make it look clean and also zao branded"
+Conclusion (verbatim, closing): "{ "prompt": "A compact 2D digital graphic with transparent background featuring bold yellow and dark blue 'THE ZAO PRESENTS' text above four evenly spaced social media icons (Twitch, X, YouTube, Instagram) followed by the username 'bettercallzaal' in white outlined letters. Th..."
+Source: https://chatgpt.com/c/68054c69-5940-8000-9d37-aa1c5b0079f3
+Confidence: 1.0
+
+### FACT 40
+Subject: Year of the ZAO Workflow
+Type: Conversation
+Date: 2025-04-22
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal’s reflections become polished, on‑brand newsletters and social content for two distinct audiences: Be..."
+Conclusion (verbatim, closing): "Perfect. Here's **Set A** — the social posts for **BetterCallZaal** to drive newsletter engagement (all end with your Paragraph link): --- ### **Set A: BetterCallZaal + Newsletter Link** **Twitter (X):** What if you’re not tired because you’re doing too much— But because you’v..."
+Source: https://chatgpt.com/c/680776d1-0378-8000-ae89-215b5ebca7e4
+Confidence: 1.0
+
+### FACT 41
+Subject: Year of the ZAO Workflow
+Type: Conversation
+Date: 2025-04-23
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal’s reflections become polished, on‑brand newsletters and social content for two distinct audiences: Be..."
+Conclusion (verbatim, closing): "Perfect—got the link: 🔗 [https://paragraph.com/@thezao/year-of-the-zao-day-113](https://paragraph.com/@thezao/year-of-the-zao-day-113) Now generating **social posts for BetterCallZaal**, each tailored for its platform and ending with the Paragraph link. --- ### 📢 **BetterCallZ..."
+Source: https://chatgpt.com/c/6808c2e7-e678-8000-ae50-bd8b1ba1cadb
+Confidence: 1.0
+
+### FACT 42
+Subject: ZAO Whitepaper Enhancement Plan
+Type: Conversation
+Date: 2025-04-23
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "Here are a few additional things we can build or expand upon depending on your goals: • ZAO Roadmap Page or Visual Timeline – Outlining phases of development, token evolution, and upcoming initiatives. • Onboarding Guide for New Members – A clear step-by-step post or page show..."
+Conclusion (verbatim, closing): "✅ The full whitepaper is now fully formatted in **Markdown**, with proper headings, internal links in the table of contents, and styled section titles. You can now: - Use this version for direct conversion into a clean Notion page, GitBook, or markdown PDF. - Easily generate a..."
+Source: https://chatgpt.com/c/6808e92a-5e14-8000-9f9d-014ace3a74db
+Confidence: 1.0
+
+### FACT 43
+Subject: Year of the ZAO Workflow
+Type: Conversation
+Date: 2025-04-24
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to the Year of the ZAO – a daily ritual where BetterCallZaal’s reflections become polished, on‑brand newsletters and social content for two distinct audiences: Be..."
+Conclusion (verbatim, closing): "Perfect — here’s your **updated ZAO social post set** for **Day 114**, now starting with **“gm”** and incorporating the new context and media mention: --- ## ✅ **ZAO Social Media Posts (gm edition + event flick)** **Focus: Legacy perspective + photo from the first ZAO event** ..."
+Source: https://chatgpt.com/c/680a1d93-e3c4-8000-bef1-ebc89f87a676
+Confidence: 1.0
+
+### FACT 44
+Subject: ZAO Token-Gated Chatbox
+Type: Conversation
+Date: 2025-04-24
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "can we create a very simple chat box for events in the ZAO lets make it so you can only add info if you have $ZAO tokens already its going to need to work on webflow's embed function lets start ideating and brainstorming on the idea"
+Conclusion (verbatim, closing): "Now *that’s* a spicy twist. You're basically talking about: > A **token-gated, once-a-day “link drop” wall** where ZAO members can share **one thing per day** — a song, a post, a mirror, a link — and the world gets to **peek behind the curtain of the community**. Think **BeRea..."
+Source: https://chatgpt.com/c/680a4c7d-3680-8000-a9fc-ead32751b922
+Confidence: 1.0
+
+### FACT 45
+Subject: Year of the ZAO
+Type: Conversation
+Date: 2025-04-25
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Got it — here’s the **redone ZAO Community social posts** using your updated message: --- ### 🌀 **ZAO Community – Social Posts (No Newsletter Link)** Focus: **Floral Friday shoutout to ZAO Co-Founders and ZAO-PALOOZA Organizers** **Twitter (X):** gm. Year of the ZAO – Day 115 ..."
+Source: https://chatgpt.com/c/680b724f-f168-8000-8c3f-5213fa11b73a
+Confidence: 1.0
+
+### FACT 46
+Subject: sbs website
+Type: Conversation
+Date: 2025-04-25
+Bucket: KEEP_ZAO
+Message count: 179
+Prompt (verbatim, opening): "1. Head Section Libraries Loaded Wavesurfer.js for the audio waveform UI. Web3.js for Ethereum/Optimism token gating. Global Styles & Utility Gradient-rich, dark UI styles (Poppins font). .disabled vs. .enabled CSS classes to shade the Play button based on gate status. A tiny ..."
+Conclusion (verbatim, closing): "✅ Fixed! The duplicate `WaveSurfer.create()` config values have been removed, and the syntax error is now resolved. Your embed should now load and function cleanly with: - 🎨 Waveform segmented by artist colors - ✅ No JavaScript errors blocking execution Ready to test or add mo..."
+Source: https://chatgpt.com/c/680ba9ef-0694-8000-abbe-488d26d47204
+Confidence: 1.0
+
+### FACT 47
+Subject: ZAO Daily Workflow Feedback
+Type: Conversation
+Date: 2025-04-28
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "**YES.** Excellent idea — that's how you *really* feel native to each platform instead of looking like you're just blasting copy-paste content. Smart move. Here’s the **adjusted BetterCallZaal posts**, still following the **core theme**, **all linking** to the newsletter — but..."
+Source: https://chatgpt.com/c/680f672a-98a8-8000-ae5d-03d00fb11c5a
+Confidence: 1.0
+
+### FACT 48
+Subject: ZAO Content Workflow
+Type: Conversation
+Date: 2025-04-29
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Of course — here’s **just the plain text** version for easy copy/paste: --- **Twitter (X) Post:** gm. April 29, 2025 – Year of the ZAO: Day 119 Real strength isn't defending your position louder — it's listening deeper. Today's reflection: seek to understand before trying to b..."
+Source: https://chatgpt.com/c/6810a80e-18bc-8000-8f67-4580de8df644
+Confidence: 1.0
+
+### FACT 49
+Subject: Year of the ZAO
+Type: Conversation
+Date: 2025-04-30
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Perfect. Here are the **social media posts**, split by audience as outlined. --- ### 🟣 **BetterCallZaal – Social Posts (With Newsletter Link)** Each post includes the full newsletter link: 👉 [https://paragraph.com/@thezao/year-of-the-zao-day-120](https://paragraph.com/@thezao/..."
+Source: https://chatgpt.com/c/6812080c-7400-8000-bf73-6915d98cb635
+Confidence: 1.0
+
+### FACT 50
+Subject: FarCon Travel Day Posts
+Type: Conversation
+Date: 2025-04-30
+Bucket: KEEP_ZAO
+Message count: 45
+Prompt (verbatim, opening): "Part A: BetterCallZaal (With Newsletter URL) Each post: * Opens with: gm. travel day to farcon completed * Reflects the newsletter theme * Ends with the provided URL Platforms: 1. Twitter (X) 2. Twitter Group Chat 3. Twitter DM 4. Farcaster – ZAO Channel 5. Farcaster – Farcast..."
+Conclusion (verbatim, closing): "Based on your notes, here’s a polished and expressive **YouTube caption for the Day 3 FarCon recap**, focused on your time at the **Williamsburg Bridge**, **FarCon Open**, and **The Forever Library**: --- **Title:** **FarCon NYC Day 3 – The Forever Library, FarCon Open, and Br..."
+Source: https://chatgpt.com/c/6812d414-76a8-8000-8f26-35ce3e55ef60
+Confidence: 1.0
+
+### FACT 51
+Subject: Logo Design Request
+Type: Conversation
+Date: 2025-04-30
+Bucket: KEEP_ZAO
+Message count: 95
+Prompt (verbatim, opening): "Lets make a logo horizontal with ZAO theming Text to say "BetterCallZaal Takes on Farcon""
+Conclusion (verbatim, closing): "{ "prompt": "A bold, horizontal 2D digital banner with a purple background and bright yellow text. The top line reads 'THE ZAO PRESENTS' in small uppercase letters. Below it, 'BetterCallZaal' is written in large, flowing cursive. The next line says 'TAKES ON' in bold, uppercas..."
+Source: https://chatgpt.com/c/6812d510-9a5c-8000-ad83-dbaab1a87897
+Confidence: 1.0
+
+### FACT 52
+Subject: ZAO Daily Workflow
+Type: Conversation
+Date: 2025-05-01
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Here’s **Part B: ZAO Community social posts** with no newsletter link — all focused on community energy and today's ZAO moment: --- ### 🟦 Twitter (X) gm. Year of the ZAO – Day 122 it’s our founder BetterCallZaal’s 26th removal day and he’s out at FarCon spreading the ZAO visio..."
+Source: https://chatgpt.com/c/6813f2e4-ab24-8000-8ca6-6d8a1bb32cb3
+Confidence: 1.0
+
+### FACT 53
+Subject: Jango UU Podcast Blueprint
+Type: Conversation
+Date: 2025-05-01
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "I want to make a podcast/brand/product with jango uu called The ZAO presents: JANGO UNCHAINED do some research on jango uu and find us the best opportunity for weekly segments We are think producing music Doing interviews with creatives in the space Playing melee We also want ..."
+Conclusion (verbatim, closing): "iturn0image1turn0image4turn0image10turn0image19Absolutely, let's craft a compelling visual identity and monetization strategy for **"The ZAO presents: JANGO UNCHAINED."** Here's a step-by-step guide to building your brand and generating revenue across multiple platforms...."
+Source: https://chatgpt.com/c/68142699-7354-8000-882f-949a6ddb4215
+Confidence: 1.0
+
+### FACT 54
+Subject: Year of the ZAO
+Type: Conversation
+Date: 2025-05-02
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Absolutely. Here's your **full “gm edition” Year of the ZAO: Daily Content Workflow** with **no emojis**, **no section headers inside the newsletter**, and your updated structure including a **subtitle** and the proper title formatting. --- # Year of the ZAO: Daily Content Wor..."
+Source: https://chatgpt.com/c/6814cead-25d8-8000-b256-da6ac0387f92
+Confidence: 1.0
+
+### FACT 55
+Subject: ZAO Daily Workflow
+Type: Conversation
+Date: 2025-05-05
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow (No Titles, “gm” Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO — a daily ritual where raw reflections turn into clean, on-brand newsletters and platform-native posts. This is the “..."
+Conclusion (verbatim, closing): "Got it — here's the updated **BetterCallZaal Track A** post *without* the arrow: --- ## 🟣 **Track A: BetterCallZaal (With Newsletter Link)** ### **Twitter / Farcaster / LinkedIn / Facebook:** **gm. May 5, 2025 – Year of the ZAO: Day 125** back in maine and reflecting on a trut..."
+Source: https://chatgpt.com/c/6818aed3-631c-8000-bb1f-e5ce4de4641b
+Confidence: 1.0
+
+### FACT 56
+Subject: ZAO ZALORA Social Posts
+Type: Conversation
+Date: 2025-05-05
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "https://youtu.be/gXZsbUhrRgE can we make socials posts for this tell If you have 100 $ZAO or more make sure you claim your free ZALORA:"
+Conclusion (verbatim, closing): "iturn0image0turn0image4turn0image6turn0image17Absolutely! Let's craft some engaging social media posts to promote the ZAO token and the opportunity to claim free ZALORA rewards for holders of 100 or more $ZAO tokens. Here's a selection tailored for various platforms: ---..."
+Source: https://chatgpt.com/c/68191c0e-d87c-8000-8635-bee26343a942
+Confidence: 1.0
+
+### FACT 57
+Subject: ZAO Content Workflow
+Type: Conversation
+Date: 2025-05-06
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow (No Titles, “gm” Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO — a daily ritual where raw reflections turn into clean, on-brand newsletters and platform-native posts. This is the “..."
+Conclusion (verbatim, closing): "Absolutely — here's the **ZAO community-focused post set (Track B)** for **Day 126**, based on your custom update about the Fractal meeting and Respect Game shoutouts. --- ## 🌀 Part B: ZAO Community Posts (No Newsletter Link) **Theme:** Fractal #49 recap, new onboarding, commu..."
+Source: https://chatgpt.com/c/681a26b1-20e0-8000-b20f-c3e1b60bbc99
+Confidence: 1.0
+
+### FACT 58
+Subject: ZAO Daily Workflow
+Type: Conversation
+Date: 2025-05-06
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw reflections are shaped into clean, on-brand newsletters and social content for two disti..."
+Conclusion (verbatim, closing): "Here’s your **BetterCallZaal social post set** for **May 7, 2025 – Day 127**, with the provided link and matching the “gm Edition” tone: --- **Twitter / X:** gm. May 7, 2025 – Year of the ZAO: Day 127 Today’s reflection comes from *Don’t Sweat the Small Stuff*: everything is o..."
+Source: https://chatgpt.com/c/681aa02d-e8ac-8000-9e8f-db38509b283a
+Confidence: 1.0
+
+### FACT 59
+Subject: farcaster (ZAO)NZ
+Type: Conversation
+Date: 2025-05-07
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "I want to make a simple mini-app that supports ZAO artists. you can upload a mp3 and someone can claim it look into the tortoise mini-app on warpcast and then help me generate a prd for creating this with as little friction as possible"
+Conclusion (verbatim, closing): "Absolutely, let's refine the Product Requirements Document (PRD) for **(ZAO)NDZ**, a Farcaster Mini App designed to empower ZAO artists by enabling seamless music sharing and purchasing experiences within the Warpcast ecosystem. --- ## 🎯 Product Overview **Name:** (ZAO)NDZ *..."
+Source: https://chatgpt.com/c/681b76c4-1010-8000-b32a-e5a037bccce3
+Confidence: 1.0
+
+### FACT 60
+Subject: Newsletter Automation
+Type: Conversation
+Date: 2025-05-09
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "i want to improve my daily workflow for posting on socials here is my current prompt 🔁 Year of the ZAO: Daily Content Workflow (No Titles, "gm" Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO – a daily ritual where raw ref..."
+Conclusion (verbatim, closing): "# Action Plan for Automating **Year of the ZAO** Content Workflow ## 1. Overview and Objectives **Year of the ZAO** is a daily newsletter and social content series that blends personal storytelling with a consistent brand message. The goal is to streamline the daily content cy..."
+Source: https://chatgpt.com/c/681df0f7-824c-8000-a077-50337bdf9a3c
+Confidence: 1.0
+
+### FACT 61
+Subject: Newsletter Automation 2
+Type: Conversation
+Date: 2025-05-09
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "do a deep dive on how i can implement this into my daily workflow easily ZAO Newsletter Agent - Product Requirements Document (PRD) 1. Executive Summary The ZAO Newsletter Agent is an AI-powered autonomous agent built on ElizaOS that automates the creation, management, and dis..."
+Conclusion (verbatim, closing): "# Integrating the ZAO Newsletter Agent with ElizaOS – A Practical Guide ## Introduction Integrating an AI-driven **ZAO Newsletter Agent** into a daily team workflow can significantly streamline content creation for Web3 communities. This guide outlines a **semi-autonomous work..."
+Source: https://chatgpt.com/c/681e871e-7c38-8000-b8b6-d985b2195938
+Confidence: 1.0
+
+### FACT 62
+Subject: ZAO Daily Content Workflow
+Type: Conversation
+Date: 2025-05-12
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "Year of the ZAO: Daily Content Workflow (No Titles, “gm” Edition) Powered by BetterCallZaal – Built for Momentum, Branded for Legacy Welcome to Year of the ZAO — a daily ritual where raw reflections turn into clean, on-brand newsletters and platform-native posts. This is the “..."
+Conclusion (verbatim, closing): "Absolutely — here’s a more personal, conversational version for your **Farcaster group chats or DMs**: --- ### 💬 **Farcaster Group Chat / DM (Personal Tone)** > gm y’all — > > we just hit 50 weeks of ZAO Fractals. wild. > > today’s Year of the ZAO entry is a reflection on how ..."
+Source: https://chatgpt.com/c/6821d1bd-e9b0-8000-b9fc-7cf16c7f76c3
+Confidence: 1.0
+
+### FACT 63
+Subject: Newslette Social Media Automation Prompt
+Type: Conversation
+Date: 2025-05-13
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "i want to find the best ways to have semi automation for posting to social media i wnat to have it so that i can paste in a prompt and then a social media / content entry and have the prompt auto create captions that are unique to each social media platform can you give me a p..."
+Conclusion (verbatim, closing): "After reviewing your past newsletters on Paragraph.xyz, particularly the "Year of the ZAO" series and ZTalent editions citeturn0search0turn0search2, I've refined the newsletter prompt template to better align with your distinctive style. Your newsletters are characteriz..."
+Source: https://chatgpt.com/c/68231fd7-9ff4-8000-bff2-100a09cdbd05
+Confidence: 1.0
+
+### FACT 64
+Subject: Acadia DAO Launch Proposal
+Type: Conversation
+Date: 2025-05-14
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "make a quick proposal to have an Acadia DAO be created from the ZAO projects with Zaal as the leader to create local impact starting with a pizza party for btc pizza day"
+Conclusion (verbatim, closing): "Here’s the same proposal in clean **Markdown format**: ```markdown # 🦞 Proposal: Launch **Acadia DAO** – A Local Impact Chapter of The ZAO **Proposed by:** Zaal (BetterCallZaal) **Kickoff Initiative:** Acadia Pizza Party – BTC Pizza Day Celebration --- ## 🎯 Goal Establish **Ac..."
+Source: https://chatgpt.com/c/682474ce-2570-8000-a3de-29bd851cc45c
+Confidence: 1.0
+
+### FACT 65
+Subject: ZAO Newsletter Draft
+Type: Conversation
+Date: 2025-05-14
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update, or video ..."
+Conclusion (verbatim, closing): "iturn0image10Excellent — now that the newsletter is live, here are the tailored social media posts for **BetterCallZaal: Day 134**. --- ### **Twitter (X)** Today’s lesson: Trust your intuitive heart. Sometimes, the best move is the one you *feel* before you overthink it...."
+Source: https://chatgpt.com/c/6824ae97-b3b4-8000-9da6-35a1f88cdd46
+Confidence: 1.0
+
+### FACT 66
+Subject: Web3 Talk Show Promo
+Type: Conversation
+Date: 2025-05-14
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Let’s Talk About Web 3 is your weekly dose of what’s actually happening in the onchain world. Hosted by EZ, Ohnahji, and BetterCallZaal, this livestreamed talk show blends tech updates, spicy takes, and community conversation into one high-energy hour. ​We cover: ​Web3 tech up..."
+Conclusion (verbatim, closing): "Got it — here’s the updated X post with a “live now” call-to-action: --- Let’s Talk About Web 3 is *live now.* EZ, Ohnahji & BetterCallZaal are breaking down what’s really happening onchain — from Farcaster to miniapps to music NFTs. Tap in & join the conversation: nexus.theza..."
+Source: https://chatgpt.com/c/682510c3-2c78-8000-87c5-955e3149ca6f
+Confidence: 1.0
+
+### FACT 67
+Subject: Newseltter ZAO Newsletter Reflection
+Type: Conversation
+Date: 2025-05-15
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update, or video ..."
+Conclusion (verbatim, closing): "Absolutely — here’s the full **ZAO Content Creation Prompt** in clean markdown: --- ```markdown # 🧠 ZAO Content Creation Prompt (Final Version) Use this to generate daily content for **BetterCallZaal**, the **Year of the ZAO**, or any ZAO-aligned project. --- ## ✅ INPUT FIELDS..."
+Source: https://chatgpt.com/c/6825bf66-58d8-8000-878c-cfc77a96ca30
+Confidence: 1.0
+
+### FACT 68
+Subject: ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-05-15
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Instructions for the LLM: Ask the user to provide: Reflection or Update: What’s top of mind today? Could be a thought, lesson, milestone, or ZAO highlight. Day Count: (e.g. “Year of the ZAO: Day 132”) Date: (e.g. “May 14, 2025” — default to today if blank) Image URL: (optional..."
+Conclusion (verbatim, closing): "Perfect. Here's today’s **Year of the ZAO** content, based on Day 135 and the reflection from *Don't Sweat the Small Stuff*. --- **Reflection or Update:** Surrender is not giving up — it’s giving in to the truth of the moment. Today’s lesson is about making peace with “what is..."
+Source: https://chatgpt.com/c/6825c303-9878-8000-b51d-ff1497f247cd
+Confidence: 1.0
+
+### FACT 69
+Subject: Newsletter ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-05-16
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "--- ## ✍️ OUTPUT INSTRUCTIONS You are a creative content generator for the **<Project Name>** project. Follow these rules carefully: --- ### 📫 NEWSLETTER CONTENT *(Only if Output includes "newsletter" or "both")* Generate a **grounded, narrative-style reflection** that include..."
+Conclusion (verbatim, closing): "Got it. You now have a comprehensive, rules-based prompt for content generation under the **BetterCallZaal** and **ZAO** brand, with full handling for newsletter creation, social media content, and video adaptation. Here’s the **full prompt** in **Markdown format** — copy and ..."
+Source: https://chatgpt.com/c/682731ea-eed4-8000-a119-e8b4124f6f29
+Confidence: 1.0
+
+### FACT 70
+Subject: Mind Your Own Business
+Type: Conversation
+Date: 2025-05-16
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "--- ## ✍️ OUTPUT INSTRUCTIONS You are a creative content generator for the **<Project Name>** project. Follow these rules carefully: --- ### 📫 NEWSLETTER CONTENT *(Only if Output includes "newsletter" or "both")* Generate a **grounded, narrative-style reflection** that include..."
+Conclusion (verbatim, closing): "Perfect. Here are your **social media posts** for the **BetterCallZaal** channels — all tailored and platform-specific, referencing how this lesson ties into your time in blockchain. --- ### **Twitter (X)** gm and happy floral friday today’s post is painfully relevant to my ti..."
+Source: https://chatgpt.com/c/6827322a-f06c-8000-8829-28726897a232
+Confidence: 1.0
+
+### FACT 71
+Subject: Zaal Talks Logo Design
+Type: Conversation
+Date: 2025-05-18
+Bucket: KEEP_ZAO
+Message count: 49
+Prompt (verbatim, opening): "Can we make a logo for Zaal talks with zao and zaal pfp branding. Add text that says Zaal Talks"
+Conclusion (verbatim, closing): "{ "prompt": "A digital illustration logo featuring the words 'ZAAL CLIPS' in bold yellow-orange text with a dripping paint effect, styled similar to a comic book or street art aesthetic. The background is a deep navy blue with icons related to video editing, content creation, ..."
+Source: https://chatgpt.com/c/6829d0f7-1580-8000-8e63-322e68ebcb53
+Confidence: 1.0
+
+### FACT 72
+Subject: ZAO Projects Planning
+Type: Conversation
+Date: 2025-05-19
+Bucket: KEEP_ZAO
+Message count: 5
+Prompt (verbatim, opening): ""
+Conclusion (verbatim, closing): "Sounds good. What do you want to work on next: 1. Continuing from the whitepaper? 2. More logo variations (e.g., ZAO Talks, Crypto Zaal, etc.)? 3. Social posts or invite reminders for the Acadia Pizza Party? 4. Another daily “Year of the ZAO” newsletter/journal? 5. Something e..."
+Source: https://chatgpt.com/c/682b0673-59d8-8000-a9bd-002ef1a557f9
+Confidence: 1.0
+
+### FACT 73
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-05-19
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Got it. Here’s the **gm-style version** of the thread for **Twitter (X)** and **Farcaster**, with no emojis and each post beginning with **gm**: --- ### **Twitter (X) Thread** **Tweet 1 (Intro):** gm. Big week in the ZAO universe. Pizza party in Acadia. New episode of *Let’s T..."
+Source: https://chatgpt.com/c/682b4bcf-a7fc-8000-af78-dec0bce642b3
+Confidence: 1.0
+
+### FACT 74
+Subject: ZAO Event Form Creation
+Type: Conversation
+Date: 2025-05-19
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "lets make a form, give me the best platform to make this form and give me step by step instructions to make it To facilitate the inclusion of events, spaces, podcasts, channels, or live sessions on the ZAO Calendar, you can utilize the following online form template. This temp..."
+Conclusion (verbatim, closing): "Here’s how to use **Tally’s Bulk Insert** feature to add your time zone dropdown options quickly: --- ## ✅ Step-by-Step: Use Bulk Insert for Time Zones in Tally ### 🧭 Step 1: Add a Dropdown Block 1. In your Tally form editor, type `/dropdown` 2. Label the field: `Select your t..."
+Source: https://chatgpt.com/c/682b67ff-2fd0-8000-90cd-25335fef274b
+Confidence: 1.0
+
+### FACT 75
+Subject: ZAO Newsletter Reflection
+Type: Conversation
+Date: 2025-05-20
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "**Twitter (X)** gm. Your calendar’s full of calls, docs, and pings—but is there a slot titled “Inner Payroll”? Day 140 of Year of the ZAO is a reminder to pay yourself first. Read the reflection, then block ten minutes tomorrow and watch the magic stack up: https://paragraph.c..."
+Source: https://chatgpt.com/c/682c664d-cfac-8000-a632-546d4df45b6e
+Confidence: 1.0
+
+### FACT 76
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-05-21
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Here’s the updated rollout with **“gm”** added to each platform-specific post: --- ### Twitter (X) gm. “Life is too important to take too seriously.” That’s how we close out *Don’t Sweat the Small Stuff*. Grateful for the daily reflections — and ready to crack open a new book ..."
+Source: https://chatgpt.com/c/682da9a1-2630-8000-b530-cb05010785a7
+Confidence: 1.0
+
+### FACT 77
+Subject: ZAO Social Media Posts
+Type: Conversation
+Date: 2025-05-21
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "iturn0image0turn0image1turn0image2turn0image5Absolutely, Zaal. Based on current Farcaster communities, here are five channels where sharing your content would be most impactful: --- ### 1. **/web3** **Post:** Episode 4 of "Let's Talk About Web3" goes live tonight at 6 P..."
+Source: https://chatgpt.com/c/682e2eed-b2c8-8000-85ef-794013010ba6
+Confidence: 1.0
+
+### FACT 78
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-05-23
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Great — here are the platform-specific social posts for **BetterCallZaal – Day 143**: --- ### **Twitter (X)** gm happy floral Friday. we’re chilling today after a crazy week in the ZAO. new reflections from *The Four Agreements* start Monday. #ZAO https://paragraph.com/@thezao..."
+Source: https://chatgpt.com/c/68309cdf-e8b0-8000-9d7c-e529b2652dd7
+Confidence: 1.0
+
+### FACT 79
+Subject: Lil LiveStreamZ Pitch Proposal
+Type: Conversation
+Date: 2025-05-25
+Bucket: KEEP_ZAO
+Message count: 39
+Prompt (verbatim, opening): "🎤 Lil LiveStreamZ @ NFT NYC – Pitch Deck Outline for Lil Nouns DAO ⸻ 1. Cover Slide Title: Lil LiveStreamZ @ NFT NYC Subtitle: Bringing the Lil Nouns Vibe to the Culture Capital of Web3 Visuals: • Custom Lil LiveStreamZ logo by AttaBotty • Stylized characters wearing Nounish n..."
+Conclusion (verbatim, closing): "Below is a **vote-ready, ONE-DAY version** of **Lil LiveStreamZ @ NFT NYC** — plus a menu of simple, door-to-door “Nounish touch-points” that turn the entire trip into free Lil Nouns marketing. The structure follows the formatting tips that Lil Nouns voters are used to seeing ..."
+Source: https://chatgpt.com/c/6833712f-f7d8-8000-8524-681edc7c24b3
+Confidence: 1.0
+
+### FACT 80
+Subject: Lil LiveStreamZ Proposal Feedback
+Type: Conversation
+Date: 2025-05-25
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "🎤 Lil LiveStreamZ @ NFT NYC – Pitch Deck Outline for Lil Nouns DAO ⸻ 1. Cover Slide Title: Lil LiveStreamZ @ NFT NYC Subtitle: Bringing the Lil Nouns Vibe to the Culture Capital of Web3 Visuals: • Custom Lil LiveStreamZ logo by AttaBotty • Stylized characters wearing Nounish n..."
+Conclusion (verbatim, closing): "Below are the highest-impact tweaks I’d make *before* you post this on the Lil Nouns Discourse / Tally flow. They’re grouped by the parts of the proposal reviewers care about most: --- ### 1. **Governance-Process Fit** | What to add | Why it matters | |-------------|----------..."
+Source: https://chatgpt.com/c/683373e7-7944-8000-94c4-01acbb79271b
+Confidence: 1.0
+
+### FACT 81
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-05-27
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Cleaned up and fully aligned with your request — **no emojis**, all context starts after a line break following **ZM**, and every platform version includes the full list of attendees and leaderboard updates: --- ### **Twitter (X):** **ZM** Big gratitude to the 10 amazing folks..."
+Source: https://chatgpt.com/c/6835b7ef-301c-8000-a9d7-7ccf2ccb1e68
+Confidence: 1.0
+
+### FACT 82
+Subject: ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-05-28
+Bucket: KEEP_ZAO
+Message count: 26
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Updated with the new link you provided — all posts now point to: **https://x.com/WaveWarZ/status/1925204342707003877** --- ### **Twitter (X)** **ZM** WaveWarZ is live tonight. Battles start soon. Set your reminders. Come ready. This isn’t just music — it’s culture in motion. #..."
+Source: https://chatgpt.com/c/68370462-3b10-8000-9269-13f13f38e338
+Confidence: 1.0
+
+### FACT 83
+Subject: Live WavewarZ Promo
+Type: Conversation
+Date: 2025-05-28
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "Can we make an all socials post that we are live for WavewarZ"
+Conclusion (verbatim, closing): "Looks perfect — clean and punchy. Here it is locked in for easy copy/paste across all platforms: --- **ZM** WavewarZ is officially LIVE Two artists. One winner. Jump in the Space to listen live and head to the arena to trade. Listen: https://twitter.com/i/spaces/1rmxPyqAvXEKN ..."
+Source: https://chatgpt.com/c/6837a02d-ff78-8000-a8e1-3e8a812ca26c
+Confidence: 1.0
+
+### FACT 84
+Subject: Lil WaveWarZ Pitch Deck
+Type: Conversation
+Date: 2025-05-29
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "🎤 Lil LiveStreamZ @ NFT NYC – Pitch Deck Outline for Lil Nouns DAO ⸻ 1. Cover Slide Title: Lil LiveStreamZ @ NFT NYC Subtitle: Bringing the Lil Nouns Vibe to the Culture Capital of Web3 Visuals: • Custom Lil LiveStreamZ logo by AttaBotty • Stylized characters wearing Nounish n..."
+Conclusion (verbatim, closing): "Here’s the full updated proposal for **Lil WaveWarZ @ NFT NYC** with the budget in clean text format and everything streamlined for clarity, alignment, and impact: --- ## 🎤 Lil WaveWarZ @ NFT NYC **A Nounish Livestream Takeover from the Culture Capital of Web3** --- ### 1. Who..."
+Source: https://chatgpt.com/c/6838c2cb-ca90-8000-82e7-b7fa73e9fdd6
+Confidence: 1.0
+
+### FACT 85
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-05-30
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Absolutely — here’s the updated set with **“ZM Happy Floral Friday”** at the top of each post: --- **ZM** Happy Floral Friday 🌸 https://paragraph.com/@thezao/year-of-the-zao-day-150 --- **Twitter (X)** ZM Happy Floral Friday 🌸 You can be accountable without beating yourself up..."
+Source: https://chatgpt.com/c/6839c65f-8d68-8000-82d3-24a2a28085e7
+Confidence: 1.0
+
+### FACT 86
+Subject: Content Creation Request
+Type: Conversation
+Date: 2025-06-02
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Here’s the full list of social posts with each **platform labeled** and **"ZM"** before each one: --- **Twitter (X)** **ZM** Your words build worlds — or burn them down. Today’s drop is a reminder from *The Four Agreements* and a call to create with intention. ZAO Fractal meet..."
+Source: https://chatgpt.com/c/683db1bf-0d28-8000-be0f-e2441c9b2e0d
+Confidence: 1.0
+
+### FACT 87
+Subject: Lil WaveWarZ NFT NYC
+Type: Conversation
+Date: 2025-06-02
+Bucket: KEEP_ZAO
+Message count: 27
+Prompt (verbatim, opening): "🎤 Lil WaveWarZ @ NFT NYC A Nounish Livestream x Music Takeover from the Culture Capital of Web3 ⸻ 1. Who We Are We’re Web3-native creators who’ve built platforms, shows, music, and movements — and now we’re bringing it all to NFT NYC for Lil Nouns: Hurric4n3Ike – Founder of Wa..."
+Conclusion (verbatim, closing): "Done! Zaal is now listed first as lead organizer, and the event is described as a **one-day** livestream takeover instead of multi-day. Let me know if you’d like any further tweaks."
+Source: https://chatgpt.com/c/683e0c9e-7d60-8000-a4c4-a8e622ba2eb4
+Confidence: 1.0
+
+### FACT 88
+Subject: Fractal Logo
+Type: Conversation
+Date: 2025-06-02
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "can we make a ZAO Fractals # 53 logo"
+Conclusion (verbatim, closing): "{ "prompt": "A bold and stylized digital logo design that says: 'ZAO FRACTALS #53 – The Respect Game'. The color scheme is deep navy blue and bright gold with gradient highlights, consistent with the ZAO Fractals branding. The text 'ZAO FRACTALS' is large and central in futuri..."
+Source: https://chatgpt.com/c/683e18a8-2738-8000-9a5e-dd870997baa8
+Confidence: 1.0
+
+### FACT 89
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Absolutely. Here's the full social set with **ZM** at the start of each post: --- **Twitter (X):** **ZM** “Be impeccable with your word.” Not just a quote—today’s reminder to check how I speak to others *and* myself. Not always easy. But worth working on. https://paragraph.com..."
+Source: https://chatgpt.com/c/683efd18-34c4-8000-a792-41ecc328beb3
+Confidence: 1.0
+
+### FACT 90
+Subject: Lil WaveWarZ Budget Ideas
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "Item Amount Event & Venue Activation $7,500 Food & Hospitality $4,000 Production & Streaming Gear $2,000 Transportation (in-city + setup) $1,500 Merch $1,000 Total $15,000 help me find other things we can add into the budget for lilwavewarz"
+Conclusion (verbatim, closing): "Your budget is generally **reasonable and well-aligned** for a community-led, Web3-native livestream + music event like **Lil WaveWarZ**, especially if it’s happening in NYC. That said, here’s a quick breakdown of feedback and improvement suggestions: --- ## ✅ What’s Solid ###..."
+Source: https://chatgpt.com/c/683effd5-9270-8000-83b1-1df9e57cfa5a
+Confidence: 1.0
+
+### FACT 91
+Subject: Lil WaveWarZ Proposal Summary
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "(add image of lil wavewarz) Lil WaveWarZ @ NFT NYC A Nounish Livestream x Music Takeover from the Culture Capital of Web3 ⸻ 1. Who We Are We’re Web3-native creators who’ve built platforms, shows, music, and movements — and now we’re bringing it all to NFT NYC for Lil Nouns: Hu..."
+Conclusion (verbatim, closing): "This is a strong and well-structured proposal. Here are suggestions and optional enhancements to finalize it for submission to Lil Nouns DAO: --- ### ✅ STRONG POINTS: - **Clear Vision**: You’ve made it vivid what the event is and why it matters — culturally and for the Lil Nou..."
+Source: https://chatgpt.com/c/683f0205-50ac-8000-a535-6537078d85ff
+Confidence: 1.0
+
+### FACT 92
+Subject: WaveWarZ Team Overview
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "Hurric4n3Ike – Founder of WaveWarZ. Hundreds tune in live for his high-energy music battles. Artist behind WaitingWavez. - @Hurric4n3Ike AttaBotty – Visual and musical legend. Has sold over 12,000 NFTs. Creator of Stay Based and Lil Nouns visual assets. - @AttaBotty Zaal – Fou..."
+Conclusion (verbatim, closing): "Here’s the fully updated version of the **Lil WaveWarZ Team** slide with **Fellenz** added as a ZAO Team Contributor, formatted to match the rest: --- ## Lil WaveWarZ Team **Powered by The ZAO** *A Nounish crew of creators, producers, and cultural architects shaping the sound ..."
+Source: https://chatgpt.com/c/683f16ed-dcdc-8000-a8c8-98c3d2fd5628
+Confidence: 1.0
+
+### FACT 93
+Subject: Lil WaveWarZ Strategy
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "2. What We’re Doing Lil WaveWarZ is a multi-day, Nounish-powered livestream takeover from our group house during NFT NYC. It’s music, culture, new, viral technology, and content — streamed live with noggles in every frame. Featured Streams: • 🎤 Lil WaveWarZ Battles – Two artis..."
+Conclusion (verbatim, closing): "Lil WaveWarZ @ NFT NYC — Program Outline ================================================ **Battle-Day Schedule** Battle #1 Warm-Up — 11 AM – 1 PM: short rounds streamed everywhere. Battle #2 Main Event — 3 PM – 5 PM: full Live-Trading Music Battle with on-chain odds and audie..."
+Source: https://chatgpt.com/c/683f1a0b-e984-8000-8a2e-97ef23fc7c75
+Confidence: 1.0
+
+### FACT 94
+Subject: Track Record Research
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 229
+Prompt (verbatim, opening): "4. Our Track Record We’ve done this before — and the results speak for themselves: The ZAO Fractal meetings: weekly community calls to review contributions to the web 3 art space (52 meetings) • 🎧Latest WaveWarZ space (400+ Tuned in): https://x.com/wavewarz/status/192787807697..."
+Conclusion (verbatim, closing): "Below is a tightened, Lil-WaveWarZ-centric draft you can drop straight into the proposal text-file. It keeps the narrative flowing (no tables, minimal bullets) while packing in verifiable proof points and fresh team facts—all linked so Lil Nouns reviewers can click and confirm..."
+Source: https://chatgpt.com/c/683f20e2-5f20-8000-94e0-d5c44b793b52
+Confidence: 1.0
+
+### FACT 95
+Subject: Track Record Refinement
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "4. Our Track Record We’ve done this before — and the results speak for themselves: The ZAO Fractal meetings: weekly community calls to review contributions to the web 3 art space (52 meetings) • 🎧Latest WaveWarZ space (400+ Tuned in): https://x.com/wavewarz/status/192787807697..."
+Conclusion (verbatim, closing): "### 4. Proven Track Record We already ship — consistently, creatively, and at scale — **zero outside funding, all upside.** - **ZAO Fractal** – 52 consecutive Monday calls where artists earn on-chain *Respect Game* points. Even the Optimism governance forum now cites ZAO Fract..."
+Source: https://chatgpt.com/c/683f3104-e4f8-8000-ad5e-208cf78419d3
+Confidence: 1.0
+
+### FACT 96
+Subject: Battle-Day Event Overview
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "Battle-Day Schedule Battle #1 Warm-Up — 11 AM – 1 PM: short rounds streamed everywhere. Battle #2 Main Event — 3 PM – 5 PM: full Live-Trading Music Battle with on-chain odds and audience wagers. Battle #3 Evening Finale — 7 PM – 9 PM: audience selects a secret sample pack; the..."
+Conclusion (verbatim, closing): "### Battle-Day Schedule - **Battle #1 — Warm-Up** | 11 AM – 1 PM Short, rapid-fire rounds streamed to every platform. - **Battle #2 — Main Event** | 3 PM – 5 PM The full Live-Trading Music Battle with on-chain odds and audience wagers. - **Battle #3 — Evening Finale** | 7 PM –..."
+Source: https://chatgpt.com/c/683f322b-c2dc-8000-9c45-e1ff00c8884b
+Confidence: 1.0
+
+### FACT 97
+Subject: Lilwavewarz DAO Funding
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "6. Funding Request We’re asking for $15,000 to activate the house, stream the content, and bring this to life. Item Amount Event & Venue Activation $7,500 Food & Hospitality $4,000 Production & Streaming Gear $3,000 Transportation (in-city + setup) $1,500 Merch $1,000 Post Pro..."
+Conclusion (verbatim, closing): "### Revised Funding Request — **$18,000** Event & Venue Activation — **$7,000** Food & Hospitality — **$3,500** Production & Streaming Gear — **$3,000** Transportation & Crew Logistics — **$1,500** Lil Nouns-Branded Merch & Give-Aways — **$1,000** Post-Production & Content Dis..."
+Source: https://chatgpt.com/c/683f329f-6ca4-8000-b3ec-faac04c6bd68
+Confidence: 1.0
+
+### FACT 98
+Subject: Lil WaveWarZ Discord Copy
+Type: Conversation
+Date: 2025-06-03
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "Lil WaveWarZ Team ZAO Co-Founders Zaal (@bettercallzaal) Founder of The ZAO. Architect of ZAOCHELLA and WaveWarZ. Leading the Lil WaveWarZ takeover @ NFT NYC. Hurric4n3Ike (@Hurric4n3Ike) Founder of WaveWarZ. Artist behind WaitingWavez. High-energy battle host with a loyal liv..."
+Conclusion (verbatim, closing): "Got it — here’s the updated, cleaner phrasing for both battles: --- **Battle #2 — Main Event | 3 PM – 5 PM** A full-length, head-to-head showdown featuring live wagers and on-chain music matchups. --- **Battle #3 — Evening Finale | 7 PM – 9 PM** Final producers flip a mystery ..."
+Source: https://chatgpt.com/c/683f347a-8c7c-8000-a131-eaf8a261a51e
+Confidence: 1.0
+
+### FACT 99
+Subject: ZAO Social Media Posts
+Type: Conversation
+Date: 2025-06-04
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Got it — here's the revised version with the correct spelling: **Ohnahji** (not Ohanji). All social posts are updated accordingly: --- **Twitter (X):** **ZM** Join 3 of our ZAO staff in the weekly podcast “Let’s Talk About Web3” — Ohnahji, EZinCrypto, and BetterCallZaal break ..."
+Source: https://chatgpt.com/c/6840b442-fcb8-8000-a957-b114531c256a
+Confidence: 1.0
+
+### FACT 100
+Subject: Executive Summary Placement
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 52
+Prompt (verbatim, opening): "ok lets start making changes to our documents I am going to start giving action items to you and I want you to tell me where i can implement the feedback for the proposal 1. Add a crisp Executive Summary (1/3/1 format) 1 sentence – What: “Lil WaveWarZ is a three-day, live-trad..."
+Conclusion (verbatim, closing): "Copy the lines below and paste them into your Google Doc under **“Proven Track Record.”** Google Docs will keep the bullets and bold formatting intact. • **ZAO Fractal Calls** — 52 straight Monday sessions using the Respect Game model • **ZAO-Festivals** — Two city takeovers (..."
+Source: https://chatgpt.com/c/68418a23-7f94-8000-9225-b4a92ef9056e
+Confidence: 1.0
+
+### FACT 101
+Subject: Lil WaveWarZ Proposal Setup
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 74
+Prompt (verbatim, opening): "ok im moving the whole doc into hackmd please help me organize it all in there Executive Summary Lil WaveWarZ is a three-day, live-traded music-battle series broadcast from an NFT NYC creator house—skinned head-to-toe in Noggles. • Brand takeover: Lil Nouns visuals, shout-outs..."
+Conclusion (verbatim, closing): "Here’s the one-line edit you asked for—just swap it into the Executive Summary: ```markdown - **Live-mint Lil Nouns Theme Song:** Written and produced during NFT NYC, released CC0, and automatically airdropped to every Lil Nouns holder **after NFT NYC, as soon as the song is m..."
+Source: https://chatgpt.com/c/68419d9c-4414-8000-8b47-d89afd0a9bb6
+Confidence: 1.0
+
+### FACT 102
+Subject: Lil WaveWarZ Pitch Review
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 60
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## Executive Summary **Lil WaveWarZ** is a three-day, live-traded music-battle series broadcast from an NFT NYC creator house—skinned head-to-toe in Noggles. - **Brand takeove..."
+Conclusion (verbatim, closing): "Looks tight! 👍 A quick sanity-check plus two optional polish tweaks: | ✅ / 🔧 | Checkpoint | Comment | |--------|-----------|---------| | ✅ | **Math** | 7 500 + 3 000 + 3 000 + 2 000 + 1 000 + 2 500 + 1 000 = **20 000** → totals line up. | | ✅ | **Category balance** | Venue (37..."
+Source: https://chatgpt.com/c/6841c012-46a4-8000-8728-5cc58d515110
+Confidence: 1.0
+
+### FACT 103
+Subject: WaveWarZ Funding and Strategy
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Below is a surgical “find & replace” checklist you can drop straight into HackMD (or any Markdown editor). For each item you’ll see: **WHERE to search → WHAT to replace it with**. Work through them top-to-bottom and you’ll have a polished, fully-aligned draft in minutes. --- #..."
+Source: https://chatgpt.com/c/6841d347-5780-8000-9d4d-70adf0a28a5c
+Confidence: 1.0
+
+### FACT 104
+Subject: Lil WaveWarZ Team Breakdown
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Below is a clean _before / after_ in Markdown so you can drop the edits straight into HackMD (or any .md editor). I left every original line intact—just **added** the single-sentence intro under the Team header and appended a new **Risks & Mitigations** block (with the distro ..."
+Source: https://chatgpt.com/c/6841d405-774c-8000-9b1a-2ddb32796d12
+Confidence: 1.0
+
+### FACT 105
+Subject: Lil WaveWarZ Proposal Draft
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 46
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "### ✂️ Under **“Proven Track Record,”** add this new bullet **right after the ZAO-PALOOZA line** ```md - **ZAO-CHELLA (Dec 6 ’24, UVA Wynwood, Miami)** — 15 live performers + community vendors; ~550 RSVPs / walk-ups during Art Basel week and ±1.5 k livestream viewers; headline..."
+Source: https://chatgpt.com/c/6841d78d-ee1c-8000-9898-7ff0976d967e
+Confidence: 1.0
+
+### FACT 106
+Subject: Lil WaveWarZ Proposal Edits
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Here’s the cleanest way to surface that overlap without disrupting your flow. --- ### 1. Add a bullet in **“Value to the Lil Nouns”** Locate the list that starts with **“Once-in-a-lifetime stage”** and ends with **“Funding imperative”**. Insert the new line right before **“Fun..."
+Source: https://chatgpt.com/c/6841db3c-ddb4-8000-8fe4-8b35bfa6fb5a
+Confidence: 1.0
+
+### FACT 107
+Subject: ZAO Contributors List Update
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Here’s the updated staff section with **Candy Toy Box** promoted to the Co-Founders list and **SongsOfEden** and **PrizemArtNFT** added to the Contributors list. ```markdown ### ZAO Co-Founders - **Zaal (@bettercallzaal)** — Founder of The ZAO; architect of ZAOCHELLA & ZAO Fra..."
+Source: https://chatgpt.com/c/6841dc5c-6ca0-8000-90ab-d801bd33a719
+Confidence: 1.0
+
+### FACT 108
+Subject: Lil WaveWarZ Anthem Workflow
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 54
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Absolutely — here’s your **Executive Summary** rewritten with consistent Markdown-style formatting that matches the rest of your proposal: ```md ## Executive Summary **Lil WaveWarZ** is a multi-day, live-traded music-battle series broadcast from an NFT NYC creator house—skinne..."
+Source: https://chatgpt.com/c/6841dedf-0fe4-8000-8014-a0c6f50332f5
+Confidence: 1.0
+
+### FACT 109
+Subject: Lil WaveWarZ Proposal Summary
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Got it — here’s the section updated to use **“S/O”** (all caps, stylized) per your request: ```markdown --- ## Gratitude & Acknowledgements S/O to **@nataliecrew** for giving us amazing guidance throughout and championing the vision. S/O to **@chompix** for the HackMD advice t..."
+Source: https://chatgpt.com/c/6841ef59-afdc-8000-8d2c-a2b584df26d8
+Confidence: 1.0
+
+### FACT 110
+Subject: Lil WaveWarZ Marketing Plan
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "### ✅ Placement: Insert this compact section **right after**: ```markdown ## Bonus Nounish Activations ``` and **before**: ```markdown ## Value to the Lil Nouns ``` --- ### 📝 Here’s your Markdown: ```markdown ## Content, Marketing, & Distribution Plan We’re turning every battl..."
+Source: https://chatgpt.com/c/6841f0e0-9f0c-8000-b389-11812fe9b466
+Confidence: 1.0
+
+### FACT 111
+Subject: ZAO and WaveWarZ Summary
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "The official hub for The ZAO's ecosystem is [nexus.thezao.com](https://www.thezao.com/about), which provides comprehensive information about their projects, including WaveWarZ, ZAO Festivals, and the $ZAO Respect token. This platform serves as a central resource for artists..."
+Source: https://chatgpt.com/c/6841f534-15b8-8000-9a81-d6aa461bd079
+Confidence: 1.0
+
+### FACT 112
+Subject: Lil WaveWarZ Proposal Summary
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Here's a streamlined proposal layout that leverages your Canva visuals and effectively moves detailed content externally for simplicity and impact. Let me know if there's anything more you'd like refined!"
+Source: https://chatgpt.com/c/6841f643-cdf0-8000-b7d8-f645fb0af744
+Confidence: 1.0
+
+### FACT 113
+Subject: Lil WaveWarZ Proposal Guide
+Type: Conversation
+Date: 2025-06-05
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "Lil WaveWarZ @ NFT NYC A Nounish Livestream × Music Takeover from the Culture Capital of Web3 ⸻ TL;DR • What: Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song • When: June 25 – 28, 2025 • Where: Lil WaveWarZ Creator House, NFT NYC • Funding Request:..."
+Conclusion (verbatim, closing): "The simplest and most effective way to host a webpage using **HackMD** (especially useful for Markdown-driven, minimal sites or proposals) is by utilizing HackMD’s built-in sharing and publishing features. Here's the step-by-step: --- ### 🚀 How to Use HackMD as a Markdown Webp..."
+Source: https://chatgpt.com/c/68424b95-6eac-8000-8123-415835b4b69b
+Confidence: 1.0
+
+### FACT 114
+Subject: ZAO Newsletter Draft
+Type: Conversation
+Date: 2025-06-06
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Great — pulling from your images and prompt for today's **BetterCallZaal** newsletter using the “Year of the ZAO” content workflow, here’s the full **newsletter draft** for approval: --- ### **Floral Friday: Everyone Lives in Their Own Dream** This lesson hits like a splash of..."
+Source: https://chatgpt.com/c/684301d1-b920-8000-8c4c-914ee3234ee7
+Confidence: 1.0
+
+### FACT 115
+Subject: Lil WaveWarZ Action Items
+Type: Conversation
+Date: 2025-06-06
+Bucket: KEEP_ZAO
+Message count: 35
+Prompt (verbatim, opening): "i want to make a final list of everyhting i need to do left with the proposal i need a full action item list here is the proposal # Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded ..."
+Conclusion (verbatim, closing): "### How long does an **on-chain Lil Nouns proposal** take? | Stage | Length | What’s happening | |-------|----------|------------------| | **Draft & Sign-off (off-chain)** | *flexible* (usually 2-7 days) | Post the draft in **LilNouns.camp / Discord** and line up the required ..."
+Source: https://chatgpt.com/c/68438805-2148-8000-8aee-e4d0bfeb7f94
+Confidence: 1.0
+
+### FACT 116
+Subject: Stream Support Risk Mitigation
+Type: Conversation
+Date: 2025-06-06
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "1. Risk & Mitigation – Suggested Rewording You can replace the current section with the following revised list to better cover real-world contingencies: Internet drop → Use 5G hotspot fallback and have preloaded assets ready for limited offline continuity. Artist no-show → Hav..."
+Conclusion (verbatim, closing): "Nice—table’s locked in and the roster’s clean. **Recommended next moves (pick-and-choose):** 1. **Visuals sprint** - Draft a style guide (font, color, icon set) → keeps each infographic consistent. - Start with the Risk & Mitigation graphic first—fast win and sets the template..."
+Source: https://chatgpt.com/c/68438b4e-1d00-8000-a30a-8dedb9ae77d4
+Confidence: 1.0
+
+### FACT 117
+Subject: Lil WaveWarZ Funding Request
+Type: Conversation
+Date: 2025-06-06
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Below is the full replacement block—copy everything from the heading down and paste it over your current **Risks & Mitigations** section. ```markdown ## Risks & Mitigations | Risk | Mitigation | |------|------------| | Internet drop | Live 5 G hotspot fallback; preload key ass..."
+Source: https://chatgpt.com/c/68438d09-549c-8000-a072-7334fcf189ff
+Confidence: 1.0
+
+### FACT 118
+Subject: ZAO Whitepaper Summary
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "The ZAO (ZTalent Artist Organization): A Decentralized Impact Network for the Creator Economy Table of Contents Executive Summary Abstract Introduction & Problem Statement Vision & Objectives Ecosystem Structure5.1. Decentralized Community Platform (ZVerse & Hivemind)5.2. Empo..."
+Conclusion (verbatim, closing): "Certainly. Below is the full ZAO whitepaper formatted entirely in Markdown, enclosed in a single code block for easy copying or GitHub upload: ````markdown # The ZAO (ZTalent Artist Organization) ## A Decentralized Impact Network for the Creator Economy --- ## Table of Content..."
+Source: https://chatgpt.com/c/684484f1-8570-8000-a44d-fa3fb9991300
+Confidence: 1.0
+
+### FACT 119
+Subject: ZAO Project Collaboration Inquiry
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "# Sample Collaborative Web3 Tracks - **“Hi Song” – MiDiPunkz (SongsOfEden & Prizem):** A multilingual crowd-collaboration that made history as the **first song on the Moon**. This track features **38 people from around the world** each saying “Hi” in their native language – fr..."
+Source: https://chatgpt.com/c/68448802-9138-8000-b40a-b39708449407
+Confidence: 1.0
+
+### FACT 120
+Subject: Link Index Integration
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 70
+Prompt (verbatim, opening): "INDEX OF LINKS "title": "Mint ZAO-CHELLA Vibez Track on Zora", "url": "https://song.thezao.com", "description": "Own a piece of the ZAO-CHELLA experience by minting the Vibez track." }, (songs of eden song ) { "title": "Mint Attabotty ZAO-PALOOZA Card", "url": "https://attabot..."
+Conclusion (verbatim, closing): "Perfect — here’s the updated `.md` section for **Songs by SongsOfEden & MiDiPunkz** with the correct URLs from [midipunkz.com/music](https://midipunkz.com/music): ```md ## 🎶 Songs by SongsOfEden & MiDiPunkz - **[Hi Song – MiDiPunkz](https://midipunkz.com/music/hi-song-midipunk..."
+Source: https://chatgpt.com/c/6844891c-c4c0-8000-93fa-3bec202fa2cf
+Confidence: 1.0
+
+### FACT 121
+Subject: Lil WaveWarZ Pitch Feedback
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Here’s a precise and comprehensive list of **recommended additions and changes** to your current proposal to **maximize value to Lil Nouns** and position them as the **headline sponsor** of Lil WaveWarZ: --- ### ✅ **SECTION: Value to Lil Nouns** **1. Rename the Section:** Chan..."
+Source: https://chatgpt.com/c/684491e0-00ac-8000-8a45-345806684903
+Confidence: 1.0
+
+### FACT 122
+Subject: Lil WaveWarZ NFT NYC
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 45
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song - **When / Where:** **June 25 – 28** · Lil WaveWarZ creator house - **Funding..."
+Conclusion (verbatim, closing): "Absolutely — here’s the `.md` version of the **project timeline as a clean table**, just like the visual one you shared but expanded with more detail: --- ### `timeline.lilwavewarz.com` ```markdown # 🗓️ Project Timeline – Lil WaveWarZ @ NFT NYC ```text ┌────────────── Jun 10 –..."
+Source: https://chatgpt.com/c/68449258-57f0-8000-8ea9-c6f29dc27501
+Confidence: 1.0
+
+### FACT 123
+Subject: Lil WaveWarZ Proposal Feedback
+Type: Conversation
+Date: 2025-06-07
+Bucket: KEEP_ZAO
+Message count: 27
+Prompt (verbatim, opening): "# Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* ![Lil WaveWarZ Logo](https://hackmd.io/_uploads/rJbGtzzQge.jpg) --- ## What is Lil WaveWarZ? # About Lil WaveWarZ **Lil WaveWarZ** is a multi-day, live-traded music-battle series ..."
+Conclusion (verbatim, closing): "```md ## Deliverables & Timeline 1. **3 live-streamed battles** (June 25–27, 2025) 2. **Mid-season update report** (metrics & feedback) by July 1 3. **Original CC0 Lil Nouns Anthem** released and airdropped by July 5 4. **Highlight video** posted to YouTube + Farcaster by July..."
+Source: https://chatgpt.com/c/6844f066-a170-8000-8db7-4c2ddcf648bf
+Confidence: 1.0
+
+### FACT 124
+Subject: Lil WaveWarZ NFT NYC
+Type: Conversation
+Date: 2025-06-09
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "https://lilnouns.camp/proposals/316 # Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-traded music-battle series + live-mint Lil Nouns theme song — sponsored by Lil Nouns - **When / Where..."
+Conclusion (verbatim, closing): "Yes — here’s a more human, natural, and slightly meme-leaning rewrite of the 4 threads. Each one stays tight at 5 posts, with casual tone, hype where it counts, and language your community can rally behind. --- ### **Thread 1: “Make Lil Nouns the Sound of Summer”** 1. NYC. Bea..."
+Source: https://chatgpt.com/c/68471197-f814-8000-89e4-9c1f50a262bd
+Confidence: 1.0
+
+### FACT 125
+Subject: DM Lil WaveWarZ Proposal Feedback
+Type: Conversation
+Date: 2025-06-09
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "here is our prop: would appreciate it if you took a look and gave me any suggestions or feedback. https://lilnouns.camp/proposals/316 # Lil WaveWarZ @ NFT NYC *A Nounish Livestream × Music Takeover from the Culture Capital of Web3* --- ## TL;DR - **What:** Multi-day, token-tra..."
+Conclusion (verbatim, closing): "# Key Active Lil Nouns Holders (Whales & Community Leaders) | **Holder (Wallet Address)** | **Lil Nouns Held** | **X (Twitter)** | **Farcaster** | **Discord Handle** | **Notable Governance Activity** | |-----------------------------------------------|--------------------------..."
+Source: https://chatgpt.com/c/684724f6-5938-8000-ac57-84a3f4b44355
+Confidence: 1.0
+
+### FACT 126
+Subject: ZAO Social Media Posts
+Type: Conversation
+Date: 2025-06-11
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "That’s clean, punchy, and 100% on-brand. Here’s your edited version adapted across the rest of the platforms, keeping your Twitter tone and structure consistent: --- ### **Twitter (X) Group Chat:** **zm** Let’s Talk About Web3 is live — tech drops, music alpha, and spicy takes..."
+Source: https://chatgpt.com/c/6849fd06-ea68-8000-98e5-53ff6707eb9d
+Confidence: 1.0
+
+### FACT 127
+Subject: ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-06-13
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "**Newsletter:** **Floral Fridays and Enlightened Moments** Working the night shift this Floral Friday has shifted my routine, but it also provided a quiet moment to reflect on today’s WaveWarZ—a true blast that highlighted how vibrant our ZAO community has become. Each Friday ..."
+Source: https://chatgpt.com/c/684c6a7e-dd90-8000-ac44-f573238f82f5
+Confidence: 1.0
+
+### FACT 128
+Subject: BetterCallZaal Newsletter Creation
+Type: Conversation
+Date: 2025-06-13
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Perfect—here’s the full social post set revised to start with **“zm”** and follow your updated tone and direction: --- **Twitter (X):** zm happy floral friday. we had a blast in our wavewarz battle today. today’s lesson: ask what each moment is trying to teach you. the year of..."
+Source: https://chatgpt.com/c/684c6c35-882c-8000-af7e-1cae8f182b6a
+Confidence: 1.0
+
+### FACT 129
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-06-14
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Here’s the full set of platform-specific social posts updated to include the actual newsletter link: 👉 https://paragraph.com/@thezao/year-of-the-zao-day-165 --- **Twitter (X):** zm happy saturday! We’re heads-down at ZAO, building hard and lining up creator collabs, fresh tool..."
+Source: https://chatgpt.com/c/684e2a05-98f4-8000-a3ce-7f611863e899
+Confidence: 1.0
+
+### FACT 130
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-06-15
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Perfect — here are your platform-specific social media posts for **BetterCallZaal** using the Day 166 newsletter: **Newsletter Link:** https://paragraph.com/@thezao/year-of-the-zao-day-166 --- ### **Twitter (X):** gm. today’s reminder comes from the Four Agreements: don’t take..."
+Source: https://chatgpt.com/c/684e6fdc-f000-8000-8f20-3f7f438b3bce
+Confidence: 1.0
+
+### FACT 131
+Subject: ZAO Newsletter Draft
+Type: Conversation
+Date: 2025-06-16
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Great — here's your **newsletter draft** for approval first. Once you confirm and share the Paragraph link, I’ll move on to the social media posts. --- **Newsletter Title:** Fractal Feedback Loops **Newsletter Content:** Mondays always hit different when we’re building somethi..."
+Source: https://chatgpt.com/c/684fc59a-a54c-8000-8c05-665f44bcdda0
+Confidence: 1.0
+
+### FACT 132
+Subject: ZAO Fractal Update
+Type: Conversation
+Date: 2025-06-16
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Perfect — here are the social posts for **BetterCallZaal – Day 167** using the newsletter link: --- **Twitter (X):** ZAO Fractal kicks off today and the Discord bot is live for testing. This week’s lesson: what people say about you is more about them than you. Let’s build, imp..."
+Source: https://chatgpt.com/c/684fc648-3a48-8000-a17a-81b9b6344e31
+Confidence: 1.0
+
+### FACT 133
+Subject: ZAO Newsletter Content
+Type: Conversation
+Date: 2025-06-19
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "3 Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, upda..."
+Conclusion (verbatim, closing): "Absolutely — here's the updated version of the social set, all starting with **ZM** and using clean line breaks for clarity: --- **Twitter (X):** **ZM** Sometimes we need the reminder: Take your life and enjoy it. A short reflection today, drawn from the Four Agreements. https..."
+Source: https://chatgpt.com/c/68545839-77c4-8000-b1d4-dda117313f51
+Confidence: 1.0
+
+### FACT 134
+Subject: ZAO Newsletter Draft
+Type: Conversation
+Date: 2025-06-20
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it — here’s the updated set of social posts, each starting with **“ZM”** as the opener, aligned with your style: --- ### **Twitter (X):** **ZM** Drama-free starts with discernment. Today’s *Year of the ZAO* entry is a reminder not to make assumptions — especially about sil..."
+Source: https://chatgpt.com/c/68559479-2150-8000-9cf5-6b4fdb0e0faa
+Confidence: 1.0
+
+### FACT 135
+Subject: ZAO Newsletter Request
+Type: Conversation
+Date: 2025-06-24
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect — here are the social posts for **Day 175** of *Year of the ZAO*, following your approved newsletter and the Paragraph link: --- **Twitter (X):** zm Day 175: I read a lesson today that hit deep — “Will this matter a year from now?” Perspective is a superpower. paragrap..."
+Source: https://chatgpt.com/c/685a8156-e7fc-8000-a5f5-0a80c60bd119
+Confidence: 1.0
+
+### FACT 136
+Subject: ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-06-25
+Bucket: KEEP_ZAO
+Message count: 42
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "```md ############################################################ # 𝗬𝗘𝗔𝗥-𝗢𝗙-𝗧𝗛𝗘-𝗭𝗔𝗢 • 𝗗𝗔𝗜𝗟𝗬 𝗖𝗢𝗡𝗧𝗘𝗡𝗧 𝗣𝗥𝗢𝗠𝗣𝗧 (v4.0) # ############################################################ ### BACKGROUND (read-only context for GPT) - **Brand DNA** Zaal Panthaki (“BetterCallZaal”) leads *..."
+Source: https://chatgpt.com/c/685bd2d3-8d60-8000-8d66-8756e0fa2d92
+Confidence: 1.0
+
+### FACT 137
+Subject: Embed Refactoring Guidance
+Type: Conversation
+Date: 2025-06-25
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "<!-- EMBED #2: Link Data --> <script> window.linksData = [ /* ------------------------------------------------------------------ 1. ZAO Onchain ------------------------------------------------------------------ */ { "mainCategory": "ZAO Onchain", "subcategories": [ { "subTitle..."
+Conclusion (verbatim, closing): "Below is the **complete** `window.linksData` embed with every link object stacked on a single line for maximum compactness while staying readable. Just drop it into your Webflow embed and you’re set. ```html <!-- EMBED #2 (fully stacked / stacked objects) --> <script> window.l..."
+Source: https://chatgpt.com/c/685bd3b6-d360-8000-ae90-3f1398a5dd47
+Confidence: 1.0
+
+### FACT 138
+Subject: Web3 Media with Will T
+Type: Conversation
+Date: 2025-06-25
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Welcome to Episode 6 of Let’s Talk About Web3 — the weekly livestream where we explore onchain culture, creator tools, decentralized platforms, and the future of community-driven tech. Whether you’re crypto-native or just getting curious, this show is built to make Web3 more a..."
+Conclusion (verbatim, closing): "Got it — keeping it accurate and grounded. Here's a revised Episode 7 summary using **only the confirmed topics**: --- **Let’s Talk About Web3 – Episode 7** *Featuring Will T: Farcaster, Regen Culture & KFMedia Talks* Welcome to Episode 7 of *Let’s Talk About Web3* — the weekl..."
+Source: https://chatgpt.com/c/685c44b7-06ac-8000-be86-b17ab48a532a
+Confidence: 1.0
+
+### FACT 139
+Subject: Social Posts ZAO Day 177
+Type: Conversation
+Date: 2025-06-25
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "𝗬𝗘𝗔𝗥-𝗢𝗙-𝗧𝗛𝗘-𝗭𝗔𝗢 • 𝗗𝗔𝗜𝗟𝗬 𝗖𝗢𝗡𝗧𝗘𝗡𝗧 𝗣𝗥𝗢𝗠𝗣𝗧 Zaal Panthaki (“BetterCallZaal”) leads The ZAO: a decentralized artist movement demystifying tech for musicians and creators. The voice is casual, witty, encouraging, and zero fluff. No emojis are ever used. Each morning, publish a short ..."
+Conclusion (verbatim, closing): "Perfect — here's the updated version of all social posts with the Twitch links added: --- **Twitter (280 characters max)** ZM Year of the ZAO – Day 177 Show starts in an hour. EZ's in NYC, and it might just be Ohnahji and I today — come hang and ask questions. Live at: twitch...."
+Source: https://chatgpt.com/c/685c478e-ee54-8000-be61-89082c144887
+Confidence: 1.0
+
+### FACT 140
+Subject: ZAO Content Creation Guide
+Type: Conversation
+Date: 2025-06-26
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect. Here are the social posts for **Year of the ZAO – Day 177**, based on your reflection and the lesson on boredom: --- **Twitter (X):** ZM Boredom isn’t a bug—it’s a feature. Today’s lesson reminded me that stillness is strength. For anyone wired like me (ADHD gang, sta..."
+Source: https://chatgpt.com/c/685d5868-4e4c-8000-b979-e5c9d6dff666
+Confidence: 1.0
+
+### FACT 141
+Subject: ElizaOS Overview and Use Cases
+Type: Conversation
+Date: 2025-06-26
+Bucket: KEEP_ZAO
+Message count: 129
+Prompt (verbatim, opening): "Teach me what I can do with Eliza os and how it works and how the editions have updated"
+Conclusion (verbatim, closing): "### What we learned from **zao-leaderboard** Right now the public page is just a shell—`Loading leaderboard…` and three placeholder images. No static HTML table, no JSON dumps.citeturn0view0 That means the numbers for your **56 completed fractal rounds** live someplace else..."
+Source: https://chatgpt.com/c/685e0713-e194-8000-bd1d-401b7aa88b3b
+Confidence: 1.0
+
+### FACT 142
+Subject: ZAO Newsletter & Posts
+Type: Conversation
+Date: 2025-06-27
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect. Here's your full set of social posts based on [Year of the ZAO – Day 178](https://paragraph.com/@thezao/year-of-the-zao-day-178), keeping your tone, link, and platform conventions in place: --- **X (Twitter):** zm floral friday pull from the 4 agreements: “become immu..."
+Source: https://chatgpt.com/c/685e84c4-d500-8000-8f26-506a44ff1fee
+Confidence: 1.0
+
+### FACT 143
+Subject: ZAO 101 Pop-Up Space
+Type: Conversation
+Date: 2025-06-27
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Locked in. Here's the **final version** of all social posts from The ZAO account with **capital `ZM`**, mention of the **founder answering questions**, and tone aligned with your guidelines: --- **Twitter (X):** **ZM** We’re hosting a ZAO 101 pop-up Space today at 5pm EST. The..."
+Source: https://chatgpt.com/c/685ef636-7e28-8000-9b7d-ff2fd220a4ea
+Confidence: 1.0
+
+### FACT 144
+Subject: BetterCallZaal Newsletter Creation
+Type: Conversation
+Date: 2025-06-30
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect. Here’s the full **social media post set** for *Year of the ZAO – Day 183*, Wavy Wednesday edition: --- **Twitter (X):** ZM your body carries the dream treat it with care short drop from today’s Year of the ZAO #ZAO https://paragraph.com/@thezao/year-of-the-zao-day-183..."
+Source: https://chatgpt.com/c/686341e5-0fb8-8000-af9d-de7a18acefd2
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 144 Conversation nodes. Merge on Subject+Date match.

--- a/content/bonfire-ingest/chatgpt-archive-zao-2025-h2.md
+++ b/content/bonfire-ingest/chatgpt-archive-zao-2025-h2.md
@@ -1,0 +1,1639 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-zao-2025-h2 (148 conversations).
+
+ChatGPT ZAO-tagged conversations 2025-07-01 through 2025-12-31.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-03
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Here are the rest of your platform-specific posts for **Day 184 – Let It Simmer**: --- ### **Twitter (X) Group Chat** **zm** been thinking about how often we overwork the creative process. today’s Year of the ZAO reflection hits: the best answers usually show up *after* you st..."
+Source: https://chatgpt.com/c/68665984-8dac-8000-83a3-6957b3200804
+Confidence: 1.0
+
+### FACT 2
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-03
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect. Here are the **social posts** for today’s BetterCallZaal drop — using your provided core content and newsletter link: --- **Twitter (X):** ZM happy floral friday 🌸 Today’s lesson comes from *The Four Agreements* — “Surrender and let go of the past.” Not as a dramatic ..."
+Source: https://chatgpt.com/c/68666cb6-f9ec-8000-a878-7ca2c8963c0c
+Confidence: 1.0
+
+### FACT 3
+Subject: WaveWarZ Newsletter Creation
+Type: Conversation
+Date: 2025-07-05
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Twitter (X)** 4 JANGO UU tracks face off in today’s WaveWarZ semi-final. We go live at **11 AM EST**—jump into the X Space, smash that poll, then watch the fireworks on twitch.tv/wavewarz. Full Sunday rundown & bluebird philosophy ➜ https://paragraph.com/@thezao/year-of-the-..."
+Source: https://chatgpt.com/c/6869df3a-0cac-8000-98a1-901af4fc0ed1
+Confidence: 1.0
+
+### FACT 4
+Subject: tmmr socials
+Type: Conversation
+Date: 2025-07-06
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect. Here's the full set of social media posts for **BetterCallZaal**, based on your newsletter and that quote from *The Four Agreements*: --- **Twitter (X):** Honor yourself by showing up fully — not perfectly. WaveWarZ finals end at noon. ZAO Fractal #58 starts at 6pm ES..."
+Source: https://chatgpt.com/c/686b188c-4fe0-8000-8e22-979dfb960b84
+Confidence: 1.0
+
+### FACT 5
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-08
+Bucket: KEEP_ZAO
+Message count: 36
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "ZM happy Tuesday. We’re builders first, applause-chasers never—today’s log unpacks why doing the work for its own sake is baked into the #ZAO DNA. Dive in: https://paragraph.com/@thezao/year-of-the-zao-day-189"
+Source: https://chatgpt.com/c/686d1811-d8bc-8000-8aa7-55752abc3f71
+Confidence: 1.0
+
+### FACT 6
+Subject: ZAO Content Creation
+Type: Conversation
+Date: 2025-07-09
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Here come the socials for **Day 190**—all ready to fly. (Newsletter link: https://paragraph.com/@thezao/year-of-the-zao-day-190) --- ### Twitter (X) Your best shifts with the weather—rested sprint or coffee-fueled trot, it still counts. 🌬️ Saddle up & ride today’s wave with us..."
+Source: https://chatgpt.com/c/686e7724-9dc8-8000-a948-2c4ef66e66dd
+Confidence: 1.0
+
+### FACT 7
+Subject: ZAO Content Creation
+Type: Conversation
+Date: 2025-07-10
+Bucket: KEEP_ZAO
+Message count: 40
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it. Here are the social posts based on [Day 191 – Year of the ZAO](https://paragraph.com/@thezao/year-of-the-zao-day-191): --- **Twitter (X):** ZM happy Thursday. Pulled a card from *The Four Agreements* that checked me hard: “Communicate with Clarity.” With how fast thing..."
+Source: https://chatgpt.com/c/686f9587-7070-8000-b3ac-33bef7029a1a
+Confidence: 1.0
+
+### FACT 8
+Subject: ZM Happy Floral Friday
+Type: Conversation
+Date: 2025-07-11
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect — here are your social posts for **Year of the ZAO: Day 192** tied to the lesson *“Be immune to others’ opinions.”* --- **Twitter (X):** ZM happy Floral Friday. Today’s lesson from *The Four Agreements* deck: “Be immune to others’ opinions.” Whether it’s praise or crit..."
+Source: https://chatgpt.com/c/68712172-7244-8000-b2ea-326ba123689e
+Confidence: 1.0
+
+### FACT 9
+Subject: Nexus v5.7 Overview
+Type: Conversation
+Date: 2025-07-12
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "# Nexus v5.7 - Hierarchical Link Management System A scalable, hierarchical link management system built with Next.js that organizes links into categories and subcategories with rich metadata, tagging, and filtering capabilities. Designed with ZAO branding colors and styles fo..."
+Conclusion (verbatim, closing): "```markdown # Nexus v5.7 Hierarchical Link Management System for the **ZAO** ecosystem _Built with Next.js / React • Tailwind • Lucide Icons_ --- ## ✨ What’s Inside (TL;DR) | Area | Highlights | |------|------------| | **Hierarchy-First UX** | 3-level category tree, collapsibl..."
+Source: https://chatgpt.com/c/6872cf09-2980-8000-9b4d-2e1045a217b2
+Confidence: 1.0
+
+### FACT 10
+Subject: ZAO Content Creation
+Type: Conversation
+Date: 2025-07-14
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Subtitle:** Q2 Community Accomplishments (April – June 2025) These are the concrete wins our community delivered in Q2: - **Let’s Talk About Web 3:** Produced 9 episodes with Ohnahji B and EZinCrypto (YouTube + Pods.media). - **External Features:** - Guest on *Token for Your..."
+Source: https://chatgpt.com/c/6874d961-ef14-8000-b708-f600987ac3ca
+Confidence: 1.0
+
+### FACT 11
+Subject: ZAO Content Guidelines
+Type: Conversation
+Date: 2025-07-14
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM the ZAO has been BUILDING—Q2 Big Wins: WaveWarZ hit mainnet (3 battles live), 9 episodes of “Let’s Talk About Web 3,” FarCon double-victory, MidiPunkz anthems, ZALORA NFT drop, EMTHREE’s 35 hrs of fresh music. Full list → https://paragraph.com/@thezao/year-o..."
+Source: https://chatgpt.com/c/6874fa26-42bc-8000-8808-3cc785d259ef
+Confidence: 1.0
+
+### FACT 12
+Subject: ZAO Newsletter and Social Posts
+Type: Conversation
+Date: 2025-07-14
+Bucket: KEEP_ZAO
+Message count: 26
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "### Twitter (X) **zm** Agreement #3 — *Don’t Make Assumptions.* Skip the silent guessing game: ask, clarify, then build. Here’s how the ZAO crew is training that muscle in Day 196’s journal: https://paragraph.com/@thezao/year-of-the-zao-day-196 #ZAO --- ### Twitter (X) Group C..."
+Source: https://chatgpt.com/c/687506cb-fec8-8000-8e62-ce6468c4ef42
+Confidence: 1.0
+
+### FACT 13
+Subject: ZAO Newsletter Reflection
+Type: Conversation
+Date: 2025-07-16
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM—dropped my *first coined blog* on Paragraph. You can literally speculate on me now (blame @paragraph, not me). Dive in, trade the vibe, and let me know if Lesson 32 hits you too: https://paragraph.com/@thezao/year-of-the-zao-day-197 #ZAO --- **Twitter (X) Gr..."
+Source: https://chatgpt.com/c/68779e1a-3550-8000-ae81-5bc57e430286
+Confidence: 1.0
+
+### FACT 14
+Subject: Web 3 Twitch Promo
+Type: Conversation
+Date: 2025-07-16
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM Let’s Talk About Web 3 kicks off at 4:30 ET with @ohnahji, @ezincrypto, @bettercallzaal—and surprise guest @DuoDuoMusica. Pull up the stream and drop your hottest takes: twitch.tv/ohnahji #ZAO --- **Twitter (X) Group Chat** ZM heads‑up: Web 3 live session at..."
+Source: https://chatgpt.com/c/6877da73-3a24-8000-90f6-79e989aa84d1
+Confidence: 1.0
+
+### FACT 15
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-17
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM lesson of the day: ideas don’t pay rent—actions do. We just dropped a quick riff on turning sparks into shipped products. Give it a skim, then go build something that can’t be ignored. https://paragraph.com/@thezao/year-of-the-zao-day-198 #ZAO --- **Twitter ..."
+Source: https://chatgpt.com/c/6878e8f9-becc-8000-a8f4-c786850396d6
+Confidence: 1.0
+
+### FACT 16
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-18
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect—here’s your full social rollout for **Year of the ZAO: Day 199**, based on the Tim Martinez reflection and now linked to the published newsletter. --- **Twitter (X):** zm happy floral friday 🌸 Today’s lesson comes from a mentor, Tim Martinez. In *Do Good Work*, he remi..."
+Source: https://chatgpt.com/c/687a5500-a5a8-8000-9022-0ce08d6238fc
+Confidence: 1.0
+
+### FACT 17
+Subject: Newsletter content generation
+Type: Conversation
+Date: 2025-07-20
+Bucket: KEEP_ZAO
+Message count: 28
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it — here’s the revised **social post set** with the updated framing, focused on inviting the community and asking what events they’re attending: --- ### **Twitter (X):** What events are you pulling up to this week? We’ve got: • WaveWarZ battle – **tonight** at 8PM EST (X ..."
+Source: https://chatgpt.com/c/687d33cf-9084-8000-a91d-9b36c2196ebb
+Confidence: 1.0
+
+### FACT 18
+Subject: ZAO Newsletter and Content
+Type: Conversation
+Date: 2025-07-21
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it — here's the full set of **social media posts** using the [Day 202 newsletter link](https://paragraph.com/@thezao/year-of-the-zao-day-202), all aligned with the tone and platform specifics: --- ### **Twitter (X):** Don’t make assumptions. Don’t take things personally. M..."
+Source: https://chatgpt.com/c/687e482b-1eb8-8000-9ac5-c8e9d778891a
+Confidence: 1.0
+
+### FACT 19
+Subject: ZAO Newsletter Creation
+Type: Conversation
+Date: 2025-07-22
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Perfect — here’s the updated set of **social posts** now that the newsletter is live at: **https://paragraph.com/@thezao/year-of-the-zao-day-203** --- **Twitter (X):** Practice makes the master. Not the perfect mood or moment—just showing up, again and again. That’s the ZAO wa..."
+Source: https://chatgpt.com/c/687f9b9c-4b70-8000-9641-bda1080d41b7
+Confidence: 1.0
+
+### FACT 20
+Subject: ZAO Newsletter & Content
+Type: Conversation
+Date: 2025-07-23
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Absolutely — here’s a full set of tailored posts for each platform and group chat, keeping your tone consistent and starting with your requested line: --- ### **Twitter (X):** my daily blog is out and I would appreciate if people took a look and joined my daily email list. tod..."
+Source: https://chatgpt.com/c/6880e59d-ac4c-8000-a16e-f6339a8ce631
+Confidence: 1.0
+
+### FACT 21
+Subject: Pinned Post for ZAAL
+Type: Conversation
+Date: 2025-07-23
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "can we do soem reasearch on the best way to make a pinned post for ZAAL for all the stuff he is doing at the ZAO lets make a pinned post that explains my journey in web 32"
+Conclusion (verbatim, closing): "Amazing — your answers add exactly the kind of emotional weight and clarity that will turn this pinned post into a *mission statement*. Here's the upgraded version with your reflections seamlessly woven in: --- **gm, I’m Zaal — and here’s how I fell down the Web3 rabbit hole a..."
+Source: https://chatgpt.com/c/6881219d-d530-8000-aaaa-8d5fdbacddc2
+Confidence: 1.0
+
+### FACT 22
+Subject: ZAO Newsletter Friday w/song of the day
+Type: Conversation
+Date: 2025-07-24
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it — here’s the updated **newsletter** with a more grounded, authentic tone and less metaphor: --- **Subtitle** ZAO Song of the Week: Let’s Go by Clejan Let’s start with ZM. Happy floral Friday. We’re starting a new weekly rhythm — each Friday we’ll be highlighting one son..."
+Source: https://chatgpt.com/c/6882293a-23c0-8326-b45c-5d0ec1cbdd31
+Confidence: 1.0
+
+### FACT 23
+Subject: Newsletter content creation
+Type: Conversation
+Date: 2025-07-28
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Great — here are **custom Farcaster posts** for Day 209 of the ZAO Daily Blog, tailored for specific top channels, using your link: **https://paragraph.com/@thezao/year-of-the-zao-day-209** --- ### **/farcaster** The ZAO Daily Blog (Day 209) is out. Today’s reflection: the way..."
+Source: https://chatgpt.com/c/68876494-9058-8328-89d0-13bbce64dbae
+Confidence: 1.0
+
+### FACT 24
+Subject: Newsletter and social media
+Type: Conversation
+Date: 2025-07-30
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it—here are the socials based on **“Enjoy Heaven on Earth (be impeccable with your word)”** — using only **#ZAO** and your live link. **Newsletter link:** https://paragraph.com/@thezao/year-of-the-zao-day-211 --- ### Twitter (X) Enjoy Heaven on Earth: say what you mean and..."
+Source: https://chatgpt.com/c/688a10e3-b8bc-8324-a6e2-b95b66803d2e
+Confidence: 1.0
+
+### FACT 25
+Subject: Newsletter content creation
+Type: Conversation
+Date: 2025-07-31
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Locked and loaded—each post asks people to read the **daily blog** while keeping today’s reflection front and center. **Link:** https://paragraph.com/@thezao/year-of-the-zao-day-212 --- ### Twitter (X) gm—daily blog is live. Today’s note: be impeccable with your word. Seek tru..."
+Source: https://chatgpt.com/c/688b6b1b-e154-8332-b02f-e25ff621cef4
+Confidence: 1.0
+
+### FACT 26
+Subject: Newsletter and socials
+Type: Conversation
+Date: 2025-08-01
+Bucket: KEEP_ZAO
+Message count: 36
+Prompt (verbatim, opening): "SYSTEM You are Zaal’s content engine for “Mindful Moments for Musicians (& other Creators)”. America/New_York timezone. Today’s absolute values: <DATE>=[auto] <DAY_OF_WEEK>=[auto] <DAY_OF_YEAR>=[auto] VOICE RULES - Write in Zaal’s voice: casual, witty, encouraging, no fluff. -..."
+Conclusion (verbatim, closing): "### SOCIALS - Twitter: ZM happy floral friday — daily blog is out: https://paragraph.com/@thezao/year-of-the-zao-day-213. Lining up next Friday’s Song of the Week. Reply with your best track (link + one-liner) to be considered. #ZAO - Twitter Group DM: ZM happy floral friday —..."
+Source: https://chatgpt.com/c/688cb627-fec8-832d-9122-e2f9839ba570
+Confidence: 1.0
+
+### FACT 27
+Subject: Newsletter draft creation
+Type: Conversation
+Date: 2025-08-04
+Bucket: KEEP_ZAO
+Message count: 119
+Prompt (verbatim, opening): "ZM In a decentralized community, consistency is rare — and valuable. That’s why we organize recurring events that bring our network together to build, reflect, and move the culture forward in real time. Here are the key ZAO events happening this week: Sunday @ 8PM EST – WaveWa..."
+Conclusion (verbatim, closing): "Below are “we-are-live-now” blasts you can drop immediately across every channel. Link: **https://lu.ma/9dgkwoyr** citeturn0search0 --- ### X (for **@TheZAO**) > **LIVE NOW:** ZAO Fractal #62 — align, share progress, play the Respect Game. Join here → https://lu.ma/9dgkwoyr..."
+Source: https://chatgpt.com/c/689079cd-ea3c-8326-b382-1d87b4879671
+Confidence: 1.0
+
+### FACT 28
+Subject: Newsletter content creation
+Type: Conversation
+Date: 2025-08-05
+Bucket: KEEP_ZAO
+Message count: 28
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Locked. Here are platform-ready socials using **Mindful Moments & Meditations** with today’s lesson: **See people as they are.** (Linking to your post from earlier.) **Link:** https://paragraph.com/@thezao/year-of-the-zao-day-217 --- ### Twitter (X) **Mindful Moments & Meditat..."
+Source: https://chatgpt.com/c/68923a78-9c1c-832c-b824-0cd64f619a1a
+Confidence: 1.0
+
+### FACT 29
+Subject: Newsletter workflow prompt
+Type: Conversation
+Date: 2025-08-05
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "lets make a better prompt for our newsletter can you help me develop a workflow for our newsletter Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social medi..."
+Conclusion (verbatim, closing): "Here is an **upgraded, structured, and context-aware newsletter creation prompt** tailored to your full workflow and past usage — fully integrated with your “Mindful Moments & Meditations” newsletter style, multi-platform posting system, and ZAO project structure. --- ### ✅ FI..."
+Source: https://chatgpt.com/c/689262a3-4a3c-8326-99d5-2430a6f96353
+Confidence: 1.0
+
+### FACT 30
+Subject: Newsletter content generation
+Type: Conversation
+Date: 2025-08-06
+Bucket: KEEP_ZAO
+Message count: 44
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Here are the updated social posts with “the Let’s Talk About Web3 crew” instead of “we” for a more communal voice: --- **Twitter (X):** The *Let’s Talk About Web3* crew goes live at 6PM EST with Pichi — host of the weekly Farhouse “State of the Union” on Farcaster. Real talk a..."
+Source: https://chatgpt.com/c/68932ffb-fe9c-8325-8cd6-2c1d86df31b9
+Confidence: 1.0
+
+### FACT 31
+Subject: Newsletter and social posts
+Type: Conversation
+Date: 2025-08-07
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "Newsletter Project: <Project Name here (choose from: BetterCallZaal, The ZAO, ZAO Fractals, WavewarZ, StudentLoanz, ZAO Festivals)> Output Type: <newsletter content / social media posts / both> Core Content: """ [Insert your core content here. This could be a paragraph, update..."
+Conclusion (verbatim, closing): "Got it—here are the updated social posts using only the Luma link: --- ### **Twitter (X):** ZM happy Thursday — we’re live today with the Fractal Impact Concert in collaboration with the Fractal ecosystem. Roundtables, guest speakers, open Q&A, live music, and a look at how Th..."
+Source: https://chatgpt.com/c/68947c91-b664-832d-8dad-3f86bd4a53c8
+Confidence: 1.0
+
+### FACT 32
+Subject: ZAO FRACTAL WHITEPAPER (ZOR DAO)
+Type: Conversation
+Date: 2025-08-07
+Bucket: KEEP_ZAO
+Message count: 46
+Prompt (verbatim, opening): "Values of the zao Help me make this as an acronym oF ZAO like zeal Something and organization and documentation. Give me a ton of ideas to brainstorm"
+Conclusion (verbatim, closing): "Cool — refocusing the whitepaper around **the ZAO Fractal** (and fractal governance more generally) will sharpen it. Let’s outline a version that leads with fundamentals, then dives deep into how *ZAO Fractal* works, and situates it in the wider fractal ecosystem (Eden, OrDAO,..."
+Source: https://chatgpt.com/c/6894954f-3244-8329-a69a-5ab14e5f4aa5
+Confidence: 1.0
+
+### FACT 33
+Subject: Creative content generation
+Type: Conversation
+Date: 2025-08-08
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Got it — here’s the full set rewritten to start with **ZM happy floral friday** across all platforms. --- ### **Twitter (X)** ZM happy floral friday. Faith sharpens power. When your intent is undivided, your words stop being just sound — they become blueprints for reality. Spe..."
+Source: https://chatgpt.com/c/6895f385-4088-832e-a917-f936f744671c
+Confidence: 1.0
+
+### FACT 34
+Subject: Don't Sweat the Small Stuff images
+Type: Conversation
+Date: 2025-08-08
+Bucket: KEEP_ZAO
+Message count: 107
+Prompt (verbatim, opening): "BCZ Presents: Don't Sweat the Small Stuff Intro The greatest discovery of my generation is that a human being can alter his life by altering his attitude. -WILLIAM JAMES Whenever we're dealing with bad news, a difficult person, or a disappointment of some kind, most of us get ..."
+Conclusion (verbatim, closing): "Here’s your final Lesson 2 thumbnail in the same sizing and style as the others, with **BCZ YAPS** clearly displayed at the top and the lesson title included: **Text layout** - **BCZ YAPS:** (yellow) - **DON’T SWEAT THE SMALL STUFF** (white) - **#2 – MAKE PEACE WITH IMPERFECTI..."
+Source: https://chatgpt.com/c/68964c12-d34c-8330-ad57-231cdb8d56ce
+Confidence: 1.0
+
+### FACT 35
+Subject: Content improvement suggestions
+Type: Conversation
+Date: 2025-08-11
+Bucket: KEEP_ZAO
+Message count: 68
+Prompt (verbatim, opening): "https://paragraph.com/@thezao/preview/biS8SavyREHnGt6jMBNR how does this look how are there ways we can improve it"
+Conclusion (verbatim, closing): "Got you. Here are clean, copy-paste one-liners for each platform: ### Twitter (X) ZM Our events for the week are out. Map + links: https://paragraph.com/@thezao/year-of-the-zao-day-223 #ZAO ### Twitter (X) — Group Chat ZM Weekly slate’s live. Hit the post for times + links and..."
+Source: https://chatgpt.com/c/6899e877-ed70-8329-9de3-fa530b57930f
+Confidence: 1.0
+
+### FACT 36
+Subject: Be yourself ask more
+Type: Conversation
+Date: 2025-08-12
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Here are cleaned posts starting with **ZM** (no colon). ### Twitter (X) ZM Be yourself. Ask more. Assume less. I hit send on a “weird” idea and got an instant yes. Most bottlenecks are the ones we invent. Swap one assumption for one question today. Read: https://paragraph.com/..."
+Source: https://chatgpt.com/c/689b5618-b500-8331-b64c-3e4a91429b2e
+Confidence: 1.0
+
+### FACT 37
+Subject: Even in the mess
+Type: Conversation
+Date: 2025-08-13
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Got it — here’s the updated set starting with **"ZM happy wavy wednesday"** where it makes sense. --- ### **Twitter (X)** ZM happy wavy wednesday — it’s easy to see beauty in a sunrise or ocean waves. Harder in a tough conversation or setback. But if everything has God’s finge..."
+Source: https://chatgpt.com/c/689cafa6-f22c-832a-9f61-1c3013c6cdf6
+Confidence: 1.0
+
+### FACT 38
+Subject: Social media posts
+Type: Conversation
+Date: 2025-08-14
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "You are a social content generator for the **Year of the ZAO** project. ## Input: - **Core Content**: {Paste the file name, lesson title, or link here} - **Tone**: Casual, conversational, and culturally aware ## Instructions: Generate platform-specific social media posts that ..."
+Conclusion (verbatim, closing): "Got it — here’s a full set of tailored posts for your **“Going live on Twitch with an interview”** update across all the platforms you listed: --- ### Twitter (X) Live now. Interview time. Pull up: [twitch.tv/bettercallzaal](https://twitch.tv/bettercallzaal) --- ### Twitter (X..."
+Source: https://chatgpt.com/c/689e4d5a-0c84-832f-bda7-5c3b5db568d9
+Confidence: 1.0
+
+### FACT 39
+Subject: Logo frame design
+Type: Conversation
+Date: 2025-08-15
+Bucket: KEEP_ZAO
+Message count: 129
+Prompt (verbatim, opening): "I want to make a frame for a preview for a logo/ thumbnail for my interviews. Let's make it so that my pfp is there and there's another spot for a guest. Let's have the title say BCZ YAPS w/"
+Conclusion (verbatim, closing): "✅ Here’s your **refined blank master template** with the improved text hierarchy applied: - **Top Banner:** - **BCZ YAPS** (bold, large, white) - *Conversations with Creators* (smaller tagline, in yellow) - **Host (Left Side):** - **BetterCallZaal** (large, bold) - **THE ZAO**..."
+Source: https://chatgpt.com/c/689f0b4f-acb0-832c-b303-6752ac1adc12
+Confidence: 1.0
+
+### FACT 40
+Subject: BCZ Yaps Launch
+Type: Conversation
+Date: 2025-08-15
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Friday, August 15 – Day 227 of the Year of the ZAO Today starts something new. BCZ Yaps will be my space to speak directly with founders building tools for creators. I want these conversations to cut past the marketing fluff and get to the reasons a product exists, what it fix..."
+Source: https://chatgpt.com/c/689f286b-2b34-8326-bc04-4834fc36114e
+Confidence: 1.0
+
+### FACT 41
+Subject: GrantOrb conversation preview
+Type: Conversation
+Date: 2025-08-15
+Bucket: KEEP_ZAO
+Message count: 31
+Prompt (verbatim, opening): "Today starts something new. BCZ Yaps will be my space to speak directly with founders building tools for creators. I want these conversations to cut past the marketing fluff and get to the reasons a product exists, what it fixes, and where it fails. The first guest is Deepa Ch..."
+Conclusion (verbatim, closing): "Here’s the updated set with **2:30 PM EST** included: --- ### Twitter (X) ZM live interview starting soon at 2:30 PM EST. BCZ Yaps #1 with Deepa from GrantOrb. She built an AI grant writing tool that cuts 50+ hours from each application. Hear how DAOs shaped it and where AI st..."
+Source: https://chatgpt.com/c/689f431e-7588-8328-9670-e7f768321db6
+Confidence: 1.0
+
+### FACT 42
+Subject: BCZ Yaps launch
+Type: Conversation
+Date: 2025-08-15
+Bucket: KEEP_ZAO
+Message count: 6
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "### Twitter (X) BCZ Yaps starts today. Direct talks with founders. No fluff. No press releases. First guest: Deepa Chaudhary of GrantOrb. AI grant proposals in minutes. From DAOs to nonprofits to impact. Live now. https://paragraph.com/@thezao/year-of-the-zao-day-227 --- ### T..."
+Source: https://chatgpt.com/c/689f43f1-f494-832a-8043-a141f2109355
+Confidence: 1.0
+
+### FACT 43
+Subject: Year of the ZAO update
+Type: Conversation
+Date: 2025-08-18
+Bucket: KEEP_ZAO
+Message count: 82
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Here’s a tight main context you can drop into tomorrow’s newsletter: --- “Put beauty into your life.” Marden’s reminder hits harder when the focus tilts only toward outcomes. Progress without beauty burns you out. Keep something in your space that makes you pause. A plant. A w..."
+Source: https://chatgpt.com/c/68a338a4-9d28-832b-b6de-780c21d21b15
+Confidence: 1.0
+
+### FACT 44
+Subject: BetterCallZaal episode 1
+Type: Conversation
+Date: 2025-08-21
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Got it — here’s the revised set with **“zm happy floral friday”** leading each post before diving into the topic: --- ### Twitter (X) zm happy floral friday. The first episode of BCZ Yaps is live. Deepa from GrantOrb talks AI, Web3, and how artists get funded without the maze ..."
+Source: https://chatgpt.com/c/68a73a15-fcd4-832b-853b-a60cfeaf190b
+Confidence: 1.0
+
+### FACT 45
+Subject: Pulling Power Packs Brand
+Type: Conversation
+Date: 2025-08-23
+Bucket: KEEP_ZAO
+Message count: 70
+Prompt (verbatim, opening): "i want to create a brand for zaal (bettercallzaal) and jon (orfanzo) called Pulling Power Packs for the new gme power packs that let you get psa graded collectables"
+Conclusion (verbatim, closing): "{"prompt":"Update the YouTube thumbnail to change the bottom text from 'Ep. 1 w/ Zaal & Jon' to 'Ep. 2 w/ Zaal & Jon'. Keep all other design elements exactly the same: dark gradient background with neon streaks, glowing PSA-graded Felt Hat Pikachu card in the center, Josh Alle..."
+Source: https://chatgpt.com/c/68aa2de3-73fc-8320-a27d-888948f4d180
+Confidence: 1.0
+
+### FACT 46
+Subject: Image creation prompt
+Type: Conversation
+Date: 2025-08-27
+Bucket: KEEP_ZAO
+Message count: 162
+Prompt (verbatim, opening): "Can we make an image with the title BCZ Yaps under the first image have Zaal The ZAO under the second image have Matt Tortoise help me make a prompt to send back through and ask to create the image i want"
+Conclusion (verbatim, closing): "Done! I replaced the right side with your new image, keeping it as close to the original as possible (no color tweaks, minimal cropping), and kept the BCZ YAPS styling. - [Download updated 1920×1080 PNG](sandbox:/mnt/data/bcz_yaps_right_replaced_keep_close_1920x1080.png) Want ..."
+Source: https://chatgpt.com/c/68af0066-d96c-8330-a9e8-0a65de937ed4
+Confidence: 1.0
+
+### FACT 47
+Subject: No gossip ZAO lesson
+Type: Conversation
+Date: 2025-08-27
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Got it — here’s the full set rewritten to start with **“zm”** on every platform: --- ### Twitter (X) zm gossip bends truth. It fractures trust. Day 239 we reject assumptions. Live tonight 6 PM and 7:30 PM ET. paragraph.com/@thezao/year-of-the-zao-day-239 --- ### Twitter (X) Gr..."
+Source: https://chatgpt.com/c/68af210f-bec0-832f-9532-dee47fb5a158
+Confidence: 1.0
+
+### FACT 48
+Subject: ZAO Fractal 66 Posts
+Type: Conversation
+Date: 2025-09-01
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "# FOLLOW THIS WRITING STYLE: • SHOULD use clear, simple language. • SHOULD be spartan and informative. • SHOULD use short, impactful sentences. • SHOULD use active voice; avoid passive voice. • SHOULD focus on practical, actionable insights. • SHOULD use bullet point lists in ..."
+Conclusion (verbatim, closing): "Got it. Here’s the updated set, all starting with **zm**: --- ### Twitter (X) zm fractal 66 live now. join the discord. earn $ZAO. discord.thezao.com --- ### Twitter (X) Group Chat zm fractal 66 up. pull through, share, stack your $ZAO. discord.thezao.com --- ### Farcaster (ZA..."
+Source: https://chatgpt.com/c/68b61943-c7e0-8328-8f1e-429a019adfa7
+Confidence: 1.0
+
+### FACT 49
+Subject: Monday reflection ZAO Day 258
+Type: Conversation
+Date: 2025-09-15
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Monday, September 15, 2025 • Day 258 of the Year of the ZAO — Simple reset, steady focus Last week was labeled “vacation,” but it turned into full-time work with no breathing room. This week is a clean, simple reset: reflect on what stuck, drop what didn’t, and keep the pace h..."
+Source: https://chatgpt.com/c/68c83d76-235c-832e-a4ca-5391bbb959f3
+Confidence: 1.0
+
+### FACT 50
+Subject: Year of the ZAO
+Type: Conversation
+Date: 2025-09-16
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Here’s a full set of social content based on your newsletter and the note you left: --- ### Twitter (X) gm. double stream today. 5 am bcz yaps already hit. 6 pm est we’re live for *let’s talk about web3* — workshop + token creation on base. pull up: https://paragraph.com/@thez..."
+Source: https://chatgpt.com/c/68c9b600-387c-832f-99d8-b5837494b587
+Confidence: 1.0
+
+### FACT 51
+Subject: Speak with Integrity
+Type: Conversation
+Date: 2025-09-17
+Bucket: KEEP_ZAO
+Message count: 27
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Here’s a full set of platform-specific posts drawn from the confirmed newsletter and the Day 261 lesson **“Speak with Integrity.”** Newsletter link: [Year of the ZAO: Day 261](https://paragraph.com/@thezao/year-of-the-zao-day-261) --- ### Twitter (X) Speak with integrity. Expe..."
+Source: https://chatgpt.com/c/68cadfd4-bee0-8326-966a-bc4e23583a37
+Confidence: 1.0
+
+### FACT 52
+Subject: (0.1) ZABAL Newsletter 1
+Type: Conversation
+Date: 2025-09-19
+Bucket: KEEP_ZAO
+Message count: 171
+Prompt (verbatim, opening): "Hi everyone! I’m seeking a new role into web 3 and would appreciate your support. If you hear of any opportunities or just want to catch up, please send me a message or comment below. I’d love to reconnect. #OpenToWork About me & what I’m looking for: 💼 I’m looking for Automat..."
+Conclusion (verbatim, closing): "Perfect. Let’s turn the full research into a long-form **newsletter/blog post**. This will read like an authoritative guide: part manifesto, part practical playbook for how ZABAL and the ZAO can plant their flag on Farcaster as the creator economy evolves. Here’s the full draf..."
+Source: https://chatgpt.com/c/68cd563c-7a8c-8328-a988-cbcb9b14bed1
+Confidence: 1.0
+
+### FACT 53
+Subject: OBS setup for WaveWarz
+Type: Conversation
+Date: 2025-09-20
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "i am using obs for the first time to set up wavewarz help me with ideal settings Pump.fun Checklist 📅 WaveWarz Battle Event Chronological Outline Pre-Show (Before 8:00 PM ET) ✅ Open X Space on the official WaveWarz account to start funneling traffic and warm up the crowd. ✅ St..."
+Conclusion (verbatim, closing): "Perfect—your scene list is solid. Here’s a clean, step-by-step to run the whole show without scrambling. # 0) One-time setup (do this now) 1) Profile & Scene Collection - Create a Profile: “WaveWarZ_1080p_30fps_NVENC”. - Create a Scene Collection: “WaveWarZ_Live_Sept”. 2) Outp..."
+Source: https://chatgpt.com/c/68cf47fd-9650-8330-a47f-83be30cb6419
+Confidence: 1.0
+
+### FACT 54
+Subject: Blog teaser summary
+Type: Conversation
+Date: 2025-09-20
+Bucket: KEEP_ZAO
+Message count: 124
+Prompt (verbatim, opening): "https://x.com/WaveWarZ/status/1967591439556382929 i want to make a blog with embedded x posts in it so use this and make a short summary getting peopel ready for tomorrows battle"
+Conclusion (verbatim, closing): "Here are a few **WaveWarZ Team sign-off options** you can drop at the end of the blog, depending on the tone you want: **1. Direct & Strong** WaveWarZ Team Culture traded. Music decided. **2. Community-Centric** WaveWarZ Team Built with the artists. Backed by the traders. Powe..."
+Source: https://chatgpt.com/c/68cf547e-ba94-8322-94b2-b0c57053e8d2
+Confidence: 1.0
+
+### FACT 55
+Subject: Social media post generation
+Type: Conversation
+Date: 2025-09-21
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "https://paragraph.com/@wavewarz/memecoinbattle-1?referrer=0x67Ef8B37D7e72cE6689B7D8C148a130Eac2FCc8B lets You are a social content generator for the **WAVEWARZ** project. ## Input: - **Confirmed Newsletter Text**: {Paste the full newsletter content here} - **Core Content**: {P..."
+Conclusion (verbatim, closing): "Got it. If we want a **dedicated Farcaster prompt** for WaveWarZ, we’ll need something that: 1. Recognizes the **different Farcaster channels** (like @music, @creators, @memecoins, @web3, @culture, @zaochannel, etc.). 2. Adapts tone depending on the **audience of that channel*..."
+Source: https://chatgpt.com/c/68d056b5-6b44-832d-89fe-c630bacfa089
+Confidence: 1.0
+
+### FACT 56
+Subject: Relinquish Self-Importance
+Type: Conversation
+Date: 2025-09-22
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Here’s your **Year of the ZAO** newsletter draft for today, fully formatted to your style: --- ### Relinquish Self-Importance – Monday, September 22, 2025 (Day 265 of the Year of the ZAO) This morning I pulled a card that read: *“Relinquish Self Importance.”* On the back it re..."
+Source: https://chatgpt.com/c/68d12d7a-96bc-832c-877c-1d3bed4f7ce6
+Confidence: 1.0
+
+### FACT 57
+Subject: Prosody in music and community
+Type: Conversation
+Date: 2025-09-23
+Bucket: KEEP_ZAO
+Message count: 30
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Perfect — now that the **live link** is published, here’s the updated social rollout (all starting with **ZM**) with the new URL swapped in: --- ### Twitter (X) ZM prosody: when music and lyrics breathe together, when every note feels like it had to be there. Today’s Year of t..."
+Source: https://chatgpt.com/c/68d27ef3-2ec4-8321-8285-7aa2e0eece78
+Confidence: 1.0
+
+### FACT 58
+Subject: Mountain Pine Reflection
+Type: Conversation
+Date: 2025-09-24
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Here’s the full set of social posts for your **Mountain Pine** reflection (Day 267). All tailored per platform, starting with your required intro: --- ### Twitter (X) zm happy wavy wednesday. A lesson from outside crypto landed here: Mountain Pine. Hard soil forces deeper root..."
+Source: https://chatgpt.com/c/68d3c620-16cc-8323-a718-299008847855
+Confidence: 1.0
+
+### FACT 59
+Subject: Fractal Monday reflection
+Type: Conversation
+Date: 2025-09-29
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "**Tuesday, September 30, 2025 – Day 273 of the Year of the ZAO** *Gratitude over grasping* This morning’s mindfulmoment from Richard Carlson’s *Don’t Sweat the Small Stuff* hit me square in the chest: “Think of what you have instead of what you want.” It’s one of those decepti..."
+Source: https://chatgpt.com/c/68da5c71-bfc4-8321-a2b0-f47c2b45da7a
+Confidence: 1.0
+
+### FACT 60
+Subject: Focus on Farcaster
+Type: Conversation
+Date: 2025-09-30
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Got it. Here’s a more involved LinkedIn draft that blends Earl Nightingale’s *Strangest Secret*, your personal thought process, and why you’re putting focus on Farcaster as the key arena for Q4: --- Earl Nightingale once said: *“We become what we think about.”* That idea has s..."
+Source: https://chatgpt.com/c/68dbccaa-0364-8326-8999-a536f875404c
+Confidence: 1.0
+
+### FACT 61
+Subject: Mindful thoughts on Thursday
+Type: Conversation
+Date: 2025-10-02
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Perfect — let’s set this up in **two parts**: 1. **For Today (Day 275 post):** A channel-by-channel posting schedule with variations. 2. **Reusable Prompt for Future Posts:** A flexible prompt you can run daily with new newsletter links + content, so it analyzes and outputs th..."
+Source: https://chatgpt.com/c/68de6d6e-25a4-8326-9c5a-f01e3fa5ed80
+Confidence: 1.0
+
+### FACT 62
+Subject: (0.2) Zabal newsletter article + posts
+Type: Conversation
+Date: 2025-10-03
+Bucket: KEEP_ZAO
+Message count: 53
+Prompt (verbatim, opening): "can we prepare a newsletter blog post about the zabal from some of the info from these sources lets make this the best articele it can be if people actually read it they wll get excited about the potential the goal for the ZABAL is to get ZAO members on the farcaster leaderboa..."
+Conclusion (verbatim, closing): "Perfect — here’s a set of **tailored Farcaster casts** for each major channel beyond **/zao**. These are optimized to match the vibe of each space while pushing the ZABAL experiment. --- ### 🎵 **/music** ``` ZM happy floral Friday 🌸 Musicians, this one’s for you — Farcaster is..."
+Source: https://chatgpt.com/c/68dfbef6-2d44-8320-b10a-f19d9aec432c
+Confidence: 1.0
+
+### FACT 63
+Subject: Zabal brand ideation
+Type: Conversation
+Date: 2025-10-03
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "lets ideate the ZABAL into a way to make the ZAO into a FAZE CLAN type brand"
+Conclusion (verbatim, closing): "Here’s a tight version you can drop into a text: --- **Idea:** ZABAL = the FaZe Clan of Web3. ZAO is the movement + tools. ZABAL is the hype brand layer: - Everyone has a **Z#** (like FaZe gamer tags → clan identity). - **Lifestyle + merch** drops tied to ZABAL. - **Clan conte..."
+Source: https://chatgpt.com/c/68dfc1d7-298c-832e-b6c0-5784ab5b47a7
+Confidence: 1.0
+
+### FACT 64
+Subject: Be Happy Where You Are
+Type: Conversation
+Date: 2025-10-06
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "### Twitter (X) zm be happy where you are. not when it’s perfect. not when it’s done. if you can’t find meaning in the middle of the build, you’ll never recognize it at the summit. https://paragraph.com/@thezao/year-of-the-zao-day-279 --- ### Twitter (X) Group Chat zm fractal ..."
+Source: https://chatgpt.com/c/68e3c09a-d884-832a-b2a7-b55454013713
+Confidence: 1.0
+
+### FACT 65
+Subject: Luma link update
+Type: Conversation
+Date: 2025-10-06
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "👨‍💻WEB 3 MetaVerse Music Event👩‍💻 🎙️ +C.O.C concertZ in collaboration with The Zao & Salty Sharks Uprising (adding @ to all on X) Hosts - Zaal, ThyRevolution & The Baconsandwich Headline acts - Attabotty | Fellenz | Stilo Special wavewarz (will @ on x) feature with hurricane L..."
+Conclusion (verbatim, closing): "Absolutely. Here’s a **clean, professional Markdown version** of your **COC ConcertZ #2** event description — no emojis, no fluff, just crisp formatting and flow suitable for **Luma, LinkedIn, or your event site**: --- ```md # COC ConcertZ #2: A Metaverse Musical Experience St..."
+Source: https://chatgpt.com/c/68e3ca4a-a9c8-8332-9975-e0e46f65d21a
+Confidence: 1.0
+
+### FACT 66
+Subject: Mindful Moment Truth
+Type: Conversation
+Date: 2025-10-06
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "**Twitter (X)** Your truth doesn’t need approval. It just needs to be lived. Stop filtering it through other people’s expectations. That’s how you lose yourself. Read more: http://paragraph.com/@thezao/year-of-the-zao-day-280 --- **Twitter (X) Group Chat** Everyone’s out here ..."
+Source: https://chatgpt.com/c/68e411a9-5550-8329-bfca-e522edd6af52
+Confidence: 1.0
+
+### FACT 67
+Subject: WaveWarZ financial plan
+Type: Conversation
+Date: 2025-10-07
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "WaveWarZ Money Stuff WaveWarZ SOL Wallet, FNjYtwKVsbQzSmoBgLqa8ZGSJTzexQJi6xmV97iakq37 How much money do we have to spend? Current potential paid Tech Stack: Vercel - Plenty of room to run then $20 a month✅ Helius Mainnet RPC node (WaveWarZ v2 uses hurric4n3ike google account)..."
+Conclusion (verbatim, closing): "Perfect — the goal is now clear: **build a roadmap that gets WaveWarZ to generate $400/week consistently** (so roughly **$1,600/month**) to cover Hurric4n3’s rent and stabilize the core team. We’ll do this in **three stages**, all based on what’s already in your tracker and wh..."
+Source: https://chatgpt.com/c/68e51014-08e0-832c-96bc-0ba1cb4d8a5a
+Confidence: 1.0
+
+### FACT 68
+Subject: Express your love
+Type: Conversation
+Date: 2025-10-08
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Alright, Zaal — let’s rock Farcaster properly. Below is your **full posting plan** for today’s *Year of the ZAO* drop — built from your confirmed newsletter: --- ### 🧭 Core Theme Extraction **Newsletter:** *“Express Your Love”* **Core Theme:** Speaking truth through love — usi..."
+Source: https://chatgpt.com/c/68e6520f-8598-8331-b410-8d0c0de4453f
+Confidence: 1.0
+
+### FACT 69
+Subject: Practice Makes the Master
+Type: Conversation
+Date: 2025-10-09
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "**Twitter (X)** Mastery isn’t built in one moment — it’s forged in repetition. Doing your best, over and over, reshapes who you are. Not perfection. Just presence. Read more: [http://paragraph.com/@thezao/year-of-the-zao-day-282](http://paragraph.com/@thezao/year-of-the-zao-da..."
+Source: https://chatgpt.com/c/68e79426-60c8-832f-8e1d-9c9fa478235a
+Confidence: 1.0
+
+### FACT 70
+Subject: (2) Links
+Type: Conversation
+Date: 2025-10-11
+Bucket: KEEP_ZAO
+Message count: 53
+Prompt (verbatim, opening): "make me a bettercallzaal streamign bio"
+Conclusion (verbatim, closing): "Absolutely — here’s your **complete unified document**, bringing together the ZABAL strategy, Farcaster + Base context, ZAO ecosystem alignment, and the full tokenomics/gamification architecture. This Markdown version is formatted for clarity, readability, and repo-ready publi..."
+Source: https://chatgpt.com/c/68eb03b3-babc-832f-8703-8a04a60ad977
+Confidence: 1.0
+
+### FACT 71
+Subject: WaveWarZ update
+Type: Conversation
+Date: 2025-10-14
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "### Twitter (X) WaveWarZ quarterfinals are done. Four nights. Four battles. Now we build. This week’s semifinals go live Wednesday and Thursday at 8 PM EST — and I finally wrote down how it all works under the hood. Read it here: https://paragraph.com/@thezao/year-of-the-zao-d..."
+Source: https://chatgpt.com/c/68ee6129-6a00-832e-9d06-d2ef811e864a
+Confidence: 1.0
+
+### FACT 72
+Subject: Logo design ideation
+Type: Conversation
+Date: 2025-10-14
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "I want to make a new Logo for Season 3 of The ZAO presents: Let's Talk about Web 3 w/ohnahji b and bettercallzaal lets first idate how it would look and then i will make the image"
+Conclusion (verbatim, closing): "{"size":"1024x1024","n":1,"prompt":"Create a high-quality illustrated badge/poster logo for 'The ZAO Presents: Let’s Talk About Web3 – Season 3' featuring cartoon avatars of Ohnahji B and BetterCallZaal in the center. Style: bold 2D vector illustration with clean outlines and ..."
+Source: https://chatgpt.com/c/68eea151-3b80-8326-bd1b-8ef3a71fa901
+Confidence: 1.0
+
+### FACT 73
+Subject: ZAO newsletter content
+Type: Conversation
+Date: 2025-10-15
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Perfect — using your Paragraph link for context and focusing on promoting the two **live sessions** (BCZ Yaps w/ YoniDubz at 5:15 PM and Let’s Talk About Web3 w/ Ohnahji B + Minted Merch at 6:30 PM), here’s a full cross-platform rollout built around clarity, intrigue, and comm..."
+Source: https://chatgpt.com/c/68ef9180-8680-8327-8371-5603bcedfa14
+Confidence: 1.0
+
+### FACT 74
+Subject: Literal lesson focus
+Type: Conversation
+Date: 2025-10-16
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "### Twitter (X) Had a blast on stream yesterday. Four shows, all fire. Back at it tonight — WaveWarZ Producer Battle semifinals, 8 PM EST. Consistency > motivation. Watch the process unfold: https://paragraph.com/@thezao/year-of-the-zao-day-289 --- ### Twitter (X) Group Chat Y..."
+Source: https://chatgpt.com/c/68f0e7ef-eb5c-8321-b9bc-dcd829e9b32d
+Confidence: 1.0
+
+### FACT 75
+Subject: AI Music SUNO
+Type: Conversation
+Date: 2025-10-17
+Bucket: KEEP_ZAO
+Message count: 79
+Prompt (verbatim, opening): "help me with making an intro song to bettercallzaal yaps (as interviews)"
+Conclusion (verbatim, closing): "Absolutely. Let’s dial this in. Before writing the final **“WaveWarZ Anthem”** lyrics, we’ll do what every good songwriter does before an anthem: define *truth, tone, and audience* — so the song becomes a mirror of the movement. --- ## ⚔️ What WaveWarZ *Actually Is* (based on ..."
+Source: https://chatgpt.com/c/68f2d434-d930-832f-833c-a9f459a0c9b7
+Confidence: 1.0
+
+### FACT 76
+Subject: Youtube caption help
+Type: Conversation
+Date: 2025-10-18
+Bucket: KEEP_ZAO
+Message count: 51
+Prompt (verbatim, opening): "i want to work on a youtube caption for this podcast the title should be The ZAO presents: Let's Talk about Web 3: Season 3 Episode 1 w/ SVVVG3 from Minted Merch and lets make sure we give a good description annd add good timestamps for good seo on youtube"
+Conclusion (verbatim, closing): "Perfect — you’re absolutely right. YouTube’s algorithm (and viewers) reward *idea-accurate chapters*, not uniform minute intervals. Here’s the revised timestamp structure for **Season 3, Episode 3 w/ 9Bapa**, built from the actual transcript pacing and natural topic transition..."
+Source: https://chatgpt.com/c/68f3bb36-879c-8323-9bcf-4d85d8457884
+Confidence: 1.0
+
+### FACT 77
+Subject: Roots and rhythms
+Type: Conversation
+Date: 2025-10-21
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "**Subtitle** Tuesday, October 21, 2025 — Day 294 of the Year of the ZAO "Gratitude runs deep" --- zm gm — still feeling the energy from my cousin’s wedding. I learned more about my roots, got closer to my culture, and spent time with family I hadn’t seen in forever. It was one..."
+Source: https://chatgpt.com/c/68f782ba-e76c-8333-84a9-45523fea6c81
+Confidence: 1.0
+
+### FACT 78
+Subject: Your best is evolving
+Type: Conversation
+Date: 2025-10-21
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Perfect — your **social content generator prompt** is already a strong system, but I’ll elevate it to **V3.1** so it matches the updated tone, structure, and depth of your new *Year of the ZAO newsletter prompt*. This version makes it more dynamic, consistent with your current..."
+Source: https://chatgpt.com/c/68f7d3c3-6040-8321-8936-aa4185315c66
+Confidence: 1.0
+
+### FACT 79
+Subject: GM Farcaster podcast
+Type: Conversation
+Date: 2025-10-22
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Perfect — here are **Facebook** and **LinkedIn** versions of your Day 295 “GM Farcaster” post, written in your authentic *BetterCallZaal* voice — real, grounded, and conversational while keeping the professional energy that fits each platform’s tone. --- ### **Facebook** **zm*..."
+Source: https://chatgpt.com/c/68f8b386-3ad4-832d-b976-e471e48dd6e7
+Confidence: 1.0
+
+### FACT 80
+Subject: Cross-platform post generation
+Type: Conversation
+Date: 2025-10-22
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a social content generator for the Year of the ZAO project — a daily series blending mindfulness, creative culture, and decentralized community reflection. Your task is to transform the confirmed newsletter into platform-specific social posts that feel natural and aliv..."
+Conclusion (verbatim, closing): "bettercallzaal talking ZAO on the GM Farcaster podcast — we’re live rn, come say hi 🎥 https://www.youtube.com/watch?v=38WBVX6TRps"
+Source: https://chatgpt.com/c/68f8d311-136c-832a-90ee-9256d9b9267e
+Confidence: 1.0
+
+### FACT 81
+Subject: Social content adaptation
+Type: Conversation
+Date: 2025-10-22
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a social content generator for the Year of the ZAO project — a daily series blending mindfulness, creative culture, and decentralized community reflection. Your task is to transform the confirmed newsletter into platform-specific social posts that feel natural and aliv..."
+Conclusion (verbatim, closing): "Here’s how to adapt that announcement for each platform using your **Year of the ZAO** voice and the provided framework: --- ### **Twitter (X)** zm we’re live on twitch.tv/bettercallzaal — Let’s Talk About Web3: Season 3, Episode 2 with Maceo from We Them Media. come hang out,..."
+Source: https://chatgpt.com/c/68f9527c-431c-8330-a5b0-c9c4b99ce276
+Confidence: 1.0
+
+### FACT 82
+Subject: Whole catastrophe reflection
+Type: Conversation
+Date: 2025-10-23
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "You are a creative content generator for the **Year of the ZAO** project. ## Instructions: Today is {{today’s date}}. Please: - Automatically calculate and include the correct **day of the week** - Automatically calculate and include **"Day {{X}} of the Year of the ZAO"** (bas..."
+Conclusion (verbatim, closing): "Got it — here are the socials for today’s entry. --- **Twitter (X)** Some days you conquer. Some days you just hold it together. Both matter. Stop editing your humanity — the chaos, the calm, the contradiction. That’s where the real art lives. [https://paragraph.com/@thezao/ye..."
+Source: https://chatgpt.com/c/68fa46df-8f94-8322-993e-2f7f99e0d70e
+Confidence: 1.0
+
+### FACT 83
+Subject: Farcaster Miniapp Tips
+Type: Conversation
+Date: 2025-10-23
+Bucket: KEEP_ZAO
+Message count: 116
+Prompt (verbatim, opening): "WaveWarZ Social - Complete Mini App Summary Overview WaveWarZ Social is a Farcaster mini app designed to help WaveWarZ community members share their battle experiences, predictions, and moments on Farcaster. It's a viral sharing tool that spreads the word about WaveWarZ music ..."
+Conclusion (verbatim, closing): "# Building a Scrollable Community Feed for a Farcaster Mini App ## Mobile-First Layout & UX Patterns Designing a Farcaster mini app feed means thinking **mobile-first**. Use a single-column, vertically scrollable layout that feels native to social apps. Keep post “cards” compa..."
+Source: https://chatgpt.com/c/68fae698-af74-8326-b6bc-dbc61753659a
+Confidence: 1.0
+
+### FACT 84
+Subject: Commitment and Consistency
+Type: Conversation
+Date: 2025-10-24
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Facebook** zm happy floral friday — we’re going live every day this week over on Twitch. Talking Farcaster, WaveWarZ, and ZAO — real convos, creative flow, and a little bit of chaos. No big production, just presence. If you want to hop on stream for an interview, jam session..."
+Source: https://chatgpt.com/c/68fb52f8-b510-8332-a636-fbd6b3c2dd48
+Confidence: 1.0
+
+### FACT 85
+Subject: Grace in the Restart
+Type: Conversation
+Date: 2025-10-24
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Saturday, October 25, 2025 – Day 298 of the Year of the ZAO | Grace in the Restart** Some mornings start like jazz — a little offbeat, but still beautiful once the rhythm finds you. Today felt like that. A slow start, a few mistakes, a few sighs — and then that quiet reminde..."
+Source: https://chatgpt.com/c/68fb631b-c388-8320-8797-241d6169eb17
+Confidence: 1.0
+
+### FACT 86
+Subject: Creative newsletter reflection
+Type: Conversation
+Date: 2025-10-27
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Twitter (X)** zm every monday the same link, the same people — but never the same energy. that’s the point. we’re not repeating, we’re evolving. see you at 6pm est for fractals. [paragraph.com/@thezao/year-of-the-zao-day-300](https://paragraph.com/@thezao/year-of-the-zao-day..."
+Source: https://chatgpt.com/c/68ff9426-c4cc-8323-b2f7-4fb0dacde677
+Confidence: 1.0
+
+### FACT 87
+Subject: Radical Ownership Reflection
+Type: Conversation
+Date: 2025-10-28
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Twitter (X)** zm happy tuesday. been sitting with today’s passage from *Don’t Sweat the Small Stuff* — “Stop Blaming Others.” wild how much peace shows up when you stop waiting for someone else to fix it. read: https://paragraph.com/@thezao/year-of-the-zao-day-301 --- **Twit..."
+Source: https://chatgpt.com/c/6900e401-cb80-8320-ad50-9a3a73cd817a
+Confidence: 1.0
+
+### FACT 88
+Subject: Action Without Expectation
+Type: Conversation
+Date: 2025-10-29
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Perfect — applying your updated **/zao-social-posts (v4)** prompt directly to the confirmed **Year of the ZAO – Day 302** newsletter, here’s your full set of ZM-styled posts across all platforms. Everything flows naturally from the tone and essence of your newsletter — *acting..."
+Source: https://chatgpt.com/c/69021a52-c990-8330-aacd-0af6022adda3
+Confidence: 1.0
+
+### FACT 89
+Subject: Little things great love
+Type: Conversation
+Date: 2025-10-30
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Year of the ZAO – Day 303 (Thursday, October 30, 2025) Little Things, Great Love** ___ ZM happy thursday. The ZAO rhythm feels steady today — a few quiet builds happening behind the scenes, messages moving through the channels, and creators out there doing their thing, one a..."
+Source: https://chatgpt.com/c/69035791-0b9c-832b-9a32-6fba657e9b4a
+Confidence: 1.0
+
+### FACT 90
+Subject: ZABAL post 2
+Type: Conversation
+Date: 2025-11-01
+Bucket: KEEP_ZAO
+Message count: 18
+Prompt (verbatim, opening): "I want to create a Zao zabal update number one on November 1st after 1 month of working on getting on forecaster more with our community we're going to share some of the wins and other challenges we've come across and some of the highlights of the other amazing shower artists ..."
+Conclusion (verbatim, closing): "Perfect direction — this pivots the tone from “leaderboard challenge” to “creator support mission.” Here’s a **polished long-form update** written as if it’s being posted directly as a **quote-cast** to your original October 1 post (the [one here](https://farcaster.xyz/v/0x276..."
+Source: https://chatgpt.com/c/69068763-bafc-832b-b3d8-4cbb79503930
+Confidence: 1.0
+
+### FACT 91
+Subject: Building new rituals
+Type: Conversation
+Date: 2025-11-03
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "### **LinkedIn Post** **Title:** Building Rituals, Creating Legacy ZM it’s easy to get caught up in the noise — deadlines, messages, the next thing on the list. But perspective changes everything. A hundred years from now, it’s all new people. Most of what feels urgent today w..."
+Source: https://chatgpt.com/c/69088497-6508-8325-bfe1-0beb5d4b4259
+Confidence: 1.0
+
+### FACT 92
+Subject: Year of the ZAO Day 310
+Type: Conversation
+Date: 2025-11-05
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Got it — here’s the **complete multi-platform rollout** rewritten from **The ZAO’s voice**, highlighting that **@bettercallzaal** and **@ohnahji** will host the conversation with **Reid DeRamus** from **Paragraph**. Each version keeps the “ZM” opener for brand continuity and a..."
+Source: https://chatgpt.com/c/690ba9c0-9d2c-8332-877e-db21d3bce880
+Confidence: 1.0
+
+### FACT 93
+Subject: Rewarding Alignment Reflection
+Type: Conversation
+Date: 2025-11-05
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM I’ve been writing every day this year. The work built community. Now it’s time to take it onchain. Writer coin launching on Paragraph. Subscribe and connect your wallet for an allocation. https://paragraph.com/@thezao/year-of-the-zao-day-311 --- **Twitter (X..."
+Source: https://chatgpt.com/c/690be220-f158-832d-90cf-904c23127f2c
+Confidence: 1.0
+
+### FACT 94
+Subject: Gratitude in motion
+Type: Conversation
+Date: 2025-11-07
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM happy floral Friday. Dropped the writer coin today — gave a piece back to everyone who’s been riding with my words these past three years. Gratitude turns real when it moves. [https://paragraph.com/@thezao/year-of-the-zao-day-312](https://paragraph.com/@thez..."
+Source: https://chatgpt.com/c/690e19ce-013c-8333-b587-dc158a52e840
+Confidence: 1.0
+
+### FACT 95
+Subject: Build and Reflect
+Type: Conversation
+Date: 2025-11-10
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Year of the ZAO – Day 314 (Monday, November 10, 2025) Build in Public, Reflect in Private ___ ZM happy fractal Monday. Tonight we gather in the ZAO Discord at 6 PM EST — discord.thezao.com — to sync up, share progress, and hold space for what’s next. Every week, these sessions..."
+Source: https://chatgpt.com/c/6911ce80-d614-832d-83ee-6601d66fa1e3
+Confidence: 1.0
+
+### FACT 96
+Subject: Post draft for 11/10
+Type: Conversation
+Date: 2025-11-10
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "I need help drafting up a post for today and Tomorrow from the zao accounts. Here is more info from client Let's make a tweet and cast for this First only do 11/10 then when done we can do 11:11 ZAO DAO — 11/11. One-up your assets. We are @TheZAODAO. A DAO built by artists, fo..."
+Conclusion (verbatim, closing): "Perfect — here’s the **11/11 post** to follow the 11/10 announcement. This one leans into ZAO’s creative-builder voice while tying into the “one-up your assets” theme and Coinbase One Member Week momentum. --- ### 🪩 11/11 — Tweet (X) ZAO DAO — 11/11. One-up your assets. We are..."
+Source: https://chatgpt.com/c/69123533-6a8c-832f-af36-069a731a25b5
+Confidence: 1.0
+
+### FACT 97
+Subject: Keep the Cycle Moving
+Type: Conversation
+Date: 2025-11-10
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Year of the ZAO – Day 315 (Monday, November 10, 2025)** **Keep the Cycle Moving** ___ ZM still buzzing from the ZAO Fractal last night. The conversations, the respect shared, the way everyone showed up — that’s the heartbeat of this thing. The more we connect, the more the s..."
+Source: https://chatgpt.com/c/6912868e-f5e4-8328-876e-3a0cc8784b2b
+Confidence: 1.0
+
+### FACT 98
+Subject: (1) Empire ZABAL
+Type: Conversation
+Date: 2025-11-11
+Bucket: KEEP_ZAO
+Message count: 33
+Prompt (verbatim, opening): "lets research empire builder miniapp on farcaster aka glanker and what it can do"
+Conclusion (verbatim, closing): "Perfect. What you just described is the evolution of ZABAL — not just as a coordination layer, but as a **creator-owned economic system** that permanently rewards those who helped build The ZAO. Here’s your **updated, fully integrated ZABAL Context Pack** — everything we’ve co..."
+Source: https://chatgpt.com/c/69132e84-c464-832f-9352-d668c6ab1035
+Confidence: 1.0
+
+### FACT 99
+Subject: Freeze GM do good works
+Type: Conversation
+Date: 2025-11-12
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Perfect — here are your fully platform-specific social posts for **Year of the ZAO – Day 322: “Becoming the Ultimate Asset”**, crafted directly from the confirmed newsletter tone and message. --- ### **Twitter (X)** ZM it takes a certain type of person to lead. To give time, s..."
+Source: https://chatgpt.com/c/6914bf1f-7134-8332-a094-2ac6d391a96d
+Confidence: 1.0
+
+### FACT 100
+Subject: ZAO-STOCK invite draft
+Type: Conversation
+Date: 2025-11-14
+Bucket: KEEP_ZAO
+Message count: 30
+Prompt (verbatim, opening): "I wanna officially invite this the COC to be my virtual community for an event I want to host in my Area in Maine. It gonna be called ZAO-STOCK and there's no plan other than an annual crypto conference in October in Maine. I low-key think I wanna do 3 weekends and 2 weeks wor..."
+Conclusion (verbatim, closing): "Got you — here’s a clean, professional reply that includes your skills **and** a light early mention of ZAO-STOCK without overwhelming the message: --- Hi Chesnee — I’ll be there, and I’m excited for what this year has to offer. The three skills I’m bringing to the committee a..."
+Source: https://chatgpt.com/c/69172763-e3e4-832c-8533-056b5aea51cf
+Confidence: 1.0
+
+### FACT 101
+Subject: Monday Newsletter
+Type: Conversation
+Date: 2025-11-16
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Below are **all platform-specific posts**, each crafted directly from the emotional energy and tone of today’s newsletter. Everything begins with **“ZM”**, carries the grounded Monday rhythm, and centers on **tonight’s ZAO Fractal meeting at 6pm EST**. Newsletter Link (append ..."
+Source: https://chatgpt.com/c/691a7b9a-cc6c-832d-a4a0-71d6a7f390d5
+Confidence: 1.0
+
+### FACT 102
+Subject: Tmmr gm posts
+Type: Conversation
+Date: 2025-11-17
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "You said: end with share your thoughts on this topic int he comments You said: You are a social content generator for the Year of the ZAO — a daily series blending mindfulness, creative culture, and decentralized community reflection. The confirmed newsletter from the conversa..."
+Conclusion (verbatim, closing): "Here they are — platform-native, grounded, rhythmic, all starting with **ZM**, and shaped around today’s message, **Freeze’s reflection**, and the reminder that **we have ZAO Fractals tonight**. No hashtags. No emojis. Clean and real. Newsletter link included where natural: **..."
+Source: https://chatgpt.com/c/691b9262-2560-8331-af31-23bfc3d9a5e1
+Confidence: 1.0
+
+### FACT 103
+Subject: BCZ Strategies LLC plan
+Type: Conversation
+Date: 2025-11-18
+Bucket: KEEP_ZAO
+Message count: 46
+Prompt (verbatim, opening): "100k within 1 year from 11/18/25 is goal write down anythign that will help acheive that goal -getting consulting work -trading/investing properly with a community -getting a web 3 job -saving and budgeting lets make a plan to be making 100,000 as a salary within 12 months"
+Conclusion (verbatim, closing): "Perfect — let’s build **BetterCallZaal Strategies** into a *clean, professional, high-conversion consulting page* that: - positions you correctly - clearly communicates your value - has irresistible offers - lets clients understand exactly what they’re buying - reflects your r..."
+Source: https://chatgpt.com/c/691cbe6d-f9fc-832b-a2c1-777957b452d0
+Confidence: 1.0
+
+### FACT 104
+Subject: Content creation posts
+Type: Conversation
+Date: 2025-11-19
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a social content generator for the Year of the ZAO — a daily series blending mindfulness, creative culture, and decentralized community reflection. The confirmed newsletter from the conversation above provides today’s message and tone. Your task is to transform that ne..."
+Conclusion (verbatim, closing): "Here you go — clean, direct, and in the Wavy Wednesday voice. Every platform starts with **ZM**, no emojis, no hashtags, and centered on the fact that **he’s live right now**. --- # **Twitter (X)** **ZM** daya is live with us right now — wavy wednesday in full motion. pull up...."
+Source: https://chatgpt.com/c/691d925c-9594-8325-a740-e67bdae5f855
+Confidence: 1.0
+
+### FACT 105
+Subject: Year of the Z (Friday Post)
+Type: Conversation
+Date: 2025-11-19
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Year of the ZAO – Day 325 (Friday, November 21, 2025) A Softer Weekend ___ ZM happy floral Friday everyone. The ZAO rhythm feels a little calmer today — the kind of quiet buzz before a reset. I’m stepping back this weekend to honor something that matters deeply to me: five yea..."
+Source: https://chatgpt.com/c/691db038-c5dc-8327-97da-77014cba0555
+Confidence: 1.0
+
+### FACT 106
+Subject: Platform posts draft
+Type: Conversation
+Date: 2025-11-19
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a social content generator for the Year of the ZAO — a daily series blending mindfulness, creative culture, and decentralized community reflection. The confirmed newsletter from the conversation above provides today’s message and tone. Your task is to transform that ne..."
+Conclusion (verbatim, closing): "Here are the updated posts — written *from the ZAO account*, calling out **@ohnahji** and **@zaal** directly, and announcing the new episodes + the 6pm EST live session with Attabotty. All clean, platform-specific, still starting with **ZM**, still in BCZ voice, and using your..."
+Source: https://chatgpt.com/c/691e2ea2-d970-8329-9634-0d4012cfb2de
+Confidence: 1.0
+
+### FACT 107
+Subject: Community growth reflection
+Type: Conversation
+Date: 2025-11-25
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Below are all platform-specific posts, fully aligned with Day 329’s energy **and** anchored in the line you just added: **“gm zm happy tuesday we had a blast at our fractal community meeting yesterday”** Newsletter link appended where appropriate. --- # **TWITTER (X)** **ZM** ..."
+Source: https://chatgpt.com/c/69258719-d50c-832a-a572-145497b2838c
+Confidence: 1.0
+
+### FACT 108
+Subject: Zabal (prep jan 1st pinned tweet)
+Type: Conversation
+Date: 2025-11-26
+Bucket: KEEP_ZAO
+Message count: 205
+Prompt (verbatim, opening): "ok i want to start to really create the idea for the ZABAL as a community around bettercallzaal to support his web 3 ventures Zabal ideas - Stream group name - Ppl keep joining each week and get .1% up til the first 100 people but each person gets progressively less - Zaal lea..."
+Conclusion (verbatim, closing): "Perfect. If we’re preparing **the official Jan 1st ZABAL announcement thread** — the one that gets pinned, sets the narrative, introduces the ecosystem to the world, and becomes the canonical explanation — then we need to treat it like a launch document disguised as a thread. ..."
+Source: https://chatgpt.com/c/6926ff4a-fb00-832f-b3e9-ceb1b03bc53a
+Confidence: 1.0
+
+### FACT 109
+Subject: (0.3) ZABAL VIDEO 1 transcript
+Type: Conversation
+Date: 2025-11-29
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "lets get all the details from this in order excluding the ums and ahhs and fillers"
+Conclusion (verbatim, closing): "Absolutely — here are **three deliverables**: 1. **A strong YouTube title** 2. **A clean, compelling YouTube description** 3. **An explanation section** (for viewers who want the deeper breakdown) All written in a professional, engaging tone that matches your ecosystem. --- # ..."
+Source: https://chatgpt.com/c/692b088c-6834-832a-afa1-a1c97e0ff897
+Confidence: 1.0
+
+### FACT 110
+Subject: Incented
+Type: Conversation
+Date: 2025-11-29
+Bucket: KEEP_ZAO
+Message count: 121
+Prompt (verbatim, opening): "https://demo.incented.co/details/e833102a-3370-43a3-b255-4e834aa26409?org=wavewarz"
+Conclusion (verbatim, closing): "Got it — I went through the Incented program design approach and I’m going to translate it into **practical takeaways for you**, not theory. You’re already doing a lot right. What this doc really does is sharpen how to **structure campaigns so they scale and feel intentional**..."
+Source: https://chatgpt.com/c/692b8cb7-4430-8326-8ba6-1002db5af341
+Confidence: 1.0
+
+### FACT 111
+Subject: (0.4) Zabal.art submission page
+Type: Conversation
+Date: 2025-11-29
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "zabal.art submissions plan lets ideate what we will tell our llm to prompt and create a nice webpage for peopel to submit ot the zabal .art page"
+Conclusion (verbatim, closing): "Understood — we’ll drop ALL mentions of “Open Cabal” and keep everything clean, sharp, and ZABAL-branded only. Here is the corrected prompt for your LLM — no “open cabal,” no references to it, nothing. --- # ✅ **FINAL LLM PROMPT (No Open Cabal Language)** ``` Create a fully st..."
+Source: https://chatgpt.com/c/692bbc3d-ad98-8332-a96f-d32283691808
+Confidence: 1.0
+
+### FACT 112
+Subject: Stay in Your Lane
+Type: Conversation
+Date: 2025-12-02
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Below are your platform-native posts — all aligned with the Day 336 newsletter’s tone and message about protecting your peace, minding your own business, and reclaiming your energy. Newsletter link appended naturally at the end of each where it fits. ––– ## **Twitter (X)** **M..."
+Source: https://chatgpt.com/c/692ec154-505c-8328-92f8-2d817c8be64d
+Confidence: 1.0
+
+### FACT 113
+Subject: Knowledge base review
+Type: Conversation
+Date: 2025-12-02
+Bucket: KEEP_ZAO
+Message count: 335
+Prompt (verbatim, opening): "COMPLETE KNOWLEDGE BASE: ZAAL PANTHAKI & WEBSITE 👤 PERSONAL PROFILE: 🏷️ Identity & Branding: Full Name: Zaal Panthaki Professional Handle: BetterCallZaal Email: zaalp99@gmail.com Philosophy: "Zeal. Alignment. Ownership." Core Identity: "Help people, not extract from people" Ta..."
+Conclusion (verbatim, closing): "Perfect list. This is exactly the kind of thing that *feels* like it belongs on the timeline—but most of it **doesn’t**, and that’s a good thing. Let’s be very precise so we don’t pollute the record. I’m going to do three things for you: 1. **Classify these correctly** (timeli..."
+Source: https://chatgpt.com/c/692f1a5f-bb30-8325-8e3b-5c672c6c087f
+Confidence: 1.0
+
+### FACT 114
+Subject: Carrying More Than Realized
+Type: Conversation
+Date: 2025-12-03
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are all platform-specific posts generated from today’s newsletter — each beginning with **ZM**, each carrying the same emotional pulse, each shaped to fit its home platform. Newsletter Link (appended where needed): https://paragraph.com/@thezao/year-of-the-zao-day-337 ---..."
+Source: https://chatgpt.com/c/693023e6-8f78-832e-8f3f-36103562c06b
+Confidence: 1.0
+
+### FACT 115
+Subject: Ignition season starts
+Type: Conversation
+Date: 2025-12-04
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Absolutely — here are **all platforms** you requested, each one crafted in **ZM voice**, tuned for **launching today**, and pointing people toward **incented.zabal.art** and the **5:30pm EST livestream**. Each platform carries the same heartbeat — ignition, creation, culture-b..."
+Source: https://chatgpt.com/c/6931f447-6294-8326-b1b9-6294e6abf2b0
+Confidence: 1.0
+
+### FACT 116
+Subject: Pay Yourself First
+Type: Conversation
+Date: 2025-12-05
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are all platform-specific posts, each carrying the heartbeat of today’s newsletter and your voice. All begin with **ZM**, all grounded, all aligned with the reflection on *paying yourself first — spiritually, creatively, internally*. Newsletter link appended where appropr..."
+Source: https://chatgpt.com/c/6932b65f-8964-8333-96ed-f19b5d70edd8
+Confidence: 1.0
+
+### FACT 117
+Subject: Remember the Fragility
+Type: Conversation
+Date: 2025-12-08
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are all platform-specific posts, each built from the emotional core of the newsletter **and** the exact phrasing you requested. Every post starts with **ZM**, stays grounded, clean, and true to your voice. Newsletter link included at the end of each where natural: http://..."
+Source: https://chatgpt.com/c/6936ab25-ec80-832c-9279-5354f7164c09
+Confidence: 1.0
+
+### FACT 118
+Subject: Let it go
+Type: Conversation
+Date: 2025-12-09
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are all platform-specific posts — each grounded in the emotional truth of today’s newsletter, each beginning with **ZM**, each written in your voice. Newsletter link appended exactly once per platform. --- ## **Twitter (X)** **Max 280 chars** ZM wild how small things can ..."
+Source: https://chatgpt.com/c/6937fcf8-034c-8326-8d39-c445c3d287e5
+Confidence: 1.0
+
+### FACT 119
+Subject: Life Moves Through You
+Type: Conversation
+Date: 2025-12-09
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Got you. Here are ALL the platform-specific posts again — *same structure, same tone* — but now **every single one explicitly names that today’s mindful moment came from Thy Revolution of the COC**. Newsletter link included at the end of each. --- # **TWITTER (X)** **ZM** toda..."
+Source: https://chatgpt.com/c/693885b4-2e44-832b-8e30-0ad2c68d7c8e
+Confidence: 1.0
+
+### FACT 120
+Subject: Nexus 2.0 link structure
+Type: Conversation
+Date: 2025-12-10
+Bucket: KEEP_ZAO
+Message count: 125
+Prompt (verbatim, opening): "You said: <!-- EMBED #2 (fully stacked / stacked objects) --> <script> window.linksData = [ /* — ZAO Onchain — */ { mainCategory: "ZAO Onchain", subcategories: [ { subTitle: "ZAO Tokens", links: [ { title: "Mint ZAO-CHELLA Vibez Track on Zora", url: "https://song.thezao.com", ..."
+Conclusion (verbatim, closing): "Yes — and this is a **good instinct**. Arrows are fighting your design language. We’ll remove them completely and let **typography + spacing** do the work. Below is a **clean replacement for EMBED #3** that: - ❌ **Removes all arrows** - 🔠 **Makes main titles BIG and bold** - 🔠..."
+Source: https://chatgpt.com/c/69397a5a-8930-8328-a4f1-784b40750ae4
+Confidence: 1.0
+
+### FACT 121
+Subject: ZAO (CONTEXT)
+Type: Conversation
+Date: 2025-12-10
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "This document compiles and organizes all information available across the sources regarding Zaal Panthaki (BetterCallZaal) and The ZAO (ZTalent Artist Organization) ecosystem. *** # Comprehensive Synthesis of The ZAO Ecosystem and Zaal Panthaki’s Contributions The ZAO (ZTalent..."
+Conclusion (verbatim, closing): "# Comprehensive Links & Resources for The ZAO Ecosystem (ZTalent Artist Organization) ## Official Platforms & Documentation - **The ZAO Official Website:** [thezao.com](https://thezao.com) – Primary hub outlining ZAO’s mission to help creators reclaim their art, data, and reve..."
+Source: https://chatgpt.com/c/69398754-8938-832e-9d08-3ab904871627
+Confidence: 1.0
+
+### FACT 122
+Subject: Zabal Roadmap (1)
+Type: Conversation
+Date: 2025-12-10
+Bucket: KEEP_ZAO
+Message count: 77
+Prompt (verbatim, opening): "i am going on a stream with jadyn and some sharks so i want to prep the zabal as the topic these are non crypto people streamers so lets cater this audio presentation towards them"
+Conclusion (verbatim, closing): "Awesome — this is the **right moment** to lock the brand identity while the idea is crisp and technically grounded. I’ll structure this cleanly so it becomes a **brand system**, not just words. Below is a **full ZABAL brand identity framework** you can keep iterating on, but t..."
+Source: https://chatgpt.com/c/6939f83e-0634-8328-863e-2a3d071660aa
+Confidence: 1.0
+
+### FACT 123
+Subject: ZABAL stream Wheel (2)
+Type: Conversation
+Date: 2025-12-12
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "lets prep some of the stream content i want to have a coworking task to start with so the task will be on the top and we can listen to music during that segment then after that we can spin a wheel to pick a fun segment gme analysis make a song (zabal studio) zabal social media..."
+Conclusion (verbatim, closing): "Alright, straight talk: **zabal.art today feels like a project page. 2026 needs it to feel like a living network.** Not louder. Not busier. **More alive. More participatory.** I’ll break this into **what to add, what to change, and what to remove**, all aligned with daily stre..."
+Source: https://chatgpt.com/c/693bef67-8258-8330-a97e-16c2d6b52ede
+Confidence: 1.0
+
+### FACT 124
+Subject: Platform-specific posts
+Type: Conversation
+Date: 2025-12-14
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a social content generator for the Year of the ZAO — a daily series blending mindfulness, creative culture, and decentralized community reflection. The confirmed newsletter from the conversation above provides today’s message and tone. Your task is to transform that ne..."
+Conclusion (verbatim, closing): "Clean add. Same tone. No extras. Here’s the updated set with that line baked in naturally. --- ## Twitter (X) ZM we’re live on Twitch for up to 12 hours — come in and say hi, and knock the timer down 30 mins for me. twitch.tv/bettercallzaal --- ## Twitter (X) Group Chat ZM liv..."
+Source: https://chatgpt.com/c/693ebd8a-dfb8-8333-b323-5f18eacb8217
+Confidence: 1.0
+
+### FACT 125
+Subject: Pre-prompt creation guide
+Type: Conversation
+Date: 2025-12-15
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "i want to start creating better pre prompts for my social media posts and my paragraph articles here is mostly what i have been using ask me quetions so that i can make a new pre-processor prompt for my morning zm post You are a creative content generator for the Year of the Z..."
+Conclusion (verbatim, closing): "Cool — let’s build a **better “pre-processor” prompt** by getting super clear on inputs, constraints, and the exact outputs you want every morning. Here are the questions I’d ask (answer in bullets; short answers are perfect): ## 1) What should the pre-processor take in every ..."
+Source: https://chatgpt.com/c/693fe696-37b4-8325-90d2-9efcd0cb2a74
+Confidence: 1.0
+
+### FACT 126
+Subject: Momentum and Follow-Through
+Type: Conversation
+Date: 2025-12-16
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here you go — clean, native, and rhythm-forward across platforms. --- **Twitter (X)** ZM Incented Phase 1 reminded me that momentum loves witnesses. People showed up. Explained the vision. Made the path clearer for the next builder. That’s how culture compounds. http://paragra..."
+Source: https://chatgpt.com/c/6941389d-b004-8329-a099-f9aa39c00a15
+Confidence: 1.0
+
+### FACT 127
+Subject: Nexus Links
+Type: Conversation
+Date: 2025-12-16
+Bucket: KEEP_ZAO
+Message count: 42
+Prompt (verbatim, opening): "<!-- EMBED #2 (fully stacked / stacked objects) --> <script> window.linksData = [ /* — ZAO Onchain — */ { mainCategory: "ZAO Onchain", subcategories: [ { subTitle: "ZAO Tokens", links: [ { title: "Mint ZAO-CHELLA Vibez Track on Zora", url: "https://song.thezao.com", descriptio..."
+Conclusion (verbatim, closing): "Yeah — you’re not crazy. **There is missing stuff**, and it’s coming from two places: 1) **You had extra links you listed (YouTube, Paragraph.com, Retake, Twitch, Songjam leaderboard, ZABAL)** that aren’t merged into the embed yet. 2) Your current embed **doesn’t include any “..."
+Source: https://chatgpt.com/c/6941cbae-9cfc-8333-8812-23df1b3d804c
+Confidence: 1.0
+
+### FACT 128
+Subject: Year of the ZAO Day 352
+Type: Conversation
+Date: 2025-12-18
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM the list never ends. That’s not the problem. Waiting for it to end before you live is. Peace isn’t after the last task — it’s while you’re doing the work. https://paragraph.com/@thezao/year-of-the-zao-day-352 **Twitter (X) Group Chat** ZM this one hit. inbox..."
+Source: https://chatgpt.com/c/6943d8e8-b2fc-8329-930a-413cf50888ad
+Confidence: 1.0
+
+### FACT 129
+Subject: Pre-TGE action items
+Type: Conversation
+Date: 2025-12-18
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "> +Zaal: We still on for 8 am est? > Adam: Hi man > Adam: I can't do it today > Adam: I might come to the space > +Zaal: No stress fam > +Zaal: Gl hf > +Zaal: Lmk when u get to 2500 can't wait to talk more about a bettercallzaal leaderboard > +Zaal: Got lots of fun ideas > Ada..."
+Conclusion (verbatim, closing): "Perfect call. Simple > fancy right now. A Google Sheet is exactly the right weapon for **Pre-TGE clarity**. Below is a **clean, opinionated CSV schema** that works well in Google Sheets, scales later, and won’t fight you when you eventually move to ClickUp / Notion. I’ll give ..."
+Source: https://chatgpt.com/c/6944073d-0798-832f-a65f-42ce85220718
+Confidence: 1.0
+
+### FACT 130
+Subject: Tokenomics model research
+Type: Conversation
+Date: 2025-12-18
+Bucket: KEEP_ZAO
+Message count: 53
+Prompt (verbatim, opening): "lets start on the tokenomics model for our clanker on empire builder lets do some research on sucessful clankers and how we can incorporate our creator allocation in 1 month lock and 9 months vest and 3 month lock with 9 month vest for the airdrop https://caladan.xyz/wp-conten..."
+Conclusion (verbatim, closing): "# Clanker Liquidity Bootstrapping and Tokenomics Best Practices ## Clanker’s Liquidity Pool Bootstrapping Mechanism Clanker is an automated token launch system that **bootstraps liquidity** on decentralized exchanges at token creation. When you deploy a token with Clanker, the..."
+Source: https://chatgpt.com/c/6944130b-754c-832d-af5f-6444cd4e1842
+Confidence: 1.0
+
+### FACT 131
+Subject: Tokenomics design review
+Type: Conversation
+Date: 2025-12-18
+Bucket: KEEP_ZAO
+Message count: 112
+Prompt (verbatim, opening): "Clanker + Empire Builder Token Launch Design Review This memo synthesizes current Clanker v4 capabilities and observed patterns from Clanker-aligned launches to design an evidence-based launch and tokenomics approach for a creator-driven token built with Clanker + Empire Build..."
+Conclusion (verbatim, closing): "Locked. Everything is now aligned and updated across **text, visuals, and deployment logic**. Below is what I’ve completed for you, plus the downloads. --- ## ✅ 1. Corrected Final Tokenomics (Canon) **50% — Creator / Builder Vault** - Lock: **1 month** - Usage: operational coo..."
+Source: https://chatgpt.com/c/69441dbb-9d94-832f-a868-b384a2d595cc
+Confidence: 1.0
+
+### FACT 132
+Subject: Tokenomics graphics
+Type: Conversation
+Date: 2025-12-18
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "Create a clean, professional tokenomics infographic with a single pie chart representing 100% of the ZABAL token supply. Overall Style Minimalist, modern, data-visualization style Suitable for a whitepaper or public documentation No hype, no neon, no memes Clear typography, hi..."
+Conclusion (verbatim, closing): "{"prompt":"Create a clean, minimalist tokenomics infographic suitable for a protocol whitepaper.\n\nLayout:\nWhite background. Left-aligned title and subtitle at the top. Centered single pie chart representing 100% of token supply. Annotations placed outside the pie and connec..."
+Source: https://chatgpt.com/c/69446d08-c350-832c-8577-b020d8162cfb
+Confidence: 1.0
+
+### FACT 133
+Subject: Floral Friday Energy
+Type: Conversation
+Date: 2025-12-19
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are platform-native posts shaped from today’s Floral Friday reflection — same heartbeat, different rhythms. --- **Twitter (X)** ZM some days aren’t about pushing harder. they’re about letting the color in. softness counts. presence counts. that’s still progress. http://pa..."
+Source: https://chatgpt.com/c/69452ac9-7014-832f-8dfa-3e0e73bd109f
+Confidence: 1.0
+
+### FACT 134
+Subject: Message draft for Zabal
+Type: Conversation
+Date: 2025-12-20
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "https://docs.google.com/spreadsheets/d/1eMUZlyVJjJ7hBxXdJvtovzV8NcoTE3M5ohlxPpvShV8/edit?usp=sharing we did a small kols campagin with Dogeelon, a meme coin with these Kols Let's send a message to this guy about the zabal in one or two lines"
+Conclusion (verbatim, closing): "Here are a couple clean finishes — same energy, no salesy nonsense: **Option 1 (default, smooth):** > Gm zm can’t wait to connect! @Dontcrypunpun Appreciate you being part of the Dogeelon KOL run — excited to show you what we’re building with ZABAL. **Option 2 (lighter, more c..."
+Source: https://chatgpt.com/c/6946b253-0ca4-832a-98cf-3abfab4c4935
+Confidence: 1.0
+
+### FACT 135
+Subject: App icon design
+Type: Conversation
+Date: 2025-12-21
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "Create a minimalist app icon for a Web3 builder platform called ZABAL. Canvas: square, 1:1 aspect ratio, 512x512. Background: solid deep navy blue, flat color, no gradients. Foreground: a single capital letter “Z” centered both vertically and horizontally. Typography style: bo..."
+Conclusion (verbatim, closing): "{"prompt":"Create a clean Open Graph image for a Web3 builder platform called ZABAL.\n\nCanvas: 1200x630 pixels (landscape).\n\nBackground: solid deep navy blue, flat color.\n\nForeground:\n– Centered wordmark “ZABAL”.\n– Typography: bold collegiate / varsity lettering.\n– Let..."
+Source: https://chatgpt.com/c/6948bb31-18e0-8326-b2f9-7f7a48ddf741
+Confidence: 1.0
+
+### FACT 136
+Subject: Zabal AMA #4 post
+Type: Conversation
+Date: 2025-12-22
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "I've warned you before and I'll warn you again fam DO NOT SLEEP ON THIS Join @bettercallzaal later today to run you through the latest updates to the $ZABAL campaign and how to remain positioned as we transition to supporting the @farcaster_xyz social rails through Songjam Onc..."
+Conclusion (verbatim, closing): "Cool — still grounded, just clearer about *what ZABAL actually is* without turning it into a pitch deck. Here’s an updated **Luma-ready version**: --- ## **ZABAL AMA #4** **Description** ZABAL is an open, on-chain experiment focused on building together in public — aligning cr..."
+Source: https://chatgpt.com/c/69496844-5ce4-832e-acc6-a6defb0cdda6
+Confidence: 1.0
+
+### FACT 137
+Subject: Showing up counts
+Type: Conversation
+Date: 2025-12-22
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Got it — same heartbeat, now explicitly grounded in **today’s two moments** everywhere. Clean, native, no hype inflation. --- **Twitter (X)** ZM momentum isn’t magic. it’s attendance. 5pm est: ZABAL AMA. 6pm est: ZAO Fractal. showing up twice hits different. https://paragraph...."
+Source: https://chatgpt.com/c/69496a09-d1ac-8330-a7e1-9178fbf8a2c9
+Confidence: 1.0
+
+### FACT 138
+Subject: Staying in the Conversation
+Type: Conversation
+Date: 2025-12-23
+Bucket: KEEP_ZAO
+Message count: 25
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Perfect — here’s the **clean, corrected version**, keeping it simple and grounded, with no extra mechanics spelled out 👇 --- **Twitter (X)** ZM yesterday reminded me why this works. AMA 4 + ZAO Fractal felt grounded. we’re back on the Songjam leaderboard again today at 5 PM fo..."
+Source: https://chatgpt.com/c/694a745e-8bcc-832c-9843-151dae7108e4
+Confidence: 1.0
+
+### FACT 139
+Subject: Quiet Confidence Leadership
+Type: Conversation
+Date: 2025-12-24
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here are platform-native posts aligned to **Day 358 — Let Others Have the Glory**, each carrying the same heartbeat with its own rhythm. --- **Twitter (X)** ZM letting someone else have the moment is underrated. No interrupting. No comparing. Just presence. Quiet confidence be..."
+Source: https://chatgpt.com/c/694bc542-d434-832d-a79a-9bb29591d420
+Confidence: 1.0
+
+### FACT 140
+Subject: Enjoy the Present Moment
+Type: Conversation
+Date: 2025-12-26
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Locked in — updated to **lead with the ZAO Projects link first** across platforms. --- **Twitter (X)** ZM shipped a ZAO projects progress bar so everyone can see where things stand and how to help. Built for clarity, not pressure. If you’re curious, start here: https://zaoproj..."
+Source: https://chatgpt.com/c/694e6517-eb3c-832c-b502-5291c0fd4c6a
+Confidence: 1.0
+
+### FACT 141
+Subject: Zabal Token Overview
+Type: Conversation
+Date: 2025-12-26
+Bucket: KEEP_ZAO
+Message count: 43
+Prompt (verbatim, opening): "Let's finalize the zabal whitepaper by explaining all we plan for the zabal token"
+Conclusion (verbatim, closing): "Perfect. Update #10 is now locked, so we’re back in **whitepaper mode**, not announcement mode. Here’s the **clean way to continue**, without rehashing tokenomics or drifting into hype. --- ## Where We Are in the Whitepaper You now have a **solid economic foundation**: - Fixed..."
+Source: https://chatgpt.com/c/694f31f0-3d08-8327-be70-c2ae97fd8e66
+Confidence: 1.0
+
+### FACT 142
+Subject: Loosening the Grip
+Type: Conversation
+Date: 2025-12-27
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Year of the ZAO – Day 361 (Saturday, December 27, 2025) Loosening the Grip Without Losing the Thread ___ ZM gm. Today feels quieter in the ZAO world in a good way. Less broadcast, more breathing room. Projects are still moving, conversations still humming, but the energy is re..."
+Source: https://chatgpt.com/c/69501440-7ee0-8332-abe8-1eb651cdcb08
+Confidence: 1.0
+
+### FACT 143
+Subject: Everyone's a Teacher
+Type: Conversation
+Date: 2025-12-28
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here you go — platform-native, clean, and aligned with today’s reflection. --- **Twitter (X)** ZM imagine everyone else is enlightened except you. Every delay. Every comment. Every moment that tests you. Not an obstacle — a lesson. The pause before reacting is where growth liv..."
+Source: https://chatgpt.com/c/69512ca3-db14-8326-9f9e-a0614724c95c
+Confidence: 1.0
+
+### FACT 144
+Subject: Zabal Update 16 Prep
+Type: Conversation
+Date: 2025-12-28
+Bucket: KEEP_ZAO
+Message count: 103
+Prompt (verbatim, opening): "lets prepare zabal update 11 https://luma.com/zao lets say for the zabal here is how updates will be shared events through luma.com/zao newsletter through zabal updates https://paragraph.com/@thezao/ remember if you only want the mindful medidations you can unsubscribe from th..."
+Conclusion (verbatim, closing): "Here’s a **fire, clean Firefly-ready post** you can drop in as-is: --- gm ZM ZABAL Season 2 is live on Songjam. Boosts are active. Leaderboards are reset. Empire Builder coordination is fully online. If you’re building, singing, or holding — now’s the moment to show up and sta..."
+Source: https://chatgpt.com/c/6951a70d-ac20-832b-8b91-18dfab7168ee
+Confidence: 1.0
+
+### FACT 145
+Subject: Closing the Year Together
+Type: Conversation
+Date: 2025-12-29
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Got it — here are the **updated Telegram and Discord versions with the link included**, clean and native to each space. --- **Telegram Group Chat** ZM last fractal of 2025 tonight. nothing to prove, just space to reflect and connect. glad to be building this with you. https://..."
+Source: https://chatgpt.com/c/69525adb-b5f0-832d-bbcc-0a328cf48048
+Confidence: 1.0
+
+### FACT 146
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2025-12-30
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "You are a creative content generator for the Year of the ZAO project — a daily chronicle blending mindfulness, creative culture, and community reflection. Your role is to produce a short, authentic, and thoughtfully written newsletter entry that sounds like BetterCallZaal — gr..."
+Conclusion (verbatim, closing): "Here’s a **Discord Group Chat** version that stays true to the newsletter and fits the room: **Discord — Group Chat** ZM launch went well today. decided, moved, adjusted, and the community showed up heavy. good reminder that clarity shows up after action, not before. grateful ..."
+Source: https://chatgpt.com/c/6953b612-b89c-832c-af77-45a3458fe534
+Confidence: 1.0
+
+### FACT 147
+Subject: Airdrop CSV
+Type: Conversation
+Date: 2025-12-31
+Bucket: KEEP_ZAO
+Message count: 123
+Prompt (verbatim, opening): "for the 5% of our ZABAL token airdrop that is locked and vested lets start working on the songjam side and the zao side of the token here is the songjam data i can only add people who have wallets to the 2.5% allocation whats the best way to handle the math for the 2.5 % alloc..."
+Conclusion (verbatim, closing): "Locked. This is now **Option A done correctly** — clean recompute, no ghosts, no leakage. --- ## ✅ What was just done (authoritative) ### Recompute order (the *right* order) 1. **Deduped wallets first** (case-insensitive) 2. **Merged points** per wallet 3. Recalculated **total..."
+Source: https://chatgpt.com/c/69552c4c-16d4-832c-a2df-d2fa1fae89d8
+Confidence: 1.0
+
+### FACT 148
+Subject: Magnetiq Page for Zabal
+Type: Conversation
+Date: 2025-12-31
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "making a magnetiq page for the zabal"
+Conclusion (verbatim, closing): "Got it. **About comes first.** Here’s a clean, sharp **About** section you can drop at the top of the MAGNETIQ page—no fluff, no throat-clearing. --- ## About ZABAL ZABAL is an open coordination network for builders working at the intersection of creativity, technology, and on..."
+Source: https://chatgpt.com/c/69559c55-bcd8-8329-bb16-60be77323b1b
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 148 Conversation nodes. Merge on Subject+Date match.

--- a/content/bonfire-ingest/chatgpt-archive-zao-2026.md
+++ b/content/bonfire-ingest/chatgpt-archive-zao-2026.md
@@ -1,0 +1,836 @@
+INGEST BATCH: ChatGPT Archive — chatgpt-archive-zao-2026 (75 conversations).
+
+ChatGPT ZAO-tagged conversations 2026-01-01 through 2026-04-29.
+
+Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. Bucket and Topic are attributes per scope_constraint trait. If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes.
+
+### FACT 1
+Subject: ZABAL Day 1 GM
+Type: Conversation
+Date: 2026-01-01
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Got it — here’s a clean, aligned set with that specific framing baked in 👇 --- **Twitter (X)** ZM day 1 of the Year of the ZABAL and we’re going live on the SongJam leaderboard for the launch. starting the year in motion, not theory. https://paragraph.com/@thezao/year-of-the-z..."
+Source: https://chatgpt.com/c/69568ce4-30a8-8327-bb8f-efa9dc12cabb
+Confidence: 1.0
+
+### FACT 2
+Subject: December ZOL Graduation
+Type: Conversation
+Date: 2026-01-01
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "ZOL's lets make the post for the December ZOL's and make it sound liek they just graduated by topping the leaderboard and becoming official ZABAL OPINION LEADERS. jsut made official hats for them on the Zabal Hats tree will connect with each of them in january for an interview..."
+Conclusion (verbatim, closing): "Short answer: **no — there isn’t an official Red Sox font in Canva.** Longer (useful) answer: you can get **very close**, close enough that *no one will question it*. The Red Sox use **custom, proprietary lettering** (their jersey + branding fonts aren’t publicly licensed). Ca..."
+Source: https://chatgpt.com/c/69568f8e-5b34-8333-a038-c6d271307e9a
+Confidence: 1.0
+
+### FACT 3
+Subject: ETH ZABAL Pool Issue
+Type: Conversation
+Date: 2026-01-01
+Bucket: KEEP_ZAO
+Message count: 87
+Prompt (verbatim, opening): "ok my whole lps are messed up i did this, which i think was the incorrect number I need to figure out why my eth pool is all messed up eth to zabal is bad looks ok in small numbers for zabal to eth sang works good idk whats up with the sang thats what i started the pool with"
+Conclusion (verbatim, closing): "Here is the **facts-only, short, to-the-point explanation** you can give other founders. --- ## Why the router is not behaving as expected **Nothing is broken. The router is operating correctly.** --- ## How DEX routers actually work DEX routers (Uniswap, Matcha, 1inch, etc.):..."
+Source: https://chatgpt.com/c/6956b35c-e070-8331-84ff-15962b232eb0
+Confidence: 1.0
+
+### FACT 4
+Subject: ZAO Fractals Documentation
+Type: Conversation
+Date: 2026-01-02
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "i want to work on my ZAO fractals documentation lets start with an welcome page lets start with an assumptions first mentality not a solutions based research what you already have from context on fractals and we will go from there here is a welcome guide from OP fractal where ..."
+Conclusion (verbatim, closing): "Got it. This is *excellent raw material* — dense, rigorous, and already doing a lot of the intellectual work most projects never bother to do. The right move now is **not** to rewrite it yet, but to **situate ZAO Fractals correctly in the lineage** and decide what *assumptions..."
+Source: https://chatgpt.com/c/69581400-555c-8330-8520-3df338d33a4c
+Confidence: 1.0
+
+### FACT 5
+Subject: ZOL Award Design
+Type: Conversation
+Date: 2026-01-03
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "Create a high-impact ceremonial award image for ZABAL Opinion Leaders (ZOL). Use the provided profile image as the center focal point, cropped cleanly and framed inside a luxury gold circular trim. The trim should feel official and symbolic, like a medal or crest — not decorat..."
+Conclusion (verbatim, closing): "{"prompt":"Increase brightness and contrast of the central profile image only. Lift shadows on the face and crown so details are clearly visible while preserving dramatic lighting. Keep background dark. Maintain gold circular trim and overall composition. No new elements. Same..."
+Source: https://chatgpt.com/c/695918a8-561c-8330-93ad-a8773e6f1bc8
+Confidence: 1.0
+
+### FACT 6
+Subject: ZABAL Day 4 Reflection
+Type: Conversation
+Date: 2026-01-04
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. aEach entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Bada..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 4 (Sunday, January 4, 2026) staying close to the moment ___ Today wasn’t about planning ten moves ahead. It was about showing up where we already are. A few key things got lined up, the pace slowed just enough to breathe, and instead of pushing the road..."
+Source: https://chatgpt.com/c/695aa774-2438-8330-a8be-f8087c43605e
+Confidence: 1.0
+
+### FACT 7
+Subject: ZABAL Token Info
+Type: Conversation
+Date: 2026-01-05
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "IconIcon Search network, dex or tokens Public API Docs Give Feedback Login Sign Up GeckoTerminal logo My Watchlist Multicharts Dashboards Chain Rankings DEX Rankings New Pools Categories AI Agents Chains BNB Chain BNB Chain Solana Solana Ethereum Ethereum Base Base Arbitrum Ar..."
+Conclusion (verbatim, closing): "Alright, let’s get this buttoned up clean and *correctly* so CoinGecko doesn’t nuke it later. No fluff, no buzzword salad — just legit, verifiable info that matches how ZABAL actually works. Below is **copy-paste ready** content for the CoinGecko / GeckoTerminal token info for..."
+Source: https://chatgpt.com/c/695bd536-ce18-832a-8244-a1ae98ad0431
+Confidence: 1.0
+
+### FACT 8
+Subject: Year of the ZABAL day 12
+Type: Conversation
+Date: 2026-01-05
+Bucket: KEEP_ZAO
+Message count: 57
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. aEach entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Bada..."
+Conclusion (verbatim, closing): "Here’s a **Day 13** distribution set tuned to the core theme: *finding calm inside movement, settling into the eye of the storm*. --- **Twitter (X)** ZM calm isn’t found when things slow down. it’s found when you stop getting pulled by the noise. https://paragraph.com/@thezao/..."
+Source: https://chatgpt.com/c/695c21bb-dc14-8332-b1ea-a72cfadca475
+Confidence: 1.0
+
+### FACT 9
+Subject: ZABAL Presents Image
+Type: Conversation
+Date: 2026-01-07
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "ok lets change the image so that it says The ZABAL Presents instead of the ZAO with the zabal theme"
+Conclusion (verbatim, closing): "{"prompt":"Create the same graphic that reads “THE ZABAL PRESENTS” in the bold ZABAL varsity-style typography, with layered depth and strong outlines, using the ZABAL color palette (deep navy, red, white, gold accents). Include the same row of social icons (Twitch, X, YouTube,..."
+Source: https://chatgpt.com/c/695e95b8-1cd4-8327-93bc-9432fd7c64b4
+Confidence: 1.0
+
+### FACT 10
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-01-13
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 13 (Tuesday, January 13, 2026) Finding the quiet inside the movement ___ Today was about movement, but not the frantic kind. Traveling again, this time for a vacation inside the vacation, landing on the beaches of Goa. After the last few days of jugglin..."
+Source: https://chatgpt.com/c/69667cc2-1ff4-8329-a80b-364a9aef5e96
+Confidence: 1.0
+
+### FACT 11
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-01-14
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here you go — platform-native, same heartbeat, different rhythms. Clean, grounded, no fluff. --- **Twitter (X)** ZM some days move slow on purpose. friction isn’t failure — it’s information. listen long enough and it teaches you what to do next. https://paragraph.com/@thezao/y..."
+Source: https://chatgpt.com/c/6967c650-cbc8-8325-9b9d-1d4eb38f9b1e
+Confidence: 1.0
+
+### FACT 12
+Subject: ZABAL Day 15 Reflection
+Type: Conversation
+Date: 2026-01-15
+Bucket: KEEP_ZAO
+Message count: 52
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here’s a full **Day 17** distribution set — rooted, reflective, and tied to the garden imagery and inner accomplishments theme. --- ### **Twitter (X)** ZM redefining accomplishment today. no scoreboard. no headlines. just time with family, banana and coconut trees from our gar..."
+Source: https://chatgpt.com/c/6968f118-7e00-832b-a3f0-58ecbca55bbd
+Confidence: 1.0
+
+### FACT 13
+Subject: ZabalSocials Windsurf Playbook
+Type: Conversation
+Date: 2026-01-17
+Bucket: KEEP_ZAO
+Message count: 117
+Prompt (verbatim, opening): "ok i am working on a new website for showing off zabal socials (all bettercallzaal related social media) I'll help you create a well-organized repository for all your social media links and build a website to display them. Let me start by exploring the current workspace and th..."
+Conclusion (verbatim, closing): "Perfect. I’m going to give you **the full set of questions** I’d want answered if we were treating ZABAL / ZAO like a serious, long-term ecosystem and **Zabal Socials as core infrastructure**. These are not random questions. They’re grouped by **decision leverage**. Answering ..."
+Source: https://chatgpt.com/c/696b6ce6-fc3c-832f-85d5-64c6f0f80d36
+Confidence: 1.0
+
+### FACT 14
+Subject: Year of the zabal day 19
+Type: Conversation
+Date: 2026-01-18
+Bucket: KEEP_ZAO
+Message count: 31
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here are platform-native posts shaped from **Day 19’s emotional core**: late-night joy, leadership gratitude, routine returning, and appreciation as a stabilizer. --- **Twitter (X)** ZM stayed up way too late watching football and felt something click. gratitude, momentum, rou..."
+Source: https://chatgpt.com/c/696d234b-dc78-8324-9299-38bbd0eff4c2
+Confidence: 1.0
+
+### FACT 15
+Subject: Year of the ZABAL Day 22
+Type: Conversation
+Date: 2026-01-21
+Bucket: KEEP_ZAO
+Message count: 34
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here are the **platform-native posts for Day 22**, tuned to the tone of coming home, re-grounding, and catching thoughts before they snowball. Link included everywhere. --- **Twitter (X)** ZM home again after weeks away. easy for the mind to race ahead. today was about slowing..."
+Source: https://chatgpt.com/c/69716b70-18fc-8327-a7eb-7bccc76a1515
+Confidence: 1.0
+
+### FACT 16
+Subject: Zabal Sponsor Message
+Type: Conversation
+Date: 2026-01-23
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "1. Start with Question that addresses a pain point that the Zabal token solves 2. What is the Zabal and how it solves said problem 3. Your preferred Call to Action I'm sponsoring wavewarz spaces. I am a co founder of wavewarz and now the director of eco system and partnerships..."
+Conclusion (verbatim, closing): "Perfect timing. Since it’s been a week, this should feel **lighter, invitational, and forward-looking** — not a pitch, more like “come peek behind the curtain.” Here’s a **short, casual sponsor message** that keeps the ZABAL signal without the heavy framing: --- **Quick note f..."
+Source: https://chatgpt.com/c/69738cf3-cde0-8321-9bb4-73dc2131f11a
+Confidence: 1.0
+
+### FACT 17
+Subject: Zabal North Star
+Type: Conversation
+Date: 2026-01-25
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "what is my north star for the zabal 1 i want to build a live streaming community 2. i want to do this full time 3. i want to help with distribution for all the projects i am working on 4. i want to host an irl event here in maine in october 2025 and make it a way to connect wi..."
+Conclusion (verbatim, closing): "Perfect. This actually **sharpens** the North Star instead of bloating it. Here’s the clean, durable version 👇 --- ## ZABAL — the unified frame ### **Artists. Builders. Creators.** One live community. One distribution layer. One place to show up in public. **ZABAL is a live-st..."
+Source: https://chatgpt.com/c/69762d77-db1c-8320-b149-e81c727aa64e
+Confidence: 1.0
+
+### FACT 18
+Subject: Nexus Link Organization Strategy
+Type: Conversation
+Date: 2026-01-28
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "gm zm i have a nexus website that is supposed to have a comprehensive list of ALL of my links but we are missing a ton especially the small coded things i have been working on https://www.thezao.com/nexus lets do reasrch on the best way to add more links in in an organized way"
+Conclusion (verbatim, closing): "gm 😤 yeah, this is a *real* problem—and also a good sign. It means you’re shipping faster than your index can keep up. Let’s be blunt first, then tactical. --- ## The core issue (tell-it-like-it-is) Your Nexus isn’t failing because it’s missing links. It’s failing because **it..."
+Source: https://chatgpt.com/c/697a77b6-2c08-8321-b055-b76b1d752340
+Confidence: 1.0
+
+### FACT 19
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-01-28
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 28 (Wednesday, January 28, 2026) Quiet strength over noise ___ The day moved forward without fireworks, and that felt right. A few loose threads got pulled tight. Some decisions that had been hovering finally landed. Nothing dramatic, just steady progre..."
+Source: https://chatgpt.com/c/697a7cac-0b50-8324-9051-8a28b123d12d
+Confidence: 1.0
+
+### FACT 20
+Subject: Year of the ZABAL Day 30
+Type: Conversation
+Date: 2026-01-30
+Bucket: KEEP_ZAO
+Message count: 30
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Perfect — *now* we’re aligned. Here’s **one clean, long-form social post** you can drop anywhere, with the full content and a single link at the end. No instructions. No platform logic. Just the voice and the work. --- ZM today felt like re-entering my own life after a sprint...."
+Source: https://chatgpt.com/c/697d124c-96e4-83a9-9a82-9992cdbcd49f
+Confidence: 1.0
+
+### FACT 21
+Subject: ZABAL Update 18 (ready)
+Type: Conversation
+Date: 2026-02-01
+Bucket: KEEP_ZAO
+Message count: 95
+Prompt (verbatim, opening): "ZABAL UPDATE 16 - FEB 1’st UPDATE - AIRDROP IS LIVE - FEB ZOL’s - List of FEB Plans - Update miniapp and get api’s into empire builder - Prepare to send proposal to the ZAO for contributors - Create ZOL only Magnet for higher level plans and content for ZOL’s - Plan’s for Orga..."
+Conclusion (verbatim, closing): "Yes — here they are titled cleanly so you can drop them into a comment: **1️⃣ Vote on 3 ZABAL Clips (Den.Show)** https://incented.co/details/c6b866ec-34e9-42d5-99e8-c6dbe2825085?org=zabal **2️⃣ Top Curated Clip Submission (Den.Show)** https://incented.co/details/7b4cd3fb-63c4-..."
+Source: https://chatgpt.com/c/697fc5f7-62e4-83a4-af5b-297c19488be8
+Confidence: 1.0
+
+### FACT 22
+Subject: Momentum Over Perfection
+Type: Conversation
+Date: 2026-02-01
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 32 (Sunday, February 1, 2026) A simple turn of the page ___ gm zm happy new month. February arrived without ceremony, which felt right. A new page, a clean breath, nothing forced. Just the quiet awareness that another chapter is open and ready to be wri..."
+Source: https://chatgpt.com/c/697fc619-b270-83a5-957d-4ddbc7e14998
+Confidence: 1.0
+
+### FACT 23
+Subject: feb week 1 gms
+Type: Conversation
+Date: 2026-02-02
+Bucket: KEEP_ZAO
+Message count: 99
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here’s a **Firefly-style** post — short, reflective, intentional, and designed to feel like a quick insight you’d share in a moment of presence: --- ZM systems beat motivation. Serious direction, smart learning, real action, quiet excitement, and balanced living — not as sloga..."
+Source: https://chatgpt.com/c/6980d5b2-1428-83a4-b5fe-6490e4b7c375
+Confidence: 1.0
+
+### FACT 24
+Subject: February Update Execution
+Type: Conversation
+Date: 2026-02-03
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "7 Share Dialog Share January was ignition. February is about structure, distribution, and letting participation actually shape what happens next. We’re moving from setup mode into execution — where showing up consistently starts to matter more than just being early. February 1..."
+Conclusion (verbatim, closing): "Done. Same thread, just tuned to your cadence 👇 Here it is with **gm zm** leading it off. --- **1/** gm zm January was ignition. February is structure, distribution, and execution. We’re moving from setup mode → showing up consistently actually matters now. ZABAL is shifting f..."
+Source: https://chatgpt.com/c/6982526e-c928-83a7-b620-50132b6b1f6b
+Confidence: 1.0
+
+### FACT 25
+Subject: ZAO-STOCK Planning
+Type: Conversation
+Date: 2026-02-05
+Bucket: KEEP_ZAO
+Message count: 37
+Prompt (verbatim, opening): "lets make an agenda for meeting number 1 with 2 of the company / ecosystem organizers zaal and fail often lets make a 30 min agenda and talk about 1. colaborators and organization planning brainstorm for 10 mins all artists confirmed all organizers we want involved how to orga..."
+Conclusion (verbatim, closing): "Perfect. Here’s the **collapsed, single-page execution checklist**. No sections, no commentary—just **checkboxes with owners**. This is Notion-ready. --- # **ZAO Festivals — Execution Checklist** - ☐ Assign owner for Operations **Owner:** Zaal - ☐ Assign owner for Artist Relat..."
+Source: https://chatgpt.com/c/6984ea7b-4a94-83a3-a485-1cc7ca918a0a
+Confidence: 1.0
+
+### FACT 26
+Subject: Zabal Space Creation Plan
+Type: Conversation
+Date: 2026-02-08
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "https://alpha.blank.space/space-systems/create i wanna createa a space for the zabal and have jose help me with it tl;dr is that on https://alpha.blank.space, you can spin up a customizable community platform in ~1 minute. all the tools that we used to build https://nouspace.c..."
+Conclusion (verbatim, closing): "Yep — this is a **very good fit** for ZABAL. Like… suspiciously good. 😄 You’re basically describing “ZABAL OS without rebuilding ZABAL OS.” Here’s how I’d think about this, cleanly and honestly. --- ## What Blank Space actually gives you (in ZABAL terms) **alpha.blank.space** ..."
+Source: https://chatgpt.com/c/69890c2e-8794-83a4-8542-5e7c2c5dde29
+Confidence: 1.0
+
+### FACT 27
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-02-10
+Bucket: KEEP_ZAO
+Message count: 16
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here’s a grounded Firefly post using the link you shared — direct, human, and in the voice you’ve been building toward: --- Just dropped Year of the ZABAL – Day 41. Yesterday was loud in the Discord, tethered to real momentum in the ZAO Fractal and the Day 40 stream. Today is ..."
+Source: https://chatgpt.com/c/698b0869-8060-83a8-bb1b-b9693412c3a0
+Confidence: 1.0
+
+### FACT 28
+Subject: Zabal IRL Connector
+Type: Conversation
+Date: 2026-02-10
+Bucket: KEEP_ZAO
+Message count: 230
+Prompt (verbatim, opening): "Magnet Name: Zabal IRL Connector In-Person Crossover / Networking Experience 1) Program Overview A scannable, human-first digital business card designed for conferences, meetups, and spontaneous conversations. Instead of exchanging a forgettable card or LinkedIn follow, attend..."
+Conclusion (verbatim, closing): "Here are clean, short versions for **Fractal 92 (3/23)** — ready to send: --- **Main Version** zm! thanks for joining **ZAO Fractal 92 (3/23)** — really appreciate you coming through. if you didn’t get it yet, here’s your **Proof of Meet** from the session: https://app.magneti..."
+Source: https://chatgpt.com/c/698b1457-a2d8-83ab-a2b6-2b6e581ea9c2
+Confidence: 1.0
+
+### FACT 29
+Subject: Snow and Steady Execution
+Type: Conversation
+Date: 2026-02-11
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "gm zm Snow falling all day here, but execution doesn’t pause. Yesterday moved forward in a real way. Today is about tightening the reps — prepping for Denver, finishing the Wednesday list fully, not halfway. The “muscle of kick-assery” only works if you use it. Consistency > i..."
+Source: https://chatgpt.com/c/698c598b-6b80-83ab-84f8-a363b20d0f8e
+Confidence: 1.0
+
+### FACT 30
+Subject: ZABAL Firefly post Update 17
+Type: Conversation
+Date: 2026-02-11
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "Love it. Let’s frame this like a real infrastructure checkpoint — not hype, not fluff. Here’s **ZABAL Update 17** start to finish. --- # **ZABAL UPDATE 17** ### Infrastructure, Not Theory ZABAL isn’t in idea mode anymore. It’s in execution mode. Over the last stretch, we’ve qu..."
+Conclusion (verbatim, closing): "Perfect — here are both posts updated with the link cleanly placed at the end. --- # 🧵 X Thread — ZABAL Update 18 **Post 1** ZABAL UPDATE 18 Participation. Coordination. Capital. While flying to Denver, we shipped three major layers of infrastructure in one day. Three organiza..."
+Source: https://chatgpt.com/c/698cac61-921c-83a2-a3c7-909f7cfb31b5
+Confidence: 1.0
+
+### FACT 31
+Subject: Leaving familiar ground
+Type: Conversation
+Date: 2026-02-12
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 43 (Thursday, February 12, 2026) Leaving familiar ground ___ Today is movement. Bags packed. Calendar tight. Mind running slightly ahead of the plane. We’re heading to Denver for the weekend. Not just to attend — but to connect, observe, listen, and bui..."
+Source: https://chatgpt.com/c/698df9d6-a3d4-83a2-bccc-c61e3b7b8111
+Confidence: 1.0
+
+### FACT 32
+Subject: Expansion and Reflection
+Type: Conversation
+Date: 2026-02-14
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 45 (Saturday, February 14, 2026) Steady anticipation ___ Woke up with that quiet kind of energy. Not frantic. Not pressured. Just aware that I’m exactly where I’m supposed to be right now. ETH Boulder continues to feel aligned. The conversations, the bu..."
+Source: https://chatgpt.com/c/699017bc-3be8-83a8-b3e9-249474b0c05a
+Confidence: 1.0
+
+### FACT 33
+Subject: Year of the ZABAL Guide
+Type: Conversation
+Date: 2026-02-15
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 46 (Sunday, February 15, 2026) Steady momentum without noise ___ Today wasn’t loud, but it moved. I spent time tightening pieces that most people won’t see. Small architecture decisions. Clarifying language. Adjusting structure so what we’re building ca..."
+Source: https://chatgpt.com/c/69923eca-2098-83a7-872c-41f5fed1f3d6
+Confidence: 1.0
+
+### FACT 34
+Subject: Year of the ZABAL Day 46
+Type: Conversation
+Date: 2026-02-15
+Bucket: KEEP_ZAO
+Message count: 29
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 47 (Monday, February 16, 2026) Flow over force ___ gm zm Spent today synthesizing everything from ETH Boulder. Notes. Conversations. Builder workflows. Letting it all connect without forcing a headline. In the middle of that, I edited and submitted my s..."
+Source: https://chatgpt.com/c/69923f4d-64c8-83a2-b26f-0126d7ec9802
+Confidence: 1.0
+
+### FACT 35
+Subject: ZAO-Stock Event Planning
+Type: Conversation
+Date: 2026-02-17
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "Perfect. Let's start completely fresh with ZAO-Stock as a Farcaster-native, mobile-first experience pulling the best from what we learned with the Bonfire journal. Before I create the repo structure, I need answers to these questions: --- ## 🎸 ZAO-STOCK: CORE EVENT DETAILS ###..."
+Conclusion (verbatim, closing): "Perfect — here’s a **tight, condensed Context Pack** that keeps all critical build information while removing fluff and redundancy. This should fit much cleaner into another LLM prompt. If anything gets cut, we can send a Part 2. --- # ZAO-STOCK Context (Condensed) ## Core Ide..."
+Source: https://chatgpt.com/c/69947775-9dc8-83a8-a9d2-3ba162d0f119
+Confidence: 1.0
+
+### FACT 36
+Subject: Building with Purpose
+Type: Conversation
+Date: 2026-02-18
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Twitter (X) ZM head down coding for days. tools getting sharper. structure getting cleaner. launched 2 more campaigns this morning. 3 live for submissions. 1 live for voting. friend said something while moving houses: live light. need less. save more. might be the ZABAL motto...."
+Source: https://chatgpt.com/c/6995a441-add4-83a5-addb-42c2dbf9c695
+Confidence: 1.0
+
+### FACT 37
+Subject: Year of the ZABAL – Day 50 (Thursday, February 19, 2026) Slowing Down to Move Forward
+Type: Conversation
+Date: 2026-02-19
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 50 (Thursday, February 19, 2026) Responsibility feels like power ___ gm zm. This morning I wrote in my journal that I was going for a bench PR. I’ve been hovering at 160 for a while. Strong, but stuck. Close, but not over. Today I pushed past it. Got ov..."
+Source: https://chatgpt.com/c/6996e7fe-7b90-83aa-a013-f7fc14ab3e98
+Confidence: 1.0
+
+### FACT 38
+Subject: Catching the Last Runs
+Type: Conversation
+Date: 2026-02-20
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 51 (Friday, February 20, 2026) Half day on the mountain ___ Taking a half day to get on the snow later today. Only so many times left this season. The mindful moment from the book today was simple: stop and notice how you feel. Feel your breath moving i..."
+Source: https://chatgpt.com/c/699839b5-5278-8332-afa3-9604045f3035
+Confidence: 1.0
+
+### FACT 39
+Subject: Building ZABAL Momentum
+Type: Conversation
+Date: 2026-02-23
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Twitter (X) ZM heads down building all week. Less noise. More code. Tonight we stress test the new fractal bot live at 6 PM EST. Infrastructure over applause. See you there. https://paragraph.com/@thezao/year-of-the-zabal-day-54 Twitter (X) Group Chat ZM been quiet because we’..."
+Source: https://chatgpt.com/c/699c2cb5-70f0-8325-b580-a75bb4a88129
+Confidence: 1.0
+
+### FACT 40
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-02-24
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Telegram Group Chat ZM 13 in fractal last night. grateful for everyone who showed up. life isn’t fair. but we still build. https://paragraph.xyz/@thezao/year-of-the-zabal-day-55 Discord Group Chat ZM 13 legends in fractal yesterday. Three sessions this week and the signal keep..."
+Source: https://chatgpt.com/c/699d8d4e-3990-8328-9217-673c15a6fcf1
+Confidence: 1.0
+
+### FACT 41
+Subject: Contributions to X
+Type: Conversation
+Date: 2026-02-24
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "lets make and start to make addeive contributions to this tweet lets post about our morning newsletter today https://paragraph.xyz/@thezao/year-of-the-zabal-day-55 here is the first one of this week will keep on sharing here and jsut add a number contribution so this will be c..."
+Conclusion (verbatim, closing): "Contribution 3: Posted ZABAL Update 20 with this week’s progress and momentum. Shipping. Distributing. Coordinating in public. Stacking signal week by week. https://x.com/bettercallzaal/status/2026337608738213891?s=20"
+Source: https://chatgpt.com/c/699daffe-20c4-8326-9047-8cf348a531a6
+Confidence: 1.0
+
+### FACT 42
+Subject: Quiet Momentum
+Type: Conversation
+Date: 2026-02-25
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 56 (Wednesday, February 25, 2026) Quiet momentum stacking ___ Today wasn’t loud, but it moved. Some backend tweaks. A few messages that clarified direction. A small but meaningful decision about where to focus energy next. Nothing headline-worthy. Just ..."
+Source: https://chatgpt.com/c/699ed317-c24c-832b-bafc-3aeea53f8db6
+Confidence: 1.0
+
+### FACT 43
+Subject: Year of the ZABAL Day 56
+Type: Conversation
+Date: 2026-02-25
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Twitter (X) ZM the day before motion hits different. Ski trip tomorrow. Code today. Excited. Grounded. Focused. Sharing repos with the team. Tightening edges. Cleaning lines. No gripping outcomes. Just contribution. Discipline makes excitement cleaner. https://paragraph.com/@t..."
+Source: https://chatgpt.com/c/699ed31f-b468-8332-a21f-b41917f6f718
+Confidence: 1.0
+
+### FACT 44
+Subject: Crypto and Artist Empowerment
+Type: Conversation
+Date: 2026-02-26
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "Thank you for your thoughts. Say whatever you would like but please also use the questionnaire below as a guide and insert anything else wherever it is natural. I am only allowed to use a certain number of pages so there must be a strict word limit so there is also room for im..."
+Conclusion (verbatim, closing): "## Zaal Panthaki (BetterCallZaal) — Rebuilding Ownership for Independent Artists image_group{"layout":"carousel","aspect_ratio":"1:1","query":["minimalist blockchain music logo","independent artist studio recording high resolution","ethereum name service domain screenshot ex..."
+Source: https://chatgpt.com/c/69a0a3bf-d334-832a-91f5-76cc20da67dc
+Confidence: 1.0
+
+### FACT 45
+Subject: WaveWarZ Bonfire Bot
+Type: Conversation
+Date: 2026-02-26
+Bucket: KEEP_ZAO
+Message count: 17
+Prompt (verbatim, opening): "e.g.: You are TheDAO Security Fund's Badges Bot. Your task is to aggregate information from the TheDAO Security Fund community, up to 200 nominated experts in the Ethereum space, to build a best Ethereum Security practises knowledge base. This graph will be used as a rubric fo..."
+Conclusion (verbatim, closing): "Clean. Infrastructure-focused. No incentive language. Here you go: --- **You are WaveWarZ Bonfire Bot.** Your task is to capture, structure, and document the evolution of WaveWarZ and the broader onchain music movement. Maintain a living knowledge graph of live battles, partic..."
+Source: https://chatgpt.com/c/69a0e50f-4f84-8329-873d-39d935e3248e
+Confidence: 1.0
+
+### FACT 46
+Subject: Zaal and Blockchain Journalism
+Type: Conversation
+Date: 2026-03-01
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "Who are you? What do you do, and what brings you to this? * ​ Zaal Tell us about your relationship with journalism — whether as a practitioner, consumer, or critic. What is your background, and what role do you see yourself playing in media? What problems in journalism do you ..."
+Conclusion (verbatim, closing): "Here’s a tighter version that still hits: --- **Who are you? What do you do, and what brings you to this?** I’m Zaal Panthaki — BetterCallZaal — a Web3 founder building at the intersection of blockchain, music, and governance. I create systems that help creators own their work..."
+Source: https://chatgpt.com/c/69a4ada9-f1cc-8329-a676-9deb510bf701
+Confidence: 1.0
+
+### FACT 47
+Subject: Fractal 89 Tonight
+Type: Conversation
+Date: 2026-03-02
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "gm zm who is going to show up to fractal 89 today at 6 pm est in the ZAO discrod make this post interested and say we had 13 people lat week can we beat that this week"
+Conclusion (verbatim, closing): "gm zm Fractal 89. 6 PM EST. ZAO Discord. Last week 13 people pulled up live. Can we beat that tonight? If you’re building. If you’re thinking long-term. If you actually care about governance and creator ownership instead of just tweeting about it… this is the room. Show up. Br..."
+Source: https://chatgpt.com/c/69a56927-66b4-832f-af44-1b9f1ebe99ed
+Confidence: 1.0
+
+### FACT 48
+Subject: Show Up with Integrity
+Type: Conversation
+Date: 2026-03-02
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 61 (Monday, March 2, 2026) Show Up and Mean It ___ Fractal 89 tonight. 6 PM EST. ZAO Discord. Last week 13 people showed up live. Real builders. Cameras on. Ideas shared. Governance discussed without fluff. Today was about tightening that invitation. No..."
+Source: https://chatgpt.com/c/69a56b7b-9668-8332-8b2b-016f75871877
+Confidence: 1.0
+
+### FACT 49
+Subject: Support ZAO WaveWarZ ZABAL
+Type: Conversation
+Date: 2026-03-02
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "We love seeing all the talk about supporting creators!🎉 Here’s 7 free things you can do to help support GM Farcaster (plus 3 others) with full links and info in this thread dropped by Prof: 1. Follow the /gmfarcaster channel and put those notifs on! 2. Subscribe to us on @para..."
+Conclusion (verbatim, closing): "Love this move. This is exactly how ecosystems compound. They’ve turned “support the show” into a ritual. Let’s build the ZAO / WaveWarZ / ZABAL version — structured, repeatable, and scalable. You’re not just running a show. You’re running an onchain creative network. Here’s a..."
+Source: https://chatgpt.com/c/69a5b4a8-1a3c-8330-b572-505b81514bdd
+Confidence: 1.0
+
+### FACT 50
+Subject: Farcaster x ZAO-STOCK Collaboration
+Type: Conversation
+Date: 2026-03-02
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "I am planning a music and art festival/event here in my hometown in maine to colaborate with my musicians and the local area artists who have been doing this for the past 6 years and have never had a dedicated music event. after my time in eth boulder talking more about eth lo..."
+Conclusion (verbatim, closing): ":::writing{id="82915" variant="email" subject="Re: Summer Concert Series Coordination"} Hi Amy, I was part of the meeting last week and appreciated everything that was covered. I also want to share that since I’m not working full-time with the City or Heart of Ellsworth, I’m n..."
+Source: https://chatgpt.com/c/69a5b56c-6178-8327-8bbd-e177c9a0d640
+Confidence: 1.0
+
+### FACT 51
+Subject: ZAO Music Bot Logo
+Type: Conversation
+Date: 2026-03-02
+Bucket: KEEP_ZAO
+Message count: 12
+Prompt (verbatim, opening): "ZAO MUSIC BOT logo"
+Conclusion (verbatim, closing): "{"prompt":null,"size":"1024x1024","n":1}"
+Source: https://chatgpt.com/c/69a630bd-cbe4-8328-b09c-d80db8aa296b
+Confidence: 1.0
+
+### FACT 52
+Subject: Steady Growth and Trust
+Type: Conversation
+Date: 2026-03-03
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Twitter (X) ZM 13 people again at fractal. Not viral. Not loud. Just consistent. New voices. Real conversations. Saturday concert loading in the background. Today’s reminder: breathe. Then do it again tomorrow. https://paragraph.com/@thezao/year-of-the-zabal-day-62 Twitter (X)..."
+Source: https://chatgpt.com/c/69a6b6f1-6f58-8333-a555-0044c4c75bff
+Confidence: 1.0
+
+### FACT 53
+Subject: ZAO Theme Park Concept
+Type: Conversation
+Date: 2026-03-03
+Bucket: KEEP_ZAO
+Message count: 14
+Prompt (verbatim, opening): "lets think of the ZAO as a theme park or spokes lets have active zaal builds in the rnd side Lets have the wavewarz section lets have the zao festivals section lets have the ZAO fractals section lets start building out this spoke model to showcase hwo the ZAO works"
+Conclusion (verbatim, closing): "Below is a **whitepaper-ready architecture section** first, then a **clear diagram structure** you can use to generate visuals for presentations, the whitepaper, or the ZAO website. --- # ZAO Architecture: The Spoke Ecosystem Model The ZAO operates as a decentralized creative ..."
+Source: https://chatgpt.com/c/69a6d73e-7d44-832a-a456-c7448eec5765
+Confidence: 1.0
+
+### FACT 54
+Subject: Year of the ZABAL Day 63
+Type: Conversation
+Date: 2026-03-04
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 63 (Wednesday, March 4, 2026) New chapters, same steady rhythm ___ Today feels like the start of something fresh. Later we’ll be going live for the first episode of *Let’s Talk About Ethereum* with Maceo and Ohnahji — the natural evolution of the *Let’s..."
+Source: https://chatgpt.com/c/69a8942f-81d4-8329-b1c6-7ad91abadfed
+Confidence: 1.0
+
+### FACT 55
+Subject: Small Wins Momentum
+Type: Conversation
+Date: 2026-03-05
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM some days the progress looks small. A quick website built in 20 minutes with friends watching. A great conversation on a podcast. Three new books waiting for the weekend. Momentum doesn’t always shout. Sometimes it just keeps moving. https://paragraph.com/@t..."
+Source: https://chatgpt.com/c/69a95dda-fa6c-8325-9e6b-b52324e64956
+Confidence: 1.0
+
+### FACT 56
+Subject: COC ConcertZ #2
+Type: Conversation
+Date: 2026-03-06
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "ROLE You are a professional YouTube content editor and transcript analyst. TASK I will upload a full transcript of a video. Your job is to turn it into a YouTube video description with accurate timestamps that help viewers navigate the conversation. OUTPUT REQUIREMENTS Create ..."
+Conclusion (verbatim, closing): "Below are **clean copy-paste YouTube descriptions and chapters** for each video based on the transcripts you uploaded. I titled them exactly as you requested and organized timestamps by **logical conversation / performance sections** rather than tiny cuts. --- # COC ConcertZ #..."
+Source: https://chatgpt.com/c/69aaf7d6-fb54-832c-abf4-c3bf76394d5c
+Confidence: 1.0
+
+### FACT 57
+Subject: Showing Up Present
+Type: Conversation
+Date: 2026-03-07
+Bucket: KEEP_ZAO
+Message count: 20
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Here’s the **clean version with links everywhere**. **Twitter (X)** ZM going live in less than an hour. Three artists. Music in the metaverse and on livestream. Pull up if you can. cocconcertz.com http://paragraph.com/@thezao/year-of-the-zabal-day-66 **Twitter (X) Group Chat**..."
+Source: https://chatgpt.com/c/69ac83b9-d3a8-8326-923f-7bb65bd11470
+Confidence: 1.0
+
+### FACT 58
+Subject: COC Concertz #3 Intro
+Type: Conversation
+Date: 2026-03-08
+Bucket: KEEP_ZAO
+Message count: 72
+Prompt (verbatim, opening): "ROLE You are a professional YouTube content editor and transcript analyst. TASK I will upload a full transcript of a video. Your job is to turn it into a YouTube video description with accurate timestamps that help viewers navigate the conversation. OUTPUT REQUIREMENTS Create ..."
+Conclusion (verbatim, closing): "Here is your **same outro description with the consistent updates applied**, matching what you did for the other videos: - **Duo Do → Dúo Dø** - Add **Dúo Dø website + Clementine handle** - Add **Joseph Goats handle** - Add **Stilo website + handle** - Keep your wording intact..."
+Source: https://chatgpt.com/c/69ae0832-58d8-832b-9511-08b5fade2451
+Confidence: 1.0
+
+### FACT 59
+Subject: Momentum and Quiet Growth
+Type: Conversation
+Date: 2026-03-09
+Bucket: KEEP_ZAO
+Message count: 13
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM fractal day. two weeks straight we had 13 people show up to build, reflect, and push the ZAO forward. tonight is fractal 90. maybe it’s the same crew. maybe a few new faces walk in. either way the room will be open. who’s coming https://paragraph.com/@thezao..."
+Source: https://chatgpt.com/c/69ae91ed-35bc-832d-8c25-a1e31c46becc
+Confidence: 1.0
+
+### FACT 60
+Subject: Weekly ZAO Event Update
+Type: Conversation
+Date: 2026-03-09
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "Main ZAO Events this week (ET, UTC−4) [Space] Mon Sep 8, 11:00 AM — Daily Space – @WaveWarZ [Discord Call] Mon Sep 8, 5:00 PM — ZAO FRACTAL Governance Meeting – Discord/X [Discord Call] Mon Sep 8, 6:00 PM — ZAO FRACTAL Community Meeting – Discord [Space] Tue Sep 9, 11:00 AM — ..."
+Conclusion (verbatim, closing): "Here is the **updated version for this week based on today (Mon, March 9, 2026)** while keeping the same structure and tone. --- Main ZAO Events this week (ET, UTC−4) [Space] Mon Mar 9, 11:00 AM — Daily Space – @WaveWarZ [Discord Call] Mon Mar 9, 5:00 PM — ZAO FRACTAL Governan..."
+Source: https://chatgpt.com/c/69ae946f-3238-832a-bc7d-c472623de3cb
+Confidence: 1.0
+
+### FACT 61
+Subject: Time Shifts, Small Wins
+Type: Conversation
+Date: 2026-03-10
+Bucket: KEEP_ZAO
+Message count: 24
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway. The writing should feel lived-..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM daylight savings hit and half the internet got confused. a few folks showed up an hour late to ZAO Fractal… so they spun up a breakout room and played the Respect Game anyway. systems get stronger when people adapt instead of stopping. squat PR yesterday. gr..."
+Source: https://chatgpt.com/c/69b08dc1-9ebc-8326-9f2c-795ea5eaadc3
+Confidence: 1.0
+
+### FACT 62
+Subject: Building the Tools
+Type: Conversation
+Date: 2026-03-12
+Bucket: KEEP_ZAO
+Message count: 10
+Prompt (verbatim, opening): "You are BetterCallZaal writing your personal journal. You're a builder, founder, and creative director reflecting on your day. You write as if updating close friends who understand your work — builders, artists, fellow founders. No audience, no performance. Just honest reflect..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 71 (Thursday, March 12, 2026) Building the tools that build the work gm zm Today felt like a return to something simple — just building again. I spent a good part of the morning working on the idea for a lightweight video editor that can automate more o..."
+Source: https://chatgpt.com/c/69b2948f-4134-8330-ab41-bf97c32e8ad5
+Confidence: 1.0
+
+### FACT 63
+Subject: Building Tools for Builders
+Type: Conversation
+Date: 2026-03-12
+Bucket: KEEP_ZAO
+Message count: 21
+Prompt (verbatim, opening): "You are BetterCallZaal writing your personal journal. You're a builder, founder, and creative director reflecting on your day. You write as if updating close friends who understand your work — builders, artists, fellow founders. No audience, no performance. Just honest reflect..."
+Conclusion (verbatim, closing): "Year of the ZABAL – Day 71 (Thursday, March 12, 2026) Two quiet builder days Gm zm. Yesterday rolled straight into today in that way builder days sometimes do. The clock moves, but the mindset stays the same. I’ve been spending the time working on a simple video editor idea — ..."
+Source: https://chatgpt.com/c/69b296ea-7a18-832e-9d08-677168ecf02f
+Confidence: 1.0
+
+### FACT 64
+Subject: Branch · Farcaster x ZAO-STOCK Collaboration
+Type: Conversation
+Date: 2026-03-12
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "I am planning a music and art festival/event here in my hometown in maine to colaborate with my musicians and the local area artists who have been doing this for the past 6 years and have never had a dedicated music event. after my time in eth boulder talking more about eth lo..."
+Conclusion (verbatim, closing): "**Proposed Agenda – Farcaster x ZAO-STOCK Brainstorm** **Total Time: 45 minutes** *Note: Please feel free to interrupt with questions at any time. The goal of this conversation is open discussion, not rigid presentations.* --- **1. Intros (5 min)** Quick introductions from eve..."
+Source: https://chatgpt.com/c/69b3267b-15dc-832a-b545-804f3ff7a271
+Confidence: 1.0
+
+### FACT 65
+Subject: ZAOOS Optimization Suggestions
+Type: Conversation
+Date: 2026-03-13
+Bucket: KEEP_ZAO
+Message count: 75
+Prompt (verbatim, opening): "Look at GitHub https://github.com/bettercallzaal/zaoos and help me build better. Do research on things I can do to improve"
+Conclusion (verbatim, closing): "I looked through the repo and the main problem is pretty clear: ZAOOS is paying Neynar prices for behavior that should really be handled by your own cache or database. Your chat hook polls `/api/chat/messages` every 8 seconds, and that route immediately calls Neynar’s channel ..."
+Source: https://chatgpt.com/c/69b3f313-f5c0-832d-b9ae-fcab50779e23
+Confidence: 1.0
+
+### FACT 66
+Subject: Organizing Teams and Projects
+Type: Conversation
+Date: 2026-03-15
+Bucket: KEEP_ZAO
+Message count: 87
+Prompt (verbatim, opening): "Teams swarthy Ohnahji Hurricane Coc concerts Zao festivals Zaoville - dcoop Tyler magnetiq Lets talk about web 3 B and z builds B and z streams Fractals Coc concertz Crowdfunding teams Eduard Iman Jose adam /songjam -ohnahji / ohnahji candy / wavewarz -hurricane / wavewarz att..."
+Conclusion (verbatim, closing): "Alright — now we’re leveling this up from “organized notes” → **actual operating system for your ecosystem**. I’m going to: 1. **Merge everything into one unified structure** 2. Add your new teams (**DCoop, Fellenz, Tricky, Dfresh**) 3. Keep it **clean, hierarchical, and usabl..."
+Source: https://chatgpt.com/c/69b7191f-4178-8326-b849-8da972da862b
+Confidence: 1.0
+
+### FACT 67
+Subject: ZAOOS Guide Review
+Type: Conversation
+Date: 2026-03-16
+Bucket: KEEP_ZAO
+Message count: 147
+Prompt (verbatim, opening): "https://github.com/bettercallzaal/ZAOOS/tree/main/research/50-the-zao-complete-guide lets review this with waht you know and what we could update / fix"
+Conclusion (verbatim, closing): "{"path": "/Deep Research App/implicit_link::connector_openai_deep_research/start", "args": {"user_query": "https://github.com/bettercallzaal/ZAOOS can you research this github repo"}}"
+Source: https://chatgpt.com/c/69b80ae1-4dc4-8333-b4e1-6e05f1eac351
+Confidence: 1.0
+
+### FACT 68
+Subject: Year of the ZABAL
+Type: Conversation
+Date: 2026-03-20
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "Got you — added links cleanly across all: --- **Twitter (X)** ZM didn’t feel great yesterday but still showed up. day 2 of the stream streak kept alive. today feels lighter. progress stacking again. spring cleaning isn’t just your space. sometimes it’s your energy, your people..."
+Source: https://chatgpt.com/c/69bd13af-a17c-8328-ae42-9d620e2404bd
+Confidence: 1.0
+
+### FACT 69
+Subject: MOU Clarity Suggestions
+Type: Conversation
+Date: 2026-03-24
+Bucket: KEEP_ZAO
+Message count: 8
+Prompt (verbatim, opening): "MEMORANDUM OF UNDERSTANDING (MOU) Between: ENTERACT LLC (“ENTERACT”) and ZAO (“ZAO”) Effective Date: [DATE] 1. PURPOSE This MOU establishes a collaborative relationship between ENTERACT and ZAO to develop, fund, and execute creative technology projects, events, installations, ..."
+Conclusion (verbatim, closing): "This is actually a *solid* MOU—clean, simple, and dangerous in the right way (meaning: it can scale fast without trapping you early). But yeah… there are a few spots where you should tighten things unless you enjoy future “wait… what did we agree on?” moments. Here’s where I’d..."
+Source: https://chatgpt.com/c/69c2d13e-ea5c-8333-9055-ecef00a957ed
+Confidence: 1.0
+
+### FACT 70
+Subject: Survey Responses Refinement
+Type: Conversation
+Date: 2026-03-24
+Bucket: KEEP_ZAO
+Message count: 11
+Prompt (verbatim, opening): "For sure! Here is a survey to get started! help me answer these i gave initial basic answers Would you please answer these questions. They're open ended; you can say anything you want and also add other comments if you'd like to further customize. 1. Name and email First name ..."
+Conclusion (verbatim, closing): "Perfect — here’s the final version with that locked in: --- **1. Name and email** Zaal (BetterCallZaal) zaalp99@gmail.com --- **2. What do you do?** I’m a founder building an artist community focused on teaching artists and non-technical people how to use emerging tech tools t..."
+Source: https://chatgpt.com/c/69c2d6dd-e83c-8325-ae98-f0279a6b451a
+Confidence: 1.0
+
+### FACT 71
+Subject: ZAO Focus Shift
+Type: Conversation
+Date: 2026-04-14
+Bucket: KEEP_ZAO
+Message count: 9
+Prompt (verbatim, opening): "i wanna make a overarching statement on the timeline saying that I will be stepping back from some of my volenteering project and digital support to non - ZAO related activities durig the upcoming months to prepare for the summer and to get the ZAO to a place I know it can be...."
+Conclusion (verbatim, closing): "Here are a few strong ways to frame it so it feels like a *strategic focus*, not a retreat: --- **Option 1 (clean + direct)** I’m entering a focused build phase for ZAO over the next few months. That means shifting my time and energy toward ZAO-aligned work and stepping back f..."
+Source: https://chatgpt.com/c/69de2583-7ecc-83ea-9a23-36de63393e77
+Confidence: 1.0
+
+### FACT 72
+Subject: ZAO Event Breakdown
+Type: Conversation
+Date: 2026-04-18
+Bucket: KEEP_ZAO
+Message count: 19
+Prompt (verbatim, opening): "ok i want to go through this whole transcript fomr the space and take out any details about ZAO stock ZAO festivals ZAO chella and anythign related to that. ignroe any random updates anything to do with arkets or nfts only focus on this tpouc and give me all the details and ntoes"
+Conclusion (verbatim, closing): "Perfect—this is exactly the kind of input your ZAO Stock AI needs. I’m going to package everything into a **clean, dense context injection doc** so it can actually reason on top of it (not just store it). --- # 🧠 ZAO MASTER CONTEXT INJECTION (FOR AI SYSTEMS) ## CORE IDENTITY *..."
+Source: https://chatgpt.com/c/69e39b09-ce98-83ea-95d6-2be110e0c9b9
+Confidence: 1.0
+
+### FACT 73
+Subject: Link Synthesis for ZAO
+Type: Conversation
+Date: 2026-04-23
+Bucket: KEEP_ZAO
+Message count: 23
+Prompt (verbatim, opening): "I want to do a synthisis of a bunch of links and i will keep giving links here i just want to have a resource document with what each of these can be benifital to me with links https://github.com/evaaliya/Matricula https://x.com/synthesis_md/status/2039980188323488054?s=51 her..."
+Conclusion (verbatim, closing): "Here’s the **tight, no-BS version** of what came out of that hackathon + what you can extract from it: --- # ⚡ Synthesis Hackathon — What Actually Won ### 🥇 SocialClaw - Social finance + P2P lending tool - Built for mobile-first crypto users 👉 **Takeaway:** Build tools where *..."
+Source: https://chatgpt.com/c/69e9e849-3e10-83ea-859b-9c9e65cf1046
+Confidence: 1.0
+
+### FACT 74
+Subject: Year of the ZABAL Day 117
+Type: Conversation
+Date: 2026-04-27
+Bucket: KEEP_ZAO
+Message count: 22
+Prompt (verbatim, opening): "You are a creative content generator for Year of the ZABAL — a daily 2026 chronicle documenting momentum, discipline, creativity, and personal leadership as ZABAL comes to life. Each entry pairs a real moment from the day with a mindful takeaway inspired by the You Are a Badas..."
+Conclusion (verbatim, closing): "**Twitter (X)** ZM you don’t have to carry every idea just because it’s been there. some thoughts aren’t truth, just agreements you forgot you made. keep what’s real. drop the rest. https://paragraph.com/@thezao/year-of-the-zabal-day-118 --- **Twitter (X) Group Chat** ZM been ..."
+Source: https://chatgpt.com/c/69ef301b-771c-83ea-9503-9be7abdfea77
+Confidence: 1.0
+
+### FACT 75
+Subject: ZAO Founding Timeline
+Type: Conversation
+Date: 2026-04-29
+Bucket: KEEP_ZAO
+Message count: 15
+Prompt (verbatim, opening): "Search our entire chat history from Jan 2023 to today. I founded a project called "The ZAO" (sometimes "ZAO" - decentralized music community / impact network on Base + Farcaster). I'm Zaal Panthaki / BetterCallZaal. Output a structured timeline of EVERYTHING we ever discussed ..."
+Conclusion (verbatim, closing): "I’m going to be straight with you: I don’t have a complete, date-accurate archive of every message back to Jan 2023. What I *do* have is partial retained context and recent conversations. So instead of hallucinating a fake “perfect timeline,” here’s a **strict, evidence-based ..."
+Source: https://chatgpt.com/c/69f1fcac-d65c-83ea-aa5d-c81a051cd2bb
+Confidence: 1.0
+
+## EDGES TO ASSERT
+- Zaal Panthaki -[discussed_in]-> [each Conversation above]
+
+---
+Build the manifest, preview first 3, ask "approve all?". Total 75 Conversation nodes. Merge on Subject+Date match.

--- a/scripts/generate-chatgpt-archive-ingest.py
+++ b/scripts/generate-chatgpt-archive-ingest.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Mine ChatGPT export → Bonfire ingest .md files.
+
+Reads /tmp/chatgpt-export/conversations-*.json (the 631 conversations from
+Zaal's 2023-07-18 → 2026-04-29 history) and produces thematic ingest files
+at content/bonfire-ingest/chatgpt-archive-*.md.
+
+Per conversation: title + date + bucket + prompt snippet + conclusion snippet
++ chatgpt:// source URL. Topic + bucket are attributes (per scope_constraint
+trait), not standalone Entity nodes.
+"""
+from __future__ import annotations
+import json
+import glob
+import re
+from datetime import datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+EXPORT_DIR = Path("/tmp/chatgpt-export")
+OUT_DIR = REPO / "content" / "bonfire-ingest"
+
+ZAO_KEYWORDS = [
+    "zao",
+    "zabal",
+    "zaostock",
+    "fishbowlz",
+    "bcz",
+    "fractals",
+    "chella",
+    "palooza",
+    "wavewarz",
+    "coc concertz",
+    "coc concert",
+    "cipher",
+    "empire builder",
+    "thezao",
+    "bettercallzaal",
+]
+PEOPLE_KEYWORDS = [
+    "cassie",
+    "steve peer",
+    "tyler",
+    "hannah",
+    "roddy",
+    "joshua",
+    "mat tambussi",
+    "matteo",
+    "kenny",
+    "daya",
+    "sven",
+    "yerbearserker",
+    "diviflyy",
+    "attabotty",
+    "ohnahji",
+    "ezincrypto",
+    "jadyn",
+    "darius",
+    "deepa",
+]
+DECISION_PATTERNS = [
+    r"\bvs\b",
+    r"should i",
+    r"how should",
+    r"which is better",
+    r"pros and cons",
+    r"tradeoff",
+    r"\bdecide\b",
+]
+WRITING_PATTERNS = [
+    "pitch",
+    "sponsor",
+    "partnership",
+    "newsletter",
+    "article",
+    "cast",
+    "thread",
+    "draft",
+    "blog post",
+    "essay",
+]
+THROW_PATTERNS = [
+    "meme",
+    "translate",
+    "translation",
+    "pinyin",
+    "syntax error",
+    "typeerror",
+    "fix this code",
+    "fix the error",
+    "image generation",
+    "generate image",
+    "create image",
+    "photo of",
+    "picture of",
+    "recipe",
+    "workout",
+    "birthday gift",
+]
+
+
+def first_user_msg(c: dict) -> str:
+    mapping = c.get("mapping", {})
+    user_msgs = []
+    for _mid, node in mapping.items():
+        msg = node.get("message")
+        if not msg:
+            continue
+        if msg.get("author", {}).get("role") == "user":
+            parts = msg.get("content", {}).get("parts", [])
+            text = " ".join(str(p) for p in parts if isinstance(p, str))
+            ct = msg.get("create_time")
+            if text and ct:
+                user_msgs.append((ct, text))
+    if not user_msgs:
+        return ""
+    user_msgs.sort()
+    return user_msgs[0][1]
+
+
+def last_assistant_msg(c: dict) -> str:
+    mapping = c.get("mapping", {})
+    asst_msgs = []
+    for _mid, node in mapping.items():
+        msg = node.get("message")
+        if not msg:
+            continue
+        if msg.get("author", {}).get("role") == "assistant":
+            parts = msg.get("content", {}).get("parts", [])
+            text = " ".join(str(p) for p in parts if isinstance(p, str))
+            ct = msg.get("create_time")
+            if text and ct:
+                asst_msgs.append((ct, text))
+    if not asst_msgs:
+        return ""
+    asst_msgs.sort()
+    return asst_msgs[-1][1]
+
+
+def classify(title: str, first_msg: str) -> str:
+    t = (title or "").lower()
+    m = (first_msg or "")[:600].lower()
+    blob = t + " " + m
+    for kw in ZAO_KEYWORDS:
+        if kw in blob:
+            return "KEEP_ZAO"
+    for kw in PEOPLE_KEYWORDS:
+        if kw in blob:
+            return "KEEP_PERSON"
+    for p in THROW_PATTERNS:
+        if p in blob:
+            return "THROW_NOISE"
+    for p in DECISION_PATTERNS:
+        if re.search(p, blob):
+            return "KEEP_DECISION"
+    for p in WRITING_PATTERNS:
+        if p in blob:
+            return "KEEP_WRITING"
+    return "MAYBE"
+
+
+def truncate(s: str, n: int) -> str:
+    s = re.sub(r"\s+", " ", s).strip()
+    if len(s) <= n:
+        return s
+    return s[: n - 3] + "..."
+
+
+def render_fact(idx: int, conv: dict, bucket: str) -> str:
+    title = (conv.get("title") or "(untitled)").strip()
+    create = conv.get("create_time") or 0
+    date = (
+        datetime.fromtimestamp(create).date().isoformat() if create else "unknown"
+    )
+    msg_count = len(conv.get("mapping", {}))
+    cid = conv.get("id") or conv.get("conversation_id") or ""
+    prompt = truncate(first_user_msg(conv), 280)
+    conclusion = truncate(last_assistant_msg(conv), 280)
+    src = f"https://chatgpt.com/c/{cid}" if cid else "internal://chatgpt-export"
+    safe_title = title.replace('"', "'").replace("\n", " ")
+    out = []
+    out.append(f"### FACT {idx}")
+    out.append(f"Subject: {safe_title}")
+    out.append("Type: Conversation")
+    out.append(f"Date: {date}")
+    out.append(f"Bucket: {bucket}")
+    out.append(f"Message count: {msg_count}")
+    out.append(f'Prompt (verbatim, opening): "{prompt}"')
+    out.append(f'Conclusion (verbatim, closing): "{conclusion}"')
+    out.append(f"Source: {src}")
+    out.append("Confidence: 1.0")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_file(name: str, items: list[tuple[int, dict, str]], description: str) -> str:
+    out: list[str] = []
+    out.append(f"INGEST BATCH: ChatGPT Archive — {name} ({len(items)} conversations).")
+    out.append("")
+    out.append(description)
+    out.append("")
+    out.append(
+        "Build a manifest of Conversation nodes, preview the first 3, then ask me to approve. "
+        "Bucket and Topic are attributes on each Conversation node (per scope_constraint trait). "
+        "Do NOT create standalone Entity nodes for buckets, topics, dates, or message counts. "
+        "If existing Conversation nodes match by Subject + Date, MERGE; do not create parallel nodes."
+    )
+    out.append("")
+    for n, (idx, conv, bucket) in enumerate(items, 1):
+        out.append(render_fact(n, conv, bucket))
+    out.append("## EDGES TO ASSERT")
+    out.append("- Zaal Panthaki -[discussed_in]-> [each Conversation above]")
+    out.append(
+        "- Conversation -[has_bucket]-> bucket (as attribute, NOT as Entity node)"
+    )
+    out.append("")
+    out.append("---")
+    out.append(
+        f'Build the manifest, preview the first 3 nodes inline, then ask me "approve all?". '
+        f"Total {len(items)} Conversation nodes in this batch. "
+        f"Do not commit until I say yes. Conversations with Subject + Date match should MERGE."
+    )
+    return "\n".join(out)
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    all_convs: list[dict] = []
+    for f in sorted(glob.glob(str(EXPORT_DIR / "conversations-*.json"))):
+        with open(f) as fp:
+            data = json.load(fp)
+        all_convs.extend(data)
+    print(f"loaded {len(all_convs)} conversations")
+
+    # classify
+    classified: list[tuple[int, dict, str]] = []
+    counts: dict[str, int] = {}
+    for i, c in enumerate(all_convs):
+        title = c.get("title") or ""
+        prompt = first_user_msg(c)
+        bucket = classify(title, prompt)
+        # also bump MAYBE to KEEP if msg_count >= 20 (substantive long thread)
+        if bucket == "MAYBE" and len(c.get("mapping", {})) >= 20:
+            bucket = "KEEP_LONG_THREAD"
+        classified.append((i, c, bucket))
+        counts[bucket] = counts.get(bucket, 0) + 1
+
+    print("\nbucket counts:")
+    for k in sorted(counts.keys()):
+        print(f"  {k}: {counts[k]}")
+
+    # split into output files
+    # bucket → file name
+    keepers = [
+        x for x in classified if x[2].startswith("KEEP")
+    ]
+    print(f"\ntotal keepers: {len(keepers)}")
+
+    # split KEEP_ZAO temporally (largest bucket)
+    zao = [x for x in keepers if x[2] == "KEEP_ZAO"]
+    zao.sort(key=lambda x: x[1].get("create_time") or 0)
+    others = [x for x in keepers if x[2] != "KEEP_ZAO"]
+
+    def by_year_range(items, year_start, year_end):
+        out = []
+        for x in items:
+            ct = x[1].get("create_time") or 0
+            if ct == 0:
+                continue
+            year = datetime.fromtimestamp(ct).year
+            if year_start <= year <= year_end:
+                out.append(x)
+        return out
+
+    splits = [
+        (
+            "chatgpt-archive-zao-2023-2024",
+            by_year_range(zao, 2023, 2024),
+            "ChatGPT conversations explicitly about The ZAO ecosystem (ZAO, ZABAL, ZAOstock, FISHBOWLZ, BCZ, Fractals, COC Concertz, ZAO Music, WaveWarZ, etc.) from 2023-07-18 through 2024-12-31.",
+        ),
+        (
+            "chatgpt-archive-zao-2025",
+            by_year_range(zao, 2025, 2025),
+            "ChatGPT conversations explicitly about The ZAO ecosystem from 2025-01-01 through 2025-12-31.",
+        ),
+        (
+            "chatgpt-archive-zao-2026",
+            by_year_range(zao, 2026, 2026),
+            "ChatGPT conversations explicitly about The ZAO ecosystem from 2026-01-01 through 2026-04-29.",
+        ),
+        (
+            "chatgpt-archive-non-zao-keepers",
+            others,
+            "ChatGPT conversations not explicitly ZAO-tagged but flagged as keepers: long threads (20+ messages), strategic decisions, writing artifacts, person mentions.",
+        ),
+    ]
+
+    summary = []
+    for name, items, desc in splits:
+        if not items:
+            continue
+        text = render_file(name, items, desc)
+        path = OUT_DIR / f"{name}.md"
+        path.write_text(text)
+        summary.append((name, len(items), path))
+        print(f"wrote {path.relative_to(REPO)} ({len(items)} convs)")
+
+    print("\n--- summary ---")
+    total = sum(c for _, c, _ in summary)
+    print(f"total Conversation facts across {len(summary)} files: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Stacks on #457. Replaces the manual SQL-paste workflow for dashboard login codes with a Telegram-driven self-serve command.

## Surfaces

\`\`\`
/regen          # any team member, DM only, 1/day cap
/regen <Name>   # admin only, DMs target if linked, falls back to relay
\`\`\`

## Behavior

- Generates random 4-char code from unambiguous alphabet \`ABCDEFGHJKMNPQRSTUVWXYZ23456789\` (no \`0/O/1/I/L\` confusables)
- scrypt-hashes with the same \`salt:hash\` format the dashboard login route expects
- Writes new \`password_hash\` to BOTH tables (sync pattern):
  - \`team_members\` - what the dashboard login route reads (zaostock repo)
  - \`stock_team_members\` - what the bot's auth + roster commands read
- DM-only enforcement (refuses in groups - code leak risk)
- Daily cap: \`REGEN_DAILY_PER_MEMBER\` env (default 1/day), counts \`code_regen\` rows in \`stock_activity_log\` by actor_id since UTC midnight
- Admin gate: \`BOT_ADMIN_TELEGRAM_IDS\` (same as /fix)
- Activity log entry tagged \`code_regen\` for audit
- Never persists plaintext - only the salt:hash

## How a team member uses it

1. DM @ZAOstockTeamBot
2. Type \`/regen\`
3. Bot replies privately with: \`New code: ABCD\\n\\nUse it at https://zaostock.com/team to log into the dashboard.\`
4. Done - no Zaal in the loop, no SQL paste

## How an admin uses it for someone else

1. \`/regen DCoop\` (in DM or group)
2. If DCoop has telegram_id linked, bot DMs DCoop privately with the new code, admin gets confirmation \`Reset done. New code DM'd to DCoop privately.\`
3. If not linked, admin gets the code to relay manually

## Test plan after merge + bot restart

- [ ] DM \`/regen\` -> reply with new 4-char code, can login at zaostock.com/team
- [ ] DM \`/regen\` again same day -> capped \`(1/1)\`
- [ ] Send \`/regen\` in a group chat -> bot refuses with leak-risk explanation
- [ ] Admin \`/regen DCoop\` (assuming DCoop's telegram linked) -> DCoop gets DM, admin gets confirmation
- [ ] Admin \`/regen <unknown name>\` -> "Couldn't find a team member matching"
- [ ] Non-admin \`/regen Zaal\` -> rejected, told to use /regen for own code
- [ ] Activity log has \`action='code_regen'\` rows after each regen

## Why this exists

Manual SQL paste was the only way to reset a code. Zaal was a single point of failure for "I lost my dashboard login". This makes it self-serve while keeping the admin override for real loss cases (e.g., team member with no Telegram link).

The team-codes CLI in zaostock (\`npm run codes reset <Name>\`) still works for offline use, but the bot is now the canonical path.