### PR TITLE
fix(tsconfig): exclude research/ from typecheck (unblock Vercel)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "scripts", "tests", "plugins", "vitest.config.ts", "playwright.config.ts", "**/*.test.ts", "**/*.test.tsx", "src/test-utils", "mcp", "src/mcp", "zabal-snap", "duodo-snap", "nouns-snap", "apps", "packages", "contracts", "bot"]
+  "exclude": ["node_modules", "scripts", "tests", "plugins", "vitest.config.ts", "playwright.config.ts", "**/*.test.ts", "**/*.test.tsx", "src/test-utils", "mcp", "src/mcp", "zabal-snap", "duodo-snap", "nouns-snap", "apps", "packages", "contracts", "bot", "research"]
 }


### PR DESCRIPTION
## Summary
- Vercel main build fails: tsc tries to type-check `research/_archive/nexus-versions/ZAONEXUS-current/page.tsx`, a standalone Next app under research/ with its own package.json that imports `lucide-react` (not in parent monorepo deps)
- Fix: add `research` to tsconfig `exclude`. research/ holds docs + archives + snapshots, never imported by `src/` (verified via grep)
- Local `npm run typecheck` now clean

## Test plan
- [x] `npm run typecheck` passes locally
- [ ] Vercel preview build green
- [ ] Merge unblocks main production deploy

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>