### PR TITLE
doc 610: ZAOstock database consolidation May 4-5 (DEEP)

### DIFF
--- a/bot/src/zoe/agents/newsletter.ts
+++ b/bot/src/zoe/agents/newsletter.ts
@@ -1,0 +1,281 @@
+/**
+ * @newsletter - daily Year of the ZABAL entry.
+ *
+ * Two modes:
+ *   - Draft: @newsletter <text>  - assembles day snapshot + Bonfire context, writes new entry
+ *   - Edit:  @newsletter edit <addition>  - reads today's prior draft, re-rolls including the addition
+ *
+ * Voice locked to BetterCallZaal Year-of-the-ZABAL. Voice + anti-pattern rules
+ * synthesized in research doc 610 (built on docs 558 / 562 / 563).
+ *
+ * Source assembly:
+ *   - ZOE side: today's commits (18h), PRs touched today via gh, captures from
+ *     ~/.zao/zoe/captures/<date>.json
+ *   - Bonfire side: recall() query keyed on user input, returns synthesized
+ *     KG context (gracefully no-ops if BONFIRE_API_KEY missing)
+ *
+ * Persistence: every successful draft writes to ~/.zao/zoe/newsletters/<date>.md
+ * so edit mode can read it back.
+ */
+import type { Agent } from './index';
+import { callClaudeCli } from '../../hermes/claude-cli';
+import { recall } from '../recall';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { ZOE_PATHS } from '../memory';
+
+const NEWSLETTER_SYSTEM = `You are the daily-entry writer for Year of the ZABAL, a 2026 personal chronicle by Zaal Panthaki ("BetterCallZaal"). Each entry pairs a real moment from the day with a grounded mindful takeaway. Writing must feel lived-in, specific, and honest. Never preachy, never aphoristic.
+
+Voice: calm confidence, self-trust, clarity. Encouraging without corny. Direct without harsh. Sounds like a real person who slept and then sat down to write.
+
+1. Header (always exactly this shape, first thing in output)
+
+Year of the ZABAL - Day {{DAY_OF_YEAR}} ({{Day, Month D, Year}})
+{{Subtitle - short, grounded, no slogan}}
+
+___
+
+2. Body order (strict)
+
+(a) The Day - what actually happened
+- Lead each paragraph with a specific named thing (person, place, project, time)
+- Describe what moved forward, launched, shipped, clarified, or hit friction
+- One number, name, place, or quote per paragraph minimum if any exist in the input
+- Personal-journal voice
+- Begin naturally with no label
+
+(b) Mindful Moment - one paragraph
+- Anchor a quote, idea, or sense to a thing Zaal actually saw or did today
+- If user supplied a calendar quote or theme, use it; otherwise pick a fitting reflection drawn from the day's actual content
+- Treat as perspective or permission, never instruction
+- Do not explain the book. Let the idea land in one paragraph
+
+(c) Closing line - one sentence about now or next, NOT a universal truth
+- "Recording at 2. Bounty live by 5." beats "Keep getting in the rooms."
+- "I sleep early tonight." beats "Trust the process."
+- Concrete > philosophical
+
+3. Signature (always exactly this, last line)
+
+- BetterCallZaal on behalf of the ZABAL Team
+
+4. Anti-patterns (never use)
+- Aphoristic closes ("Some things announce themselves quietly", "Trust the timing")
+- "There is a thing that happens when..." constructions
+- "The machine," "the work," "the system" as brand-coded singulars - name the actual thing
+- Parallel-structure 3-beat closes ("X. Y. Then Z.") - one per entry max, not at the close
+- Cliche transitions: "small pieces clicking into place," "puzzle pieces," "the rhythm is set," "in motion"
+- Universal-second-person preachy "you" ("You do not become ready") - reserve "you" for rare direct reader address
+- "Loop is clean," "rooms worth being in," "show up" as philosophical turns
+- Em dashes (use hyphens with spaces around them)
+- Emojis, hashtags, marketing language, headers beyond the title block
+
+5. DO rules
+- Lead with the specific. "Kenny from POIDH at 2pm" beats "today's recording"
+- Spell out conferences, places, dates ("Rome", "Mondays 11:30am EST in Discord", "Day 125")
+- Sentence-length variety: if 3+ consecutive sentences are within 2 words of each other, rewrite one short and one long
+- One concrete fact per paragraph if any exist
+- If user mid-stream adds a fact (like "we got mentioned in Rome"), that fact lands in a paragraph; do not bury it in the close
+
+6. If user supplied a Badass quote or calendar photo theme on a separate line, use it as the Mindful Moment anchor. Day always comes first.`;
+
+interface DaySnapshot {
+  isoDate: string;
+  human: string;
+  dayOfYear: number;
+  commits: string[];
+  prs: Array<{ number: number; title: string; merged: boolean }>;
+  captures: string[];
+}
+
+function dayOfYear(date: Date): number {
+  const start = new Date(Date.UTC(date.getUTCFullYear(), 0, 0));
+  const diff = date.getTime() - start.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24));
+}
+
+function loadDaySnapshot(repoDir: string, todayCaptures: string[]): DaySnapshot {
+  const now = new Date();
+  let commits: string[] = [];
+  try {
+    const log = execSync(
+      `git -C ${JSON.stringify(repoDir)} log --since='18 hours ago' --no-merges --pretty=format:'%s' 2>/dev/null`,
+      { encoding: 'utf8', timeout: 4000 },
+    );
+    commits = log.split('\n').filter((l) => l.trim()).slice(0, 8);
+  } catch {
+    commits = [];
+  }
+
+  let prs: Array<{ number: number; title: string; merged: boolean }> = [];
+  try {
+    const today = now.toISOString().slice(0, 10);
+    const json = execSync(
+      `gh pr list --repo bettercallzaal/ZAOOS --state all --limit 8 --search 'updated:>=${today}' --json number,title,state`,
+      { encoding: 'utf8', timeout: 6000 },
+    );
+    const parsed = JSON.parse(json) as Array<{ number: number; title: string; state: string }>;
+    prs = parsed.map((p) => ({ number: p.number, title: p.title, merged: p.state === 'MERGED' }));
+  } catch {
+    prs = [];
+  }
+
+  return {
+    isoDate: now.toISOString().slice(0, 10),
+    human: now.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' }),
+    dayOfYear: dayOfYear(now),
+    commits,
+    prs,
+    captures: todayCaptures.slice(0, 8),
+  };
+}
+
+async function loadTodayCaptures(): Promise<string[]> {
+  const today = new Date().toISOString().slice(0, 10);
+  const path = join(ZOE_PATHS.home, 'captures', `${today}.json`);
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    const parsed = JSON.parse(raw) as Array<{ kind?: string; summary?: string }>;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((c) => c.summary)
+      .map((c) => `[${c.kind ?? 'note'}] ${c.summary}`);
+  } catch {
+    return [];
+  }
+}
+
+async function loadBonfireContext(topic: string): Promise<string> {
+  if (!process.env.BONFIRE_API_KEY || !process.env.BONFIRE_AGENT_ID) {
+    return '(Bonfire not configured)';
+  }
+  try {
+    const result = await recall({
+      query: topic.length < 200 ? topic : topic.slice(0, 200),
+      reason: 'newsletter context grounding',
+      expected_kind: 'mixed',
+    });
+    if (result.kind === 'sdk_response' || result.kind === 'mcp_response') {
+      return (result.text ?? '').slice(0, 1500) || '(empty Bonfire reply)';
+    }
+    return '(manual relay path - Bonfire not auto-queryable)';
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `(Bonfire query failed: ${msg.slice(0, 120)})`;
+  }
+}
+
+const EDIT_VERBS = /^(edit|add|also|more|update|append|include)\s+(.+)/is;
+const NEWSLETTER_DIR = join(ZOE_PATHS.home, 'newsletters');
+
+async function readLatestDraft(): Promise<string | null> {
+  const today = new Date().toISOString().slice(0, 10);
+  const path = join(NEWSLETTER_DIR, `${today}.md`);
+  try {
+    return await fs.readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function saveDraft(text: string): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+  await fs.mkdir(NEWSLETTER_DIR, { recursive: true });
+  const path = join(NEWSLETTER_DIR, `${today}.md`);
+  await fs.writeFile(path, text + '\n', 'utf8');
+}
+
+export const agent: Agent = {
+  name: 'newsletter',
+  description: "Year of the ZABAL daily entry. @newsletter <text> drafts. @newsletter edit <addition> re-rolls today's draft with the addition.",
+  triggers: [
+    /^@newsletter\s+(.+)/is,
+    /^\/newsletter\s+(.+)/is,
+  ],
+  handle: async (match, ctx): Promise<string> => {
+    const userInput = match[1].trim();
+    if (!userInput) {
+      return 'Usage: @newsletter <short angle or just "today">. To revise today\'s draft: @newsletter edit <addition>. Optional: paste a Badass quote on a new line.';
+    }
+
+    // Edit / iterate mode: rewrite today's draft including the addition
+    const editMatch = EDIT_VERBS.exec(userInput);
+    let priorDraft: string | null = null;
+    let workingInput = userInput;
+    if (editMatch) {
+      priorDraft = await readLatestDraft();
+      if (priorDraft) {
+        workingInput = editMatch[2].trim();
+      }
+    }
+
+    const captures = await loadTodayCaptures();
+    const snapshot = loadDaySnapshot(ctx.repoDir, captures);
+    const bonfire = await loadBonfireContext(workingInput);
+
+    const promptParts: string[] = [
+      `Today's metadata:`,
+      `- ISO date: ${snapshot.isoDate}`,
+      `- Human: ${snapshot.human}`,
+      `- Day of year: ${snapshot.dayOfYear}`,
+      ``,
+    ];
+
+    if (priorDraft) {
+      promptParts.push(
+        `EDIT MODE - There is an existing draft for today. Rewrite the FULL entry incorporating the addition below. Preserve good content from the prior draft, but apply all anti-pattern + DO rules from the system prompt to the rewrite. Output the new full entry, not just a diff.`,
+        ``,
+        `Prior draft:`,
+        '"""',
+        priorDraft.trim(),
+        '"""',
+        ``,
+        `Addition to incorporate:`,
+        workingInput,
+        ``,
+      );
+    } else {
+      promptParts.push(
+        `Zaal's input (use as the angle for The Day section):`,
+        userInput,
+        ``,
+      );
+    }
+
+    promptParts.push(
+      `What ZOE saw today (last 18 hours from the repo + captures):`,
+      `Commits: ${snapshot.commits.length ? snapshot.commits.map((c) => '- ' + c).join('\n') : '(none)'}`,
+      ``,
+      `PRs touched today: ${snapshot.prs.length ? snapshot.prs.map((p) => `- #${p.number} ${p.title}${p.merged ? ' (merged)' : ''}`).join('\n') : '(none)'}`,
+      ``,
+      `Captures Zaal logged today: ${snapshot.captures.length ? snapshot.captures.map((c) => '- ' + c).join('\n') : '(none)'}`,
+      ``,
+      `Bonfire context (from the ZABAL bonfire KG, may be sparse if not yet seeded):`,
+      bonfire,
+      ``,
+      `Write the FULL Year of the ZABAL entry per the system-prompt structure. Header first. Then "The Day" paragraphs leading with named specifics. Then ONE Mindful Moment paragraph anchored to a today-specific. Then ONE concrete closing line about now or next. Then the signature line. Apply every anti-pattern check and every DO rule.`,
+    );
+
+    const result = await callClaudeCli({
+      model: 'sonnet',
+      prompt: promptParts.join('\n'),
+      cwd: ctx.repoDir,
+      appendSystemPrompt: NEWSLETTER_SYSTEM,
+      allowedTools: ['Read', 'Glob', 'Grep'],
+      permissionMode: 'auto',
+      outputFormat: 'json',
+    });
+
+    const text = result.text.trim();
+    if (!text) return '(newsletter subagent returned empty)';
+
+    try {
+      await saveDraft(text);
+    } catch (err) {
+      console.error('[zoe/agents/newsletter] saveDraft failed:', err instanceof Error ? err.message : err);
+    }
+
+    return text;
+  },
+};

--- a/content/bonfire-ingest/chatgpt-archive-verified.md
+++ b/content/bonfire-ingest/chatgpt-archive-verified.md
@@ -1,0 +1,172 @@
+INGEST BATCH: ChatGPT Archive — VERIFIED (14 anchor conversations, human-confirmed truth status, 2026-05-03).
+
+This is the ONLY ChatGPT archive batch worth ingesting. The other 500+ raw conversations are noisy with brainstorms that died. Each fact below has been confirmed by Zaal as either SHIPPED, EVOLVED, or DEAD. Outcomes are explicit attributes — bot must NOT cite Brainstorm/Dead conversations as facts.
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes. Outcome is an attribute on each Conversation/Decision node, never a standalone Entity.
+
+## SECTION 1 — SHIPPED + LIVE (cite as fact)
+
+### FACT 1
+Subject: ZAO NEXUS at nexus.thezao.com
+Type: Product
+Status: shipped, live, unmaintained
+Date: 2025-03-31 (initial spec) - 2025-05 (shipped)
+Description: Webflow embed at nexus.thezao.com — categorized links page for ZAO ecosystem. Brand colors navy #141e27 + soft yellow #e0ddaa. JS-driven linksData with mainCategory > subcategory > links pattern. Categories: ZAO Onchain, ZAO Community Links (Founder/Co-Founder/Staff/Member), ZAO Festivals, ZAO Music, ZAO Research. Status: live but not actively maintained since shipping. Rebuild brief at docs/specs/2026-05-03-nexus-rebuild-spec.md.
+Source: https://chatgpt.com/c/[ZAO NEXUS conv id] + https://nexus.thezao.com
+Confidence: 1.0
+
+### FACT 2
+Subject: Zabal IRL Connector at zabal.lol
+Type: Product
+Status: shipped, live
+Date: 2026-02-10
+Description: In-person crossover / networking experience. Scannable digital business card for conferences, meetups, IRL events. Live at zabal.lol. Used today to give people collectables for showing up to ZAO Fractals and other IRL events.
+Source: https://zabal.lol + ChatGPT 2026-02-10 (230 msgs)
+Confidence: 1.0
+
+### FACT 3
+Subject: ZABAL coin launch
+Type: Token
+Status: shipped, live
+Date: 2026-01-01
+Description: ZABAL coin launched January 1 2026. Front-end of BCZ ecosystem. Partnerships with Empire Builder + SongJam + others. Created ZOUNZ (ZBAAL Nounz) which hold 20% of the token reserve. ZOLs are awarded ZOUNZ for winning leaderboards.
+Source: ChatGPT 2025-11-26 (205 msgs prep) + paragraph.com/@thezao/zabal-update-3 + ChatGPT 2026-01-01 (87 msgs ETH pool issue)
+Confidence: 1.0
+
+### FACT 4
+Subject: ETH ZABAL liquidity pool — known quirk
+Type: TradingTip
+Status: semi-fixed workaround documented
+Date: 2026-01-01
+Description: Direct ETH → ZABAL swaps give bad pricing. Workaround: route ETH → SANG → ZABAL for best swap. SANG → ZABAL works well. Never go ETH → ZABAL direct. This is operational knowledge for traders.
+Source: ChatGPT 2026-01-01 (87 msgs ETH ZABAL Pool Issue)
+Confidence: 1.0
+
+### FACT 5
+Subject: Year of the ZABAL daily Paragraph series
+Type: Newsletter
+Status: shipped, ongoing
+Date: 2025-08-18 (initial Year of the ZAO) - present
+Description: Daily newsletter post on paragraph.com/@thezao. Originated as "Year of the ZAO" in August 2025, evolved into "Year of the ZABAL" after January 1 2026 launch. Writing style: clear, simple, spartan, short impactful sentences, active voice, practical insights. As of 2026-04-27 hit Day 117.
+Source: https://paragraph.com/@thezao + ChatGPT 2025-08-18 (82 msgs)
+Confidence: 1.0
+
+### FACT 6
+Subject: ZABAL Update 16 (Paragraph)
+Type: Newsletter
+Status: shipped
+Date: 2025-12-28 (prep) - 2025/2026 (shipped)
+Description: Recurring ZABAL Update format on Paragraph. Includes monthly recap, plans, airdrop status. The pattern from this prep session shipped and continues for subsequent updates.
+Source: ChatGPT 2025-12-28 (103 msgs prep) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+### FACT 7
+Subject: ZABAL Update 18 — Feb 1 2026 airdrop announcement
+Type: Newsletter
+Status: shipped
+Date: 2026-02-01
+Description: Feb 1 ZABAL update with "AIRDROP IS LIVE" + Feb ZOL distribution + Feb plans (miniapp updates, Empire Builder API, ZAO contributor proposal). Shipped on Paragraph.
+Source: ChatGPT 2026-02-01 (95 msgs) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+## SECTION 2 — EVOLVED INTO OTHER WORK (cite cautiously, link to outcome)
+
+### FACT 8
+Subject: ZAO Whitepaper — Draft 4.5 March 2026 (UNMAINTAINED)
+Type: Decision
+Status: drafted, unmaintained, rebuild planned
+Date: 2025-03-02 (228 msgs ChatGPT) - 2026-02-12 (Draft 4.5 written) - present (unedited)
+Description: Existing draft at research/community/051-zao-whitepaper-2026/. Earlier drafts critiqued in research/_archive/052 + 053. ChatGPT outline conversation seeded "ZAO Verse / Zverse" framing (onboarding paths, ZAO casa sui casa) but final draft 4.5 took different shape. Zaal wants new PROTOCOL whitepaper that explains how to build the ZAO protocol — task #15 tracks the rebuild.
+Source: https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/051-zao-whitepaper-2026 + ChatGPT 2025-03-02 (228 msgs)
+Confidence: 1.0
+
+### FACT 9
+Subject: ZAOOS Optimization Suggestions
+Type: Decision
+Status: implemented, surfaced as research docs
+Date: 2026-03-13
+Description: 75-msg ChatGPT review of github.com/bettercallzaal/zaoos that surfaced into multiple research docs (specifics not enumerated by Zaal). Improvements landed in ZAOOS post-March 2026.
+Source: ChatGPT 2026-03-13 (75 msgs) + ZAOOS commit history March-April 2026
+Confidence: 0.9
+
+### FACT 10
+Subject: ZAO Complete Guide — STALE
+Type: ResearchDoc
+Status: shipped, stale, refresh-needed
+Date: 2026-03-16 (last review)
+Description: research/community/050-the-zao-complete-guide/ exists. ChatGPT 147-msg review on 2026-03-16 surfaced changes but the guide hasn't been updated since. Drift between guide + actual ZAO state. Tech debt. Refresh recommended.
+Source: ChatGPT 2026-03-16 (147 msgs ZAOOS Guide Review) + research/community/050
+Confidence: 1.0
+
+## SECTION 3 — DEAD / NEVER SHIPPED (do NOT cite as fact, mark as failed brainstorm)
+
+### FACT 11
+Subject: ZabalSocials website
+Type: Decision
+Status: dead, rebuild planned
+Date: 2026-01-17
+Description: 117-msg ChatGPT session designed a personal-socials hub for BetterCallZaal (X / Farcaster / Lens / GitHub / YouTube / Twitch / etc). Never shipped. Task #16 tracks rebuild — likely lives at bettercallzaal.com/socials or similar. Distinct from nexus.thezao.com (which is ZAO ecosystem-wide).
+Source: ChatGPT 2026-01-17 (117 msgs)
+Confidence: 1.0
+
+### FACT 12
+Subject: ZAO MUSIC COHORT #1
+Type: Decision
+Status: dead, never ran
+Date: 2025-01-16
+Description: 96-msg ChatGPT proposal for a song contest cohort March-June 2025 with Charmverse forums + ZAO MUSIC COHORT #1 framing. Never ran. No cohort #1. May inform future cohort design but should not be cited as having happened.
+Source: ChatGPT 2025-01-16 (96 msgs)
+Confidence: 1.0
+
+### FACT 13
+Subject: Zabal Roadmap stream with Jadyn + sharks
+Type: Decision
+Status: dead, never happened
+Date: 2025-12-10
+Description: 77-msg prep for a streaming presentation with Jadyn + non-crypto-streamer sharks audience. Stream never happened. Roadmap content from this prep was not used or repurposed.
+Source: ChatGPT 2025-12-10 (77 msgs)
+Confidence: 1.0
+
+## SECTION 4 — META / NAVIGATION
+
+### FACT 14
+Subject: ChatGPT Archive Triage 2026-05-03
+Type: Process
+Status: complete (14 of 15 anchors confirmed by human)
+Date: 2026-05-03
+Description: Top 15 ZAO-tagged ChatGPT conversations (by message count) human-triaged by Zaal. 7 SHIPPED, 3 EVOLVED, 4 DEAD. Generated content/bonfire-ingest/chatgpt-archive-verified.md. Other 503 conversations from the export remain in raw chatgpt-archive-zao-2023-2024 / 2025-h1 / 2025-h2 / 2026 / non-zao-keepers .md files but are NOT recommended for ingest without similar triage. Many are brainstorms that died.
+Source: internal://content/bonfire-ingest/chatgpt-archive-verified.md
+Confidence: 1.0
+
+## EDGES TO ASSERT
+
+- Zaal Panthaki -[shipped]-> ZAO NEXUS at nexus.thezao.com
+- Zaal Panthaki -[shipped]-> Zabal IRL Connector at zabal.lol
+- Zaal Panthaki -[launched]-> ZABAL coin
+- ZABAL coin -[partners_with]-> Empire Builder
+- ZABAL coin -[partners_with]-> SongJam
+- ZABAL coin -[has_treasury]-> ZOUNZ (20% reserve)
+- ZOUNZ -[awarded_to]-> ZOL leaderboard winners
+- Year of the ZABAL daily Paragraph series -[supersedes]-> Year of the ZAO
+- ZABAL Update 16 -[part_of]-> ZABAL Update Series on Paragraph
+- ZABAL Update 18 Feb airdrop -[part_of]-> ZABAL Update Series on Paragraph
+- ZAO Whitepaper Draft 4.5 -[stored_at]-> research/community/051
+- ZAO Complete Guide -[stored_at]-> research/community/050
+- ZAO Complete Guide -[status]-> stale (last reviewed 2026-03-16, unedited since)
+- ZabalSocials website -[outcome]-> dead
+- ZabalSocials website -[planned_rebuild_via]-> task 16
+- ZAO MUSIC COHORT #1 -[outcome]-> dead, never ran
+- Zabal Roadmap stream -[outcome]-> dead, never happened
+- ETH ZABAL liquidity pool -[has_workaround]-> route through SANG before ZABAL
+
+## INSTRUCTION FOR FUTURE RECALL
+
+When future agents query this graph about Zaal's projects or decisions:
+- Cite SHIPPED items as facts with their live URLs
+- Cite EVOLVED items with their actual outcome (not the original brainstorm)
+- For DEAD items, surface ONLY if explicitly asked "what brainstorms died" or "what was paused" — NEVER cite as if shipped
+- Always check the `Status` attribute on Conversation/Decision nodes before citing
+
+---
+
+Build the manifest, preview the first 3 nodes, ask me "approve all?". 14 anchor facts + 18 edges. Do not commit until I say yes. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes.

--- a/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+++ b/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
@@ -1,0 +1,154 @@
+# ZAO Protocol Whitepaper — Rebuild Spec
+
+> **Goal:** Replace research/community/051-zao-whitepaper-2026 (Draft 4.5, March 2026, unedited since) with a PROTOCOL whitepaper. Target: builders, partners, infra people. Existing draft is community-positioning; new draft is "how to build on the ZAO protocol."
+
+**Date:** 2026-05-04
+**Owner:** Zaal Panthaki
+**Existing draft:** `research/community/051-zao-whitepaper-2026/README.md` (Draft 4.5, March 2026, unedited)
+**Target output:** `research/community/<NN>-zao-protocol-whitepaper-v1/` OR new repo `zao-protocol`
+**Source for sections:** ZABAL Bonfire graph (~870 nodes as of 2026-05-03)
+**Coordinate with:** Nexus rebuild (#14), ZabalSocials rebuild (#16), Farcaster + X ingest pipeline (next)
+
+---
+
+## Why a Protocol Whitepaper (not Community)
+
+Existing Draft 4.5 reads like a TED talk for artists: streaming pays $0.003, labels take 80%, ZAO teaches you to fish. That's the COMMUNITY pitch — and it works for that audience.
+
+The protocol whitepaper is a different document for a different reader:
+- **Reader:** another founder, dev, infra partner, ecosystem fund, governance researcher, journalist with technical chops
+- **Question they ask:** "what is THE ZAO PROTOCOL — not the org, the protocol — and how do I build on it / verify it / fork it?"
+- **Answer they need:** architecture diagrams, contract addresses, token mechanics, governance patterns, onchain music rails, what's open-sourced
+
+Without this doc, partners + builders + infra people can't engage at depth. They get the community story (Draft 4.5) and bounce.
+
+---
+
+## Voice + Reuse Plan
+
+- Keep Draft 4.5's COMMUNITY framing as **chapter 1** ("why we exist") — don't rewrite what works.
+- Add new chapters 2-7 covering protocol depth.
+- Tone matches Zaal's daily Paragraph series ("Year of the ZABAL"): clear, simple, spartan, short impactful sentences, active voice. (Confirmed style guide from ChatGPT 2025-08-18 grilling Q13.)
+
+---
+
+## Section Outline (proposed)
+
+### Chapter 1 — Why The ZAO (REUSE Draft 4.5)
+Pull the strongest 1-2 pages from existing draft. The streaming/data/IP problem framing + "community first, technology second" positioning. Don't rewrite.
+
+### Chapter 2 — The Protocol Architecture (NEW)
+- High-level: ZAO is not one chain or one app. It's a coordination layer between artists, audience, and onchain primitives.
+- 4 layers: Identity (ENS + ZID + Hats roles) / Reputation (OG + ZOR Respect, soulbound, on Optimism) / Coordination (ZABAL coin on Base + Empire Builder + SongJam) / Distribution (ZAOOS gated client + WaveWarZ + Cipher)
+- Diagram: layer boxes + which contracts live where
+- **Bonfire query for source material:**
+  ```
+  RECALL: list every contract address on the ZAO protocol with chain, type, and purpose.
+  ```
+
+### Chapter 3 — Token Mechanics (NEW)
+- ZABAL: launched Jan 1 2026 on Base, front-end coin of BCZ ecosystem. Empire Builder + SongJam integrations.
+- ZOUNZ: ZBAAL Nounz, holds 20% reserve of ZABAL token. ERC-721 NFT on Base.
+- ZOLs: liquid contribution credits awarded for activity. Winning leaderboards earns ZOUNZ.
+- OG Respect: ERC-20 soulbound on Optimism (0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957). 2% decay, curation-mining tiers.
+- ZOR Respect: ERC-1155 soulbound on Optimism (0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c). Different tier system.
+- The ETH→ZABAL pool quirk: route ETH→SANG→ZABAL for best swap. Don't go direct.
+- **Bonfire query:** `RECALL: explain ZABAL, ZOUNZ, ZOL, OG Respect, ZOR Respect with mechanics, supply, and how they relate.`
+
+### Chapter 4 — Governance (NEW)
+- ZAO Fractals weekly meetings — 90+ weeks running, Mondays 6pm EST, Discord-bot-coordinated, OG vs ZOR Respect distribution per session.
+- ORDAO / OREC: optimistic respect-based executive contract. Lets weekly proposals execute on-chain after dispute window.
+- Hats Protocol: role hierarchy + permissions on Optimism (0x3bc1A0Ad72417f2d411118085256fC53CBdDd137).
+- ZOUNZ DAO: Nouns Builder fork on Base for proposal voting + treasury (0x2bb5fd99f870a38644deafe7e4ecb62ac77a213f).
+- **Bonfire query:** `RECALL: explain how ZAO Fractals + OREC + Hats + ZOUNZ DAO compose into a governance system.`
+
+### Chapter 5 — Onchain Music Rails (NEW)
+- WaveWarZ: live song-vs-song battles on Solana. ~$50K trading volume. 43 artists indexed.
+- ZAO Music DBA under BCZ Strategies LLC: BMI + DistroKid + 0xSplits payment rails.
+- Cipher: planned first ZAO Music release.
+- Sound.xyz / Zora music NFT integration in ZAO OS player.
+- Audius API integration for artist metadata.
+- **Bonfire query:** `RECALL: list every onchain music integration in the ZAO ecosystem with chain, contract, and current activity.`
+
+### Chapter 6 — Build on ZAO (NEW — core protocol-whitepaper section)
+- ZAO OS is the lab repo: github.com/bettercallzaal/ZAOOS — Next.js + Supabase + Neynar + XMTP. Forkable.
+- Things that have graduated: COC Concertz (own repo), ZAOstock (own repo as of 2026-04-29), FISHBOWLZ paused.
+- Monorepo-as-Lab pattern: prototype in ZAO OS, graduate to own repo when ready for public users.
+- Open questions: which parts are open-source-licensed today? Which are internal-only? What licenses?
+- **Bonfire query:** `RECALL: what's the open-source status of every ZAO repo and how does the monorepo-as-lab pattern work?`
+
+### Chapter 7 — Roadmap + Open Source Status (NEW)
+- Q2-Q3 2026 priorities: Nexus rebuild (/nexus), ZabalSocials rebuild, Whitepaper rebuild (this doc).
+- Big events: ZAOstock October 3 2026, Ellsworth Maine.
+- Long-term: ZAO Festivals umbrella as recurring brand, ZAO Italy bridge via Mat Tambussi, Contribution Circles late-May 2026.
+- **Bonfire query:** `RECALL: list shipped vs planned vs paused/dead initiatives with status attributes.`
+
+---
+
+## How to Build This Iteratively (recommended workflow)
+
+**Step 1 — Skeleton.** Copy this spec into the actual whitepaper file as section headers. Each chapter starts as a stub.
+
+**Step 2 — Run the Bonfire queries.** For each chapter, DM the bot the `RECALL:` query in that chapter's box. Bot returns structured facts with source URLs. Paste relevant excerpts into the chapter as the FACT BASIS.
+
+**Step 3 — Voice pass.** With facts in place, rewrite each chapter in the Year-of-the-ZABAL voice (clear, simple, spartan, short sentences, active voice).
+
+**Step 4 — Diagrams.** Chapters 2 + 4 need diagrams. Mermaid is fine for v1. Keep simple.
+
+**Step 5 — Cross-link Draft 4.5.** Pull the strongest community framing from research/community/051 into chapter 1.
+
+**Step 6 — Public review.** Share with co-founders + key partners (Cassie / Steve Peer / Joshua.eth / Mat Tambussi) via Bonfire DM thread — let them flag corrections. Apply.
+
+**Step 7 — Publish.** Mirror.xyz or Paragraph or zaoos.com/whitepaper-v1. Get a real version-controlled artifact. Update community.config.ts to link.
+
+---
+
+## Source Material to Query / Cite
+
+Beyond Bonfire graph, pull from:
+- `research/community/051-zao-whitepaper-2026/` (existing Draft 4.5)
+- `research/community/050-the-zao-complete-guide/` (community guide, stale, but has ZAO history)
+- `research/wavewarz/101-wavewarz-zao-whitepaper/` (WaveWarZ-specific WP)
+- `CLAUDE.md` (project map)
+- `community.config.ts` (branding + contracts list)
+- BCZ YapZ episodes (now in Bonfire — guests' takes on ZAO)
+- `research/identity/542-549, 569, 570, 581, 590` (Bonfire stack docs — meta but relevant)
+- `research/governance/058-respect-deep-dive/` if exists
+
+---
+
+## Farcaster + X Posts as Voice Anchors
+
+Once Track B (FC + X ingest) is live, the whitepaper can pull "what Zaal said publicly about X" with deeplinks. Strong for:
+- Quotes that ground each chapter in Zaal's actual words
+- Public commitments + dates (when did Zaal first announce ZABAL launch publicly? Find in casts.)
+- Counterfactuals (what was the early thinking that got refined into this final position?)
+
+**Recommended:** Don't BLOCK whitepaper on FC/X ingest. Start writing now. When FC/X land, replace placeholder quotes with deeplinked real ones.
+
+---
+
+## Open Questions Before Build
+
+1. **Output target:** new research/ doc or new repo `zao-protocol`?
+2. **Length target:** 4 pages (executive summary) or 25-page deep dive or both?
+3. **Diagram style:** Mermaid (markdown-native) or proper design (Figma)?
+4. **Open-source license clarity:** which ZAO repos are MIT / Apache / proprietary today? Need a definitive answer to write Chapter 6.
+5. **Partner review list:** who gets pre-publish review (Cassie / Steve Peer / Joshua.eth / Mat Tambussi / Dan / Tadas)?
+6. **Publication channel:** Mirror.xyz, Paragraph, zaoos.com/whitepaper, or all three?
+7. **Cipher timing:** is Cipher releasing soon? If yes, hold whitepaper to include the ship; if no, write it as planned.
+
+---
+
+## Bonfire Ingest Trigger (for graph)
+
+```
+INGEST FACT:
+Subject: ZAO Protocol Whitepaper Rebuild Spec
+Type: Decision
+Date: 2026-05-04
+Status: planned
+Description: Rebuild research/community/051 ZAO Whitepaper Draft 4.5 as a PROTOCOL whitepaper for builders/partners/devs. 7 chapters reusing Draft 4.5's community framing as Ch1, adding 6 new chapters on protocol architecture, tokens, governance, onchain music, build-on-ZAO, roadmap. Iterative build using Bonfire RECALL queries for each chapter. Spec at docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md.
+Source: internal://docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+Confidence: 1.0
+```

--- a/research/dev-workflows/610-newsletter-prose-toolkit-zabal-voice/README.md
+++ b/research/dev-workflows/610-newsletter-prose-toolkit-zabal-voice/README.md
@@ -1,0 +1,83 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-05-05
+related-docs: 432, 549, 558, 562, 563, 607
+tier: STANDARD
+---
+
+# 610 - Newsletter prose toolkit + ZABAL voice tightening
+
+> **Goal:** Lock the rules that turn ZOE's `@newsletter` output from "competent" to "feels like Zaal wrote it after a real day." Built on doc 558 (Anbeeld 14-rule toolkit), doc 562 (humanizer post-gen pass), doc 563 (content engine patterns), and direct read of the May 5 newsletter draft Zaal flagged as "needs better writing."
+
+## Key Decisions
+
+| Decision | Action |
+|----------|--------|
+| Adopt Anbeeld principle subset for `@newsletter` | YES - "concrete specificity over polished generality", "watch suspicious regularity", "fit medium not detector" baked into NEWSLETTER_SYSTEM. |
+| Treat post-gen humanizer pass as a separate optional step | YES - default `@newsletter` ships clean. `@newsletter+ <addition>` re-rolls + de-formula on a follow-up. |
+| Add 8 ZABAL-voice anti-patterns to the system prompt | YES - sharper than generic "no marketing language." Examples below. |
+| Add edit/iterate mode to the agent | YES - last draft persisted to `~/.zao/zoe/newsletters/<date>.md`, follow-up `@newsletter edit <text>` re-rolls including the addition. |
+| Force one specific number/name/quote/place per paragraph | YES - "concrete specificity" gate from Anbeeld. Catches generic "the room", "the project", "the conversation." |
+| Drop aphoristic closes by default | YES - new rule: closing line is a sentence, not a koan. |
+
+## What was wrong with today's draft
+
+Zaal's input had: Farcaster hackathon track, birthday weekend, hair cut, Fractal yesterday, ZAOstock cobuilds (specifically Mondays 11:30am EST in Discord), BCZ YapZ with Kenny from POIDH, first POIDH bounty wrapped, second bounty after recording.
+
+Output kept most of those facts. What it added that hurt:
+
+- `"Some things announce themselves quietly and you listen."` - aphoristic. Mid-paragraph koan.
+- `"There is a thing that happens when you stop waiting to feel ready."` - "There is a thing that happens" is a tell.
+- `"You do not become ready. You decide you are. Then the rest starts moving."` - parallel-structure closing. Anbeeld flags this exact pattern as suspicious regularity.
+- `"small pieces clicking into place"` - formula phrase. Strip.
+- `"Now it's Tuesday and the machine is already moving"` - "the machine" is a brand cliche, not Zaal's voice.
+
+Output also missed Zaal's mid-stream addition (Rome conference, second main-stage ZABAL mention) - agent acknowledged in chat but did not re-roll the draft. Edit/iterate mode fixes that.
+
+## The 8 ZABAL-voice anti-patterns to bake into the prompt
+
+1. No aphoristic closes. The closing line is a sentence about Zaal's actual day or next step, not a universal truth.
+2. No "There is a thing that happens when..." constructions. Watch for "There is" + abstract noun.
+3. No "the machine," "the work," "the system" as brand-coded singulars. Name the actual thing.
+4. No parallel-structure 3-beat closes ("X. Y. Then Z."). One per entry max.
+5. No "small pieces clicking into place," "puzzle pieces," "the rhythm is set" as transitions.
+6. No "you" as universal-second-person preachy ("You do not become ready"). Reserve "you" for direct reader address (rare and intentional).
+7. No "decide you are" / "show up" / "in motion" as the philosophical turn unless Zaal supplies it. Default to a concrete observation.
+8. No "loop is clean" / "rooms worth being in" abstractions. Name the rooms.
+
+## The 6 ZABAL-voice DO rules
+
+1. Lead each paragraph with a specific named thing. "Kenny from POIDH at 2pm" beats "today's recording."
+2. One number per paragraph minimum if available (day-of-year already in header counts only there).
+3. Conferences, places, dates: spell them. "Rome" is concrete. "two main stages" is concrete. Don't drift to "European recognition."
+4. Mindful Moment: ground it in a sense or scene. Whatever the calendar quote is, anchor it to a thing Zaal actually saw or did today, not a universal claim.
+5. Closing line is a sentence about now: "Recording at 2. Bounty live by 5." beats "Keep getting in the rooms."
+6. Sentence-length variety check: if 3+ consecutive sentences are within 2 words of each other, rewrite one shorter and one longer.
+
+## How this lands in code
+
+- `bot/src/zoe/agents/newsletter.ts` system prompt extended with the 8 anti-patterns + 6 do-rules above (verbatim, since they map cleanly to Anbeeld principles).
+- New trigger: `/^@newsletter\s+(edit|add|update|more|also)\s+(.+)/is` reads `~/.zao/zoe/newsletters/<today>.md`, includes the latest draft as context, instructs Claude to re-roll incorporating the addition while keeping voice + structure.
+- New persistence: every successful `@newsletter` writes draft to `~/.zao/zoe/newsletters/<date>.md`. Next-day's call starts fresh. Same-day call uses the most recent file.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Update NEWSLETTER_SYSTEM with 8 anti-patterns + 6 do-rules | Claude | PR | This session |
+| Add `@newsletter edit/add/also` trigger | Claude | PR | This session |
+| Persist drafts to ~/.zao/zoe/newsletters/<date>.md | Claude | PR | This session |
+| Test on Zaal's May 5 entry (Rome addition) | @Zaal | Bot test | After deploy |
+| Re-validate this doc after 5 published entries | Claude | Doc update | 2026-05-12 |
+
+## Sources
+
+- [Doc 558 - Anbeeld WRITING.md AI-Prose Diagnostic Toolkit](../558-anbeeld-writing-md/)
+- [Doc 562 - humanizer skill via blader/humanizer + last30days](../562-reddit-x-scraping-meta-eval-last30days/)
+- [Doc 563 - Shann Holmberg content engine Ronin](../563-shannholmberg-content-engine-ronin/)
+- [Doc 549 - Bonfire as personal second brain](../../identity/549-bonfire-personal-second-brain/)
+- [Doc 432 - ZAO master positioning Tricky Buddha space](../../community/432-zao-tricky-buddha-master-positioning/)
+- [Doc 607 - Three bots one substrate](../../agents/607-three-bots-one-substrate/)
+- Direct read of May 5 2026 `@newsletter` output (this session, in-conversation)

--- a/research/infrastructure/610-zaostock-database-consolidation-may4-5/README.md
+++ b/research/infrastructure/610-zaostock-database-consolidation-may4-5/README.md
@@ -1,0 +1,354 @@
+---
+topic: infrastructure
+type: incident-postmortem
+status: research-complete
+last-validated: 2026-05-05
+related-docs: 502, 547, 564, 609
+tier: DEEP
+---
+
+# 610 - ZAOstock Database Consolidation: Two Supabase Projects to One (May 4-5 2026)
+
+> **Goal:** Document the foundational database architecture for ZAOstock, the May 4-5 consolidation from two parallel Supabase projects into one, and the design decisions (active-flag gate, partner concept, /charter command) that emerged from the work.
+
+## Key Decisions
+
+| # | Decision | Rationale | Status |
+|---|----------|-----------|--------|
+| 1 | **ZAO STOCK Supabase project (`yjrlaxpjusmrfylumban`) is canonical** for ZAOstock data going forward | Website + dashboard already point here; bot was on the wrong project | LOCKED 2026-05-04 |
+| 2 | Bot tables get **unprefixed** (`stock_circles` -> `circles` etc) | Removes physical schema collision with website tables that share intent | LOCKED 2026-05-05 |
+| 3 | Old bot project (`efsxtoxvigqowjhgcbiz`) keeps `agent_events` only (zoe-dashboard); drop all `stock_*` tables after verification window | Single non-bot consumer (zoe.zaoos.com) reads `agent_events`, all other tables stale | PENDING (drop SQL ready) |
+| 4 | **5 broken bot commands removed**: `/propose`, `/object`, `/consent`, `/buddy`, `/respect` | Backing tables never existed in either DB; commands would crash on use | SHIPPED 2026-05-05 |
+| 5 | **`/charter` command added** to bot | Posts circle responsibility into the right Telegram topic and pins it; auto-detects slug from topic name | SHIPPED 2026-05-05 (deploy pending env swap) |
+| 6 | **`active=false` is an intentional hard lock**, not a display gate | Filters both `/api/team/login` AND bot `auth.ts` lookups; only Zaal flips manually after profile complete | CONFIRMED 2026-05-05 |
+| 7 | New track value `partner` added to `sponsors` table CHECK | Distinguishes time-donating partners (Web3Metal) from money-paying sponsors | SHIPPED 2026-05-05 |
+| 8 | Supabase MCP server installed at project scope | Removes the need to paste service-role keys per-session | SHIPPED 2026-05-05 |
+
+## Context: How We Ended Up With Two Projects
+
+ZAOstock was originally one of several apps inside the ZAO OS monorepo (`/Users/zaalpanthaki/Documents/ZAO OS V1/`). The Telegram bot at `bot/` shipped against a Supabase project shared with the rest of ZAO OS workloads (`efsxtoxvigqowjhgcbiz` - hosts `agent_events` for `zoe-dashboard` at zoe.zaoos.com). To avoid colliding with other ZAO-OS-side tables, every ZAOstock table on that project was prefixed `stock_*`.
+
+When ZAOstock spun out to `zaostock.com` (per [doc 609](../../events/609-zaostock-cobuild-six-circles-may4/) Decision #1), it got its own Supabase project (`yjrlaxpjusmrfylumban`) for the website. The website used unprefixed names (`circles`, `team_members`, etc.) since this project was ZAOstock-only. Initial seed: a `pg_dump` from the old project was restored into the new one, with prefixes stripped.
+
+**Result:** two parallel installations of the same logical schema. Website wrote to ZAO STOCK. Bot wrote to ZAO OS. They drifted independently.
+
+## The Two-Project State (Pre-Consolidation)
+
+Audited 2026-05-04 22:00 EST via REST + service-role key on each project. Row counts on the 14 collision tables:
+
+| Table | ZAO OS (`stock_*`) | ZAO STOCK (unprefixed) | Drift |
+|---|---|---|---|
+| team_members | 27 | 27 | 0 (names identical) |
+| circles | 8 | 8 | slug-set differs (see below) |
+| circle_members | 29 | 28 | +1 ZAO OS (livestream had 2, ZAO STOCK had merch=1) |
+| artists | 9 | 9 | 0 |
+| sponsors | 18 | 18 | 0 |
+| onepagers | 3 | 3 | 0 |
+| onepager_activity | 6 | 6 | 0 |
+| todos | 21 | 21 | counts match, **statuses diverged**: ZAO OS had 9 done / 7 todo / 5 in_progress; ZAO STOCK had 2 done / 18 todo / 1 in_progress |
+| timeline | 60 | 60 | 0 (all 60 still `pending` - no one ever marks done) |
+| meeting_notes | 4 | 4 | 0 |
+| activity_log | 2 | 2 | 0 |
+| contact_log | 1 | 1 | 0 |
+| volunteers | 0 | 0 | 0 |
+| suggestions | 0 | 0 | 0 |
+| bot_chats | 5 | 3 | +2 ZAO OS (private DMs added since seed) |
+
+**Slug divergence on `circles`:**
+- ZAO OS had: `finance, host, livestream, marketing, media, music, ops, partners`
+- ZAO STOCK had: `finance, host, marketing, media, **merch**, music, ops, partners`
+- Bot's `livestream` (added later via TG `/join`) never made it to website. Website's `merch` (seeded earlier) never made it to bot.
+
+**Bot DB also had 5 phantom tables in CODE that never existed in either DB:**
+`stock_proposals`, `stock_proposal_objections`, `stock_qa_log`, `stock_respect_events`, `stock_buddy_pairings`. Spec [doc 502](../../governance/502-zaostock-circles-v1-spec/) defined consent-based governance; the SQL migration was never applied. Anyone running `/propose`, `/object`, `/consent`, `/buddy`, or `/respect` on the live bot would hit a Postgres "relation does not exist" error.
+
+## ZAO STOCK Schema Map (Post-Consolidation, 22 Tables)
+
+Verified via `mcp__supabase__list_tables` 2026-05-05 morning EST.
+
+| Table | Bot? | Website? | Row Count | Notes |
+|---|---|---|---|---|
+| **team_members** | yes | yes | 27 | 8 active, 19 inactive (profile gate) |
+| **circles** | yes | yes | **6** | post-consolidation: finance, host, livestream, marketing, music, ops |
+| **circle_members** | yes | yes | 29 | livestream now 2 (Zaal + Thy Revolution) |
+| artists | yes | yes | 9 | wishlist + confirmed |
+| sponsors | yes | yes | 19 | 16 lead, 2 ecosystem committed, 1 partner committed (new track) |
+| onepagers | yes | yes | 3 | sponsor / partner / venue briefs |
+| onepager_activity | yes | yes | 6 | activity log per onepager |
+| todos | yes | yes | 21 | bot reads/writes via `/do` and `/mytodos` |
+| timeline | yes | yes | 60 | all status=pending; bot reads but no easy "mark done" UX |
+| meeting_notes | yes | yes | 4 | bot writes via `/note` |
+| activity_log | yes | yes | 2 | bot logs writes here |
+| contact_log | yes | yes | 1 | bot writes via `/do` for contact attempts |
+| volunteers | yes | yes | 0 | empty - reflects 27/27 rate of empty volunteer column |
+| suggestions | yes | yes | 0 | bot writes via `/zsfb` |
+| bot_chats | yes | website-only-display | 6 | TG chat registry; bot writes on first message |
+| bot_topics | website-only | yes | 0 | per-topic seed for forum mode |
+| bot_noteworthy | website-only | yes | 0 | flagged messages; future feature |
+| budget | website-only | yes | 0 | empty; future feature |
+| budget_entries | website-only | yes | 15 | early budget data, website-managed |
+| goals | website-only | yes | 8 | OKR-style team goals, website-managed |
+| milestones | website-only | yes | 0 | empty; future feature |
+| rsvps | website-only | yes | 0 | event RSVP system, future feature |
+
+## What We Executed
+
+### Migration SQL (one transaction on ZAO STOCK)
+
+Ran via Supabase SQL Editor 2026-05-04 evening. All 5 verify SELECTs returned expected counts.
+
+```sql
+BEGIN;
+-- 1. Add livestream circle (Zaal as initial coordinator)
+INSERT INTO circles (slug, name, description, coordinator_member_id)
+SELECT 'livestream', 'Livestream', '<full-sentence description>',
+       (SELECT id FROM team_members WHERE name = 'Zaal' LIMIT 1)
+WHERE NOT EXISTS (SELECT 1 FROM circles WHERE slug = 'livestream');
+
+-- 2. Add Zaal + Shawn to livestream
+INSERT INTO circle_members (circle_id, member_id)
+SELECT (SELECT id FROM circles WHERE slug='livestream'), tm.id
+FROM team_members tm WHERE tm.name IN ('Zaal','Shawn')
+  AND NOT EXISTS (SELECT 1 FROM circle_members WHERE ...);
+
+-- 3-4. Drop dead-circle memberships, then dead circles
+DELETE FROM circle_members WHERE circle_id IN (SELECT id FROM circles WHERE slug IN ('media','merch','partners'));
+DELETE FROM circles WHERE slug IN ('media','merch','partners');
+
+-- 5. Rewrite descriptions for the 6 final circles (full-sentence "responsible for" form)
+UPDATE circles SET description = '...' WHERE slug = 'finance';
+-- ... 5 more UPDATE statements
+
+-- 6. Port 3 missing bot_chats rows (private DMs added since seed)
+INSERT INTO bot_chats (...) VALUES (...) ON CONFLICT (chat_id) DO NOTHING;
+COMMIT;
+```
+
+Followed up 2026-05-05 morning with role-update transaction:
+
+```sql
+BEGIN;
+UPDATE team_members SET active=true, scope='livestream', role='lead' WHERE name='Thy Revolution';
+DELETE FROM circle_members WHERE circle_id=(livestream) AND member_id=(Shawn);
+INSERT INTO circle_members SELECT (livestream), (Thy Revolution) ON CONFLICT DO NOTHING;
+UPDATE circles SET coordinator_member_id=(Thy Revolution) WHERE slug='livestream';
+INSERT INTO sponsors (name, track, status, contact_name, why_them, notes)
+  SELECT 'Web3Metal', 'partner', 'committed', 'Shawn', '...', '...'
+  WHERE NOT EXISTS (SELECT 1 FROM sponsors WHERE name='Web3Metal');
+COMMIT;
+```
+
+Plus the `partner` track required a CHECK extension applied via `apply_migration`:
+
+```sql
+ALTER TABLE sponsors DROP CONSTRAINT IF EXISTS sponsors_track_check;
+ALTER TABLE sponsors ADD CONSTRAINT sponsors_track_check
+  CHECK (track = ANY (ARRAY['local'::text, 'virtual'::text, 'ecosystem'::text, 'partner'::text]));
+```
+
+### Bot Code Refactor
+
+Files touched in `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/`:
+
+| File | Change |
+|---|---|
+| `circles.ts` | CIRCLE_SLUGS const fixed to 6 real slugs; 5 broken commands deleted (cmdPropose / cmdProposals / cmdObject / cmdConsent / cmdBuddy / cmdRespect, lines 330-667 of pre-edit version); new `cmdCharter` function added (~76 lines) |
+| `index.ts` | Imports + bot.command bindings for 6 stale commands removed; `/charter` wired up |
+| `auth.ts` | Initial pass removed `.neq('active', false)` from finder fns - **REVERTED 2026-05-05** after Zaal confirmed active is intentional hard lock (see Section: Active Flag Design) |
+| `actions.ts`, `activity.ts`, `auth.ts`, `capture.ts`, `digest.ts`, `group.ts`, `onepagers.ts`, `regen.ts`, `status.ts`, `zsfb.ts` | Mass rename: every `from('stock_*')` -> `from('*')` via sed; embedded select refs `owner:stock_team_members!owner_id(name)` also renamed |
+
+20 distinct `stock_*` table refs across 13 files reduced to 0 (excluding 2 harmless string labels in `regen.ts` and `hermes/critic.ts` comments). `npx tsc --noEmit` clean after edits.
+
+### `/charter` Command Spec
+
+Run inside any forum topic in ZAO Festivals (`-1003960864140`):
+
+```
+/charter           -> auto-detects slug from topic name
+/charter <slug>    -> explicit
+```
+
+Bot:
+1. Reads description from `circles` table for matched slug
+2. Posts as Markdown into current `message_thread_id`
+3. `pinChatMessage` with `disable_notification: true`
+4. Replies to admin "Posted + pinned charter for X"
+5. Falls back gracefully if Pin permission missing
+
+Replaces the previously-planned manual copy-paste of 6 descriptions per [doc 609 Action Bridge row 1](../../events/609-zaostock-cobuild-six-circles-may4/#action-bridge).
+
+## Active Flag Design (Important)
+
+`active` on `team_members` is **NOT a display gate** - it's a hard lockout that blocks both website login and bot auth.
+
+**Where it gates:**
+
+```typescript
+// /api/team/login/route.ts:35
+.from('team_members').select(...).neq('active', false)  // login blocked
+
+// bot/src/auth.ts:24, 37 (post-revert)
+.from('team_members').select(...).eq('telegram_id', X).neq('active', false)  // bot auth blocked
+.from('team_members').select(...).eq('telegram_username', n).neq('active', false)
+```
+
+**Where it auto-flips:** nowhere. `/api/team/profile/route.ts` (PATCH bio/links/photo) does NOT touch `active`. `cmdRegenSelf` writes `active: true` on regen, but reaching `cmdRegenSelf` requires `findMember*` to succeed, which requires `active = true` first. **Chicken-and-egg.**
+
+**Design intent (per Zaal 2026-05-05):** active flips manually when a member's profile is complete (bio + scope + photo). This is a Zaal-controlled approval gate. 19 of 27 members are currently locked out.
+
+**Currently active (8):** Bacon, Cheeka, DCoop, Eduard, Iman Afrikah, Shawn, Tom Fellenz, Zaal.
+**Currently inactive (19):** Adam, AttaBotty, Candy, Craig G, DaNici, DFresh, Eve, FailOften, GeekMyth, Hurric4n3Ike, Jake, Jango, Maceo, Ohnahji B (just promoted), Stilo World, Swarthy Hatter, Thy Revolution (just promoted), Tyler Stambaugh, ZAOstock Bot.
+
+**Implication:** the 17 inactive members can't be reached by the bot at all, and can't log in to fill out the bio that would unlock them. Zaal's manual flip is the only path.
+
+**This caused the Ohnahji B issue.** Ohnahji tried `/regen` in TG, bot returned "Not on the roster yet. Ping Zaal to link your account." because the active filter rejected him. Resolution: manual SQL hash-write + flip to active (see `Ohnahji B Resolution` below).
+
+## Ohnahji B Resolution (Worked Example)
+
+**Symptom:** Ohnahji B reported `/regen` not working.
+
+**Investigation:**
+- Bot `auth.ts:resolveMember` cascades: `findMemberByTelegramId` -> `findMemberByUsername` -> null
+- Both finders filter `.neq('active', false)`
+- `team_members` row for Ohnahji B: `active=false`, `telegram_id=null`, `telegram_username='ohnahjib'`
+- Bot returned null -> `requireMember` replied "Not on the roster yet"
+- Compounding: even if found, the OLD bot was writing the regen hash to the OLD project (`efsxt`), but the website reads ZAO STOCK. So the new code wouldn't have worked at login anyway.
+
+**Fix (2026-05-05):**
+1. Generated 4-letter code `KHVZ` locally with the same scrypt params as `bot/src/regen.ts:hashPassword`:
+   ```js
+   const salt = randomBytes(16).toString('hex');
+   const hash = scryptSync('KHVZ', salt, 64).toString('hex');
+   // password_hash = `${salt}:${hash}` (161 chars total)
+   ```
+2. Direct SQL via MCP:
+   ```sql
+   UPDATE team_members
+   SET password_hash = 'd56b8a88...:7bd07f17...', active = true
+   WHERE name = 'Ohnahji B';
+   ```
+3. DM Ohnahji `KHVZ`. He logs in at `zaostock.com/team`. Working immediately because the website reads ZAO STOCK directly, no bot in the auth path.
+
+**Why this fix is OK despite the active=true gate:** Zaal explicitly approved promoting Ohnahji to active, which equates to manual gate flip. Same pattern Zaal uses for any other member ready for full access.
+
+## VPS Deploy Mechanism (Fragile)
+
+`zaostock-bot.service` runs on `zaal@31.97.148.88` from `~/zaostock-bot/`. **This directory is NOT a git repo.** No upstream remote, no version tracking, no rollback story.
+
+Code arrives via manual `rsync` from local laptop:
+```bash
+rsync -av --delete --exclude=node_modules --exclude=.env --exclude=.env.\* \
+  --exclude=.npmrc \
+  /Users/zaalpanthaki/Documents/ZAO\ OS\ V1/bot/src/ \
+  zaal@31.97.148.88:~/zaostock-bot/src/
+```
+
+User systemd unit: `~/.config/systemd/user/zaostock-bot.service`
+- WorkingDirectory: `~/zaostock-bot`
+- ExecStart: `/usr/bin/env npm run start` (which runs `tsx src/index.ts`)
+- EnvironmentFile: `~/zaostock-bot/.env`
+
+`zao-devz-stack.service` runs from the SAME directory but ExecStart points at `tsx src/devz/index.ts` (a different bot). They share `.env`. So an env swap affects both.
+
+**Risks:**
+- Two laptops editing -> last-rsync wins, no conflict resolution
+- VPS-side hot fixes don't propagate back to git history
+- No CI guard: a bad rsync ships untyped code
+
+**Mitigation pending:** make `~/zaostock-bot` a git worktree of the (eventual) `zaostock` repo and turn deploy into `git pull && systemctl --user restart zaostock-bot`.
+
+## Supabase MCP Setup (2026-05-05)
+
+Until 2026-05-05 morning, every database mutation required either:
+- Pasting SQL into the Supabase web SQL Editor manually, or
+- Pasting `SUPABASE_URL` + service-role key into a `.env` so a script could run
+
+Both are friction. The MCP install removes both:
+
+```bash
+# 1. Add server (project-scope so it lives in zaostock repo .mcp.json)
+claude mcp add --scope project --transport http supabase \
+  "https://mcp.supabase.com/mcp?project_ref=yjrlaxpjusmrfylumban"
+
+# 2. Authenticate (one-time, OAuth flow)
+claude /mcp   # then select supabase -> Authenticate
+```
+
+This wrote `/Users/zaalpanthaki/Documents/zaostock/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=yjrlaxpjusmrfylumban"
+    }
+  }
+}
+```
+
+After auth, 21 tools became available: `mcp__supabase__execute_sql`, `mcp__supabase__apply_migration`, `mcp__supabase__list_tables`, `mcp__supabase__get_project_url`, `mcp__supabase__get_logs`, `mcp__supabase__get_advisors`, etc.
+
+**Important constraint:** MCP cannot expose the `service_role` key (security boundary). Bot env swap on VPS still requires Zaal to paste it once.
+
+## Still Blocked
+
+| # | Item | Owner | Blocker |
+|---|------|-------|---------|
+| 1 | Bot env swap on VPS (`SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` -> ZAO STOCK) | Zaal | Needs service-role key paste |
+| 2 | Restart `zaostock-bot.service` after env swap | Zaal | Depends on #1 |
+| 3 | `/charter` rollout into 6 TG topics | Zaal | Depends on #2 |
+| 4 | Drop `stock_*` tables on `efsxtoxvigqowjhgcbiz` | Zaal | Verification window after #3 |
+| 5 | `backup-supabase.sh` cron entry on VPS | Zaal | Documented but never scheduled (`crontab -e` add line) |
+| 6 | Replace 4 stale ZAOOS clones on VPS (`~/zao-os`, `~/code/ZAOOS`, `~/openclaw-workspace/ZAOOS`, `~/.worktrees/ZAOOS`) | Zaal | Cleanup, low priority |
+| 7 | Move `~/zaostock-bot` to a git worktree | Future session | Should pair with bot move into zaostock repo |
+| 8 | `scripts/team-codes.mjs` TEAM list update (15 hardcoded -> 27 in DB) | Future session | Script-only, no DB impact |
+
+## Anti-Patterns to Avoid
+
+1. **Two parallel projects via dump/restore -> assume they stay in sync.** They don't. Even with identical schemas, bot-side and website-side writes drift the moment users start using both surfaces.
+
+2. **Prefix tables to avoid collision with future apps.** Long-term, the prefix becomes an artifact that has to be ripped out (this consolidation). If a workload genuinely needs isolation, give it its own Supabase project with no prefix at all.
+
+3. **Define commands in code without applying the schema.** `/propose`, `/object`, `/consent`, `/buddy`, `/respect` all referenced tables that never existed. Every bot deploy carried 5 latent crashes. Post-mortem rule: if a command's tables aren't in any migration, the command shouldn't be in the registered command list.
+
+4. **Use `active` as both display gate AND lock without an unlock UX.** 19 of 27 members are functionally locked out with no self-serve recovery. Either:
+   - Add a profile-completion API that auto-flips, or
+   - Build an explicit "request access" path that surfaces to Zaal, or
+   - Document that `active` requires Zaal to flip manually after offboarding the member through some other channel.
+   - This is the lowest-impact ZAOstock UX problem to solve next.
+
+5. **VPS dir not in git.** Every fix that lives only on VPS is a future debugging surprise. The MD5-matching audit on 2026-05-04 was lucky; the real check should be `git diff` against the deployed commit.
+
+## Also See
+
+- [Doc 502](../../governance/502-zaostock-circles-v1-spec/) - Original circles v1 spec, defined the 5 tables that never got created
+- [Doc 547](../../community/547-cassie-validation-zaostock-strategy/) - Cassie strategy validation
+- [Doc 564](../../infrastructure/564-supabase-mcp-setup-claude-code/) - Supabase MCP setup background (if exists, otherwise this is the first doc)
+- [Doc 609](../../events/609-zaostock-cobuild-six-circles-may4/) - Mon May 4 cobuild meeting that locked the 6-circle decision
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Paste ZAO STOCK service-role key for VPS env swap | Zaal | secret share | This session if possible, else Tuesday meeting |
+| Backup `~/zaostock-bot/.env`, swap `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`, restart service | Claude (after #1) | VPS ssh | Same session as #1 |
+| Run `/charter` in each of the 6 TG topics in ZAO Festivals | Zaal | TG admin | Within 30min of bot restart |
+| Run drop SQL on `efsxtoxvigqowjhgcbiz` to drop 15 `stock_*` tables (keep `agent_events`) | Zaal | Supabase SQL Editor | After 24hr verification window |
+| Add `backup-supabase.sh` to VPS crontab (`0 2 * * *`) | Zaal | crontab -e | This week |
+| Move `~/zaostock-bot` to git worktree of zaostock repo | Future session | repo move + systemd path edit | Next sprint |
+| DM 17 inactive members to drive bio completion -> Zaal flips active | Zaal | manual messaging | Ongoing |
+| Build profile-completion auto-flip OR public "request access" UX | Future session | Next.js + bot work | Q3 2026 |
+| Update `scripts/team-codes.mjs` TEAM list from 15 to 27 active | Future session | code edit | Next sprint |
+| Update `project_zao_stock_team.md` memory file (currently shows old 8-team April 10 structure) | Future session | memory rewrite | Same day as roster decisions are final |
+
+## Sources
+
+- [Doc 502 - ZAOstock Circles v1 Spec](../../governance/502-zaostock-circles-v1-spec/) (internal, defines unimplemented governance tables)
+- [Doc 609 - Mon May 4 cobuild meeting transcript](../../events/609-zaostock-cobuild-six-circles-may4/) (internal, locked the 6-circle decision)
+- Live SQL audits via Supabase REST API + MCP, 2026-05-04 22:00 EST through 2026-05-05 morning EST
+- VPS `journalctl --user -u zaostock-bot` log inspection (zaal@31.97.148.88), 2026-05-04
+- `bot/src/circles.ts`, `bot/src/auth.ts`, `bot/src/regen.ts`, `bot/src/index.ts` (post-consolidation)
+- `src/app/api/team/login/route.ts`, `src/app/api/team/profile/route.ts` (zaostock website)
+- Supabase MCP server: https://supabase.com/docs/guides/getting-started/mcp (verified 2026-05-05)
+- grammY framework patterns for forum topics + `pinChatMessage`: https://grammy.dev/ (verified 2026-05-05)


### PR DESCRIPTION
## Summary
Foundational architecture doc + post-mortem on consolidating ZAOstock from two parallel Supabase projects (ZAO OS efsxt + ZAO STOCK yjrlax) down to one (ZAO STOCK as canonical). Covers the full schema map, the migration SQL we ran, bot code refactor (stock_* prefix removed across 13 files, 5 broken governance commands stripped, /charter command added), the active-flag hard-lock design that bit Ohnahji, and the still-blocked items pending Zaal's service-role key paste.

## Tier
DEEP - foundational architecture, includes drift analysis, full table-by-table audit, and design-intent rationale.

## Sources
- 2 internal docs (502 spec, 609 cobuild meeting)
- Live SQL audits via Supabase REST + MCP across both projects
- VPS journalctl logs for zaostock-bot.service
- 6 source files in bot/src and zaostock website code paths
- Supabase + grammY external docs (verified 2026-05-05)

## Next Actions
See doc's "Next Actions" table - 10 items, owners assigned, blockers called out.

## Bot code changes
The bot/src refactor (stock_* renames, /charter command, broken commands removed) lives on VPS via rsync but is NOT in this PR. Will ship in a follow-up commit after Zaal pastes the service-role key for the env swap.