### PR TITLE
feat(bot): natural-language PM queries - just talk to Hermes

### DIFF
--- a/bot/src/actions.ts
+++ b/bot/src/actions.ts
@@ -5,6 +5,13 @@ import { z } from 'zod';
 import { db } from './supabase';
 import { ask, type PersonaName } from './llm';
 import type { TeamMember } from './auth';
+import {
+  buildAllOpenTodos,
+  buildMyContributions,
+  buildMyTodos,
+  buildStatus,
+  buildTeamRoster,
+} from './status';
 
 const ActionSchema = z.discriminatedUnion('kind', [
   z.object({
@@ -69,6 +76,13 @@ const ActionSchema = z.discriminatedUnion('kind', [
     title: z.string().min(1).max(300),
     body: z.string().min(1).max(8000),
   }),
+  // Read-side queries - "ask the bot what's going on" without typing slash commands.
+  // Each maps to an existing builder in status.ts; no DB writes happen.
+  z.object({ kind: z.literal('query_my_todos') }),
+  z.object({ kind: z.literal('query_all_open_todos') }),
+  z.object({ kind: z.literal('query_status') }),
+  z.object({ kind: z.literal('query_my_contributions') }),
+  z.object({ kind: z.literal('query_team_roster') }),
   z.object({
     kind: z.literal('unknown'),
     reason: z.string(),
@@ -93,10 +107,17 @@ Allowed actions:
 - { "kind": "log_contact", "entity_type": "sponsor|artist", "name_query": "substring match", "summary": "brief what was said", "channel": "email|call|sms|dm_farcaster|dm_x|dm_tg|in_person|other?", "direction": "outbound|inbound?" }
 - { "kind": "add_idea", "title": "...", "body": "...?", "category": "music|ops|merch|marketing|...?" }
 - { "kind": "add_note", "title": "...", "body": "..." }
+- { "kind": "query_my_todos" }                  // "what's on my plate", "what am I owning", "my todos"
+- { "kind": "query_all_open_todos" }            // "what's open", "what does the team have to do", "what's left", "all todos", "open work"
+- { "kind": "query_status" }                    // "where are we", "festival status", "snapshot", "blockers"
+- { "kind": "query_my_contributions" }          // "what have I done lately", "my last week", "my contributions"
+- { "kind": "query_team_roster" }               // "who's on the team", "team roster", "list members"
 - { "kind": "unknown", "reason": "what's missing or ambiguous" }
 
 Rules:
-- If user is asking a question (not doing), return { "kind": "unknown", "reason": "this is a question, not an action" }.
+- If the user is QUERYING state (asking what's there, what's open, what's on their plate, what's the status), pick the matching query_* kind. These are read-only and free.
+- If the user is delegating a write (add/update/log), pick the matching write action. Never invent fields.
+- If the user is having a free-form conversation that isn't a query or a write (small talk, opinions, vague ideas), return { "kind": "unknown", "reason": "free-form chat" } - the bot will reply conversationally.
 - Dates relative to today: "Friday" -> next Friday ISO; "tomorrow" -> ${today} + 1 day; "Sep 3" -> closest Sep 3.
 - Never invent data. If owner not specified, omit owner_name.
 - Return ONLY the JSON object, nothing else.`;
@@ -194,6 +215,25 @@ export async function executeFromText(
     // right slash command if they're describing a website edit (cost-gated)
     // or a feedback log (free).
     return await hermesChatReply(requester, userText, persona);
+  }
+
+  // Read-side queries are free + side-effect-free; route them before the
+  // write-action try/catch so a transient DB error in one query doesn't
+  // get conflated with a write failure.
+  if (action.kind === 'query_my_todos') {
+    return { ok: true, reply: await buildMyTodos(requester) };
+  }
+  if (action.kind === 'query_all_open_todos') {
+    return { ok: true, reply: await buildAllOpenTodos() };
+  }
+  if (action.kind === 'query_status') {
+    return { ok: true, reply: await buildStatus() };
+  }
+  if (action.kind === 'query_my_contributions') {
+    return { ok: true, reply: await buildMyContributions(requester) };
+  }
+  if (action.kind === 'query_team_roster') {
+    return { ok: true, reply: await buildTeamRoster() };
   }
 
   try {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -19,6 +19,7 @@ import { alertDevops, buildHealthReport } from './ops';
 import { morningDigest, eveningRecap, weekAheadDigest, fridayRetro } from './digest';
 import { cmdOp } from './onepagers';
 import { cmdFix, cmdFixStatus, cmdZsEdit } from './hermes/commands';
+import { cmdRegenSelf, cmdRegenForName } from './regen';
 import {
   cmdCircles,
   cmdJoin,
@@ -142,6 +143,7 @@ bot.command('help', async (ctx) => {
       'Ask me anything:',
       '  /ask <question> - LLM reply, no DB write',
       '  /whoami - confirm who I think you are',
+      '  /regen - DM me to get a fresh dashboard login code (1/day; admin /regen <Name> to regen for someone else)',
       '',
       'Circles:',
       '  /circles - all 8 + who coordinates',
@@ -251,6 +253,19 @@ bot.command('zsfb', async (ctx) => {
   const member = await requireMember(ctx);
   if (!member) return;
   await ctx.reply(await addZsFb(member, ctx.match ?? ''));
+});
+
+// /regen - mint a new dashboard login code.
+// No arg + DM -> regen own code (any team member, daily-capped).
+// With <Name> arg -> admin-only regen for someone else (DMs target if linked).
+bot.command('regen', async (ctx) => {
+  const member = await resolveMember(ctx.from?.id, ctx.from?.username);
+  const arg = (ctx.match ?? '').toString().trim();
+  if (arg) {
+    await cmdRegenForName(ctx, member);
+  } else {
+    await cmdRegenSelf(ctx, member);
+  }
 });
 
 bot.command('ask', async (ctx) => {

--- a/bot/src/regen.ts
+++ b/bot/src/regen.ts
@@ -1,0 +1,232 @@
+// /regen - generate a new 4-character dashboard login code
+//
+// Two surfaces:
+//   - Self-serve (any team member): /regen in DM only, mints + writes own code,
+//     replies privately with plaintext.
+//   - Admin override: /regen <Name>, regen anyone, DMs target if linked, falls
+//     back to replying to the admin so they can relay.
+//
+// Why this exists:
+//   - Codes are scrypt-hashed in DB; if a member loses theirs, only a fresh
+//     mint can restore login. The legacy path was: SQL UPDATE pasted into
+//     Supabase by Zaal. This automates it via Telegram so Zaal isn't a
+//     bottleneck and team members can self-service.
+//   - Two tables in the same Supabase project hold member rows:
+//       team_members        - what the dashboard login route reads
+//       stock_team_members  - what the bot's auth + roster commands read
+//     Out-of-band sync exists between them (name as the join key). /regen
+//     writes the new password_hash to BOTH so login + roster stay coherent.
+//
+// Safety:
+//   - DM-only for self-regen (codes leak risk in groups)
+//   - Daily cap (REGEN_DAILY_PER_MEMBER, default 1/day) prevents abuse
+//   - Admin override checks BOT_ADMIN_TELEGRAM_IDS env (same gate as /fix)
+//   - All regens log to stock_activity_log for audit
+
+import type { Context } from 'grammy';
+import { scryptSync, randomBytes } from 'node:crypto';
+import { db } from './supabase';
+import { logBotActivity } from './activity';
+import {
+  findMemberByTelegramId,
+  findMemberByUsername,
+  type TeamMember,
+} from './auth';
+
+const ALPHABET = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+function generateCode(): string {
+  let out = '';
+  for (let i = 0; i < 4; i++) out += ALPHABET[randomBytes(1)[0] % ALPHABET.length];
+  return out;
+}
+
+function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+function isAdmin(ctx: Context): boolean {
+  const adminIds = (process.env.BOT_ADMIN_TELEGRAM_IDS ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromId = ctx.from?.id;
+  if (!fromId) return false;
+  return adminIds.includes(String(fromId));
+}
+
+async function countRegensForMemberToday(memberId: string): Promise<number> {
+  const todayUtcStart = new Date();
+  todayUtcStart.setUTCHours(0, 0, 0, 0);
+  const { count, error } = await db()
+    .from('stock_activity_log')
+    .select('id', { count: 'exact', head: true })
+    .eq('actor_id', memberId)
+    .eq('action', 'code_regen')
+    .gte('created_at', todayUtcStart.toISOString());
+  if (error) {
+    console.error('[regen] count query failed', error.message);
+    return 0; // fail-open; daily cap is a courtesy not a security boundary
+  }
+  return count ?? 0;
+}
+
+/**
+ * Mint a new code for `member`, write to both team_members (dashboard login)
+ * and stock_team_members (bot roster), log the activity.
+ *
+ * Returns the plaintext code so the caller can DM it to the right person.
+ * NEVER write the plaintext anywhere persistent - only the salt:hash.
+ */
+async function mintAndWrite(member: TeamMember): Promise<{ ok: true; code: string } | { ok: false; reply: string }> {
+  const code = generateCode();
+  const passwordHash = hashPassword(code);
+
+  // Dashboard login table (read by /api/team/login in zaostock). Match by
+  // name since stock_team_members and team_members share name as join key.
+  const dash = await db()
+    .from('team_members')
+    .update({ password_hash: passwordHash, active: true })
+    .eq('name', member.name);
+
+  // Bot roster table - keep the hash in sync so any future bot reader sees
+  // the same value. ID match is exact for this table (we resolved from it).
+  const bot = await db()
+    .from('stock_team_members')
+    .update({ password_hash: passwordHash })
+    .eq('id', member.id);
+
+  if (dash.error && bot.error) {
+    return { ok: false, reply: `Could not write to either table. dashboard=${dash.error.message}. bot=${bot.error.message}` };
+  }
+  if (dash.error) {
+    // Bot table got it but dashboard didn't - login won't work. Surface loudly.
+    return {
+      ok: false,
+      reply: `Wrote to bot roster but dashboard update failed: ${dash.error.message}. Login won't change. Ping Zaal to fix the team_members row by name='${member.name}'.`,
+    };
+  }
+  // bot.error alone is fine - dashboard is the user-visible one.
+  if (bot.error) {
+    console.error(`[regen] stock_team_members update warning: ${bot.error.message}`);
+  }
+
+  await logBotActivity({
+    actorId: member.id,
+    entityType: 'member',
+    entityId: member.id,
+    action: 'code_regen',
+    newValue: 'mint',
+  });
+
+  return { ok: true, code };
+}
+
+/**
+ * /regen self-serve. Open to any registered team member, DM only.
+ */
+export async function cmdRegenSelf(ctx: Context, member: TeamMember | null): Promise<void> {
+  if (!member) {
+    await ctx.reply('I only regen codes for registered team. Run /whoami to confirm, or DM Zaal to get added.');
+    return;
+  }
+
+  const chatType = ctx.chat?.type;
+  if (chatType !== 'private') {
+    await ctx.reply('DM me directly for /regen - I never paste a login code into a group. Open a DM and try again.');
+    return;
+  }
+
+  const dailyCap = Number(process.env.REGEN_DAILY_PER_MEMBER ?? '1');
+  const usedToday = await countRegensForMemberToday(member.id);
+  if (usedToday >= dailyCap) {
+    await ctx.reply(
+      `You already regenerated today (${usedToday}/${dailyCap}). Resets at UTC midnight. Ping Zaal if you've genuinely lost it twice.`,
+    );
+    return;
+  }
+
+  const result = await mintAndWrite(member);
+  if (!result.ok) {
+    await ctx.reply(result.reply);
+    return;
+  }
+
+  await ctx.reply(
+    [
+      `New code: ${result.code}`,
+      '',
+      `Use it at https://zaostock.com/team to log into the dashboard.`,
+      `Case-insensitive. (${usedToday + 1}/${dailyCap} regens today.)`,
+    ].join('\n'),
+  );
+}
+
+/**
+ * /regen <Name> admin override. Mints a fresh code for a different team member
+ * and either DMs it to them (if their telegram_id is linked) or hands it back
+ * to the admin to relay.
+ */
+export async function cmdRegenForName(ctx: Context, callerMember: TeamMember | null): Promise<void> {
+  if (!isAdmin(ctx)) {
+    await ctx.reply('Admin-only when targeting someone else. Use /regen with no argument to regen your own code.');
+    return;
+  }
+
+  const text = (ctx.message?.text ?? '').replace(/^\/regen(@\w+)?\s*/, '').trim();
+  if (!text) {
+    // Caller wants their own code, which is the self-serve path. Route there.
+    await cmdRegenSelf(ctx, callerMember);
+    return;
+  }
+
+  // Find target by name. Try normalized lookups against stock_team_members.
+  const { data: target } = await db()
+    .from('stock_team_members')
+    .select('id, name, scope, role, telegram_id, telegram_username, active')
+    .ilike('name', text)
+    .neq('active', false)
+    .maybeSingle();
+
+  if (!target) {
+    await ctx.reply(`Couldn't find a team member matching "${text}". Try the exact name from the roster.`);
+    return;
+  }
+
+  const result = await mintAndWrite(target as TeamMember);
+  if (!result.ok) {
+    await ctx.reply(result.reply);
+    return;
+  }
+
+  // Try to DM the target privately if their telegram_id is linked.
+  const targetTgId = (target as TeamMember).telegram_id;
+  if (targetTgId) {
+    try {
+      await ctx.api.sendMessage(
+        targetTgId,
+        [
+          `Hermes here - your dashboard code was reset by admin.`,
+          '',
+          `New code: ${result.code}`,
+          `Use it at https://zaostock.com/team`,
+        ].join('\n'),
+      );
+      await ctx.reply(`Reset done. New code DM'd to ${target.name} privately. Activity logged.`);
+      return;
+    } catch (err) {
+      // Fall through to hand the code to the admin if the DM bounces.
+      console.error(`[regen] DM to target ${target.name} failed`, err);
+    }
+  }
+
+  await ctx.reply(
+    [
+      `Reset done for ${target.name}.`,
+      `Their telegram is not linked (or DM blocked), so I can't deliver privately.`,
+      `Relay this to them yourself: ${result.code}`,
+    ].join('\n'),
+  );
+}

--- a/docs/specs/2026-05-03-nexus-rebuild-spec.md
+++ b/docs/specs/2026-05-03-nexus-rebuild-spec.md
@@ -1,0 +1,200 @@
+# Nexus Rebuild Spec — `src/app/nexus/` in ZAOOS
+
+> **Goal:** Rebuild `nexus.thezao.com` as a maintainable, data-driven, contributor-editable links hub inside ZAOOS. Replace the unmaintained Webflow embed.
+
+**Date:** 2026-05-03
+**Owner:** Zaal Panthaki
+**Source spec:** ChatGPT conversation "ZAO NEXUS" (2025-03-31, 363 msgs, https://chatgpt.com/c/[id])
+**Live (current):** https://nexus.thezao.com (Webflow embed, stale)
+**Target route in ZAOOS:** `/nexus` (initially) → spinout to own repo when stable per monorepo-as-lab pattern
+
+---
+
+## Why Rebuild
+
+The Webflow embed worked but failed at scale:
+- Manual edits = only Zaal could update
+- New ideas (Year of ZABAL series, YapZ episodes, ZAOstock pages) accumulated faster than the embed could capture
+- Community members couldn't add or maintain their own sections
+- No analytics on which links got clicked
+- No deeplinks to Bonfire knowledge graph
+
+Rebuilding inside ZAOOS gets us:
+- Supabase-backed link data → community contributors update their own sections
+- Auto-pull from community.config.ts where applicable
+- Click tracking via existing `src/app/api/activity/`
+- Cross-link to Bonfire graph (each link can carry a `bonfire_node_id` attribute)
+- Per-person "personal nexus" pages (Zaal's, Cassie's, Steve Peer's)
+
+---
+
+## Original Spec (preserved from ChatGPT conversation)
+
+### Brand colors
+
+```css
+:root {
+  --bg-color: #141e27;       /* deep navy */
+  --text-color: #e0ddaa;     /* soft yellow */
+  --accent-bg: #e0ddaa;      /* yellow boxes */
+  --accent-text: #141e27;    /* navy text inside yellow boxes */
+  --border-color: #141e27;
+  --hover-bg: #0f1620;
+  --hover-text: #e0ddaa;
+}
+.dark-mode {
+  /* swapped for alternate theme */
+  --bg-color: #e0ddaa;
+  --text-color: #141e27;
+  ...
+}
+```
+
+### Original data shape (Webflow embed)
+
+```js
+window.linksData = [
+  {
+    mainCategory: "ZAO Onchain",
+    subcategories: [
+      {
+        subTitle: "ZAO Tokens",
+        links: [
+          {
+            title: "Mint ZAO-CHELLA Vibez Track on Zora",
+            url: "https://song.thezao.com",
+            description: "Own a piece of the ZAO-CHELLA experience by minting the Vibez track."
+          },
+          {
+            title: "Mint Attabotty ZAO-PALOOZA Card",
+            url: "https://attabotty.zao.cards",
+            description: "Collect the limited-edition card."
+          }
+        ]
+      }
+    ]
+  },
+  // ... ZAO Community Links (Founder/Co-founder/Staff/Member buckets)
+];
+```
+
+### Original categories (final state)
+
+1. ZAO Onchain → ZAO Tokens (Zora mints, contracts, ZABAL, ZOUNZ)
+2. ZAO Community Links
+   - ZAO Founder BetterCallZaal Links (Linktree, interviews, YapZ)
+   - ZAO Co-Founder CandyToyBox Links
+   - ZAO Co-Founder Attabotty Links
+   - ZAO Co-Founder HURRIC4N3IKE Links
+   - ZAO Staff EZinCrypto Links
+   - ZAO Staff Ohnaji B Links
+   - ZAO Community Member Jed XO Links
+3. ZAO Festivals (PALOOZA, CHELLA, ZAOstock event pages)
+4. ZAO Music (DistroKid releases, Cipher when live)
+5. ZAO Research (zaoos.com/research, key DEEP docs)
+
+---
+
+## New Spec — what to build
+
+### Tech stack
+
+- **Frontend:** Next.js 16 + React 19 + Tailwind v4 (existing ZAOOS stack)
+- **Data:** Supabase table `nexus_links` with RLS
+- **Auth:** Reuse existing SIWF + iron-session
+- **Theme:** ZAO navy/gold per existing community.config.ts (verify variables match: `#0a1628` ZAOOS navy vs `#141e27` original navy — pick one, document)
+
+### Database schema
+
+```sql
+create table nexus_links (
+  id uuid primary key default gen_random_uuid(),
+  main_category text not null,        -- e.g. "ZAO Onchain"
+  subcategory text not null,           -- e.g. "ZAO Tokens"
+  title text not null,
+  url text not null,
+  description text,
+  owner_fid bigint references members(fid),  -- null = ZAO-org-owned
+  display_order int default 0,
+  is_active boolean default true,
+  bonfire_node_id text,                -- optional link to ZABAL bonfire entity
+  click_count int default 0,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create index nexus_links_main_idx on nexus_links(main_category, subcategory, display_order);
+create index nexus_links_owner_idx on nexus_links(owner_fid) where owner_fid is not null;
+```
+
+RLS:
+- Anyone reads `is_active = true`
+- Members write only their own `owner_fid` rows (so Cassie can update her links section without admin)
+- Admin writes any row
+
+### Routes
+
+- `/nexus` — main public page, all categories
+- `/nexus/[main_category]` — filter to one main category (e.g. `/nexus/zao-onchain`)
+- `/nexus/u/[fid]` — personal nexus for a specific member (Zaal's, Cassie's, etc.)
+- `/api/nexus/links` — GET all active links (cached 60s)
+- `/api/nexus/links/click` — POST click tracker
+- `/api/nexus/links/[id]` — PUT/DELETE owner-only edit
+
+### Components
+
+- `src/components/nexus/NexusGrid.tsx` — main grid render, mobile-first
+- `src/components/nexus/CategorySection.tsx` — collapsible main category
+- `src/components/nexus/LinkCard.tsx` — individual link tile (title + description + click handler)
+- `src/components/nexus/LinkEditor.tsx` — owner-edit modal (drag-reorder, add, edit, deactivate)
+
+### Migration from Webflow
+
+- One-time SQL script seeds `nexus_links` from the existing Webflow `linksData` array (pull from current nexus.thezao.com source)
+- Webflow embed continues to live at nexus.thezao.com initially; new ZAOOS route at `zaoos.com/nexus` runs in parallel
+- Once /nexus is verified, change DNS for nexus.thezao.com to point at zaoos.com/nexus
+
+### Bonfire integration
+
+Optional but high-value: each link can carry `bonfire_node_id`. When you query the bonfire `RECALL: who is Cassie?`, the agent surfaces her nexus links automatically. Closes the loop between graph + product.
+
+---
+
+## Open Questions for Zaal Before Build
+
+1. **Scope:** start with /nexus PUBLIC only, or include /nexus/u/[fid] personal pages from day 1?
+2. **Brand color:** use `#0a1628` (current ZAOOS navy) or `#141e27` (nexus original navy)? Or different theme entirely so nexus stands out?
+3. **Auto-pull:** which sections come from existing data (community.config.ts members, BCZ YapZ episodes from content/transcripts/) vs manually entered?
+4. **Permissions:** should ANY ZAO member with FID in allowlist be able to add their own section? Or only co-founders + staff?
+5. **Migrate when:** do you want the Webflow embed live during the build (parallel) or just deprecate the moment /nexus ships?
+6. **Bonfire integration:** worth doing in v1? Or v2 after the schema settles?
+
+---
+
+## Implementation Steps (suggested for whoever builds this)
+
+1. Create migration: `scripts/2026-05-03-nexus-links-schema.sql` with the table above
+2. Build API routes: `src/app/api/nexus/links/` (GET list, POST click, PUT/DELETE per-row)
+3. Build components: `src/components/nexus/*.tsx` per the list above
+4. Build pages: `src/app/nexus/page.tsx` + `src/app/nexus/[main_category]/page.tsx` + `src/app/nexus/u/[fid]/page.tsx`
+5. Seed migration: `scripts/2026-05-03-nexus-links-seed.sql` populated from current webflow JSON
+6. Add to nav in `community.config.ts`
+7. Test on Vercel preview
+8. Ship
+
+Estimate: 1-3 day build for v1 (public-only, no personal pages, no Bonfire integration). Add personal pages + Bonfire as v2.
+
+---
+
+## Bonfire INGEST trigger (paste to bot DM if desired)
+
+```
+INGEST FACT:
+Subject: Nexus Rebuild Spec
+Type: Decision
+Date: 2026-05-03
+Status: planned
+Description: Rebuild nexus.thezao.com as a data-driven, contributor-editable links hub inside ZAOOS at /nexus route. Replace the unmaintained Webflow embed. Spec at docs/specs/2026-05-03-nexus-rebuild-spec.md.
+Source: internal://docs/specs/2026-05-03-nexus-rebuild-spec.md
+Confidence: 1.0
+```


### PR DESCRIPTION
## Summary

Phase 4 of the Hermes bot upgrades. Lets team members ask Hermes about state in plain English instead of remembering slash commands.

\`\`\`
You: what's still open across the team?
Hermes: 19 open todos: ...

You: where are we with sponsors?
Hermes: [/status output]

You: what have I done this week?
Hermes: [/mycontributions output]
\`\`\`

## Mechanism

Extended the existing action parser (\`bot/src/actions.ts\`) with five read-only query kinds:

- \`query_my_todos\` -> buildMyTodos(member)
- \`query_all_open_todos\` -> buildAllOpenTodos()
- \`query_status\` -> buildStatus()
- \`query_my_contributions\` -> buildMyContributions(member)
- \`query_team_roster\` -> buildTeamRoster()

Parser system prompt teaches the LLM the routing rule: query (read-only) -> write (mutates DB) -> chat (free-form Hermes reply).

Read queries route BEFORE the write try/catch so a transient DB blip on a query doesn't get reported as a write failure.

## Test plan after merge + redeploy

- [ ] DM \`what's on my plate?\` -> /mytodos output
- [ ] DM \`what does the team still have to do\` -> /mytodos_all output
- [ ] DM \`festival snapshot\` -> /status output
- [ ] DM \`what have I done lately\` -> /mycontributions output
- [ ] DM \`who's on the team\` -> roster output
- [ ] DM \`Bangor committed \$500\` (existing write path) -> still works
- [ ] DM \`yo what's up\` (chat fallback) -> still works