### PR TITLE
fix(zaostock-bot): consolidate to ZAO STOCK Supabase + mention/routing hardening

### DIFF
--- a/bot/src/actions.ts
+++ b/bot/src/actions.ts
@@ -1,5 +1,5 @@
 // Natural-language -> structured action -> Supabase write, with full attribution.
-// Every write logs {via_bot, requested_by, original_text, persona} in stock_activity_log.new_value.
+// Every write logs {via_bot, requested_by, original_text, persona} in activity_log.new_value.
 
 import { z } from 'zod';
 import { db } from './supabase';
@@ -168,7 +168,7 @@ async function logDelegation(args: {
   actionName: string;
 }): Promise<void> {
   try {
-    await db().from('stock_activity_log').insert({
+    await db().from('activity_log').insert({
       actor_id: args.requester.id,
       entity_type: args.entityType,
       entity_id: args.entityId,
@@ -189,7 +189,7 @@ async function logDelegation(args: {
 
 async function findMemberByName(name: string): Promise<TeamMember | null> {
   const { data } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select('id, name, scope, role, telegram_id, telegram_username, active')
     .ilike('name', name)
     .neq('active', false)
@@ -245,7 +245,7 @@ export async function executeFromText(
           if (m) ownerId = m.id;
         }
         const { data, error } = await db()
-          .from('stock_todos')
+          .from('todos')
           .insert({
             title: action.title,
             owner_id: ownerId,
@@ -268,21 +268,21 @@ export async function executeFromText(
       }
       case 'update_todo_status': {
         const { data: match } = await db()
-          .from('stock_todos')
+          .from('todos')
           .select('id, title')
           .ilike('title', `%${action.title_query}%`)
           .order('created_at', { ascending: false })
           .limit(1)
           .maybeSingle();
         if (!match) return { ok: false, reply: `No todo matched "${action.title_query}".` };
-        const { error } = await db().from('stock_todos').update({ status: action.status, updated_at: new Date().toISOString() }).eq('id', match.id);
+        const { error } = await db().from('todos').update({ status: action.status, updated_at: new Date().toISOString() }).eq('id', match.id);
         if (error) return { ok: false, reply: `Update failed: ${error.message}` };
         await logDelegation({ requester, action, originalText: userText, persona: usedPersona, entityType: 'todo', entityId: match.id, actionName: 'bot_update_todo_status' });
         return { ok: true, reply: `Set "${match.title}" to ${action.status}. via bot @ ${usedPersona}` };
       }
       case 'add_sponsor': {
         const { data, error } = await db()
-          .from('stock_sponsors')
+          .from('sponsors')
           .insert({
             name: action.name,
             track: action.track ?? 'local',
@@ -299,7 +299,7 @@ export async function executeFromText(
       }
       case 'update_sponsor_status': {
         const { data: match } = await db()
-          .from('stock_sponsors')
+          .from('sponsors')
           .select('id, name')
           .ilike('name', `%${action.name_query}%`)
           .order('created_at', { ascending: false })
@@ -309,14 +309,14 @@ export async function executeFromText(
         const updates: Record<string, unknown> = { status: action.status, updated_at: new Date().toISOString() };
         if (action.status === 'contacted' || action.status === 'in_talks') updates.last_contacted_at = new Date().toISOString();
         if (action.amount_committed !== undefined) updates.amount_committed = action.amount_committed;
-        const { error } = await db().from('stock_sponsors').update(updates).eq('id', match.id);
+        const { error } = await db().from('sponsors').update(updates).eq('id', match.id);
         if (error) return { ok: false, reply: `Update failed: ${error.message}` };
         await logDelegation({ requester, action, originalText: userText, persona: usedPersona, entityType: 'sponsor', entityId: match.id, actionName: 'bot_update_sponsor_status' });
         return { ok: true, reply: `Set ${match.name} to ${action.status}${action.amount_committed ? ` @ $${action.amount_committed}` : ''}. via bot @ ${usedPersona}` };
       }
       case 'add_artist': {
         const { data, error } = await db()
-          .from('stock_artists')
+          .from('artists')
           .insert({
             name: action.name,
             genre: action.genre ?? '',
@@ -332,21 +332,21 @@ export async function executeFromText(
       }
       case 'update_artist_status': {
         const { data: match } = await db()
-          .from('stock_artists')
+          .from('artists')
           .select('id, name')
           .ilike('name', `%${action.name_query}%`)
           .order('created_at', { ascending: false })
           .limit(1)
           .maybeSingle();
         if (!match) return { ok: false, reply: `No artist matched "${action.name_query}".` };
-        const { error } = await db().from('stock_artists').update({ status: action.status, updated_at: new Date().toISOString() }).eq('id', match.id);
+        const { error } = await db().from('artists').update({ status: action.status, updated_at: new Date().toISOString() }).eq('id', match.id);
         if (error) return { ok: false, reply: `Update failed: ${error.message}` };
         await logDelegation({ requester, action, originalText: userText, persona: usedPersona, entityType: 'artist', entityId: match.id, actionName: 'bot_update_artist_status' });
         return { ok: true, reply: `Set ${match.name} to ${action.status}. via bot @ ${usedPersona}` };
       }
       case 'add_milestone': {
         const { data, error } = await db()
-          .from('stock_timeline')
+          .from('timeline')
           .insert({
             title: action.title,
             due_date: action.due_date,
@@ -360,7 +360,7 @@ export async function executeFromText(
         return { ok: true, reply: `Added milestone: "${data.title}" due ${data.due_date}. via bot @ ${usedPersona}` };
       }
       case 'log_contact': {
-        const table = action.entity_type === 'sponsor' ? 'stock_sponsors' : 'stock_artists';
+        const table = action.entity_type === 'sponsor' ? 'sponsors' : 'artists';
         let { data: match } = await db()
           .from(table)
           .select('id, name')
@@ -386,7 +386,7 @@ export async function executeFromText(
           match = created as { id: string; name: string };
         }
         const { data: contact, error } = await db()
-          .from('stock_contact_log')
+          .from('contact_log')
           .insert({
             entity_type: action.entity_type,
             entity_id: match.id,
@@ -407,7 +407,7 @@ export async function executeFromText(
           .filter(Boolean)
           .join('\n\n') || action.title;
         const { data, error } = await db()
-          .from('stock_activity_log')
+          .from('activity_log')
           .insert({
             actor_id: requester.id,
             entity_type: 'idea',
@@ -432,7 +432,7 @@ export async function executeFromText(
       }
       case 'add_note': {
         const { data, error } = await db()
-          .from('stock_meeting_notes')
+          .from('meeting_notes')
           .insert({
             title: action.title,
             notes: action.body,
@@ -445,7 +445,7 @@ export async function executeFromText(
           .single();
         if (error || !data) {
           // Fallback to activity log if meeting_notes shape doesn't match
-          await db().from('stock_activity_log').insert({
+          await db().from('activity_log').insert({
             actor_id: requester.id,
             entity_type: 'note',
             entity_id: null,

--- a/bot/src/activity.ts
+++ b/bot/src/activity.ts
@@ -12,7 +12,7 @@ export async function logBotActivity(args: {
   fieldChanged?: string;
 }) {
   try {
-    await db().from('stock_activity_log').insert({
+    await db().from('activity_log').insert({
       actor_id: args.actorId,
       entity_type: args.entityType,
       entity_id: args.entityId,

--- a/bot/src/auth.ts
+++ b/bot/src/auth.ts
@@ -18,7 +18,7 @@ function normalizeUsername(u: string | undefined | null): string | null {
 
 export async function findMemberByTelegramId(telegramId: number): Promise<TeamMember | null> {
   const { data } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select(SELECT)
     .eq('telegram_id', telegramId)
     .neq('active', false)
@@ -31,7 +31,7 @@ export async function findMemberByUsername(username: string): Promise<TeamMember
   const n = normalizeUsername(username);
   if (!n) return null;
   const { data } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select(SELECT)
     .eq('telegram_username', n)
     .neq('active', false)
@@ -61,7 +61,7 @@ export async function resolveMember(
   // auto-link telegram_id so next lookup is the fast path
   if (byUsername.telegram_id !== telegramId) {
     await db()
-      .from('stock_team_members')
+      .from('team_members')
       .update({ telegram_id: telegramId })
       .eq('id', byUsername.id);
   }
@@ -84,7 +84,7 @@ export async function linkUsernameToMember(
 
   // 1. Exact (case-insensitive) match first
   const { data: exact, error } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select(SELECT)
     .ilike('name', trimmed)
     .neq('active', false);
@@ -95,7 +95,7 @@ export async function linkUsernameToMember(
   // 2. Substring fallback ("thy rev" -> "Thy Revolution")
   if (candidates.length === 0) {
     const { data: subs } = await db()
-      .from('stock_team_members')
+      .from('team_members')
       .select(SELECT)
       .ilike('name', `%${trimmed}%`)
       .neq('active', false);
@@ -107,7 +107,7 @@ export async function linkUsernameToMember(
     const firstToken = trimmed.split(/\s+/)[0];
     if (firstToken && firstToken.length >= 3) {
       const { data: tok } = await db()
-        .from('stock_team_members')
+        .from('team_members')
         .select(SELECT)
         .ilike('name', `${firstToken}%`)
         .neq('active', false);
@@ -124,7 +124,7 @@ export async function linkUsernameToMember(
   const target = candidates[0];
 
   const { error: updateErr } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .update({ telegram_username: username })
     .eq('id', target.id);
   if (updateErr) return { ok: false, reason: `Link failed: ${updateErr.message}` };
@@ -139,7 +139,7 @@ export async function unlinkUsername(
   if (!username) return { ok: false, reason: 'Username required' };
 
   const { data, error } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select(SELECT)
     .eq('telegram_username', username)
     .maybeSingle();
@@ -147,7 +147,7 @@ export async function unlinkUsername(
   if (!data) return { ok: false, reason: `@${username} not linked to anyone` };
 
   const { error: updateErr } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .update({ telegram_username: null, telegram_id: null })
     .eq('id', data.id);
   if (updateErr) return { ok: false, reason: `Unlink failed: ${updateErr.message}` };

--- a/bot/src/capture.ts
+++ b/bot/src/capture.ts
@@ -5,7 +5,7 @@ import type { TeamMember } from './auth';
 export async function addGemba(member: TeamMember, text: string): Promise<string> {
   if (!text.trim()) return 'Say something after /gemba — what moved or got blocked?';
   const { data, error } = await db()
-    .from('stock_activity_log')
+    .from('activity_log')
     .insert({
       actor_id: member.id,
       entity_type: 'member',
@@ -22,7 +22,7 @@ export async function addGemba(member: TeamMember, text: string): Promise<string
 export async function addIdea(member: TeamMember, text: string): Promise<string> {
   if (!text.trim()) return 'Say something after /idea — what should we try?';
   const { data, error } = await db()
-    .from('stock_suggestions')
+    .from('suggestions')
     .insert({
       name: member.name,
       contact: `tg:${member.id}`,
@@ -46,7 +46,7 @@ export async function addNote(member: TeamMember, text: string): Promise<string>
   const today = new Date().toISOString().slice(0, 10);
   // Find the most recent upcoming meeting note, else create one for today.
   const { data: recent } = await db()
-    .from('stock_meeting_notes')
+    .from('meeting_notes')
     .select('id, notes, meeting_date')
     .gte('meeting_date', today)
     .order('meeting_date', { ascending: true })
@@ -59,14 +59,14 @@ export async function addNote(member: TeamMember, text: string): Promise<string>
   if (recent) {
     const newBody = recent.notes ? `${recent.notes}\n\n${stamp}` : stamp;
     const { error } = await db()
-      .from('stock_meeting_notes')
+      .from('meeting_notes')
       .update({ notes: newBody })
       .eq('id', recent.id);
     if (error) return `Could not append: ${error.message}`;
     noteId = recent.id;
   } else {
     const { data, error } = await db()
-      .from('stock_meeting_notes')
+      .from('meeting_notes')
       .insert({
         title: 'Async notes (bot-created)',
         meeting_date: today,

--- a/bot/src/circles.ts
+++ b/bot/src/circles.ts
@@ -1,12 +1,11 @@
-// Circles governance commands: /join /leave /mycircles /circles /coordinators /propose /proposals /object /consent /buddy /respect
-// Mirrors spec doc 502: 6 circles, coordinator rotation, 48h consent window, Respect tracking.
+// Circles commands: /join /leave /mycircles /circles /coordinators /charter
+// 6 circles after May 2026 consolidation: finance, host, livestream, marketing, music, ops.
 
 import { Context } from 'grammy';
 import type { TeamMember } from './auth';
 import { db } from './supabase';
-import { alertDevops } from './ops';
 
-const CIRCLE_SLUGS = ['music', 'ops', 'partners', 'finance', 'merch', 'marketing', 'media', 'host'] as const;
+const CIRCLE_SLUGS = ['finance', 'host', 'livestream', 'marketing', 'music', 'ops'] as const;
 type CircleSlug = (typeof CIRCLE_SLUGS)[number];
 
 interface Circle {
@@ -71,7 +70,7 @@ function suggestSlug(input: string): CircleSlug | null {
 
 async function getCircle(slug: CircleSlug): Promise<Circle | null> {
   const { data, error } = await db()
-    .from('stock_circles')
+    .from('circles')
     .select('id, slug, name, coordinator_member_id')
     .eq('slug', slug)
     .maybeSingle();
@@ -81,14 +80,14 @@ async function getCircle(slug: CircleSlug): Promise<Circle | null> {
   const row = data as { id: string; slug: CircleSlug; name: string; coordinator_member_id: string | null };
 
   const { data: members } = await db()
-    .from('stock_circle_members')
+    .from('circle_members')
     .select('member_id')
     .eq('circle_id', row.id);
 
   let coordinator_name: string | null = null;
   if (row.coordinator_member_id) {
     const { data: coord } = await db()
-      .from('stock_team_members')
+      .from('team_members')
       .select('name')
       .eq('id', row.coordinator_member_id)
       .maybeSingle();
@@ -107,7 +106,7 @@ async function getCircle(slug: CircleSlug): Promise<Circle | null> {
 
 async function getMemberCircles(memberId: string): Promise<CircleSlug[]> {
   const { data: rows } = await db()
-    .from('stock_circle_members')
+    .from('circle_members')
     .select('circle_id')
     .eq('member_id', memberId);
 
@@ -115,7 +114,7 @@ async function getMemberCircles(memberId: string): Promise<CircleSlug[]> {
   const circleIds = (rows as Array<{ circle_id: string }>).map((r) => r.circle_id);
 
   const { data: circles } = await db()
-    .from('stock_circles')
+    .from('circles')
     .select('slug')
     .in('id', circleIds);
 
@@ -129,7 +128,7 @@ async function getMemberCircles(memberId: string): Promise<CircleSlug[]> {
 export async function cmdCircles(ctx: Context): Promise<void> {
   try {
     const { data: circles, error } = await db()
-      .from('stock_circles')
+      .from('circles')
       .select('id, slug, name, coordinator_member_id')
       .order('slug');
 
@@ -146,7 +145,7 @@ export async function cmdCircles(ctx: Context): Promise<void> {
     const coordMap = new Map<string, string>();
     if (coordIds.length > 0) {
       const { data: coords } = await db()
-        .from('stock_team_members')
+        .from('team_members')
         .select('id, name')
         .in('id', coordIds);
       for (const c of (coords as Array<{ id: string; name: string }> | null) ?? []) {
@@ -156,7 +155,7 @@ export async function cmdCircles(ctx: Context): Promise<void> {
 
     // Batch member counts
     const { data: allMembers } = await db()
-      .from('stock_circle_members')
+      .from('circle_members')
       .select('circle_id');
     const counts = new Map<string, number>();
     for (const m of (allMembers as Array<{ circle_id: string }> | null) ?? []) {
@@ -197,7 +196,7 @@ export async function cmdJoin(ctx: Context, member: TeamMember, slug: string): P
 
     // Pre-check (composite PK is (member_id, circle_id), so select an actual column)
     const { data: existing } = await db()
-      .from('stock_circle_members')
+      .from('circle_members')
       .select('member_id')
       .eq('circle_id', circle.id)
       .eq('member_id', member.id)
@@ -209,7 +208,7 @@ export async function cmdJoin(ctx: Context, member: TeamMember, slug: string): P
     }
 
     const { error } = await db()
-      .from('stock_circle_members')
+      .from('circle_members')
       .insert({
         circle_id: circle.id,
         member_id: member.id,
@@ -252,7 +251,7 @@ export async function cmdLeave(ctx: Context, member: TeamMember, slug: string): 
     }
 
     const { error } = await db()
-      .from('stock_circle_members')
+      .from('circle_members')
       .delete()
       .eq('circle_id', circle.id)
       .eq('member_id', member.id);
@@ -293,7 +292,7 @@ export async function cmdMyCircles(ctx: Context, member: TeamMember): Promise<vo
 export async function cmdCoordinators(ctx: Context): Promise<void> {
   try {
     const { data: circles, error } = await db()
-      .from('stock_circles')
+      .from('circles')
       .select('slug, name, coordinator_member_id')
       .order('slug');
 
@@ -309,7 +308,7 @@ export async function cmdCoordinators(ctx: Context): Promise<void> {
     const nameById = new Map<string, string>();
     if (ids.length > 0) {
       const { data: members } = await db()
-        .from('stock_team_members')
+        .from('team_members')
         .select('id, name')
         .in('id', ids);
       for (const m of (members as Array<{ id: string; name: string }> | null) ?? []) {
@@ -328,340 +327,78 @@ export async function cmdCoordinators(ctx: Context): Promise<void> {
   }
 }
 
-export async function cmdPropose(ctx: Context, member: TeamMember, args: string): Promise<void> {
-  const m = args.match(/^(\S+)\s+(.+?)\s*\|\s*(.+)$/s);
-  if (!m) {
-    await ctx.reply('Usage: /propose <circle> <title> | <body>\nExample: /propose music Book 3 outdoor stages | We need to finalize sound setup.');
+// /charter <slug?> - Post the circle's responsibility description into the
+// current Telegram topic and pin it. Slug is inferred from the topic name
+// (case-insensitive, exact match) when omitted, so `/charter` works in any
+// of the 6 circle topics in ZAO Festivals.
+export async function cmdCharter(ctx: Context, rawSlug?: string): Promise<void> {
+  let slug = (rawSlug ?? '').toLowerCase().trim();
+
+  if (!slug) {
+    const reply = ctx.message?.reply_to_message;
+    const topicName: string | undefined =
+      (reply && 'forum_topic_created' in reply && (reply as { forum_topic_created?: { name?: string } }).forum_topic_created?.name) ||
+      undefined;
+    if (topicName) slug = topicName.toLowerCase().trim();
+  }
+
+  if (!slug) {
+    await ctx.reply('Usage: /charter <slug>. In a forum topic, the slug is auto-detected from the topic name.');
     return;
   }
 
-  const [, slug, title, body] = m;
   if (!validateCircleSlug(slug)) {
-    await ctx.reply(`Unknown circle: ${slug}.`);
+    const guess = suggestSlug(slug);
+    await ctx.reply(
+      guess
+        ? `Unknown circle: ${slug}. Did you mean /charter ${guess}?`
+        : `Unknown circle: ${slug}. Valid: ${CIRCLE_SLUGS.join(', ')}.`,
+    );
     return;
   }
 
   try {
-    const circle = await getCircle(slug);
-    if (!circle) {
-      await ctx.reply(`Circle not found: ${slug}.`);
-      return;
-    }
-
-    // Check member is in circle
-    const { data: isMember } = await db()
-      .from('stock_circle_members')
-      .select('id')
-      .eq('circle_id', circle.id)
-      .eq('member_id', member.id)
+    const { data: row, error } = await db()
+      .from('circles')
+      .select('name, description')
+      .eq('slug', slug)
       .maybeSingle();
 
-    if (!isMember) {
-      await ctx.reply(`You must be in ${circle.name} to propose.`);
+    if (error || !row) {
+      await ctx.reply(`Could not load circle: ${error?.message ?? 'not found'}`);
       return;
     }
 
-    const now = new Date();
-    const endsAt = new Date(now.getTime() + 48 * 60 * 60 * 1000); // 48h from now
-
-    const { data: proposal, error } = await db()
-      .from('stock_proposals')
-      .insert({
-        circle_id: circle.id,
-        proposer_member_id: member.id,
-        title: title.trim(),
-        body: body.trim(),
-        status: 'open',
-        opened_at: now.toISOString(),
-        consent_window_ends_at: endsAt.toISOString(),
-      })
-      .select('id')
-      .single();
-
-    if (error || !proposal) {
-      await ctx.reply(`Could not create proposal: ${error?.message ?? 'unknown'}`);
+    const r = row as { name: string; description: string | null };
+    if (!r.description) {
+      await ctx.reply(`${r.name} has no description set in the database yet.`);
       return;
     }
 
-    await ctx.reply(
-      [`Proposal created in **${circle.name}**:`, ``, `**${title.trim()}**`, ``, body.trim().slice(0, 200), ``, `ID: \`${proposal.id}\``, `Consent window: 48h`].join(
-        '\n',
-      ),
-    );
-
-    // TODO: notify circle members
-  } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
-  }
-}
-
-export async function cmdProposals(ctx: Context, member: TeamMember): Promise<void> {
-  try {
-    const { data: circles } = await db()
-      .from('stock_circle_members')
-      .select('circle_id')
-      .eq('member_id', member.id);
-
-    if (!circles || circles.length === 0) {
-      await ctx.reply('You are not in any circles. Use /join <circle> to join first.');
+    const text = `**${r.name} circle - what we are responsible for**\n\n${r.description}`;
+    const threadId = ctx.message?.message_thread_id;
+    const chatId = ctx.chat?.id;
+    if (chatId == null) {
+      await ctx.reply('Could not resolve chat id.');
       return;
     }
 
-    const circleIds = circles.map((c: { circle_id: string }) => c.circle_id);
-
-    const { data: proposals } = await db()
-      .from('stock_proposals')
-      .select('id, circle_id, proposer_member_id, title, status, created_at')
-      .in('circle_id', circleIds)
-      .eq('status', 'open')
-      .order('created_at', { ascending: false });
-
-    if (!proposals || proposals.length === 0) {
-      await ctx.reply('No open proposals in your circles.');
-      return;
-    }
-
-    type ProposalRow = { id: string; circle_id: string; proposer_member_id: string; title: string; status: string };
-    const rows = (proposals as ProposalRow[]) ?? [];
-
-    // Batch lookups
-    const cIds = Array.from(new Set(rows.map((p) => p.circle_id)));
-    const pIds = Array.from(new Set(rows.map((p) => p.proposer_member_id)));
-
-    const [{ data: circleRows }, { data: memberRows }] = await Promise.all([
-      db().from('stock_circles').select('id, slug, name').in('id', cIds),
-      db().from('stock_team_members').select('id, name').in('id', pIds),
-    ]);
-
-    const circleById = new Map<string, { slug: string; name: string }>();
-    for (const c of (circleRows as Array<{ id: string; slug: string; name: string }> | null) ?? []) {
-      circleById.set(c.id, { slug: c.slug, name: c.name });
-    }
-    const memberById = new Map<string, string>();
-    for (const m of (memberRows as Array<{ id: string; name: string }> | null) ?? []) {
-      memberById.set(m.id, m.name);
-    }
-
-    const lines = rows.map((p) => {
-      const circle = circleById.get(p.circle_id);
-      const proposer = memberById.get(p.proposer_member_id) ?? '(unknown)';
-      return `• [${circle?.slug ?? '?'}] ${p.title} by ${proposer} - id:${p.id.slice(0, 8)}`;
+    const sent = await ctx.api.sendMessage(chatId, text, {
+      message_thread_id: threadId,
+      parse_mode: 'Markdown',
     });
 
-    await ctx.reply(
-      ['Open proposals:', '', ...lines.slice(0, 10), lines.length > 10 ? `... and ${lines.length - 10} more.` : ''].filter(Boolean).join('\n'),
-    );
-  } catch (err) {
-    await ctx.reply(`Could not fetch proposals: ${err instanceof Error ? err.message : 'unknown'}`);
-  }
-}
-
-export async function cmdObject(ctx: Context, member: TeamMember, args: string): Promise<void> {
-  const m = args.match(/^(\S+)\s+(.+)$/s);
-  if (!m) {
-    await ctx.reply('Usage: /object <proposal-id> <reason>');
-    return;
-  }
-
-  const [, proposalId, reason] = m;
-
-  try {
-    const { data: proposal } = await db()
-      .from('stock_proposals')
-      .select('id, circle_id, status')
-      .eq('id', proposalId.trim())
-      .maybeSingle();
-
-    if (!proposal) {
-      await ctx.reply('Proposal not found.');
-      return;
+    try {
+      await ctx.api.pinChatMessage(chatId, sent.message_id, { disable_notification: true });
+      await ctx.reply(`Posted + pinned charter for ${r.name}.`, { reply_parameters: { message_id: sent.message_id } });
+    } catch (pinErr) {
+      await ctx.reply(
+        `Posted charter for ${r.name}, but pin failed (need "Pin Messages" admin perm in this chat): ${
+          pinErr instanceof Error ? pinErr.message : 'unknown'
+        }`,
+        { reply_parameters: { message_id: sent.message_id } },
+      );
     }
-
-    if (proposal.status !== 'open') {
-      await ctx.reply(`Proposal is ${proposal.status}, cannot object.`);
-      return;
-    }
-
-    // Verify member is in circle
-    const { data: isMember } = await db()
-      .from('stock_circle_members')
-      .select('id')
-      .eq('circle_id', proposal.circle_id)
-      .eq('member_id', member.id)
-      .maybeSingle();
-
-    if (!isMember) {
-      await ctx.reply('You must be in this circle to object.');
-      return;
-    }
-
-    const { error } = await db()
-      .from('stock_proposal_objections')
-      .insert({
-        proposal_id: proposal.id,
-        member_id: member.id,
-        reason: reason.trim(),
-      });
-
-    if (error) {
-      await ctx.reply(`Could not record objection: ${error.message}`);
-      return;
-    }
-
-    await ctx.reply(`Objection recorded: "${reason.trim().slice(0, 100)}${reason.trim().length > 100 ? '...' : ''}"`);
-
-    // TODO: notify proposer
-  } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
-  }
-}
-
-export async function cmdConsent(ctx: Context, member: TeamMember, proposalId: string): Promise<void> {
-  try {
-    const { data: proposal } = await db()
-      .from('stock_proposals')
-      .select('id, circle_id, status')
-      .eq('id', proposalId.trim())
-      .maybeSingle();
-
-    if (!proposal) {
-      await ctx.reply('Proposal not found.');
-      return;
-    }
-
-    if (proposal.status !== 'open') {
-      await ctx.reply(`Proposal is ${proposal.status}, cannot consent.`);
-      return;
-    }
-
-    // Verify member is in circle
-    const { data: isMember } = await db()
-      .from('stock_circle_members')
-      .select('id')
-      .eq('circle_id', proposal.circle_id)
-      .eq('member_id', member.id)
-      .maybeSingle();
-
-    if (!isMember) {
-      await ctx.reply('You must be in this circle to consent.');
-      return;
-    }
-
-    // Log explicit consent (as answered in qa_log)
-    const { error } = await db()
-      .from('stock_qa_log')
-      .insert({
-        circle_id: proposal.circle_id,
-        member_id_asked: member.id,
-        member_id_answered: member.id,
-        question_text: `consent-${proposal.id}`,
-        answered_at: new Date().toISOString(),
-      });
-
-    if (error) {
-      await ctx.reply(`Could not record consent: ${error.message}`);
-      return;
-    }
-
-    await ctx.reply('Consent recorded.');
-  } catch (err) {
-    await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
-  }
-}
-
-export async function cmdBuddy(ctx: Context, member: TeamMember): Promise<void> {
-  try {
-    const { data: existing } = await db()
-      .from('stock_buddy_pairings')
-      .select('buddy_member_id')
-      .eq('new_member_id', member.id)
-      .is('ended_at', null)
-      .maybeSingle();
-
-    if (existing && (existing as { buddy_member_id: string }).buddy_member_id) {
-      const buddyId = (existing as { buddy_member_id: string }).buddy_member_id;
-      const { data: buddy } = await db()
-        .from('stock_team_members')
-        .select('name, telegram_username')
-        .eq('id', buddyId)
-        .maybeSingle();
-      if (buddy) {
-        const b = buddy as { name: string; telegram_username: string | null };
-        const tgHandle = b.telegram_username ? `@${b.telegram_username}` : b.name;
-        await ctx.reply(`Your buddy: ${b.name} (${tgHandle})`);
-        return;
-      }
-    }
-
-    const circles = await getMemberCircles(member.id);
-    if (circles.length === 0) {
-      await ctx.reply('You must be in at least one circle first. Use /join <circle>.');
-      return;
-    }
-
-    const { data: circleRows } = await db()
-      .from('stock_circles')
-      .select('id')
-      .in('slug', circles);
-
-    if (!circleRows || circleRows.length === 0) {
-      await ctx.reply('No active circles found.');
-      return;
-    }
-    const circleIds = (circleRows as Array<{ id: string }>).map((c) => c.id);
-
-    const { data: peerRows } = await db()
-      .from('stock_circle_members')
-      .select('member_id')
-      .in('circle_id', circleIds)
-      .neq('member_id', member.id);
-
-    if (!peerRows || peerRows.length === 0) {
-      await ctx.reply('No other members in your circles yet.');
-      return;
-    }
-    const peerIds = Array.from(new Set((peerRows as Array<{ member_id: string }>).map((p) => p.member_id)));
-
-    const { data: peers } = await db()
-      .from('stock_team_members')
-      .select('id, name, telegram_username, active')
-      .in('id', peerIds)
-      .neq('active', false);
-
-    const candidates = (peers as Array<{ id: string; name: string; telegram_username: string | null }> | null) ?? [];
-    if (candidates.length === 0) {
-      await ctx.reply('No active peers in your circles.');
-      return;
-    }
-
-    const buddy = candidates[Math.floor(Math.random() * candidates.length)];
-
-    const { error } = await db()
-      .from('stock_buddy_pairings')
-      .insert({ new_member_id: member.id, buddy_member_id: buddy.id });
-
-    if (error) {
-      await ctx.reply(`Could not pair buddy: ${error.message}`);
-      return;
-    }
-
-    const tgHandle = buddy.telegram_username ? `@${buddy.telegram_username}` : buddy.name;
-    await ctx.reply(`Buddy paired: ${buddy.name} (${tgHandle}). Reach out and introduce yourself.`);
-  } catch (err) {
-    await ctx.reply(`Could not pair buddy: ${err instanceof Error ? err.message : 'unknown'}`);
-  }
-}
-
-export async function cmdRespect(ctx: Context, member: TeamMember): Promise<void> {
-  try {
-    const { data: events } = await db()
-      .from('stock_respect_events')
-      .select('amount')
-      .eq('awarded_to', member.id);
-
-    const total = events?.reduce((sum: number, e: { amount: number }) => sum + e.amount, 0) ?? 0;
-
-    await ctx.reply(`Your ZAOstock Respect: **${total}** points.`);
   } catch (err) {
     await ctx.reply(`Error: ${err instanceof Error ? err.message : 'unknown'}`);
   }

--- a/bot/src/digest.ts
+++ b/bot/src/digest.ts
@@ -23,9 +23,9 @@ export async function morningDigest(): Promise<string> {
   const s = db();
   const today = new Date().toISOString().slice(0, 10);
   const [todosR, timelineR, sponsorsR] = await Promise.all([
-    s.from('stock_todos').select('title, status, owner:stock_team_members!owner_id(name)').neq('status', 'done').limit(50),
-    s.from('stock_timeline').select('title, due_date, status').neq('status', 'done').order('due_date').limit(20),
-    s.from('stock_sponsors').select('name, status, last_contacted_at').in('status', ['contacted', 'in_talks']),
+    s.from('todos').select('title, status, owner:team_members!owner_id(name)').neq('status', 'done').limit(50),
+    s.from('timeline').select('title, due_date, status').neq('status', 'done').order('due_date').limit(20),
+    s.from('sponsors').select('name, status, last_contacted_at').in('status', ['contacted', 'in_talks']),
   ]);
 
   const todos = todosR.data ?? [];
@@ -84,12 +84,12 @@ export async function eveningRecap(): Promise<string> {
   const since = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
   const [activityR, todosClosedR] = await Promise.all([
     s
-      .from('stock_activity_log')
-      .select('action, entity_type, actor:stock_team_members!actor_id(name)')
+      .from('activity_log')
+      .select('action, entity_type, actor:team_members!actor_id(name)')
       .gte('created_at', since)
       .order('created_at', { ascending: false })
       .limit(100),
-    s.from('stock_todos').select('title, updated_at, owner:stock_team_members!owner_id(name)').eq('status', 'done').gte('updated_at', since).limit(20),
+    s.from('todos').select('title, updated_at, owner:team_members!owner_id(name)').eq('status', 'done').gte('updated_at', since).limit(20),
   ]);
 
   const activity = activityR.data ?? [];
@@ -134,14 +134,14 @@ export async function weekAheadDigest(): Promise<string> {
   const weekOut = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const [timelineR, sponsorsR, artistsR] = await Promise.all([
     s
-      .from('stock_timeline')
-      .select('title, due_date, status, category, owner:stock_team_members!owner_id(name)')
+      .from('timeline')
+      .select('title, due_date, status, category, owner:team_members!owner_id(name)')
       .neq('status', 'done')
       .lte('due_date', weekOut)
       .order('due_date')
       .limit(30),
-    s.from('stock_sponsors').select('status, amount_committed'),
-    s.from('stock_artists').select('status'),
+    s.from('sponsors').select('status, amount_committed'),
+    s.from('artists').select('status'),
   ]);
 
   const milestones = timelineR.data ?? [];
@@ -178,8 +178,8 @@ export async function fridayRetro(): Promise<string> {
   const s = db();
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const [actR, commitR] = await Promise.all([
-    s.from('stock_activity_log').select('action, actor:stock_team_members!actor_id(name)').gte('created_at', since).limit(500),
-    s.from('stock_sponsors').select('status, amount_committed').in('status', ['committed', 'paid']),
+    s.from('activity_log').select('action, actor:team_members!actor_id(name)').gte('created_at', since).limit(500),
+    s.from('sponsors').select('status, amount_committed').in('status', ['committed', 'paid']),
   ]);
   const act = actR.data ?? [];
   const commits = commitR.data ?? [];

--- a/bot/src/group.ts
+++ b/bot/src/group.ts
@@ -20,7 +20,7 @@ export async function ensureChatRegistered(args: {
   forum_enabled?: boolean;
 }): Promise<ChatRow> {
   const { data: existing } = await db()
-    .from('stock_bot_chats')
+    .from('bot_chats')
     .select('chat_id, chat_type, title, mode, forum_enabled, post_digests')
     .eq('chat_id', args.chat_id)
     .maybeSingle();
@@ -28,7 +28,7 @@ export async function ensureChatRegistered(args: {
 
   const mode: ChatMode = args.chat_type === 'private' ? 'private' : 'staging';
   const { data } = await db()
-    .from('stock_bot_chats')
+    .from('bot_chats')
     .insert({
       chat_id: args.chat_id,
       chat_type: args.chat_type,
@@ -43,7 +43,7 @@ export async function ensureChatRegistered(args: {
 
 export async function getChatRow(chat_id: number): Promise<ChatRow | null> {
   const { data } = await db()
-    .from('stock_bot_chats')
+    .from('bot_chats')
     .select('chat_id, chat_type, title, mode, forum_enabled, post_digests')
     .eq('chat_id', chat_id)
     .maybeSingle();
@@ -51,16 +51,16 @@ export async function getChatRow(chat_id: number): Promise<ChatRow | null> {
 }
 
 export async function setChatMode(chat_id: number, mode: ChatMode): Promise<void> {
-  await db().from('stock_bot_chats').update({ mode }).eq('chat_id', chat_id);
+  await db().from('bot_chats').update({ mode }).eq('chat_id', chat_id);
 }
 
 export async function setPostDigests(chat_id: number, on: boolean): Promise<void> {
-  await db().from('stock_bot_chats').update({ post_digests: on }).eq('chat_id', chat_id);
+  await db().from('bot_chats').update({ post_digests: on }).eq('chat_id', chat_id);
 }
 
 export async function getDigestChats(): Promise<ChatRow[]> {
   const { data } = await db()
-    .from('stock_bot_chats')
+    .from('bot_chats')
     .select('chat_id, chat_type, title, mode, forum_enabled, post_digests')
     .eq('post_digests', true)
     .eq('mode', 'team');
@@ -69,7 +69,7 @@ export async function getDigestChats(): Promise<ChatRow[]> {
 
 export async function getDevopsChats(): Promise<ChatRow[]> {
   const { data } = await db()
-    .from('stock_bot_chats')
+    .from('bot_chats')
     .select('chat_id, chat_type, title, mode, forum_enabled, post_digests')
     .eq('mode', 'devops');
   return (data as ChatRow[]) ?? [];

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -42,6 +42,23 @@ const ADMIN_IDS = (process.env.BOT_ADMIN_TELEGRAM_IDS ?? '')
 
 const bot = new Bot<Context>(token);
 
+// Routing policy: bot must NEVER post in the ZAO Festivals General topic.
+// Anything that lacks an explicit message_thread_id when targeting that
+// supergroup gets redirected to the Operations topic. Set OPS_TOPIC_ID via
+// .env if it ever changes; default 2 matches current ZAO Festivals layout.
+const ZAO_FESTIVALS_CHAT_ID = -1003960864140;
+const OPS_TOPIC_ID = Number(process.env.OPS_TOPIC_ID ?? 2);
+bot.api.config.use(async (prev, method, payload) => {
+  if (method === 'sendMessage' || method === 'sendPhoto' || method === 'sendDocument' || method === 'sendVideo' || method === 'sendAnimation') {
+    const p = payload as { chat_id?: number | string; message_thread_id?: number };
+    const chatId = typeof p.chat_id === 'number' ? p.chat_id : Number(p.chat_id);
+    if (chatId === ZAO_FESTIVALS_CHAT_ID && (p.message_thread_id == null || Number.isNaN(p.message_thread_id))) {
+      p.message_thread_id = OPS_TOPIC_ID;
+    }
+  }
+  return prev(method, payload);
+});
+
 // Register every chat we see (on first message).
 bot.use(async (ctx, next) => {
   if (ctx.chat) {
@@ -523,15 +540,26 @@ bot.on('message:text', async (ctx) => {
     return;
   }
 
-  // Group / supergroup: respond ONLY when @mentioned
+  // Group / supergroup: respond ONLY when @-mentioned conversationally.
+  // Substring match was too eager (broadcasts that mention the bot in body
+  // text trigger replies). Now we require:
+  //   1. A mention entity (Telegram-tagged, not just text)
+  //   2. The mention is at offset 0 (first token) — i.e. directed at the bot
   const username = await ensureUsername();
-  const mentioned = username && text.toLowerCase().includes(`@${username}`);
-  if (!mentioned) return;
+  if (!username) return;
+  const entities = ctx.message.entities ?? [];
+  const directlyAddressed = entities.some(
+    (e) =>
+      e.offset === 0 &&
+      (e.type === 'mention' || e.type === 'text_mention') &&
+      text.slice(0, e.length).toLowerCase() === `@${username}`,
+  );
+  if (!directlyAddressed) return;
 
   const member = await requireMember(ctx);
   if (!member) return;
 
-  const cleaned = text.replace(new RegExp(`@${username}`, 'gi'), '').trim();
+  const cleaned = text.replace(new RegExp(`^@${username}\\s*`, 'i'), '').trim();
   if (!cleaned) {
     await ctx.reply(`Hi ${member.name}. Tag me with something like "@${username} add todo X" or ask a question.`);
     return;

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -26,12 +26,7 @@ import {
   cmdLeave,
   cmdMyCircles,
   cmdCoordinators,
-  cmdPropose,
-  cmdProposals,
-  cmdObject,
-  cmdConsent,
-  cmdBuddy,
-  cmdRespect,
+  cmdCharter,
 } from './circles';
 
 const token = process.env.ZAOSTOCK_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN;
@@ -247,7 +242,7 @@ bot.command('note', async (ctx) => {
 });
 
 // /zsfb <comment> - low-friction ZAOstock /test feedback (open to all team).
-// Saves to stock_suggestions with [zsfb:<section>] prefix for downstream
+// Saves to suggestions with [zsfb:<section>] prefix for downstream
 // Hermes triage. Distinct from /idea so the /test backlog stays scoped.
 bot.command('zsfb', async (ctx) => {
   const member = await requireMember(ctx);
@@ -499,55 +494,9 @@ bot.command('coordinators', async (ctx) => {
   await cmdCoordinators(ctx);
 });
 
-bot.command('propose', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  const args = (ctx.match ?? '').trim();
-  if (!args) {
-    await ctx.reply('Usage: /propose <circle-slug> <title> | <body>');
-    return;
-  }
-  await cmdPropose(ctx, member, args);
-});
-
-bot.command('proposals', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  await cmdProposals(ctx, member);
-});
-
-bot.command('object', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  const args = (ctx.match ?? '').trim();
-  if (!args) {
-    await ctx.reply('Usage: /object <proposal-id> <reason>');
-    return;
-  }
-  await cmdObject(ctx, member, args);
-});
-
-bot.command('consent', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  const proposalId = (ctx.match ?? '').trim();
-  if (!proposalId) {
-    await ctx.reply('Usage: /consent <proposal-id>');
-    return;
-  }
-  await cmdConsent(ctx, member, proposalId);
-});
-
-bot.command('buddy', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  await cmdBuddy(ctx, member);
-});
-
-bot.command('respect', async (ctx) => {
-  const member = await requireMember(ctx);
-  if (!member) return;
-  await cmdRespect(ctx, member);
+bot.command('charter', async (ctx) => {
+  const slug = (ctx.match ?? '').trim();
+  await cmdCharter(ctx, slug || undefined);
 });
 
 // ---- Free-text + @mention handler ------------------------------------------

--- a/bot/src/onepagers.ts
+++ b/bot/src/onepagers.ts
@@ -21,7 +21,7 @@ const STATUSES = ['draft', 'review', 'final', 'sent', 'archived'] as const;
 
 async function listAll(): Promise<OnePagerRow[]> {
   const { data, error } = await db()
-    .from('stock_onepagers')
+    .from('onepagers')
     .select('id, slug, title, audience, purpose, body, status, visibility, meeting_date, meeting_location, version, updated_at')
     .order('updated_at', { ascending: false });
   if (error) throw error;
@@ -30,7 +30,7 @@ async function listAll(): Promise<OnePagerRow[]> {
 
 async function getBySlug(slug: string): Promise<OnePagerRow | null> {
   const { data, error } = await db()
-    .from('stock_onepagers')
+    .from('onepagers')
     .select('id, slug, title, audience, purpose, body, status, visibility, meeting_date, meeting_location, version, updated_at')
     .eq('slug', slug)
     .maybeSingle();
@@ -45,7 +45,7 @@ async function logActivity(
   content: string,
   metadata: Record<string, unknown> = {},
 ): Promise<void> {
-  await db().from('stock_onepager_activity').insert({ onepager_id, member_id, type, content, metadata });
+  await db().from('onepager_activity').insert({ onepager_id, member_id, type, content, metadata });
 }
 
 function formatList(rows: OnePagerRow[]): string {
@@ -141,7 +141,7 @@ export async function cmdOp(ctx: CommandContext<Context>, member: TeamMember | n
       }
       const previous = pager.status;
       const { error } = await db()
-        .from('stock_onepagers')
+        .from('onepagers')
         .update({ status: target, last_edited_by: member.id })
         .eq('id', pager.id);
       if (error) throw error;
@@ -184,7 +184,7 @@ export async function cmdOp(ctx: CommandContext<Context>, member: TeamMember | n
       const sep = pager.body.endsWith('\n') ? '\n' : '\n\n';
       const newBody = `${pager.body}${sep}${text}\n`;
       const { error } = await db()
-        .from('stock_onepagers')
+        .from('onepagers')
         .update({ body: newBody, version: pager.version + 1, last_edited_by: member.id })
         .eq('id', pager.id);
       if (error) throw error;

--- a/bot/src/regen.ts
+++ b/bot/src/regen.ts
@@ -13,7 +13,7 @@
 //     bottleneck and team members can self-service.
 //   - Two tables in the same Supabase project hold member rows:
 //       team_members        - what the dashboard login route reads
-//       stock_team_members  - what the bot's auth + roster commands read
+//       team_members  - what the bot's auth + roster commands read
 //     Out-of-band sync exists between them (name as the join key). /regen
 //     writes the new password_hash to BOTH so login + roster stay coherent.
 //
@@ -21,7 +21,7 @@
 //   - DM-only for self-regen (codes leak risk in groups)
 //   - Daily cap (REGEN_DAILY_PER_MEMBER, default 1/day) prevents abuse
 //   - Admin override checks BOT_ADMIN_TELEGRAM_IDS env (same gate as /fix)
-//   - All regens log to stock_activity_log for audit
+//   - All regens log to activity_log for audit
 
 import type { Context } from 'grammy';
 import { scryptSync, randomBytes } from 'node:crypto';
@@ -61,7 +61,7 @@ async function countRegensForMemberToday(memberId: string): Promise<number> {
   const todayUtcStart = new Date();
   todayUtcStart.setUTCHours(0, 0, 0, 0);
   const { count, error } = await db()
-    .from('stock_activity_log')
+    .from('activity_log')
     .select('id', { count: 'exact', head: true })
     .eq('actor_id', memberId)
     .eq('action', 'code_regen')
@@ -75,7 +75,7 @@ async function countRegensForMemberToday(memberId: string): Promise<number> {
 
 /**
  * Mint a new code for `member`, write to both team_members (dashboard login)
- * and stock_team_members (bot roster), log the activity.
+ * and team_members (bot roster), log the activity.
  *
  * Returns the plaintext code so the caller can DM it to the right person.
  * NEVER write the plaintext anywhere persistent - only the salt:hash.
@@ -85,7 +85,7 @@ async function mintAndWrite(member: TeamMember): Promise<{ ok: true; code: strin
   const passwordHash = hashPassword(code);
 
   // Dashboard login table (read by /api/team/login in zaostock). Match by
-  // name since stock_team_members and team_members share name as join key.
+  // name since team_members and team_members share name as join key.
   const dash = await db()
     .from('team_members')
     .update({ password_hash: passwordHash, active: true })
@@ -94,7 +94,7 @@ async function mintAndWrite(member: TeamMember): Promise<{ ok: true; code: strin
   // Bot roster table - keep the hash in sync so any future bot reader sees
   // the same value. ID match is exact for this table (we resolved from it).
   const bot = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .update({ password_hash: passwordHash })
     .eq('id', member.id);
 
@@ -110,7 +110,7 @@ async function mintAndWrite(member: TeamMember): Promise<{ ok: true; code: strin
   }
   // bot.error alone is fine - dashboard is the user-visible one.
   if (bot.error) {
-    console.error(`[regen] stock_team_members update warning: ${bot.error.message}`);
+    console.error(`[regen] team_members update warning: ${bot.error.message}`);
   }
 
   await logBotActivity({
@@ -182,9 +182,9 @@ export async function cmdRegenForName(ctx: Context, callerMember: TeamMember | n
     return;
   }
 
-  // Find target by name. Try normalized lookups against stock_team_members.
+  // Find target by name. Try normalized lookups against team_members.
   const { data: target } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select('id, name, scope, role, telegram_id, telegram_username, active')
     .ilike('name', text)
     .neq('active', false)

--- a/bot/src/status.ts
+++ b/bot/src/status.ts
@@ -9,11 +9,11 @@ function daysSince(iso: string | null): number {
 export async function buildStatus(): Promise<string> {
   const s = db();
   const [sponsorsR, artistsR, volunteersR, todosR, milestonesR] = await Promise.all([
-    s.from('stock_sponsors').select('status, amount_committed, last_contacted_at, name'),
-    s.from('stock_artists').select('status, name'),
-    s.from('stock_volunteers').select('confirmed, role, shift'),
-    s.from('stock_todos').select('status'),
-    s.from('stock_timeline').select('status, title, due_date'),
+    s.from('sponsors').select('status, amount_committed, last_contacted_at, name'),
+    s.from('artists').select('status, name'),
+    s.from('volunteers').select('confirmed, role, shift'),
+    s.from('todos').select('status'),
+    s.from('timeline').select('status, title, due_date'),
   ]);
 
   const sponsors = sponsorsR.data || [];
@@ -89,7 +89,7 @@ export async function buildStatus(): Promise<string> {
 
 export async function buildMyTodos(member: TeamMember): Promise<string> {
   const { data } = await db()
-    .from('stock_todos')
+    .from('todos')
     .select('title, status, created_at')
     .eq('owner_id', member.id)
     .neq('status', 'done')
@@ -109,7 +109,7 @@ export async function buildMyTodos(member: TeamMember): Promise<string> {
 
 export async function buildAllOpenTodos(): Promise<string> {
   const { data } = await db()
-    .from('stock_todos')
+    .from('todos')
     .select('title, status, owner_id, created_at')
     .neq('status', 'done')
     .order('created_at', { ascending: false })
@@ -122,7 +122,7 @@ export async function buildAllOpenTodos(): Promise<string> {
   const nameById = new Map<string, string>();
   if (ownerIds.length > 0) {
     const { data: owners } = await db()
-      .from('stock_team_members')
+      .from('team_members')
       .select('id, name')
       .in('id', ownerIds);
     for (const o of (owners as Array<{ id: string; name: string }> | null) ?? []) {
@@ -156,7 +156,7 @@ export async function buildAllOpenTodos(): Promise<string> {
 
 export async function buildTeamRoster(): Promise<string> {
   const { data, error } = await db()
-    .from('stock_team_members')
+    .from('team_members')
     .select('name, scope, role, telegram_id, telegram_username, active')
     .neq('active', false)
     .order('name');
@@ -199,7 +199,7 @@ export async function buildTeamRoster(): Promise<string> {
 export async function buildMyContributions(member: TeamMember): Promise<string> {
   const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
   const { data } = await db()
-    .from('stock_activity_log')
+    .from('activity_log')
     .select('action, entity_type, new_value, created_at')
     .eq('actor_id', member.id)
     .gte('created_at', since)

--- a/bot/src/zsfb.ts
+++ b/bot/src/zsfb.ts
@@ -1,14 +1,14 @@
 // /zsfb <comment> - low-friction ZAOstock /test feedback intake
 //
 // Open to all team members (not admin-gated like /fix). Saves to
-// stock_suggestions with a [zsfb:<section>] prefix so the dashboard + Hermes
+// suggestions with a [zsfb:<section>] prefix so the dashboard + Hermes
 // can filter for /test feedback specifically.
 //
 // Section auto-detected from keywords. If none match, tagged 'general'. The
 // section keyword is a hint for downstream triage, not a hard label - Hermes
 // always reads the full text.
 //
-// Why prefix vs new column: stock_suggestions schema is shared with /idea +
+// Why prefix vs new column: suggestions schema is shared with /idea +
 // public submissions. Adding a column would require a migration and would
 // fragment the suggestion pool. Prefix is reversible, dashboard-friendly, and
 // keeps everything in one bucket.
@@ -56,7 +56,7 @@ export async function addZsFb(member: TeamMember, text: string): Promise<string>
   const tagged = `[zsfb:${section}] ${trimmed}`;
 
   const { data, error } = await db()
-    .from('stock_suggestions')
+    .from('suggestions')
     .insert({
       name: member.name,
       contact: `tg:${member.id}`,


### PR DESCRIPTION
## Summary
Two-commit PR. Companion to research doc 610 (#477).

**Commit 1** - The May 4-5 consolidation work:
- Mass rename `from('stock_*')` -> `from('*')` across 13 files (bot now talks to unprefixed schema on ZAO STOCK Supabase project)
- `CIRCLE_SLUGS` const cut from 8 stale slugs to the real 6 (finance, host, livestream, marketing, music, ops)
- 5 broken governance commands removed (`cmdPropose`, `cmdProposals`, `cmdObject`, `cmdConsent`, `cmdBuddy`, `cmdRespect`) - their tables never existed in either DB
- New `cmdCharter` command added: posts circle responsibility into the current Telegram topic and pins it; auto-detects slug from topic name

**Commit 2** - Two follow-up bug fixes surfaced post-consolidation:
- Tighter `@mention` detection: requires Telegram mention entity at offset 0 instead of substring match. Prevents bot LLM auto-replies to broadcasts that name the bot in body text.
- API transformer that redirects any `sendMessage`/`sendPhoto`/etc to the ZAO Festivals supergroup without an explicit `message_thread_id` to the Operations topic. Bot will no longer fall back to General per team policy.

## Activation
Lives dormant on VPS until Zaal updates `~/zaostock-bot/.env` with the ZAO STOCK `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` and restarts the service. Until then bot keeps reading the old efsxt project on the OLD code already running in memory.

## Test plan
- [ ] After env swap + restart: `/circles` returns 6 circles from ZAO STOCK
- [ ] After env swap + restart: `/charter` in any of the 6 topics posts + pins the right description
- [ ] `/mytodos` works against ZAO STOCK team_members
- [ ] No reply to broadcast that mentions @ZAOstockTeamBot in body text (must be at offset 0 to trigger)
- [ ] Cron digest posts go to ops topic, not General

## Related
- Doc 609 (#475) - the cobuild that locked 6-circle structure
- Doc 610 (#477) - full DB consolidation post-mortem