### PR TITLE
feat(zaostock-bot): /timeline_done command

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -8,7 +8,7 @@ import {
   unlinkUsername,
   type TeamMember,
 } from './auth';
-import { buildStatus, buildMyTodos, buildMyContributions, buildAllOpenTodos, buildTeamRoster } from './status';
+import { buildStatus, buildMyTodos, buildMyContributions, buildAllOpenTodos, buildTeamRoster, markTimelineDone } from './status';
 import { addGemba, addIdea, addNote } from './capture';
 import { addZsFb } from './zsfb';
 import { executeFromText } from './actions';
@@ -202,6 +202,17 @@ bot.command('mycontributions', async (ctx) => {
   const member = await requireMember(ctx);
   if (!member) return;
   await ctx.reply(await buildMyContributions(member));
+});
+
+// /timeline-done <id-prefix or unique title fragment> - close out a stuck
+// timeline entry without leaving Telegram. Was a 60-pending entry problem
+// because the dashboard had no easy "mark done" UX. Now anyone in the team
+// can clear them from chat.
+bot.command('timeline_done', async (ctx) => {
+  const member = await requireMember(ctx);
+  if (!member) return;
+  const arg = (ctx.match ?? '').trim();
+  await ctx.reply(await markTimelineDone(arg, member));
 });
 
 bot.command('fix', async (ctx) => {

--- a/bot/src/status.ts
+++ b/bot/src/status.ts
@@ -217,3 +217,61 @@ export async function buildMyContributions(member: TeamMember): Promise<string> 
   }
   return lines.join('\n');
 }
+
+// /timeline-done <id_prefix_or_title_substring>
+// Marks a timeline entry done. Accepts:
+//  - 8-char UUID prefix (matches first segment)
+//  - Substring of the title (case-insensitive, only if it matches exactly one entry)
+export async function markTimelineDone(query: string, member: TeamMember): Promise<string> {
+  const q = query.trim();
+  if (!q) return 'Usage: /timeline-done <id-prefix or unique title fragment>';
+
+  const s = db();
+  // Try UUID prefix first (8 chars common, but accept anything 4+)
+  const isUuidLike = /^[0-9a-f]{4,}/i.test(q.replace(/-/g, ''));
+
+  let target: { id: string; title: string; status: string } | null = null;
+
+  if (isUuidLike && q.length >= 4) {
+    const { data } = await s
+      .from('timeline')
+      .select('id, title, status')
+      .ilike('id', `${q}%`)
+      .limit(2);
+    if (data && data.length === 1) target = data[0] as { id: string; title: string; status: string };
+    if (data && data.length > 1) {
+      return `Multiple timeline entries match "${q}". Try a longer prefix.`;
+    }
+  }
+
+  if (!target) {
+    const { data } = await s
+      .from('timeline')
+      .select('id, title, status')
+      .ilike('title', `%${q}%`)
+      .limit(3);
+    if (!data || data.length === 0) {
+      return `No timeline entry matches "${q}".`;
+    }
+    if (data.length > 1) {
+      return `Multiple timeline entries match "${q}":\n${data.map((d) => `  - ${d.title}`).join('\n')}\nUse a more specific fragment or pass an id prefix.`;
+    }
+    target = data[0] as { id: string; title: string; status: string };
+  }
+
+  if (target!.status === 'done') {
+    return `"${target!.title}" is already marked done.`;
+  }
+
+  const { error } = await s
+    .from('timeline')
+    .update({
+      status: 'done',
+      notes: `[done by ${member.name} via /timeline-done ${new Date().toISOString().slice(0, 10)}]`,
+    })
+    .eq('id', target!.id);
+
+  if (error) return `Could not update: ${error.message}`;
+
+  return `Marked "${target!.title}" done.`;
+}


### PR DESCRIPTION
Closes the 60-pending-timeline-entries problem from doc 610. Team can now mark timeline items done from Telegram.

## Usage

\`\`\`
/timeline_done <id-prefix>      - by UUID prefix
/timeline_done <title fragment> - by title substring
\`\`\`

## Already deployed

Synced to VPS at \`~/zaostock-bot/src/\`. Bot restarted clean at May 6 23:54 UTC. setMyCommands updated, /timeline_done shows up in autocomplete.

## Test

DM @ZAOstockTeamBot:
- \`/timeline_done bangor\` -> "No timeline entry matches" (Bangor is in todos, not timeline)
- \`/timeline_done lineup\` -> finds something in timeline that mentions lineup

## Companion to PR #478
The earlier consolidation PR. Same theme: ship the operational tooling that closes loose ends from the May 4-5 database work.