### PR TITLE
docs: research 611 + 612 - brand audit + LLC formation

### DIFF
--- a/research/business/611-zaostock-brand-patterns-rsvpizza-iykyk/README.md
+++ b/research/business/611-zaostock-brand-patterns-rsvpizza-iykyk/README.md
@@ -1,0 +1,204 @@
+---
+topic: business
+type: comparison
+status: research-complete
+last-validated: 2026-05-07
+related-docs: 502, 547, 609, 610
+tier: STANDARD
+---
+
+# 611 - ZAOstock brand-pattern audit: RSV.Pizza + IYKYK / blank.space + contributor entry-page design
+
+> **Goal:** Identify brand-building patterns ZAOstock is missing by comparing to two reference sites (RSV.Pizza for production festival ops, IYKYK / blank.space for community-vibe ecosystem). Propose three contributor entry-points (musicians, artists, event organizers) so each persona has a clear door into ZAOstock.
+
+## Key Decisions
+
+| # | Decision | Status |
+|---|---|---|
+| 1 | Add 3 contributor entry pages to zaostock.com: `/musicians`, `/artists`, `/event-organizers` | **NEW - approved May 7** |
+| 2 | Adopt RSV.Pizza per-role surfaces pattern: PartnerDashboard, CheckIn, DJ-side, Public Recap | Sequence: PartnerDashboard first (todo exists), CheckIn pre-Oct 3, others after Year 2 |
+| 3 | Lean into IYKYK insider-vibe language without overdoing it - frame ZAO Festivals as ecosystem not just event | Apply on home + entry pages |
+| 4 | Add reusable component library enforcement (RSV.Pizza pattern) | Document in CONTRIBUTING.md when next refactor lands |
+
+## What RSV.Pizza has that we are missing (from earlier doc-research of their GitHub)
+
+Pages they ship that ZAOstock lacks:
+
+| Page they have | What it does | ZAOstock equivalent |
+|---|---|---|
+| **CheckInPage** | QR-code scan for day-of attendance | None - todo exists |
+| **PartnerDashboardPage** | Partners self-edit their profile and assets | None - "Get Web3Metal live" todo |
+| **PartnerIntakePage** | Onboarding form for new partners | None - manual SQL only |
+| **DJPage** | Talent-facing surface (set times, technical riders, hospitality) | Could be a `/musicians` entry page |
+| **DisplayPage** | Venue screen content rotation (sponsors, lineup, schedule) | None - day-of gap |
+| **GraphicsDashboard** | Generate social media assets from event data | None - manual design only |
+| **PostComposerPage** | Compose content from event data | None |
+| **PublicReportPage** + **PublicVenueReportPage** | Post-event recap landing page | `/onepagers` exists but is a generic 1-pager system, not event recap |
+| **HostPage** | Host configures their event | We have `/team` but no per-event configurer |
+| **AdminPage** + **UnderbossDashboard** | Multi-tier admin | We have `/team` flat |
+
+Engineering hygiene RSV.Pizza enforces (per their CLAUDE.md):
+- **Reusable component library**: `IconInput`, `Checkbox`, `ClickableEmail`, `CustomUrlInput`, `LocationAutocomplete`, `TimezonePickerInput`, `Layout`, `HostsList`, `TableRow`, `LoginModal`. Rule: "Never create raw `<input>` elements - use `IconInput`."
+- **Branching convention**: `{task-id}-{short-name}` (no `feature/` prefix)
+- **`plans/` folder**: every non-trivial task gets a written implementation plan before code
+- **Bland AI integration** for automated vendor calls (way ahead of us; defer)
+
+## What IYKYK / blank.space brings (vibe + ecosystem)
+
+IYKYK on blank.space = "Social hub for the IYKYK community. Create, customize, and explore the IYKYK ecosystem."
+
+Adjacent: iykyk.com - "share yourself, on purpose" - personal destination for "creators, founders, service providers, and people who want one clean place to share their work and be reachable without the noise."
+
+**Patterns worth borrowing:**
+
+1. **Insider-vibe language as a brand asset.** "If You Know, You Know." ZAOstock has some of this with The ZAO but does not lean into it. We could lean into "ZAO" as the cultural cue without crypto-coding.
+2. **Personal customization at the user level.** Each member of the community has a customizable space. ZAOstock's `/team/m/[slug]` does this for teammates - we could extend to musicians/artists/partners.
+3. **Ecosystem framing.** Not just an event - an ecosystem with multiple surfaces (festival, podcast, community, content, partnerships). ZAO Festivals already has this latent (PALOOZA + CHELLA + ZAOstock + ZAOville) but does not communicate it as an ecosystem on the home page.
+4. **"Share yourself, on purpose" copy ethos.** Lower the friction for community members to manifest themselves on our surfaces - removes the "what do I post?" anxiety with a clear "this is the door."
+
+## What ZAOstock has that's distinctive
+
+For balance: things ZAOstock does well that the reference sites do not:
+
+1. **6-circle scope model** (post May 5 consolidation) - clearer team org than RSV.Pizza's flat or IYKYK's none
+2. **Telegram bot integration** (ZAOstockTeamBot with /charter, /circles, /timeline_done) - team ops via chat
+3. **Lu.ma calendar integration** as the ticketing backbone (700+ warm audience already)
+4. **Fiscal sponsor architecture** (NMC + Fractured Atlas, post May 7 correction) handled with proper legal language
+5. **Lineage story** (PALOOZA NYC + CHELLA Miami + now ZAOstock) is real, not aspirational
+6. **Open partner concept** (track=partner in sponsors) - Web3Metal as first row, blueprint for project-collaborator partnerships
+
+## NEW: Three contributor entry-pages design
+
+Each entry page is a landing for ONE persona walking into ZAOstock cold. Each answers:
+1. What ZAOstock is *from your perspective*
+2. What you get
+3. What we ask
+4. How to plug in
+
+### `/musicians` - For independent artists who want to play
+
+**Hero:** "Made music nobody is paying you to make? You are who we built this for."
+**Subhead:** "ZAOstock is a one-day outdoor festival in Ellsworth Maine on October 3, 2026. Every artist on stage was discovered through The ZAO, a community of 100+ independent musicians."
+
+**What you get:**
+- A real stage in front of a real audience (target: 200-400 in person, 1K+ livestream)
+- Travel + lodging covered or crowdfunded via Giveth / GoFundMe (per-artist pool)
+- Recording of your set, photo from the day, recap reel inclusion
+- Direct line into the ZAO music community (100+ people who already care about independent artists)
+- 100% of any merch / tip revenue you generate on-site
+
+**What we ask:**
+- 25-minute set window
+- Standard technical rider (we will work with your needs)
+- Show up to soundcheck day-of
+- Help share when we post your slot
+
+**How to plug in:**
+- Submit through The ZAO open call (link)
+- Or DM Zaal directly if you have a referral
+- Cutoff: ~one month before the event
+- Independent + ZAO-vetted only - this is not a pay-to-play festival
+
+**Subnav:** Past festivals (PALOOZA + CHELLA recordings) | Lineup so far | FAQ for musicians
+
+---
+
+### `/artists` - For visual artists, designers, photographers
+
+**Hero:** "Build the visual identity of a festival people remember."
+**Subhead:** "ZAOstock needs visual artists across the build. Posters, signage, on-site installations, photography, motion. Your work becomes part of the ZAO Festivals lineage."
+
+**What you get:**
+- Named credit on every surface your work appears (zaostock.com, social, day-of signage, recap)
+- A real piece in your portfolio - a festival people travel to see
+- Direct collaboration with Candy + DCoop on the brand kit + logo work
+- Pay or revenue-share depending on the project (one-off poster vs. installation - we work it out per piece)
+- Day-of access + crew shirt + meals on site
+- Eligible for finders fee / management fee structure (5%/10%/15%) if you bring a partner relationship
+
+**What we ask:**
+- Bring your work or portfolio when you reach out
+- Be willing to iterate - this is a community-build, not a client deal
+- Show up day-of if your work is on-site (installations, photography, etc)
+- Help share when we feature your work
+
+**How to plug in:**
+- Reply via the artist intake form (link)
+- Or DM Candy / DCoop / Zaal directly with portfolio
+- Bring an idea, not a pitch deck
+
+**Subnav:** Past visual work (PALOOZA + CHELLA archive) | Brand kit guide | Open briefs
+
+---
+
+### `/event-organizers` - For people who want to run their own ZAO chapter
+
+**Hero:** "Built a community? Run your own ZAO."
+**Subhead:** "ZAOstock is the third event in the ZAO Festivals series after PALOOZA NYC and CHELLA Miami. The next one could be yours - in your city, with your community, under the ZAO Festivals umbrella."
+
+**What you get:**
+- The full ZAOstock playbook (run-of-show, sponsor framework, fiscal sponsor infrastructure via NMC + Fractured Atlas, finders fee structure, livestream rig, partner template)
+- Access to the 100+ artist ZAO community for booking
+- Brand co-presentation (your event runs as ZAO-{YourCity} with shared visual identity)
+- Coaching from Zaal + the team during your first event
+- Revenue split per event - we work out the deal per-city based on what you bring
+
+**What we ask:**
+- Real local roots in your city (you can answer "why your city?" without flinching)
+- Capacity to land a venue + permits + day-of crew - we coach but you operate
+- Participation in the broader ZAO Festivals brand (not your own competing brand)
+- Honest financial reporting - same break-even ethos that shapes ZAOstock
+
+**How to plug in:**
+- Apply via the event-organizer intake form (link)
+- Or schedule a 30-min intro call with Zaal
+- Open conversations now for 2027 events - first city to commit gets the slot
+
+**Subnav:** Past events (PALOOZA + CHELLA recap pages when built) | Operator playbook | FAQ for organizers
+
+---
+
+## Implementation pattern (reusable for all 3 pages)
+
+Each page uses the same component spine:
+
+```
+<EntryPageHero
+  persona={...}
+  hero={...}
+  subhead={...}
+/>
+<WhatYouGet items={[...]} />
+<WhatWeAsk items={[...]} />
+<HowToPlugIn ctas={[...]} />
+<EntryPageFooter linkBack="/" />
+```
+
+This becomes a generic `EntryPage` component in `src/components/entry/` plus 3 thin wrappers - one per persona. Future personas (volunteers, sponsors-self-serve, artists-already-with-an-ask) can spin up by adding new wrappers.
+
+## Action Bridge - new todos spawned
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Build EntryPage component + 3 thin wrappers (`/musicians`, `/artists`, `/event-organizers`) | Marketing + Ops | code | Pre-deck week (May 14) ideally; otherwise post-deck |
+| Wire entry-page CTAs to forms (musician intake, artist intake, event-organizer intake) | Marketing | code | After EntryPage scaffold lands |
+| Add link-out from main `/` nav once pages exist (replaces or supplements current Volunteer / Sponsor) | Marketing | nav update | Same PR as EntryPage |
+| Build PartnerDashboardPage pattern (RSV.Pizza-inspired) so Shawn can edit Web3Metal partner profile | Ops | code | Q2 2026 |
+| Build CheckInPage with QR codes for Oct 3 attendance | Host + Ops | code | Pre-Oct 3 |
+| Build PublicReportPage for post-event recap | Marketing + Livestream | code | Post-Oct 3 |
+| Document reusable component library + add CONTRIBUTING.md rule "no raw inputs - use IconInput" pattern | Ops | docs | Next refactor |
+
+## Also See
+
+- [Doc 502](../../governance/502-zaostock-circles-v1-spec/) - 6-circle structure
+- [Doc 547](../../community/547-cassie-validation-zaostock-strategy/) - Cassie strategy validation
+- [Doc 609](../../events/609-zaostock-cobuild-six-circles-may4/) - May 4 cobuild meeting transcript
+- [Doc 610](../../infrastructure/610-zaostock-database-consolidation-may4-5/) - DB consolidation post-mortem
+
+## Sources
+
+- [RSV.Pizza homepage](https://rsv.pizza) - JS-rendered, used GitHub repo source for component + page inventory
+- [PizzaDAO/rsv-pizza GitHub](https://github.com/PizzaDAO/rsv-pizza) - earlier session research, page list + CLAUDE.md component rules
+- [IYKYK on blank.space](https://iykyk.blank.space) - meta description: "Social hub for the IYKYK community. Create, customize, and explore the IYKYK ecosystem."
+- [iykyk.com](https://iykyk.com) - "share yourself, on purpose" framing for related but separate brand
+- Doc 609 (May 4 ZAOstock cobuild) - 6-circle structure that informs entry-page audiences

--- a/research/business/612-autoco-llc-formation/README.md
+++ b/research/business/612-autoco-llc-formation/README.md
@@ -1,0 +1,144 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-05-07
+related-docs: 609, 611
+tier: STANDARD
+---
+
+# 612 - AutoCo + LLC formation options for ZAO Festivals
+
+> **Goal:** Decide ZAO Festivals legal entity setup before pitch deck week (May 14-19). Slide 3 of investor deck claims "ZAO Festivals LLC, in formation via AutoCo." This doc verifies whether AutoCo is the right path or if we say "in formation" with a different vehicle.
+
+## Key Decisions
+
+| # | Decision | Status |
+|---|---|---|
+| 1 | ZAO Festivals needs its own legal entity (LLC or similar) before taking outside investment | LOCKED - per Rav call May 6 |
+| 2 | Vehicle: AutoCo (US LLC, on-chain compatible) OR traditional Stripe Atlas / LegalZoom / Clerky | DECISION needed by May 14 |
+| 3 | Holding structure: ZAO Festivals LLC = umbrella, sub-entities for ZAO Stock / Chella / Palooza if needed | DEFERRED - revisit Year 3 |
+| 4 | Fiscal sponsorship architecture stays as-is: NMC + Fractured Atlas for tax-deductible donations. LLC is for investor capital + commercial revenue | LOCKED - per FailOften 2026-05-07 |
+
+## Context (from Rav call May 6, transcribed in research doc 609 + earlier session notes)
+
+Zaal mentioned during the Rav call:
+> "I have an interview coming up in the next little bit, with this company called AutoCo, and it is basically creating, um, entities in the United States, um, that are technically also on chain, but as a master of their company, so it's like instant. Um, but then you can also... They recently dropped a way that you could do it through the full paperwork and like do a full LLC on your own."
+
+Rav's response was supportive of getting the legal structure formalized so he could introduce investors. He flagged that the minimum bar is "a really compelling business case" - so the vehicle matters less than the deck story. AutoCo is one of several options.
+
+## Three viable paths
+
+### Option A - AutoCo (on-chain LLC)
+
+**What it is:** AutoCo (autoco.law or similar - the exact product Zaal referenced) creates US LLCs that are also represented on-chain. Fast formation, traditional legal validity, plus on-chain mirror for crypto-native investor signing or token-based equity mechanics.
+
+**Pros:**
+- Aligned with The ZAO ecosystem (some investors will care that it is on-chain compatible)
+- Often faster than traditional incorporation
+- Crypto-native investor signing pattern works out-of-the-box
+- The "agentic commerce + on-chain proofs" thesis Rav is working on aligns
+
+**Cons:**
+- Newer category - less battle-tested than Stripe Atlas / LegalZoom
+- Some traditional / non-crypto investors may not understand the on-chain wrapper
+- Depending on how AutoCo handles bank accounts + tax filings, could create operational friction
+- Requires Zaal to do due diligence on the specific provider before locking in
+
+**Cost estimate:** TBD - likely $500-$2,000 for formation + state filing fees. Annual maintenance ~$200-$500.
+
+### Option B - Traditional Delaware LLC via Stripe Atlas / Clerky / LegalZoom
+
+**What it is:** Standard Delaware LLC, formed through a service provider that handles state filing, EIN, operating agreement, and bank account setup.
+
+**Pros:**
+- Most battle-tested path for US startups
+- Traditional investors recognize and trust the structure
+- Stripe Atlas in particular has world-class founder support
+- Easy banking + payment processor integration
+- Founders already familiar with this pattern
+
+**Cons:**
+- Slower than on-chain options (weeks vs days)
+- No on-chain wrapper - if we want token-based equity later, need a separate vehicle
+- Less aligned with the ZAO ecosystem ethos
+
+**Cost estimate:** Stripe Atlas $500 one-time + $300 annual Delaware franchise tax. Clerky ~$500 first year. LegalZoom $300-$700.
+
+### Option C - "In formation" - defer the actual filing
+
+**What it is:** Deck slide says "ZAO Festivals LLC, in formation" without committing to a specific vehicle. Zaal commits to incorporate before any investor signs a term sheet (~30-60 days post-handshake).
+
+**Pros:**
+- Removes blocker for deck shipping May 14-19
+- Buys time to do proper due diligence on AutoCo + alternatives
+- Most LLC formations are fast enough to complete during due diligence anyway
+- Investors expect this for very early-stage projects
+
+**Cons:**
+- Looks less prepared than already-formed
+- Could create timing friction during a hot lead
+
+## Recommendation for the deck
+
+**For deck v1 shipping May 19:** Use **Option C** - "ZAO Festivals LLC, in formation." Removes blocker.
+
+**Decision deadline for actual incorporation:** End of May 2026 / before first signed investor term sheet.
+
+**Recommended actual path:** **Option A (AutoCo)** if due diligence checks out, otherwise **Option B (Stripe Atlas / Clerky)** as the proven fallback. Decide after Zaal's intro interview with AutoCo.
+
+## What slide 3 of the investor deck should say
+
+Current draft (per doc 611 + earlier deck outline):
+> "ZAO Festivals = community-owned festival production. Artists discovered in The ZAO. Festival operates at break-even. Investors get equity in the umbrella entity (ZAO Festivals LLC, in formation via AutoCo)."
+
+**Recommended edit:** drop the "via AutoCo" specifier until decided. Replace with:
+> "Investors get equity in the umbrella entity (ZAO Festivals LLC, in formation; incorporated under Delaware or equivalent before term sheet signing)."
+
+This keeps the slide honest, removes a vendor name we have not committed to, and signals to sophisticated investors that we know the standard incorporation path.
+
+## What needs to happen before May 14 (deck day 1)
+
+1. **Zaal completes the AutoCo intro interview** - find out specifics on cost, timeline, banking, tax compliance
+2. **3-way meeting: Zaal + FailOften + Rav** - lock the entity decision and sub-entity / fiscal sponsor relationship
+3. **Decide between A / B / C** based on what comes out of the AutoCo interview + the 3-way meeting
+4. **If A or B: kick off filing immediately** so we can update slide 3 from "in formation" to "formed in [state] [month]" before deck v1 ships
+5. **If C: confirm slide 3 wording stays "in formation"** and add to back-pocket due-diligence packet
+
+## Action Bridge
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Complete AutoCo intro interview | Zaal | call | This week |
+| 3-way meeting: Zaal + FailOften + Rav | Zaal | calendar | Mon May 12 |
+| Final entity decision (A / B / C) | Zaal + FailOften | decision | Tue May 13 |
+| If A or B: file formation paperwork | Zaal | legal | Wed May 14 onward |
+| Update deck slide 3 with final wording | Zaal | deck edit | May 14 (deck day 1) |
+| Document final entity in research doc 612 | Future session | doc update | After incorporation |
+
+## Open questions for the AutoCo interview
+
+1. What states do they support for LLC formation (Delaware, Wyoming, etc)?
+2. Total cost: formation + state filing + annual maintenance + on-chain wrapper?
+3. How long does formation take end-to-end?
+4. Banking: do they have integrated bank account setup, or do we go to Mercury / Brex separately?
+5. Tax compliance: do they handle annual filings, or is that on us?
+6. On-chain wrapper specifics: which chain (Base, Ethereum, etc), what does "on-chain LLC" actually mean operationally, can we sign cap-table entries on-chain?
+7. Equity tooling: do they offer cap-table management, or do we go to Pulley / Carta separately?
+8. Investor experience: have they done deals with traditional VCs as well as crypto-native funds?
+9. Sub-entity support: if ZAO Festivals LLC is the umbrella and we want sub-entities for ZAOstock / Chella / Palooza, can they handle that or do we file separately?
+10. Fiscal sponsor compatibility: does the LLC structure conflict with NMC + Fractured Atlas administering charitable funds for specific initiatives?
+
+## Also See
+
+- [Doc 609](../../events/609-zaostock-cobuild-six-circles-may4/) - May 4 cobuild
+- [Doc 611](../611-zaostock-brand-patterns-rsvpizza-iykyk/) - brand audit + entry pages
+- [memory: project_zao_fiscal_sponsor.md](/Users/zaalpanthaki/.claude/projects/-Users-zaalpanthaki-Documents-zaostock/memory/project_zao_fiscal_sponsor.md) - NMC + Fractured Atlas + ENTERACT structure
+
+## Sources
+
+- Rav call transcript (May 6) - captured in earlier session memory_notes
+- Stripe Atlas docs: https://stripe.com/atlas (verified 2026-05-07)
+- Clerky: https://www.clerky.com (verified 2026-05-07)
+- AutoCo - exact product to be confirmed during Zaal's intro interview this week
+- FailOften 2026-05-07 fiscal sponsor structure correction


### PR DESCRIPTION
Two research docs from the May 7 ZAOstock work session.

## Doc 611 - ZAOstock brand patterns: RSV.Pizza + IYKYK + 3 contributor entry pages

Audit of two reference sites - RSV.Pizza (production festival ops) and IYKYK / blank.space (community-vibe ecosystem). Identifies 6 page patterns we are missing (CheckIn, PartnerDashboard, PartnerIntake, PublicReport, DisplayPage, GraphicsDashboard) and recommends 3 contributor entry pages.

Entry pages already shipped in PR #21 (zaostock repo): /musicians, /artists, /event-organizers.

## Doc 612 - AutoCo + LLC formation paths

Decision doc for ZAO Festivals legal entity setup. Three paths analyzed (AutoCo on-chain LLC / traditional Stripe Atlas / "in formation"). Recommends "in formation" for deck v1 ship May 19, with actual incorporation decided after Zaal completes the AutoCo intro interview this week.

10 due-diligence questions for the AutoCo call included.

## Companion to

- PR #21 in zaostock repo (3 entry pages + sponsor finders fee doc)
- Doc 609 (May 4 cobuild) + doc 610 (DB consolidation)