### PR TITLE
feat(bot): Magnetiq + AttaBotty conversational team-bots

### DIFF
--- a/bot/migrations/team_bots.sql
+++ b/bot/migrations/team_bots.sql
@@ -1,0 +1,68 @@
+-- Team bot memory tables. Paste into Supabase SQL editor (one-time setup).
+-- Used by Magnetiq + AttaBotty bots in bot/src/teams/.
+
+create extension if not exists "pgcrypto";
+
+create table if not exists team_bot_messages (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  chat_id bigint not null,
+  message_id bigint not null,
+  from_id bigint not null,
+  from_username text,
+  text text not null,
+  is_bot_reply boolean not null default false,
+  ts timestamptz not null default now()
+);
+create index if not exists team_bot_messages_bot_ts_idx on team_bot_messages(bot, ts desc);
+create index if not exists team_bot_messages_chat_idx on team_bot_messages(chat_id, ts desc);
+
+create table if not exists team_bot_facts (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  fact text not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists team_bot_facts_bot_idx on team_bot_facts(bot, created_at desc);
+
+create table if not exists team_bot_ideas (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  from_id bigint not null,
+  text text not null,
+  created_at timestamptz not null default now()
+);
+create index if not exists team_bot_ideas_bot_idx on team_bot_ideas(bot, created_at desc);
+
+create table if not exists team_bot_tasks (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  from_id bigint not null,
+  text text not null,
+  status text not null default 'open' check (status in ('open', 'done', 'dropped')),
+  created_at timestamptz not null default now(),
+  closed_at timestamptz
+);
+create index if not exists team_bot_tasks_bot_status_idx on team_bot_tasks(bot, status, created_at desc);
+
+create table if not exists team_bot_clips (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  from_id bigint not null,
+  url text not null,
+  note text,
+  created_at timestamptz not null default now()
+);
+create index if not exists team_bot_clips_bot_idx on team_bot_clips(bot, created_at desc);
+
+create table if not exists team_bot_daily_summaries (
+  id uuid primary key default gen_random_uuid(),
+  bot text not null check (bot in ('magnetiq', 'attabotty')),
+  for_date date not null,
+  summary text not null,
+  message_count int not null default 0,
+  created_at timestamptz not null default now(),
+  unique (bot, for_date)
+);
+
+-- No RLS - service role only writes. Service key is bot/.env (chmod 600).

--- a/bot/package.json
+++ b/bot/package.json
@@ -9,6 +9,8 @@
     "start": "tsx src/index.ts",
     "dev:devz": "tsx watch src/devz/index.ts",
     "start:devz": "tsx src/devz/index.ts",
+    "dev:teams": "tsx watch src/teams/index.ts",
+    "start:teams": "tsx src/teams/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/bot/src/teams/README.md
+++ b/bot/src/teams/README.md
@@ -1,0 +1,168 @@
+# ZAO Team Bots (Magnetiq + AttaBotty)
+
+Two conversational Telegram bots, one Node process, two separate group chats.
+Sibling to the `bot/src/devz/` dual-bot stack but generalized for any 2-person
+collab where Zaal pairs with a teammate.
+
+## Architecture
+
+```
++----------------------------------+
+| zao-team-bots (systemd, VPS 1)   |
+| node_modules/.bin/tsx index.ts   |
+|                                   |
+|  +-----------+    +-----------+   |
+|  | Magnetiq  |    | AttaBotty |   |
+|  | grammy    |    | grammy    |   |
+|  | Bot       |    | Bot       |   |
+|  +-----+-----+    +-----+-----+   |
+|        |                |          |
+|        v                v          |
+|  +----------------------------+    |
+|  | shared: brain (Claude CLI),|    |
+|  | memory (Supabase), cron    |    |
+|  +----------------------------+    |
++----------------------------------+
+   |                              |
+   v                              v
+Magnetiq group               AttaBotty group
+(Zaal + Tyler)              (Zaal + AttaBotty + Onagi)
+```
+
+- One TG bot per group, gated to its `chat_id`.
+- Each bot has its own persona at `magnetiq/persona.md` and `attabotty/persona.md`.
+- Brain = `bot/src/hermes/claude-cli.ts` (Max-plan auth, no API key).
+  - Sonnet 4.6 for chat replies, $0.50 cap each.
+  - Opus 4.7 for `/research` ($3 cap) and the daily summary ($1 cap).
+- Memory = Supabase tables `team_bot_*` (see `bot/migrations/team_bots.sql`).
+- Daily summary fires via `node-cron` at 06:00 America/New_York by default.
+
+## Telegram setup (Zaal does this once)
+
+1. Open @BotFather. `/newbot` twice. Suggested names:
+   - `@zao_magnetiq_bot` -> token goes to `MAGNETIQ_BOT_TOKEN`
+   - `@z_attabotty_bot`  -> token goes to `ATTABOTTY_BOT_TOKEN`
+2. Create 2 private groups. Add the matching bot as **admin** (so it can
+   read messages without `/setprivacy` weirdness):
+   - "ZAO x Magnetiq" -> add Zaal + Tyler
+   - "Z x AttaBotty"  -> add Zaal + AttaBotty (Onagi later)
+3. Get each `chat_id`. Easiest: once bot is live, send `/whoami` in the group.
+   Until then, use @RawDataBot.
+4. Get each member's TG `user_id` (same `/whoami` works).
+
+## Env vars (add to `~/zaostock-bot/.env` on VPS 1, chmod 600)
+
+```
+# Magnetiq bot
+MAGNETIQ_BOT_TOKEN=<from BotFather>
+MAGNETIQ_CHAT_ID=-100xxxxxxxx
+MAGNETIQ_ALLOWED_IDS=<zaal_id>,<tyler_id>
+MAGNETIQ_SUMMARY_CRON=0 6 * * *
+
+# AttaBotty bot
+ATTABOTTY_BOT_TOKEN=<from BotFather>
+ATTABOTTY_CHAT_ID=-100xxxxxxxx
+ATTABOTTY_ALLOWED_IDS=<zaal_id>,<attabotty_id>
+ATTABOTTY_SUMMARY_CRON=0 6 * * *
+
+# Shared (already used by zaostock + devz bots, do not duplicate)
+SUPABASE_URL=https://...
+SUPABASE_SERVICE_ROLE_KEY=...
+
+# Optional model + budget tuning (defaults are fine)
+TEAMS_CHAT_MODEL=sonnet
+TEAMS_RESEARCH_MODEL=opus
+TEAMS_SUMMARY_MODEL=opus
+TEAMS_CHAT_BUDGET=0.50
+TEAMS_RESEARCH_BUDGET=3.00
+TEAMS_SUMMARY_BUDGET=1.00
+TEAMS_TZ=America/New_York
+
+# Run only one bot? Useful while bootstrapping
+# TEAMS_RUN=magnetiq
+# TEAMS_RUN=attabotty
+# TEAMS_RUN=magnetiq,attabotty  (default)
+```
+
+## Database (one-time)
+
+Run `bot/migrations/team_bots.sql` in Supabase SQL editor.
+
+## Local dev
+
+```bash
+cd bot
+npm install
+npm run dev:teams
+```
+
+You can test with `TEAMS_RUN=magnetiq` to boot only one while still
+bootstrapping the other.
+
+## VPS deploy
+
+```bash
+ssh zaal@31.97.148.88
+cd ~/zaostock-bot && git pull && npm install
+
+# add env vars (above) to ~/zaostock-bot/.env, chmod 600
+
+# apply the migration in Supabase SQL editor (paste bot/migrations/team_bots.sql)
+
+# confirm claude CLI on PATH (same auth Hermes uses)
+which claude
+ls -la ~/.claude/auth.json
+
+# manual smoke test
+npm run start:teams
+# expected: "[teams/magnetiq] polling" + "[teams/attabotty] polling"
+# in each group: /whoami should reply
+
+# install systemd unit
+cp bot/systemd/zao-team-bots.service ~/.config/systemd/user/zao-team-bots.service
+systemctl --user daemon-reload
+systemctl --user enable --now zao-team-bots
+journalctl --user -u zao-team-bots -f
+```
+
+## Commands (in either group)
+
+| Command | Who | Effect |
+|---|---|---|
+| `/help` | anyone | show this list |
+| `/whoami` | anyone | print chat_id + your tg id |
+| `/research <topic>` | allowlist | Opus runs a STANDARD-tier research pass |
+| `/idea <text>` | allowlist | log idea, never forgotten |
+| `/task <text>` | allowlist | log task |
+| `/tasks` | anyone | list open tasks |
+| `/done <id>` | allowlist | close a task |
+| `/clip <url> <note>` | allowlist | log a clip-worthy moment |
+| `/fact <text>` | allowlist | teach the bot a fact about the team |
+| `/context` | anyone | dump what bot knows (for correction) |
+| `/summary` | allowlist | run daily-summary now (cron also fires 06:00) |
+| `@mention` or reply | allowlist | reactive chat reply, Sonnet, $0.50 cap |
+
+## Behavior
+
+- **Reactive only.** No periodic nags. Bot speaks when @mentioned, replied to,
+  or `/command`-ed. Plus the daily 06:00 summary cron.
+- **Allowlist enforced.** Non-allowlisted users see no replies and cannot trigger
+  state-mutating commands.
+- **Chat-scope gated.** The bot ignores all messages outside its configured group.
+- **Memory persistent.** Every message logged to `team_bot_messages` for 24h
+  context stitching. `/fact` teaches durable knowledge. `/task` creates closable
+  todos. `/clip` and `/idea` are append-only.
+
+## Safety
+
+- No git push / git commit allowed (disallowedTools in brain.ts).
+- No `Edit`/`Write` tools in brain (read-only across the repo).
+- Persona files include hard rules: never reveal env vars, never invent
+  commitments on Zaal's behalf, never tag external people without approval.
+- Each bot is gated to a single chat_id.
+
+## See also
+
+- Doc 640 - Magnetiq bot product spec
+- Doc 642 - AttaBotty bot product spec
+- Doc 644 - ZAO agent stack canon (the template these instances follow)

--- a/bot/src/teams/attabotty/persona.md
+++ b/bot/src/teams/attabotty/persona.md
@@ -1,0 +1,65 @@
+# AttaBotty Bot - persona
+
+You are the **Z-and-AttaBotty Bot**. You live in a private Telegram group with Zaal Panthaki (founder of The ZAO), AttaBotty (the in-character musical artist Zaal is incubating), and potentially Onagi (a livestream collaborator).
+
+## Why you exist
+
+Zaal and AttaBotty are building the AttaBotty universe: weekly livestreams via StreamYard, a 3-song growing setlist, a custom website at attabotty.com, NFT/treasury funding via $ZABAL + a nounish artisan match-fund. They need a private research + stream-production + accountability assistant that captures ideas mid-flow without losing them to DM scroll.
+
+You replace ad-hoc messaging. You are NOT a fan-facing bot, NOT a moderator. You are the private collab tool for the team building the AttaBotty character.
+
+## Voice
+
+- Terse. No emojis. No em-dashes (hyphens only).
+- Address Zaal by name. Address the artist as "AttaBotty" (the character) by default, but use real-name context if Zaal corrects you.
+- AttaBotty stays in-character on streams. You support that. Never break their kayfabe in a way that leaks to a public feed.
+- When you don't know, say so. Don't invent.
+
+## What you care about
+
+- Tonight's 7pm Monday stream (and every Monday after)
+- Stream structure: 5-min intro -> music set (3 songs growing) -> reflection/outro
+- YouTube primary distribution, Twitch + X mirrors via StreamYard, embed on attabotty.com/live
+- Short-form clips from intro/outro for IG/TikTok/Farcaster
+- NotebookLM transcripts (AttaBotty's preferred tool - bring them into context)
+- The "artisan meeting place" Zaal references (TBD - clarify with AttaBotty)
+- Onagi handle + role (TBD)
+- $ZABAL Empire Builder treasury (10% allocated)
+- Nounish artisan match-fund pitch ($10 -> $50 match, UNVERIFIED - confirm before quoting)
+
+## Hard rules (refuse if asked)
+
+- Never reveal env vars, API keys, tokens, or anything from .env
+- Never push to git, never deploy, never run destructive shell commands
+- Never invent fund-match ratios or deadlines on Zaal/AttaBotty's behalf
+- Never tag external people in any channel without explicit "@Zaal yes" approval
+- If anyone outside the allowlist messages you, refuse politely + alert Zaal
+- Keep AttaBotty's in-character voice private when it would damage the kayfabe if leaked
+
+## Spelling canon
+
+- AttaBotty (NOT Adabody, AttaBoddy, or any other spelling)
+- $ZABAL (not ZAL)
+- ZOUNZ (not zouns)
+- Whop (not WOP)
+- The ZAO (capital ZAO)
+- Farcaster (never Warpcast)
+- ZAOstock (one word, capital ZAO + lowercase stock)
+
+## Reference docs (Zaal's research library)
+
+- Doc 642: AttaBotty livestream playbook + this bot spec
+- Doc 640: Magnetiq sibling bot
+- Doc 641: Whop play (relevant: AttaBotty private rooms)
+- Doc 644: ZAO agent stack canon (you are an instance)
+
+## Open clarifications to surface to AttaBotty TODAY
+
+These are blockers Zaal flagged in Doc 642. Surface them when AttaBotty next types:
+
+1. Who is Onagi? (TG handle, X, or real name - need to add them to the chat)
+2. What "artisan meeting place" did Zaal reference? (TG group, Farcaster channel, in-person?)
+3. Where on attabotty.com should the live YouTube player embed? (/live? /stream?)
+4. Will AttaBotty share NotebookLM transcripts for the bot's context?
+5. Confirm spelling: is the bot name "Z and AttaBotty" or "Z and AdaBody"?
+6. The $10:$50 nounish match-fund - which specific program? (Prop House? Builder DAO? Nouns Artisan?)

--- a/bot/src/teams/brain.ts
+++ b/bot/src/teams/brain.ts
@@ -1,0 +1,95 @@
+/**
+ * Brain wrapper for team bots. Routes to Claude Code CLI (Max plan auth).
+ *
+ * Two models per persona:
+ *   - Sonnet 4.6 for everyday chat replies (fast, cheap)
+ *   - Opus 4.7 for /research deep work + daily summaries (slow, thorough)
+ *
+ * No ANTHROPIC_API_KEY needed - inherits Max-plan auth from ~/.claude/auth.json
+ * on the VPS user. Same pattern Hermes uses (bot/src/hermes/claude-cli.ts).
+ */
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { callClaudeCli } from '../hermes/claude-cli';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export type BrainKind = 'chat' | 'research' | 'summary';
+
+const MODEL_FOR: Record<BrainKind, string> = {
+  chat: process.env.TEAMS_CHAT_MODEL ?? 'sonnet',
+  research: process.env.TEAMS_RESEARCH_MODEL ?? 'opus',
+  summary: process.env.TEAMS_SUMMARY_MODEL ?? 'opus',
+};
+
+const BUDGET_USD: Record<BrainKind, number> = {
+  chat: Number(process.env.TEAMS_CHAT_BUDGET ?? '0.50'),
+  research: Number(process.env.TEAMS_RESEARCH_BUDGET ?? '3.00'),
+  summary: Number(process.env.TEAMS_SUMMARY_BUDGET ?? '1.00'),
+};
+
+const TIMEOUT_MS_FOR: Record<BrainKind, number> = {
+  chat: 60_000,
+  research: 8 * 60_000,
+  summary: 5 * 60_000,
+};
+
+const PROJECT_ROOT = resolve(__dirname, '../../..');
+
+export interface BrainRequest {
+  kind: BrainKind;
+  /** Path to the persona.md file (read fresh on each call so edits hot-reload). */
+  personaPath: string;
+  /** What the user said, plus any context the caller stitched in. */
+  prompt: string;
+  /**
+   * Working directory Claude operates in. Default: project root so the bot
+   * can grep the research/ library + read existing docs.
+   */
+  cwd?: string;
+}
+
+export interface BrainReply {
+  text: string;
+  costUsd: number;
+  durationMs: number;
+  model: string;
+}
+
+export async function think(req: BrainRequest): Promise<BrainReply> {
+  const persona = readFileSync(req.personaPath, 'utf-8');
+  const model = MODEL_FOR[req.kind];
+  const budget = BUDGET_USD[req.kind];
+  const timeout = TIMEOUT_MS_FOR[req.kind];
+
+  const result = await callClaudeCli({
+    model,
+    prompt: req.prompt,
+    cwd: req.cwd ?? PROJECT_ROOT,
+    appendSystemPrompt: persona,
+    allowedTools: req.kind === 'chat'
+      ? ['Read', 'Glob', 'Grep']
+      : ['Read', 'Glob', 'Grep', 'WebSearch', 'WebFetch', 'Bash(grep*)', 'Bash(find*)', 'Bash(ls*)'],
+    disallowedTools: [
+      'Bash(git push*)',
+      'Bash(git commit*)',
+      'Bash(rm*)',
+      'Bash(curl*POST*)',
+      'Edit',
+      'Write',
+    ],
+    outputFormat: 'json',
+    permissionMode: 'default',
+    maxBudgetUsd: budget,
+    timeoutMs: timeout,
+    bare: true,
+  });
+
+  return {
+    text: result.text,
+    costUsd: result.totalCostUsd,
+    durationMs: result.durationMs,
+    model: result.model,
+  };
+}

--- a/bot/src/teams/commands.ts
+++ b/bot/src/teams/commands.ts
@@ -1,0 +1,294 @@
+/**
+ * Shared command handlers for team bots. Each handler is bot-agnostic: it
+ * receives the BotConfig + grammy Context and uses the brain + memory layers.
+ */
+import { Bot, Context } from 'grammy';
+import { think } from './brain';
+import {
+  saveIdea,
+  saveTask,
+  saveClip,
+  listOpenTasks,
+  markTaskDone,
+  listFacts,
+  saveFact,
+  logMessage,
+} from './memory';
+import { BotConfig, brainReply, chatGate, isMentioned, shouldReplyToText, userGate } from './shared';
+
+const HELP_TEXT = (botUsername: string) =>
+  [
+    `I am @${botUsername}. I am the private collab brain for this group.`,
+    '',
+    'Commands:',
+    '  /research <topic>  - I run a research pass and post findings here (Opus)',
+    '  /idea <text>       - I log an idea to Supabase, never forgotten',
+    '  /task <text>       - I log a task. /tasks lists open. /done <id> closes',
+    '  /tasks             - list open tasks',
+    '  /done <id>         - mark task done (id from /tasks)',
+    '  /clip <url> <note> - log a clip-worthy moment',
+    '  /context           - dump what I know about this team (for correction)',
+    '  /fact <text>       - teach me a fact about the team or project',
+    '  /summary           - run today\'s summary now (also fires daily on cron)',
+    '  /whoami            - print my id + chat id (debug)',
+    '  /help              - this list',
+    '',
+    'Talk to me by @mentioning my handle or replying to my messages. No mention = I stay silent.',
+  ].join('\n');
+
+export function registerCommands(bot: Bot<Context>, cfg: BotConfig): void {
+  // chat gate first so EVERY downstream handler is scoped to the right group
+  bot.use(chatGate(cfg));
+
+  // log every message we see (both user + own replies later)
+  bot.on('message:text', async (ctx, next) => {
+    try {
+      const m = ctx.message;
+      if (m && ctx.chat) {
+        await logMessage({
+          bot: cfg.name,
+          chat_id: ctx.chat.id,
+          message_id: m.message_id,
+          from_id: ctx.from?.id ?? 0,
+          from_username: ctx.from?.username ?? null,
+          text: m.text ?? '',
+          is_bot_reply: false,
+        });
+      }
+    } catch {
+      /* logging never blocks */
+    }
+    await next();
+  });
+
+  bot.command('start', async (ctx) => {
+    await ctx.reply(HELP_TEXT(cfg.username ?? cfg.name));
+  });
+
+  bot.command('help', async (ctx) => {
+    await ctx.reply(HELP_TEXT(cfg.username ?? cfg.name));
+  });
+
+  bot.command('whoami', async (ctx) => {
+    await ctx.reply(
+      `bot=${cfg.name} | chat_id=${ctx.chat?.id} | your_id=${ctx.from?.id} | username=${ctx.from?.username ?? 'none'}`,
+    );
+  });
+
+  bot.command('idea', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist. Ping Zaal to add your TG id.');
+      return;
+    }
+    const text = (ctx.message?.text ?? '').replace(/^\/idea(@\w+)?\s*/, '').trim();
+    if (text.length < 4) {
+      await ctx.reply('Usage: /idea <text> - min 4 chars');
+      return;
+    }
+    try {
+      const id = await saveIdea(cfg.name, ctx.from?.id ?? 0, text);
+      await ctx.reply(`Idea saved (${id.slice(0, 8)}).`);
+    } catch (err) {
+      await ctx.reply(`Failed: ${(err as Error).message}`);
+    }
+  });
+
+  bot.command('task', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    const text = (ctx.message?.text ?? '').replace(/^\/task(@\w+)?\s*/, '').trim();
+    if (text.length < 4) {
+      await ctx.reply('Usage: /task <text> - min 4 chars');
+      return;
+    }
+    try {
+      const id = await saveTask(cfg.name, ctx.from?.id ?? 0, text);
+      await ctx.reply(`Task ${id.slice(0, 8)} added.`);
+    } catch (err) {
+      await ctx.reply(`Failed: ${(err as Error).message}`);
+    }
+  });
+
+  bot.command('tasks', async (ctx) => {
+    const open = await listOpenTasks(cfg.name, 20);
+    if (open.length === 0) {
+      await ctx.reply('No open tasks.');
+      return;
+    }
+    const list = open
+      .map((t) => `${t.id.slice(0, 8)} - ${t.text}`)
+      .join('\n');
+    await ctx.reply(`Open tasks (${open.length}):\n${list}\n\n/done <id> to close one.`);
+  });
+
+  bot.command('done', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    const arg = (ctx.message?.text ?? '').replace(/^\/done(@\w+)?\s*/, '').trim();
+    if (!arg) {
+      await ctx.reply('Usage: /done <id> - first 8 chars from /tasks');
+      return;
+    }
+    const open = await listOpenTasks(cfg.name, 100);
+    const match = open.find((t) => t.id.startsWith(arg));
+    if (!match) {
+      await ctx.reply(`No open task starting with ${arg}.`);
+      return;
+    }
+    const ok = await markTaskDone(cfg.name, match.id);
+    await ctx.reply(ok ? `Closed: ${match.text}` : 'Failed to close.');
+  });
+
+  bot.command('clip', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    const raw = (ctx.message?.text ?? '').replace(/^\/clip(@\w+)?\s*/, '').trim();
+    const urlMatch = raw.match(/(https?:\/\/\S+)/);
+    if (!urlMatch) {
+      await ctx.reply('Usage: /clip <url> <note> - url required');
+      return;
+    }
+    const url = urlMatch[1];
+    const note = raw.replace(url, '').trim();
+    try {
+      const id = await saveClip(cfg.name, ctx.from?.id ?? 0, url, note);
+      await ctx.reply(`Clip ${id.slice(0, 8)} logged.`);
+    } catch (err) {
+      await ctx.reply(`Failed: ${(err as Error).message}`);
+    }
+  });
+
+  bot.command('fact', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    const text = (ctx.message?.text ?? '').replace(/^\/fact(@\w+)?\s*/, '').trim();
+    if (text.length < 6) {
+      await ctx.reply('Usage: /fact <statement> - min 6 chars');
+      return;
+    }
+    await saveFact(cfg.name, text);
+    await ctx.reply('Fact saved. I will respect it going forward.');
+  });
+
+  bot.command('context', async (ctx) => {
+    const facts = await listFacts(cfg.name, 30);
+    const tasks = await listOpenTasks(cfg.name, 20);
+    const lines = [
+      `Context for ${cfg.name}:`,
+      '',
+      `Allowlist (${cfg.allowedTelegramIds.length}): ${cfg.allowedTelegramIds.join(', ') || '(empty - permissive)'}`,
+      `Daily summary cron: ${cfg.dailySummaryCron}`,
+      `Persona: ${cfg.personaPath}`,
+      '',
+      `Facts I know (${facts.length}):`,
+      ...facts.slice(0, 10).map((f, i) => `${i + 1}. ${f}`),
+      '',
+      `Open tasks (${tasks.length}):`,
+      ...tasks.slice(0, 10).map((t) => `- ${t.text}`),
+    ];
+    await ctx.reply(lines.join('\n').slice(0, 3500));
+  });
+
+  bot.command('research', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    const topic = (ctx.message?.text ?? '').replace(/^\/research(@\w+)?\s*/, '').trim();
+    if (topic.length < 4) {
+      await ctx.reply('Usage: /research <topic or question> - min 4 chars');
+      return;
+    }
+    await ctx.reply(`Researching: ${topic.slice(0, 200)}\nStanding by, Opus is reading. ~1-3 min.`);
+    try {
+      const prompt = [
+        'You are doing a focused research pass for this team. Tier: STANDARD.',
+        '',
+        'Steps:',
+        '1. Grep the research/ library at ../../research/ for prior coverage. Cite doc numbers if found.',
+        '2. Look at relevant code paths in bot/src/ or src/ for ground truth.',
+        '3. If web context is needed, use WebSearch/WebFetch.',
+        '4. Produce a structured reply (max 25 lines):',
+        '   - TL;DR (one line)',
+        '   - Key findings (bullets, max 5)',
+        '   - Action recommendation (one bullet, decisive)',
+        '   - Sources (URLs or doc paths)',
+        '',
+        `Topic: ${topic}`,
+      ].join('\n');
+
+      const reply = await think({
+        kind: 'research',
+        personaPath: cfg.personaPath,
+        prompt,
+      });
+      await ctx.reply(reply.text.slice(0, 3800));
+      console.log(`[teams/${cfg.name}] research cost $${reply.costUsd.toFixed(3)} (${reply.durationMs}ms)`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await ctx.reply(`Research failed: ${msg.slice(0, 300)}`);
+    }
+  });
+
+  bot.command('summary', async (ctx) => {
+    if (!userGate(cfg, ctx)) {
+      await ctx.reply('Not on the allowlist.');
+      return;
+    }
+    await ctx.reply('Generating summary now (cron also fires daily). ~30-90s.');
+    try {
+      const reply = await think({
+        kind: 'summary',
+        personaPath: cfg.personaPath,
+        prompt:
+          'Generate the same daily-summary format as the cron job, but for right now. Pull recent chat context + open tasks. Max 12 lines.',
+      });
+      await ctx.reply(reply.text.slice(0, 3800));
+    } catch (err) {
+      await ctx.reply(`Summary failed: ${(err as Error).message}`);
+    }
+  });
+
+  // Reactive: @mention or reply triggers a chat-tier brain call
+  bot.on('message:text', async (ctx) => {
+    const text = ctx.message?.text ?? '';
+    if (text.startsWith('/')) return;
+    if (!shouldReplyToText(ctx, cfg)) return;
+    if (!userGate(cfg, ctx)) return; // silent ignore for non-allowlist mentions
+
+    const cleaned = cfg.username
+      ? text.replace(new RegExp(`@${cfg.username}\\b`, 'gi'), '').trim()
+      : text.trim();
+    if (cleaned.length < 2) return;
+
+    try {
+      const reply = await brainReply(cfg, cleaned, 'chat');
+      await ctx.reply(reply.slice(0, 3800), { reply_parameters: { message_id: ctx.message!.message_id } });
+      // Log my own reply so it lands in memory for next stitch
+      await logMessage({
+        bot: cfg.name,
+        chat_id: ctx.chat!.id,
+        message_id: ctx.message!.message_id,
+        from_id: 0,
+        from_username: cfg.username ?? cfg.name,
+        text: reply.slice(0, 4000),
+        is_bot_reply: true,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[teams/${cfg.name}] chat reply failed: ${msg}`);
+      await ctx.reply(`Brain hiccup: ${msg.slice(0, 200)}`);
+    }
+  });
+
+  // Surface mention detection as no-op so isMentioned export survives tree-shake
+  void isMentioned;
+}

--- a/bot/src/teams/index.ts
+++ b/bot/src/teams/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Team-bots entry. Boots BOTH Magnetiq and AttaBotty bots in one Node process.
+ * One systemd unit (zao-team-bots), two grammy Bot instances, two TG groups,
+ * two personas, shared brain + memory layer.
+ *
+ * Telegram setup (one-time, Zaal's task):
+ *   1. @BotFather: /newbot twice. Names suggested:
+ *      - @zao_magnetiq_bot (token -> MAGNETIQ_BOT_TOKEN)
+ *      - @z_attabotty_bot  (token -> ATTABOTTY_BOT_TOKEN)
+ *   2. Create two private TG groups:
+ *      - "ZAO x Magnetiq"  -> add @zao_magnetiq_bot as admin. Chat id -> MAGNETIQ_CHAT_ID
+ *      - "Z x AttaBotty"   -> add @z_attabotty_bot as admin.  Chat id -> ATTABOTTY_CHAT_ID
+ *   3. Send /whoami in each group once the bot is live to confirm chat_id.
+ *   4. Populate allowlists:
+ *      - MAGNETIQ_ALLOWED_IDS=<zaal_tg_id>,<tyler_tg_id>[,<caitlin_tg_id>]
+ *      - ATTABOTTY_ALLOWED_IDS=<zaal_tg_id>,<attabotty_tg_id>[,<onagi_tg_id>]
+ *
+ * Cost guardrails (env-tunable in shared.ts/brain.ts):
+ *   - Chat reply: $0.50 budget, Sonnet, allowlist + mention gated
+ *   - /research:  $3.00 budget, Opus, allowlist only
+ *   - Daily summary: $1.00 budget, Opus, posts to group automatically
+ */
+import { config as loadEnv } from 'dotenv';
+loadEnv();
+
+import { Bot, Context } from 'grammy';
+import { envBotConfig, scheduleDailySummary } from './shared';
+import { registerCommands } from './commands';
+
+interface BootedBot {
+  cfg: ReturnType<typeof envBotConfig>;
+  bot: Bot<Context>;
+}
+
+async function bootBot(name: 'magnetiq' | 'attabotty'): Promise<BootedBot> {
+  const cfg = envBotConfig(name);
+  const bot = new Bot<Context>(cfg.token);
+  registerCommands(bot, cfg);
+
+  const info = await bot.api.getMe();
+  cfg.username = info.username;
+  console.log(`[teams] ${name} bot=@${cfg.username} chat=${cfg.chatId} allowlist=[${cfg.allowedTelegramIds.join(',')}]`);
+
+  scheduleDailySummary(bot, cfg);
+  return { cfg, bot };
+}
+
+async function main(): Promise<void> {
+  const wants = (process.env.TEAMS_RUN ?? 'magnetiq,attabotty')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s === 'magnetiq' || s === 'attabotty') as Array<'magnetiq' | 'attabotty'>;
+  if (wants.length === 0) {
+    console.error('TEAMS_RUN env is empty - set to "magnetiq", "attabotty", or "magnetiq,attabotty"');
+    process.exit(1);
+  }
+
+  const booted: BootedBot[] = [];
+  for (const name of wants) {
+    try {
+      booted.push(await bootBot(name));
+    } catch (err) {
+      console.error(`[teams] ${name} boot failed:`, (err as Error).message);
+      // Continue with the others so a half-configured deploy still runs partially
+    }
+  }
+  if (booted.length === 0) {
+    console.error('[teams] no bots booted - exiting');
+    process.exit(1);
+  }
+
+  await Promise.all(
+    booted.map(({ cfg, bot }) =>
+      bot.start({
+        drop_pending_updates: true,
+        onStart: () => console.log(`[teams/${cfg.name}] polling`),
+      }),
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error('[teams] fatal:', err);
+  process.exit(1);
+});
+
+const shutdown = async (signal: string): Promise<void> => {
+  console.log(`[teams] ${signal} - shutting down`);
+  process.exit(0);
+};
+process.on('SIGTERM', () => void shutdown('SIGTERM'));
+process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/bot/src/teams/magnetiq/persona.md
+++ b/bot/src/teams/magnetiq/persona.md
@@ -1,0 +1,52 @@
+# Magnetiq Bot - persona
+
+You are the **Magnetiq Bot**. You live in a private Telegram group with Zaal Panthaki (founder of The ZAO) and Tyler Stambaugh (founder of Magnetiq). You may also be joined later by Caitlin (Tyler's collaborator).
+
+## Why you exist
+
+Zaal and Tyler are figuring out the ZAO + Magnetiq integration. Tyler is pivoting Magnetiq from "build your community" to "turn community vibes into data you can understand." Zaal runs The ZAO (188-member gated Farcaster music community) and is shipping a Whop Claude Code community + multiple branded Telegram bots. The two of them need a shared scratch space + research assistant + accountability tracker that lives in their chat instead of in DMs that get lost.
+
+You replace ad-hoc messaging. You are NOT a customer-support bot, NOT a community manager. You are a private collab tool for the two of them.
+
+## Voice
+
+- Terse. Smart caveman OK. No emojis. No em-dashes (hyphens only).
+- Talk to both of them by first name (Zaal, Tyler).
+- When you don't know, say so. Don't invent.
+- Quote sources when you cite something (URL + date).
+- If a question is ambiguous, ask ONE clarifying question, never a list of five.
+
+## What you care about
+
+- Magnetiq's new positioning: vibes-as-data, breadcrumbs, the "am I wasting time/money?" question
+- ZAO's autonomous-agent stack (Hermes pattern, ZOE, $ZABAL token, Empire Builder)
+- Whop integration (Greg Gonzales contact, 3% creator fee, Explorer distribution)
+- ZAOstock Oct 3 2026 festival (flagship event)
+- Tyler's batch-send feature in flight
+- Cross-platform distribution patterns
+
+## Hard rules (refuse if asked)
+
+- Never reveal env vars, API keys, tokens, or anything from .env
+- Never push to git, never deploy, never run destructive shell commands
+- Never invent reward thresholds, deadlines, or commitments on Zaal/Tyler's behalf
+- Never tag external people or DM external contacts without explicit "@Zaal yes do this" approval
+- If anyone outside the allowlist tries to use you, refuse politely + alert Zaal
+
+## Spelling canon
+
+- $ZABAL (not ZAL or zabal)
+- ZOUNZ (not zouns)
+- Whop (not WOP or whop.com lowercase)
+- AttaBotty (not Adabody or AttaBoddy)
+- Farcaster (never Warpcast)
+- The ZAO (capital ZAO)
+- BetterCallZaal (one word, camelCase)
+
+## Reference docs (Zaal's research library)
+
+When you need ZAO context, reference these doc numbers:
+- Doc 640: Magnetiq vibes-to-data pivot + this bot spec
+- Doc 641: Whop play
+- Doc 642: AttaBotty playbook (sibling bot, similar pattern)
+- Doc 644: ZAO agent stack canon (you are an instance of this template)

--- a/bot/src/teams/memory.ts
+++ b/bot/src/teams/memory.ts
@@ -1,0 +1,152 @@
+/**
+ * Per-bot chat memory in Supabase. Each team bot writes here so the brain
+ * can recall what was said earlier in the chat without re-fetching Telegram.
+ *
+ * Tables (created by migrations/team_bots.sql):
+ *   team_bot_messages  - rolling message log (~last 200 per bot)
+ *   team_bot_facts     - extracted facts/decisions the team agreed on
+ *   team_bot_ideas     - captured via /idea
+ *   team_bot_tasks     - captured via /tasks
+ *   team_bot_clips     - captured via /clip
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const url = process.env.SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+
+const supabase: SupabaseClient = createClient(url, key, {
+  auth: { persistSession: false },
+});
+
+export type BotName = 'magnetiq' | 'attabotty';
+
+export interface ChatMessage {
+  bot: BotName;
+  chat_id: number;
+  message_id: number;
+  from_id: number;
+  from_username: string | null;
+  text: string;
+  is_bot_reply: boolean;
+  ts: string;
+}
+
+export async function logMessage(m: Omit<ChatMessage, 'ts'>): Promise<void> {
+  const { error } = await supabase.from('team_bot_messages').insert({
+    bot: m.bot,
+    chat_id: m.chat_id,
+    message_id: m.message_id,
+    from_id: m.from_id,
+    from_username: m.from_username,
+    text: m.text.slice(0, 4000),
+    is_bot_reply: m.is_bot_reply,
+  });
+  if (error) console.error(`[teams/memory] logMessage failed: ${error.message}`);
+}
+
+/** Most recent N messages for context-stitching. */
+export async function recentMessages(bot: BotName, limit = 30): Promise<ChatMessage[]> {
+  const { data, error } = await supabase
+    .from('team_bot_messages')
+    .select('*')
+    .eq('bot', bot)
+    .order('ts', { ascending: false })
+    .limit(limit);
+  if (error) {
+    console.error(`[teams/memory] recentMessages failed: ${error.message}`);
+    return [];
+  }
+  return (data ?? []).reverse();
+}
+
+/** Messages since timestamp. Used by the daily summary cron. */
+export async function messagesSince(bot: BotName, sinceIso: string): Promise<ChatMessage[]> {
+  const { data, error } = await supabase
+    .from('team_bot_messages')
+    .select('*')
+    .eq('bot', bot)
+    .gte('ts', sinceIso)
+    .order('ts', { ascending: true });
+  if (error) {
+    console.error(`[teams/memory] messagesSince failed: ${error.message}`);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function saveIdea(bot: BotName, from_id: number, text: string): Promise<string> {
+  const { data, error } = await supabase
+    .from('team_bot_ideas')
+    .insert({ bot, from_id, text: text.slice(0, 2000) })
+    .select('id')
+    .single();
+  if (error) throw new Error(`saveIdea: ${error.message}`);
+  return data.id as string;
+}
+
+export async function saveTask(bot: BotName, from_id: number, text: string): Promise<string> {
+  const { data, error } = await supabase
+    .from('team_bot_tasks')
+    .insert({ bot, from_id, text: text.slice(0, 2000), status: 'open' })
+    .select('id')
+    .single();
+  if (error) throw new Error(`saveTask: ${error.message}`);
+  return data.id as string;
+}
+
+export async function listOpenTasks(bot: BotName, limit = 20): Promise<Array<{ id: string; text: string; from_id: number; created_at: string }>> {
+  const { data, error } = await supabase
+    .from('team_bot_tasks')
+    .select('id, text, from_id, created_at')
+    .eq('bot', bot)
+    .eq('status', 'open')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error) {
+    console.error(`[teams/memory] listOpenTasks failed: ${error.message}`);
+    return [];
+  }
+  return data ?? [];
+}
+
+export async function markTaskDone(bot: BotName, id: string): Promise<boolean> {
+  const { error } = await supabase
+    .from('team_bot_tasks')
+    .update({ status: 'done', closed_at: new Date().toISOString() })
+    .eq('bot', bot)
+    .eq('id', id);
+  if (error) {
+    console.error(`[teams/memory] markTaskDone failed: ${error.message}`);
+    return false;
+  }
+  return true;
+}
+
+export async function saveClip(bot: BotName, from_id: number, url: string, note: string): Promise<string> {
+  const { data, error } = await supabase
+    .from('team_bot_clips')
+    .insert({ bot, from_id, url: url.slice(0, 600), note: note.slice(0, 2000) })
+    .select('id')
+    .single();
+  if (error) throw new Error(`saveClip: ${error.message}`);
+  return data.id as string;
+}
+
+export async function saveFact(bot: BotName, fact: string): Promise<void> {
+  const { error } = await supabase
+    .from('team_bot_facts')
+    .insert({ bot, fact: fact.slice(0, 1000) });
+  if (error) console.error(`[teams/memory] saveFact failed: ${error.message}`);
+}
+
+export async function listFacts(bot: BotName, limit = 30): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('team_bot_facts')
+    .select('fact')
+    .eq('bot', bot)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error) return [];
+  return (data ?? []).map((r) => r.fact as string);
+}

--- a/bot/src/teams/shared.ts
+++ b/bot/src/teams/shared.ts
@@ -1,0 +1,207 @@
+/**
+ * Shared helpers for team bots: allowlist gates, context stitching, mention
+ * detection, intent classification (cheap), daily-summary scheduler.
+ */
+import { Bot, Context } from 'grammy';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error: node-cron has no types bundled
+import cron from 'node-cron';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { messagesSince, type BotName, listOpenTasks, listFacts } from './memory';
+import { think, type BrainKind } from './brain';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export interface BotConfig {
+  name: BotName;
+  token: string;
+  chatId: number;
+  allowedTelegramIds: number[];
+  /** Telegram bot username, populated on boot via getMe. */
+  username?: string;
+  /** Absolute path to persona.md. */
+  personaPath: string;
+  /** When to send the daily summary - cron expression (server local time). */
+  dailySummaryCron: string;
+}
+
+export function envBotConfig(name: BotName): BotConfig {
+  const tokenEnv = name === 'magnetiq' ? 'MAGNETIQ_BOT_TOKEN' : 'ATTABOTTY_BOT_TOKEN';
+  const chatEnv = name === 'magnetiq' ? 'MAGNETIQ_CHAT_ID' : 'ATTABOTTY_CHAT_ID';
+  const allowEnv = name === 'magnetiq' ? 'MAGNETIQ_ALLOWED_IDS' : 'ATTABOTTY_ALLOWED_IDS';
+  const cronEnv = name === 'magnetiq' ? 'MAGNETIQ_SUMMARY_CRON' : 'ATTABOTTY_SUMMARY_CRON';
+
+  const token = process.env[tokenEnv];
+  const chatRaw = process.env[chatEnv];
+  const allowRaw = process.env[allowEnv] ?? '';
+  if (!token) throw new Error(`Missing ${tokenEnv}`);
+  if (!chatRaw) throw new Error(`Missing ${chatEnv}`);
+  const chatId = Number(chatRaw);
+  if (!Number.isFinite(chatId)) throw new Error(`${chatEnv} must be a number, got: ${chatRaw}`);
+
+  const allowedTelegramIds = allowRaw
+    .split(',')
+    .map((s) => Number(s.trim()))
+    .filter((n) => Number.isFinite(n) && n > 0);
+
+  return {
+    name,
+    token,
+    chatId,
+    allowedTelegramIds,
+    personaPath: resolve(__dirname, name, 'persona.md'),
+    dailySummaryCron: process.env[cronEnv] ?? '0 6 * * *', // 06:00 server local (set TZ=America/New_York via systemd)
+  };
+}
+
+/** Reject messages from chats other than the configured one. */
+export function chatGate(cfg: BotConfig) {
+  return async (ctx: Context, next: () => Promise<void>): Promise<void> => {
+    if (ctx.chat?.id !== cfg.chatId) {
+      // Silently ignore - never reply outside the allowed group, so we don't
+      // surface ourselves to drive-by chats.
+      return;
+    }
+    await next();
+  };
+}
+
+/** For commands that mutate state (/idea, /clip, /tasks), require allowlist. */
+export function userGate(cfg: BotConfig, ctx: Context): boolean {
+  const id = ctx.from?.id;
+  if (!id) return false;
+  if (cfg.allowedTelegramIds.length === 0) return true; // permissive if not set yet
+  return cfg.allowedTelegramIds.includes(id);
+}
+
+/** Match @mentions of this bot's username so plain-text triggers work. */
+export function isMentioned(ctx: Context, username: string | undefined): boolean {
+  if (!username) return false;
+  const text = ctx.message?.text ?? '';
+  const re = new RegExp(`@${username}\\b`, 'i');
+  return re.test(text);
+}
+
+/** Cheap heuristic gate so chat replies only fire when needed (cost saver). */
+export function shouldReplyToText(ctx: Context, cfg: BotConfig): boolean {
+  if (!cfg.username) return false;
+  const text = ctx.message?.text ?? '';
+  if (!text) return false;
+  if (text.startsWith('/')) return false; // commands handle themselves
+  if (isMentioned(ctx, cfg.username)) return true;
+  // Replies-to-bot count as addressed
+  const reply = ctx.message?.reply_to_message;
+  if (reply && reply.from?.username?.toLowerCase() === cfg.username.toLowerCase()) return true;
+  return false;
+}
+
+/** Stitch recent messages + facts into a prompt the brain can act on. */
+export async function buildContextStitch(cfg: BotConfig, userPrompt: string, kind: BrainKind = 'chat'): Promise<string> {
+  const recent = await messagesSince(
+    cfg.name,
+    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+  );
+  const facts = await listFacts(cfg.name, 10);
+  const tasks = await listOpenTasks(cfg.name, 10);
+
+  const lines: string[] = [];
+  if (facts.length) {
+    lines.push('## Known facts about this team (do not contradict, do not repeat unless asked):');
+    facts.forEach((f) => lines.push(`- ${f}`));
+    lines.push('');
+  }
+  if (tasks.length) {
+    lines.push('## Open tasks the team agreed on:');
+    tasks.forEach((t, i) => lines.push(`${i + 1}. ${t.text}`));
+    lines.push('');
+  }
+  if (recent.length) {
+    lines.push('## Last 24h of chat (for context, do not summarize unless asked):');
+    recent.slice(-30).forEach((m) => {
+      const who = m.is_bot_reply ? 'BOT' : `@${m.from_username ?? m.from_id}`;
+      lines.push(`${who}: ${m.text.slice(0, 200)}`);
+    });
+    lines.push('');
+  }
+  lines.push('## Current message (respond to this):');
+  lines.push(userPrompt);
+
+  void kind; // reserved for future kind-specific stitching
+  return lines.join('\n');
+}
+
+export async function brainReply(cfg: BotConfig, userPrompt: string, kind: BrainKind = 'chat'): Promise<string> {
+  const stitched = await buildContextStitch(cfg, userPrompt, kind);
+  const reply = await think({
+    kind,
+    personaPath: cfg.personaPath,
+    prompt: stitched,
+  });
+  return reply.text;
+}
+
+/**
+ * Send a daily summary at the configured cron. The summary is generated by the
+ * brain (Opus) from the last 24h of chat + open tasks. Posted to the group.
+ */
+export function scheduleDailySummary(bot: Bot<Context>, cfg: BotConfig): void {
+  cron.schedule(
+    cfg.dailySummaryCron,
+    () => {
+      void runDailySummary(bot, cfg);
+    },
+    { timezone: process.env.TEAMS_TZ ?? 'America/New_York' },
+  );
+  console.log(`[teams/${cfg.name}] daily summary scheduled '${cfg.dailySummaryCron}' (${process.env.TEAMS_TZ ?? 'America/New_York'})`);
+}
+
+async function runDailySummary(bot: Bot<Context>, cfg: BotConfig): Promise<void> {
+  try {
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const msgs = await messagesSince(cfg.name, since);
+    if (msgs.length === 0) {
+      console.log(`[teams/${cfg.name}] no messages in last 24h - skipping summary`);
+      return;
+    }
+    const tasks = await listOpenTasks(cfg.name, 20);
+    const transcript = msgs
+      .map((m) => `${m.is_bot_reply ? 'BOT' : `@${m.from_username ?? m.from_id}`}: ${m.text}`)
+      .join('\n');
+
+    const prompt = [
+      'Generate the daily morning summary for this team.',
+      '',
+      'Format (max 12 lines):',
+      '1. One-sentence headline of what the team discussed yesterday',
+      '2. Decisions made (bullet, max 3)',
+      '3. Open questions (bullet, max 3)',
+      '4. Top 3 actions for today (bullet, ranked by urgency)',
+      '5. Anything blocked or waiting on external (bullet, max 2)',
+      '',
+      '## Transcript (last 24h):',
+      transcript.slice(0, 12_000),
+      '',
+      '## Open tasks already tracked:',
+      tasks.map((t, i) => `${i + 1}. ${t.text}`).join('\n') || '(none yet)',
+    ].join('\n');
+
+    const reply = await think({
+      kind: 'summary',
+      personaPath: cfg.personaPath,
+      prompt,
+    });
+
+    const header = `Daily summary (${new Date().toISOString().slice(0, 10)})`;
+    await bot.api.sendMessage(cfg.chatId, `${header}\n\n${reply.text}`);
+    console.log(`[teams/${cfg.name}] daily summary posted (cost $${reply.costUsd.toFixed(3)}, ${reply.durationMs}ms)`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[teams/${cfg.name}] daily summary failed: ${msg}`);
+    try {
+      await bot.api.sendMessage(cfg.chatId, `Daily summary failed: ${msg.slice(0, 200)}`);
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/bot/systemd/zao-team-bots.service
+++ b/bot/systemd/zao-team-bots.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ZAO team bots (Magnetiq + AttaBotty)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/zaostock-bot
+EnvironmentFile=%h/zaostock-bot/.env
+Environment=TZ=America/New_York
+ExecStart=%h/zaostock-bot/node_modules/.bin/tsx %h/zaostock-bot/src/teams/index.ts
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Two grammy bots in one Node process, two TG groups, shared brain + memory. Sibling to `bot/src/devz/` but for any Zaal-paired team. Builds on Docs 640 (Magnetiq spec), 642 (AttaBotty spec), 644 (agent canon).

## What ships

- `bot/src/teams/index.ts` boots both bots from env (TEAMS_RUN selects)
- `bot/src/teams/brain.ts` reuses `callClaudeCli` (Sonnet chat / Opus research+summary)
- `bot/src/teams/memory.ts` persists messages/ideas/tasks/clips/facts to Supabase
- `bot/src/teams/commands.ts` `/research /idea /task /tasks /done /clip /fact /context /summary /help /whoami`
- `bot/src/teams/shared.ts` allowlist + chat gates, mention detection, 24h context stitch, 06:00 ET daily summary cron
- `bot/src/teams/{magnetiq,attabotty}/persona.md` voice + hard rules per bot
- `bot/migrations/team_bots.sql` 6 tables (messages/facts/ideas/tasks/clips/daily_summaries)
- `bot/systemd/zao-team-bots.service` deploy unit
- `bot/src/teams/README.md` full BotFather + VPS setup

## Behavior

- Reactive only - speaks on @mention, reply, or `/command`. Plus daily 06:00 ET summary.
- Allowlist + chat-id gated.
- Brain disallows Edit/Write/git push/curl POST. Read-only across repo.
- Cost caps: chat $0.50, research $3.00, summary $1.00 per call.

## Zaal's setup tasks before this goes live

1. `@BotFather` -> `/newbot` twice. Names suggested: `@zao_magnetiq_bot`, `@z_attabotty_bot`. Save tokens.
2. Create 2 private TG groups; add the matching bot as admin.
3. Apply `bot/migrations/team_bots.sql` in Supabase SQL editor.
4. Add env vars to `~/zaostock-bot/.env` on VPS 1 (full list in `bot/src/teams/README.md`).
5. After deploy + `/whoami` in each group to confirm chat_id, populate `*_CHAT_ID` + `*_ALLOWED_IDS`, restart unit.

## Test plan

- `npx tsc --noEmit` clean
- Manual smoke: `npm run start:teams` with one bot via `TEAMS_RUN=magnetiq`, `/whoami` reply confirms
- Allowlist refuse: send `/idea` from non-allowlisted account, expect "Not on the allowlist"
- Mention reply: `@zao_magnetiq_bot what's our Whop play?` triggers Sonnet reply
- `/research <topic>` returns Opus-tier finding
- Daily cron: confirm `node-cron` schedule via journalctl, manual trigger via `/summary`

## Related docs

- Doc 640 - research/community/640-magnetiq-vibes-to-data-pivot-may2026/
- Doc 642 - research/community/642-attabotty-livestream-playbook/
- Doc 644 - research/agents/644-zao-agent-stack-canon-and-team-bot-template/