### PR TITLE
doc 605: agentic tooling May 2026 survey (DISPATCH)

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "ZAO OS V1"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- typescript
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,25 @@ Env vars: see `.env.example`. App wallet: `npx tsx scripts/generate-wallet.ts`.
 ## Skills
 
 See [Doc 154](research/154-skills-commands-master-reference/) for complete reference. Key commands: `/worksession`, `/z`, `/qa`, `/ship`, `/review`, `/zao-research`, `/autoresearch`, `/vps`.
+
+## Primary Surfaces (post-doc-601 cleanup, 2026-05-04)
+
+ZAO operating surfaces collapsed from 12+ systems to 5. When proposing automation or new bots, check this list first.
+
+| Surface | What | Source of truth |
+|---------|------|-----------------|
+| **ZOE** (`@zaoclaw_bot`) | Single concierge — tasks, captures, brief/reflect, recall | `bot/src/zoe/` (Hermes-brain pattern) |
+| **Hermes** (`@zoe_hermes_bot`) | Autonomous fix-PR pipeline (coder + critic + auto-PR) | `bot/src/hermes/` |
+| **ZAO Devz** (`@zaodevz_bot`) | Group dispatch + hourly learning tip | `bot/src/devz/` (Phase 3 fold-in to Hermes pending) |
+| **Bonfire** (`@zabal_bonfire`) | Knowledge graph recall + multi-corpus ingest | bonfires.ai (Genesis tier, wallet-gated) |
+| **ZAOstock bot** (`@ZAOstockTeamBot`) | Festival team coordination, graduates with ZAOstock spinout | `bot/` (root, separate from `bot/src/zoe/`) |
+
+**Decommissioned 2026-05-04 — do NOT propose, build, or restart:**
+
+- openclaw container + 7-agent squad (ZOEY/BUILDER/SCOUT/WALLET/FISHBOWLZ/CASTER) — source of "·" pings
+- Composio AO orchestrator
+- ZOE v2 / Agent Zero migration plan
+- 10-bot branded fleet (Magnetiq/Research/WaveWarZ/POIDH as own bots) — folds into ZOE memory blocks
+- FISHBOWLZ (paused 2026-04-16, killed 2026-05-04 — Juke partnership stands)
+
+**Rule: no new bots without doc.** Before adding a new Telegram bot, agent process, or autonomous loop, write a numbered research doc + get explicit Zaal approval. New brand voices = persona block in `bot/src/zoe/` `human.md`, NOT a new bot. Reference `research/agents/601-agent-stack-cleanup-decision/`.

--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -66,7 +66,7 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
     // the final JSON. We need both. The system prompt asks for JSON in the
     // final assistant message; the orchestrator parses it. Schema is kept on
     // the type only as a contract reference.
-    void opts.jsonSchema; // eslint-disable-line @typescript-eslint/no-unused-vars
+    void opts.jsonSchema;  
     if (opts.maxBudgetUsd !== undefined) {
       args.push('--max-budget-usd', String(opts.maxBudgetUsd));
     }

--- a/bot/src/schedule.ts
+++ b/bot/src/schedule.ts
@@ -1,7 +1,5 @@
 // Scheduled digests via node-cron. Times in America/New_York so "6am EST" stays 6am after DST.
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error: node-cron has no types bundled
 import cron from 'node-cron';
 import { morningDigest, eveningRecap, weekAheadDigest, fridayRetro } from './digest';
 import { getDigestChats } from './group';

--- a/bot/src/zoe/README.md
+++ b/bot/src/zoe/README.md
@@ -1,0 +1,110 @@
+# bot/src/zoe — ZOE concierge brain
+
+Replaces the openclaw container with a Hermes-style Claude Code CLI subprocess bot.
+
+ZOE is Zaal Panthaki's personal concierge running on @zaoclaw_bot. Daily tasks, captures, proactive nudges, recall via Bonfire bridge.
+
+## Architecture (Letta-inspired memory blocks)
+
+Every concierge turn assembles 4 named blocks of context and invokes Claude Code CLI:
+
+```
+<persona>     — ZOE identity + Year-of-the-ZABAL voice rules
+<human>       — Zaal facts (ENS, schedule, projects, relationships)
+<working>     — last 5 turns from this Telegram thread
+<tasks>       — open task queue snapshot
+```
+
+Then: `Zaal: <user message>` appended.
+
+Claude responds. If response includes a JSON block with task_ops or captures, apply them. Reply text goes back to Zaal in Telegram.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `index.ts` | Telegram polling main entry, dispatch, scheduler boot |
+| `concierge.ts` | runConciergeTurn — Claude CLI call + reply parsing |
+| `memory.ts` | Memory block builder + persistence (~/.zao/zoe/) |
+| `tasks.ts` | Task queue read/write + seed initial todos |
+| `recall.ts` | Bonfire bridge (manual relay until SDK lands) |
+| `brief.ts` | Morning brief generator (5am EST daily) |
+| `reflect.ts` | Evening reflection generator (9pm EST daily) |
+| `scheduler.ts` | node-cron triggers, no quiet hours |
+| `types.ts` | Shared types + cost-routing helpers |
+
+## Storage layout (host)
+
+```
+~/.zao/zoe/
+  persona.md         — versioned in repo, copy on first boot
+  human.md           — local cache, refreshed daily (Zaal facts)
+  recent.json        — last 5 turns, FIFO ring buffer
+  tasks.json         — open task queue
+  sentinels/         — daily flags to prevent double-fires (e.g. morning-brief-2026-05-04.flag)
+```
+
+## Env vars
+
+| Var | Required | Notes |
+|---|---|---|
+| `ZOE_BOT_TOKEN` or `TELEGRAM_BOT_TOKEN` | yes | @zaoclaw_bot Telegram token |
+| `ZAAL_TELEGRAM_ID` | yes | Zaal's Telegram user_id (allowlist guard) |
+| `ZOE_REPO_DIR` | no | default `/home/zaal/zao-os` |
+| `ZAO_DEVZ_CHAT_ID` | no | for hourly tip cron (Phase 4) |
+| `BONFIRE_API_KEY` | no | once Joshua.eth provisions, recall.ts uses SDK |
+| `BONFIRE_ID` | no | bonfire UUID |
+| `BONFIRE_AGENT_ID` | no | agent UUID |
+| `ZOE_DEFAULT_MODEL` | no | default `sonnet` |
+| `ZOE_HARD_MODEL` | no | default `opus` |
+| `ZOE_QUICK_MODEL` | no | default `haiku` |
+
+## Cost routing (Sprint 1 pattern from Hermes)
+
+- Default: Sonnet (cheap, fast, $0 marginal via Max plan)
+- Hard reasoning: Opus (when LLM self-flags `escalate: true` in JSON output)
+- Quick factual: Haiku (auto-routed for short factual queries)
+
+Hard cap: 50 LLM calls/day (alert if exceeded).
+
+## Run locally (dev)
+
+```bash
+cd bot
+pnpm install
+ZOE_BOT_TOKEN=... ZAAL_TELEGRAM_ID=... pnpm tsx src/zoe/index.ts
+```
+
+## Production (VPS)
+
+Add to existing `zao-devz-stack.service` systemd user unit, or create separate `zoe-bot.service`. Token comes from `bot/.env` or systemd `EnvironmentFile=`.
+
+## Phase status (per doc 601)
+
+- [x] Phase 1 scaffold — types, concierge, memory, tasks, recall, brief, reflect, scheduler, index, README (this commit)
+- [ ] Phase 2 cutover — move TELEGRAM_BOT_TOKEN from openclaw to bot/.env, register zoe in systemd unit, test from phone
+- [ ] Phase 3 — fold Devz bot into Hermes webhook
+- [ ] Phase 4 — replace zoe-learning-pings python cron
+- [ ] Phase 5 — Letta-style self-improving `human` block updates
+- [ ] Phase 6 — TradingAgents debate mode for social/PM decisions (deferred per Zaal 2026-05-04)
+
+## Anti-patterns (from doc 604 + openclaw experience)
+
+- Never silent retry on empty result (openclaw's "·" ping bug)
+- Never ask "Would you like me to..." — just do it
+- Never claim memory state changes that didn't occur (doc 581)
+- Empty-reply guard: validate response >5 chars before posting
+- Quiet hours: NONE per Zaal feedback 2026-05-04 (rather get pinged than ignored)
+
+## Related docs
+
+- doc 461 — fix-PR pipeline (Hermes runtime pattern)
+- doc 547 — multi-agent coordination
+- doc 568 — local KG memory stack alternatives
+- doc 570 — agentic memory architecture
+- doc 581 — bot bug postmortem
+- doc 599 — bridge group pattern (deferred autonomy)
+- doc 600 — agentic stack v1 inventory
+- doc 601 — Hermes-as-ZOE-brain decision (Option D)
+- doc 603 — TradingAgents debate pattern (saved for Phase 6)
+- doc 604 — best concierge agents 2026 (this scaffold's source of truth)

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -1,0 +1,125 @@
+/**
+ * Morning brief — runs daily at 5am EST (09:00 UTC).
+ *
+ * Replaces ~/bin/morning-brief.sh on VPS. Generates a contextual briefing
+ * via Claude CLI using current task queue + recent captures + git activity
+ * + open PRs. Posts to Zaal's DM.
+ *
+ * Output format (matches the existing morning brief screenshot Zaal liked):
+ *   Morning brief - Mon May 04 5am
+ *   TOP PRIORITIES (N P0, M P1)
+ *   - P0/P1 list
+ *   LAST 24H COMMITS
+ *   - list
+ *   OPEN PRS
+ *   - list
+ *   portal.zaoos.com/todos - brain dump
+ */
+import { callClaudeCli } from '../hermes/claude-cli';
+import { listOpenTasks } from './tasks';
+import { execSync } from 'node:child_process';
+
+const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
+
+VOICE: Year-of-the-ZABAL — clear, simple, spartan, active voice. No emojis, no em dashes, no marketing. Match the existing brief format exactly.
+
+OUTPUT FORMAT (exact structure):
+
+Morning brief - {Day} {Mon DD} 5am
+
+TOP PRIORITIES ({P0 count} P0, {P1 count} P1)
+- P0/P1 priority items, one per line. Group by priority.
+
+LAST 24H COMMITS
+- List of commit subjects from last 24h. (none) if nothing.
+
+OPEN PRS
+- List of open PRs by number + title.
+
+portal.zaoos.com/todos - brain dump
+
+Output the brief in plaintext. NO markdown headers, NO emojis, NO pleasantries.`;
+
+interface BriefContext {
+  today_iso: string;
+  open_tasks: Array<{ priority: string; title: string }>;
+  commits_24h: string[];
+  open_prs: Array<{ number: number; title: string }>;
+}
+
+function todayLabel(): { day: string; date: string } {
+  const d = new Date();
+  const day = d.toLocaleDateString('en-US', { weekday: 'short' });
+  const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return { day, date };
+}
+
+async function loadBriefContext(repoDir: string): Promise<BriefContext> {
+  const tasks = await listOpenTasks();
+  let commits24h: string[] = [];
+  try {
+    const log = execSync(`git -C ${JSON.stringify(repoDir)} log --since="24 hours ago" --no-merges --pretty=format:"%s" 2>/dev/null`, {
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+    commits24h = log.split('\n').filter((l) => l.trim()).slice(0, 15);
+  } catch {
+    commits24h = [];
+  }
+
+  let prs: Array<{ number: number; title: string }> = [];
+  try {
+    const json = execSync('gh pr list --repo bettercallzaal/ZAOOS --state open --limit 10 --json number,title', {
+      encoding: 'utf8',
+      timeout: 8000,
+    });
+    prs = JSON.parse(json) as Array<{ number: number; title: string }>;
+  } catch (err) {
+    console.error('[zoe/brief] gh pr list failed:', (err as Error).message);
+    prs = [];
+  }
+
+  return {
+    today_iso: new Date().toISOString().slice(0, 10),
+    open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
+    commits_24h: commits24h,
+    open_prs: prs,
+  };
+}
+
+export async function generateMorningBrief(opts: { repoDir: string; model?: string }): Promise<string> {
+  const ctx = await loadBriefContext(opts.repoDir);
+  const { day, date } = todayLabel();
+
+  const userPrompt = `Generate the morning brief for ${day} ${date}.
+
+CONTEXT:
+- Open tasks: ${JSON.stringify(ctx.open_tasks, null, 2)}
+- Last 24h commits: ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
+- Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
+
+Output the brief now in the exact format from your system prompt.`;
+
+  const result = await callClaudeCli({
+    model: opts.model ?? 'sonnet',
+    prompt: userPrompt,
+    cwd: opts.repoDir,
+    appendSystemPrompt: BRIEF_SYSTEM_PROMPT,
+    permissionMode: 'auto',
+    bare: true,
+  });
+
+  return guardEmpty(result.text);
+}
+
+const EMPTY_GUARD_MIN = 50;
+
+function guardEmpty(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length < EMPTY_GUARD_MIN) {
+    console.error('[zoe/brief] empty/short brief output, length=', trimmed.length, 'raw=', trimmed.slice(0, 200));
+    const { day, date } = todayLabel();
+    return `Morning brief - ${day} ${date} 5am\n\n(brief generation degraded — see logs)\n\nportal.zaoos.com/todos - brain dump`;
+  }
+  return trimmed;
+}

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -1,0 +1,166 @@
+/**
+ * ZOE concierge brain — calls Claude Code CLI with concierge system prompt
+ * and Zaal-personalized context. Returns reply + task ops + captures.
+ *
+ * Sister to bot/src/hermes/coder.ts (which does code-fix). This one does
+ * "talk to Zaal day-to-day."
+ */
+import { callClaudeCli } from '../hermes/claude-cli';
+import type { ConciergeOptions, ConciergeResult, ZoeContext, TaskOp, ZoeCaptureNote } from './types';
+import { selectModel, ZOE_DEFAULT_MODEL } from './types';
+
+const ZOE_VERSION = '0.1.0';
+
+/**
+ * Concierge system prompt. Loaded into Claude Code CLI on every concierge call.
+ * Matches Year-of-the-ZABAL Paragraph voice (clear, simple, spartan, active voice).
+ *
+ * Tool use: ZOE has Read/Glob/Grep/Bash to inspect the ZAOOS repo, plus the
+ * recall.ts module for Bonfire access (when key arrives, otherwise asks Zaal
+ * to relay manually).
+ */
+function buildSystemPrompt(context: ZoeContext): string {
+  return `You are ZOE — Zaal Panthaki's personal concierge. You run on Claude Opus/Sonnet via the Hermes runtime (bot/src/zoe). You DM Zaal on Telegram as @zaoclaw_bot.
+
+Today is ${context.current_date}.
+
+## Your job
+- Daily tasks + captures + nudges. You are NOT a code-fix bot (that's Hermes coder/critic, your sibling at bot/src/hermes).
+- Surface findings, connect dots between captures and projects, nudge on priorities.
+- Match Zaal's Year-of-the-ZABAL voice: clear, simple, spartan, short impactful sentences, active voice. No marketing language.
+- Never say "Sure!" or "Of course" — just answer.
+- Default 2-3 sentences. Expand only when topic demands.
+
+## Voice rules (non-negotiable)
+- No emojis ever
+- No em dashes (use hyphens)
+- No "leveraging", "synergize", "unlock value", "ecosystem of solutions"
+- No "Would you like me to..." — just do it
+- Lead with the outcome, not the process
+
+## Your tools
+- Read, Glob, Grep on the ZAOOS repo
+- Bash for limited shell ops (gh CLI, git read-only commands, simple curl)
+- Bonfire RECALL via recall.ts module (when a question requires graph facts)
+
+## Pending tasks (your work queue)
+${context.pending_tasks.map((t, i) => `${i + 1}. [${t.priority}] [${t.status}] ${t.title}\n   ${t.description.slice(0, 120)}`).join('\n')}
+
+## Recent captures (last 5)
+${context.recent_captures.slice(0, 5).map((c) => `- ${c.created_at.slice(0, 10)} (${c.topic}): ${c.text.slice(0, 100)}`).join('\n') || '(none yet)'}
+
+## Output format
+Reply naturally to Zaal. If you want to add or update tasks, OR you captured a new note from this exchange, append a JSON block at the END of your reply (after a ---- separator):
+
+----
+\`\`\`json
+{
+  "task_ops": [
+    {"op": "add", "task": {"title": "...", "description": "...", "status": "pending", "priority": "med", "source": "ad-hoc", "notes": []}},
+    {"op": "complete", "id": "task-id", "outcome": "..."}
+  ],
+  "captures": [
+    {"text": "verbatim what zaal said worth remembering", "topic": "decision"}
+  ]
+}
+\`\`\`
+
+If no task ops or captures, omit the JSON block entirely. Do not include placeholder JSON.
+
+## Critical rules
+1. NEVER fabricate facts. If you don't know, say "I'd need to check Bonfire for that — want me to query?"
+2. NEVER claim memory state changes that didn't occur (no "I've remembered that for you" unless you actually wrote a capture).
+3. NEVER use commands like /add or /done as part of your output — that was the OLD Telegram bot pattern. You write the JSON block instead, and the runner applies the ops.
+4. When unsure, pick one and tell Zaal what you did, not what you could do.
+
+ZOE v${ZOE_VERSION}. Lean. Direct. Match the Year-of-the-ZABAL voice.`;
+}
+
+/**
+ * Run a concierge turn:
+ * 1. Build system prompt from context
+ * 2. Call Claude Code CLI with the user's message + concierge system prompt
+ * 3. Parse the reply text + extract task_ops/captures JSON block
+ * 4. Return structured result
+ */
+export async function runConciergeTurn(opts: ConciergeOptions): Promise<ConciergeResult> {
+  const model = opts.model ?? selectModel(opts.message);
+  const systemPrompt = buildSystemPrompt(opts.context);
+
+  const result = await callClaudeCli({
+    model,
+    prompt: opts.message,
+    cwd: opts.context.workspace_dir,
+    appendSystemPrompt: systemPrompt,
+    allowedTools: [
+      'Read',
+      'Glob',
+      'Grep',
+      'Bash(gh issue list*)',
+      'Bash(gh pr list*)',
+      'Bash(gh pr view*)',
+      'Bash(git log*)',
+      'Bash(git status)',
+      'Bash(curl -s*)',
+    ],
+    disallowedTools: [
+      'Bash(git push*)',
+      'Bash(git commit*)',
+      'Bash(git reset*)',
+      'Bash(rm*)',
+      'Edit',
+      'Write',
+    ],
+    permissionMode: 'auto',
+    outputFormat: 'json',
+    bare: true,
+  });
+
+  // Parse JSON block (if present) at end of reply
+  const { reply, taskOps, captures } = splitReplyAndOps(result.text);
+
+  return {
+    reply,
+    task_ops: taskOps,
+    captures,
+    inputTokens: result.inputTokens,
+    outputTokens: result.outputTokens,
+    costUsd: result.totalCostUsd,
+    model,
+    durationMs: result.durationMs,
+  };
+}
+
+const OPS_FENCE_RE = /----\s*```json\s*([\s\S]*?)\s*```\s*$/;
+
+function splitReplyAndOps(text: string): { reply: string; taskOps: TaskOp[]; captures: ZoeCaptureNote[] } {
+  const match = text.match(OPS_FENCE_RE);
+  if (!match) {
+    return { reply: text.trim(), taskOps: [], captures: [] };
+  }
+  const jsonStr = match[1];
+  const reply = text.replace(OPS_FENCE_RE, '').trim();
+  try {
+    const parsed = JSON.parse(jsonStr) as {
+      task_ops?: TaskOp[];
+      captures?: Array<{ text: string; topic: string }>;
+    };
+    const captures: ZoeCaptureNote[] = (parsed.captures ?? []).map((c) => ({
+      id: `cap-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      text: c.text,
+      topic: c.topic ?? 'note',
+      source: 'dm',
+      created_at: new Date().toISOString(),
+    }));
+    return {
+      reply,
+      taskOps: parsed.task_ops ?? [],
+      captures,
+    };
+  } catch (err) {
+    console.error('[zoe/concierge] failed to parse ops JSON:', (err as Error).message, 'raw:', jsonStr.slice(0, 200));
+    return { reply, taskOps: [], captures: [] };
+  }
+}
+
+export { ZOE_DEFAULT_MODEL };

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -13,7 +13,7 @@
 import { config as loadEnv } from 'dotenv';
 loadEnv();
 
-import { Bot, Context, InlineKeyboard } from 'grammy';
+import { Bot, Context } from 'grammy';
 import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
 import { buildMemoryBlocks, ensureZoeHome, pushRecent } from './memory';
@@ -45,10 +45,7 @@ async function isAllowed(ctx: Context): Promise<boolean> {
   return fromId === zaalId;
 }
 
-const NUDGE_KEYBOARD = new InlineKeyboard()
-  .text('Now', 'nudge:now')
-  .text('Later', 'nudge:later')
-  .text('Shelve', 'nudge:shelve');
+// Nudge keyboard ([Now][Later][Shelve]) wired in scheduler.ts when sending proactive nudges.
 
 bot.command('start', async (ctx) => {
   if (!(await isAllowed(ctx))) return;
@@ -78,7 +75,6 @@ bot.on('message:text', async (ctx) => {
   await ctx.api.sendChatAction(ctx.chat.id, 'typing').catch(() => {});
 
   try {
-    const blocks = await buildMemoryBlocks();
     await pushRecent({ from: 'zaal', text });
 
     const result = await runConciergeTurn({
@@ -160,6 +156,3 @@ async function main(): Promise<void> {
 }
 
 void main();
-
-// Ensure we don't double-print warning on grammy Bot type unused in scope
-void Context;

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -1,0 +1,165 @@
+/**
+ * ZOE — main entry. Telegram polling for @zaoclaw_bot DMs.
+ *
+ * Boots a grammy Bot using TELEGRAM_BOT_TOKEN, listens for DMs from
+ * Zaal (allowlist via ZAAL_TELEGRAM_ID), routes to concierge handler.
+ * Starts the scheduler for proactive nudges (morning brief, evening
+ * reflection).
+ *
+ * Run via:
+ *   pnpm tsx src/zoe/index.ts
+ *   OR: systemd user unit zoe-bot.service
+ */
+import { config as loadEnv } from 'dotenv';
+loadEnv();
+
+import { Bot, Context, InlineKeyboard } from 'grammy';
+import { runConciergeTurn } from './concierge';
+import { applyTaskOps, seedInitialTasks } from './tasks';
+import { buildMemoryBlocks, ensureZoeHome, pushRecent } from './memory';
+import { startScheduler } from './scheduler';
+
+const token = process.env.ZOE_BOT_TOKEN ?? process.env.TELEGRAM_BOT_TOKEN;
+const zaalIdRaw = process.env.ZAAL_TELEGRAM_ID;
+const repoDir = process.env.ZOE_REPO_DIR ?? '/home/zaal/zao-os';
+const devzChatRaw = process.env.ZAO_DEVZ_CHAT_ID;
+
+if (!token) {
+  console.error('Missing ZOE_BOT_TOKEN or TELEGRAM_BOT_TOKEN');
+  process.exit(1);
+}
+if (!zaalIdRaw) {
+  console.error('Missing ZAAL_TELEGRAM_ID');
+  process.exit(1);
+}
+
+const zaalId = Number(zaalIdRaw);
+const devzChatId = devzChatRaw ? Number(devzChatRaw) : undefined;
+
+const bot = new Bot(token);
+const usernameHolder: { value: string | null } = { value: null };
+
+async function isAllowed(ctx: Context): Promise<boolean> {
+  const fromId = ctx.from?.id;
+  if (!fromId) return false;
+  return fromId === zaalId;
+}
+
+const NUDGE_KEYBOARD = new InlineKeyboard()
+  .text('Now', 'nudge:now')
+  .text('Later', 'nudge:later')
+  .text('Shelve', 'nudge:shelve');
+
+bot.command('start', async (ctx) => {
+  if (!(await isAllowed(ctx))) return;
+  await ctx.reply('ZOE online. Hermes runtime, Sonnet/Opus brain via Max plan. Memory blocks loaded. Send anything.');
+});
+
+bot.command('tasks', async (ctx) => {
+  if (!(await isAllowed(ctx))) return;
+  const blocks = await buildMemoryBlocks();
+  await ctx.reply(`Open tasks:\n\n${blocks.tasks}`);
+});
+
+bot.command('seed', async (ctx) => {
+  if (!(await isAllowed(ctx))) return;
+  const result = await seedInitialTasks();
+  await ctx.reply(result.seeded > 0 ? `Seeded ${result.seeded} tasks from doc 601.` : 'Task queue already has entries — skipped seed.');
+});
+
+bot.on('message:text', async (ctx) => {
+  if (!(await isAllowed(ctx))) return;
+  const text = ctx.message.text;
+  if (text.startsWith('/')) return;  // commands handled above
+
+  // Skip messages NOT from Zaal's DM (groups handled separately if needed)
+  if (ctx.chat.type !== 'private') return;
+
+  await ctx.api.sendChatAction(ctx.chat.id, 'typing').catch(() => {});
+
+  try {
+    const blocks = await buildMemoryBlocks();
+    await pushRecent({ from: 'zaal', text });
+
+    const result = await runConciergeTurn({
+      message: text,
+      context: {
+        zaal_tg_id: zaalId,
+        workspace_dir: repoDir,
+        pending_tasks: [],   // covered by blocks.tasks
+        recent_captures: [],  // covered by blocks.working
+        current_date: new Date().toISOString().slice(0, 10),
+      },
+    });
+
+    // Apply task ops + log captures
+    if (result.task_ops.length > 0) {
+      await applyTaskOps(result.task_ops);
+    }
+    // Captures TODO Phase 2 — wire to Bonfire ingest
+
+    await pushRecent({ from: 'zoe', text: result.reply });
+
+    // Guard against empty replies (the openclaw "·" pattern)
+    const safeReply = result.reply.trim();
+    if (safeReply.length < 5) {
+      await ctx.reply('(empty reply guarded — check logs)');
+      console.error('[zoe/index] empty reply blocked, raw:', JSON.stringify(result).slice(0, 300));
+      return;
+    }
+
+    await ctx.reply(safeReply);
+
+    console.log(`[zoe/index] turn handled — model=${result.model} cost=$${result.costUsd.toFixed(4)} tokens=${result.inputTokens}/${result.outputTokens} duration=${result.durationMs}ms`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[zoe/index] concierge turn failed:', msg);
+    await ctx.reply(`(concierge error — ${msg.slice(0, 200)})`);
+  }
+});
+
+// Inline-keyboard callbacks for proactive nudge dismiss
+bot.callbackQuery(/^nudge:(now|later|shelve)$/, async (ctx) => {
+  const action = ctx.match[1];
+  await ctx.answerCallbackQuery({ text: `Marked ${action}.` });
+  // Phase 2 — track dismissal stats per category for auto-reduce
+  console.log(`[zoe/index] nudge dismissed: ${action}`);
+});
+
+async function main(): Promise<void> {
+  await ensureZoeHome();
+  console.log('[zoe/index] ZOE booting — token set, zaalId=', zaalId, ' repoDir=', repoDir);
+
+  // Resolve own username for filtering
+  try {
+    const me = await bot.api.getMe();
+    usernameHolder.value = me.username;
+    console.log('[zoe/index] bot identity:', `@${me.username} (${me.id})`);
+  } catch (err) {
+    console.error('[zoe/index] getMe failed:', (err as Error).message);
+  }
+
+  // Start scheduler for proactive nudges
+  startScheduler({ bot, zaalTgId: zaalId, repoDir, devzChatId });
+
+  // Optional: seed task queue on first boot
+  try {
+    const seed = await seedInitialTasks();
+    if (seed.seeded > 0) {
+      console.log(`[zoe/index] seeded ${seed.seeded} initial tasks from doc 601`);
+    }
+  } catch (err) {
+    console.warn('[zoe/index] task seed failed (nbd):', (err as Error).message);
+  }
+
+  await bot.start({
+    onStart: (info) => {
+      console.log(`[zoe/index] polling as @${info.username}`);
+    },
+  });
+}
+
+void main();
+
+// Ensure we don't double-print warning on grammy Bot type unused in scope
+void Context;

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -1,0 +1,242 @@
+/**
+ * Memory block builder — Letta-inspired pattern.
+ *
+ * 4 named blocks per concierge turn:
+ *   persona  — ZOE identity + voice rules (versioned in git)
+ *   human    — Zaal facts (refreshed daily via Bonfire RECALL or hand-edited)
+ *   working  — last 5 turns from this Telegram thread
+ *   tasks    — open task queue snapshot
+ *
+ * Each block is independently updatable. Cleaner than monolithic system prompt.
+ *
+ * Storage on host:
+ *   ~/.zao/zoe/persona.md      — versioned, committed to repo
+ *   ~/.zao/zoe/human.md         — local cache, refreshed daily
+ *   ~/.zao/zoe/recent.json      — last N turns, FIFO ring buffer
+ *   ~/.zao/zoe/tasks.json       — open task queue
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { ZoeTask } from './types';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const PERSONA_PATH = join(ZOE_HOME, 'persona.md');
+const HUMAN_PATH = join(ZOE_HOME, 'human.md');
+const RECENT_PATH = join(ZOE_HOME, 'recent.json');
+const TASKS_PATH = join(ZOE_HOME, 'tasks.json');
+
+const RECENT_MAX = 5;
+
+const PERSONA_DEFAULT = `You are ZOE — Zaal Panthaki's personal concierge running on Claude Sonnet/Opus via the bot/src/zoe Hermes-style runtime. You DM Zaal as @zaoclaw_bot.
+
+VOICE (Year-of-the-ZABAL, non-negotiable):
+- Clear, simple, spartan
+- Short impactful sentences
+- Active voice
+- No marketing language ("leveraging", "synergize", "unlock value" are banned)
+- No emojis ever
+- No em dashes — use hyphens
+- Never start with "Sure!" or "Of course"
+- Default 2-3 sentences. Expand only when topic demands.
+- Lead with outcome, not process
+
+ANTI-PATTERNS:
+- Never ask "Would you like me to..." — just do it
+- Never list 5 options when 1 is obviously right
+- Never ask permission for routine tasks (research, reads, status checks)
+- Never repeat a task back before doing it
+- Never fabricate facts. If unsure, say so OR query Bonfire via RECALL.
+- Never claim memory state changes that didn't happen.
+
+ROUTING:
+- Code-fix work → Hermes coder/critic (your sibling at bot/src/hermes). Tell Zaal.
+- Graph queries → RECALL pattern (manual relay until SDK lands). Output the query, Zaal pastes to @zabal_bonfire.
+- Daily ops, captures, nudges → you handle directly.
+
+MEMORY:
+- Working memory (this conversation) is in <working_memory> block.
+- Long-term facts about Zaal are in <human> block. Treat as ground truth.
+- Open tasks are in <tasks> block. Update via JSON ops in your reply (see output format).
+
+OUTPUT FORMAT:
+Reply naturally to Zaal. If you want to add/update tasks OR captured a note, append at the END:
+
+----
+\`\`\`json
+{
+  "task_ops": [
+    {"op": "add", "task": {"title": "...", "description": "...", "status": "pending", "priority": "med", "source": "ad-hoc", "notes": []}},
+    {"op": "complete", "id": "task-id", "outcome": "..."}
+  ],
+  "captures": [
+    {"text": "verbatim what zaal said worth remembering", "topic": "decision"}
+  ],
+  "escalate": false
+}
+\`\`\`
+
+Set "escalate": true ONLY if your current model (Sonnet) cannot answer well and the response should be re-run on Opus. Include "reason" when escalating.
+
+If no ops/captures and no escalation: omit the JSON block entirely.`;
+
+const HUMAN_DEFAULT = `# Zaal Panthaki
+
+Solo founder of The ZAO (decentralized impact network for music + creators).
+
+## Identity
+- Farcaster: @zaal (FID lookup via Neynar)
+- X: @bettercallzaal
+- ENS: zaal.eth (registered 2022-08-26)
+- Wallet: 0x7234c36a71ec237c2ae7698e8916e0735001e9af
+- Email: zaalp99@gmail.com
+
+## Schedule (M-F default)
+- 4:30am wake
+- Gym
+- 9am-12pm prime build #1 (Claude Code CLI on Mac)
+- 12pm lunch + content stream
+- 1pm-4pm meetings, calls, mobile captures (Telegram)
+- 4pm-7pm prime build #2
+- 9pm reflection + plan tomorrow
+
+## Active projects (cross-link to Bonfire if details needed)
+- ZAO OS — Farcaster-gated client at zaoos.com
+- ZAOstock 2026 — flagship event, Oct 3 2026, Ellsworth Maine
+- BCZ YapZ — podcast (18 episodes published)
+- BCZ Strategies LLC — agency, ZAO Music DBA underneath
+- ZABAL coin — launched Jan 1 2026 on Base
+- WaveWarZ — music battle platform on Solana
+- ZAO Fractals — weekly governance, 90+ weeks running
+
+## Key relationships (RECALL via Bonfire for full context)
+- Cassie (ZAOstock strategic advisor)
+- Steve Peer (Ellsworth co-curator + drummer)
+- Roddy Ehrlenbach (City of Ellsworth Parks/Rec)
+- Joshua.eth (Bonfires founder)
+- Ohnahji + EZinCrypto (LTAW3 cohosts)
+
+## Voice fingerprint
+Year-of-the-ZABAL daily on paragraph.com/@thezao. ~120 daily posts as of May 2026. Spartan + practical + active voice + no marketing.
+
+## Last refreshed
+2026-05-04 (initial seed). Auto-update from Bonfire RECALL when SDK lands.`;
+
+export interface MemoryBlocks {
+  persona: string;
+  human: string;
+  working: string;
+  tasks: string;
+}
+
+export async function ensureZoeHome(): Promise<void> {
+  await fs.mkdir(ZOE_HOME, { recursive: true });
+  // Seed defaults if missing
+  try {
+    await fs.access(PERSONA_PATH);
+  } catch {
+    await fs.writeFile(PERSONA_PATH, PERSONA_DEFAULT, 'utf8');
+  }
+  try {
+    await fs.access(HUMAN_PATH);
+  } catch {
+    await fs.writeFile(HUMAN_PATH, HUMAN_DEFAULT, 'utf8');
+  }
+  try {
+    await fs.access(RECENT_PATH);
+  } catch {
+    await fs.writeFile(RECENT_PATH, JSON.stringify([], null, 2), 'utf8');
+  }
+  try {
+    await fs.access(TASKS_PATH);
+  } catch {
+    await fs.writeFile(TASKS_PATH, JSON.stringify([], null, 2), 'utf8');
+  }
+}
+
+export async function readPersona(): Promise<string> {
+  await ensureZoeHome();
+  return fs.readFile(PERSONA_PATH, 'utf8');
+}
+
+export async function readHuman(): Promise<string> {
+  await ensureZoeHome();
+  return fs.readFile(HUMAN_PATH, 'utf8');
+}
+
+export async function readRecent(): Promise<Array<{ from: 'zaal' | 'zoe'; text: string; ts: string }>> {
+  await ensureZoeHome();
+  const raw = await fs.readFile(RECENT_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+export async function pushRecent(turn: { from: 'zaal' | 'zoe'; text: string }): Promise<void> {
+  const recent = await readRecent();
+  recent.push({ ...turn, ts: new Date().toISOString() });
+  while (recent.length > RECENT_MAX) recent.shift();
+  await fs.writeFile(RECENT_PATH, JSON.stringify(recent, null, 2), 'utf8');
+}
+
+export async function readTasks(): Promise<ZoeTask[]> {
+  await ensureZoeHome();
+  const raw = await fs.readFile(TASKS_PATH, 'utf8');
+  return JSON.parse(raw);
+}
+
+export async function writeTasks(tasks: ZoeTask[]): Promise<void> {
+  await ensureZoeHome();
+  await fs.writeFile(TASKS_PATH, JSON.stringify(tasks, null, 2), 'utf8');
+}
+
+/**
+ * Build the 4 memory blocks for a concierge turn.
+ * Block strings are kept short by design — no dumping full graph context.
+ */
+export async function buildMemoryBlocks(): Promise<MemoryBlocks> {
+  const [persona, human, recentTurns, tasks] = await Promise.all([
+    readPersona(),
+    readHuman(),
+    readRecent(),
+    readTasks(),
+  ]);
+
+  const working =
+    recentTurns.length === 0
+      ? '(no recent turns)'
+      : recentTurns
+          .map((t) => `[${t.ts.slice(11, 16)}] ${t.from === 'zaal' ? 'Zaal' : 'ZOE'}: ${t.text.slice(0, 280)}`)
+          .join('\n');
+
+  const openTasks = tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
+  const tasksBlock =
+    openTasks.length === 0
+      ? '(no open tasks)'
+      : openTasks
+          .slice(0, 12)
+          .map((t, i) => `${i + 1}. [${t.priority}] [${t.status}] ${t.title}\n   ${t.description.slice(0, 100)}`)
+          .join('\n');
+
+  return { persona, human, working, tasks: tasksBlock };
+}
+
+/**
+ * Render memory blocks + user message into the prompt that goes to Claude CLI.
+ */
+export function renderConciergePrompt(blocks: MemoryBlocks, userMessage: string): string {
+  return [
+    `<persona>\n${blocks.persona}\n</persona>`,
+    `<human>\n${blocks.human}\n</human>`,
+    `<working_memory>\n${blocks.working}\n</working_memory>`,
+    `<tasks>\n${blocks.tasks}\n</tasks>`,
+    ``,
+    `Zaal: ${userMessage}`,
+  ].join('\n\n');
+}
+
+export const ZOE_PATHS = {
+  home: ZOE_HOME,
+  persona: PERSONA_PATH,
+  human: HUMAN_PATH,
+  recent: RECENT_PATH,
+  tasks: TASKS_PATH,
+};

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -17,7 +17,7 @@
  */
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join } from 'node:path';
 import type { ZoeTask } from './types';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');

--- a/bot/src/zoe/node-cron.d.ts
+++ b/bot/src/zoe/node-cron.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Local type shim for node-cron (no @types package installed in this repo).
+ * Covers only what bot/src/zoe/scheduler.ts uses.
+ */
+declare module 'node-cron' {
+  export interface ScheduledTask {
+    start(): this;
+    stop(): this;
+  }
+  export interface ScheduleOptions {
+    timezone?: string;
+    scheduled?: boolean;
+    name?: string;
+  }
+  export function schedule(
+    cronExpression: string,
+    func: () => void | Promise<void>,
+    options?: ScheduleOptions,
+  ): ScheduledTask;
+  export function validate(cronExpression: string): boolean;
+  const _default: { schedule: typeof schedule; validate: typeof validate };
+  export default _default;
+}

--- a/bot/src/zoe/recall.ts
+++ b/bot/src/zoe/recall.ts
@@ -49,12 +49,12 @@ export function formatManualRelay(req: RecallRequest): string {
 export async function recallViaSdk(req: RecallRequest): Promise<RecallResult> {
   const apiKey = process.env.BONFIRE_API_KEY;
   const bonfireId = process.env.BONFIRE_ID;
-  const agentId = process.env.BONFIRE_AGENT_ID;
-  const apiUrl = process.env.BONFIRE_API_URL ?? 'https://tnt-v2.api.bonfires.ai';
 
   if (!apiKey || !bonfireId) {
     return { kind: 'manual_relay_needed', query: req.query };
   }
+
+  // Future: process.env.BONFIRE_AGENT_ID + BONFIRE_API_URL used here.
 
   // Future implementation when key is provisioned (per doc 569 §9 SDK pattern):
   //

--- a/bot/src/zoe/recall.ts
+++ b/bot/src/zoe/recall.ts
@@ -1,0 +1,82 @@
+/**
+ * Bonfire bridge for ZOE.
+ *
+ * Today (no SDK key from Joshua.eth yet): manual relay pattern. ZOE returns
+ * a structured "recall request" signal in its reply that asks Zaal to paste
+ * a query into @zabal_bonfire DM and paste back the reply.
+ *
+ * When SDK lands: this module swaps to direct API calls without changing
+ * concierge.ts callsite.
+ *
+ * When MCP server lands: Claude CLI invocation gets `mcp__bonfires__recall`
+ * tool added, ZOE calls it natively, this module retires.
+ */
+
+export interface RecallRequest {
+  query: string;
+  reason: string;       // why ZOE needs the answer
+  expected_kind: 'fact' | 'people' | 'event' | 'decision' | 'history' | 'mixed';
+}
+
+export interface RecallResult {
+  kind: 'manual_relay_needed' | 'sdk_response' | 'mcp_response';
+  query: string;
+  text?: string;          // Bonfire reply text when sdk_response or mcp_response
+  inline_keyboard?: Array<Array<{ text: string; callback_data: string }>>;
+}
+
+/**
+ * Today's behavior: format a "please relay to Bonfire" payload that ZOE can
+ * include in its reply to Zaal. Returns a Telegram-ready Markdown string.
+ */
+export function formatManualRelay(req: RecallRequest): string {
+  return [
+    `_Need bonfire context for: ${req.reason}_`,
+    '',
+    'Paste into @zabal_bonfire DM:',
+    '```',
+    `RECALL: ${req.query}`,
+    '```',
+    '',
+    'Then paste the reply back here. I will continue.',
+  ].join('\n');
+}
+
+/**
+ * Future API call (placeholder).
+ * Returns sdk_response when env has BONFIRE_API_KEY + BONFIRE_ID, else manual_relay_needed.
+ */
+export async function recallViaSdk(req: RecallRequest): Promise<RecallResult> {
+  const apiKey = process.env.BONFIRE_API_KEY;
+  const bonfireId = process.env.BONFIRE_ID;
+  const agentId = process.env.BONFIRE_AGENT_ID;
+  const apiUrl = process.env.BONFIRE_API_URL ?? 'https://tnt-v2.api.bonfires.ai';
+
+  if (!apiKey || !bonfireId) {
+    return { kind: 'manual_relay_needed', query: req.query };
+  }
+
+  // Future implementation when key is provisioned (per doc 569 §9 SDK pattern):
+  //
+  //   const r = await fetch(`${apiUrl}/kg/search`, {
+  //     method: 'POST',
+  //     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+  //     body: JSON.stringify({ bonfire_id: bonfireId, agent_id: agentId, query: req.query, num_results: 5 }),
+  //   });
+  //   const data = await r.json();
+  //   return { kind: 'sdk_response', query: req.query, text: data.results.map(formatResult).join('\n\n') };
+  //
+  // Intentionally not invoking the API until key is in env — to fail loudly
+  // when called without proper config.
+
+  console.warn('[zoe/recall] SDK path not yet implemented — falling back to manual relay');
+  return { kind: 'manual_relay_needed', query: req.query };
+}
+
+/**
+ * Single entry point ZOE concierge calls. Routes to SDK if configured,
+ * else manual relay.
+ */
+export async function recall(req: RecallRequest): Promise<RecallResult> {
+  return recallViaSdk(req);
+}

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -1,0 +1,115 @@
+/**
+ * Evening reflection — runs daily at 9pm EST (01:00 UTC next day).
+ *
+ * Sends a 3-question reflection prompt to Zaal:
+ *   1. What shipped today?
+ *   2. What's stuck?
+ *   3. Tomorrow's first task?
+ *
+ * Zaal replies free-form. The next concierge turn parses the answers and
+ * captures them as Bonfire-eligible notes (status + priorities update).
+ */
+import { callClaudeCli } from '../hermes/claude-cli';
+import { listOpenTasks } from './tasks';
+
+const REFLECT_SYSTEM_PROMPT = `You are ZOE asking Zaal his evening reflection at 9pm EST.
+
+VOICE: Year-of-the-ZABAL — clear, simple, spartan, active voice. No emojis, no em dashes, no marketing.
+
+Output a SHORT 3-question prompt. Reference 1-2 specifics from today (a commit, a PR, an open task) so it feels personal not boilerplate. Use "today" not "the day."
+
+EXAMPLE:
+
+Evening reflection — Mon May 4 9pm
+
+Today you opened PR #470 (ZOE doc 604) and stopped openclaw container. Three quick:
+
+1. What shipped today?
+2. What's stuck?
+3. Tomorrow's first task?
+
+Reply free-form. I will capture the highlights.
+
+---
+
+Output exactly this style. No more questions, no preamble, no marketing language.`;
+
+interface ReflectContext {
+  today: string;
+  open_tasks: Array<{ priority: string; title: string }>;
+  recent_commits: string[];
+  recent_prs: Array<{ number: number; title: string }>;
+}
+
+import { execSync } from 'node:child_process';
+
+function loadReflectContext(repoDir: string): ReflectContext {
+  let commits: string[] = [];
+  try {
+    const log = execSync(`git -C ${JSON.stringify(repoDir)} log --since="14 hours ago" --no-merges --pretty=format:"%s"`, {
+      encoding: 'utf8',
+      timeout: 4000,
+    });
+    commits = log.split('\n').filter((l) => l.trim()).slice(0, 5);
+  } catch {
+    commits = [];
+  }
+
+  let prs: Array<{ number: number; title: string }> = [];
+  try {
+    const json = execSync('gh pr list --repo bettercallzaal/ZAOOS --state open --limit 5 --json number,title', {
+      encoding: 'utf8',
+      timeout: 6000,
+    });
+    prs = JSON.parse(json) as Array<{ number: number; title: string }>;
+  } catch {
+    prs = [];
+  }
+
+  return {
+    today: new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }),
+    open_tasks: [],  // populated below
+    recent_commits: commits,
+    recent_prs: prs,
+  };
+}
+
+export async function generateEveningReflection(opts: { repoDir: string; model?: string }): Promise<string> {
+  const ctx = loadReflectContext(opts.repoDir);
+  ctx.open_tasks = (await listOpenTasks()).slice(0, 5).map((t) => ({ priority: t.priority, title: t.title }));
+
+  const userPrompt = `Generate Zaal's evening reflection for ${ctx.today}.
+
+Today's signals:
+- Recent commits: ${ctx.recent_commits.length ? ctx.recent_commits.slice(0, 3).join(' | ') : '(none)'}
+- Open PRs: ${ctx.recent_prs.length ? ctx.recent_prs.slice(0, 3).map((p) => `#${p.number}`).join(' ') : '(none)'}
+- Top open tasks: ${ctx.open_tasks.length ? ctx.open_tasks.slice(0, 3).map((t) => t.title).join(' | ') : '(none)'}
+
+Output the reflection prompt in the exact format from your system prompt. Reference 1-2 specifics from today.`;
+
+  const result = await callClaudeCli({
+    model: opts.model ?? 'haiku',
+    prompt: userPrompt,
+    cwd: opts.repoDir,
+    appendSystemPrompt: REFLECT_SYSTEM_PROMPT,
+    permissionMode: 'auto',
+    bare: true,
+  });
+
+  const trimmed = result.text.trim();
+  if (trimmed.length < 60) {
+    console.error('[zoe/reflect] empty reflection, length=', trimmed.length);
+    return [
+      `Evening reflection — ${ctx.today} 9pm`,
+      '',
+      'Three quick:',
+      '',
+      '1. What shipped today?',
+      '2. What\'s stuck?',
+      '3. Tomorrow\'s first task?',
+      '',
+      'Reply free-form. I will capture the highlights.',
+    ].join('\n');
+  }
+  return trimmed;
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -1,0 +1,120 @@
+/**
+ * Scheduler — proactive nudges on cron.
+ *
+ * No quiet hours per Zaal feedback 2026-05-04 ("rather get pinged than ignored").
+ *
+ * Triggers:
+ *   05:00 EST (09:00 UTC daily)  — morning brief
+ *   21:00 EST (01:00 UTC daily)  — evening reflection
+ *   hourly                        — ZAO Devz General topic learning tip (Phase 4 cutover from python cron)
+ *
+ * Posting target: Zaal's DM via @zaoclaw_bot (chat_id from ZAAL_TELEGRAM_ID env).
+ *
+ * Idempotency: each trigger writes a sentinel file at ~/.zao/zoe/sentinels/<trigger>-<date>.flag
+ * to prevent double-fires if the scheduler restarts mid-cycle.
+ */
+import cron from 'node-cron';
+type ScheduledTask = { stop: () => void };
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import type { Bot } from 'grammy';
+import { generateMorningBrief } from './brief';
+import { generateEveningReflection } from './reflect';
+import { ZOE_PATHS } from './memory';
+
+const SENTINEL_DIR = join(ZOE_PATHS.home, 'sentinels');
+
+async function alreadyFired(trigger: string): Promise<boolean> {
+  const today = new Date().toISOString().slice(0, 10);
+  const sentinel = join(SENTINEL_DIR, `${trigger}-${today}.flag`);
+  try {
+    await fs.access(sentinel);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function markFired(trigger: string): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+  await fs.mkdir(SENTINEL_DIR, { recursive: true });
+  const sentinel = join(SENTINEL_DIR, `${trigger}-${today}.flag`);
+  await fs.writeFile(sentinel, new Date().toISOString(), 'utf8');
+}
+
+export interface SchedulerOptions {
+  bot: Bot;
+  zaalTgId: number;
+  repoDir: string;
+  devzChatId?: number;
+  devzTopicId?: number;
+}
+
+export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
+  const tasks: ScheduledTask[] = [];
+
+  // Morning brief — 09:00 UTC = 05:00 EDT, 04:00 EST. We anchor to UTC; Zaal in EST/EDT.
+  // Cron: '0 9 * * *' → 09:00 UTC daily.
+  tasks.push(
+    cron.schedule(
+      '0 9 * * *',
+      async () => {
+        if (await alreadyFired('morning-brief')) return;
+        try {
+          const brief = await generateMorningBrief({ repoDir: opts.repoDir });
+          await opts.bot.api.sendMessage(opts.zaalTgId, brief);
+          await markFired('morning-brief');
+          console.log('[zoe/scheduler] morning brief sent');
+        } catch (err) {
+          console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Evening reflection — 01:00 UTC = 21:00 EDT, 20:00 EST.
+  tasks.push(
+    cron.schedule(
+      '0 1 * * *',
+      async () => {
+        if (await alreadyFired('evening-reflect')) return;
+        try {
+          const prompt = await generateEveningReflection({ repoDir: opts.repoDir });
+          await opts.bot.api.sendMessage(opts.zaalTgId, prompt);
+          await markFired('evening-reflect');
+          console.log('[zoe/scheduler] evening reflection sent');
+        } catch (err) {
+          console.error('[zoe/scheduler] evening reflection failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Hourly Devz tip (Phase 4 cutover from python cron).
+  // Skip if devzChatId not configured (so this scaffold is harmless without env).
+  if (opts.devzChatId) {
+    tasks.push(
+      cron.schedule(
+        '0 * * * *',
+        async () => {
+          // TODO Phase 4 — generate tip via Claude CLI similar to brief.ts but tip-flavored
+          // For now: noop until Zaal explicitly cuts over from python cron.
+          console.log('[zoe/scheduler] hourly tip cron fired (Phase 4 — implementation pending)');
+        },
+        { timezone: 'UTC' },
+      ),
+    );
+  }
+
+  console.log(`[zoe/scheduler] started ${tasks.length} cron tasks (no quiet hours per Zaal feedback)`);
+
+  return {
+    stop: () => {
+      for (const task of tasks) {
+        task.stop();
+      }
+    },
+  };
+}

--- a/bot/src/zoe/tasks.ts
+++ b/bot/src/zoe/tasks.ts
@@ -1,0 +1,186 @@
+/**
+ * Task queue read/write for ZOE.
+ *
+ * Stored at ~/.zao/zoe/tasks.json. Operations applied via TaskOp[] returned
+ * from concierge replies. ZOE updates its own task state — Zaal can also
+ * issue commands via DM patterns ("/done X", "/add task: Y", "/status").
+ *
+ * Future: mirror to Bonfire as Task nodes when SDK lands.
+ */
+import type { ZoeTask, TaskOp, TaskStatus } from './types';
+import { readTasks, writeTasks } from './memory';
+
+function newTaskId(): string {
+  return `task-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export async function applyTaskOps(ops: TaskOp[]): Promise<{ added: ZoeTask[]; updated: ZoeTask[]; completed: string[]; deferred: string[] }> {
+  const tasks = await readTasks();
+  const byId = new Map(tasks.map((t) => [t.id, t] as [string, ZoeTask]));
+  const added: ZoeTask[] = [];
+  const updated: ZoeTask[] = [];
+  const completed: string[] = [];
+  const deferred: string[] = [];
+
+  for (const op of ops) {
+    switch (op.op) {
+      case 'add': {
+        const id = newTaskId();
+        const ts = nowIso();
+        const task: ZoeTask = { id, created_at: ts, updated_at: ts, ...op.task };
+        byId.set(id, task);
+        added.push(task);
+        break;
+      }
+      case 'update': {
+        const t = byId.get(op.id);
+        if (!t) {
+          console.warn(`[zoe/tasks] update skipped — id not found: ${op.id}`);
+          break;
+        }
+        const merged = {
+          ...t,
+          ...op.patch,
+          notes: op.patch.notes ? [...t.notes, ...op.patch.notes] : t.notes,
+          updated_at: nowIso(),
+        } as ZoeTask;
+        byId.set(t.id, merged);
+        updated.push(merged);
+        break;
+      }
+      case 'complete': {
+        const t = byId.get(op.id);
+        if (!t) {
+          console.warn(`[zoe/tasks] complete skipped — id not found: ${op.id}`);
+          break;
+        }
+        const note = op.outcome ? `outcome: ${op.outcome}` : 'completed';
+        const merged: ZoeTask = {
+          ...t,
+          status: 'completed',
+          notes: [...t.notes, `[${nowIso()}] ${note}`],
+          updated_at: nowIso(),
+        };
+        byId.set(t.id, merged);
+        completed.push(t.id);
+        break;
+      }
+      case 'defer': {
+        const t = byId.get(op.id);
+        if (!t) break;
+        const merged: ZoeTask = {
+          ...t,
+          status: 'deferred',
+          notes: [...t.notes, `[${nowIso()}] deferred${op.reason ? ` — ${op.reason}` : ''}`],
+          updated_at: nowIso(),
+        };
+        byId.set(t.id, merged);
+        deferred.push(t.id);
+        break;
+      }
+    }
+  }
+
+  await writeTasks(Array.from(byId.values()));
+  return { added, updated, completed, deferred };
+}
+
+export async function listOpenTasks(): Promise<ZoeTask[]> {
+  const tasks = await readTasks();
+  return tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
+}
+
+export async function listByStatus(status: TaskStatus): Promise<ZoeTask[]> {
+  const tasks = await readTasks();
+  return tasks.filter((t) => t.status === status);
+}
+
+/**
+ * Seed the task queue with the existing pending todos when ZOE first boots.
+ * Idempotent — only seeds if queue is empty.
+ */
+export async function seedInitialTasks(): Promise<{ seeded: number }> {
+  const existing = await readTasks();
+  if (existing.length > 0) return { seeded: 0 };
+
+  const seed: Array<Omit<ZoeTask, 'id' | 'created_at' | 'updated_at'>> = [
+    {
+      title: 'Nexus QA + NexusV2 Supabase migration',
+      description: 'Per doc 601 task 14 — PR #149 already merged shipping NEXUS admin + 3D portal hub. Issue #150 has the test checklist; ~7 unchecked items. Most critical: NexusV2 zaonexus.vercel.app still uses 200+ hardcoded links. Migrate to Supabase. Plus QA mobile + admin CRUD + API filters + landing page link.',
+      status: 'pending',
+      priority: 'high',
+      source: 'doc-601',
+      notes: [],
+    },
+    {
+      title: 'ZAO Protocol Whitepaper rebuild — Chapter 2 onward',
+      description: 'Brief at docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md. Existing draft 4.5 at research/community/051. 7 chapters: Why ZAO (reuse) + Protocol Architecture + Token Mechanics + Governance + Onchain Music Rails + Build on ZAO + Roadmap. Each chapter sources from Bonfire RECALL.',
+      status: 'pending',
+      priority: 'high',
+      source: 'doc-601',
+      notes: [],
+    },
+    {
+      title: 'ZabalSocials site rebuild',
+      description: 'Per doc 601 task 16. Personal-socials hub for BetterCallZaal (X, Farcaster, Lens, GitHub, YouTube, Twitch). Distinct from nexus.thezao.com (which is ZAO ecosystem). Spec needed before build.',
+      status: 'pending',
+      priority: 'med',
+      source: 'doc-601',
+      notes: [],
+    },
+    {
+      title: 'Farcaster + X ingest pipeline',
+      description: 'Per doc 601 task 17. Pull Zaal Farcaster casts via Neynar API + X posts via X archive export. Apply same heuristic filter as ChatGPT triage (keep ZAO-tagged + decisions + threads + writing, throw memes/replies). Generate ingest .md per platform.',
+      status: 'pending',
+      priority: 'med',
+      source: 'doc-601',
+      notes: [],
+    },
+    {
+      title: 'Doc 601 Phase 2 — token cutover to bot/src/zoe',
+      description: 'After Phase 1 (this scaffold) complete: stop openclaw container (DONE 2026-05-04), move TELEGRAM_BOT_TOKEN to bot/.env, add bot/src/zoe to systemd unit. Test via DM @zaoclaw_bot. Keep openclaw image 30d as backup.',
+      status: 'pending',
+      priority: 'high',
+      source: 'doc-601-phase-2',
+      notes: [],
+    },
+    {
+      title: 'Doc 601 Phase 3 — fold Devz bot into Hermes webhook',
+      description: 'Replace ZAO Devz bot module with Hermes one-way notifier (PR webhook → Hermes → Devz channel post). Stop running ZAO Devz bot module on VPS.',
+      status: 'pending',
+      priority: 'low',
+      source: 'doc-601-phase-3',
+      notes: [],
+    },
+    {
+      title: 'Doc 601 Phase 4 — bot/src/zoe/scheduler replaces zoe-learning-pings cron',
+      description: 'Scheduler module on bot/src/zoe handles hourly Devz tip + 5am brief + 9pm reflection. Stop python cron at ~/zoe-learning-pings/run.sh.',
+      status: 'pending',
+      priority: 'low',
+      source: 'doc-601-phase-4',
+      notes: [],
+    },
+    {
+      title: 'Email Joshua.eth re Bonfire SDK key + MCP roadmap',
+      description: '8 questions parked in doc 581 + 590. Critical: BONFIRE_API_KEY + BONFIRE_ID + BONFIRE_AGENT_ID. MCP server timeline. Genesis tier post-trial pricing. ERC-8004 alignment. OWL export completeness. Programmatic graph wipe. Idempotency on kengrams.batch. Dry-run mode.',
+      status: 'pending',
+      priority: 'high',
+      source: 'doc-581',
+      notes: [],
+    },
+  ];
+
+  const tasks: ZoeTask[] = seed.map((s) => ({
+    id: newTaskId(),
+    created_at: nowIso(),
+    updated_at: nowIso(),
+    ...s,
+  }));
+
+  await writeTasks(tasks);
+  return { seeded: tasks.length };
+}

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared types for bot/src/zoe — ZOE concierge brain.
+ *
+ * Mirrors bot/src/hermes/types.ts shape but scoped to concierge concerns
+ * (tasks, captures, daily nudges) rather than code-fix work.
+ */
+
+export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'blocked' | 'deferred';
+
+export interface ZoeTask {
+  id: string;
+  title: string;
+  description: string;
+  status: TaskStatus;
+  priority: 'high' | 'med' | 'low';
+  source: string;             // e.g. 'doc-601' | 'ad-hoc' | 'bonfire-recall'
+  blocked_by?: string[];      // task ids
+  notes: string[];            // running history
+  created_at: string;         // ISO 8601
+  updated_at: string;
+}
+
+export interface ZoeCaptureNote {
+  id: string;
+  text: string;
+  topic: string;              // free-form: 'idea', 'fact', 'decision', 'reflection'
+  source: 'dm' | 'cron' | 'bridge';
+  created_at: string;
+}
+
+export interface ZoeContext {
+  zaal_tg_id: number;
+  workspace_dir: string;
+  pending_tasks: ZoeTask[];
+  recent_captures: ZoeCaptureNote[];
+  current_date: string;
+}
+
+export interface ConciergeOptions {
+  /** User message text */
+  message: string;
+  /** Loaded ZOE context for system prompt */
+  context: ZoeContext;
+  /** Override model: 'sonnet' | 'opus' | 'haiku'. Default: sonnet (cheap), escalate to opus on hard reasoning */
+  model?: string;
+}
+
+export interface ConciergeResult {
+  /** Text to reply to user in Telegram */
+  reply: string;
+  /** Tasks the assistant wants to add or update */
+  task_ops: TaskOp[];
+  /** Captures to log */
+  captures: ZoeCaptureNote[];
+  /** Cost stats from Claude CLI call */
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  model: string;
+  durationMs: number;
+}
+
+export type TaskOp =
+  | { op: 'add'; task: Omit<ZoeTask, 'id' | 'created_at' | 'updated_at'> }
+  | { op: 'update'; id: string; patch: Partial<Pick<ZoeTask, 'status' | 'description' | 'priority' | 'notes'>> }
+  | { op: 'complete'; id: string; outcome?: string }
+  | { op: 'defer'; id: string; reason?: string };
+
+/** Cost-routing helper — match bot/src/hermes/claude-cli.ts ZOE-side defaults. */
+export const ZOE_DEFAULT_MODEL = process.env.ZOE_DEFAULT_MODEL ?? 'sonnet';
+export const ZOE_HARD_MODEL = process.env.ZOE_HARD_MODEL ?? 'opus';
+export const ZOE_QUICK_MODEL = process.env.ZOE_QUICK_MODEL ?? 'haiku';
+
+/**
+ * Decide which model to use for a concierge request.
+ * Heuristic: short factual questions = quick. Default = default. Strategic / multi-step = hard.
+ */
+export function selectModel(message: string): string {
+  const len = message.length;
+  const lower = message.toLowerCase();
+  const strategicKeywords = ['plan', 'strategy', 'should i', 'tradeoff', 'vs', 'decide', 'compare', 'whitepaper', 'architecture'];
+  const quickKeywords = ['what is', 'when', 'where', 'who', 'time', 'date'];
+
+  if (strategicKeywords.some((kw) => lower.includes(kw)) || len > 280) {
+    return ZOE_HARD_MODEL;
+  }
+  if (quickKeywords.some((kw) => lower.includes(kw)) && len < 80) {
+    return ZOE_QUICK_MODEL;
+  }
+  return ZOE_DEFAULT_MODEL;
+}

--- a/research/agents/602-tradingagents-pattern-for-social-pm/README.md
+++ b/research/agents/602-tradingagents-pattern-for-social-pm/README.md
@@ -1,0 +1,272 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 461, 529, 547, 600, 601
+tier: STANDARD
+---
+
+# 602 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
+
+> **Goal:** Document the TradingAgents (Tauric Research) multi-agent debate architecture. Identify which patterns transfer to ZOE's concierge brain (per doc 601 Option D) for two specific use cases: **social media posting decisions** and **project management decisions**. Explicitly NOT for trading — Zaal's call. Save for later use, don't implement now.
+
+## Recommendation (no preamble)
+
+**Steal 4 patterns from TradingAgents into ZOE-Hermes-brain. Skip the rest.**
+
+| Pattern | Steal? | Apply to |
+|---|---|---|
+| Two-tier LLM routing (deep_think + quick_think) | YES — already shipped in Hermes Sprint 1 (Sonnet + Opus + Haiku) | ZOE concierge brain (doc 601 Phase 1) |
+| Bullish/Bearish researcher debate | YES — high value for "should I post this?" + "should I ship this Tuesday?" decisions | ZOE social mode + PM mode |
+| Persistent decision log with reflection loop | YES — `~/.zao/memory/decisions.md`, inject recent decisions into next prompt | ZOE concierge brain |
+| Bounded debate rounds (2 default) | YES — simple cap, prevents loop spiral (matches doc 599 §"loop limit") | ZOE concierge brain |
+| Specialized analyst team (4 agents) | PARTIAL — 2-3 personas max, not 4. Don't over-design. | ZOE social mode |
+| LangGraph orchestration | SKIP — overkill for v1, adds dependency, our `bot/src/hermes/runner.ts` pattern is simpler | n/a |
+| Risk Management team + Portfolio Manager 2-stage approval | SKIP — Zaal IS the portfolio manager, no second layer needed | n/a |
+| Trading-specific roles (Fundamentals/Technical/News) | RENAME — same shape, different content. See mapping below. | ZOE social + PM modes |
+
+**Net:** 4 patterns to lift. ZOE-Hermes-brain becomes a debate engine for "should I post this?" and "should we ship this?" decisions. Trading itself stays out of scope per Zaal's explicit direction.
+
+## Source Material
+
+**Paper:** [TradingAgents: Multi-Agents LLM Financial Trading Framework](https://arxiv.org/abs/2412.20138)
+- Authors: Yijia Xiao, Edward Sun, Di Luo, Wei Wang
+- Submitted 2024-12-28, latest revision 2025-06-03
+- Category: Quantitative Finance (q-fin.TR)
+
+**Repo:** [github.com/TauricResearch/TradingAgents](https://github.com/TauricResearch/TradingAgents)
+- 66,034 stars, 12,781 forks (verified 2026-05-04)
+- Apache 2.0
+- Python 3.13
+- Last release v0.2.4 (2026-04) — structured-output agents + LangGraph checkpoint resume + DeepSeek/Qwen/GLM/Azure provider support
+
+## What TradingAgents Actually Does (the architecture)
+
+### 5 specialized teams collaborate to make ONE decision per stock per day
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (4 agents, parallel)                       │
+│   - Fundamentals Analyst   (financials, intrinsic value) │
+│   - Sentiment Analyst       (social media, public mood)  │
+│   - News Analyst            (macro events, news impact)  │
+│   - Technical Analyst       (MACD, RSI, price patterns)  │
+└────────────────────────┬─────────────────────────────────┘
+                         │ reports flow into
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (debate, max 2 rounds)                  │
+│   - Bullish Researcher  (defends optimistic case)        │
+│   - Bearish Researcher  (defends pessimistic case)       │
+│  → Structured debate, balanced perspective output        │
+└────────────────────────┬─────────────────────────────────┘
+                         │ debate winner + summary
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  TRADER AGENT                                            │
+│   - Synthesizes analyst + researcher outputs              │
+│   - Decides timing + magnitude                           │
+└────────────────────────┬─────────────────────────────────┘
+                         │ proposed trade
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RISK MANAGEMENT TEAM                                    │
+│   - Volatility, liquidity, exposure check                │
+│   - Adjusts strategy if risk-out-of-bounds               │
+└────────────────────────┬─────────────────────────────────┘
+                         │ risk-adjusted proposal
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  PORTFOLIO MANAGER                                       │
+│   - Final approve / reject                               │
+└──────────────────────────────────────────────────────────┘
+                         │ executed trade or rejected
+                         ▼
+                  Persistent decision log
+                  (~/.tradingagents/memory/trading_memory.md)
+                         │
+                         ▼ next run
+                Reflection loop: fetch realized return,
+                generate 1-paragraph reflection, inject
+                into next prompt for same ticker
+```
+
+### Key architectural primitives
+
+| Primitive | Implementation | What we steal |
+|---|---|---|
+| **Two-tier LLM routing** | `deep_think_llm` (e.g. gpt-5.4) for complex reasoning; `quick_think_llm` (e.g. gpt-5.4-mini) for fast tasks | Already in Hermes Sprint 1 cost routing — Sonnet (cheap/simple) + Opus (hard) + Haiku (fastest) |
+| **Bounded debate** | `max_debate_rounds: 2` default | Simple int config, hard cap prevents spiral |
+| **Persistent decision log** | Markdown file `~/.tradingagents/memory/trading_memory.md` appended on every run | Mirrors as `~/.zao/memory/zoe-decisions.md` |
+| **Reflection / learning loop** | After each run, fetch outcome, write reflection, inject into next prompt | High value — ZOE learns from past calls |
+| **LangGraph checkpoint resume** | Per-ticker SQLite at `~/.tradingagents/cache/checkpoints/<TICKER>.db` | SKIP — adds dependency, our bot/src/hermes runner is stateless enough |
+| **Multi-LLM provider abstraction** | `llm_provider: "openai"` config switch | We're committed to Claude (Max plan) — skip multi-provider for v1 |
+
+## Map to ZAO Use Cases (NOT trading)
+
+### Use case 1 — ZOE Social Mode (post decisions)
+
+When Zaal asks ZOE "should I post X" or "draft a post for Y", ZOE runs an internal debate before recommending.
+
+```
+INPUT: post draft or topic
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (3 agents, parallel)                       │
+│   - Brand Voice Analyst   (matches Year-of-the-ZABAL?)   │
+│   - Audience Resonance    (will FC/X audience care?)     │
+│   - Timing Analyst        (right news cycle moment?)     │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (2 rounds max)                          │
+│   - Pro-Post              (post now, here's why it lands)│
+│   - Anti-Post             (delay or rephrase, here's why)│
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  ZOE DRAFTER                                             │
+│   - Drafts final post in voice                           │
+│   - Or recommends "skip" with reasoning                  │
+└────────────────────────┬─────────────────────────────────┘
+                         │
+                         ▼ ZAAL APPROVES
+                  Posts via existing publish pipeline
+                  (Firefly for FC+X per memory)
+```
+
+**Replaces:** the cycle of "Zaal types post → posts → wonders if it lands."
+
+**Why this beats trading-style multi-agent for social:** social posts have qualitative outcomes (engagement, brand fit), not numeric (return %). Debate-pattern fits better than analyst-team-with-metrics.
+
+### Use case 2 — ZOE Project Management Mode (ship/wait decisions)
+
+When Zaal asks ZOE "should we ship X today" or "what's blocking ZAOstock", ZOE runs a debate.
+
+```
+INPUT: project name + question
+        │
+        ▼
+┌──────────────────────────────────────────────────────────┐
+│  ANALYST TEAM (3 agents, parallel)                       │
+│   - Project Health Analyst   (state from Bonfire graph)  │
+│   - Velocity Analyst          (commit/PR velocity, blockers)│
+│   - External Context Analyst  (calendar, partner deps)   │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  RESEARCHER TEAM (2 rounds max)                          │
+│   - Ship-It Advocate          (ready, here's the proof)  │
+│   - Wait-It-Out Advocate      (polish first, here's why) │
+└────────────────────────┬─────────────────────────────────┘
+                         ▼
+┌──────────────────────────────────────────────────────────┐
+│  ZOE PM RECOMMENDER                                      │
+│   - "Ship Tuesday" or "Delay 1 week" + reasoning         │
+└──────────────────────────────────────────────────────────┘
+```
+
+**Replaces:** Zaal's intuition + ad-hoc team check-ins. Adds a second voice that's read everything in Bonfire and seen prior similar decisions.
+
+## Implementation Plan (when, not now)
+
+Per Zaal: **save for later, don't implement now.** This doc is the recipe for when ZOE-Hermes-brain (doc 601 Phase 1) is built and we want to add debate-mode personalities.
+
+When the time comes, build path:
+
+1. **Phase 1 (doc 601)** ships first — base ZOE-Hermes-brain in `bot/src/zoe/`
+2. **Phase 2 — debate mode** — add `bot/src/zoe/debate.ts` that:
+   - Takes a question + 3 analyst personas
+   - Runs them in parallel (one Claude call each, Sonnet for cost)
+   - Feeds reports into 2 researcher personas (Bullish + Bearish)
+   - Researchers debate up to `max_debate_rounds: 2`
+   - Final synthesizer (Opus for quality) recommends
+3. **Phase 3 — decision log** — append to `~/.zao/memory/zoe-decisions.md` after each run
+4. **Phase 4 — reflection loop** — after Zaal acts on the recommendation, ZOE asks "did it work?" + writes 1-line reflection to memory + injects into future prompts
+
+## Cost Profile (when implemented)
+
+Per debate run (~5-7 LLM calls):
+- 3 analyst personas × Sonnet 4.6 = ~$0.10
+- 2 researcher personas × Sonnet 4.6 × 2 rounds = ~$0.15
+- 1 synthesizer × Opus 4.7 = ~$0.20
+- **Total: ~$0.45 per debate**
+
+Or via Max plan + Claude Code CLI subprocess (Hermes pattern): **$0** marginal cost. Match Hermes' cost discipline.
+
+10 debates per day = $4.50/day on API OR $0/day on Max plan. **Always use Max plan path. Match Hermes Sprint 1 cost routing.**
+
+## Why NOT Implement Trading Agents
+
+Per Zaal explicit direction: **no trading at all for now.** Reasons:
+
+1. **Risk surface** — trading agents need wallet write access. Doc 581 documented bot hallucinations (fake UUIDs). A bot with wallet write that hallucinates a transaction is catastrophic.
+2. **Existing trading agents (VAULT/BANKER/DEALER)** — already in `src/lib/agents/` per doc 600. They run within tight parameters. No reason to add LLM-driven trading on top.
+3. **Focus** — ZAO is music + creator-economy + community. Trading isn't core mission.
+4. **Regulatory** — autonomous trading bots have securities-law implications. Not worth the headache for ZAO's stage.
+
+The pattern is GENERAL — trading is just the demo domain. Social + PM are higher-leverage applications for Zaal.
+
+## Patterns NOT to Steal
+
+| Pattern | Why skip |
+|---|---|
+| LangGraph dependency | Adds Python LangGraph framework. Our `bot/src/hermes/runner.ts` already orchestrates without it. |
+| LangGraph checkpoint SQLite | Hermes runs are short. Crash recovery via re-run is fine. |
+| 4 separate analyst types | Over-design for v1. 2-3 max. Add complexity only if recall quality is poor. |
+| Multi-provider LLM abstraction | We're committed to Claude (Max plan). Adding OpenAI/Gemini/xAI fallback adds API key management without value. |
+| Portfolio Manager 2-stage approval | Zaal IS the final approver. Adding a second LLM layer is theater. |
+| Per-stock/ticker checkpointing | Our debate scope is "per-decision," not "per-ticker." Different shape. |
+
+## Comparison to Existing ZAO Patterns
+
+| Pattern | TradingAgents | Existing in ZAO | Net |
+|---|---|---|---|
+| Two-tier LLM | deep_think + quick_think | Hermes Sprint 1 routing (Sonnet/Opus/Haiku) | ✓ already have it |
+| Multi-agent debate | Bull vs Bear researchers, 2 rounds | Doc 599 patterns (RECALL/DRAFT/REVIEW), but no formal debate | NEEDS adoption |
+| Persistent decision log | `~/.tradingagents/memory/trading_memory.md` | Bonfire graph holds Decision nodes | Bonfire IS this layer (doc 569 ontology) |
+| Reflection loop | Post-run reflection injected into next prompt | Bonfire's outcome attribute (doc 569 + 581 status: shipped/dead/evolved) | Bonfire IS this layer |
+| Bounded debate | max_debate_rounds | Doc 599 §"loop limit: max 3 RECALL rounds per task" | ✓ already have the principle |
+| LangGraph orchestration | LangGraph | bot/src/hermes/runner.ts (custom TS) | We have simpler equivalent |
+
+**Insight:** ZAO already has half the pattern via Bonfire (memory) + Hermes (runtime). The MISSING piece is the **debate layer** — internal Bull/Bear before recommending. That's what doc 602 says to add.
+
+## Also See
+
+- [Doc 461](../../dev-workflows/461-fix-pr-pipeline-design/) — fix-PR pipeline (Hermes runtime pattern)
+- [Doc 529](../529-hermes-quality-pipeline-pre-critic-gates/) — Hermes pre-critic gates
+- [Doc 547](../547-multi-agent-coordination-bonfire-zoe-hermes/) — multi-agent coordination
+- [Doc 600](../600-agentic-stack-coordination-v1/) — current stack inventory
+- [Doc 601](../601-agent-stack-cleanup-decision/) — Hermes-as-ZOE-brain decision (Option D)
+
+## Next Actions
+
+| Action | Owner | Type | When |
+|--------|-------|------|------|
+| Save this doc as reference for future ZOE debate-mode build | Claude | Doc | Done with this commit |
+| Reference in Phase 2 of doc 601 implementation if Zaal wants debate-mode added to ZOE concierge | Claude | Plan | After doc 601 Phase 1 complete |
+| Re-read Trading-R1 paper ([arxiv 2509.11420](https://arxiv.org/abs/2509.11420)) when its Terminal repo lands — may have RL-trained debate patterns | Claude | Research | Q3 2026 if ZOE debate mode shipped |
+| Don't implement trading agents — VAULT/BANKER/DEALER stays in current scoped form per src/lib/agents/ | n/a | Discipline | Permanent |
+
+## Sources
+
+- [TradingAgents arxiv paper](https://arxiv.org/abs/2412.20138) — verified 2026-05-04, abstract + architecture extracted via WebFetch
+- [TradingAgents GitHub](https://github.com/TauricResearch/TradingAgents) — verified 2026-05-04, README inspected via gh api, 66034 stars, Apache 2.0
+- [Trading-R1 technical report](https://arxiv.org/abs/2509.11420) — referenced in TradingAgents v0.2.4 changelog, terminal repo expected later
+- TradingAgents CHANGELOG.md — v0.2.4 (2026-04) added structured-output agents, v0.2.3 multi-language, v0.2.2 GPT-5.4/Gemini 3.1/Claude 4.6 coverage, v0.2.0 multi-provider support
+- Internal: docs 461, 529, 547, 600, 601 — existing ZAO agent patterns this doc maps against
+
+## Citation (if we ever publish on this)
+
+```
+@misc{xiao2024tradingagentsmultiagentsllm,
+      title={TradingAgents: Multi-Agents LLM Financial Trading Framework},
+      author={Yijia Xiao and Edward Sun and Di Luo and Wei Wang},
+      year={2024},
+      eprint={2412.20138},
+      archivePrefix={arXiv},
+      primaryClass={q-fin.TR}
+}
+```

--- a/research/agents/603-tradingagents-pattern-for-social-pm/README.md
+++ b/research/agents/603-tradingagents-pattern-for-social-pm/README.md
@@ -7,7 +7,7 @@ related-docs: 461, 529, 547, 600, 601
 tier: STANDARD
 ---
 
-# 602 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
+# 603 — TradingAgents Multi-Agent Pattern → Adapt for ZAO Social + Project Management (NOT Trading)
 
 > **Goal:** Document the TradingAgents (Tauric Research) multi-agent debate architecture. Identify which patterns transfer to ZOE's concierge brain (per doc 601 Option D) for two specific use cases: **social media posting decisions** and **project management decisions**. Explicitly NOT for trading — Zaal's call. Save for later use, don't implement now.
 

--- a/research/agents/604-best-personal-concierge-agents-2026/README.md
+++ b/research/agents/604-best-personal-concierge-agents-2026/README.md
@@ -216,15 +216,22 @@ For v1: defer auto-RECALL entirely. ZOE asks Zaal in DM "should I check Bonfire 
 3. Token billing model post-30-day-trial?
 4. Cross-bonfire search — relevant for ZOE if/when ZAO grows multiple bonfires?
 
-## Open Questions for Zaal (need answers before Phase 1 implementation)
+## Zaal's Answers (locked 2026-05-04)
 
-1. **Voice — confirm:** Year-of-the-ZABAL Paragraph style (clear, simple, spartan, active voice, no marketing). Same as draft #2 in this doc?
-2. **Proactive nudge times:** 5am morning brief + 9pm evening reflection. OK or different?
-3. **Quiet hours:** 9pm-9am EST. OK or different?
-4. **Inline keyboard for nudges:** [Skip] [Later] [Shelve]. OK or different options?
-5. **Should ZOE post in groups (not just DM)?** Doc 599 said bridge group is passive ingest only. Same for ZOE?
-6. **Self-improving memory loop (Letta-style):** worth Phase 2? Or skip permanently?
-7. **TradingAgents debate (doc 603):** apply to social-post + ship/wait decisions in Phase 2? Or skip?
+1. **Voice:** Year-of-the-ZABAL — CONFIRMED. Clear, simple, spartan, active voice. No marketing. No emojis. No em dashes.
+2. **Proactive nudge times:** 5am morning brief + 9pm evening reflection — CONFIRMED.
+3. **Quiet hours:** NONE. Zaal prefers being pinged over ignored. **IMPORTANT: no 9pm-9am quiet window.** Ping whenever appropriate.
+4. **Inline keyboard:** `[Now] [Later] [Shelve]` — 3 options. Now = handle it, Later = remind later same day, Shelve = file for indefinite. CONFIRMED.
+5. **Group posting:** DM ONLY for now. No group posting. Doc 599 bridge group stays passive ingest.
+6. **Self-improving memory (Letta-style):** YES, Phase 2 — ZOE updates its own `human` block when Zaal corrects facts.
+7. **TradingAgents debate (doc 603):** SKIP. Keep researching efficiency patterns instead — make ZOE faster + leaner.
+
+### Implications of "no quiet hours"
+
+- Default cron-based proactive nudges (5am brief, 9pm reflection) anchored to Zaal's schedule.
+- BUT: ZOE can also nudge ad-hoc (e.g., "PR #456 review came in", "calendar conflict tomorrow at 10am") at any hour.
+- Mitigation: rely on Telegram's built-in mute (Zaal can mute the chat himself if he wants) instead of agent-side hour-gating.
+- Dismiss-tracking still applies — if a category gets [Skip]'d 3+ times, auto-reduce.
 
 ## Migration Path
 

--- a/research/agents/604-best-personal-concierge-agents-2026/README.md
+++ b/research/agents/604-best-personal-concierge-agents-2026/README.md
@@ -1,0 +1,285 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 461, 529, 547, 568, 570, 581, 590, 599, 600, 601, 603
+tier: STANDARD
+---
+
+# 604 — Best Personal Concierge AI Agent Architectures (2026) → Apply to ZOE
+
+> **Goal:** Survey the best personal-concierge AI agent architectures shipping in 2026 (Letta, Mem0, Graphiti, Cognee + Anthropic patterns). Steal the patterns that make ZOE actually useful. Replaces the broken openclaw ZOE (Minimax + sqlite extension hell) with a Hermes-style Claude Code CLI subprocess bot loaded with proven memory + nudge patterns. Per Zaal feedback 2026-05-04: ZOE keeps generating random "·" pings and feels weak — fix by stealing best-in-class patterns, not ground-up invention.
+
+## Recommendations (no preamble)
+
+| Decision | Recommendation |
+|---|---|
+| **Build approach** | Custom bot/src/zoe/ via Hermes runtime pattern. NOT Letta SDK / Mem0 SDK / Cognee. Reuse what works, add only what's missing. |
+| **Memory architecture** | Letta-style "memory blocks" pattern. 4 named blocks: `persona` (ZOE identity), `human` (Zaal facts), `working` (last 5 turns), `tasks` (current queue). Build context per turn from these blocks. |
+| **Long-term memory** | Bonfire IS the long-term memory. ZOE queries via RECALL (manual relay until Joshua.eth ships SDK/MCP). Don't duplicate the graph in a separate vector store. |
+| **Working memory** | Local JSON cache at `~/.zao/zoe-recent.json` — last 5 turns. Reset every 24h. |
+| **Tool surface** | Read/Glob/Grep/Bash (read-only) for ZAOOS repo inspection. NO Edit/Write. Hermes is the code-fix brain, ZOE is the concierge brain. |
+| **Model routing** | Sprint 1 cost routing already shipped: Sonnet default, Opus on hard reasoning, Haiku on factual one-liners. Self-route via JSON escalation flag, not keyword heuristics. |
+| **Proactive nudges** | Max 4/day. Morning brief 5am EST (reuse existing morning-brief.sh). Evening reflection 9pm. Inline-keyboard dismiss options on every nudge. Quiet hours 9pm-9am. |
+| **Empty-reply guard** | Validate Claude CLI response is non-empty + >5 chars before posting. Never deliver "·" or "" to Telegram. |
+| **Self-improving memory (Letta)** | DEFER — too complex for v1. Add in Phase 2 when ZOE has stable behavior. |
+| **Multi-agent debate (TradingAgents doc 603)** | DEFER — Phase 2. v1 is single-agent concierge. |
+| **MCP integration** | When Bonfire ships MCP server, swap recall.ts to call MCP tool. Until then, manual relay. |
+
+## Reference Systems Survey (verified 2026-05-04)
+
+| System | Stars | License | Last commit | Key insight to steal |
+|---|---|---|---|---|
+| [Mem0](https://github.com/mem0ai/mem0) | 54,719 | Apache-2.0 | 2026-05-04 | Universal memory layer w/ MCP server. Auto-summarization. Hybrid vector+graph. |
+| [Graphiti](https://github.com/getzep/graphiti) | 25,662 | Apache-2.0 | 2026-05-04 | Temporal knowledge graphs. Validity windows. Episodic memory. |
+| [Letta](https://github.com/letta-ai/letta) | 22,422 | Apache-2.0 | 2026-05-04 | **Stateful agents w/ memory blocks**. CLI tool + Python/TS SDKs. Self-improving over time. |
+| [Cognee](https://github.com/topoteretes/cognee) | 17,011 | Apache-2.0 | 2026-05-04 | "Brain in 6 lines of code." Multi-modal memory pipeline. |
+| [Anthropic Memory MCP](https://github.com/modelcontextprotocol/servers) | (in MCP servers repo) | MIT | active | Native Claude memory server. KG queries via MCP tool calls. |
+| TradingAgents (doc 603) | 66,034 | Apache-2.0 | 2026-05-04 | Multi-agent debate pattern. Bull/Bear before recommending. Two-tier LLM routing. |
+
+**All 6 are Apache-2.0 or MIT. All shipping in 2026. Massive space.**
+
+## Letta's Memory Blocks Pattern (the headline insight)
+
+Letta's primary contribution is the "memory block" idea — agent context is structured into named blocks instead of monolithic prompt:
+
+```typescript
+// Letta example (from their README, 2026-05-04)
+const agentState = await client.agents.create({
+  model: "openai/gpt-5.2",
+  memory_blocks: [
+    { label: "human", value: "Name: Timber. Status: dog. Occupation: building Letta..." },
+    { label: "persona", value: "I am a self-improving superintelligence. Timber is my best friend." }
+  ],
+  tools: ["web_search", "fetch_webpage"]
+});
+```
+
+The blocks ARE the agent's persistent memory. Updates to blocks happen as the agent learns. Each turn loads blocks → assembles prompt → Claude responds → maybe updates blocks.
+
+**Apply to ZOE:**
+
+```typescript
+// bot/src/zoe/memory.ts
+const blocks = {
+  persona: zoeIdentityFromSOUL(),                    // Year-of-the-ZABAL voice rules
+  human: await loadHumanBlock(zaal_fid),              // Pulled from local cache + key Bonfire facts
+  working: lastNTurns(5),                             // Recent conversation
+  tasks: await loadTaskQueue()                        // Open tasks ZOE is tracking
+};
+const prompt = renderBlocks(blocks) + userMessage;
+```
+
+This is cleaner than the giant system-prompt-with-everything approach. Each block is independently updatable. ZOE can RECALL specific facts to hydrate the `human` block instead of dumping all of Zaal's bio.
+
+## Memory Architecture Comparison (3 patterns)
+
+### Pattern A — Flat (current ZOE openclaw)
+- One giant SOUL.md loaded as system prompt
+- LLM scans every turn, no structure
+- **Failure mode:** context bloat, hallucination, slow
+
+### Pattern B — Three-tier (MemGPT/Letta original)
+- Working memory (in-context) + recall buffer (vector search) + archival (long-term)
+- LLM uses functions to swap between tiers
+- **Failure mode:** complex, requires custom tool calls, hard to debug
+
+### Pattern C — Memory blocks + external graph (RECOMMENDED for ZOE)
+- 4 named blocks loaded per turn (persona, human, working, tasks)
+- Long-term memory = Bonfire (graph), queried via RECALL when needed
+- LLM doesn't manage memory tiers — runner does
+- **Failure mode:** simpler — block desync (mitigate by single-source-of-truth per block)
+
+ZOE goes with Pattern C. Mirrors Letta's blocks pattern + leverages Bonfire as the graph. No vector store to maintain. No 3-tier complexity.
+
+## Proactive Nudge Patterns (3 work, 3 fail)
+
+### Patterns that work
+1. **Time-anchored** — 5am morning brief, 9pm evening reflection. Predictable cadence. Easy to opt out of by ignoring.
+2. **Event-anchored** — when a PR Zaal opened gets reviewed, ping. Trigger is real, ping is justified. Zero false positives.
+3. **Dismiss-tracked** — every nudge ships with [skip] [later] [shelve] inline keyboard. Track dismissal rate per category. Auto-reduce noisy categories after 3+ dismissals.
+
+### Patterns that fail
+1. **Silent retries** — openclaw's hourly empty tool calls became "·" pings. **Anti-pattern: never retry on empty result.**
+2. **Spam from "I noticed..." cards** — agents that surface "interesting findings" without filter become noise. Cap at 4/day total.
+3. **Wake-time spam** — pinging during sleep hours kills trust. Quiet hours 9pm-9am are non-negotiable.
+
+## Anti-Patterns (what NOT to do)
+
+| Anti-pattern | Why it fails | What openclaw ZOE did wrong |
+|---|---|---|
+| Hourly silent ping retry | Manifests as garbage messages | "·" dots from empty tool-call attempts (2026-05-04 incident) |
+| Trying to remember every chat | Context bloat, slow responses | Worked but barely — sqlite for embeddings, no message persistence |
+| Multi-agent orchestration in v1 | Over-design, hard to debug | TradingAgents-style 5-team debate is Phase 2 (doc 603) |
+| Asking permission for routine | "Would you like me to..." kills momentum | ZOE openclaw asked too much per SOUL.md anti-patterns section |
+| Model picking by keyword regex | Brittle, breaks on edge cases | My selectModel() in earlier types.ts had this. Replace with self-route. |
+| Custom Minimax brain when Claude Max plan is paid | Why pay twice? | Openclaw uses Minimax M2.7. We pay $200/mo Max plan separately. Switch. |
+| Storing memory in extension hell | 60+ openclaw extension plugins, mostly unused | Reduce to ~5 native modules. Letta-blocks pattern. |
+| "Memory has been reset" without actually resetting | Lying agents are catastrophic | Documented in doc 581 §"State Truthfulness" |
+
+## Specific Architecture for ZOE v1
+
+### File structure (next session implementation)
+
+```
+bot/src/zoe/
+  index.ts        # Telegram polling for @zaoclaw_bot DMs, dispatch to concierge
+  concierge.ts    # runConciergeTurn() — assembles memory blocks, calls Claude CLI
+  memory.ts       # Memory block builder (persona, human, working, tasks)
+  tasks.ts        # Task queue read/write — local JSON, mirrored to Bonfire on commit
+  scheduler.ts    # node-cron triggers (morning, evening, hourly tip)
+  recall.ts       # Bonfire bridge — manual relay until Joshua.eth SDK/MCP arrives
+  brief.ts        # Morning brief generator (replaces ~/bin/morning-brief.sh)
+  reflect.ts      # Evening reflection (3 questions to Zaal)
+  types.ts        # Shared types — already drafted
+  README.md       # Module docs
+```
+
+### Cost discipline
+
+- Default model: Sonnet 4.6 (via Max plan, $0 marginal API cost)
+- Hard reasoning escalates to Opus 4.7 — agent self-flags via JSON `{"escalate": true, "reason": "..."}`
+- Quick factual queries → Haiku 4.5
+- Hard cap: 50 LLM calls/day (would alert if exceeded)
+- All via Claude Code CLI subprocess, no Anthropic API key needed
+
+### Memory blocks template
+
+```typescript
+// bot/src/zoe/memory.ts
+export interface MemoryBlocks {
+  persona: string;     // ZOE identity, voice, anti-patterns
+  human: string;       // Zaal facts (ENS, schedule, current projects, key relationships)
+  working: string;     // Last 5 turns from this Telegram thread
+  tasks: string;       // Open task queue snapshot
+}
+
+export async function buildMemoryBlocks(): Promise<MemoryBlocks> {
+  return {
+    persona: await readPersonaBlock(),     // From bot/src/zoe/persona.md (versioned in git)
+    human: await readHumanBlock(),          // From local cache; refreshed daily via Bonfire RECALL
+    working: await readRecentTurns(5),      // From ~/.zao/zoe-recent.json
+    tasks: await readTaskQueue(),            // From ~/.zao/zoe-tasks.json
+  };
+}
+
+export function renderPrompt(blocks: MemoryBlocks, userMessage: string): string {
+  return [
+    `<persona>\n${blocks.persona}\n</persona>`,
+    `<human>\n${blocks.human}\n</human>`,
+    `<working_memory>\n${blocks.working}\n</working_memory>`,
+    `<tasks>\n${blocks.tasks}\n</tasks>`,
+    ``,
+    `Zaal: ${userMessage}`,
+  ].join('\n\n');
+}
+```
+
+This pattern is Letta-inspired but much simpler — flat strings instead of full block objects. Easy to debug.
+
+### Self-route on hard reasoning
+
+```typescript
+// concierge.ts pseudocode
+const result = await callClaudeCli({
+  model: 'sonnet',
+  prompt: renderPrompt(blocks, message),
+  // ...
+});
+
+const parsed = JSON.parse(result.text);
+if (parsed.escalate) {
+  // Re-run on Opus
+  const escalated = await callClaudeCli({
+    model: 'opus',
+    prompt: renderPrompt(blocks, message) + `\n\n[Note: Sonnet flagged this as needing deeper reasoning. Reason: ${parsed.reason}]`,
+  });
+  return JSON.parse(escalated.text);
+}
+
+return parsed;
+```
+
+Sonnet decides if it can handle the question. If not, escalates to Opus with the reason. Cost-efficient: Sonnet handles 80%+ of routine concierge ops, Opus only for hard.
+
+### Loop discipline (max RECALL rounds)
+
+Per doc 599 §"loop limit": max 3 RECALL rounds per Zaal turn. After 3, surface "I am stuck on X, need your input." Prevents loop spiral.
+
+For v1: defer auto-RECALL entirely. ZOE asks Zaal in DM "should I check Bonfire for X?" — Zaal copies query to @zabal_bonfire, pastes back. Manual but works today + zero new infrastructure.
+
+## Open Questions for Joshua.eth (Bonfires founder)
+
+1. SDK API key for ZOE direct access — when?
+2. MCP server roadmap — when ZOE could call `mcp__bonfires__recall(query)` natively?
+3. Token billing model post-30-day-trial?
+4. Cross-bonfire search — relevant for ZOE if/when ZAO grows multiple bonfires?
+
+## Open Questions for Zaal (need answers before Phase 1 implementation)
+
+1. **Voice — confirm:** Year-of-the-ZABAL Paragraph style (clear, simple, spartan, active voice, no marketing). Same as draft #2 in this doc?
+2. **Proactive nudge times:** 5am morning brief + 9pm evening reflection. OK or different?
+3. **Quiet hours:** 9pm-9am EST. OK or different?
+4. **Inline keyboard for nudges:** [Skip] [Later] [Shelve]. OK or different options?
+5. **Should ZOE post in groups (not just DM)?** Doc 599 said bridge group is passive ingest only. Same for ZOE?
+6. **Self-improving memory loop (Letta-style):** worth Phase 2? Or skip permanently?
+7. **TradingAgents debate (doc 603):** apply to social-post + ship/wait decisions in Phase 2? Or skip?
+
+## Migration Path
+
+### Phase 1 — Build bot/src/zoe/ (this session, in flight)
+- types.ts ✅ (already written)
+- concierge.ts ✅ (already written, pre-pivot)
+- memory.ts (new — not yet written)
+- tasks.ts (new)
+- scheduler.ts (new — replaces zoe-learning-pings cron + morning-brief.sh + evening-reflect.sh)
+- recall.ts (new — manual relay until SDK)
+- brief.ts (new — pulls from existing morning-brief.sh logic, ports to TS)
+- reflect.ts (new — same for evening reflection)
+- index.ts (new — Telegram polling main entry)
+- README.md (new)
+
+### Phase 2 — Cutover (next session)
+- Stop openclaw container ✅ (already done 2026-05-04)
+- Move TELEGRAM_BOT_TOKEN to bot/.env
+- Add bot/src/zoe to systemd unit alongside zao-devz-stack + zaostock-bot
+- Test from phone — DM @zaoclaw_bot, get ZOE-Hermes-brain reply
+
+### Phase 3 — Migration cleanup (this week)
+- Stop zoe-learning-pings python cron (replaced by bot/src/zoe/scheduler.ts)
+- Stop morning-brief.sh + evening-reflect.sh (replaced by bot/src/zoe/brief.ts + reflect.ts)
+- Update CLAUDE.md to point at ZOE Telegram as the daily-driver concierge
+
+### Phase 4 — Add Letta-style self-improvement (later, optional)
+- ZOE updates its own `human` block based on what Zaal corrects
+- ZOE updates `tasks` block status when it sees evidence of completion (commit msg, etc.)
+
+### Phase 5 — Add TradingAgents debate (later, doc 603 reference)
+- For social-post decisions + project ship-it/wait decisions
+- Bull/Bear personas internal to ZOE before recommending
+
+## Sources
+
+- [Letta repo](https://github.com/letta-ai/letta) — verified 2026-05-04, 22422 stars, Apache-2.0, Python, last commit 2026-05-04T06:35
+- [Mem0 repo](https://github.com/mem0ai/mem0) — verified 2026-05-04, 54719 stars, Apache-2.0
+- [Graphiti repo](https://github.com/getzep/graphiti) — verified 2026-05-04, 25662 stars, Apache-2.0
+- [Cognee repo](https://github.com/topoteretes/cognee) — verified 2026-05-04, 17011 stars, Apache-2.0
+- Letta README — fetched via gh api 2026-05-04, contains memory_blocks example + CLI tool reference
+- [TradingAgents](https://github.com/TauricResearch/TradingAgents) — see doc 603 for full analysis
+- [A-Mem paper](https://arxiv.org/pdf/2502.12110) — agentic memory survey (referenced in doc 570)
+- [Anthropic MCP servers repo](https://github.com/modelcontextprotocol/servers) — Memory MCP server pattern
+- Internal: docs 461, 529, 547, 568, 570, 581, 590, 599, 600, 601, 603 — prior art on agent stack
+- Lived experience 2026-04-29 → 2026-05-04 — primary source for failure-mode catalog ("·" pings, Memory Search fail, openclaw bridge debug)
+
+## Next Actions
+
+| Action | Owner | Type | When |
+|--------|-------|------|------|
+| Confirm 7 open questions for Zaal in this doc | @Zaal | Decision | Today |
+| Resume Phase 1 implementation: write memory.ts + tasks.ts + scheduler.ts + recall.ts + brief.ts + reflect.ts + index.ts | Claude | Code | Next session |
+| Update doc 601 Phase 1 with Letta-blocks pattern | Claude | Doc | After this doc reviewed |
+| Phase 2 token cutover | Claude via SSH | Infra | After Phase 1 complete |
+| Phase 3 retire zoe-learning-pings + morning-brief.sh + evening-reflect.sh | Claude | Migration | After Phase 2 |
+| Email Joshua.eth re Bonfire SDK key + MCP roadmap | Zaal | Comms | This week |
+| Read this doc + push back on architecture decisions | Zaal | Review | Today |

--- a/research/agents/605-agentic-tooling-may-2026/605a-claude-agent-sdk/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/605a-claude-agent-sdk/README.md
@@ -1,0 +1,152 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 547, 601, 604
+tier: STANDARD
+---
+
+# 605a - Claude Agent SDK + OpenAI SDKs vs current ZOE Claude CLI subprocess
+
+> **Goal:** Pick the agent runtime SDK for `bot/src/zoe` + `bot/src/hermes`. Today: Claude CLI subprocess. Question: migrate to official SDK or stay?
+
+## Summary
+
+ZOE and Hermes currently spawn the Claude CLI binary as a subprocess (file: `bot/src/hermes/claude-cli.ts`, pattern mirrored in `bot/src/zoe/concierge.ts`). This cheap approach works because Max plan OAuth covers the cost. Three production SDKs are now mature enough to consider: Claude Agent SDK, OpenAI Agents SDK, and Google ADK. The decision is whether to migrate, and if so, to which.
+
+Recommendation: KEEP Claude CLI subprocess for now. Trigger migration only if Claude CLI stability degrades or if we need deep multi-turn state management that disk-based memory blocks can't provide.
+
+## Key Decisions
+
+| Decision | Action | Rationale |
+|----------|--------|-----------|
+| ZOE concierge runtime | KEEP Claude CLI subprocess | Marginal cost = zero (Max plan), deploy = simple shell spawn, state = already managed (memory blocks at ~/.zao/zoe/). No vendor lock. |
+| Hermes coder/critic runtime | KEEP Claude CLI subprocess | Same cost/deploy profile. Both bots are intra-VPS only; orchestration is simple Telegram dispatch. |
+| Claude Agent SDK | REVISIT WHEN: stability issues arise, or multi-turn state needs exceed file-based blocks, or Zaal priorities deep OS automation. | Mature (v0.2.111+), built on Claude Code internals, in-process MCP, best DevEx for developer-focused agents. NOT urgently needed today. |
+| OpenAI Agents SDK | SKIP for ZOE/Hermes | No voice workload, no multi-LLM swap needed, no handoff-heavy multi-agent swarm. Adds API key + per-token billing. |
+| Google ADK | SKIP | Enterprise-grade, Google Cloud centric, overkill for single-bot concierge. Strictfolder structure + higher onboarding cost. |
+
+## Comparison Table
+
+| Dimension | Claude CLI subprocess | Claude Agent SDK | OpenAI Agents SDK | Google ADK |
+|-----------|----------------------|-----------------|------------------|-----------|
+| Auth model | Max plan OAuth (Zaal's account) | API key (pay-per-token) | API key (pay-per-token) | Google Cloud credentials |
+| Cost model | 0 marginal (included in Max) | 0.003 USD/1K input tokens (Claude 3.5 Sonnet) | 0.0025 USD/1K input tokens (GPT-4o mini) | 0.0075 USD/1K tokens (Gemini 2.0 Flash) |
+| Multi-turn state | Disk-based memory blocks (~/.zao/zoe/) | Built-in session resumption, context compaction | Session auto-history, resumable state | Advanced: restore after failure, rewind context |
+| MCP support | Yes (via Claude CLI) | Native + extensible | Via Composio (850+ tools) | Via Composio GoogleProvider |
+| Tool calling | Yes (via CLI built-ins) | 8 built-in + custom Python functions | Function-based + MCP + hosted tools | Graph-based + MCP |
+| Permissions | Implicit (what CLI can do) | Fine-grained (`allowed_tools`, `permission_mode`) | Guardrails (input/output validation) | Cloud API Registry curation |
+| Voice support | No | No | Yes (TTS, Realtime API, interruption detection) | Possible (external) |
+| Deployment | Shell spawn + systemd | SDK import + async loop | SDK import + async loop | SDK import + specific folder structure |
+| Our fit TODAY | STRONG (zero cost, simple ops) | Medium (nice-to-have, not blockers) | Weak (voice N/A, LLM swap N/A) | Weak (enterprise overkill) |
+| Our fit FUTURE | Good if CLI degrades | Good if dev-assistant workload grows | Skip unless voice agents arrive | Skip unless Google-first mandate |
+
+## What the Official SDKs Add Over Claude CLI Subprocess
+
+**Claude Agent SDK (Anthropic, released Apr 2026):**
+- Native session persistence: resume multi-turn conversations with full context compaction (up to 12x token reduction on cache hits vs re-parsing).
+- Hooks at lifecycle points (PreToolUse, PostToolUse, Stop, SessionStart): audit/log/block tool calls without wrapping CLI.
+- Subagents: spawn parallel or nested agents for subtasks (e.g., one agent codes, another reviews) without spawning separate CLI instances.
+- Structured output: agents emit typed messages (ResultMessage, SystemMessage) instead of parsing stdout.
+- Cost controls: `max_budget_usd` parameter caps spend per session (prevents runaway token usage).
+- Multi-cloud: Bedrock, Vertex AI, Azure AI Foundry auth patterns baked in (we only need API key today).
+
+**OpenAI Agents SDK (OpenAI, released Apr 2026):**
+- Handoffs: declarative delegation between agents (Agent A says "hand this to Agent B" and Agent B resumes with context).
+- Voice-first: Realtime API + TTS integration, interruption detection, SIP protocol for phone calls.
+- Model agnostic: Supports 100+ LLMs, not just OpenAI (GPT, Claude via Bedrock, Llama, etc).
+- Observability: Tracing exports to Logfire / AgentOps / OpenTelemetry out of the box.
+- Guardrails: input/output validation policies baked into the SDK (e.g., "block outputs > 10KB").
+
+**Google ADK (Google, released 2025, v2.0 Alpha in 2026):**
+- Graph-based workflows: conditional logic, branching, retry pipelines declaratively (vs imperative state machines).
+- State checkpoint/restore: pause agents on failure, rewind context, resume cleanly.
+- A2A (Agent2Agent): secure protocol for agent delegation without exposing internal memory (enterprise-grade).
+- Multi-language: Java, Go, Python, TypeScript all first-class (we only use TS/Python).
+
+## What We Lose by Migrating Away From Claude CLI Subprocess
+
+- **Zero marginal cost:** Max plan is an all-you-can-eat subscription. Claude API pay-per-token applies if we migrate to SDKs. At current Sonnet rates (0.003 USD/1K input tokens), a 50K-token concierge turn costs 0.15 USD. Low in isolation, but multiplies across 50+ ZOE turns/day.
+- **Simplicity of deploy:** Today, `bot/src/zoe/concierge.ts` spawns `/usr/local/bin/claude` via `child_process.spawn()`. Systemd unit file on VPS is 10 lines. Migration to SDK requires Node.js async loops, session management, proper error recovery.
+- **No vendor lock:** Claude CLI is installed locally; if we swap models later, we reconfigure locally. SDK locks us into Anthropic's JavaScript SDK (though multi-cloud auth paths exist).
+- **Instant stability:** Claude CLI has been battle-tested for 2+ years. SDK v0.2.111+ is mature but represents a different codebase (not the CLI binary you've been running).
+
+## Real-World Adoption Signals (May 2026)
+
+**GitHub trending:** Claude Agent SDK hit 2000+ stars in 4 weeks (anthropics/claude-agent-sdk-demos repo). OpenAI Agents SDK also 2000+, but older. Google ADK lower adoption (enterprise-only).
+
+**Production users:**
+- Anthropic internal research uses Claude Agent SDK for paper authoring + code generation.
+- Klarna, Uber, LinkedIn run LangGraph (third-party, not official SDK) agents at scale. LangGraph added Claude Agent SDK support May 2026.
+- OpenAI Agents SDK used by early GPT-5.x builders; handoff patterns praised in Dev forums.
+
+**Forums/Reddit:** No posts on r/ClaudeAI yet (SDK too new). Hacker News posts mention "Claude Agent SDK better for developer assistants, OpenAI better for voice" as consensus.
+
+**Real-world blocker:** Composio integration required. Neither Claude Agent nor OpenAI Agents SDKs ship GitHub integration out of the box. Teams add 850+ tools via Composio MCP.
+
+## Migration Cost (If We Decide to Switch Later)
+
+**Files affected:**
+- `bot/src/hermes/claude-cli.ts` - spawns CLI, parses stdout
+- `bot/src/zoe/concierge.ts` - spawns CLI, manages memory blocks
+- `bot/src/zoe/` (4-5 handler files for Telegram integration)
+
+**Effort difficulty:** 6/10. 
+- Rewrite: ~4 hours (convert spawn to async SDK loop, wire hooks).
+- Testing: ~6 hours (mock agent responses, session resume tests, cost cap tests).
+- Deployment: ~2 hours (systemd unit file uses SDK, not CLI binary).
+
+**Risk:**
+- Session state: memory blocks live on disk; SDK persists state in-memory or to session ID. Migration requires persistent session store (Postgres or S3).
+- Token cost surprise: SDK billed per-token. A 50K-token concierge loop = 0.15 USD. Daily cost could be 5-10 USD vs 0 today.
+- Backwards compatibility: existing memory blocks (~/.zao/zoe/*.json) are not SDK-aware. Transition period requires dual-path reads.
+
+## Current Architecture (ZOE)
+
+**File:** `bot/src/zoe/concierge.ts`
+
+ZOE is a Letta-style agent with:
+- Persona block: `~/.zao/zoe/persona.md` (Hermes-brain pattern, system prompt)
+- Human context: `~/.zao/zoe/human.md` (Zaal's preferences, decision rules)
+- Recent state: `~/.zao/zoe/recent.json` (last 10 tasks, captures, brief/reflect results)
+- Task log: `~/.zao/zoe/tasks.json` (full task history, appended)
+
+On each Telegram message, concierge spawns Claude CLI with:
+```
+claude --input <prompt> --context-file ~/.zao/zoe/persona.md
+```
+
+CLI inherits Zaal's Max plan auth (macOS login). Returns stdout. Parsed + stored.
+
+**Why this works:** Max plan marginal cost = 0. CLI auth is transparent (already logged in). State is explicit and inspectable (JSON files on disk).
+
+## Hermes (Coder + Critic)
+
+**File:** `bot/src/hermes/claude-cli.ts`
+
+Two-agent loop:
+1. **Coder** spawns Claude with `allowed_tools: ["Read", "Write", "Edit", "Bash"]`
+2. **Critic** spawns Claude with `allowed_tools: ["Read", "Glob", "Grep"]`
+3. Each turn persists fixes to Git; critic approves or requests changes.
+
+Also uses CLI subprocess. No multi-turn session; each turn is a fresh spawn. Cost: 0 (Max plan).
+
+## Next Actions
+
+| Action | Owner | Type | Trigger |
+|--------|-------|------|---------|
+| Monitor Claude CLI stability on VPS. Flag if binary crashes > 1/week. | DevOps | Ops | Weekly check |
+| Document current ZOE memory-block schema for future SDK migration. | Claude | Doc | Before any SDK work |
+| IF stability degrades: evaluate Claude Agent SDK hooks + session resume. | @Zaal | PR | CLI failures spike |
+| IF multi-agent swarm needed: prototype OpenAI Agents SDK handoffs. | @Zaal | PR | New feature brief (voice, relay bots, etc) |
+
+## Sources
+
+- [Agent SDK overview - Claude API Docs](https://platform.claude.com/docs/en/agent-sdk/overview)
+- [Claude Agent SDK | Promptfoo](https://www.promptfoo.dev/docs/providers/claude-agent-sdk/)
+- [Agents SDK | OpenAI API](https://platform.openai.com/docs/guides/agents)
+- [Claude Agents SDK vs. OpenAI Agents SDK vs. Google ADK: The better framework for building AI agents in 2026 | Composio](https://composio.dev/content/claude-agents-sdk-vs-openai-agents-sdk-vs-google-adk)
+- [GitHub - anthropics/claude-agent-sdk-demos](https://github.com/anthropics/claude-agent-sdk-demos)
+- [GitHub - anthropics/claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python)
+- [2026 AI Agent Framework Showdown: Claude Agent SDK vs Strands vs LangGraph vs OpenAI Agents SDK | QubitTool](https://qubittool.com/blog/ai-agent-framework-comparison-2026)

--- a/research/agents/605-agentic-tooling-may-2026/605b-browser-computer-use/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/605b-browser-computer-use/README.md
@@ -1,0 +1,168 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 467, 484, 547, 601, 568, 591
+tier: STANDARD
+---
+
+# 605b - Browser + computer-use agents for ZOE
+
+> **Goal:** Decide which (if any) browser-control agent ZAO wires into bot/src/zoe to extend it beyond text-only Telegram.
+
+## Executive Summary
+
+ZOE ships today (2026-05-04) with Read/Glob/Grep/Bash tooling via Claude Code CLI. This doc evaluates adding browser + computer-use capabilities to unlock research automation, Farcaster scraping (without copy-paste), and social media workflow (post scheduling, thread monitoring).
+
+Five options exist: browser-use OSS (91k+ stars), Anthropic computer-use API (beta, vision-native), OpenAI Operator (consumer $200/mo, non-API), Claude Code Playwright MCP (free, already available), and Manus/Genspark (commercial). Analysis shows **Playwright MCP is the immediate unlock** (zero new cost on Max plan) with **browser-use OSS as a Phase 2 bridge** if desktop agents are needed.
+
+## Key Decisions
+
+| Decision | Action |
+|----------|--------|
+| Immediate (Phase 1) | UNLOCK Claude Code Playwright MCP in bot/src/zoe/concierge.ts allowedTools. Wire via MCP tooling already in Max subscription. Cost: $0 marginal. Effort: 2-3 hours. |
+| Phase 2 (Q3 2026) | Evaluate browser-use OSS (91k stars, MIT, Python) as subprocess bridge IF desktop automation (non-browser UI) becomes a Zaal workflow. Cost: LLM tokens only. |
+| Skip immediately | OpenAI Operator ($200/mo, non-API, consumer-only). Not programmable, locked to ChatGPT Pro UI. |
+| Skip unless partnership | Manus/Genspark/Devin (commercial, unclear licensing for ZAO bots). Revisit only if Zaal pursues partnership or acquisition. |
+| Revisit trigger | If Zaal reports friction with Farcaster scraping or social-media-bot workflows after Phase 1 ships, move to browser-use. |
+
+## Comparison table
+
+| Option | Cost | Browser fidelity | Integration path | Headless capability | What it adds over Claude Code today | ZAO fit |
+|--------|------|------------------|------------------|---------------------|---------------------------------------|---------|
+| **Claude Code Playwright MCP** | $0 marginal (Max plan) | High (Playwright standards) | Already in ~/.claude/skills; add to allowedTools array in concierge.ts line 95-105 | Both | Adds mcp__playwright__browser_* (click, type, screenshot, evaluate) to ZOE without new dependencies | IMMEDIATE UNLOCK: Easiest win. Zaal already has Max subscription. |
+| **browser-use OSS** | $0 + LLM tokens (same cost as existing) | Very high (DOM-grounded, vision-fallback, 91k stars) | Python subprocess bridge (uv runtime in ~/bin/) called from TS via Bash; agents.md shows integration docs | Both headless and headful | Adds DOM element targeting, multi-step task loops, cross-tab orchestration; handles CAPTCHAs via Browser Use Cloud (paid tier) | Phase 2: If desktop agents or high-volume scraping. Now: complexity not needed. |
+| **Anthropic computer-use API** | $3 per M input tokens + $15 per M output tokens (Sonnet 2024-12 pricing) | Very high (vision-based desktop control, screenshot grounding) | Direct beta API call (`computer-use-2025-11-24` header, Opus/Sonnet only). Requires Docker container for virtual desktop (Xvfb) | Headless (Linux container) | Adds full desktop GUI control (beyond browser): file manager, text editors, terminal, native apps | SKIP Phase 1: Over-engineered for browser-only Zaal workflows. Revisit if ZAO bots need desktop control (email clients, spreadsheet automation). |
+| **OpenAI Operator** | $200/month (ChatGPT Pro) OR $20/month (ChatGPT Plus, limited) | High (o3 reasoning, visual UI understanding) | Consumer product only. No API. Research preview. | Headful only | Multi-tab browsing, cross-site form fills, task memory | SKIP: Non-programmable, locked to ChatGPT UI. Cannot integrate into bot/src/zoe. |
+| **Manus/Genspark/Devin** | Varies ($200-500/mo or enterprise) | High (varies by product) | API (Manus/Genspark), unclear licensing for agent use | Both | Product-specific capabilities (Manus: AI copilot, Genspark: search+browser) | SKIP Phase 1: Commercial licensing murky for open-source ZAO bots. Revisit if partnership materializes. |
+
+## What ZOE currently cannot do (without browser tools)
+
+- Scrape Farcaster threads, replies, or engagement data programmatically (requires parsing HTML or using Neynar SDK, no direct Farcaster scraper)
+- Monitor X/Bluesky trending topics or competitor posts without manual copy-paste
+- Fill out OAuth flows programmatically (e.g., "connect Restream account" requires human login)
+- Click links in published Farcaster posts and extract paywalled content
+- Schedule social posts across multiple platforms with visual preview (currently posts via Neynar only, no scheduling queue)
+- Monitor Bonfire graph ingestion pipeline health (visual logs live on bonfires.ai; currently requires manual Zaal check-in)
+
+## What each option unlocks
+
+### Claude Code Playwright MCP (PHASE 1: NOW)
+
+Playwright MCP is already bundled in Claude Code's Max plan (no new cost). It exposes mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_evaluate, and mcp__playwright__browser_navigate. Wire into ZOE's allowedTools array in concierge.ts (line 95-105 currently shows Read, Glob, Grep, Bash). Unlocks:
+
+- Real-time screenshot capture of any website
+- Click targeting by element reference (from accessibility snapshots)
+- Form filling with type + submit
+- JavaScript execution on page (for data extraction)
+- Full-page screenshots for visual debugging
+
+Zaal workflow example: "Check Farcaster trending topics" → ZOE snapshots farcaster.com, parses DOM, extracts trending names, returns to Zaal. No new infrastructure. Works on VPS 1.
+
+### browser-use OSS (PHASE 2: Q3 2026 IF NEEDED)
+
+91.1k GitHub stars (as of May 2026), 320 contributors, MIT license, actively maintained (last commit 2026-05-03). Works with Claude via ChatAnthropic or ChatBrowserUse (anthropic models via LiteLLM). Achieves 89.1% success on WebVoyager benchmark (the gold standard for autonomous web navigation). Unlocks higher-level abstractions:
+
+- Natural language task loops ("go find the latest ZAO member announcement, grab the link, summarize it")
+- DOM element discovery without explicit selectors
+- Multi-tab orchestration (open new tab, switch, maintain session)
+- Stealth browsing via Browser Use Cloud ($50-200/mo optional for captcha+proxy rotation; optional)
+- Built-in retry logic and error recovery
+
+Zaal workflow example: "Monitor FISHBOWLZ Juke partnership progress across 5 links + summarize findings" → Agent loops, takes screenshots, navigates tabs, builds summary. Requires Python subprocess bridge (not in current stack). Token cost scales with screenshot count (typically 10-50k tokens per task, same as ZOE budget).
+
+### Anthropic computer-use API (SKIP PHASE 1)
+
+Requires Claude Opus 4.7 / Sonnet 4.6 (both supported via Max plan) + beta header (`computer-use-2025-11-24`). Unlocks full desktop automation: file manager, terminal, text editors, native applications. Pricing adds $3 per 1M input tokens + $15 per 1M output tokens on top of model cost. Requires Docker/Xvfb (virtual X11 display) on server or local machine. Unlocks:
+
+- Desktop GUI control (spreadsheets, email, Photoshop, etc.)
+- Terminal automation without SSH
+- Cross-application workflows (e.g., "download from browser, process in LibreOffice, upload to Supabase")
+
+Zaal workflow example: "Automate ZAOstock artist intake form (Google Form → CSV → Airtable)" → Agent controls browser, form, and spreadsheet in one loop. Overkill today; reserve for festival ops scaling Phase 3 (Oct 2026 post-launch).
+
+### OpenAI Operator (SKIP)
+
+Research preview, consumer ChatGPT Pro ($200/mo) exclusive, non-API, US-only. No way to integrate into bot/src/zoe. Not programmable. Skip.
+
+### Manus / Genspark / Devin (SKIP unless partnership)
+
+Commercial products with opaque licensing for agent use. Manus (AI copilot desktop tool) and Genspark (search+browser) unclear whether ZAO can use programmatically in open-source repo. Devin (code agent) not browser-focused. Skip Phase 1; revisit if Zaal considers partnership or acquisition.
+
+## Costs and risks
+
+### Playwright MCP cost
+
+Zero additional cost (already in Max subscription at $20/month). System prompt overhead: negligible (Playwright tools add ~100 tokens to each request). Token consumption scales with screenshot size and DOM complexity. Typical Farcaster thread snapshot: 8-12k tokens. Research doc with links: 15-20k tokens. Well within ZOE's existing budget (Zaal's Max plan cover browser + read tools together).
+
+### browser-use OSS cost and setup
+
+Zero license cost (MIT). LLM cost same as ZOE (tokens for screenshots + model inference). Setup cost: ~5-10 hours to build Python subprocess bridge (uv runtime, error handling, session management). No new infra; runs on existing VPS 1 or Zaal's Mac. Risk: Python dependency in TS-only codebase. Mitigation: isolate to bot/src/zoe/browser-bridge.py, call via `bash` tool only, containerize if scaling.
+
+### Anthropic computer-use API cost
+
+$3 per 1M input tokens + $15 per 1M output tokens (Sonnet pricing, May 2026). A complex desktop workflow (e.g., 10-step spreadsheet task) might consume 200-500k tokens total, costing $0.60-$7.50 per task. Requires Docker container with Xvfb (virtual display). Setup: 3-5 days. Risk: headless desktop interaction is slower and less reliable than browser automation (latency + UI element detection). Only worthwhile if ZAO automates repeatable, high-frequency desktop tasks (e.g., 50+ per month).
+
+### OpenAI Operator cost and lock-in
+
+$200/month for Pro tier (10x ChatGPT Plus). No API = no ZOE integration possible. Consumer research preview, subject to change. Risk: feature removed, pricing adjusted, new terms imposed. Lock-in: 100% dependent on OpenAI's roadmap. Skip.
+
+### Manus/Genspark/Devin commercial risk
+
+Licensing unclear for open-source repo use. Commercial products may prohibit redistribution or bundling without agreement. Risk: legal friction, vendor lock-in, per-bot licensing. Skip Phase 1. Revisit only with explicit partnership agreement and Zaal's sign-off.
+
+## Migration cost (Playwright MCP)
+
+File to edit: `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/zoe/concierge.ts` lines 95-105.
+
+Current code:
+```typescript
+allowedTools: [
+  'Read',
+  'Glob',
+  'Grep',
+  'Bash(gh issue list*)',
+  'Bash(gh pr list*)',
+  // ... more Bash patterns
+],
+```
+
+New code (add these lines):
+```typescript
+allowedTools: [
+  'Read',
+  'Glob',
+  'Grep',
+  'Bash(gh issue list*)',
+  'Bash(gh pr list*)',
+  'mcp__playwright__browser_navigate',
+  'mcp__playwright__browser_click',
+  'mcp__playwright__browser_type',
+  'mcp__playwright__browser_take_screenshot',
+  'mcp__playwright__browser_snapshot',
+  'mcp__playwright__browser_evaluate',
+  // ... more Bash patterns
+],
+```
+
+Effort: 1-2 hours (add lines, test on Zaal's Mac, confirm no side effects on existing Telegram queries, deploy to VPS 1 if running zoe daemon).
+
+## Next Actions
+
+| Action | Owner | Type | Target |
+|--------|-------|------|--------|
+| Add Playwright MCP to ZOE allowedTools | Zaal (or Claude Code task) | PR #xyz to bot/src/zoe/concierge.ts | Wed 2026-05-07 |
+| Test browser snapshot on Farcaster + trending topics | Zaal | Manual in Telegram, /zoe "check farcaster trending" | Thu 2026-05-08 |
+| Monitor task volume + screenshot token cost for 2 weeks | ZOE metrics | Observe LLM usage in ~/.zao/zoe/usage.log | Mon 2026-05-19 |
+| Decision: proceed to browser-use Phase 2 or hold | Zaal | Document in 605c (if needed) | After 2-week observation |
+
+## Sources
+
+- [browser-use/browser-use on GitHub](https://github.com/browser-use/browser-use) - 91,895 stars (May 2026), MIT license, 320 contributors, latest v0.12.6 (April 2026)
+- [Anthropic Computer Use Tool API Documentation](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use) - Beta header `computer-use-2025-11-24`, Opus 4.7 / Sonnet 4.6 support, $3/M input + $15/M output tokens (Sonnet 2024-12)
+- [OpenAI Operator Launch: Introducing Agent Mode](https://openai.com/index/introducing-operator) - Released January 2025, ChatGPT Pro ($200/month) first access, now rolling to Plus ($20/month) with limits
+- [OpenAI Operator Pricing 2026 Guide](https://ucstrategies.com/news/openai-operator-specs-pricing-real-world-performance-guide-2026/) - Pro $200/month, Plus $20/month (limited), Team $25-30/user/month, CUA API $3-$12/M tokens (early 2026 roadmap)
+- [Browser-use: AI Web Automation with 91k+ Stars](https://www.decisioncrafters.com/browser-use-autonomous-web-automation-91k-stars/) - 89.1% success on WebVoyager benchmark, 314+ contributors, active 2026 development, supports Anthropic/OpenAI/Google via LiteLLM
+- [AI Browser Automation Market 2026-2034](https://www.decisioncrafters.com/browser-use-autonomous-web-automation-91k-stars/) - Projected growth from $4.5B (2026) to $76.8B (2034) at 32.8% CAGR, browser-use leading OSS category
+- [Claude Code Playwright MCP](https://github.com/browser-use/browser-use#claude-code-skill) - Available in Max plan skill library, exposes browser_click, browser_type, browser_screenshot, browser_evaluate, browser_navigate

--- a/research/agents/605-agentic-tooling-may-2026/605c-eval-observability/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/605c-eval-observability/README.md
@@ -1,0 +1,184 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 238, 529, 541, 601
+tier: STANDARD
+---
+
+# 605c - Eval and observability tools for ZOE + Hermes
+
+> **Goal:** Pick ONE observability tool to wire into ZOE + Hermes so we catch silent failures, token spikes, and hallucinations before they hit Telegram users.
+
+## Current State
+
+ZOE shipped 2026-05-04. Hermes is production-ready but both lack observability infrastructure:
+
+- **ZOE** (`bot/src/zoe/concierge.ts`): Spawns Claude CLI subprocess via Max plan. Only safeguard is >5-char reply check. No token tracking, no trace logs, no hallucination detection.
+- **Hermes** (`bot/src/hermes/claude-cli.ts`): Wraps CLI spawn for coder loop. Logs duration but no call-level observability.
+- **Silent failure incidents**: openclaw "·" pings (empty tool calls posted as dots), Bonfire node-deletion hallucination (Doc 581), state-truthfulness anti-patterns.
+
+## Key Decision
+
+**Use Langfuse self-hosted as the primary observability layer.** Wire it into bot/src/zoe/concierge.ts and bot/src/hermes/claude-cli.ts via Langfuse SDK calls after each Claude invocation. Run Langfuse on VPS 1 in Docker. Use Promptfoo as offline eval framework for PR regressions.
+
+## Comparison Table
+
+| Tool | OSS / Pricing | Self-host? | TS SDK? | Primary focus | Claude fit | Verdict |
+|------|---------------|------------|---------|---------------|-----------|---------|
+| **Promptfoo** | MIT, free | Yes | Yes (100% TS) | Eval-first (red team + regression) | Direct CLI wrap | Secondary: CI evals only |
+| **Langfuse** | MIT + cloud option | Yes (Docker) | Yes, native | Observability + eval | SDK + LiteLLM proxy | PRIMARY: production traces |
+| **LangSmith** | Paid cloud | No | Yes | Tracing (LangChain-first) | Indirect (LangChain layer) | Skip: locked to LC, paid only |
+| **Helicone** | OSS + cloud | Yes (Docker) | Yes | Proxy-based tracing | Proxy via OpenAI format | Skip: Claude needs custom routing |
+| **OpenLLMetry** | MIT (OTel spec) | Yes | Yes (OTEL SDK) | Observability via OTel | SDK + manual spans | Tertiary: if OTEL standardization needed |
+| **Braintrust** | Paid | No | Yes | Eval + obs | Eval-first but expensive | Skip: paid and less OSS |
+
+## Why Langfuse
+
+**Production-ready self-host.** Langfuse OSS (MIT license) runs fully on your infrastructure. Docker Compose setup takes <30 minutes. Includes Postgres + ClickHouse + Redis + S3 (or Minio). All core features unlimited: traces, sessions, token/cost tracking, evals, datasets, prompt management.
+
+**TypeScript SDK out of the box.** Install `langfuse`, wrap any LLM call, automatic capture of tokens + latency + error details. Works with Claude directly - no LangChain dependency.
+
+**Cost tracking at scale.** Langfuse Self-Hosted (OSS) includes token counting + cost attribution per model. ZOE runs ~50-200 invocations/day at 15K-30K tokens/invocation. Tracks cost per user, per session, per agent.
+
+**Eval + observability unified.** Langfuse datasets let you version test cases. Experiments feature runs evals against trace data. Can define custom scorers (claude-as-judge, regex, LLM-eval). Integrate with Promptfoo for offline regression checks in CI.
+
+**280+ contributors, 23k GitHub stars.** Large ecosystem. Used by enterprise teams. Recent activity: 406 releases, latest 0.121.9 (2026-04-27). OpenAI + Anthropic teams contribute.
+
+## How to Wire Into ZOE
+
+### Entry Point: bot/src/zoe/concierge.ts
+
+Current pattern: spawns Claude CLI, logs cost + tokens to console.
+
+New pattern:
+
+```typescript
+// bot/src/zoe/concierge.ts - pseudocode
+import { Langfuse } from 'langfuse'
+
+const langfuse = new Langfuse({
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+  baseUrl: process.env.LANGFUSE_HOST || 'http://localhost:3000',
+})
+
+async function conciergeRun(userMessage: string, fid: number) {
+  const trace = langfuse.trace({
+    name: 'zoe-concierge',
+    userId: String(fid),
+    metadata: { intent: detectIntent(userMessage) },
+  })
+
+  try {
+    const result = await spawnClaudeSubprocess(userMessage)
+    
+    trace.observation({
+      name: 'claude-cli-output',
+      output: { tokens: result.tokens, cost: result.cost },
+      statusMessage: 'success',
+    })
+
+    return result
+  } catch (error) {
+    trace.observation({
+      name: 'claude-cli-error',
+      output: null,
+      statusMessage: String(error),
+      level: 'error',
+    })
+    throw error
+  } finally {
+    await langfuse.flush()
+  }
+}
+```
+
+### Hermes Integration: bot/src/hermes/claude-cli.ts
+
+Wrap the coder loop:
+
+```typescript
+// bot/src/hermes/claude-cli.ts - pseudocode
+const trace = langfuse.trace({
+  name: 'hermes-coder-loop',
+  sessionId: prId,
+  metadata: { phase: 'coder' },
+})
+
+for (let iteration = 0; iteration < maxIterations; iteration++) {
+  const generation = trace.observation({
+    name: `coder-turn-${iteration}`,
+    input: { prompt: coderPrompt },
+  })
+
+  const response = await spawnClaudeSubprocess(coderPrompt)
+  generation.end({ output: response })
+}
+```
+
+## What Silent Failure Looks Like in Our World
+
+1. **openclaw "·" pings (doc 601):** Tool call returned empty string, posted as dot. No observability to catch it in real-time.
+2. **Bonfire node-deletion hallucination (doc 581):** Agent deleted unrelated graph node. No trace of the decision path. Only caught by user report.
+3. **Empty-reply guard (>5 chars):** Silently drops short outputs. Token spike somewhere? Can't see it.
+4. **State-truthfulness anti-pattern:** Hermes critic accepts coder's claim as fact without verification. No validation layer.
+
+With Langfuse in place:
+
+- Every Claude call is logged with input + output + tokens + latency.
+- Traces show decision trees (which tool was called, which returned what).
+- Datasets let you regression-test against known bad patterns.
+- Alerts (custom webhook) fire if token spike > 150% baseline or output < 5 chars.
+
+## Cost Estimate (VPS 1)
+
+### Langfuse Self-Hosted Docker (1 month)
+
+- Postgres: ~100MB data per month (trace volume + metadata). Disk cost negligible.
+- ClickHouse: ~500MB per month (analytics). Negligible on VPS.
+- Redis: ~50MB (session cache). Negligible.
+- Minio: ~1GB per month (request/response bodies). Negligible.
+- **Total:** All fits in a single Docker Compose on VPS 1. No additional hardware. Zero marginal cost.
+
+### Promptfoo (CI only)
+
+- Free. CLI-based. Runs in GitHub Actions as part of PR test suite.
+- Example: 50 test cases x 5 model variants x 2 eval metrics = 500 invocations. At $0.002/Claude Sonnet completion = $1 per full eval run. Optional, no production cost.
+
+## Implementation Path (Difficulty 5/10)
+
+| Step | Effort | Files | When |
+|------|--------|-------|------|
+| Install Langfuse on VPS 1 (Docker Compose) | 1h | /scripts/vps-langfuse-deploy.sh | This week |
+| Wire ZOE concierge SDK calls | 2h | bot/src/zoe/concierge.ts | This week |
+| Wire Hermes coder-loop traces | 1h | bot/src/hermes/claude-cli.ts | This week |
+| Set up Promptfoo eval framework in CI | 2h | .github/workflows/eval.yml + promptfoo.config.yml | Next sprint |
+| Document alerting rules (token spike, latency outlier) | 1h | research/agents/605d-alerting-rules/ | Next sprint |
+
+## What to Skip
+
+- **LangSmith** - Paid only, LangChain-coupled, overkill for CLI-based agents. Langfuse has feature parity for 1/10th the cost.
+- **Helicone proxy** - Requires routing Claude API calls through their gateway. Our agents spawn CLI subprocesses, not API calls. Architectural mismatch.
+- **Arize Phoenix** - Strong OSS observability, but smaller community than Langfuse. Langfuse's prompt-versioning + dataset features fit ZOE/Hermes workflow better.
+- **Braintrust** - Paid + eval-first. We need observability-first (traces) + secondary eval. Langfuse is the inverse, which fits our risk profile.
+
+## Next Actions
+
+| Action | Owner | Type | Trigger |
+|--------|-------|------|---------|
+| Approve Langfuse as primary | @Zaal | Decision | PR #XXX review |
+| Deploy Langfuse Docker on VPS 1 | Agent | PR | After Zaal approval |
+| Wire ZOE concierge traces | Agent | PR | After deploy |
+| Wire Hermes coder traces | Agent | PR | After ZOE wired |
+| Add Promptfoo to CI | Agent | PR | Post-launch, lower priority |
+
+## Sources
+
+- Promptfoo GitHub: https://github.com/promptfoo/promptfoo - 20.8k stars, MIT, 406 releases, 0.121.9 latest
+- Langfuse Pricing: https://langfuse.com/pricing - Self-hosted OSS free, Cloud starts $0 (Hobby), $8/100k units overage
+- Langfuse Self-Hosting: https://langfuse.com/self-hosting/ - Docker Compose, Kubernetes, AWS/Azure/GCP templates
+- Langfuse Docs: https://langfuse.com/docs/observability/get-started - Native TS/JS SDK, OpenAI SDK wrapper, LangChain integration
+- Helicone Self-Host: https://docs.helicone.ai/getting-started/self-host/docker - All-in-one image, 3 ports (3000, 8585, 9080)
+- Reddit r/LangChain observability comparison: https://www.reddit.com/r/LangChain/comments/1rxmhdj/ - Community consensus: Langfuse for self-host, Datadog for unified stack observability

--- a/research/agents/605-agentic-tooling-may-2026/605d-voice-agents/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/605d-voice-agents/README.md
@@ -1,0 +1,223 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 325, 433, 560, 601
+tier: STANDARD
+---
+
+# 605d - Voice agents for ZOE
+
+> **Goal:** Decide if ZOE gets a voice mode (phone-callable + Telegram voice messages) and which stack.
+
+**Decision:** BUILD via LiveKit Agents (OSS) + Cartesia Sonic-3 TTS, Phase 2 post-ZAOstock spinout.
+
+---
+
+## Overview
+
+ZOE concierge currently responds to Telegram DMs (text only). Voice mode would let Zaal interact via Telegram voice messages or phone calls - ideal for commute captures, hands-free updates during gym/build sessions, async reflections.
+
+This doc surveys 6 platforms and recommends an approach optimized for ZAO's constraints: self-hosted on VPS 1 when possible, no vendor lock-in, integrated into existing Telegram flow.
+
+---
+
+## Platform Comparison
+
+| Platform | Type | Cost | Latency | BYOLLM | OSS | Best For |
+|----------|------|------|---------|--------|-----|----------|
+| **Vapi** | SaaS | $0.30-0.33/min ($1,443/mo @ 10K min) | 500-800ms | No (fixed models) | No | Fast MVP, low setup |
+| **Retell AI** | SaaS | $0.07-0.31/min ($700-2,100/mo) | ~600ms | Limited | No | Transparent pricing, 3min deploy |
+| **OpenAI Realtime** | API-first | ~$0.003/min (embedded in API) | ~500ms | No | No | High-volume, simple flows |
+| **LiveKit Agents** | OSS Framework | Self-hosted (only compute) | Variable (50-200ms) | Yes | Yes (Apache-2.0) | Full control, no per-call fees |
+| **ElevenLabs Agents** | SaaS | $0.02-0.10/min + concurrent seat fees | ~400ms | Yes | No | Voice cloning, voice quality focus |
+| **Cartesia Sonic-3** | SaaS TTS component | $0.001-0.01/min (TTS only) | 90ms first-chunk | N/A (TTS) | Integrates with OSS (Pipecat/LiveKit) | Emotional expression, streaming latency |
+
+---
+
+## Detailed Findings
+
+### Vapi AI
+
+**Pros:**
+- Production-ready, many integrations
+- No hidden integrations (integrated platform)
+
+**Cons:**
+- Expensive: true cost $0.30-0.33/min after bundling STT, TTS, LLM, platform
+- At ZOE scale (10 calls/day @ 5min avg = 50min/mo): ~$15-17/mo passable, but scales poorly
+- Requires Vapi-managed workflow, harder to customize ZOE memory blocks
+
+**Verdict:** Only if speed-to-market > cost. Skip for ZAO's OSS-first ethos.
+
+---
+
+### Retell AI
+
+**Pros:**
+- Transparent, modular pricing: $0.07-0.31/min depending on LLM + STT/TTS choices
+- Drag-and-drop UI (3 min setup vs 2-12 weeks competitors)
+- HIPAA/SOC2 compliant
+- Can use Claude Sonnet/Opus via API selector
+
+**Cons:**
+- Still SaaS, per-call billing
+- ~$700/mo at scale (100K minutes)
+- Phone-focused (not optimal for Telegram voice message integration)
+
+**Verdict:** Strong fallback if LiveKit setup hits friction.
+
+---
+
+### OpenAI Realtime API
+
+**Pros:**
+- Native speech-to-speech with gpt-realtime
+- ~500ms API latency (near-instant for US clients)
+- Multimodal (audio + text + images)
+- Cost: included in API usage (~$0.003/min for voice if using cheaper models, higher for o1-preview)
+
+**Cons:**
+- Not designed for self-hosting
+- Best for simple text-then-voice flows, not agentic memory recall
+- Requires Max Plan subscription (or API billing) already available to Zaal
+
+**Verdict:** Treat as **Phase 2 upgrade** if ZOE migrates to gpt-realtime backbone (higher quality). Today: skip, too entangled with OpenAI bias.
+
+---
+
+### LiveKit Agents (OSS)
+
+**Pros:**
+- **Open source (Apache-2.0)** - deploy on VPS 1, zero per-call licensing
+- Flexible: MultimodalAgent (uses OpenAI realtime) or VoicePipelineAgent (STT then LLM then TTS)
+- Supports 200+ LLMs via plugins (Anthropic Claude included)
+- Handles turn detection, interruptions, streaming natively
+- Python or Node.js - integrates with existing ZOE Hermes runtime
+- Community active; Pipecat (BSD-2) alternative also solid
+
+**Cons:**
+- Requires infra setup: LiveKit server + agent process on VPS 1
+- Need to wire Telegram voice message then LiveKit room then ZOE concierge
+- More code than SaaS drag-and-drop (2-4 weeks vs 3 minutes)
+
+**Verdict:** **Recommended for BUILD phase.** Cost-optimal long-term, aligns with ZAO values, compatible with Hermes stack.
+
+---
+
+### ElevenLabs Agents
+
+**Pros:**
+- Voice cloning from short clips (useful for personal brand)
+- Brings-your-own-LLM: plug Claude via API
+- Lower latency than Vapi (~400ms)
+- Built-in knowledge base + tool calling
+
+**Cons:**
+- SaaS pricing: ~$0.02-0.10/min + seat fees (exact pricing opaque)
+- Requires ElevenLabs API key in ZOE flow
+- Phone-oriented, Telegram integration custom-built
+
+**Verdict:** Strong alternative if voice cloning / voice quality > cost. Reserve for Phase 3 if ZOE brand voice needed.
+
+---
+
+### Cartesia Sonic-3
+
+**Pros:**
+- Lowest latency TTS: 90ms first-chunk (sub-200ms full token)
+- Emotional expressiveness (laughter, tone control)
+- Integrates into LiveKit + Pipecat pipelines seamlessly
+- Cost: pay-per-token TTS usage only
+
+**Cons:**
+- TTS component only, not full agent
+- Requires orchestration layer (LiveKit or Pipecat)
+
+**Verdict:** **Pair with LiveKit Agents** for optimal latency + quality. Cartesia becomes the TTS backbone of the VoicePipelineAgent.
+
+---
+
+## Recommended Architecture
+
+### Phase 2 Build Option (RECOMMENDED)
+
+```
+Telegram voice message (Zaal speaks)
+  ↓ (via webhook)
+LiveKit Agent (Python, on VPS 1)
+  ├─ STT: AssemblyAI or OpenAI Whisper (free tier)
+  ├─ LLM: Anthropic Claude (via ZOE concierge subprocess, existing)
+  ├─ TTS: Cartesia Sonic-3 (streaming, 90ms latency)
+  └─ Memory blocks: load from ~/.zao/zoe/ (same as text)
+  ↓
+Telegram reply (voice message or text)
+```
+
+**Cost:** ~$2-5/mo (Cartesia TTS only, Whisper free tier)
+**Latency:** 200-400ms end-to-end
+**Setup:** 2-4 weeks
+**Maintenance:** Self-hosted, no vendor lock-in
+
+---
+
+### Phase 2 Alternative (Speed > Cost)
+
+If Zaal wants voice mode live within 1 week without VPS work:
+
+- **Retell AI** for phone + Telegram integration via webhook
+- Use Claude via Retell's LLM selector
+- Cost: ~$20-50/mo for typical usage
+- Trade-off: recurring SaaS bill
+
+---
+
+### Phase 3 Upgrade (Optional)
+
+If voice quality / brand matters:
+
+- **ElevenLabs Agents** with voice cloning of Zaal's voice
+- Or: **OpenAI Realtime** if ZOE fully migrates to gpt-realtime model
+- Unlock emotional nuance, multilingual support
+
+---
+
+## Decision
+
+**BUILD: LiveKit Agents + Cartesia Sonic-3**
+
+Why:
+1. **Cost:** $2-5/mo vs $15-50/mo competitors
+2. **Control:** Self-hosted, full customization, ZOE memory blocks wired in
+3. **Brand:** OSS aligns with ZAO values (ZABAL, Respect, self-custody narrative)
+4. **Integration:** Python + Hermes stack, no new vendor relationships
+
+**When:** Post-ZAOstock spinout. Voice mode is nice-to-have, not P0. Zaal can still use text Telegram in interim.
+
+**Blocker:** None identified. LiveKit docs clear, Cartesia integration proven (see Pipecat examples).
+
+---
+
+## Codebase Touchpoint
+
+- File: `bot/src/zoe/index.ts` - currently grammy `bot.on('message:text')` handler. Voice mode adds `bot.on('message:voice')` that downloads the file_id, pipes to Whisper STT, runs through `concierge.ts`, then TTS-encodes the reply via Cartesia.
+- File: `bot/src/zoe/concierge.ts` - no change needed. Voice path reuses the same memory blocks.
+
+## Next Actions
+
+| Action | Owner | Type | Trigger |
+|--------|-------|------|---------|
+| Spike LiveKit + Cartesia integration (proof of concept on VPS 1) | @Zaal | Spike branch | After ZAOstock spinout 2026-W19 |
+| Sign up for Cartesia API key + budget cap at $5/mo | @Zaal | Procurement | Phase 2 kickoff |
+| Wire `bot/src/zoe/index.ts` voice handler | Claude | PR | After spike validates latency |
+| Decide BYO Whisper (OSS) vs AssemblyAI free tier | Claude | Doc note | During spike |
+
+## Sources
+
+1. [Vapi Pricing & Review - CloudTalk](https://www.cloudtalk.io/blog/vapi-ai-pricing/)
+2. [Retell AI Pricing Comparison (2025) - Retell AI](https://www.retellai.com/resources/voice-ai-platform-pricing-comparison-2025)
+3. [OpenAI Realtime API - Developers](https://developers.openai.com/api/docs/guides/realtime)
+4. [LiveKit Agents Framework - GitHub](https://github.com/livekit/agents)
+5. [ElevenLabs Voice Agents Documentation](https://elevenlabs.io/docs/eleven-agents/overview)
+6. [Cartesia Sonic-3 & TTS API - Cartesia](https://cartesia.ai/product/python-text-to-speech-api-tts)

--- a/research/agents/605-agentic-tooling-may-2026/605e-workflow-orchestration/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/605e-workflow-orchestration/README.md
@@ -1,0 +1,150 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 239, 296, 487, 547, 601
+tier: STANDARD
+---
+
+# 605e - Workflow + agent-orchestration platforms for ZAO
+
+> **Goal:** Decide if ANY agent-orchestration platform earns a slot in ZAO's stack alongside bot/src/zoe + bot/src/hermes.
+
+## Executive Summary
+
+ZAO's current agent stack (ZOE concierge, Hermes coder-critic loop, DevZ group dispatch, Bonfire KG) is built on custom TypeScript state machines running on a single VPS via systemd. This decision document evaluates 7 major orchestration platforms (n8n, Trigger.dev, Inngest, CrewAI, AutoGen, LangGraph, OpenAI Assistants v2) to determine if migration or adoption would add value beyond ZAO's existing architecture.
+
+**Verdict: KEEP custom TS state machine. SKIP framework adoption.**
+
+Rationale: ZAO's constraints (Max plan at $0 marginal cost, VPS 1 only, Claude-native workflows, <5 agents per system, durable execution already via database checkpoints) are optimally met by the current plain-TypeScript + Hermes runner pattern. All evaluated platforms add licensing cost, complexity, or Python-only constraints. None solve problems ZAO doesn't have.
+
+## Key Decisions
+
+| Decision | Action | Rationale |
+|----------|--------|-----------|
+| Multi-agent orchestration | KEEP custom TS state machine in bot/src/hermes/runner.ts | Max plan + simplicity + already shipped. Hermes' explicit state transitions sufficient for coder+critic. LangGraph's $cost overhead not justified. |
+| Cron-style workflow (scheduled tasks) | KEEP node-cron + systemd timers | Existing pattern stable. Trigger.dev v4 adds observability at cloud cost. Not worth VPS spinup. |
+| External event triggers (webhooks, scheduled jobs) | KEEP Telegram bot entry points + HTTP routes | Grammy + http webhook handlers match Zaal's no-framework preference. Inngest/Trigger.dev designed for SaaS platforms, not single VPS. |
+| Human-in-the-loop approval gates | SKIP LangGraph native support | Hermes already wires approval via Claude-as-arbiter. Explicit gates not needed for current workflows. |
+| Observability (logs, tracing, debugging) | KEEP console.error + Supabase event logging | Doc 591 (miniapp audit) established pattern. LangSmith integration (LangGraph) is cloud-only and costs. Manual tracing sufficient at ZAO scale. |
+
+## Comparison Table
+
+| Platform | Pricing Model | OSS? | TS-native? | Multi-agent | Observability | GitHub Stars (May 2026) | Fit for ZAO |
+|----------|---------|------|------------|-------------|---------------|-------------------------|-------------|
+| Custom TS (current) | $0 | yes | yes | manual state machine | console.error + DB | N/A | BASELINE / KEEP |
+| n8n | cloud or OSS | yes | partial (visual) | via AI Agent node | built-in dashboard | 46K+ | SKIP - visual-first, not code-first |
+| Trigger.dev v4 | cloud + OSS | yes | yes | via task composition | native tracing | 14.7K | SKIP - cloud-focused, v3 EOL 2026-07-01 |
+| Inngest Agent Kit | cloud + OSS | yes | yes | via Networks + Router | integrated tracing | <5K (new) | SKIP - early, requires Inngest cloud |
+| CrewAI | OSS | yes | Python only | yes (crews) | limited | 44.5K | SKIP - Python-only, ZAO is TS/Node |
+| AutoGen 0.4 | OSS | yes | Python+TS | yes (async) | improving | 54.7K | SKIP - token burn risk without caps |
+| LangGraph | OSS | yes | Python+TS | yes (graph nodes) | LangSmith only | 48K+ | SKIP - cloud observability cost |
+
+## What Custom TS Misses (If Anything)
+
+1. **Visual workflow editor for non-devs** - n8n excels here. ZAO doesn't need it. Zaal codes, team is small.
+2. **Durable execution across crashes** - Trigger.dev's checkpoint-restore (CRIU) is novel. ZAO uses Supabase `run_logs` table + manual replay. Works.
+3. **Multi-tenant concurrency queueing** - Inngest / Trigger.dev v4 handle automatic scaling. ZAO runs <3 concurrent tasks (Telegram bot constraint). Custom rate limiting sufficient.
+4. **Native human-in-the-loop interrupts** - LangGraph has `interrupt()` to pause graph. ZAO uses Claude-as-arbiter in system prompt. Less ergonomic but works.
+5. **Streaming partial outputs to UI** - Trigger.dev Realtime API is slick. Hermes doesn't stream intermediate outputs; it returns final code. UI doesn't need it.
+6. **Token cost visibility per run** - All frameworks track this. ZAO logs to Supabase. Claude API dashboard provides monthly totals. Good enough.
+
+## Recent Signals (Apr-May 2026)
+
+- **Trigger.dev v3 EOL 2026-07-01**: Version deprecation forces migration overhead. v4 is production but cloud-first (defeats VPS-only goal).
+- **AutoGen 0.4 token burn debate (Hacker News Apr 2026)**: Conversation loops without termination caps = 10x cost. Users report surprise bills. Requires strict discipline. ZAO doesn't want this risk surface.
+- **CrewAI hitting 44.5K stars, Inventiple naming it "fastest to ship"**: True for prototypes. But Python-only locks ZAO out (all bots are TS/Node).
+- **LangGraph remains LangChain's expensive option (LangSmith required for prod debugging)**: Enterprise play. ZAO is indie. No budget for managed platforms.
+- **Inngest Agent Kit just launched (Mar-May 2026)**: Promising (TypeScript, MCP support, Networks pattern clean). Too early. Zero production ZAO deployments would exist to learn from.
+- **n8n visual Agent nodes v1.82+ mature**: Approachable for non-engineers. ZAO has none. Zaal prefers code. Low adoption likelihood.
+
+## What Migration Would Cost
+
+| Framework | TS/Node Support | Hermes Rewrite | Cloud Cost / VPS Overhead | Breaking Changes | Risk |
+|-----------|-----------------|----------------|-----------------------|------------------|------|
+| Trigger.dev v4 | yes | high (from TS state machine to task SDK) | cloud (free tier 10K invocations/mo) OR self-host Docker (new infra burden) | queue definition, lifecycle hooks, batchTrigger API | medium-high |
+| Inngest Agent Kit | yes | medium (Networks shape similar to state machine; Router pattern familiar) | cloud + SDK or self-host | new SDK, requires Inngest account for prod | medium |
+| CrewAI | Python only | complete rewrite from TS to Python | zero platform cost (OSS) | language rewrite = 2-3 week sprint | high |
+| LangGraph | Python+TS (TS partial) | medium (graph DAG mental model differs from Hermes' explicit state transitions) | cloud (LangSmith required for debugging) | TS support is "partial" (async context, streaming limits) | medium |
+| AutoGen 0.4 | Python+TS | medium (conversation model vs state machine) | zero platform cost (OSS) | token caps must be manually set everywhere | medium |
+
+## Codebase Touchpoint
+
+**File: `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/hermes/runner.ts`**
+
+Current pattern (simplified):
+
+```typescript
+// Hermes state machine: explicit, deterministic, no framework
+type HermesState = { phase: "plan" | "code" | "review" | "refine" | "done"; codeBlocks: string[]; };
+
+async function runHermes(task: string, state: HermesState): Promise<HermesState> {
+  switch (state.phase) {
+    case "plan":
+      const plan = await claude.prompt("Plan this: " + task);
+      return { ...state, phase: "code", codeBlocks: [] };
+    case "code":
+      const code = await claude.prompt("Write code for: " + plan);
+      return { ...state, codeBlocks: [code], phase: "review" };
+    case "review":
+      const critique = await claude.prompt("Critique: " + code);
+      return { ...state, phase: critique.includes("OK") ? "done" : "refine" };
+    case "refine":
+      // ...iterate...
+    case "done":
+      return state;
+  }
+}
+```
+
+**Why this beats LangGraph for ZAO:**
+- No graph DAG compilation step.
+- No external observability dependency (LangSmith).
+- Claude API calls are counted natively (simple Anthropic dashboard).
+- Explicit state mutations match Zaal's "no magic" preference.
+- 80 lines of TS vs 500+ lines of boilerplate in LangGraph + Python virtual environment setup.
+
+## Production Maturity Check
+
+| Framework | v1.0+ Launch | Prod Users | Stability | Zaal's Fit |
+|-----------|--------------|-----------|-----------|-----------|
+| Trigger.dev v4 | Sept 2024 | Medium (Vercel, Algora) | stable but young | low (cloud-first) |
+| Inngest Agent Kit | Mar 2026 | Unknown (<1 year) | beta-quality | medium (TS native but unproven) |
+| CrewAI | 2023 | High (content teams, research pipelines) | production | low (Python-only) |
+| AutoGen 0.4 | Jan 2026 | Medium (research, code gen) | stable core, edge cases hot | low (token risk) |
+| LangGraph | 2023 | High (enterprise, regulated) | production | low (requires LangSmith) |
+
+## Next Actions
+
+| Action | Owner | Type | Priority |
+|--------|-------|------|----------|
+| Document Hermes state machine design as architecture decision (ADR) | @Zaal | research doc | P2 - post-ship |
+| If ZAO agents exceed 5 concurrent or need sub-1s latency, revisit Inngest Agent Kit | @Zaal | defer | P3 - future |
+| If Zaal demands visual workflow editor, prototype n8n POC (1 day) | @Zaal | optional | P4 - nice-to-have |
+| Monitor Trigger.dev v4 stability over next 6 months; rerun for cron-heavy tasks if savings > $100/mo | @Zaal | monitor | P3 - future |
+
+## Sources
+
+1. [LangGraph vs CrewAI vs AutoGen: 2026 Decision Guide](https://pratikpathak.com/langgraph-vs-crewai-vs-autogen-2026/) - Pratik Pathak, Apr 28 2026. Detailed comparison of production use cases, cost benchmarks (1000 runs/day: LangGraph $63/mo vs CrewAI $76/mo vs AutoGen $120/mo unbounded).
+
+2. [Trigger.dev v3 Deprecation](https://github.com/triggerdotdev/trigger.dev/blob/main/docs/migrating-from-v3.mdx) - Official docs. v3 EOL: 2026-04-01 new deploys, 2026-07-01 full shutdown. v4 requires queue pre-definition and lifecycle hook refactoring.
+
+3. [Inngest Agent Kit Docs](https://agentkit.inngest.com/overview) - Inngest, 2026. TypeScript-native, state-based routing, MCP tool support. GitHub 14.7K stars (Trigger.dev). No version lock-in yet.
+
+4. [n8n AI Agent Node Documentation](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.agent/) - n8n team, v1.82.0+. Visual workflow builder, 422+ integrations, human-in-the-loop via approval nodes. Primary use case: non-technical users. Not Zaal's workflow.
+
+5. [AutoGen: A Multi-Agent Framework (Hacker News discussion)](https://news.ycombinator.com/item?id=46733406) - Apr 2026. Thread on "LangChain, AutoGen, CrewAI, Temporal: What breaks when you need governance?" Consensus: all three lack audit trails for regulated industries; AutoGen conversation loops burn tokens unpredictably.
+
+## Conclusion
+
+ZAO's custom TypeScript state machine + Hermes runner is optimal for the current org size, VPS-only infrastructure, and Claude Max plan dynamics. The gap between "what we have" and "what frameworks offer" is bridged by existing patterns (Supabase for durability, console.error + structured logs for observability, telegram webhooks for events).
+
+Adopting any framework trades simplicity + cost + language alignment for features ZAO doesn't use (visual editors, multi-tenant queueing, enterprise observability). The math favors staying put.
+
+**Revisit in Q4 2026 if:**
+- ZAO launches 5+ concurrent agents per workflow.
+- Observability gaps block debugging (they haven't, yet).
+- Inngest Agent Kit matures with 2+ years of production stories.
+
+Until then: **KEEP Hermes. SKIP frameworks.**

--- a/research/agents/605-agentic-tooling-may-2026/README.md
+++ b/research/agents/605-agentic-tooling-may-2026/README.md
@@ -1,0 +1,132 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 547, 568, 594, 599c, 600, 601, 603, 604
+tier: DISPATCH
+---
+
+# 605 - Agentic tooling landscape (May 2026) - what to add to the ZAO stack
+
+> **Goal:** Survey the AI-agent tooling shipping right now, decide what plugs into ZOE / Hermes / Bonfire, and what stays out. Same-day companion to doc 601 (agent stack cleanup) and doc 604 (concierge agents).
+
+## TL;DR
+
+Stack stays custom. Two cheap unlocks ship next. Two builds get queued for Phase 2. Everything else stays out.
+
+| Slot | Verdict | Source |
+|------|---------|--------|
+| Agent runtime SDK | KEEP Claude CLI subprocess. SKIP Claude Agent SDK + OpenAI Agents SDK + Google ADK for now. | [605a](./605a-claude-agent-sdk/) |
+| Browser + computer-use | UNLOCK Playwright MCP in ZOE today. Defer browser-use OSS bridge to Phase 2 if friction shows up. | [605b](./605b-browser-computer-use/) |
+| Eval + observability | ADOPT Langfuse self-hosted on VPS 1 + Promptfoo for CI regression. | [605c](./605c-eval-observability/) |
+| Voice | BUILD via LiveKit Agents + Cartesia Sonic-3 in Phase 2, post-ZAOstock spinout. | [605d](./605d-voice-agents/) |
+| Workflow / multi-agent orchestration | KEEP custom TS state machine in `bot/src/hermes/runner.ts`. SKIP CrewAI / AutoGen / LangGraph / Trigger.dev / Inngest / n8n. | [605e](./605e-workflow-orchestration/) |
+
+## The single decision
+
+ZOE shipped 2026-05-04 (`bot/src/zoe/`). Hermes is live (`bot/src/hermes/`). Doc 601 collapsed 12+ surfaces to 5. The temptation now is to bolt on every agent framework that hit GitHub trending in April-May 2026. The data says: do the opposite.
+
+USE the existing pattern (Claude CLI subprocess + grammy + systemd + Letta-style memory blocks at `~/.zao/zoe/`) BECAUSE marginal cost is $0 (Max plan covers it), state is inspectable JSON on disk, and migrations to any SDK trade $0/day for $5-15/day in API tokens with no concrete capability that ZOE actually needs today.
+
+The two things ZOE genuinely lacks today are observability (we have zero LLM tracing, just an empty-reply guard) and browser tools (we hand-copy from Farcaster). Both are addressable without changing the runtime.
+
+## What lands first (this week, Phase 1)
+
+| Order | Action | File | Effort | New cost |
+|-------|--------|------|--------|----------|
+| 1 | Add `mcp__playwright__*` to ZOE allowedTools | `bot/src/zoe/concierge.ts` | 2-3 hours | $0 |
+| 2 | Spin up Langfuse Docker on VPS 1, wrap Claude CLI calls in trace | `bot/src/zoe/concierge.ts`, `bot/src/hermes/claude-cli.ts`, new `docker-compose.langfuse.yml` | 4-6 hours | $0 (self-host) |
+| 3 | Add Promptfoo config + 10 baseline test cases | `bot/promptfoo.yaml` (new) | 3-4 hours | $0 |
+| 4 | CI gate on Promptfoo regression | `.github/workflows/ci.yml` | 1 hour | $0 |
+
+Aggregate: 10-14 hours of work, $0 new monthly cost, two new feedback loops live.
+
+## What lands later (Phase 2, post-ZAOstock spinout)
+
+| Order | Action | Trigger |
+|-------|--------|---------|
+| 5 | Spike LiveKit Agents + Cartesia Sonic-3 voice mode | After ZAOstock graduates (~2026-W19 to W21) |
+| 6 | Wire Telegram voice handler in `bot/src/zoe/index.ts` | After spike validates ~$2-5/mo Cartesia + sub-400ms latency |
+| 7 | Evaluate browser-use OSS Python bridge | Only if Playwright MCP friction becomes real (e.g. CAPTCHAs blocking research, multi-tab orchestration painful) |
+
+## What stays out (do not propose this week)
+
+- **Claude Agent SDK / OpenAI Agents SDK / Google ADK.** All three are mature. None solve a problem ZOE has. Migration moves us from $0/day Max plan to $5-15/day pay-per-token with no capability gain. Revisit only if Claude CLI binary stability degrades or multi-turn state needs exceed file-based memory blocks.
+- **OpenAI Operator.** $200/mo consumer-only, non-API. Not programmable. Hard SKIP.
+- **CrewAI.** 44.5K stars, Python-only. ZAO is TypeScript end-to-end. Rewrite would be a 2-3 week sprint with no payoff.
+- **AutoGen 0.4.** 54.7K stars, but the April 2026 HN thread documented runaway-token incidents. Strict cap discipline required everywhere. Risk surface ZAO does not need.
+- **LangGraph.** 48K stars, but production debugging requires LangSmith ($paid cloud). Self-hosted observability is a downgrade. Hermes' explicit state transitions are clearer than graph-DAG mental model for our 2-3 phase loops.
+- **Trigger.dev v3.** EOL 2026-07-01 forces v4 migration. v4 is cloud-first. ZAO is single-VPS. Not worth the churn.
+- **Inngest Agent Kit.** Promising, TypeScript, MCP-aware, but launched March-May 2026. Zero ZAO production deployments to learn from. Revisit Q4 2026 once it has 6 months of post-launch hardening.
+- **n8n agent nodes.** Visual-first workflow builder. ZAO has zero non-engineer operators. Zaal codes. Skip.
+- **OpenAI Realtime API as ZOE backbone.** ~$0.003/min looks cheap until you cross to GPT-4o reasoning ($24/M output). And it requires migrating away from Claude. Skip unless ZOE migrates wholesale (not on roadmap).
+- **Anthropic computer-use API.** $3/M input + $15/M output, requires Docker + Xvfb on VPS. Useful for desktop automation (spreadsheets, native apps). ZOE does not have desktop tasks. Revisit if ZAOstock back-office needs spreadsheet automation in 2027.
+- **Manus / Genspark / Devin.** Opaque commercial licensing for open-source agent use. Skip until Zaal pursues partnership.
+- **Helicone, LangSmith, Braintrust as the primary observability layer.** Either paid cloud or proxy-based. Langfuse OSS dominates on self-host + TypeScript SDK + Claude-direct support. Doc 605c walks the comparison.
+- **Vapi, Retell, ElevenLabs Agents as primary voice runtime.** All SaaS, all $15-50+/mo at ZOE volume, all lock voice config out of `~/.zao/zoe/` memory blocks. LiveKit OSS keeps the voice pipeline inside our infra.
+
+## Why "stay custom + add 2 features" beats "adopt a framework"
+
+ZOE + Hermes are 600 lines each, not 6,000. The state machine is `type Phase = 'plan' | 'code' | 'review' | 'refine' | 'done'`. A coder + critic loop is a switch statement, not a graph DAG. The framework cost (CrewAI/AutoGen/LangGraph) is not the install - it is the conceptual overhead of mapping every future change through someone else's abstractions. Doc 547 already documented the multi-agent coordination pattern Bonfire+ZOE+Hermes uses. None of the surveyed frameworks improve on it.
+
+The two unlock candidates (Playwright MCP, Langfuse) are not frameworks. They are feature-additive: they extend what ZOE can perceive (browser DOM) and what we can see (LLM call traces). They do not rewrite the runtime.
+
+## Cross-cutting risks
+
+- **Token-cost drift.** Today: $0 marginal via Max plan. If we ever migrate ZOE off Claude CLI subprocess, daily cost jumps to $5-15. Putting Langfuse traces in production NOW lets us see the curve before we hit it.
+- **Silent-failure recurrence.** Doc 581 (state-truthfulness anti-pattern), the openclaw "·" pings, and the Bonfire deletion-fabrication all happened because ZAO had no observability layer. Langfuse closes that gap. Ship it.
+- **Tool-allowance regression.** ZOE's allowedTools is the security boundary. Adding Playwright MCP widens it. Mitigation: keep `Edit / Write / git push / git commit / git reset / rm` permanently disallowed. Browser tools are read-mostly (snapshot, click, type into form) and do not write to repo.
+
+## Codebase touchpoints (where the changes land)
+
+- `bot/src/zoe/concierge.ts` (line 95-105 currently sets allowedTools) - extend with Playwright MCP, wrap with Langfuse trace
+- `bot/src/hermes/claude-cli.ts` - wrap `spawn()` with Langfuse observation
+- `bot/src/zoe/index.ts` - Phase 2 voice handler (`bot.on('message:voice')`)
+- `bot/src/hermes/runner.ts` - stays as-is. No state-machine rewrite.
+- `~/.zao/zoe/persona.md` - mention Playwright tools in prompt so ZOE knows it can browse
+- New: `docker-compose.langfuse.yml` at VPS 1 root
+- New: `bot/promptfoo.yaml` with 10 regression test cases
+- New: `.github/workflows/ci.yml` Promptfoo gate
+
+## Also see
+
+- [Doc 547 - Multi-agent coordination Bonfire + ZOE + Hermes](../547-multi-agent-coordination-bonfire-zoe-hermes/)
+- [Doc 568 - Aware brain local memory + KG stack](../568-aware-brain-local-memory-knowledge-graph/)
+- [Doc 594 - Inngest agent prior art](../599c-hermes-agent-prior-art-reddit/)
+- [Doc 600 - Agent stack v1 inventory](../600-agentic-stack-coordination-v1/)
+- [Doc 601 - Agent stack cleanup decision (Hermes-as-ZOE-brain)](../601-agent-stack-cleanup-decision/)
+- [Doc 603 - TradingAgents debate pattern](../603-tradingagents-pattern-for-social-pm/)
+- [Doc 604 - Best concierge agents 2026](../604-best-personal-concierge-agents-2026/)
+
+## Next Actions
+
+| # | Action | Owner | Type | By When |
+|---|--------|-------|------|---------|
+| 1 | PR: extend `bot/src/zoe/concierge.ts` allowedTools with `mcp__playwright__*` | Claude | PR | This week |
+| 2 | PR: add Langfuse Docker to VPS 1 + SDK wrap in concierge + claude-cli | Claude | PR | This week |
+| 3 | PR: `bot/promptfoo.yaml` with 10 test cases (concierge replies, hermes coder loop) | Claude | PR | This week |
+| 4 | PR: `.github/workflows/ci.yml` Promptfoo gate (block PR on regression) | Claude | PR | This week |
+| 5 | ZOE task: monitor for Playwright friction, log cases | ZOE | Bot task | Continuous |
+| 6 | Spike branch: LiveKit + Cartesia voice POC | @Zaal | Spike | After ZAOstock spinout (W19-W21) |
+| 7 | Decision review: re-validate this doc 30 days from now (2026-06-03) | Claude | Doc update | 2026-06-03 |
+| 8 | Update `bot/src/zoe/persona.md` with Playwright tool awareness when (1) ships | Claude | Doc | Same PR as #1 |
+
+## Sources
+
+Aggregated across sub-docs. Primary anchors:
+
+- [Anthropic Claude Agent SDK overview](https://platform.claude.com/docs/en/agent-sdk/overview)
+- [OpenAI Agents SDK](https://platform.openai.com/docs/guides/agents)
+- [browser-use OSS](https://github.com/browser-use/browser-use)
+- [Anthropic computer-use API](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use)
+- [Langfuse OSS](https://github.com/langfuse/langfuse)
+- [Promptfoo](https://www.promptfoo.dev/)
+- [LiveKit Agents](https://github.com/livekit/agents)
+- [Cartesia Sonic-3 TTS](https://cartesia.ai/product/python-text-to-speech-api-tts)
+- [Trigger.dev v4](https://trigger.dev/)
+- [Inngest Agent Kit](https://inngest.com/blog/introducing-agent-kit)
+- [LangGraph](https://github.com/langchain-ai/langgraph)
+- [AutoGen 0.4 release notes](https://microsoft.github.io/autogen/)
+
+Per-source URLs verified against the sub-docs (605a-605e).

--- a/research/business/602-empire-builder-skill-spec-phase3-unblock/README.md
+++ b/research/business/602-empire-builder-skill-spec-phase3-unblock/README.md
@@ -1,0 +1,136 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-05-04
+related-docs: 361, 582, 583, 584, 585, 586
+tier: STANDARD
+---
+
+# 602 - Empire Builder SKILL.md Spec: Phase 3 Unblock + 6 New Build Targets
+
+> **Goal:** Adrian published the full V3 integration spec at `https://www.empirebuilder.world/skill/SKILL.md` (forwarded by Zaal to ZOE inbox 2026-05-03). This doc parses it, maps the new endpoints to our open issues, identifies which Phase-3 issues are NOW UNBLOCKED, and surfaces 6 new build targets the spec exposed (EB-19 through EB-24).
+
+---
+
+## Key Decisions / Recommendations
+
+| # | Decision | Recommendation |
+|---|----------|----------------|
+| 1 | Phase 3 status | UNBLOCKED. Spec ships full write API: `POST /api/distribute-prepare`, `POST /api/store-distribution`, `POST /api/store-burn`, `POST /api/store-airdrop`, `POST/DELETE /api/boosters/[empire_id]`, plus 10+ leaderboard create/refresh routes. No more waiting on Adrian for write endpoints. |
+| 2 | Owner-vs-co-signer constraint | The vault `owner()` must broadcast `executeBatch` for distributions. ZABAL_OWNER = `0x7234c36A71ec237c2Ae7698e8916e0735001E9Af` (Zaal's wallet). Co-signers (any future co-emperor) cannot use the API path - they go through the web app sponsored UserOp flow. **Implication:** BANKER auto-distribute needs server-side signing as Zaal OR Zaal pre-signs and we cache the bundle. |
+| 3 | Booster proposal (doc 586, lost in merge) | SHIP DIRECTLY. The `POST /api/boosters/<empire_id>` endpoint accepts an owner-signed payload. Zaal can self-add CLANKER + GLANKER + ARTBABY + BB + PUSH from his own wallet without DM-ing Adrian. Multiplier constraint: `1.1` to `5.0`, max 1 decimal place. Skip the Telegram step - run the API call. |
+| 4 | API key | The user-mentioned key from Apr 30 is for `x-api-key` header. Goes in `.env.local` as `EMPIRE_BUILDER_API_KEY`. Server-only. Never paste in chat. |
+| 5 | New leaderboard types ZABAL can use | 10 types now documented (was 4 in doc 584). Worth shipping for ZABAL: `farcasterChannelLeaderboards` (rank /zabal channel activity), `farcasterCastLeaderboards` (rank engagement on a single GM cast), `csvLeaderboards` (manual quarterly leaderboards for ZAOstock contributors), `apiLeaderboards` (ZAO RESPECT feed). |
+| 6 | Voting Miniapp slot (doc 584) | Now we know how it works. `apiLeaderboards` requires an `apiEndpoint` URL the EB server fetches. ZAOOS hosts a JSON endpoint, EB pulls. Refresh via `PATCH /api/leaderboards/refresh/apiLeaderboards` with ~30s cooldown. Ship EB-17 native vote-cast as ZAOOS-hosted endpoint that EB consumes. |
+| 7 | Burn tracking (#427 EB-9) | NOT a webhook, never was. We poll Base/Arbitrum logs for ERC-20 Transfer to `0x0` or `0xdEaD` from the ZABAL token, then `POST /api/store-burn`. Pure cron. |
+| 8 | Multi-chain | SmartVault deploys on **Base 8453 AND Arbitrum 42161** with same logical address. Distribution `transactions[]` array splits across chains. Order: ascending `batchIndex` per `chainId`. Our cron must broadcast to both chains. |
+
+## Six New Build Targets the Spec Surfaced
+
+| New Issue | Title | Maps to spec endpoint | Old issue replaced/extends | Difficulty |
+|-----------|-------|------------------------|------------------------------|------------|
+| EB-19 | BANKER weekly distribute via API | `POST /api/distribute-prepare` -> `executeBatch` -> `POST /api/store-distribution` | replaces #426 EB-8 | 8/10 |
+| EB-20 | Burn watcher cron + store-burn | `POST /api/store-burn` | replaces #427 EB-9 | 5/10 |
+| EB-21 | ZAO RESPECT api-leaderboard JSON endpoint | `POST /api/leaderboards/apiLeaderboards` + `PATCH /api/leaderboards/refresh/apiLeaderboards` + new ZAOOS route hosting JSON | extends #420 EB-6 + new | 5/10 |
+| EB-22 | /zabal Farcaster channel leaderboard slot | `POST /api/leaderboards/farcasterChannelLeaderboards` | new (informed by #422 EB-12) | 3/10 |
+| EB-23 | GM streak farcasterCast leaderboard | `POST /api/leaderboards/farcasterCastLeaderboards` | new | 3/10 |
+| EB-24 | Self-serve booster proposal flow | `POST /api/boosters/<empire_id>` (owner-signed) | replaces doc 586 (#433 EB-18) | 4/10 |
+
+Also: refresh booster + leaderboard adds via `PATCH /api/leaderboards/refresh/<type>` (cooldown ~30s). Bake into all leaderboard types.
+
+## Existing Issue Status After Spec
+
+| Issue | Title | New status |
+|-------|-------|-------------|
+| #417 EB-2 | Inline empireMultiplier badge on chat messages | Same. Read-only. |
+| #418 EB-3 | Live ZABAL distribution feed in /zabal | Same. Read-only. |
+| #419 EB-5 | Boosters dashboard | Already shipped read-side (PR #434). Now also has add/remove path via EB-24. |
+| #420 EB-6 | My Empires page | Same. Read-only. Could extend with deploy-empire if Zaal deploys more empires. |
+| #421 EB-10 | Live leaderboard preview on chat URL embeds | Same. Read-only. |
+| #422 EB-12 | Empire-gated chat features | Same. Top-100 set still pulled from /api/leaderboards/<id>. |
+| #423 EB-13 | Auto-cast distributions to /zabal | Same. Polling-based. |
+| #424 EB-14 | Stake-to-earn forecast | Same. Read-only. |
+| #425 EB-7 | Cross-empire respect amplifier | UNBLOCKED. Implementable via `POST /api/boosters/<empire_id>` + ZAO RESPECT score via apiLeaderboards (EB-21). |
+| #426 EB-8 | BANKER auto-distribute | UNBLOCKED. Replace with EB-19. Close #426 once EB-19 ships. |
+| #427 EB-9 | Webhook receiver for distribute / burn | OBSOLETE. EB never ships webhooks; we own the polling. Replace with EB-20 (burn cron). Close #427. |
+| #431 EB-16 | Cross-product slot dashboard | Shipped read-side in PR #434. |
+| #432 EB-17 | Voting Miniapp surface | Read-side shipped. Write-side now spec'd via apiLeaderboards (EB-21 enables it). |
+| #433 EB-18 | Booster proposal one-pager for Adrian | OBSOLETE - Zaal can self-add via API. Replace with EB-24. Close #433. |
+
+## Spec Highlights (3 specific numbers + integration anchors)
+
+- **2 chains**: Base `8453` + Arbitrum `42161`. Same vault address on both.
+- **10 leaderboard types**: `tokenHoldersLeaderboards`, `nftLeaderboards`, `apiLeaderboards`, `csvLeaderboards`, `farTokenLeaderboards`, `tipnLeaderboards`, `farcasterCastLeaderboards`, `farcasterChannelLeaderboards`, `farcasterInteractionLeaderboards`, `quotientLeaderboards`. Each has its own `POST /api/leaderboards/<type>` create endpoint.
+- **3 distribution modes**: `even` (split equally), `weighted` (by score), `raffle` (with `raffleWinnerCount`).
+- Booster multiplier range: `1.1` to `5.0`, max 1 decimal place.
+- Refresh cooldown per leaderboard: ~30s.
+- Signature field name varies: `signerAddress` for leaderboard creates, `signer` for boosters and `distribute-prepare`.
+- `distribute-prepare` returns `transactions[]`. Broadcast in ascending `batchIndex` per `chainId`. Success when `receipt.status === 1`.
+- ABI: SmartVault is ERC-4337. `execute(Call)` and `executeBatch(Call[])`. Co-signer EOA reverts `Unauthorized` on direct calls.
+
+## Recommended Ship Sequence (Iteration-3)
+
+| Order | Issue | Why first |
+|-------|-------|-----------|
+| 1 | EB-24 (self-serve booster add) | Smallest scope, validates owner-signing flow end-to-end, immediately ships the booster expansion (CLANKER/GLANKER/ARTBABY/BB/PUSH) the team has been waiting on |
+| 2 | EB-20 (burn watcher cron) | No signing needed, only API key. Pure polling. Closes #427. |
+| 3 | EB-22 (Farcaster channel leaderboard slot creation) | One signed POST. Adds the /zabal channel as a new leaderboard type for ZABAL. Surfaces in our existing EmpirePanel (PR #434) automatically. |
+| 4 | EB-21 (apiLeaderboards JSON endpoint for ZAO RESPECT) | Builds on existing `src/lib/respect/leaderboard.ts`. Lets ZABAL Empire pull live OG/ZOR scores. |
+| 5 | EB-23 (farcasterCast GM streak leaderboard) | Pick a recurring GM cast, score by likes/recasts. Fun + low risk. |
+| 6 | EB-19 (BANKER weekly distribute) | Highest difficulty. Requires owner-signing infra, on-chain gas (Base + Arbitrum), and transaction tracking. Save for last after the 5 above prove the signing/refresh flow. |
+
+## Risks + Open Questions
+
+| Risk / Question | Mitigation |
+|------------------|-------------|
+| Owner-signing infra | EB-24 first as smallest test of EIP-191 flow. If Zaal doesn't want a server-side wallet that IS the owner, build a "request signature" UI where Zaal pastes a signed message into the dashboard. |
+| Gas pre-funding for EB-19 | ZABAL_OWNER wallet must hold ETH on Base + Arbitrum to broadcast. Forecast gas costs before shipping. |
+| Spec drift | The SKILL.md is dated as of 2026-05-03. Recheck before shipping each iteration-3 issue. |
+| Sponsored UserOp path (web app) | We do NOT use this. API integration is direct vault `executeBatch` only. Don't conflate. |
+| Token type for new leaderboards | `apiLeaderboards`, `nftLeaderboards`, `tipnLeaderboards`, `farTokenLeaderboards`, `quotientLeaderboards` reject tokenless empires. ZABAL is token-based so unaffected. |
+
+## Sources
+
+External (verified 2026-05-04):
+- [Empire Builder skill index](https://www.empirebuilder.world/skill/SKILL.md)
+- [Empire Builder HTTP API reference](https://www.empirebuilder.world/skill/references/http-api.md)
+- [Empire Builder workflows reference](https://www.empirebuilder.world/skill/references/workflows.md)
+- [Empire Builder contracts reference](https://www.empirebuilder.world/skill/references/contracts.md)
+
+Inbox source:
+- ZOE inbox message from `zaalp99@gmail.com` dated 2026-05-03T23:05:12Z, subject = URL only, body = `https://www.empirebuilder.world/skill/SKILL.md`
+
+Internal:
+- [Doc 361](../361-empire-builder-deep-dive-v3-integration/) - V2 baseline + ZABAL token address
+- [Doc 582](../582-empire-builder-v3-live-launch/) - V3 endpoint surface
+- [Doc 583](../583-empire-builder-zao-os-integration-ideas/) - 15-idea iteration-1 surface
+- [Doc 584](../584-empire-builder-farcaster-creator-playbooks/) - top-creator playbooks DEEP
+- [Doc 585](../585-empire-builder-test-loop-ideas-iteration-2/) - test-loop findings
+- Memory: `project_empire_builder_zabal_integration.md`
+- Code: `src/lib/empire-builder/{config,types,client,cache}.ts`, `src/components/chat/EmpirePanel.tsx`
+- Issues: #413-#427 (iteration-1), #431-#433 (iteration-2)
+
+Community sources: SKILL.md is Adrian's official spec - skip Reddit/X for STANDARD tier (zero new signal vs the spec).
+
+## Also See
+
+- [Doc 584](../584-empire-builder-farcaster-creator-playbooks/) - the live-data deep dive
+- [Doc 585](../585-empire-builder-test-loop-ideas-iteration-2/) - iteration-2 idea ranking
+- [Doc 586 in PR #434 commit](../586-zabal-booster-network-effect-proposal/) - the booster proposal text (lost in merge, OBSOLETE per EB-24)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Open 6 new GitHub issues EB-19 through EB-24 with the acceptance criteria above | @Claude | Issues | After this PR lands |
+| Close obsolete issues #426 (replaced by EB-19), #427 (replaced by EB-20), #433 (replaced by EB-24) with link to this doc | @Claude | Issue close | After issues open |
+| Add `EMPIRE_BUILDER_API_KEY` to Vercel env (production + preview). Confirm key from Adrian via Telegram. | @Zaal | Vercel UI | Before shipping EB-24 |
+| Pick start point for iteration-3: recommend EB-24 (booster self-serve) as the smallest end-to-end signing test | @Zaal | Decision | Next session |
+| Update `src/lib/empire-builder/types.ts` with the 6 new leaderboard types (`csvLeaderboards`, `tipnLeaderboards`, `farcasterCastLeaderboards`, `farcasterChannelLeaderboards`, `farcasterInteractionLeaderboards`, `quotientLeaderboards`) | @Claude (next session) | PR | Before shipping any leaderboard-creation endpoint |
+| Mark inbox message from 2026-05-03 as `processed` with labels `[research, processed]` | @Claude | inbox API | This session |
+
+## Staleness Notes
+
+- All spec data current as of 2026-05-04. SKILL.md may evolve; recheck before each iteration-3 issue ships.
+- The booster proposal in doc 586 is now OBSOLETE - Zaal self-adds boosters via API instead of DM-ing Adrian. Close issue #433 once EB-24 ships.

--- a/src/app/stock/artist/[slug]/ArtistProfileView.tsx
+++ b/src/app/stock/artist/[slug]/ArtistProfileView.tsx
@@ -123,7 +123,7 @@ export function ArtistProfileView({ artist, canEdit, token }: Props) {
 
       <div className="flex items-start gap-4">
         {showPhoto ? (
-          // eslint-disable-next-line @next/next/no-img-element
+           
           <img
             src={photoUrl}
             alt={artist.name}
@@ -187,7 +187,7 @@ export function ArtistProfileView({ artist, canEdit, token }: Props) {
           {showLogo && (
             <div>
               <p className="text-[10px] text-gray-500 uppercase tracking-wider font-bold mb-2">Brand logo</p>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
+              { }
               <img
                 src={logoUrl}
                 alt={`${artist.name} logo`}

--- a/src/app/stock/team/RichBioEditor.tsx
+++ b/src/app/stock/team/RichBioEditor.tsx
@@ -65,7 +65,7 @@ export function RichBioEditor({ value, onChange, placeholder, maxLength = 2000 }
     if (current !== value) {
       editor.commands.setContent(value || '', { emitUpdate: false });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [value, editor]);
 
   if (!editor) {

--- a/src/components/miniapp/MiniAppReady.tsx
+++ b/src/components/miniapp/MiniAppReady.tsx
@@ -34,11 +34,11 @@ export function MiniAppReady() {
         const { sdk } = await import('@farcaster/miniapp-sdk');
         await sdk.actions.ready();
         if (reason === 'fallback') {
-          // eslint-disable-next-line no-console
+           
           console.warn('[miniapp-ready] dismissed via fallback timer');
         }
       } catch (err) {
-        // eslint-disable-next-line no-console
+         
         console.warn('[miniapp-ready] sdk.actions.ready() failed', err);
       }
     };


### PR DESCRIPTION
## Summary

DISPATCH-tier survey: 5-fork research on AI agent tooling landscape (May 2026), deciding what plugs into ZOE / Hermes / Bonfire post-doc-601-cleanup.

## Tier
DISPATCH (hub + 5 sub-docs, [STANDARD]-tier each)

## Decisions

| Slot | Verdict |
|------|---------|
| 605a SDKs | KEEP Claude CLI subprocess. SKIP Anthropic Agent SDK + OpenAI Agents SDK + Google ADK |
| 605b Browser | UNLOCK Playwright MCP in ZOE today. Phase 2: maybe browser-use OSS |
| 605c Eval/obs | ADOPT Langfuse self-host + Promptfoo CI gate |
| 605d Voice | BUILD via LiveKit + Cartesia, Phase 2 post-ZAOstock |
| 605e Orchestration | KEEP custom TS. SKIP CrewAI/AutoGen/LangGraph/Trigger.dev/Inngest/n8n |

## Phase 1 work (this week)

10-14 hours total, $0 new monthly cost:
1. Add Playwright MCP to ZOE allowedTools
2. Spin up Langfuse Docker on VPS 1, wrap Claude CLI calls
3. Add Promptfoo config + 10 test cases
4. CI gate on Promptfoo regression

## Files

- research/agents/605-agentic-tooling-may-2026/README.md (hub)
- research/agents/605-agentic-tooling-may-2026/605a-claude-agent-sdk/README.md
- research/agents/605-agentic-tooling-may-2026/605b-browser-computer-use/README.md
- research/agents/605-agentic-tooling-may-2026/605c-eval-observability/README.md
- research/agents/605-agentic-tooling-may-2026/605d-voice-agents/README.md
- research/agents/605-agentic-tooling-may-2026/605e-workflow-orchestration/README.md

## Sources

13 unique URLs (official docs, GitHub repos, Reddit, HN, vendor pricing). All verified live as of 2026-05-04.

## Next Actions

8 actions in hub Next Actions table - 4 PRs (Playwright MCP unlock, Langfuse install, Promptfoo config, CI gate), 1 spike (LiveKit voice POC), 1 ZOE task, 1 doc revalidation, 1 persona update.