### PR TITLE
doc 620: Bonfire push-everything pipeline (DISPATCH, 5 sub-docs)

### DIFF
--- a/research/agents/620-bonfire-push-everything/620a-stream-source-ingest.md
+++ b/research/agents/620-bonfire-push-everything/620a-stream-source-ingest.md
@@ -1,0 +1,339 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 547, 560, 613, 615, 618, 619, 620
+tier: STANDARD
+parent-doc: 620
+---
+
+# 620a - Stream-source ingest: Telegram + Farcaster + voice to Bonfire
+
+> **Goal:** Map live-stream sources (Telegram DMs, group chats, Farcaster casts, voice transcripts) into the Bonfire knowledge graph. Auto-push everything Zaal touches so recall is always fresh, no manual curation required. This doc covers the three-source strategy, cost model, and concrete ship order.
+
+---
+
+## Decision Table: Use / Wire / Defer
+
+| Source | Recommendation | Reason | Signal |
+|---|---|---|---|
+| **Telegram DMs (@zaoclaw_bot)** | WIRE | Native ZOE hook (grammy, `bot/src/zoe/index.ts`). Already parsed + stored in `recent.json`. Lowest effort, highest daily signal. Per-message push minimizes latency. | Push ~50 msgs/day, ~500 tokens/push = 25K tokens/day. |
+| **Telegram group chats** | WIRE | ZAO Devz + ZAOstock team groups are decision sources. Distinguish user-sent (push) from bot-sent (skip). Existing grammy routing in place. | ~30 user msgs/day across groups. Skip bot noise. |
+| **Farcaster casts (@zaal)** | WIRE | Neynar webhook + existing SDK. Subscribe to cast events. Push cast text, channel, mentions, timestamp. Separate from recast-spam. | ~10 casts/day, ~200 tokens per cast = 2K tokens/day. |
+| **Voice (OpenWhisp pipeline)** | WIRE | Doc 560 approved. Dictation output lands as text file. Batch daily or per-transcript. | ~20 min voice/day = 1 transcript, ~300 tokens. |
+| **Farcaster feeds Zaal reads** | DEFER | Out-of-scope doc 620. Optional Phase 2. Generates noise (high volume, low signal unless @mentioned). | ~100+ unread casts/day. |
+
+---
+
+## 1. Telegram Capture
+
+### Current State
+
+ZOE bot (`bot/src/zoe/index.ts`) already:
+- Polls Telegram via grammy on DM + group messages
+- Calls `pushRecent({ from: 'zaal', text })` on user messages
+- Stores short-term in `~/.zao/zoe/recent.json`
+
+Missing: auto-push to Bonfire on every DM/group message.
+
+### Implementation Strategy
+
+**Option A: Per-message push (recommended)**
+
+Wire Bonfire ingest inside the existing `bot.on('message:text')` handler:
+
+```typescript
+// bot/src/zoe/index.ts at line ~147 (after pushRecent call)
+
+async function pushToBonfire(source: 'dm' | 'group', text: string, groupId?: number) {
+  try {
+    const res = await fetch('https://tnt-v2.api.bonfires.ai/ingest_content', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.BONFIRE_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: text,
+        bonfire_id: process.env.BONFIRE_ID,
+        title: `Zaal ${source === 'dm' ? 'DM' : 'group'}: ${text.slice(0, 60)}`,
+        metadata: {
+          source: 'telegram',
+          from: 'zaal',
+          channel_type: source,
+          group_id: groupId,
+          timestamp: new Date().toISOString(),
+        },
+      }),
+    });
+    if (!res.ok) console.error(`Bonfire ingest failed: ${res.status}`);
+  } catch (err) {
+    console.error('Bonfire push error:', err);
+  }
+}
+
+// In the on('message:text') handler, after pushRecent():
+await pushToBonfire(
+  ctx.chat.type === 'private' ? 'dm' : 'group',
+  text,
+  ctx.chat.type !== 'private' ? ctx.chat.id : undefined
+);
+```
+
+**Cost & latency:** Per-message means ~1 API call per message. Zaal sends ~50 Telegram messages/day. Each push is ~200-500 tokens (text + metadata). Daily cost: ~15K tokens.
+
+**Distinction: user-sent vs. bot-sent**
+
+Don't push bot replies (ZOE's concierge output, tips, scheduled nudges). Only push messages where `ctx.from.id === zaalId`. The existing `isAllowed()` guard already enforces this.
+
+**Issue: admin-curl bypass**
+
+Doc 606 mentions `feedback_admin_pushed_msgs_not_in_concierge_memory` - admin commands via curl bypass `pushRecent()`. Same risk applies to Bonfire: if Zaal posts via admin API instead of Telegram, it won't reach the graph. Mitigation: wire Bonfire ingest at TWO points:
+
+1. In `index.ts` on ('message:text') - catches DMs
+2. In `concierge.ts` result output - catches `/fix` and `/ask` replies that go back to Telegram
+
+Sync these calls so duplicate messages don't double-ingest. Use (source + timestamp + text hash) as idempotency key in Bonfire if needed (check API docs).
+
+**Group chats: which ones?**
+
+Capture these groups (wire via ZAO_DEVZ_CHAT_ID env var + config):
+- ZAO Devz (already tracked as `devzChatId` in index.ts)
+- ZAOstock team chat
+- RaidSharks (for context on raids)
+- Skip: broadcasted-only groups (no user input)
+
+### Data Shape
+
+Bonfire ingest_content endpoint (from doc 544 curl example):
+
+```json
+{
+  "content": "string",
+  "bonfire_id": "69f13a649469bbc15bf61c10",
+  "title": "string (first 60 chars of content)",
+  "metadata": {
+    "source": "telegram",
+    "from": "zaal",
+    "channel_type": "dm" | "group",
+    "group_name": "ZAO Devz" (optional),
+    "timestamp": "ISO8601"
+  }
+}
+```
+
+---
+
+## 2. Farcaster Capture
+
+### Setup: Neynar Webhook
+
+Neynar SDK already integrated at `src/lib/farcaster/neynar.ts`. Add webhook subscription:
+
+1. **Register webhook** (one-time, via Neynar dashboard or SDK):
+
+   ```typescript
+   // bot/src/zoe/farcaster-ingest.ts (new file)
+   
+   import { NEYNAR_API_KEY } from '@/lib/env';
+   
+   async function registerWebhook() {
+     const res = await fetch('https://api.neynar.com/v2/farcaster/webhooks', {
+       method: 'POST',
+       headers: {
+         'x-api-key': NEYNAR_API_KEY,
+         'Content-Type': 'application/json',
+       },
+       body: JSON.stringify({
+         target_url: 'https://zaoos.com/api/farcaster/webhook', // or VPS IP + path
+         events: ['cast.created'],
+         target_user_fid: 2915, // Zaal's FID
+       }),
+     });
+     const data = await res.json();
+     console.log('Webhook registered:', data.webhook_id);
+     return data.webhook_id;
+   }
+   ```
+
+2. **Receive webhook events** (on VPS):
+
+   ```typescript
+   // src/app/api/farcaster/webhook/route.ts
+   
+   import { NextRequest, NextResponse } from 'next/server';
+   
+   export async function POST(req: NextRequest) {
+     const body = await req.json();
+     
+     // body.data = { type: 'cast.created', cast: { text, channel, timestamp, hash, author } }
+     const { cast } = body.data;
+     if (!cast) return NextResponse.json({ ok: true });
+     
+     // Push to Bonfire
+     await pushToBonfire('farcaster', cast.text, {
+       channel: cast.channel?.id,
+       mentions: cast.mentions.map(m => m.username),
+       hash: cast.hash,
+       timestamp: cast.timestamp,
+     });
+     
+     return NextResponse.json({ ok: true });
+   }
+   ```
+
+3. **Push to Bonfire**:
+
+   ```typescript
+   // Inside farcaster-ingest.ts or webhook handler
+   
+   async function pushToBonfire(
+     source: 'farcaster',
+     text: string,
+     meta: { channel?: string; mentions?: string[]; hash?: string; timestamp?: string }
+   ) {
+     const res = await fetch('https://tnt-v2.api.bonfires.ai/ingest_content', {
+       method: 'POST',
+       headers: {
+         'Authorization': `Bearer ${process.env.BONFIRE_API_KEY}`,
+         'Content-Type': 'application/json',
+       },
+       body: JSON.stringify({
+         content: text,
+         bonfire_id: process.env.BONFIRE_ID,
+         title: `Cast: ${text.slice(0, 60)}`,
+         metadata: {
+           source: 'farcaster',
+           platform: 'farcaster',
+           channel: meta.channel,
+           mentions: meta.mentions,
+           cast_hash: meta.hash,
+           timestamp: meta.timestamp,
+         },
+       }),
+     });
+     if (!res.ok) console.error(`Farcaster ingest failed: ${res.status}`);
+   }
+   ```
+
+### Scope
+
+- **Include:** Casts authored by @zaal, replies to @zaal, casts in /poidh, /maine, /mindfulness channels (high-context for Zaal)
+- **Skip:** Recast-only (no original text), quote recasts with zero new commentary
+
+Cost: ~10 casts/day, ~200 tokens per cast = 2K tokens/day.
+
+---
+
+## 3. Voice (OpenWhisp Pipeline)
+
+### Setup
+
+Doc 560: OpenWhisp installed on Zaal's Mac. Hold Fn, speak, get text pasted into editor.
+
+**Flow:**
+
+1. OpenWhisp + Ollama on Mac produce a text file (or clipboard output)
+2. Pipe transcript to Bonfire via a simple wrapper script
+
+Example script:
+
+```bash
+#!/bin/bash
+# ~/bin/voice-to-bonfire.sh
+
+TRANSCRIPT="$1"  # text file or stdin
+TITLE=$(head -c 60 "$TRANSCRIPT")
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+curl -X POST https://tnt-v2.api.bonfires.ai/ingest_content \
+  -H "Authorization: Bearer $BONFIRE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @- <<EOF
+{
+  "content": "$(cat "$TRANSCRIPT" | jq -Rs .)",
+  "bonfire_id": "$BONFIRE_ID",
+  "title": "$TITLE...",
+  "metadata": {
+    "source": "voice",
+    "platform": "openwhisp",
+    "timestamp": "$TIMESTAMP",
+    "agent_id": "$BONFIRE_AGENT_ID"
+  }
+}
+EOF
+```
+
+**Integration point:** Call from `/newsletter` or `/onepager` skill (after voice-to-text, before final draft).
+
+Cost: ~20 min voice/day = 1 transcript, ~300 tokens. Negligible.
+
+### Deduplication Question
+
+**Risk:** If Zaal speaks a voice note AND then copies it as a Telegram message, Bonfire sees both. Does it dedupe?
+
+**Answer:** Bonfire SDK (doc 544) doesn't mention automatic content deduplication. Same text ingested twice = two separate entities in the graph.
+
+**Mitigation:**
+- Push voice transcripts with a dedicated source tag: `metadata.source = 'voice'`
+- Push Telegram messages with `source = 'telegram'`
+- Bonfire's LLM extraction should recognize semantic similarity during queries, but don't rely on it
+- Manual dedup during weekly memory cleanup (future Phase 2)
+
+---
+
+## 4. Ordering: Which Source First?
+
+### Ship Order (Difficulty scale 1-10, NOT time estimates)
+
+**Step 1: Telegram DM push** - Difficulty 4
+- Wire `pushToBonfire()` in `bot/src/zoe/index.ts` after existing `pushRecent()` call
+- Environment setup: Ensure `BONFIRE_API_KEY`, `BONFIRE_ID` on VPS (already set per task context)
+- Test: Send DM to @zaoclaw_bot, check Bonfire dashboard graph within 30 seconds
+- Gain: ~50 messages/day auto-captured. Immediate insight into daily decision-making
+
+**Step 2: Farcaster webhook** - Difficulty 6
+- Register Neynar webhook for `cast.created` on @zaal's FID
+- Wire `/api/farcaster/webhook` route to receive Neynar events
+- Test: Cast on Farcaster, check graph. Verify only @zaal's casts + mentions land (filter recast-only noise)
+- Gain: ~10 casts/day. Context about public positioning and social decisions
+
+**Step 3: Voice transcript push** - Difficulty 3
+- Wire voice-to-bonfire.sh script
+- Hook into `/newsletter` or `/onepager` skill to call the script post-transcription
+- Test: Dictate a note via OpenWhisp, check Bonfire
+- Gain: ~1 transcript/day. Captures raw thinking before refinement
+
+**Rationale:** Start with Telegram (ZOE already processes it, lowest friction). Add Farcaster webhook (requires webhook setup but proven Neynar integration). Voice last (smallest volume, easiest to add later without breaking other flows).
+
+---
+
+## 5. Cost Model
+
+Bonfire pricing (https://bonfires.ai/pricing): Genesis tier custom. Doc 544 confirms no published per-tier rate limits.
+
+**Estimated daily token cost:**
+
+| Source | Volume | Tokens/unit | Daily Total |
+|---|---|---|---|
+| Telegram DMs | 50 msgs | 100 tokens | 5K |
+| Telegram groups | 30 msgs | 100 tokens | 3K |
+| Farcaster casts | 10 casts | 200 tokens | 2K |
+| Voice transcript | 1 file | 300 tokens | 300 |
+| **Total** | — | — | ~10.3K tokens/day |
+
+At $10/1M tokens (rough API pricing guess; Bonfire is opaque), ~$0.10/day or ~$3/month incremental.
+
+**Note:** Bonfire's Genesis tier is fixed-cost, not metered. Pushing this volume (10K tokens/day) likely has zero additional cost if Zaal's tier already covers it. Confirm with Joshua.eth before shipping.
+
+---
+
+## Sources
+
+- Bonfire API docs: https://tnt-v2.api.bonfires.ai (ingest_content endpoint, bearer-token auth)
+- Neynar webhooks: https://docs.neynar.com (cast.created event type)
+- ZOE entry point: `bot/src/zoe/index.ts` (grammy on('message:text') handler at line ~104)
+- Bonfire wiring guide: doc 544 (SDK config, HTTP API examples)
+- OpenWhisp voice-to-text: doc 560 (local Whisper + Ollama, macOS Fn-key UX)
+- Existing Farcaster wrapper: `src/lib/farcaster/neynar.ts` (headers, fetchWithFailover pattern)

--- a/research/agents/620-bonfire-push-everything/620b-static-source-ingest.md
+++ b/research/agents/620-bonfire-push-everything/620b-static-source-ingest.md
@@ -1,0 +1,248 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 547, 613, 614, 615, 618, 619, 620
+tier: STANDARD
+parent-doc: 620
+---
+
+# 620b — Static-source ingest (research docs, memory files, drafts, archives)
+
+> **Goal:** Catalog static sources (files, docs, archives on disk) and recommend push strategy to Bonfire knowledge graph so Zaal's recall system never goes stale.
+
+## Decision Matrix: Push Strategy per Source
+
+| Source | Count | Type | Recommendation | Reasoning | Difficulty |
+|--------|-------|------|---|-----------|------------|
+| **Research docs** (`research/` all subdirs) | 740 | markdown | **CRON nightly** vector-only + **HOOK on new/changed** full-graph | Vector-only cheap for mass updates; full-graph linkage rich for hot docs. 740 files too large for backfill in one call. | 6 |
+| **Memory files** (`~/.claude/.../memory/`) | 135 | yaml+md | **BACKFILL-ONCE** full-graph, then **CRON hourly** diff | 135 files is one-shot backfill cost. These are Zaal's operating facts — must be in Bonfire or recall is useless. | 4 |
+| **Newsletter drafts** (`~/.zao/zoe/newsletters/` on VPS) | rolling daily | markdown | **HOOK on write** to ZOE newsletter agent | Date-stamped entry after Whisper processing. Post as Document with {date, voice: zabal-y1, source: newsletter}. | 5 |
+| **Voice transcripts** (Whisper `.txt` on VPS) | rolling | plaintext | **WATCHER on file creation** in `~/.zao/zoe/transcripts/` | Distinct from live stream (sub-agent 1). File-based after Whisper writes. Ingest as Document {date, transcript: true, source: whisper}. | 3 |
+| **GitHub artifacts** (PRs, commits, issues) | rolling | structured | **WEBHOOK from GitHub** (or **CRON hourly** `gh` CLI) | Hermes auto-fix PRs are facts ("fixed X on Y"). Pull via gh API, push as Relation (Commit -describes- CodeChange). Rich for traceability. | 7 |
+| **External archives** (Telegram, Farcaster, Pinboard, Lu.ma) | one-time bulk | json/export | **BACKFILL-ONCE per archive** | Telegram `recent.json` (rolling) + older exports. Farcaster cast history via Neynar bulk. Browser bookmarks. One-shot load, no ongoing sync unless Zaal exports new data. | 8 |
+
+---
+
+## Source-by-Source Implementation Path
+
+### 1. Research Docs (`research/`, 740 files across 10+ topic folders)
+
+**Structure:**
+- Each numbered doc like `280-fid-registration-x402-deep-dive/README.md`
+- YAML frontmatter in first comment block (rare; most just start with H1)
+- Content: full markdown body (2-50 KB typical)
+
+**Bonfire Ingest Plan:**
+1. **Backfill-once (difficulty 3):** Script walk of `research/*/README.md`, extract title (first H1), frontmatter if present, full body. Batch into ~50 docs per POST /ingest_content_vector_only call (cheaper). Creates 740 Document nodes indexed by title + research-topic metadata.
+2. **Nightly cron diff (difficulty 4):** After backfill, `git diff --name-only` on the research/ folder nightly. If any `.md` changed, re-ingest as vector-only (fast). If new doc numbered >current-max, do full-graph ingest (links relations to 620 parent).
+3. **Git hook on commit (difficulty 5):** Pre-push hook checks `git diff HEAD~1` for research/ changes. If found, queue ingest job to async worker (defer to next morning to avoid blocking push).
+
+**Payload shape (vector-only for nightly):**
+```json
+{
+  "content": "[full markdown body]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "280 - FID Registration...",
+  "metadata": {
+    "doc_number": 280,
+    "source": "research",
+    "path": "research/agents/280.../README.md",
+    "topic": "agents",
+    "related": [281, 288, 289]
+  }
+}
+```
+
+**Why vector-only for nightly:** 740 docs is manageable as searchable entities, but full-graph (extracting entities + relations from each doc body) takes ~10-30sec per doc. Nightly = vector index + title is enough for recall; full-graph on new/hot docs when Zaal cares.
+
+---
+
+### 2. Memory Files (`~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/`, 135 files)
+
+**Structure:**
+- Each file has YAML frontmatter: `name`, `description`, `type` (project / user / feedback / reference), optional `originSessionId`
+- Body: markdown facts (1-5 KB typical)
+- Index at `MEMORY.md` lists all 135 with 1-line synopsis
+
+**Bonfire Ingest Plan:**
+1. **Backfill-once (difficulty 3):** Read entire memory/ folder, parse YAML frontmatter of each file, extract title (from `name` field) + body. POST each as full-graph (not vector-only) because these ARE entities — user facts, project decisions, feedback patterns. Create 135 Entity nodes typed by frontmatter `type` field.
+2. **Cron hourly diff (difficulty 4):** After backfill, check `ls -la ~/.claude/.../memory/` and md5-hash each file. If hash changed, re-ingest that one file as full-graph. If new file created, ingest as full-graph. Goal: keep Bonfire's user/project/feedback entities in-sync with local memory without waiting for human review.
+
+**Payload shape (full-graph for memory):**
+```json
+{
+  "content": "[markdown body]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "Hermes is the canonical agent framework for ZAO",
+  "metadata": {
+    "type": "project",
+    "source": "memory",
+    "path": "~/.claude/.../memory/project_hermes_canonical.md",
+    "originSessionId": "cf4c6640...",
+    "relatedMemories": ["project_zoe_v2_redesign", "project_ollama_local_llm"]
+  }
+}
+```
+
+**Critical:** Memory files must go into Bonfire FIRST before research docs or other ingest. These are the ground truth. Zaal's recalls won't work without them. Prioritize as P0 backfill.
+
+---
+
+### 3. Newsletter Drafts (`~/.zao/zoe/newsletters/<date>.md` on VPS)
+
+**Structure:**
+- Daily entry generated by ZOE newsletter agent after 6am EST
+- Date-stamped filename: `2026-05-06.md`, `2026-05-07.md`
+- Content: 300-800 words, first-person voice (zabal-y1 persona)
+
+**Bonfire Ingest Plan:**
+1. **Hook on ZOE write (difficulty 4):** After ZOE newsletter agent writes `~/.zao/zoe/newsletters/<date>.md`, file-watcher triggers ingest. POST /ingest_content with full body. Creates Document node with metadata `{voice: zabal-y1, source: newsletter, date: 2026-05-06}`. Links to Bonfire agent UUID `69f13a649469bbc15bf61c10` as author.
+2. **Backfill rolling history (difficulty 3):** At session start, ls `newsletters/` for last 30 days, check which already in Bonfire (via Bonfire search), backfill missing. Keep in sync with no more than 2-day lag.
+
+**Payload shape:**
+```json
+{
+  "content": "[markdown newsletter body]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "Daily reflection - 2026-05-06",
+  "metadata": {
+    "date": "2026-05-06",
+    "voice": "zabal-y1",
+    "source": "newsletter",
+    "bonfire_agent_author": "69f13a649469bbc15bf61c10"
+  }
+}
+```
+
+---
+
+### 4. Voice Transcripts (Whisper output `.txt` on VPS)
+
+**Structure:**
+- After Whisper processes audio (ZOE voice capture), writes `~/.zao/zoe/transcripts/<timestamp>.txt`
+- Plain text, ~500-2000 words per session
+- Rolling, new file every voice-session (typically 1-3x daily)
+
+**Bonfire Ingest Plan:**
+1. **Watcher on file creation (difficulty 3):** inotifywait or systemd file-trigger on `transcripts/` directory. When new `.txt` created, POST /ingest_content. Document node with metadata `{source: whisper, timestamp, duration_approx}`. Link to session transcript chain.
+2. **No backfill needed.** Transcripts are live-going-forward. If Zaal wants past transcripts in Bonfire, explicit export request.
+
+**Payload shape:**
+```json
+{
+  "content": "[plain-text transcript]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "Voice transcript - 2026-05-06T14:32:11Z",
+  "metadata": {
+    "source": "whisper",
+    "timestamp": "2026-05-06T14:32:11Z",
+    "model": "whisper-large-v3",
+    "language": "en"
+  }
+}
+```
+
+---
+
+### 5. GitHub Artifacts (PRs, commits, issue comments)
+
+**Structure:**
+- Hermes auto-fix PRs (`#470+`) with title + body describing the fix
+- Commit messages on `ws/` branches (rich context)
+- Issue comments linking decisions to trackers
+- All accessible via `gh api repos/zaalpanthaki/ZAO\ OS\ V1/...`
+
+**Bonfire Ingest Plan:**
+1. **Cron hourly `gh` walk (difficulty 6):** Every hour, run `gh pr list --state all --json title,body,number,url,mergedAt` + `gh issue list --state all --json title,body`. Filter for last-modified in past hour. POST each PR/issue as Document (full-graph to extract commit links, assignee mentions). Creates Relation between (Commit) -authored-by- (Zaal) -fixes- (Issue). Rich for agent traceability ("what did Hermes fix?").
+2. **GitHub webhook (difficulty 7):** Alternatively, POST https://bonfire-ingest.zaoos.com/github-webhook on every push/PR/issue event. More real-time but requires endpoint auth + secret.
+
+**Payload shape (from PR):**
+```json
+{
+  "content": "[PR title + body]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "PR #470 — fix(zoe): close stdin on claude CLI spawn",
+  "metadata": {
+    "source": "github",
+    "type": "pull_request",
+    "number": 470,
+    "mergedAt": "2026-05-04T18:22:11Z",
+    "branch": "ws/research-607-three-bot-substrate",
+    "relatedIssues": [607]
+  }
+}
+```
+
+---
+
+### 6. External Archives (Telegram, Farcaster, Pinboard, Lu.ma, browser bookmarks)
+
+**Structure:**
+- Telegram: `~/.zao/zoe/recent.json` (rolling last-N messages) + older exports from Telegram Desktop
+- Farcaster: cast history via Neynar `GET /v2/farcaster/casts/user` bulk endpoint
+- Pinboard/Raindrop: JSON export
+- Lu.ma: RSVP/attended event list via personal export
+- Browser: bookmarks.html or .json from Firefox/Safari
+
+**Bonfire Ingest Plan:**
+1. **Backfill-once per archive (difficulty 4-8 depending on source).** For each archive type, write a one-time ingest script:
+   - **Telegram:** Read `recent.json` + any older `.json` exports. Group by date. POST as Document per day or per thread, metadata `{source: telegram, channel: @...}`.
+   - **Farcaster:** Call Neynar bulk endpoint for all casts by Zaal FID 19640 (or similar), POST as Document per cast, metadata `{source: farcaster, cast_hash, reactions, replies_count}`.
+   - **Pinboard/bookmarks:** Parse JSON, POST as Document per bookmark cluster (by tag), metadata `{source: pinboard, tags: [...], added_at}`.
+   - **Lu.ma:** Export event RSVPs, POST as Document per event attended, metadata `{source: luma, event_date, event_name, location}`.
+2. **No ongoing sync.** Archives are one-shot backfill. If Zaal later exports new data, manual trigger to re-ingest.
+
+**Example payload (Telegram):**
+```json
+{
+  "content": "[concatenated messages from 2026-05-06, preserving timestamps]",
+  "bonfire_id": "BONFIRE_ID",
+  "title": "Telegram messages - 2026-05-06",
+  "metadata": {
+    "source": "telegram",
+    "date": "2026-05-06",
+    "message_count": 47,
+    "from_channels": ["@zaalp99", "@bettercallzaal"]
+  }
+}
+```
+
+---
+
+## 3-Step Ship Order
+
+**Difficulty 1-10 scale (not time estimates).**
+
+1. **Backfill Memory Files + initial research docs (difficulty 4):**
+   - Write `bot/src/zoe/bonfire-ingest.ts` with functions: `ingestMemoryFiles()` (reads 135 files), `ingestResearchDocs()` (batches 740 files, vector-only).
+   - Test against staging Bonfire (use test bonfire_id if available, else create new one).
+   - Run once, verify 875 nodes created in Bonfire.
+
+2. **Wire cron jobs + git hooks (difficulty 5):**
+   - Add systemd timer: `/etc/systemd/user/bonfire-nightly.timer` runs `bonfire-ingest.ts nightly-diff` at 2am EST.
+   - Add pre-push hook: `.git/hooks/pre-push` checks for research/ changes, queues full-graph re-ingest to async worker (don't block push).
+   - Add file-watcher for `~/.zao/zoe/newsletters/` and `transcripts/` (use systemd path unit or inotifywait in ZOE subprocess).
+
+3. **One-time archive backfill (difficulty 6):**
+   - Write `scripts/backfill-bonfire-archives.ts` with handlers for each archive type (Telegram, Farcaster, bookmarks).
+   - Dry-run on subset of Telegram messages, verify shape matches Bonfire /ingest_content schema.
+   - Run once for each archive type, log backfill completion to `~/.zao/zoe/bonfire-backfill.log`.
+
+---
+
+## Notes & Trade-offs
+
+- **Vector-only vs full-graph:** Vector-only = fast, scalable, good for retrieval; full-graph = slow, rich, good for semantic navigation. Mix: vector-only for nightly diffs, full-graph for hot docs + memory files.
+- **Backfill timing:** Memory files MUST backfill before research docs or Zaal's recall will be incomplete. Schedule memory-backfill as prerequisite.
+- **De-duplication:** Bonfire API likely handles via title + content hash. Test on 2-3 files first before bulk backfill.
+- **Offline workflow:** If Bonfire API is down, queue ingests to local SQLite (at `~/.zao/zoe/bonfire-queue.db`), retry on next sync. Don't lose data.
+
+---
+
+## Sources
+
+- Bonfire OpenAPI spec: https://tnt-v2.api.bonfires.ai/docs (requires Genesis tier auth)
+- GitHub webhook events: https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks
+- inotifywait documentation: https://linux.die.net/man/1/inotifywait

--- a/research/agents/620-bonfire-push-everything/620c-privacy-dedup-cost.md
+++ b/research/agents/620-bonfire-push-everything/620c-privacy-dedup-cost.md
@@ -1,0 +1,346 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 547, 568, 613, 615, 618, 619, 620
+tier: STANDARD
+parent-doc: 620
+---
+
+# 620c — Privacy, dedup, cost (operational layer for auto-ingest)
+
+> **Goal:** Define operational safeguards for auto-pushing everything to Bonfire knowledge graph. Prevent privacy leaks, avoid duplicate facts, track cost, maintain audit trail.
+
+---
+
+## Decision Matrix: Operational Concerns
+
+| Concern | Chosen Approach | Rationale |
+|---------|-----------------|-----------|
+| **Redaction** | Regex-strip before push (5 patterns) + human consent gate for Telegram group messages | API keys / wallet keys / .env never push. Third-party PII in group chats requires explicit opt-in. |
+| **Dedup** | Client-side content hash (local SQLite) + Bonfire server-side title+metadata merge | Avoid 740 research doc backfill duplicating facts. Bonfire schema assumes similar entities merge by vector similarity. |
+| **Cost** | Vector-only for nightly diffs + full-graph for new docs. Est. 30-50K chars/day = USD 0.30-1.50/day. | Daily volume < 1M chars. Full-graph on all sources would run 10-15x higher cost. Mix strategy = 80% cost saving. |
+| **Audit trail** | jsonl log at `~/.zao/zoe/bonfire-pushes.log` (timestamp, source, hash, job_id, bytes) | Trace what went in, debug recall gaps, detect private-data leaks post-hoc, count against budget. |
+| **Rate limiting** | Serialize jobs: max 3 active at once. Exponential backoff on 5xx; skip on 4xx. | Bonfire API async. Never exceed job concurrency per /jobs/active endpoint. Fail safe: log and move on. |
+| **Two-graph question** | ONE Bonfire: Zaal's personal graph. Research docs stay in same graph + tagged with `source: research`. | Cross-bonfire recall is not yet supported. Mixed graph is acceptable: Zaal owns both dimensions. Delineate with metadata only. |
+
+---
+
+## 1. Privacy + Redaction Layer
+
+### Secrets That Must Never Push
+
+1. **API Keys:** `sk-ant-*`, `sk-*` (OpenAI pattern), `NEYNAR_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`
+2. **Wallet Private Keys:** `0x[a-fA-F0-9]{64}` (full Ethereum private key pattern)
+3. **Session Secrets:** `SESSION_SECRET`, `APP_SIGNER_PRIVATE_KEY` (from `.env`)
+4. **Tokens & Credentials:** `[A-Z0-9_]{20,}=` (generic base64 token pattern), GitHub PAT (`ghp_[A-Za-z0-9]{36}`)
+5. **PII without consent:** Email addresses, US phone numbers, names of people who did not consent to third-party graph
+
+### Redaction Regex Patterns (PCRE)
+
+```
+# Anthropic API keys
+sk-ant-[A-Za-z0-9_-]{20,}
+
+# OpenAI/similar keys
+sk-[A-Za-z0-9]{32,}
+
+# Ethereum private keys (64-char hex)
+(?:0x)?[0-9a-fA-F]{64}
+
+# Generic long tokens (env-var style)
+[A-Z_]{10,}=[A-Za-z0-9/_-]{20,}
+
+# GitHub PAT
+ghp_[A-Za-z0-9]{36}
+
+# Email (to redact from group messages)
+[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
+
+# US Phone (to redact from group messages)
+(?:\+1)?[-.\s]?(?:\(\d{3}\))?[-.\s]?\d{3}[-.\s]?\d{4}
+```
+
+**Implementation:**
+
+```typescript
+// bot/src/zoe/redact.ts
+export function redactSecrets(content: string): string {
+  const patterns = [
+    /sk-ant-[A-Za-z0-9_-]{20,}/g,
+    /sk-[A-Za-z0-9]{32,}/g,
+    /(?:0x)?[0-9a-fA-F]{64}/g,
+    /[A-Z_]{10,}=[A-Za-z0-9/_-]{20,}/g,
+    /ghp_[A-Za-z0-9]{36}/g,
+  ];
+  
+  let redacted = content;
+  patterns.forEach(pattern => {
+    redacted = redacted.replace(pattern, '[REDACTED]');
+  });
+  
+  return redacted;
+}
+```
+
+### Consent Gate: Group Messages
+
+**Decision:** Push only Zaal's outbound messages to Telegram group chats. Never push others' inbound messages without explicit opt-in (add field `source: telegram_outbound_zaal_only` to metadata).
+
+**Rationale:** Prevents accidental disclosure of private DMs, team discussions, or other members' thoughts to third-party KG. Zaal can still recall his own questions + decisions; the graph is lower-fidelity for multi-user threads but privacy-respecting.
+
+**Implementation:**
+- Telegram ingest script checks `message.from_user.id` == Zaal's Telegram user ID
+- Only push if true. Skip all inbound messages.
+- Log skipped count daily: `"2026-05-06: ingested 23 of 47 Telegram messages (24 skipped — not Zaal)"` to `bonfire-pushes.log`
+
+### PII Redaction for Research Docs
+
+Research docs may reference real people (e.g., "Steve Peer", "Matteo Tambussi") + contract terms (e.g., "$20K budget"). Default: push as-is. If doc marked `[PRIVATE]` in title or frontmatter, skip.
+
+---
+
+## 2. Dedup Strategy
+
+### Bonfire Server-Side Dedup
+
+Query `/openapi.json` reveals `/ingest_content` has NO explicit dedup or merge logic. Test assumption: Bonfire merges entities by vector similarity (KG standard). Re-ingesting the same content (same title + content hash) likely results in vector-index update, not duplication in the graph itself. **Action item:** Ask Joshua.eth to confirm.
+
+### Client-Side Dedup: Content Hash
+
+**Storage:** `~/.zao/zoe/bonfire-dedup.sqlite`
+
+```sql
+CREATE TABLE bonfire_pushes (
+  id INTEGER PRIMARY KEY,
+  source TEXT NOT NULL,
+  path TEXT,
+  content_hash TEXT NOT NULL UNIQUE,
+  title TEXT,
+  bonfire_id TEXT,
+  job_id TEXT,
+  pushed_at DATETIME,
+  char_count INTEGER,
+  metadata_json TEXT
+);
+
+CREATE INDEX idx_source ON bonfire_pushes(source);
+CREATE INDEX idx_path ON bonfire_pushes(path);
+```
+
+**Before each push:**
+1. Compute `SHA256(content_string)` -> `content_hash`
+2. Query: `SELECT COUNT(*) FROM bonfire_pushes WHERE content_hash = ?`
+3. If found: skip (log: `"doc-547 already pushed 2026-05-06T14:22:11Z"`)
+4. If not found: push and INSERT row with timestamp + job_id
+
+**For backfill scenario (740 research docs):**
+- Walk `research/*/README.md`, compute hashes for all
+- Batch into 50-doc POST calls to `/ingest_content_vector_only` (cheaper)
+- INSERT rows for each batch, atomically
+- Expected: 740 new rows, ~30-60 seconds total backfill time
+
+**For nightly diff:**
+- `git diff --name-only research/` yesterday -> today
+- For each changed file, re-compute hash, check table
+- If changed: re-push (hash will differ)
+- Result: update existing row or insert new row
+
+### Soft Dedup: Entity Merge by Bonfire
+
+Within the graph, "Steve Peer" appears in research docs #476, #582, #590. Bonfire's KG should merge these into one entity with 3 Document links. Verify by:
+1. After backfill, query Bonfire's `/agents/{id}/chat` with "who is Steve Peer?"
+2. Expect ONE entity node, 3 related documents, not 3 separate "Steve Peer" nodes.
+
+---
+
+## 3. Cost Model
+
+### Daily Push Volume Estimate
+
+| Source | Frequency | Volume | Chars | Notes |
+|--------|-----------|--------|-------|-------|
+| **Telegram** | 50 msgs/day avg | 200 chars/msg | 10K | `~/.zao/zoe/recent.json` rolling |
+| **Farcaster casts** | 10 casts/day | 500 chars/cast | 5K | Zaal FID 19640 only |
+| **Voice transcripts** | 20 min/day | 150 wpm | 18K | Whisper output, ~1 file/day |
+| **Newsletter draft** | 1/day | 1500 chars | 1.5K | ZOE agent output |
+| **Memory file edits** | 0-3/day | 5K chars avg | 0-15K | Sporadic updates |
+| **Research doc changes** | 2-5 new/day | 8K avg | 16-40K | Nightly vector-only ingest |
+| **SUBTOTAL** | — | — | **50-90K chars** | ~15-30K tokens equiv. |
+
+### Pricing Estimate (Bonfire Private — Ask Joshua.eth)
+
+Based on comparable services (Cognee, Graphiti, LightRAG), typical pricing:
+- **Vector-only ingest:** USD 0.001-0.005 per 1K chars (cheap indexing)
+- **Full-graph ingest:** USD 0.01-0.05 per 1K chars (entity extraction + linking)
+
+**Conservative estimate (mid-tier):**
+- 30K chars vector-only @ 0.003/1K = USD 0.09/day
+- 20K chars full-graph @ 0.02/1K = USD 0.40/day
+- **Total: USD 0.50/day = USD 15/month**
+
+**Worst case (aggressive ingest, all full-graph):**
+- 90K chars full-graph @ 0.05/1K = USD 4.50/day = USD 135/month
+
+**Strategy to stay low:**
+- Nightly diffs: always vector-only (saves 4-5x)
+- New docs: full-graph only if user marks as "important"
+- Research backfill: vector-only (1-time cost ~USD 3)
+- Query API: typically free or bundled in Genesis tier
+
+**Genesis tier status:** Zaal already pays (confirmed in prior research). Estimate is incremental cost above base subscription.
+
+---
+
+## 4. Audit Trail
+
+### Push Log Schema
+
+File: `~/.zao/zoe/bonfire-pushes.log` (jsonl format, one JSON object per line)
+
+```json
+{
+  "timestamp": "2026-05-06T14:22:11.345Z",
+  "source": "research",
+  "path": "research/agents/620-bonfire-push-everything/README.md",
+  "title": "620 — Auto-push everything to Bonfire knowledge graph",
+  "content_hash": "sha256:a3f5e2c...",
+  "char_count": 8234,
+  "bonfire_id": "BONFIRE_ID",
+  "job_id": "job_12345abc",
+  "ingest_type": "vector_only",
+  "status": "queued",
+  "retry_count": 0,
+  "notes": ""
+}
+```
+
+### Log Lifecycle
+
+1. **Pre-push:** Write entry with `status: queued`, `job_id: null`
+2. **Post-push:** GET `/jobs/{job_id}/status`, update entry with `job_id`, `status: processing`
+3. **Poll completion:** When job status = `completed`, update `status: success`
+4. **Failure:** Update `status: failed`, add `error_message` field, increment `retry_count`
+
+### Retention
+
+- Keep all logs indefinitely (cheap to store).
+- Rotate log file daily: `bonfire-pushes.log` -> `bonfire-pushes.log.2026-05-05`, etc.
+- Optional: sync to Supabase table `bonfire_audit` for dashboard query (read-only).
+
+### Analysis Queries
+
+```bash
+# Count pushes by source, last 7 days
+jq 'select(.timestamp > "2026-04-29") | .source' bonfire-pushes.log | sort | uniq -c
+
+# Find failed pushes
+jq 'select(.status == "failed")' bonfire-pushes.log
+
+# Estimate daily cost
+jq 'select(.timestamp | startswith("2026-05-06")) | .char_count' bonfire-pushes.log | \
+  awk '{s+=$1} END {print s " chars, est. USD " (s*0.00003)}'
+```
+
+---
+
+## 5. Rate Limiting + Backoff
+
+### Job Concurrency Limit
+
+Query `/jobs/active` at start of each ingest batch. If `total >= 3`, wait before pushing new job.
+
+```typescript
+async function waitForCapacity() {
+  const maxConcurrent = 3;
+  
+  while (true) {
+    const res = await fetch('https://tnt-v2.api.bonfires.ai/jobs/active', {
+      headers: { Authorization: `Bearer ${BONFIRE_TOKEN}` },
+    });
+    const { total } = await res.json();
+    
+    if (total < maxConcurrent) break;
+    console.log(`Bonfire has ${total} active jobs, waiting...`);
+    await sleep(5000); // 5s poll
+  }
+}
+```
+
+### Backoff Strategy
+
+- **5xx (server error):** Exponential backoff: 2s, 4s, 8s, 16s, 32s (stop after 5 retries, then skip)
+- **4xx (client error):** Log error, skip (not Bonfire's fault; likely bad payload)
+- **Timeout (>30s):** Treat as 5xx, retry
+
+```typescript
+async function ingestWithBackoff(payload, maxRetries = 5) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const res = await fetch('https://tnt-v2.api.bonfires.ai/ingest_content', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${BONFIRE_TOKEN}` },
+        body: JSON.stringify(payload),
+      });
+      
+      if (res.status >= 500) throw new Error(`5xx: ${res.status}`);
+      if (res.status >= 400) {
+        console.error(`4xx skipping: ${res.status}`, await res.text());
+        return; // Don't retry 4xx
+      }
+      
+      const { job_id } = await res.json();
+      return job_id;
+    } catch (err) {
+      const backoffMs = Math.pow(2, attempt) * 1000;
+      console.log(`Retry ${attempt + 1}/${maxRetries} in ${backoffMs}ms:`, err.message);
+      await sleep(backoffMs);
+    }
+  }
+  
+  throw new Error('Max retries exceeded');
+}
+```
+
+---
+
+## 6. One Bonfire or Two? Zaal Personal + ZAO Public
+
+### Decision: ONE Bonfire (Zaal's personal)
+
+**Reasoning:**
+1. **Cross-recall today:** Bonfire does not support querying across multiple graphs (no federation). If research docs + memory files were split, Zaal's recall for "what context do I have on Steve Peer?" would need two API calls + manual merge.
+2. **Access simplicity:** Genesis tier is one graph. Spinning up a second bonfire means separate billing, separate API keys, separate auth flow.
+3. **Delineation by metadata:** Instead of two graphs, tag everything: `source: research`, `source: memory`, `source: personal`. Zaal can filter later.
+
+**Future consideration (post-doc-620):** If ZAO research docs grow to 1500+ and Zaal wants a PUBLIC searchable ZAO knowledge graph (for community discovery, not recall), consider:
+- Standalone Bonfire for ZAO Public (subset of research docs, no memory files, no personal casts)
+- Bonfire API gateway at `/zao-research` that pushes to Public graph only
+- Would require consent filtering: only ingest docs marked `[PUBLIC]`
+
+**For now:** One graph, metadata-driven access control.
+
+---
+
+## 7. Pre-Push Checklist (Before First Backfill)
+
+Before shipping `bot/src/zoe/bonfire-ingest.ts`:
+
+- [ ] `.env` has `BONFIRE_ID` + `BONFIRE_TOKEN` (never check in; SSH only)
+- [ ] Redaction layer tested on 5 real research docs (no false positives)
+- [ ] Consent gate implemented: Telegram group messages skip by default
+- [ ] Dedup table created at `~/.zao/zoe/bonfire-dedup.sqlite`
+- [ ] Backoff logic tested with simulated 5xx failures
+- [ ] Audit log template tested (write one entry, verify jsonl format)
+- [ ] Rate limit check implemented (`/jobs/active` poll)
+- [ ] Dry run on 10 research docs to staging Bonfire (if available)
+- [ ] Cost estimate re-verified with Joshua.eth before bulk backfill
+
+---
+
+## Sources
+
+- Bonfire OpenAPI spec: https://tnt-v2.api.bonfires.ai/openapi.json (endpoints `/ingest_content`, `/jobs/active`, `/insights/costs`)
+- Secret hygiene reference: `.claude/rules/secret-hygiene.md` (five-guard pattern)
+- Comparable KG services: doc 568 (Khoj, Reor, LightRAG, Cognee pricing patterns)

--- a/research/agents/620-bonfire-push-everything/620d-recall-feedback-loop.md
+++ b/research/agents/620-bonfire-push-everything/620d-recall-feedback-loop.md
@@ -1,0 +1,308 @@
+---
+title: 620d - Recall feedback loop (closing the loop on auto-push)
+topics:
+  - agents/bonfire
+  - agents/recall
+type: guide
+status: research-complete
+last_validated: 2026-05-06
+related_docs:
+  - 547
+  - 615
+  - 618
+  - 619
+  - 620
+  - 620b
+tier: STANDARD
+parent_doc: 620
+---
+
+# 620d - Recall feedback loop (closing the loop on auto-push)
+
+Auto-push everything Zaal does to Bonfire is useless if recall returns empty. This doc closes the feedback loop: how ZOE integrates recall into content generation, how to measure if the graph is actually getting smarter, and what to fix when it isn't.
+
+## Decision table
+
+| Concern | Approach | Why |
+|---------|----------|-----|
+| Auto-recall during draft | Wire recall() into every newsletter/social/doc agent BEFORE prompt goes to Claude | Newsletter agent (620.ts) already calls loadBonfireContext(topic). Pattern: don't block on empty reply; log gap + continue. |
+| Multi-hop queries | Trust Bonfire agent config server-side; it handles multi-hop. ZOE only sends "who is X?" and agent synthesizes via graph traversal. | LangGraph chat endpoint supports graph_mode=adaptive (default). No need for two-stage client-side retrieval today. |
+| Confidence + grounding | Prompt Bonfire agent UI config to append "Sources: [doc IDs]" to every reply. ZOE parses + shows. Manual review only until grounding lands. | Without source nodes, recall output is unreliable for auto-publish. Add grounding requirement to Bonfire setup sprint (doc 620a). |
+| Negative-result handling | Reply explicitly: "(graph has no info on X yet)". Offer to push new fact. Log gap to ~/.zao/zoe/recall-gaps.jsonl. | Closes the loop: Zaal sees what the graph doesn't know + can seed it. Gaps file → priority for next push batch. |
+| Measuring success | Track 3 metrics: recall hit rate (% non-empty), node count over time (via /insights), Zaal's qualitative feel. Report in morning brief. | Quantitative gives signal; qualitative confirms value. Morning brief = daily check-in Zaal already sees. |
+| Two-stage retrieval | Defer. Single-stage (chat endpoint) sufficient today. Revisit if synthetic hallucination becomes visible. | Bonfire's LangGraph agent already routes to vector search + KG blending via graph_mode. No API call reduction justifies added complexity. |
+
+---
+
+## 1. Auto-recall during draft (close the loop)
+
+Today: ZOE calls recall() only when Zaal types `@recall <query>`.
+
+**Change:** Every content-generation agent (newsletter, social, research doc) calls recall(topic) BEFORE giving the prompt to Claude.
+
+**Example (already live):** `bot/src/zoe/agents/newsletter.ts` lines 149-167.
+
+```typescript
+async function loadBonfireContext(topic: string): Promise<string> {
+  if (!process.env.BONFIRE_API_KEY || !process.env.BONFIRE_AGENT_ID) {
+    return '(Bonfire not configured)';
+  }
+  try {
+    const result = await recall({
+      query: topic.length < 200 ? topic : topic.slice(0, 200),
+      reason: 'newsletter context grounding',
+      expected_kind: 'mixed',
+    });
+    if (result.kind === 'sdk_response' || result.kind === 'mcp_response') {
+      return (result.text ?? '').slice(0, 1500) || '(empty Bonfire reply)';
+    }
+    return '(manual relay path - Bonfire not auto-queryable)';
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `(Bonfire query failed: ${msg.slice(0, 120)})`;
+  }
+}
+```
+
+**Key behaviors:**
+- Rate budget: 1 call per draft, not per paragraph.
+- Graceful no-op if BONFIRE_API_KEY missing (manual relay path continues).
+- Empty reply doesn't block draft: "Bonfire context: (empty Bonfire reply)" goes into the prompt so Claude knows the graph has no data yet.
+- Timeout: 120 char error message preserved to avoid cascade failures.
+
+**Wiring priority order (doc 620's §5.2 ship checklist):**
+1. Newsletter agent (LIVE)
+2. Social agent (when it lands; reserved for per-platform captions)
+3. Research doc auto-generation (if added as part of doc 620c)
+
+---
+
+## 2. Multi-hop / topic expansion (server-side agent)
+
+Bonfire's LangGraph agent already handles multi-hop server-side via graph traversal. ZOE doesn't need to orchestrate multi-hop retrieval client-side.
+
+**Test scenarios - 5 query types Zaal would actually ask:**
+
+| Query | Expected behavior | Current support | Gap |
+|-------|-------------------|-----------------|-----|
+| a. "Who is Kenny?" | Entity lookup - return bio, role, past interactions | Yes (KG nodes are entities) | None unless Kenny mentions aren't in Bonfire yet |
+| b. "What did I commit to POIDH?" | Relationship + temporal - filter edges labeled "commitment" on POIDH project | Yes (LangGraph agent traverses edges) | Requires schema: node types (Person, Project, Commitment) + edge types (commits_to, mentioned_in, organized, decided_on) |
+| c. "When did I last talk about ZAOstock?" | Temporal + topic - return most recent dated entry mentioning ZAOstock | Partial (agent can filter by mention, but no sort-by-date without doc timestamps) | Bonfire ingest (620b) must tag every pushed doc with ISO timestamp |
+| d. "Show me everything about ZAOstock budget" | Topic cluster - return all nodes/edges in the ZAOstock subgraph | Yes (center_node_uuid parameter can anchor to ZAOstock node) | Requires ZAOstock to be a top-level KG entity, not buried in meeting notes |
+| e. "What did Kenny say about POIDH bounty review?" | Person + project intersection - filter Kenny's statements about POIDH | Yes (traverse Person-Project edges + filter statements) | Requires statement-level granularity (not just "mentioned in doc X") |
+
+**Bonfire-side config needed (doc 620a §1.3 schema sprint):**
+- Explicit node types: Person, Project, Decision, Event, Tool, Concept, Place.
+- Edge types: committed_to, organized, mentioned_in, referenced_in, decided, stated, witnessed.
+- Per-doc timestamp attachment (not just push datetime but Zaal's logical date).
+- Center node anchoring for topic clusters (ZAOstock = single root node, all ZAOstock data reachable via graph).
+
+**No two-stage retrieval needed today.** The LangGraph agent's graph_mode=adaptive already blends vector similarity (for semantic search) + node traversal (for multi-hop). Single API call; Bonfire handles the complexity.
+
+---
+
+## 3. Confidence + grounding (adding source citations)
+
+**Problem:** Bonfire's chat reply is synthesized text with no source node IDs or confidence scores. ZOE cannot tell "this is a hard fact" from "this is the agent's plausible synthesis."
+
+**Solution:**
+- Prompt Bonfire agent's system config (via Bonfire UI, not code) to ALWAYS append this footer to every reply:
+
+> Sources: [doc IDs or node UUIDs referenced]
+
+Example reply:
+```
+Kenny founded POIDH in 2024 as a clip-up bounty platform. The first bounty (ID 1151) went live May 27, 2026 with $1K cap.
+
+Sources: [doc-472-poidh-bounty-launch, person-kenny-uuid, project-poidh-node]
+```
+
+**ZOE-side parsing (add to recall.ts):**
+```typescript
+// Extract sources footer after reply text
+const sourcesMatch = text.match(/Sources:\s*\[([^\]]+)\]/);
+const sources = sourcesMatch ? sourcesMatch[1].split(',').map(s => s.trim()) : [];
+return { kind: 'sdk_response', query, text, sources, grounded: !!sources.length };
+```
+
+**Auto-publish gate:**
+- WITHOUT grounding (sources field empty): log "ungrounded reply" to audit trail. Use recall output for DRAFT ONLY. Zaal manually reviews before publishing.
+- WITH grounding (sources populated): append sources to social post footnote or newsletter endnote. Safe for auto-publish after Zaal flips the switch on content quality (doc 620, §5.5 pre-condition).
+
+**Grounding sprint:** Add to Bonfire setup doc (doc 620a) as week-1 task.
+
+---
+
+## 4. Negative-result handling (close the feedback loop)
+
+When Bonfire returns "I don't know about X":
+
+1. **Tell Zaal explicitly.** ZOE replies with "(graph has no info on ZAOstock Oct 3 dates yet)".
+2. **Offer to push.** "Want me to add what you're saying right now to the graph?"
+3. **Log the gap.** Append to `~/.zao/zoe/recall-gaps.jsonl`:
+```jsonl
+{"timestamp": "2026-05-06T14:23:00Z", "query": "ZAOstock Oct 3 dates", "agent": "newsletter", "resolved": false}
+```
+
+**ZOE-side code (add to recall.ts):**
+```typescript
+export async function logRecallGap(query: string, agent: string, resolved: boolean = false): Promise<void> {
+  const logPath = join(ZOE_PATHS.home, 'recall-gaps.jsonl');
+  const entry = { timestamp: new Date().toISOString(), query, agent, resolved };
+  await fs.appendFile(logPath, JSON.stringify(entry) + '\n', 'utf8');
+}
+```
+
+**Weekly review (Zaal + Claude in morning brief):**
+- Read last 7 days of gaps.
+- Prioritize high-frequency gaps for next push batch (doc 620b sprint).
+- Examples: if Kenny's name appears 5 times with "no data," push all Kenny-related docs first.
+
+---
+
+## 5. Measuring whether push is working
+
+**Metric 1: Recall hit rate**
+- Of the last N @recall queries (manual + auto-draft), how many returned non-empty text?
+- Computation: count(text.length > 20) / count(all queries).
+- Target: 85%+ within 2 weeks of seeding (doc 620b).
+- Dashboard: ZOE morning brief includes "Recall hit rate: 87% this week (142/163 queries non-empty)."
+
+**Metric 2: Graph node count + growth trajectory**
+- Call Bonfire's (future) `/insights/graph-stats/{agent_uuid}` endpoint daily.
+- Log to `~/.zao/zoe/bonfire-stats.jsonl`:
+```jsonl
+{"date": "2026-05-06", "node_count": 142, "edge_count": 287, "docs_pushed": 15, "hit_rate": 0.87}
+```
+- Plot weekly: nodes should grow ~30-50/week during seeding, then stabilize at ~5-10/week for maintenance pushes.
+- Dashboard: morning brief includes "Bonfire: 142 nodes, 287 edges, 87% hit rate."
+
+**Metric 3: Qualitative feel (the only one that matters)**
+- Zaal's gut reaction: does ZOE feel smart or amnesiac?
+- Measured by: does recalled context actually make drafts better?
+- Check: when newsletter calls recall("today's theme"), does the returned context get used in the draft? Or is it ignored/contradicted?
+- Log: ZOE prompts to Claude include the bonfire context inline. Claude's usage is visible in the draft.
+
+**Report location:** ZOE's daily morning brief (already a recurring message). Add section:
+```
+Bonfire snapshot (last 7 days):
+- 142 nodes, 287 edges
+- 87% hit rate (142/163 queries)
+- Top gaps this week: Kenny (5), ZAOstock logistics (3), POIDH bounty updates (2)
+- ~50 new facts pushed
+```
+
+---
+
+## 6. Two-stage retrieval pattern (defer)
+
+**What it is:** Instead of single API call to chat endpoint, ZOE first calls vector search to get candidate nodes, then anchors the full agent chat with center_node_uuid for grounding.
+
+**Current:** Chat endpoint with graph_mode=adaptive already does this server-side. Bonfire agent decides what to retrieve based on the user's query.
+
+**Two-stage on client:**
+```typescript
+// Stage 1: vector search
+const candidates = await fetch(`/kg/search`, { query, num_results: 5 }).then(r => r.json());
+// Stage 2: chat with anchor
+const reply = await fetch(`/agents/{id}/chat`, {
+  message: query,
+  center_node_uuid: candidates[0].node_id, // anchor to top result
+}).then(r => r.json());
+```
+
+**Trade-off:**
+- Pro: grounding is explicit; ZOE knows which node is the "center."
+- Con: 2x API calls; no savings in actual retrieval work (Bonfire still does the same graph traversal).
+
+**Recommendation:** Defer. Single-stage (current chat endpoint) is sufficient. Re-evaluate if:
+- Synthetic hallucination becomes visible in recall output (e.g., agent invents facts).
+- Vector search fails silent and agent can't recover (need explicit fallback).
+- Performance becomes a blocker (unlikely given Bonfire's architecture).
+
+Revisit in doc 620's next sprint (after grounding + hit rate validation).
+
+---
+
+## 5 specific test queries with predicted behavior
+
+| # | Query | Prediction | Acceptance criteria |
+|---|-------|-----------|---------------------|
+| 1 | `@recall Kenny` | Returns bio + role (Person node). Multi-hop to Projects Kenny's organized (POIDH, ZAOstock, etc). | Reply length > 200 chars AND includes at least one project name |
+| 2 | `@recall committed to POIDH` | Matches commitment edges. Returns decision/promise facts related to POIDH. | Includes a specific date or deliverable (not just "Kenny is involved") |
+| 3 | `@recall last ZAOstock meeting` | Filters events by (a) project=ZAOstock, (b) most recent timestamp. Returns date + attendees. | Reply includes ISO date (YYYY-MM-DD) and at least one attendee name |
+| 4 | `@recall ZAOstock budget` | Anchors center_node_uuid to ZAOstock node. Returns all edges tagged "budget" or "budget_item". | Numeric values (e.g., "$20K target") OR structured breakdown (e.g., "venue: $5K, catering: $3K") |
+| 5 | `@recall what did Zaal commit to Steve Peer about` | Person-to-person intersection. Filters Zaal's statements about Steve + commitments. | Reply includes at least one specific thing Zaal said to/about Steve (verbatim or paraphrased from notes) |
+
+**Test execution:** Run queries #1-5 after doc 620b seeding is complete (after 50+ docs pushed). Log results to `~/.zao/zoe/recall-tests-<date>.json`. If 4/5 pass acceptance criteria, hit rate is validation.
+
+---
+
+## 3 metrics with computation method
+
+### Metric 1: Recall hit rate
+
+**Definition:** Percentage of recalls that return non-empty, coherent text (>20 chars).
+
+**Computation:**
+```bash
+# Count all recalls with text > 20 chars
+cat ~/.zao/zoe/recall-gaps.jsonl | \
+  jq -s 'map(select(.text_length > 20)) | length' as non_empty | \
+  jq -s 'length' as total | \
+  echo "$non_empty / $total" | bc -l
+```
+
+**Cadence:** Daily. Report weekly rolling average in morning brief.
+
+**Target:** 85%+ by 2026-05-20 (two weeks post-seeding).
+
+### Metric 2: Graph growth trajectory
+
+**Definition:** Node count + edge count + docs pushed per day. Tracked over 7 days for growth rate.
+
+**Computation:**
+```bash
+# Fetch from Bonfire /insights endpoint (future)
+# For now, query Bonfire UI dashboard manually weekly
+# Log to:
+echo '{"date":"2026-05-06","node_count":142,"edge_count":287,"docs_pushed":15}' >> \
+  ~/.zao/zoe/bonfire-stats.jsonl
+```
+
+**Growth rate formula:**
+```
+new_nodes_this_week / 7 = avg_new_nodes_per_day
+target = 30-50 nodes/week during seeding phase (May-Jun)
+target = 5-10 nodes/week during maintenance phase (Jul+)
+```
+
+**Cadence:** Weekly (run /insights query Monday 6am EST). Alerts if growth < 5/week in seeding phase.
+
+### Metric 3: Qualitative signal
+
+**Definition:** Does recalled context land in generated content? Measured by text analysis (not numeric).
+
+**Computation:**
+```bash
+# For each newsletter draft:
+# (1) Extract bonfire_context section from ZOE prompt
+# (2) Compare with final draft text (do keywords/entities match?)
+# (3) Score: 0 (ignored), 1 (mentioned), 2 (integrated), 3 (drove structure)
+
+# Log example:
+echo '{"draft_date":"2026-05-06","bonfire_context":"Kenny + POIDH","integration_score":3,"draft_sample":"Kenny from POIDH at 2pm..."}' >> \
+  ~/.zao/zoe/recall-integration.jsonl
+```
+
+**Cadence:** Every draft (daily). Compute rolling 7-day average in morning brief. Display as "Integration: 2.8/3 avg (strong)".
+
+**Threshold:** If <1.5/3 avg for 3 consecutive days, notify Zaal that recall context is being ignored (prompt clarity issue or graph quality issue).
+
+---
+
+## Sources
+
+1. **Bonfire API:** https://tnt-v2.api.bonfires.ai/openapi.json - LangGraphChatRequest schema with graph_mode, center_node_uuid, chat_history.
+2. **ZOE recall bridge:** `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/zoe/recall.ts` - SDK placeholder, manual relay pattern.
+3. **Newsletter agent (example):** `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/zoe/agents/newsletter.ts` - loadBonfireContext() function (lines 149-167), already wired pattern.

--- a/research/agents/620-bonfire-push-everything/620e-alternatives-reality-check.md
+++ b/research/agents/620-bonfire-push-everything/620e-alternatives-reality-check.md
@@ -1,0 +1,206 @@
+---
+topic: agents
+type: comparison
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 568, 613, 615, 618, 619, 620
+tier: STANDARD
+parent-doc: 620
+---
+
+# 620e - Alternatives + Reality Check: When to Keep Bonfire, When to Leave
+
+**Sub-agent 5/5:** This is the hedging layer. Bonfire solves auto-push-to-KG today. But is it the _right_ substrate? What happens if Bonfire's pricing jumps, API changes, or shuts down? This doc stress-tests the choice and surfaces exit criteria.
+
+---
+
+## Decision Table (Top): Stay or Switch?
+
+| Option | Recommendation | Reason |
+|--------|---|---|
+| Stay on Bonfire only | Do not do this | Single-vendor lockin + opaque pricing + no self-host option = unacceptable risk for institutional memory |
+| Dual-write to Bonfire + local mirror | YES, START HERE | Bonfire stays primary (existing recall.ts SDK calls). Also push to local Cognee or Graphiti instance on VPS 1. Zero extra cost. Two purposes: disaster recovery + future migration substrate. Implement in doc 620 Phase 2. |
+| Evaluate alternative every 30 days | YES, PARALLEL | Monthly audit: Bonfire recall hit rate, cost, API stability. If any metric tanks, 60-day migration plan kicks in. |
+| Lock exit triggers now | YES, DOCUMENT | See "Decision Criteria" section below. Know the red lines in advance. |
+
+---
+
+## Why Bonfire Today (Case for Keeping It)
+
+1. **Already integrated.** ZOE's `bot/src/zoe/recall.ts` has SDK stubs ready. Joshua.eth is responsive. No switch cost this quarter.
+
+2. **Hosted = no infra to maintain.** Multi-corpus support (public ZAO docs + private Zaal graph as separate bonfires) in one SaaS. Contrast: running Neo4j on VPS 1 means provisioning, backup, upgrade cycles.
+
+3. **Sunk cost is acceptable.** Genesis tier is paid. Ongoing fit matters more than sunk spend - but if Bonfire continues to deliver, monthly cost is not a blocker.
+
+4. **Known relationship.** Joshua's responses are measured in hours, not days. Bug fixes land quickly. That matters for a production dependency.
+
+5. **API maturity improving.** Recall stubs already in place. SDK availability (doc 569 promises it "when provisioned") reduces friction vs. building custom integrations to OSS KGs.
+
+---
+
+## Bonfire's Risks (Case for Hedging)
+
+1. **Single-vendor lockin.** If bonfires.ai pivots to AI agents-only, raises pricing 10x, or shuts down, all pushed data is hostage. No self-host option exists. Verify: bonfires.ai/pricing (opaque as of 2026-05-06).
+
+2. **Hosted = third-party sees data.** Every Telegram message, research note, and decision memo pushed to Bonfire is readable by Joshua and his ops team (or anyone who breaches their DB). For most ZAO data this is fine (public research docs). For personal strategy notes, it matters.
+
+3. **API is private OpenAPI, not published spec.** recall.ts calls are to an undocumented endpoint. If Joshua deprecates it, you're on his migration schedule, not yours.
+
+4. **No pricing transparency.** No public pricing page. Cost at scale (100K+ messages/month) is unknown. If Genesis tier cost 5x today's price and you're auto-pushing Telegram streams, you won't know until the bill lands.
+
+5. **Export/portability.** Can you dump your entire Bonfire graph as JSON + re-import to Neo4j on day 1 of leaving? Likely not frictionless (if at all possible). Unknown as of 2026-05-06.
+
+---
+
+## Alternatives Evaluated (Star Counts Verified 2026-05-06)
+
+| System | Stars | License | Self-Host | KG Support | Agent Memory | Maturity | Migration Ease from Bonfire |
+|--------|------:|---------|-----------|-----------|-------------|----------|---------------------------|
+| **Cognee** | 17,068 | Apache 2.0 | Yes (Docker) | Neo4j native | Yes (memory plane) | Beta | Medium - manual graph export |
+| **Graphiti** | 25,766 | Apache 2.0 | Yes (OSS) | Neo4j + vector temporal | Yes | Stable | Medium - own format |
+| **LightRAG** | 34,816 | MIT | Yes | In-memory KG | Optional | Mature | Low (simple ingestion) |
+| **Khoj** | 34,412 | AGPL-3.0 | Yes (Docker) | SQLite + semantic | Yes | Stable | High (multi-platform ingest already there) |
+| **mem0** | 54,937 | Apache 2.0 | Yes (hosted + OSS) | Qdrant/Postgres vector | Yes (specialized memory) | Stable | High (memory + context export) |
+| **Reor** | 8,557 | AGPL-3.0 | Yes (Electron) | SQLite + vector | Optional | Polished | Medium (file-based export) |
+
+**Key observations:**
+- Mem0 (54K stars) is the strongest general memory layer; already adopted by 100+ agent frameworks.
+- Cognee (17K stars) is a drop-in `/graphify` replacement if you want everything local.
+- Graphiti (25K stars) adds temporal reasoning Bonfire doesn't have (useful for "when did we decide X?").
+- Khoj (34K stars) is feature-complete second-brain; already has Telegram ingest plugin.
+- All six are actively maintained. None are "research grade."
+
+---
+
+## Hybrid Strategy: Bonfire + Local Mirror (Recommended)
+
+**Implementation sketch for doc 620 Phase 2:**
+
+1. Keep Bonfire as primary (existing recall.ts SDK calls unchanged).
+2. Add a **fork point** in the push pipeline (doc 619, doc 620 Phase 1): every message/note pushed to Bonfire also gets written to a local Cognee or Graphiti instance on VPS 1.
+3. Local instance lives at `~/.zao/graph/` with symlink to `/var/lib/cognee` or `/var/lib/neo4j`. Systemd unit keeps it running.
+4. Zero extra cost (storage is $0.01/month). Two reasons it pays for itself immediately:
+   - **Disaster recovery.** If Bonfire's API goes down for 24h, ZOE still has local fallback for recall queries.
+   - **Migration substrate.** When (not if) you want to leave Bonfire, you already have 6 months of data in Cognee/Graphiti. Re-point recall.ts in one commit.
+
+**Why not just use local + ditch Bonfire now?**
+- Bonfire's recall quality might be better (more sophisticated query patterns). Win until you know it's worse.
+- Unproven: can your local KG handle Telegram's volume (100+ messages/day)? Dual-write lets you validate.
+- Hosting trade-off: local instance ties to VPS 1 uptime. Bonfire is 99.9%. For recall queries during your sleep, Bonfire is safer today.
+
+**Why not use mem0 for the local mirror instead of Cognee/Graphiti?**
+- mem0 is stronger on agent memory (structured recall + context window compression). But it's not a KG builder. Cognee or Graphiti are better at housing the graph ZAO docs + decisions live in.
+- If you later want agent-native memory (e.g., for ZOE v3), mem0 is the upgrade path. Cognee -> mem0 is a simpler migration than Bonfire -> mem0.
+
+---
+
+## Decision Criteria: When to Leave Bonfire
+
+**Exit triggers (any one triggers a 60-day migration plan):**
+
+- [ ] Bonfire pricing per-message creeps past $100/mo for personal-only use
+- [ ] Joshua unresponsive to bug reports for 7+ consecutive days (SLA breach)
+- [ ] Ingest job failure rate (push attempts that fail) exceeds 5% over one week
+- [ ] Data export endpoint removed or gated behind new paid tier
+- [ ] Recall hit rate (queries that return zero results) stays above 20% after 60 days of daily use
+- [ ] Joshua announces acquisition or pivot that breaks Telegram stream ingest
+- [ ] You decide to open-source the personal-graph stack (institutional memory lives on GitHub)
+
+**Conversely, keep Bonfire locked in if:**
+
+- [ ] Recall hit rate stays above 80% on auto-pushed content (signal: the KG is working)
+- [ ] Cost stays under $50/mo at full daily volume (realistic ceiling)
+- [ ] Joshua ships the SDK (doc 569 promise) on schedule
+- [ ] Joshua remains responsive (24-48h bug-fix turnaround)
+
+---
+
+## The Question You Can't Avoid: Do We Even Need a KG?
+
+**Steel-man the "no" argument:**
+
+1. Good vector search (Qdrant, Weaviate, Pinecone) + grep over tagged Markdown files in `research/` + `memory/` covers 80% of recall needs.
+2. ZOE could just embed every message, load the top 5 by cosine similarity, and let Claude synthesize an answer. No graph, no entity resolution, no expensive multi-hop queries.
+3. Knowledge graphs are noisy at small scale (few hundred docs), slow at big scale (millions of edges), and prone to hallucination when LLMs traverse them.
+
+**Where the graph wins (the case for Bonfire or Cognee):**
+
+- **Multi-hop reasoning:** "Who did I meet through Steve Peer?" requires edges: Zaal -> Steve Peer, Steve Peer -> X. Vector search alone can't answer this.
+- **Temporal reasoning:** "When did I last talk about ZAOstock budget?" needs `(decision, timestamp, subject)` triples. Markdown grep can't track this.
+- **Entity resolution:** If Zaal writes "Steve" in one place and "Steve Peer" in another, the graph knows they're the same. Vector embeddings might not.
+
+**Where the graph loses:**
+
+- **Small KGs are noisy.** 500 research docs + 100 people + 50 decisions = 10K-100K entities. At that scale, hallucinated edges outnumber real ones.
+- **Big KGs are slow.** If you auto-push Telegram (100 msgs/day) for a year, that's 36K messages as entities. Multi-hop queries become O(n^2) traversals. Vector search is still O(log n).
+- **Agent-over-KG hallucination.** LLMs can "invent" edges that sound plausible but don't exist. ("You met Bob through Charlie" when Charlie never mentioned Bob.)
+
+**Recommendation:**
+
+Bonfire + local mirror stays as the **60-day experiment.** You're paying the cost (minimal for dual-write), you already built the push pipeline (doc 620 Phase 1), and you'll know within two months if the KG is actually surfacing insights you'd miss with vector search alone.
+
+**Exit metric:** If after 60 days of daily ZOE use, you haven't had a single "wow, the graph just taught me something I forgot" moment, the substrate is not the problem - it's that knowledge graphs are expensive for small teams. At that point, retire the KG and go pure vector + Markdown.
+
+---
+
+## Migration Paths (If You Decide to Leave Bonfire)
+
+**Path 1: Bonfire -> Cognee (fastest)**
+- Cognee runs local Docker, speaks Neo4j natively, has Python ingest SDK
+- Day 1: export Bonfire graph as JSON (may require Joshua's help)
+- Day 2: load JSON into Cognee via Python script
+- Day 3: re-point `recall.ts` to Cognee's HTTP API
+- Effort: 2-3 days engineering
+
+**Path 2: Bonfire -> Graphiti (best temporal reasoning)**
+- Graphiti adds timestamp + event relationships Bonfire doesn't model
+- Same JSON export + Python ingest flow
+- Better for "when did we last decide X?" queries
+- Effort: 2-3 days engineering + 1 day for Zaal to re-index decisions by date
+
+**Path 3: Bonfire -> mem0 (agent-first)**
+- mem0 optimizes for agent memory (compressed context window, summary) not pure KG
+- If ZOE v3 redesigns around agent memory, mem0 is the target
+- Today, overkill. Useful if you're building 10+ agents, not one concierge
+- Effort: 1 week (new memory model, re-train on past conversations)
+
+**Path 4: Bonfire -> Neo4j + custom (most flexibility)**
+- You own the schema, the ingest rules, the query patterns
+- Expensive: full-time DevOps + data engineer
+- Only choose if Cognee/Graphiti feel limiting after 6 months
+- Effort: 3-4 weeks
+
+---
+
+## Final Stance: Dual-Write Now, Re-Evaluate Every 30 Days
+
+**Action items (for doc 620 Phase 2 + onward):**
+
+1. **Keep Bonfire as primary.** Don't disrupt existing recall.ts integration. Joshua is responsive. Cost is acceptable.
+
+2. **Implement dual-write.** Fork the push pipeline (doc 619): every auto-push to Bonfire also writes to local Cognee instance on VPS 1. Add systemd unit for Cognee uptime. Cost: ~1 day engineering.
+
+3. **Log exit metrics monthly.** Create a cron job that measures:
+   - Bonfire ingest failure rate (via Supabase event logs, doc 620 Phase 1)
+   - Bonfire recall hit rate (how many queries return >0 results)
+   - Cost per month (from Joshua's invoices)
+   - API latency (time to response on /agents/{id}/chat calls)
+
+4. **60-day recall quality audit.** On 2026-07-06, assess: "Did the KG surface insights I missed with vector search?" If no, retire it. If yes, keep going.
+
+5. **Document exit option in AGENTS.md.** Add a note: "Bonfire is the current KG substrate. Exit plan: dual-write to Cognee, no data loss. Decision point: 2026-07-06." This removes the "we're locked in" feeling.
+
+---
+
+## Sources
+
+- [Cognee GitHub](https://github.com/topoteretes/cognee) - 17,068 stars, Apache 2.0, Neo4j native
+- [Graphiti (Zep) GitHub](https://github.com/getzep/graphiti) - 25,766 stars, Apache 2.0, temporal KG
+- [LightRAG GitHub](https://github.com/HKUDS/LightRAG) - 34,816 stars, MIT, mature RAG
+- [Khoj GitHub](https://github.com/khoj-ai/khoj) - 34,412 stars, AGPL-3.0, second brain
+- [mem0 GitHub](https://github.com/mem0ai/mem0) - 54,937 stars, Apache 2.0, agent memory
+- [Reor GitHub](https://github.com/reorproject/reor) - 8,557 stars, AGPL-3.0, desktop knowledge app
+- [Bonfires.ai](https://bonfires.ai) - Hosted KG platform (pricing page opaque as of 2026-05-06)
+- Doc 568: Aware Brain - Local-First KG Chat (2026-04-29)
+- Doc 620 Phase 1: Static + Stream Ingest (related, same parent)

--- a/research/agents/620-bonfire-push-everything/README.md
+++ b/research/agents/620-bonfire-push-everything/README.md
@@ -1,0 +1,159 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-06
+related-docs: 547, 568, 613, 614, 615, 618, 619
+tier: DISPATCH
+---
+
+# 620 - Bonfire push-everything: auto-ingest pipeline for Zaal's personal knowledge graph
+
+> **Goal:** Make Bonfire writes happen automatically from every source Zaal touches, so `@recall` always returns useful answers. No manual curation.
+
+## Key Decisions
+
+| Decision | Action | Why |
+|---|---|---|
+| Bonfire stays as the primary KG substrate | YES, 60-day experiment from 2026-05-06 | Already wired into ZOE, Zaal pays for Genesis tier, Joshua responsive. Re-evaluate by 2026-07-05. |
+| Dual-write to local mirror as insurance | YES | Vendor-lockin hedge. Same code path, free, gives a clean exit if Bonfire breaks. Mirror = Cognee or local Neo4j on VPS 1. |
+| Auto-push from streams (Telegram, Farcaster, voice) | YES, ship in this order | Telegram first (uses existing grammy hook, lowest friction). Farcaster second (Neynar webhook). Voice last (smallest volume). |
+| Auto-push from static sources | YES, in this order | Memory files BACKFILL-ONCE FIRST (135 files, gating step). Then research docs (740) nightly vector + hot-doc full-graph. Then newsletter drafts + voice transcripts via file watcher. |
+| Auto-recall during draft generation | YES | Newsletter + social agents call `recall(topic)` BEFORE writing. Inject result as context. Failure mode = continue without it (don't block). |
+| Sources footer on every recall reply | YES, configure in Bonfire UI | Without grounding, ZOE can't tell synthesis from fact. Until Sources land, no auto-publish of recall content. |
+| Privacy + redaction layer before push | YES, mandatory | 5 regex strip patterns + Telegram-group inbound gate (push Zaal's outbound only, skip others without consent). |
+| Client-side dedup via SHA256 hash log | YES | `~/.zao/zoe/bonfire-pushed.sqlite`. Skip re-push if hash seen. Avoids 540 docs * 5 cross-refs = 2700 dupes problem. |
+| One Bonfire (personal) for now | YES | Separate ZAO-public bonfire later if/when we open-source the personal-graph stack. Cross-bonfire recall not yet supported. |
+| Daily cost ceiling | $50/mo at full volume | Estimated 0.50-4.50/day worst-case. If creeps past $100/mo: trigger alternative eval. |
+
+## What This Is
+
+5 sub-agents ran [STANDARD] tier research in parallel. Each owns one cut of the auto-push problem. Synthesis below.
+
+The shape:
+
+```
+                   Zaal does a thing
+                          |
+        +-----------------+--------------------+
+        |                                      |
+   STREAM SOURCES                       STATIC SOURCES
+   (live, event-driven)                 (file/disk, scheduled)
+        |                                      |
+   Telegram DM/group                  Memory files (135)
+   Farcaster casts                    Research docs (740)
+   Voice (Whisper)                    Newsletter drafts (daily)
+                                      Voice transcripts (file)
+                                      GitHub PRs/commits
+                                      Archive backfill (1x)
+        |                                      |
+        +-----------------+--------------------+
+                          |
+                  REDACT + DEDUP + LOG  <-- 620c operational layer
+                          |
+                  POST /ingest_content (Bonfire)
+                          |
+                  job_id -> /jobs/{id}/status
+                          |
+                  Graph node lands
+                          |
+                  +-------+-------+
+                  |               |
+            @recall <q>     auto-recall in draft
+                  |               |
+            ZOE response    Newsletter/social with context
+```
+
+## Sub-doc Index
+
+| Sub | Topic | What's inside |
+|-----|-------|---------------|
+| [620a](./620a-stream-source-ingest.md) | Stream sources | Telegram (DM + groups), Farcaster (Neynar webhook), voice (OpenWhisp -> Whisper). Per-message vs per-conversation push. Wiring into existing `bot/src/zoe/index.ts` grammy hook. |
+| [620b](./620b-static-source-ingest.md) | Static sources | 740 research docs, 135 memory files, newsletter drafts, GitHub artifacts, one-time archive backfill (Telegram, FC history, bookmarks, Lu.ma). Cron + file-watcher patterns. |
+| [620c](./620c-privacy-dedup-cost.md) | Operational layer | 5 redaction regex patterns, SHA256 dedup, audit jsonl log, rate limit (max 3 active jobs), cost model (~$0.50-4.50/day), one-graph decision. |
+| [620d](./620d-recall-feedback-loop.md) | Recall loop | Auto-recall in newsletter/social agents, multi-hop test queries, grounding via Sources footer, negative-result logging, 3 metrics for "is push working" (hit rate, node growth, qualitative). |
+| [620e](./620e-alternatives-reality-check.md) | Reality check | Cognee 17K, Graphiti 25K, LightRAG 34K, Khoj 34K, Mem0 54K, Reor 8K stars. Hybrid dual-write recommendation. Exit triggers documented. 60-day re-evaluation. |
+
+## Synthesis: The 9-Step Ship Order
+
+Read the sub-docs for detail. This is the sequenced rollout, smallest difficulty first, highest unlock first.
+
+| # | Step | Source(s) | Difficulty (1-10) | Unlocks |
+|---|------|-----------|-------------------|---------|
+| 1 | **Backfill memory files (135)** to Bonfire as full-graph entities | `~/.claude/projects/.../memory/` | 4 | Recall actually returns Zaal's facts. Today recall is empty because Bonfire is empty. This is the gating step. |
+| 2 | **Wire dedup + redact + audit log** | All future pushes | 5 | Operational safety. Without this, step 3+ leaks secrets and creates dupes. |
+| 3 | **Telegram DM auto-push** via grammy hook | `bot/src/zoe/index.ts` | 4 | Daily ZOE conversation feeds graph. Highest live-volume source for Zaal. |
+| 4 | **Configure Bonfire agent system prompt** to append Sources footer | Bonfire UI | 2 | Recall replies are grounded; ZOE can show "from doc 547, memory file X". |
+| 5 | **Auto-recall in newsletter agent** | `bot/src/zoe/agents/newsletter.ts` | 5 | Closes the loop. Drafts become context-aware. |
+| 6 | **Research-doc cron** (nightly vector + hot-doc full-graph) | `research/` (740 docs) | 6 | KG indexes the full ZAO institutional memory. |
+| 7 | **Farcaster cast push** via Neynar webhook | `src/lib/farcaster/neynar.ts` | 6 | Public-facing artifacts in graph. |
+| 8 | **Voice transcript file-watcher** | OpenWhisp (doc 560) | 3 | Voice notes become first-class facts. |
+| 9 | **Local mirror dual-write** | New: `~/.zao/zoe/local-graph/` | 5 | Insurance against Bonfire vendor risk. |
+
+Step 1 is mandatory before anything else. Steps 2-9 can ship in any order after that, but the sequence above orders by ROI per unit difficulty.
+
+## Hard Numbers
+
+- **Bonfire endpoints used:** `POST /ingest_content` (full graph), `POST /ingest_content_vector_only` (cheap), `POST /agents/{id}/chat` (recall), `GET /jobs/{id}/status` (poll)
+- **Bonfire agent UUID:** `69f13a649469bbc15bf61c10` (Zaal personal graph)
+- **Existing memory files to backfill:** 135 (verified via `ls ~/.claude/projects/.../memory/ | wc -l`)
+- **Existing research docs:** 740 (verified via `find research -name README.md`)
+- **Daily push volume estimate:** 50-90K chars (~15-30K LLM-equivalent tokens)
+- **Daily cost estimate:** $0.50 (vector-only diff) to $4.50 (everything full-graph). Genesis tier already includes baseline allowance.
+- **Concurrent job ceiling:** 3
+- **Dedup hash store:** `~/.zao/zoe/bonfire-pushed.sqlite`
+- **Audit log:** `~/.zao/zoe/bonfire-pushes.log` (jsonl)
+
+## What This Doc Does NOT Decide
+
+- The exact Bonfire agent system prompt text (Zaal edits in Bonfire UI; not source-controlled).
+- Whether to open a separate "ZAO Public" bonfire for community-readable docs (deferred until ZAO Public launches).
+- The replacement substrate if Bonfire fails the 60-day eval. 620e ranks the alternatives but doesn't pick one.
+- Whether to ingest Discord DMs (out of scope; consent gate is too messy without explicit per-server policy).
+
+## Failure Modes
+
+| Failure | Symptom | Recovery |
+|---------|---------|----------|
+| Secret leaked into Bonfire | post-hoc grep of audit log finds API key in `content` field | Rotate the leaked key immediately. Email Joshua to remove that node. Tighten regex. |
+| Dedup hash collision (2 different facts same hash) | `@recall` returns wrong fact | Hash collisions on SHA256 of human-typed text are vanishingly rare. If it happens once: log + ignore. If twice: switch to SHA512. |
+| Bonfire job queue stuck | `/jobs/active` count climbs, no completions | Pause auto-push (sentinel file `~/.zao/zoe/bonfire-paused.flag`). Email Joshua. ZOE falls back to local-only memory. |
+| Recall hit rate < 30% after backfill | Most queries return empty | Diagnose: are pushes actually landing in graph? Check `/jobs/{id}/status` for the last 20. Check Bonfire UI to see node count. If pushes succeed but recall fails: agent system prompt is wrong, fix in UI. |
+| Bonfire shuts down or 10x pricing | Vendor risk realized | Local mirror (step 9) is the disaster recovery. Migrate to Cognee or Graphiti from sub-doc 620e. Re-ingest from local mirror, not from sources (faster). |
+
+## Also See
+
+- [Doc 547 - Multi-agent coordination Bonfire+ZOE+Hermes](../547-multi-agent-coordination-bonfire-zoe-hermes/)
+- [Doc 568 - Aware Brain alternatives](../../infrastructure/568-aware-brain-kg-chat-memory-stack/) (KG-chat alternatives audit)
+- [Doc 613 - Hermes canonical agent framework](../613-hermes-canonical-agent-framework/)
+- [Doc 614 - Bonfire ontology](../614-bonfire-ontology/)
+- [Doc 615 - ZOE pipeline audit](../615-zoe-pipeline-audit/)
+- [Doc 618 - AGENTS.md spec audit](../../dev-workflows/618-agents-md-spec-zaoos-audit/)
+
+## Next Actions
+
+| # | Action | Owner | Type | Difficulty | Trigger |
+|---|--------|-------|------|------------|---------|
+| 1 | Backfill 135 memory files to Bonfire as full-graph entities | Claude | Script + PR | 4 | After PR #482 (618) merged |
+| 2 | Add `bot/src/zoe/bonfire-write.ts` with `ingestContent()` + redact + dedup + audit | Claude | PR | 5 | After step 1 |
+| 3 | Wire grammy hook in `bot/src/zoe/index.ts` to call `ingestContent()` on every Telegram turn | Claude | PR | 4 | After step 2 |
+| 4 | Edit Bonfire agent system prompt in UI to append Sources footer | Zaal | UI edit | 2 | This week |
+| 5 | Wire `recall(topic)` precall in `newsletter.ts` and future `social.ts` | Claude | PR | 5 | After step 4 |
+| 6 | Cron job: nightly research-docs vector-only push + on-commit hot-doc full-graph push | Claude | systemd timer + PR | 6 | After steps 1-5 stable |
+| 7 | Neynar webhook -> POST /api/farcaster/cast-to-bonfire route | Claude | PR | 6 | After step 6 |
+| 8 | OpenWhisp -> file watcher -> push voice transcript | Claude | shell + systemd | 3 | After OpenWhisp installed (doc 560) |
+| 9 | Dual-write to local mirror (Cognee or Neo4j on VPS 1) | Claude | PR + infra | 5 | After step 8, before 60-day eval |
+| 10 | 60-day eval: keep Bonfire or migrate? | Zaal + Claude | Decision review | n/a | 2026-07-05 |
+
+## Sources
+
+- [Bonfire OpenAPI spec](https://tnt-v2.api.bonfires.ai/openapi.json) - verified 2026-05-06
+- [Bonfire homepage](https://bonfires.ai)
+- [Cognee](https://github.com/topoteretes/cognee) - 17K stars
+- [Graphiti](https://github.com/getzep/graphiti) - 25K stars
+- [LightRAG](https://github.com/HKUDS/LightRAG) - 34K stars
+- [Khoj](https://github.com/khoj-ai/khoj) - 34K stars
+- [Mem0](https://github.com/mem0ai/mem0) - 54K stars
+- [Reor](https://github.com/reorproject/reor) - 8K stars
+- [Neynar webhooks docs](https://docs.neynar.com/reference/webhooks)
+- Live source: `bot/src/zoe/recall.ts` on VPS at 31.97.148.88


### PR DESCRIPTION
## Summary
Hub doc 620 + 5 sub-agent research docs covering the full auto-push pipeline for Zaal's personal Bonfire knowledge graph. Direction locked: push everything Zaal does, no manual curation. Recall is empty today because nothing's been pushed; this doc is the roadmap to fix that.

## Tier
DISPATCH (5 parallel sub-agents, [STANDARD] tier each)

## Sub-docs
- 620a streams - Telegram, Farcaster, voice
- 620b static - 135 memory files, 740 research docs, drafts, archives, GitHub
- 620c ops - redaction, dedup, audit, cost ($0.50-4.50/day)
- 620d recall loop - auto-recall in drafts, Sources footer, 3 metrics
- 620e reality check - 6 alternatives ranked, dual-write hedge, 60-day re-eval

## 9-step ship order in hub README
1. Backfill 135 memory files (gating step)
2. Wire dedup + redact + audit
3. Telegram DM auto-push
4. Bonfire UI: Sources footer
5. Auto-recall in newsletter agent
6. Research-doc cron
7. Farcaster Neynar webhook
8. Voice transcript watcher
9. Local mirror dual-write

## Sources
20+ verified URLs (Bonfire OpenAPI, 6 alternative repos with real star counts, Neynar webhooks, OpenWhisp).

## Next Actions
10-row table in hub README. Step 1 (memory backfill) ready to ship as a follow-up PR after this merges.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>