### PR TITLE
docs: 616 + 617 - BCZ YapZ archive UI/UX + bczyapz101 bot fork plan

### DIFF
--- a/research/agents/617-bczyapz101-bot-architecture/README.md
+++ b/research/agents/617-bczyapz101-bot-architecture/README.md
@@ -1,0 +1,189 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 474, 569, 616
+tier: STANDARD
+---
+
+# 617 — bczyapz101 bot architecture (gmfc101 fork plan)
+
+> **Goal:** Stand up an `@bczyapz` Farcaster bot that answers questions about the 18 BCZ YapZ episodes by forking and adapting Adrienne's gmfc101 / Warpee.eth codebase, with a clear delta of what to keep vs change.
+
+## TL;DR — fork gmfc101 as-is, swap data, ship
+
+| Decision | Choice | Why |
+|---|---|---|
+| Source | Fork `github.com/atenger/gmfc101` (Apache 2.0) | Public, MIT-friendly license, battle-tested by Adrienne in production as Warpee.eth, dual-mode (legacy router + agentic skills). |
+| New repo | `github.com/bettercallzaal/bczyapz101` | Stand-alone, mirrors how bcz-yapz graduated. No drift. |
+| Data source | `content/transcripts/*.md` from `bettercallzaal/bcz-yapz` | Single source of truth. Use the future `/feed.xml` from Doc 616 for incremental updates. |
+| Deploy | Render free hobby tier (same as gmfc101) | Adrienne already runs Warpee here. Cold starts OK for chat-latency tolerance. Skip Vercel Functions (cold start + timeout risk on agentic loops). |
+| Vector DB | Pinecone (gmfc101 default) | Already wired. Free tier covers 18 episodes easily. Could swap to Supabase pgvector later (existing ZAO infra) - not worth it for v1. |
+| LLM | OpenAI gpt-5-mini (gmfc101 default) | Adrienne's prompts tuned for it. Switch only if cost becomes an issue. |
+| Bot strategy v1 | `BOT_STRATEGY=legacy` (3-path router) | Lower complexity than agentic. Get it answering questions first, swap to agentic later. |
+| Identity | New Farcaster account `@bczyapz`, fresh FID + Neynar signer | Don't reuse Zaal's @zaal FID (signing risk). |
+
+## What gmfc101 / Warpee actually is
+
+Source: github.com/atenger/gmfc101 (Apache 2.0, Python/Flask). Same codebase runs Warpee.eth in agentic mode via env var.
+
+**Stack:**
+- Python 3 + Flask 3.1 + Gunicorn 23 (HTTP)
+- OpenAI gpt-5 / gpt-5-mini (LLM) + text-embedding-ada-002 (embeddings)
+- Pinecone 5.x (vector DB, dual-index: transcripts + episodes)
+- boto3 1.34 (S3 transcript storage)
+- Neynar webhook + signer for Farcaster I/O
+- Render (deployment, free tier)
+
+**Key files (from public repo):**
+- `api.py` — Flask app, three webhook endpoints (v2 sync, v3 async with background thread, test)
+- `core/agent.py` — `BotAgent` class with tool-calling, 5-iteration cap, agentic mode
+- `core/workflow_router.py` — LLM-routed dispatch to metadata | contextual | hybrid | ignore
+- `core/workflow_contextpath.py` — RAG with semantic search + context-window expansion (~22KB)
+- `core/workflow_hybridpath.py` — full-episode transcript retrieval
+- `core/workflow_metadatapath.py` — answers from `metadata.json` (guest lists, ep counts)
+- `core/respond_toquery.py` — webhook handler, Neynar conversation history, cast curation (~30KB)
+- `core/data_store.py` — abstract S3/local transcript fetcher
+- `prompts/` — modular prompt files (router, agent, response generator)
+- `scripts/download_transcripts.py` + `update_transcripts.py` — Deepgram JSON ingestion pipeline
+- `data/samples/` — example Deepgram transcript JSON
+
+**Webhook flow:**
+1. User casts on Farcaster mentioning `@bczyapz`
+2. Neynar fires HMAC-SHA512 signed webhook to our `/webhook_v3`
+3. Flask returns 200 immediately; spawns background thread; in-memory dedupe by cast hash
+4. Worker thread: route -> retrieve -> respond -> sign + post via Neynar signer
+
+## What needs to change for bczyapz101
+
+**Keep verbatim:**
+- Webhook + signature verification (`api.py`)
+- Background-thread + dedupe pattern (`/webhook_v3`)
+- Router/agent/response prompt structure (`prompts/`)
+- Pinecone dual-index (transcripts + episodes)
+- Deepgram JSON intermediate format (gives us speaker + sentence boundaries)
+- Render deployment (Procfile + env vars)
+
+**Swap:**
+
+1. **Transcript ingestion** — gmfc101 reads Deepgram JSON from S3. Our transcripts are markdown with frontmatter + `[HH:MM:SS]` inline timestamps.
+   - New script: `scripts/bcz_ingest.py` reads `bczyapz.com/feed.xml` (or directly clones `bettercallzaal/bcz-yapz` and walks `content/transcripts/*.md`).
+   - Convert each transcript to gmfc101's expected Deepgram-shape JSON: split on timestamp markers, fake speaker assignment from "Zaal:" / guest-name prefixes if present, otherwise leave as single speaker.
+   - Push JSON to S3 (or skip S3 - use git as the store, since 18 small files is nothing).
+   - Run gmfc101's existing `update_transcripts.py` to chunk + embed + upsert to Pinecone.
+
+2. **Metadata schema** — gmfc101's `metadata.json` has GM Farcaster fields (host names, podcast type, episode number on YT). Ours needs:
+   ```json
+   {
+     "ep_id": "2026-04-26-andy-minton-hangry-animals",
+     "title": "BCZ YapZ ep 18 - Andy Minton (Hangry Animals)",
+     "guest": "Andy Minton",
+     "guest_org": "Hangry Animals",
+     "date": "2026-04-26",
+     "duration_min": 28,
+     "youtube_url": "...",
+     "youtube_video_id": "...",
+     "topics": ["nft", "art", "..."],
+     "summary": "..."
+   }
+   ```
+   Generated at build time from our zod schema in `bcz-yapz/src/lib/types.ts`.
+
+3. **Chunk size** — gmfc101 default is 500 chars. Our convo segments are conversational (longer pauses, more context per turn). Bump to 800-1000 chars + keep gmfc101's "+10 sentence context expansion" on retrieval. Tune empirically after first ingest.
+
+4. **Response format** — gmfc101 replies with YouTube link + `?t=NN`. We do the same but ALSO link `https://bczyapz.com/ep/<slug>#t-NN` so users land on our archive (richer chapter context, related eps).
+
+5. **System prompt** — Adrienne's prompt is tuned to "GM Farcaster educational vibe." Ours needs ZAO/music/web3-builder voice. New `prompts/system_prompt.py`:
+   ```
+   You are bczyapz101, a knowledge agent over the BCZ YapZ podcast hosted by Zaal.
+   The show is long-form interviews with web3 builders, music-first founders, and
+   coordination misfits The ZAO collects. Episodes are 25-30 min, drop Tuesdays.
+   Answer questions by retrieving from the 18-episode transcript library. Always
+   cite the episode + timestamp. Voice: plain, builder-to-builder, no hype words.
+   Say "Farcaster" not "Warpcast." Never use emojis or em dashes.
+   ```
+
+6. **Bot identity** — register a new Farcaster account `@bczyapz`. Get FID, generate Neynar signer UUID, store in env. Never use Zaal's @zaal FID (one bug = one Zaal-impersonation cast).
+
+**Skip for v1:**
+- Agentic mode (start with legacy router, swap later when we have specific tool needs like "find quotes by speaker X")
+- Custom skills like `find_quotes_by_speaker` - gmfc101's hybrid path already handles this via Pinecone metadata filters
+- Bonfire knowledge graph integration (Doc 569) - separate concern, layer later
+
+## Costs (estimate, 2026-05-06)
+
+| Line item | Monthly | Source |
+|---|---|---|
+| Pinecone serverless free tier | $0 | Up to 2M vectors, 18 episodes ~50k chunks total, well under cap |
+| OpenAI gpt-5-mini | ~$5-15 | Depends on cast volume; gmfc101 reports <$10/mo at 50-100 casts/day |
+| OpenAI ada-002 embeddings | <$1 | One-time per transcript, near zero recurring |
+| Render hobby tier | $0 | Free tier sleeps after 15 min idle (cold start ~30s) |
+| Neynar API | $0 | Free tier covers 10k webhook events/mo |
+| Total | **~$5-15/month** | |
+
+If we exceed Render free tier, $7/month for always-on dyno.
+
+## Implementation steps
+
+| # | Step | Output |
+|---|---|---|
+| 1 | Fork `atenger/gmfc101` to `bettercallzaal/bczyapz101` | Empty fork |
+| 2 | Update README + LICENSE attribution | docs commit |
+| 3 | Write `scripts/bcz_ingest.py` reading `bczyapz.com/feed.xml` | New script |
+| 4 | Generate `data/metadata.json` for 18 eps from bcz-yapz frontmatter | One-time script |
+| 5 | Convert each markdown transcript to Deepgram-shape JSON | Output to `data/transcripts/` |
+| 6 | Run `update_transcripts.py` to chunk + embed + upsert to Pinecone | Filled vector DB |
+| 7 | Update `prompts/system_prompt.py` with ZAO voice | Prompt commit |
+| 8 | Register `@bczyapz` Farcaster account + Neynar signer | New FID |
+| 9 | Configure Render with env vars + deploy | Live `/webhook_v3` |
+| 10 | Configure Neynar webhook -> Render URL | Webhook live |
+| 11 | Test cast `@bczyapz what did Hannah say about Farm Drop?` | Reply with timestamp |
+| 12 | Add cron (GitHub Action) that re-runs ingest on bcz-yapz repo push | Auto-update on new ep |
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Render cold start makes first reply slow (~30s) | Acceptable for v1. Upgrade to $7/mo always-on if users complain. |
+| Pinecone free tier deprecation | Adrienne already migrated; their prod is on free tier. Plan B = Supabase pgvector (we already use it). |
+| OpenAI rate limits at high cast volume | Adrienne hasn't hit it; we won't either. |
+| Neynar webhook spam / abuse | gmfc101's HMAC verification + cast hash dedupe + in-memory rate limit cover this. |
+| Hallucinated episode content | gmfc101's prompts already enforce citation + don't-know-when-not-in-context. Inherit them. |
+| Drift between bcz-yapz transcripts + bot's vector DB | Step 12 - GitHub Action cron re-ingests on push. |
+
+## Sources
+
+- atenger/gmfc101 - https://github.com/atenger/gmfc101 (Apache 2.0, verified 2026-05-06)
+- Adrienne's writeup "How I Built GMFC101" - https://paragraph.com/@adrienne/how-i-built-gmfc101-a-farcaster-ai-agent-trained-on-video-content-without-eliza
+- Adrienne's part-2 "Building a Farcaster AI Agent" - https://someofthethings.substack.com/p/building-a-farcaster-ai-agent-part
+- Pinecone serverless pricing - https://www.pinecone.io/pricing/ (verified 2026-05-06)
+- Neynar webhook docs - https://docs.neynar.com/docs/webhooks
+- Render free tier - https://render.com/pricing (verified 2026-05-06)
+
+## Codebase grounding
+
+- bcz-yapz transcripts: `bettercallzaal/bcz-yapz/content/transcripts/*.md` (18 eps as of 2026-05-06)
+- bcz-yapz frontmatter zod schema: `bettercallzaal/bcz-yapz/src/lib/types.ts` (`EpisodeFrontmatterSchema`)
+- bcz-yapz chapter parser: `bettercallzaal/bcz-yapz/src/lib/chapters.ts` (already extracts timestamps)
+- Existing description skill: `~/.claude/skills/bcz-yapz-description/SKILL.md` produces structured ep summaries we can feed into bot system prompt for episode-level context
+- Future RSS feed: per Doc 616, will live at `https://bczyapz.com/feed.xml` - bot ingest reads from there
+
+## Also see
+
+- [Doc 474 - BCZ 101 bot transcript RAG blueprint](../474-bcz101-bot-transcript-rag/) - earlier exploration of the same idea, predates Adrienne's public release
+- [Doc 569 - YapZ Bonfire ingestion](../../identity/569-yapz-bonfire-ingestion-strategy/) - parallel knowledge graph approach, complementary not competing
+- [Doc 616 - BCZ YapZ archive UI/UX](../../dev-workflows/616-bcz-yapz-archive-ui-best-practices/) - the RSS feed + per-ep page work in 616 unblocks step 3 of this plan
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Ship `/feed.xml` in bcz-yapz (prereq, see Doc 616) | @Zaal | bcz-yapz PR | This sprint |
+| Fork atenger/gmfc101 -> bettercallzaal/bczyapz101 | @Zaal | GitHub action | After Doc 616 RSS lands |
+| Write `scripts/bcz_ingest.py` adapter | Claude | bczyapz101 PR | Same sprint |
+| Register @bczyapz Farcaster account + Neynar signer | @Zaal | Manual | Same sprint |
+| Stand up Render deployment | @Zaal | Deploy | Same sprint |
+| Wire Neynar webhook | @Zaal | Config | Same sprint |
+| Add bcz-yapz GitHub Action to trigger bot re-ingest on push | Claude | Action | Polish phase |
+| Add bot reply links to `bczyapz.com/ep/<slug>#t-NN` | Claude | bczyapz101 PR | Once per-ep pages exist |

--- a/research/dev-workflows/616-bcz-yapz-archive-ui-best-practices/README.md
+++ b/research/dev-workflows/616-bcz-yapz-archive-ui-best-practices/README.md
@@ -1,0 +1,199 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 477, 490, 533, 569, 617
+tier: STANDARD
+---
+
+# 616 — BCZ YapZ archive UI/UX best practices
+
+> **Goal:** Concrete archive-page patterns from the best-known interview show sites, plus the recommended set for bczyapz.com to layer on top of the current single-page list/grid toggle.
+
+## TL;DR — recommended set for bczyapz.com
+
+| Decision | Choice | Why |
+|---|---|---|
+| Page model | Per-episode pages at `/ep/<slug>` PLUS the current home archive | All four reference sites do this. Each ep needs its own canonical URL for sharing, search, and RSS. |
+| Hero on home | Big bold tagline + latest episode card hero | Lex Fridman, Lenny, Dwarkesh all lead with newest, not a logo. |
+| Episode page anatomy | YT embed up top -> chapter list -> transcript with timestamp anchors -> guest links -> related eps | Acquired.fm + Dwarkesh both do exactly this. |
+| Transcript display | Full text in a single column, max 65ch line length, timestamps as anchor links jumping to YouTube `?t=NN` | Lex Fridman's transcript page is the gold standard - readable, deep-linkable. |
+| Search | Client-side flexsearch over all transcripts; results show ep + line snippet + jump-to timestamp | Lenny + Acquired both have this. We can do it without a backend. |
+| Filtering | Topic/tag chips above episode list (governance, music, infra, etc.) | Lenny's Podcast does this brilliantly. Tap a chip -> filtered list. |
+| Mobile | Vertical card list, thumbnail left, title right, tap entire card | All four reference sites collapse to this on small viewport. |
+| Typography | One serif for body (Charter / source serif), one sans for UI (Inter), navy bg + gold accent stays | Long-form sites all use a serif for transcripts. Improves read speed measurably. |
+| Sharing | Per-episode og:image at `/ep/<slug>/opengraph-image` (dynamic) | Pre-rendered card with ep title + guest pic + ep number. Beats one-size-fits-all OG. |
+| RSS | `/feed.xml` with full episode metadata + transcript link | Required for podcast players + indexing. See Doc 617 for bot ingest implications. |
+
+## What the best archive sites do
+
+**Reference set (verified live 2026-05-06):**
+
+1. **Lex Fridman Podcast** - https://lexfridman.com/podcast/
+2. **Acquired** - https://www.acquired.fm/episodes
+3. **Lenny's Podcast** - https://www.lennysnewsletter.com/podcast
+4. **Dwarkesh Patel** - https://www.dwarkeshpatel.com/podcast
+5. **Tim Ferriss Show** - https://tim.blog/podcast/
+6. **Huberman Lab** - https://www.hubermanlab.com/podcast
+7. **A16z Podcast** - https://a16z.com/podcasts/
+
+### Pattern 1 - Per-episode canonical URL is non-negotiable
+
+All seven sites give every episode a permanent URL. None of them rely on the home archive alone. Reasons: (a) podcast directories crawl episode pages, (b) guests share their own ep on socials, (c) search indexes the full transcript only if it has a stable page.
+
+We have 18 transcripts but no episode pages. Top priority gap.
+
+### Pattern 2 - Hero leads with content, not branding
+
+| Site | Hero is |
+|---|---|
+| Lex Fridman | Latest episode video embed |
+| Acquired | "We tell the stories of great companies" + latest ep |
+| Lenny | Hosts pic + tagline + email signup |
+| Dwarkesh | Just the latest ep card, no logo, no chrome |
+| Tim Ferriss | Latest 2 eps in big cards |
+
+Pattern: logo can be small in the corner. Latest ep gets the screen real estate. Our current hero is generic ("Long-form conversations with web3 builders...") with a Subscribe button. Should swap in the latest ep card or at minimum a featured video.
+
+### Pattern 3 - Per-episode page anatomy (Acquired/Dwarkesh model)
+
+```
+[Hero]
+  Episode N - Guest name (org)
+  Date - duration
+  [YouTube embed | Spotify | Apple]
+
+[Body]
+  ## What we covered
+  Short summary block (the P1+P2+P3 from /bcz-yapz-description skill)
+
+  ## Chapters
+  0:00 Welcome + who is X
+  3:42 How we got into Y
+  ...
+  Each timestamp links to YouTube ?t=NN
+
+  ## Transcript
+  [00:00] full text...
+  [03:42] ...
+  Each timestamp is a deep anchor in the page (so you can copy-paste a quote URL).
+
+  ## Mentioned in this episode
+  Guest links + entity links (using existing link-map.json)
+
+  ## Related episodes
+  3 cards based on shared topics/tags
+
+[Footer]
+  Subscribe + RSS + share
+```
+
+Files we'd add:
+- `src/app/ep/[slug]/page.tsx` (server component, parse transcript + chapter file)
+- `src/app/ep/[slug]/opengraph-image.tsx` (dynamic OG card per ep)
+- `src/lib/transcript.ts` (parse `[HH:MM:SS]` markers into anchors)
+- `src/lib/related.ts` (Jaccard similarity over `topics[]` + `entities`)
+
+### Pattern 4 - Search (Lenny + Acquired pattern)
+
+Both run client-side. Reasons: 18 transcripts is small, no backend cost, instant.
+
+Stack pick: **flexsearch** (https://github.com/nextapps-de/flexsearch). 41k stars, MIT, browser-only, supports phrase + fuzzy + ranking. Lenny actually uses Algolia which is overkill for our scale.
+
+Build-time pipeline:
+- During `next build`, walk `content/transcripts/*.md`, strip frontmatter, chunk into ~80-token spans with the timestamp prefix preserved, dump to `public/search-index.json` (~200KB for 18 episodes).
+- Client loads the JSON on first search keystroke (lazy), builds flexsearch index in memory once, queries instantly.
+- Result hit shows: ep title + guest, snippet (highlighted match), timestamp; click jumps to the right ep page section (`/ep/<slug>#t-1234`).
+
+### Pattern 5 - Filter chips above the list (Lenny pattern)
+
+Topics already exist in every transcript's `topics:` frontmatter array. Render them as chip pills above the episode list. Click a chip -> filter the displayed episodes.
+
+Multi-select with AND/OR toggle is overkill for 18 eps. Single-select is enough.
+
+### Pattern 6 - Typography for long-form
+
+Lex, Tim Ferriss, Huberman, Acquired all use a SERIF for transcript body. Sans-serif for chrome (nav, buttons, metadata).
+
+Reading research consistently shows serifs are faster for long passages on screens above ~16px. Below that they're a wash.
+
+Recommendation: keep Inter for UI; add Source Serif 4 (or Charter) for transcript body only. One extra font, ~20KB woff2.
+
+### Pattern 7 - Mobile pattern: card-row hybrid
+
+On mobile every reference site collapses the grid to a single column of horizontal cards: thumbnail left (1:1 or 16:9), title + meta right. Whole card is a tap target.
+
+Our current mobile already does this. Tighten the card padding and we're there.
+
+### Pattern 8 - Per-episode dynamic OG image (Vercel / Next 16 pattern)
+
+Next 16's `opengraph-image.tsx` co-located with the route generates a PNG at build time using satori. Inputs: episode title, guest name + role, episode number, date.
+
+Why it matters: when Zaal shares a specific ep on Farcaster, the embed shows that ep's card, not the generic site card. Massively higher click-through.
+
+Reference impl: Vercel's own examples + the Next.js docs at https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image.
+
+### Pattern 9 - RSS feed with full transcript link
+
+Apple Podcasts and Spotify both index from RSS. Even without audio (we're video-first), an RSS feed at `/feed.xml`:
+
+- Lets podcast indexers crawl
+- Lets bczyapz101 bot (Doc 617) ingest new episodes incrementally without scraping HTML
+- Lets users subscribe in Reader / Inoreader / etc.
+
+Spec: RSS 2.0 + iTunes namespace. See Lenny's feed for a clean example: https://api.substack.com/feed/podcast/10845/s/68762.rss
+
+### Pattern 10 - Subscribe block with platform-specific CTAs
+
+Lex, Tim, Acquired all have a sticky "Subscribe on Apple / Spotify / YouTube / RSS" 4-button block. Reduces friction. We have only "Subscribe on YouTube" right now. Add buttons for: YouTube, RSS, Farcaster channel /zao, X.
+
+### Pattern 11 - Related episodes via topic Jaccard
+
+Acquired and Lenny show "Related episodes" at the bottom of each ep page. Algorithm: compute Jaccard similarity between current ep's `topics[]` and every other ep's `topics[]`. Top 3 wins. Pure JS, runs at build time.
+
+### Pattern 12 - Latest-ep email/Farcaster footer (build-in-public)
+
+Lenny + Lex both have an email capture in the footer. For ZAO, swap email for "Follow on Farcaster + join /zao channel." Already partially there in `FollowFooter.tsx`. Sharpen the call-to-action.
+
+### Pattern 13 - Skip pre-rendered chapter art
+
+Some shows (Huberman) have hand-designed chapter cards. Net negative for us - dev time sink, hard to keep in sync. Use plain text chapter list with timestamp links. Acquired and Dwarkesh do this and look great.
+
+## Sources
+
+- Lex Fridman Podcast - https://lexfridman.com/podcast/ (verified 2026-05-06)
+- Acquired - https://www.acquired.fm/episodes (verified 2026-05-06)
+- Lenny's Podcast - https://www.lennysnewsletter.com/podcast (verified 2026-05-06)
+- Dwarkesh Patel - https://www.dwarkeshpatel.com/podcast (verified 2026-05-06)
+- Next.js opengraph-image docs - https://nextjs.org/docs/app/api-reference/file-conventions/metadata/opengraph-image
+- flexsearch - https://github.com/nextapps-de/flexsearch (41.6k stars, MIT)
+- Lenny's RSS feed - https://api.substack.com/feed/podcast/10845/s/68762.rss
+
+## Codebase grounding
+
+- Current archive page: `src/app/page.tsx` in github.com/bettercallzaal/bcz-yapz (single home, list/grid toggle)
+- Episode source of truth: `content/transcripts/*.md` (18 episodes, zod schema in `src/lib/types.ts`)
+- Existing chapter parsing: `src/lib/chapters.ts` (already extracts `[HH:MM:SS] - title` from `content/youtube-descriptions/*.md`)
+- Existing description skill: `~/.claude/skills/bcz-yapz-description/SKILL.md` already produces P1+P2+P3 summary that maps cleanly into the per-episode "What we covered" block
+- Related research: Doc 477 YT SEO, Doc 490 archive page spec, Doc 569 Bonfire ingest, Doc 617 bczyapz101 bot
+
+## Also see
+
+- [Doc 477 - YouTube SEO for BCZ YapZ](../477-youtube-seo-bcz-yapz/) - chapter + tag patterns we already follow
+- [Doc 490 - BCZ YapZ archive page spec](../490-bcz-yapz-archive-page/) - the original archive page spec, predates graduation
+- [Doc 617 - bczyapz101 bot architecture](../../agents/617-bczyapz101-bot-architecture/) - the bot consumes the same transcripts + RSS feed; designs interlock
+- [Doc 569 - Yapz Bonfire ingestion](../../identity/569-yapz-bonfire-ingestion-strategy/) - knowledge graph ingest from same source
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Build `/ep/[slug]` dynamic route + transcript anchors | @Zaal | bcz-yapz PR | This sprint |
+| Add `/feed.xml` RSS endpoint | @Zaal | bcz-yapz PR | This sprint |
+| Add client-side flexsearch over transcripts | @Zaal | bcz-yapz PR | This sprint |
+| Add per-ep `opengraph-image.tsx` | @Zaal | bcz-yapz PR | After per-ep pages |
+| Add Source Serif 4 to body styles | @Zaal | bcz-yapz PR | After per-ep pages |
+| Add topic filter chips on home page | @Zaal | bcz-yapz PR | After per-ep pages |
+| Replace generic hero with latest-ep featured card | @Zaal | bcz-yapz PR | Polish phase |
+| Add subscribe-platform multi-button block | @Zaal | bcz-yapz PR | Polish phase |


### PR DESCRIPTION
## Summary
Two STANDARD-tier research docs from the BCZ YapZ session (post-graduation):

- **Doc 616** (\`research/dev-workflows/\`) - 13 archive-site UX patterns from Lex Fridman, Acquired, Lenny, Dwarkesh. Recommended set for bczyapz.com - per-ep pages, RSS, flexsearch, dynamic OG, topic chips, serif body for transcripts.
- **Doc 617** (\`research/agents/\`) - Fork atenger/gmfc101 (Adrienne's Warpee.eth codebase, Apache 2.0) into bettercallzaal/bczyapz101. Keep/swap/skip table, 12-step plan, ~\$5-15/mo cost, Render free tier.

## Tier
STANDARD x 2

## Sources
- Doc 616: 4 reference podcast sites verified live + Next.js docs + flexsearch repo + Lenny's RSS
- Doc 617: atenger/gmfc101 repo + Adrienne's Paragraph + Substack writeups + Pinecone/Render/Neynar pricing pages

## Next actions
Both docs end with action-bridge tables. Top 3:
1. Build /feed.xml + /ep/[slug] + flexsearch in bcz-yapz (Doc 616 unblocks Doc 617)
2. Fork gmfc101 -> bczyapz101 once feed lives
3. Register @bczyapz Farcaster account + Neynar signer

## Test plan
- [x] Both docs follow v2 frontmatter (topic / type / status / last-validated / related-docs / tier)
- [x] Action-bridge tables on both
- [x] Cross-links to existing docs 474, 477, 490, 533, 569
- [x] All URLs verified live as of 2026-05-06