### PR TITLE
doc 603: TradingAgents pattern → ZAO social + PM (not trading) (STANDARD)

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "ZAO OS V1"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/research/agents/602-tradingagents-pattern-for-social-pm/README.md
+++ b/research/agents/602-tradingagents-pattern-for-social-pm/README.md
@@ -1,0 +1,272 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 461, 529, 547, 600, 601
+tier: STANDARD
+---
+
+# 602 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
+
+> **Goal:** Document the TradingAgents (Tauric Research) multi-agent debate architecture. Identify which patterns transfer to ZOE's concierge brain (per doc 601 Option D) for two specific use cases: **social media posting decisions** and **project management decisions**. Explicitly NOT for trading — Zaal's call. Save for later use, don't implement now.
+
+## Recommendation (no preamble)
+
+**Steal 4 patterns from TradingAgents into ZOE-Hermes-brain. Skip the rest.**
+
+| Pattern | Steal? | Apply to |
+|---|---|---|
+| Two-tier LLM routing (deep_think + quick_think) | YES — already shipped in Hermes Sprint 1 (Sonnet + Opus + Haiku) | ZOE concierge brain (doc 601 Phase 1) |
+| Bullish/Bearish researcher debate | YES — high value for "should I post this?" + "should I ship this Tuesday?" decisions | ZOE social mode + PM mode |
+| Persistent decision log with reflection loop | YES — `~/.zao/memory/decisions.md`, inject recent decisions into next prompt | ZOE concierge brain |
+| Bounded debate rounds (2 default) | YES — simple cap, prevents loop spiral (matches doc 599 §"loop limit") | ZOE concierge brain |
+| Specialized analyst team (4 agents) | PARTIAL — 2-3 personas max, not 4. Don't over-design. | ZOE social mode |
+| LangGraph orchestration | SKIP — overkill for v1, adds dependency, our `bot/src/hermes/runner.ts` pattern is simpler | n/a |
+| Risk Management team + Portfolio Manager 2-stage approval | SKIP — Zaal IS the portfolio manager, no second layer needed | n/a |
+| Trading-specific roles (Fundamentals/Technical/News) | RENAME — same shape, different content. See mapping below. | ZOE social + PM modes |
+
+**Net:** 4 patterns to lift. ZOE-Hermes-brain becomes a debate engine for "should I post this?" and "should we ship this?" decisions. Trading itself stays out of scope per Zaal's explicit direction.
+
+## Source Material
+
+**Paper:** [TradingAgents: Multi-Agents LLM Financial Trading Framework](https://arxiv.org/abs/2412.20138)
+- Authors: Yijia Xiao, Edward Sun, Di Luo, Wei Wang
+- Submitted 2024-12-28, latest revision 2025-06-03
+- Category: Quantitative Finance (q-fin.TR)
+
+**Repo:** [github.com/TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents)
+- 66,034 stars, 12,781 forks (verified 2026-05-04)
+- Apache 2.0
+- Python 3.13
+- Last release v0.2.4 (2026-04) — structured-output agents + LangGraph checkpoint resume + DeepSeek/Qwen/GLM/Azure provider support
+
+## What TradingAgents Actually Does (the architecture)
+
+### 5 specialized teams collaborate to make ONE decision per stock per day
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (4 agents, parallel)                       │
+│   - Fundamentals Analyst   (financials, intrinsic value) │
+│   - Sentiment Analyst       (social media, public mood)  │
+│   - News Analyst            (macro events, news impact)  │
+│   - Technical Analyst       (MACD, RSI, price patterns)  │
+└────────────────────────┬─────────────────────────────────┘
+                         │ reports flow into
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (debate, max 2 rounds)                  │
+│   - Bullish Researcher  (defends optimistic case)        │
+│   - Bearish Researcher  (defends pessimistic case)       │
+│  → Structured debate, balanced perspective output        │
+└────────────────────────┬─────────────────────────────────┘
+                         │ debate winner + summary
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  TRADER AGENT                                            │
+│   - Synthesizes analyst + researcher outputs              │
+│   - Decides timing + magnitude                           │
+└────────────────────────┬─────────────────────────────────┘
+                         │ proposed trade
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RISK MANAGEMENT TEAM                                    │
+│   - Volatility, liquidity, exposure check                │
+│   - Adjusts strategy if risk-out-of-bounds               │
+└────────────────────────┬─────────────────────────────────┘
+                         │ risk-adjusted proposal
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  PORTFOLIO MANAGER                                       │
+│   - Final approve / reject                               │
+└──────────────────────────────────────────────────────────┘
+                         │ executed trade or rejected
+                         ▼
+                  Persistent decision log
+                  (~/.tradingagents/memory/trading_memory.md)
+                         │
+                         ▼ next run
+                Reflection loop: fetch realized return,
+                generate 1-paragraph reflection, inject
+                into next prompt for same ticker
+```
+
+### Key architectural primitives
+
+| Primitive | Implementation | What we steal |
+|---|---|---|
+| **Two-tier LLM routing** | `deep_think_llm` (e.g. gpt-5.4) for complex reasoning; `quick_think_llm` (e.g. gpt-5.4-mini) for fast tasks | Already in Hermes Sprint 1 cost routing — Sonnet (cheap/simple) + Opus (hard) + Haiku (fastest) |
+| **Bounded debate** | `max_debate_rounds: 2` default | Simple int config, hard cap prevents spiral |
+| **Persistent decision log** | Markdown file `~/.tradingagents/memory/trading_memory.md` appended on every run | Mirrors as `~/.zao/memory/zoe-decisions.md` |
+| **Reflection / learning loop** | After each run, fetch outcome, write reflection, inject into next prompt | High value — ZOE learns from past calls |
+| **LangGraph checkpoint resume** | Per-ticker SQLite at `~/.tradingagents/cache/checkpoints/<TICKER>.db` | SKIP — adds dependency, our bot/src/hermes runner is stateless enough |
+| **Multi-LLM provider abstraction** | `llm_provider: "openai"` config switch | We're committed to Claude (Max plan) — skip multi-provider for v1 |
+
+## Map to ZAO Use Cases (NOT trading)
+
+### Use case 1 — ZOE Social Mode (post decisions)
+
+When Zaal asks ZOE "should I post X" or "draft a post for Y", ZOE runs an internal debate before recommending.
+
+```
+INPUT: post draft or topic
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (3 agents, parallel)                       │
+│   - Brand Voice Analyst   (matches Year-of-the-ZABAL?)   │
+│   - Audience Resonance    (will FC/X audience care?)     │
+│   - Timing Analyst        (right news cycle moment?)     │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (2 rounds max)                          │
+│   - Pro-Post              (post now, here's why it lands)│
+│   - Anti-Post             (delay or rephrase, here's why)│
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  ZOE DRAFTER                                             │
+│   - Drafts final post in voice                           │
+│   - Or recommends "skip" with reasoning                  │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼ ZAAL APPROVES
+                  Posts via existing publish pipeline
+                  (Firefly for FC+X per memory)
+```
+
+**Replaces:** the cycle of "Zaal types post → posts → wonders if it lands."
+
+**Why this beats trading-style multi-agent for social:** social posts have qualitative outcomes (engagement, brand fit), not numeric (return %). Debate-pattern fits better than analyst-team-with-metrics.
+
+### Use case 2 — ZOE Project Management Mode (ship/wait decisions)
+
+When Zaal asks ZOE "should we ship X today" or "what's blocking ZAOstock", ZOE runs a debate.
+
+```
+INPUT: project name + question
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (3 agents, parallel)                       │
+│   - Project Health Analyst   (state from Bonfire graph)  │
+│   - Velocity Analyst          (commit/PR velocity, blockers)│
+│   - External Context Analyst  (calendar, partner deps)   │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (2 rounds max)                          │
+│   - Ship-It Advocate          (ready, here's the proof)  │
+│   - Wait-It-Out Advocate      (polish first, here's why) │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  ZOE PM RECOMMENDER                                      │
+│   - "Ship Tuesday" or "Delay 1 week" + reasoning         │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Replaces:** Zaal's intuition + ad-hoc team check-ins. Adds a second voice that's read everything in Bonfire and seen prior similar decisions.
+
+## Implementation Plan (when, not now)
+
+Per Zaal: **save for later, don't implement now.** This doc is the recipe for when ZOE-Hermes-brain (doc 601 Phase 1) is built and we want to add debate-mode personalities.
+
+When the time comes, build path:
+
+1. **Phase 1 (doc 601)** ships first — base ZOE-Hermes-brain in `bot/src/zoe/`
+2. **Phase 2 — debate mode** — add `bot/src/zoe/debate.ts` that:
+   - Takes a question + 3 analyst personas
+   - Runs them in parallel (one Claude call each, Sonnet for cost)
+   - Feeds reports into 2 researcher personas (Bullish + Bearish)
+   - Researchers debate up to `max_debate_rounds: 2`
+   - Final synthesizer (Opus for quality) recommends
+3. **Phase 3 — decision log** — append to `~/.zao/memory/zoe-decisions.md` after each run
+4. **Phase 4 — reflection loop** — after Zaal acts on the recommendation, ZOE asks "did it work?" + writes 1-line reflection to memory + injects into future prompts
+
+## Cost Profile (when implemented)
+
+Per debate run (~5-7 LLM calls):
+- 3 analyst personas × Sonnet 4.6 = ~$0.10
+- 2 researcher personas × Sonnet 4.6 × 2 rounds = ~$0.15
+- 1 synthesizer × Opus 4.7 = ~$0.20
+- **Total: ~$0.45 per debate**
+
+Or via Max plan + Claude Code CLI subprocess (Hermes pattern): **$0** marginal cost. Match Hermes' cost discipline.
+
+10 debates per day = $4.50/day on API OR $0/day on Max plan. **Always use Max plan path. Match Hermes Sprint 1 cost routing.**
+
+## Why NOT Implement Trading Agents
+
+Per Zaal explicit direction: **no trading at all for now.** Reasons:
+
+1. **Risk surface** — trading agents need wallet write access. Doc 581 documented bot hallucinations (fake UUIDs). A bot with wallet write that hallucinates a transaction is catastrophic.
+2. **Existing trading agents (VAULT/BANKER/DEALER)** — already in `src/lib/agents/` per doc 600. They run within tight parameters. No reason to add LLM-driven trading on top.
+3. **Focus** — ZAO is music + creator-economy + community. Trading isn't core mission.
+4. **Regulatory** — autonomous trading bots have securities-law implications. Not worth the headache for ZAO's stage.
+
+The pattern is GENERAL — trading is just the demo domain. Social + PM are higher-leverage applications for Zaal.
+
+## Patterns NOT to Steal
+
+| Pattern | Why skip |
+|---|---|
+| LangGraph dependency | Adds Python LangGraph framework. Our `bot/src/hermes/runner.ts` already orchestrates without it. |
+| LangGraph checkpoint SQLite | Hermes runs are short. Crash recovery via re-run is fine. |
+| 4 separate analyst types | Over-design for v1. 2-3 max. Add complexity only if recall quality is poor. |
+| Multi-provider LLM abstraction | We're committed to Claude (Max plan). Adding OpenAI/Gemini/xAI fallback adds API key management without value. |
+| Portfolio Manager 2-stage approval | Zaal IS the final approver. Adding a second LLM layer is theater. |
+| Per-stock/ticker checkpointing | Our debate scope is "per-decision," not "per-ticker." Different shape. |
+
+## Comparison to Existing ZAO Patterns
+
+| Pattern | TradingAgents | Existing in ZAO | Net |
+|---|---|---|---|
+| Two-tier LLM | deep_think + quick_think | Hermes Sprint 1 routing (Sonnet/Opus/Haiku) | ✓ already have it |
+| Multi-agent debate | Bull vs Bear researchers, 2 rounds | Doc 599 patterns (RECALL/DRAFT/REVIEW), but no formal debate | NEEDS adoption |
+| Persistent decision log | `~/.tradingagents/memory/trading_memory.md` | Bonfire graph holds Decision nodes | Bonfire IS this layer (doc 569 ontology) |
+| Reflection loop | Post-run reflection injected into next prompt | Bonfire's outcome attribute (doc 569 + 581 status: shipped/dead/evolved) | Bonfire IS this layer |
+| Bounded debate | max_debate_rounds | Doc 599 §"loop limit: max 3 RECALL rounds per task" | ✓ already have the principle |
+| LangGraph orchestration | LangGraph | bot/src/hermes/runner.ts (custom TS) | We have simpler equivalent |
+
+**Insight:** ZAO already has half the pattern via Bonfire (memory) + Hermes (runtime). The MISSING piece is the **debate layer** — internal Bull/Bear before recommending. That's what doc 602 says to add.
+
+## Also See
+
+- [Doc 461](../../dev-workflows/461-fix-pr-pipeline-design/) — fix-PR pipeline (Hermes runtime pattern)
+- [Doc 529](../529-hermes-quality-pipeline-pre-critic-gates/) — Hermes pre-critic gates
+- [Doc 547](../547-multi-agent-coordination-bonfire-zoe-hermes/) — multi-agent coordination
+- [Doc 600](../600-agentic-stack-coordination-v1/) — current stack inventory
+- [Doc 601](../601-agent-stack-cleanup-decision/) — Hermes-as-ZOE-brain decision (Option D)
+
+## Next Actions
+
+| Action | Owner | Type | When |
+|--------|-------|------|------|
+| Save this doc as reference for future ZOE debate-mode build | Claude | Doc | Done with this commit |
+| Reference in Phase 2 of doc 601 implementation if Zaal wants debate-mode added to ZOE concierge | Claude | Plan | After doc 601 Phase 1 complete |
+| Re-read Trading-R1 paper ([arxiv 2509.11420](https://arxiv.org/abs/2509.11420)) when its Terminal repo lands — may have RL-trained debate patterns | Claude | Research | Q3 2026 if ZOE debate mode shipped |
+| Don't implement trading agents — VAULT/BANKER/DEALER stays in current scoped form per src/lib/agents/ | n/a | Discipline | Permanent |
+
+## Sources
+
+- [TradingAgents arxiv paper](https://arxiv.org/abs/2412.20138) — verified 2026-05-04, abstract + architecture extracted via WebFetch
+- [TradingAgents GitHub](https://github.com/TauricResearch/TradingAgents) — verified 2026-05-04, README inspected via gh api, 66034 stars, Apache 2.0
+- [Trading-R1 technical report](https://arxiv.org/abs/2509.11420) — referenced in TradingAgents v0.2.4 changelog, terminal repo expected later
+- TradingAgents CHANGELOG.md — v0.2.4 (2026-04) added structured-output agents, v0.2.3 multi-language, v0.2.2 GPT-5.4/Gemini 3.1/Claude 4.6 coverage, v0.2.0 multi-provider support
+- Internal: docs 461, 529, 547, 600, 601 — existing ZAO agent patterns this doc maps against
+
+## Citation (if we ever publish on this)
+
+```
+@misc{xiao2024tradingagentsmultiagentsllm,
+      title={TradingAgents: Multi-Agents LLM Financial Trading Framework},
+      author={Yijia Xiao and Edward Sun and Di Luo and Wei Wang},
+      year={2024},
+      eprint={2412.20138},
+      archivePrefix={arXiv},
+      primaryClass={q-fin.TR}
+}
+```

--- a/research/agents/603-tradingagents-pattern-for-social-pm/README.md
+++ b/research/agents/603-tradingagents-pattern-for-social-pm/README.md
@@ -7,7 +7,7 @@ related-docs: 461, 529, 547, 600, 601
 tier: STANDARD
 ---
 
-# 602 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
+# 603 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
 
 > **Goal:** Document the TradingAgents (Tauric Research) multi-agent debate architecture. Identify which patterns transfer to ZOE's concierge brain (per doc 601 Option D) for two specific use cases: **social media posting decisions** and **project management decisions**. Explicitly NOT for trading — Zaal's call. Save for later use, don't implement now.
 

--- a/research/business/602-empire-builder-skill-spec-phase3-unblock/README.md
+++ b/research/business/602-empire-builder-skill-spec-phase3-unblock/README.md
@@ -1,0 +1,136 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 361, 582, 583, 584, 585, 586
+tier: STANDARD
+---
+
+# 602 - Empire Builder SKILL.md Spec: Phase 3 Unblock + 6 New Build Targets
+
+> **Goal:** Adrian published the full V3 integration spec at `https://www.empirebuilder.world/skill/SKILL.md` (forwarded by Zaal to ZOE inbox 2026-05-03). This doc parses it, maps the new endpoints to our open issues, identifies which Phase-3 issues are NOW UNBLOCKED, and surfaces 6 new build targets the spec exposed (EB-19 through EB-24).
+
+---
+
+## Key Decisions / Recommendations
+
+| # | Decision | Recommendation |
+|---|----------|----------------|
+| 1 | Phase 3 status | UNBLOCKED. Spec ships full write API: `POST /api/distribute-prepare`, `POST /api/store-distribution`, `POST /api/store-burn`, `POST /api/store-airdrop`, `POST/DELETE /api/boosters/[empire_id]`, plus 10+ leaderboard create/refresh routes. No more waiting on Adrian for write endpoints. |
+| 2 | Owner-vs-co-signer constraint | The vault `owner()` must broadcast `executeBatch` for distributions. ZABAL_OWNER = `0x7234c36A71ec237c2Ae7698e8916e0735001E9Af` (Zaal's wallet). Co-signers (any future co-emperor) cannot use the API path - they go through the web app sponsored UserOp flow. **Implication:** BANKER auto-distribute needs server-side signing as Zaal OR Zaal pre-signs and we cache the bundle. |
+| 3 | Booster proposal (doc 586, lost in merge) | SHIP DIRECTLY. The `POST /api/boosters/<empire_id>` endpoint accepts an owner-signed payload. Zaal can self-add CLANKER + GLANKER + ARTBABY + BB + PUSH from his own wallet without DM-ing Adrian. Multiplier constraint: `1.1` to `5.0`, max 1 decimal place. Skip the Telegram step - run the API call. |
+| 4 | API key | The user-mentioned key from Apr 30 is for `x-api-key` header. Goes in `.env.local` as `EMPIRE_BUILDER_API_KEY`. Server-only. Never paste in chat. |
+| 5 | New leaderboard types ZABAL can use | 10 types now documented (was 4 in doc 584). Worth shipping for ZABAL: `farcasterChannelLeaderboards` (rank /zabal channel activity), `farcasterCastLeaderboards` (rank engagement on a single GM cast), `csvLeaderboards` (manual quarterly leaderboards for ZAOstock contributors), `apiLeaderboards` (ZAO RESPECT feed). |
+| 6 | Voting Miniapp slot (doc 584) | Now we know how it works. `apiLeaderboards` requires an `apiEndpoint` URL the EB server fetches. ZAOOS hosts a JSON endpoint, EB pulls. Refresh via `PATCH /api/leaderboards/refresh/apiLeaderboards` with ~30s cooldown. Ship EB-17 native vote-cast as ZAOOS-hosted endpoint that EB consumes. |
+| 7 | Burn tracking (#427 EB-9) | NOT a webhook, never was. We poll Base/Arbitrum logs for ERC-20 Transfer to `0x0` or `0xdEaD` from the ZABAL token, then `POST /api/store-burn`. Pure cron. |
+| 8 | Multi-chain | SmartVault deploys on **Base 8453 AND Arbitrum 42161** with same logical address. Distribution `transactions[]` array splits across chains. Order: ascending `batchIndex` per `chainId`. Our cron must broadcast to both chains. |
+
+## Six New Build Targets the Spec Surfaced
+
+| New Issue | Title | Maps to spec endpoint | Old issue replaced/extends | Difficulty |
+|-----------|-------|------------------------|------------------------------|------------|
+| EB-19 | BANKER weekly distribute via API | `POST /api/distribute-prepare` -> `executeBatch` -> `POST /api/store-distribution` | replaces #426 EB-8 | 8/10 |
+| EB-20 | Burn watcher cron + store-burn | `POST /api/store-burn` | replaces #427 EB-9 | 5/10 |
+| EB-21 | ZAO RESPECT api-leaderboard JSON endpoint | `POST /api/leaderboards/apiLeaderboards` + `PATCH /api/leaderboards/refresh/apiLeaderboards` + new ZAOOS route hosting JSON | extends #420 EB-6 + new | 5/10 |
+| EB-22 | /zabal Farcaster channel leaderboard slot | `POST /api/leaderboards/farcasterChannelLeaderboards` | new (informed by #422 EB-12) | 3/10 |
+| EB-23 | GM streak farcasterCast leaderboard | `POST /api/leaderboards/farcasterCastLeaderboards` | new | 3/10 |
+| EB-24 | Self-serve booster proposal flow | `POST /api/boosters/<empire_id>` (owner-signed) | replaces doc 586 (#433 EB-18) | 4/10 |
+
+Also: refresh booster + leaderboard adds via `PATCH /api/leaderboards/refresh/<type>` (cooldown ~30s). Bake into all leaderboard types.
+
+## Existing Issue Status After Spec
+
+| Issue | Title | New status |
+|-------|-------|-------------|
+| #417 EB-2 | Inline empireMultiplier badge on chat messages | Same. Read-only. |
+| #418 EB-3 | Live ZABAL distribution feed in /zabal | Same. Read-only. |
+| #419 EB-5 | Boosters dashboard | Already shipped read-side (PR #434). Now also has add/remove path via EB-24. |
+| #420 EB-6 | My Empires page | Same. Read-only. Could extend with deploy-empire if Zaal deploys more empires. |
+| #421 EB-10 | Live leaderboard preview on chat URL embeds | Same. Read-only. |
+| #422 EB-12 | Empire-gated chat features | Same. Top-100 set still pulled from /api/leaderboards/<id>. |
+| #423 EB-13 | Auto-cast distributions to /zabal | Same. Polling-based. |
+| #424 EB-14 | Stake-to-earn forecast | Same. Read-only. |
+| #425 EB-7 | Cross-empire respect amplifier | UNBLOCKED. Implementable via `POST /api/boosters/<empire_id>` + ZAO RESPECT score via apiLeaderboards (EB-21). |
+| #426 EB-8 | BANKER auto-distribute | UNBLOCKED. Replace with EB-19. Close #426 once EB-19 ships. |
+| #427 EB-9 | Webhook receiver for distribute / burn | OBSOLETE. EB never ships webhooks; we own the polling. Replace with EB-20 (burn cron). Close #427. |
+| #431 EB-16 | Cross-product slot dashboard | Shipped read-side in PR #434. |
+| #432 EB-17 | Voting Miniapp surface | Read-side shipped. Write-side now spec'd via apiLeaderboards (EB-21 enables it). |
+| #433 EB-18 | Booster proposal one-pager for Adrian | OBSOLETE - Zaal can self-add via API. Replace with EB-24. Close #433. |
+
+## Spec Highlights (3 specific numbers + integration anchors)
+
+- **2 chains**: Base `8453` + Arbitrum `42161`. Same vault address on both.
+- **10 leaderboard types**: `tokenHoldersLeaderboards`, `nftLeaderboards`, `apiLeaderboards`, `csvLeaderboards`, `farTokenLeaderboards`, `tipnLeaderboards`, `farcasterCastLeaderboards`, `farcasterChannelLeaderboards`, `farcasterInteractionLeaderboards`, `quotientLeaderboards`. Each has its own `POST /api/leaderboards/<type>` create endpoint.
+- **3 distribution modes**: `even` (split equally), `weighted` (by score), `raffle` (with `raffleWinnerCount`).
+- Booster multiplier range: `1.1` to `5.0`, max 1 decimal place.
+- Refresh cooldown per leaderboard: ~30s.
+- Signature field name varies: `signerAddress` for leaderboard creates, `signer` for boosters and `distribute-prepare`.
+- `distribute-prepare` returns `transactions[]`. Broadcast in ascending `batchIndex` per `chainId`. Success when `receipt.status === 1`.
+- ABI: SmartVault is ERC-4337. `execute(Call)` and `executeBatch(Call[])`. Co-signer EOA reverts `Unauthorized` on direct calls.
+
+## Recommended Ship Sequence (Iteration-3)
+
+| Order | Issue | Why first |
+|-------|-------|-----------|
+| 1 | EB-24 (self-serve booster add) | Smallest scope, validates owner-signing flow end-to-end, immediately ships the booster expansion (CLANKER/GLANKER/ARTBABY/BB/PUSH) the team has been waiting on |
+| 2 | EB-20 (burn watcher cron) | No signing needed, only API key. Pure polling. Closes #427. |
+| 3 | EB-22 (Farcaster channel leaderboard slot creation) | One signed POST. Adds the /zabal channel as a new leaderboard type for ZABAL. Surfaces in our existing EmpirePanel (PR #434) automatically. |
+| 4 | EB-21 (apiLeaderboards JSON endpoint for ZAO RESPECT) | Builds on existing `src/lib/respect/leaderboard.ts`. Lets ZABAL Empire pull live OG/ZOR scores. |
+| 5 | EB-23 (farcasterCast GM streak leaderboard) | Pick a recurring GM cast, score by likes/recasts. Fun + low risk. |
+| 6 | EB-19 (BANKER weekly distribute) | Highest difficulty. Requires owner-signing infra, on-chain gas (Base + Arbitrum), and transaction tracking. Save for last after the 5 above prove the signing/refresh flow. |
+
+## Risks + Open Questions
+
+| Risk / Question | Mitigation |
+|------------------|-------------|
+| Owner-signing infra | EB-24 first as smallest test of EIP-191 flow. If Zaal doesn't want a server-side wallet that IS the owner, build a "request signature" UI where Zaal pastes a signed message into the dashboard. |
+| Gas pre-funding for EB-19 | ZABAL_OWNER wallet must hold ETH on Base + Arbitrum to broadcast. Forecast gas costs before shipping. |
+| Spec drift | The SKILL.md is dated as of 2026-05-03. Recheck before shipping each iteration-3 issue. |
+| Sponsored UserOp path (web app) | We do NOT use this. API integration is direct vault `executeBatch` only. Don't conflate. |
+| Token type for new leaderboards | `apiLeaderboards`, `nftLeaderboards`, `tipnLeaderboards`, `farTokenLeaderboards`, `quotientLeaderboards` reject tokenless empires. ZABAL is token-based so unaffected. |
+
+## Sources
+
+External (verified 2026-05-04):
+- [Empire Builder skill index](https://www.empirebuilder.world/skill/SKILL.md)
+- [Empire Builder HTTP API reference](https://www.empirebuilder.world/skill/references/http-api.md)
+- [Empire Builder workflows reference](https://www.empirebuilder.world/skill/references/workflows.md)
+- [Empire Builder contracts reference](https://www.empirebuilder.world/skill/references/contracts.md)
+
+Inbox source:
+- ZOE inbox message from `zaalp99@gmail.com` dated 2026-05-03T23:05:12Z, subject = URL only, body = `https://www.empirebuilder.world/skill/SKILL.md`
+
+Internal:
+- [Doc 361](../361-empire-builder-deep-dive-v3-integration/) - V2 baseline + ZABAL token address
+- [Doc 582](../582-empire-builder-v3-live-launch/) - V3 endpoint surface
+- [Doc 583](../583-empire-builder-zao-os-integration-ideas/) - 15-idea iteration-1 surface
+- [Doc 584](../584-empire-builder-farcaster-creator-playbooks/) - top-creator playbooks DEEP
+- [Doc 585](../585-empire-builder-test-loop-ideas-iteration-2/) - test-loop findings
+- Memory: `project_empire_builder_zabal_integration.md`
+- Code: `src/lib/empire-builder/{config,types,client,cache}.ts`, `src/components/chat/EmpirePanel.tsx`
+- Issues: #413-#427 (iteration-1), #431-#433 (iteration-2)
+
+Community sources: SKILL.md is Adrian's official spec - skip Reddit/X for STANDARD tier (zero new signal vs the spec).
+
+## Also See
+
+- [Doc 584](../584-empire-builder-farcaster-creator-playbooks/) - the live-data deep dive
+- [Doc 585](../585-empire-builder-test-loop-ideas-iteration-2/) - iteration-2 idea ranking
+- [Doc 586 in PR #434 commit](../586-zabal-booster-network-effect-proposal/) - the booster proposal text (lost in merge, OBSOLETE per EB-24)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Open 6 new GitHub issues EB-19 through EB-24 with the acceptance criteria above | @Claude | Issues | After this PR lands |
+| Close obsolete issues #426 (replaced by EB-19), #427 (replaced by EB-20), #433 (replaced by EB-24) with link to this doc | @Claude | Issue close | After issues open |
+| Add `EMPIRE_BUILDER_API_KEY` to Vercel env (production + preview). Confirm key from Adrian via Telegram. | @Zaal | Vercel UI | Before shipping EB-24 |
+| Pick start point for iteration-3: recommend EB-24 (booster self-serve) as the smallest end-to-end signing test | @Zaal | Decision | Next session |
+| Update `src/lib/empire-builder/types.ts` with the 6 new leaderboard types (`csvLeaderboards`, `tipnLeaderboards`, `farcasterCastLeaderboards`, `farcasterChannelLeaderboards`, `farcasterInteractionLeaderboards`, `quotientLeaderboards`) | @Claude (next session) | PR | Before shipping any leaderboard-creation endpoint |
+| Mark inbox message from 2026-05-03 as `processed` with labels `[research, processed]` | @Claude | inbox API | This session |
+
+## Staleness Notes
+
+- All spec data current as of 2026-05-04. SKILL.md may evolve; recheck before each iteration-3 issue ships.
+- The booster proposal in doc 586 is now OBSOLETE - Zaal self-adds boosters via API instead of DM-ing Adrian. Close issue #433 once EB-24 ships.


### PR DESCRIPTION
## Summary
Researched arxiv 2412.20138 + github.com/TauricResearch/TradingAgents (66K stars, Apache 2.0). Documented the 5-team multi-agent debate architecture. Mapped to ZAO use cases: ZOE Social Mode + ZOE PM Mode. **Explicitly NOT for trading per Zaal — saved for later use as part of ZOE-Hermes-brain (doc 601 Phase 2+).**

Originally numbered 602 — renumbered to 603 to avoid collision with research/business/602-empire-builder-skill-spec-phase3-unblock from parallel session.

## Tier
STANDARD — paper + repo + 1 cross-reference (Trading-R1)

## Steal (4 patterns)
1. Two-tier LLM routing (already in Hermes Sprint 1)
2. Bullish vs Bearish debate for ship/post decisions
3. Persistent decision log (Bonfire already does this via Decision nodes)
4. Bounded debate (2 rounds, matches doc 599 loop limit)

## Skip
LangGraph dependency, 4 analyst types (over-design), multi-provider LLM abstraction (Claude Max plan committed), 2-stage approval theater, per-ticker checkpoints.

## Use Cases (when implemented later)
- ZOE Social Mode: 3 analyst personas → Pro/Anti-Post debate → drafter
- ZOE PM Mode: 3 analyst personas → Ship-It/Wait-It-Out debate → recommendation

## Why no trading
Wallet write surface + hallucination risk + off-mission for ZAO + securities-law headaches. VAULT/BANKER/DEALER stays scoped in src/lib/agents/.

## Next
Reference in doc 601 Phase 2 build when ZOE concierge is shipped + we want to add debate-mode.