### PR TITLE
docs(research): docs 644 + 645 - agent canon + team-bots audit

### DIFF
--- a/research/agents/644-zao-agent-stack-canon-and-team-bot-template/README.md
+++ b/research/agents/644-zao-agent-stack-canon-and-team-bot-template/README.md
@@ -1,0 +1,478 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-11
+related-docs: [640, 642, 483, 547, 601]
+tier: DEEP
+source: synthesis-of-existing-docs-2026-05-11
+---
+
+# 644 - ZAO Agent Stack Canon + Team Bot Template
+
+Reference doc for builders. Locks the canonical agent pattern, the conversational-group-chat template both Magnetiq and AttaBotty bots will use, and the path to add future team bots.
+
+**TL;DR:** All ZAO bots use Hermes pattern (Claude CLI subprocess) + Telegraf + per-bot persona files (human.md, agents.md, soul.md, heartbeat.md) + Telegram group allowlists. One template. Five operating surfaces. No new bots without research doc + Zaal approval.
+
+---
+
+## Locked Canon (Non-Negotiable)
+
+### Agent Framework: Hermes + Claude Code CLI
+
+ALL ZAO agents use the **Hermes pattern** from `bot/src/hermes/claude-cli.ts`:
+
+- Spawn `claude` CLI as subprocess, not direct API calls
+- Auth via Claude Code Max plan OAuth (~/.claude/auth.json), NOT `ANTHROPIC_API_KEY`
+- System prompt injected per invocation via `--append-system-prompt`
+- Tool restrictions via `--allowedTools` / `--disallowedTools`
+- Parse JSON response via `--output-format json`
+- Zero marginal cost, stable model quality (Sonnet/Opus), no billing surprises
+
+**Why Hermes:** Max plan = shared auth infrastructure. No Anthropic API key sprawl. Stable for production. Past experiments (Composio AO, Agent Zero migration, ZOE v2) hit quality walls or complexity ceilings. Hermes is locked 2026-05-05, no reopening.
+
+**Free local LLM:** Ollama on VPS :11434 (llama3.1:8b, 4.9GB) for low-stakes work only (entity classification, inbox routing). Wrapper: `bot/src/zoe/ollama.ts`. NOT for writing, brand outputs, research, or concierge replies.
+
+### Five Operating Surfaces (Post-Doc-601 Collapse)
+
+ZAO went from 12+ systems to 5. When proposing automation or bots, check this list first.
+
+| Surface | Purpose | Users | Source | Model |
+|---------|---------|-------|--------|-------|
+| **ZOE** (@zaoclaw_bot) | Concierge: tasks, captures, brief/reflect, recall, research | Zaal + team | bot/src/zoe/ (Hermes-brain) | Sonnet/Opus |
+| **Hermes** (@zoe_hermes_bot) | Autonomous fix-PR pipeline: coder + critic + auto-PR | DevOps | bot/src/hermes/ | Opus |
+| **ZAO Devz** (@zaodevz_bot) | Group dispatch + hourly learning tip (Phase 3: fold into Hermes) | Engineers | bot/src/devz/ | Sonnet/Haiku |
+| **Bonfire** (@zabal_bonfire) | Knowledge graph recall + multi-corpus ingest | Members | bonfires.ai (external) | Claude |
+| **ZAOstock bot** (@ZAOstockTeamBot) | Festival team coordination (graduating to own repo) | Team | bot/ (root, separate) | Sonnet |
+
+**Decommissioned — do NOT propose, build, restart:**
+- openclaw container + 7-agent squad (ZOEY/BUILDER/SCOUT/WALLET/FISHBOWLZ/CASTER)
+- Composio AO orchestrator
+- ZOE v2 + Agent Zero migration plan
+- 10-bot branded fleet (features fold into ZOE memory blocks instead)
+
+**Rule:** No new bots without a numbered research doc + explicit Zaal approval in writing.
+
+### Infrastructure
+
+- **VPS only:** Hostinger KVM 2 at 31.97.148.88 (31GB RAM, 8 cores). NO second box.
+- **Code deployment:** rsync from local to VPS, never git-clone on server (env vars stay local)
+- **Service management:** systemd user units at `~/.config/systemd/user/<bot>.service`
+- **Bot tokens + secrets:** `~/<bot-name>/.env` (chmod 600, never committed, never pushed)
+- **Secrets hygiene:** apply all 5 guards from `secret-hygiene.md` on any agent commit
+
+---
+
+## Conversational-Group-Chat Bot Template
+
+This is the standard for Magnetiq, AttaBotty, and any approved future team bot.
+
+### File Layout
+
+```
+bot/src/<bot-name>/
+├── human.md               # Persona, voice, values, what they care about
+├── agents.md              # Capabilities matrix - tools, commands, model choice
+├── soul.md                # Hard rules, mission, what they refuse, secret refusal
+├── heartbeat.md           # Cadence rules - summarization, nag timing, silence windows
+├── config.ts              # Telegraf setup, TG token, allowed group, allowed users, model
+├── index.ts               # Main bot entry - Telegraf setup, message handler, classify -> route
+├── commands/
+│   ├── research.ts        # /research <topic> -> Claude-powered research (like /zao-research)
+│   ├── idea.ts            # /idea <text> -> capture to Supabase ideas table
+│   ├── context.ts         # /context -> dump what bot knows (let humans correct)
+│   ├── task.ts            # /task <text> -> add to shared task list
+│   └── workflow.ts        # /workflow <date> -> generate checklist (bot-specific)
+├── memory/
+│   ├── chat_history.jsonl # Rolling Supabase-backed chat log
+│   └── facts.md           # Extracted team/project knowledge bot has learned
+└── package.json           # (inherits from bot/ root, no duplicates)
+```
+
+### Message Flow (Sequence)
+
+```
+[Human posts to group]
+        |
+        v
+Telegraf receives update
+        |
+        v
+Check: @mention or /command?
+        |
+     /  \
+    Y    N
+   /      \
+  v        v
+Route to   Check allowlist:
+command    - allowed group ID?
+handler    - allowed user ID?
+  |        |
+  v        |  N
+Execute    |  -> Ignore
+  |        v  Y
+  |      Extract text
+  |        |
+  |        v
+  |      Classify intent
+  |      (Ollama or rule-based)
+  |        |
+  |        v
+  |      Match route:
+  |      - greeting? respond
+  |      - question? research
+  |      - decision? synthesize
+  |      - task? add to list
+  |        |
+  |        v
+  |      Call Claude CLI
+  |      (Hermes pattern)
+  |        |
+  |        v
+  |      Generate reply
+  |        |
+  v        v
+Save to   Send TG message
+history   |
+          v
+          Log to Supabase
+```
+
+### Bot Persona Files (Locked Template)
+
+#### human.md
+```markdown
+# <Bot Name> Persona
+
+## Who You Are
+[2-3 sentences: voice, role, what you stand for]
+
+## What You Care About
+- [Specific to the bot's purpose]
+- [Specific to the users]
+- [Specific to the domain]
+
+## Tone
+[Casual, formal, witty, supportive? One-liner.]
+
+## Example Conversation Snippet
+[Show a good interaction, not prescriptive but illustrative]
+```
+
+#### agents.md
+```markdown
+# <Bot Name> - Capabilities & Tools
+
+## Model Choice
+[Haiku for classify / Sonnet for synthesis / Opus for complex reasoning]
+
+## Commands
+| Command | What It Does | Example |
+|---------|-------------|---------|
+| /research | Find information | /research ZAO history |
+| ... | ... | ... |
+
+## Tools Available
+- Allowed: [Bash, Read, Grep, etc.]
+- Disallowed: [Write, Edit if not needed, etc.]
+
+## Integration Points
+- Reads from: [Supabase tables, files, external APIs]
+- Writes to: [Supabase, Telegram, logs]
+```
+
+#### soul.md
+```markdown
+# <Bot Name> - Hard Rules & Refusals
+
+## Mission
+[One-liner: why this bot exists and what it achieves]
+
+## What You Do
+- [Specific, achievable commitment]
+- [Specific, achievable commitment]
+
+## What You REFUSE
+- Never reveal secrets (tokens, keys, passwords) in group chat. If asked, respond: "I can't share secrets here. Refer to <owner>."
+- Never take destructive actions (delete, broadcast) without user confirmation.
+- Never fabricate team facts. If unsure, say: "I don't have that info. Ask <owner>."
+
+## Approval Gates
+Commands that need explicit confirmation:
+- /broadcast <message> - always ask "Send to [group]? (yes/no)"
+- /archive <data> - always ask "Archive [X] records? (yes/no)"
+```
+
+#### heartbeat.md
+```markdown
+# <Bot Name> - Cadence & Timing Rules
+
+## Automatic Digests
+- [None, or list specific times/cadences]
+
+## When to Speak
+- Only on /command or @mention (no auto-replies to all messages)
+- Read all messages for context (passive listening)
+- React (emoji) to noteworthy messages if natural
+
+## When to Stay Silent
+- Group chatter, off-topic banter (unless @mentioned)
+- During specific hours: [list if applicable, e.g., 9pm-6am EST]
+
+## Summarization Rules
+- After N messages or X hours, offer: "/context to dump what I know"
+- Don't summarize unless asked or weekly digest scheduled
+```
+
+#### config.ts
+```typescript
+// Example: Magnetiq bot
+
+export const MAGNETIQ_BOT_CONFIG = {
+  telegramToken: process.env.MAGNETIQ_BOT_TOKEN!,
+  allowedGroupId: -1001234567890,  // Zaal + Tyler private group
+  allowedUserIds: [123456789, 987654321], // Zaal, Tyler Telegram IDs
+  supabaseUrl: process.env.SUPABASE_URL!,
+  supabaseKey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  model: 'claude-opus', // or 'claude-sonnet' for lower cost
+  ollamaUrl: 'http://31.97.148.88:11434', // for classify only
+  systemPrompt: `You are Magnetiq Bot, a research assistant helping Zaal and Tyler spec the ZAO-Magnetiq integration...`,
+};
+```
+
+#### index.ts
+```typescript
+// Sketch
+import { Bot, Context } from 'grammy';
+import { callClaudeCli } from '../hermes/claude-cli';
+
+const bot = new Bot(config.telegramToken);
+
+bot.on('message', async (ctx) => {
+  // Check allowlist
+  if (!isAllowed(ctx.from?.id, ctx.chat.id)) {
+    return; // Ignore
+  }
+
+  // Extract text, check for /command or @mention
+  const text = ctx.message?.text || '';
+  
+  if (text.startsWith('/')) {
+    await handleCommand(ctx, text);
+  } else if (text.includes('@magnetiq_bot') || text.includes('@magnetiq_bot')) {
+    const result = await callClaudeCli({
+      model: config.model,
+      prompt: text,
+      cwd: process.cwd(),
+      appendSystemPrompt: config.systemPrompt,
+      allowedTools: ['Read', 'Bash', 'Grep'],
+    });
+    await ctx.reply(result.text);
+  }
+
+  // Log to Supabase
+  await logMessage(ctx);
+});
+```
+
+---
+
+## Magnetiq Bot Spec (Doc 640 Extracted)
+
+| Aspect | Details |
+|--------|---------|
+| **Name** | ZAO MAGNETIQ (or @zaom bot) |
+| **Users** | Zaal + Tyler (private TG chat) |
+| **Purpose** | Dual-user research assistant for ZAO-Magnetiq integration spec |
+| **Context** | Tyler will send Magnetiq data + API docs via Telegram |
+| **Folder** | `bot/src/magnetiq/` |
+| **Model** | Sonnet (fast, good enough for research synthesis) |
+| **Cadence** | No auto-digests; responds on /command + @mention |
+| **Key Commands** | /research <topic>, /context, /idea <note> |
+| **Deployment** | VPS 1, systemd service, `~/magnetiq-bot/.env` |
+
+---
+
+## AttaBotty Bot Spec (Doc 642 Extracted)
+
+| Aspect | Details |
+|--------|---------|
+| **Name** | Z + AttaBotty (or @zab_live bot) |
+| **Users** | Zaal + AttaBotty (private TG chat) |
+| **Purpose** | Stream production assistant, research, task tracking, VOD review |
+| **Context** | NotebookLM transcripts, stream SOPs, playbook (Doc 642) |
+| **Folder** | `bot/src/attabotty/` |
+| **Model** | Sonnet (but use Opus for /stream-review if budget allows) |
+| **Key Commands** | /research, /stream-review <url>, /workflow <date>, /task, /context |
+| **Deployment** | VPS 1, systemd service, `~/attabotty-bot/.env` |
+| **Knowledge Load** | This playbook + NotebookLM transcripts + stream metadata |
+
+---
+
+## Hard Requirements (Non-Negotiable)
+
+1. **Allowlists:** Every bot has a hardcoded allowlist of group IDs + user IDs. Ignore messages outside.
+2. **Command gating:** Admin commands (/broadcast, /link, /archive) only to Zaal's Telegram ID.
+3. **Secrets refusal:** soul.md includes "never reveal secrets in group chat" + always refer to owner.
+4. **Confirmation gates:** Any destructive action (delete, broadcast, post) requires explicit yes/no.
+5. **Passive listening:** Bot reads all messages for context but only speaks on /command or @mention.
+6. **No hallucination on facts:** If bot doesn't know a team fact, say so and refer to owner.
+7. **Supabase tables per bot:** chat_history, ideas, tasks live in bot-specific tables (magnetiq_*, attabotty_*, etc.)
+8. **Logging:** Every action logged to Supabase (who, what, when). Audit trail is non-negotiable.
+
+---
+
+## How to Add a 3rd Team Bot (7-Step Playbook)
+
+### 1. Write a research doc
+Create `research/agents/64X-<name>-telegram-bot/README.md`. Include:
+- Who the users are (Zaal + whom?)
+- What problem it solves
+- Commands needed
+- Knowledge base sources (docs, transcripts, links)
+- Deployment target (VPS 1)
+
+### 2. Get Zaal's approval
+Share doc with Zaal. Wait for explicit "yes, build this." Unblock only then.
+
+### 3. Create the folder
+```bash
+mkdir -p bot/src/<name>
+touch bot/src/<name>/{human.md,agents.md,soul.md,heartbeat.md,config.ts,index.ts}
+mkdir -p bot/src/<name>/{commands,memory}
+```
+
+### 4. Fill persona files
+- **human.md:** Who is this bot? What's the voice?
+- **agents.md:** What commands? What model? What tools?
+- **soul.md:** Hard rules. What won't you do?
+- **heartbeat.md:** When to speak? When to stay silent?
+
+### 5. Copy Hermes pattern in index.ts
+Start with `bot/src/hermes/claude-cli.ts` as import. Use the sequence diagram above to structure message handler. Apply allowlist logic.
+
+### 6. Add systemd service
+```bash
+cat > ~/.config/systemd/user/<name>-bot.service <<EOF
+[Unit]
+Description=<Name> Telegram Bot
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/node /home/zaal/<name>-bot/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user enable <name>-bot
+systemctl --user start <name>-bot
+```
+
+### 7. Test + deploy
+```bash
+# Local test (if possible)
+npm run dev
+
+# Push to VPS
+rsync -av --delete --exclude=node_modules --exclude=.env bot/src/<name>/ zaal@31.97.148.88:~/<name>-bot/
+
+# Verify on VPS
+ssh zaal@31.97.148.88 'systemctl --user status <name>-bot && journalctl --user -u <name>-bot -n 10'
+```
+
+---
+
+## Provisioning: Shared Environment Script
+
+Extend `bot/scripts/sync-supabase-env.sh` to parameterize per-bot env vars:
+
+```bash
+#!/bin/bash
+# Usage: ./sync-supabase-env.sh <bot-name> (e.g., magnetiq, attabotty)
+
+BOT_NAME=${1:-zaostock}
+ENV_FILE="$HOME/${BOT_NAME}-bot/.env"
+
+# Pull from Supabase dashboard or .env.local
+echo "SUPABASE_URL=..." >> "$ENV_FILE"
+echo "SUPABASE_SERVICE_ROLE_KEY=..." >> "$ENV_FILE"
+echo "${BOT_NAME^^}_BOT_TOKEN=..." >> "$ENV_FILE"
+
+chmod 600 "$ENV_FILE"
+systemctl --user restart "${BOT_NAME}-bot"
+```
+
+---
+
+## Comparison Table: 5 Surfaces
+
+| Aspect | ZOE | Hermes | Magnetiq Bot | AttaBotty Bot | ZAOstock |
+|--------|-----|--------|--------------|---------------|----------|
+| **Purpose** | Concierge: tasks, research, brief/reflect | Autonomous PR fixer | Research assistant (Tyler collab) | Stream + music research | Festival team ops |
+| **Users** | Zaal + team | DevOps team | Zaal + Tyler | Zaal + AttaBotty | ZAOstock crew |
+| **Primary Channel** | TG group + Matrix | TG group | TG private | TG private | TG group |
+| **Commands** | /task, /capture, /research, /brief, /reflect | /fix-pr, /review, /merge | /research, /idea, /context | /research, /stream-review, /workflow, /task | /status, /mytodos, /gemba, /note |
+| **Model** | Sonnet (fast) | Opus (quality critical) | Sonnet | Sonnet/Opus | Sonnet |
+| **Brain** | Letta-style memory blocks (persistent disk) | Claude CLI + git state | Claude CLI + chat history | Claude CLI + NotebookLM | Supabase tables |
+| **Deployed** | VPS 1 | VPS 1 | VPS 1 (this week) | VPS 1 (this week) | VPS 1 (live) |
+| **Folder** | bot/src/zoe/ | bot/src/hermes/ | bot/src/magnetiq/ | bot/src/attabotty/ | bot/ (root) |
+
+---
+
+## Unresolved Questions for Zaal
+
+These three questions must be answered before Magnetiq and AttaBotty bots ship:
+
+### 1. MAGNETIQ BOT: Should the bot auto-summarize chat after N messages?
+
+Tyler will send long context docs + API specs. The bot will read all of it for context, but should it:
+- *Option A:* Summarize automatically every 50 messages or after 1 hour of inactivity?
+- *Option B:* Only summarize when asked via /context?
+- *Option C:* Smart mode - summarize if it detects a new topic/conversation shift?
+
+Decision affects: heartbeat.md cadence rules + memory table schema.
+
+### 2. ATTABOTTY BOT: Where should the bot store VOD review notes + clip suggestions?
+
+After /stream-review <youtube-url>, the bot will ingest the VOD transcript and suggest timestamps for short clips. Should these be:
+- *Option A:* Stored in a Supabase table (queryable, exportable, audit trail)?
+- *Option B:* Logged to a shared Google Doc (shareable with AttaBotty collaborators, Gdrive native)?
+- *Option C:* Both (Supabase for bot data, Google Doc export for human consumption)?
+
+Decision affects: data schema + commands/stream-review.ts implementation.
+
+### 3. FUTURE BOTS: Should there be a shared "team bot registry"?
+
+As bots multiply, should there be a single source of truth (API, Supabase table, or docs file) that lists:
+- All active bots + their group IDs
+- All allowed users per bot
+- Health status + last ping time
+- Commands available
+
+This would let a human or bot quickly see "what bots are running?" without SSH. Should we build this now (before bot 3) or wait until bot 5+?
+
+Decision affects: VPS monitoring, /admin dashboard, and bot discovery patterns.
+
+---
+
+## Sources
+
+- Doc 640: Magnetiq vibes-to-data pivot + bot spec (Tyler call 2026-05-11)
+- Doc 642: AttaBotty livestream playbook + bot spec (William call 2026-05-11)
+- Doc 483: Hermes agent framework (local LLM + Claude CLI)
+- Doc 547: Multi-agent coordination (ZOE/Hermes/Bonfire surfaces)
+- Doc 601: Agent stack cleanup decision (5 surfaces decision)
+- Memory: project_hermes_canonical (locked 2026-05-05)
+- Memory: project_zaostock_bot_live (VPS deployment pattern)
+- Code: bot/src/hermes/claude-cli.ts (Hermes subprocess pattern)
+- Code: bot/ (ZAOstock bot as template for file layout)
+
+---
+
+**Last updated:** 2026-05-11
+**Status:** Ready for build (waiting on Zaal's answers to 3 questions above)

--- a/research/agents/645-agent-canon-and-team-bots-audit/README.md
+++ b/research/agents/645-agent-canon-and-team-bots-audit/README.md
@@ -1,0 +1,170 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-05-11
+related-docs: [601, 607, 640, 642, 644]
+tier: DISPATCH
+source: dispatched-3-subagents-inventory-canon-audit
+---
+
+# 645 - Agent canon + team-bots audit (Magnetiq + AttaBotty)
+
+> Goal: synthesize every ZAO agent doc into one reference, then pressure-test the team-bots code that shipped in PR #503 against that canon. Decide ship/hold.
+
+## Recommendation: GO SHIP
+
+Team-bots code (`bot/src/teams/`) follows Hermes canon precisely. **Zero code blockers.** One pre-deploy ops check (secret-scan persona files). Five P1 gaps for the 7-day post-launch window. One over-build to clean up.
+
+Deploy tonight once tokens land. Track P1s as next-sprint follow-ups.
+
+## Key decisions table (top first, no preamble)
+
+| # | Decision | Action |
+|---|----------|--------|
+| 1 | Ship team-bots as-is to VPS 1 once tokens + chat IDs land | Zaal sends tokens, I deploy |
+| 2 | Drop unused `team_bot_daily_summaries` table OR wire writes to it | Choose path before next migration runs |
+| 3 | Add per-user @mention cooldown (60s) before bot has 7 days uptime | New PR after deploy validation |
+| 4 | Add daily-budget alert DM to Zaal if any bot exhausts $0.50/$3/$1 cap | New PR within 7 days |
+| 5 | Paginate `/context` output, truncate at 2500 chars not 3500 | New PR within 7 days |
+| 6 | Validate persona files on hot-reload (non-empty, has heading) | New PR within 7 days |
+| 7 | Add secret-scan pre-commit hook for `bot/src/teams/**` | This branch or next infra PR |
+| 8 | Answer 3 unresolved canon questions (auto-summarize cadence, VOD storage, bot registry) | Zaal decides, I write to memory |
+
+## Inventory headline numbers
+
+- **99 agent-focused docs** in `research/agents/` (some doc nums appear twice as variants)
+- **20 agent-adjacent docs** across other folders
+- **119 total** agent research surface
+- **17 docs explicitly decommissioned** (do-not-rebuild list)
+- **15 most load-bearing** for team-bots design - top 5: Doc 644 (canon), 495 (team bot patterns), 245 (ZOE workflow), 527 (multi-bot collisions), 467 (Magnetiq spec)
+
+Full list: [inventory.md](./inventory.md)
+
+## Canon at a glance (8 locked dimensions)
+
+| # | Dimension | LOCKED | DECOMMISSIONED |
+|---|-----------|--------|----------------|
+| 1 | Framework + brain | Hermes (claude-cli subprocess, Max OAuth, --append-system-prompt, --allowedTools). Sonnet for chat, Opus for hard. Ollama for low-stakes only. | openclaw, Composio AO, Agent Zero, ZOE v2, 10-bot fleet, Hermes Telegram identity |
+| 2 | Surfaces + identity | 5 surfaces: ZOE, Hermes, ZAO Devz, Bonfire, ZAOstock bot. Magnetiq + AttaBotty approved per doc 640/642. No new bots without numbered doc + Zaal approval. | FISHBOWLZ (paused), 10-bot dream, Hermes Telegram |
+| 3 | Deployment | VPS 1 only (Hostinger KVM 2, 31.97.148.88). rsync not git-clone. systemd user units. `~/.env` chmod 600. All 5 secret-hygiene guards. | Docker/openclaw container, any VPS 2 |
+| 4 | Auth | Claude Code Max plan OAuth via `~/.claude/auth.json`. Own Telegram token per bot identity. Bonfire SDK pending Joshua.eth. | ANTHROPIC_API_KEY env var, direct Minimax, Composio AO key infra |
+| 5 | Memory + retrieval | Bonfire substrate with 3 tiers (PUBLIC/ZAOSTOCK_TEAM/ZAAL_PRIVATE). No demotion. Per-bot Supabase tables. ZOE Letta-style memory blocks. Quarterly OWL backup. | Local sqlite embeddings, bot-to-bot graph sharing pre-SDK |
+| 6 | Orchestration | Zaal is orchestrator. ZOE dispatcher pattern (@zaostock, @bonfire, @hermes prefixes). Bridge group passive. Failure isolation per systemd unit. | Bot-to-bot autonomous coordination, Hermes Telegram, cross-bot narrator pairs |
+| 7 | Safety + cost | Per-bot allowlists (chat_id + user_id). Confirmation gates on destructive commands. Secrets refusal. Passive listening (speaks on cmd/mention only). Total cost ~$250-350/mo. | OpenClaw tool registry, Composio AO tools, unbounded tool access |
+| 8 | MCP + tools | --allowedTools / --disallowedTools per bot. Ollama for classify, not writing. Bonfire MCP server pending. | dangerouslySetInnerHTML, console.log in prod, .env writes, OpenClaw plugins |
+
+Full canon: [canon.md](./canon.md)
+
+## Audit of PR #503 (team-bots code) vs canon
+
+### Ship-as-is (good, do not touch)
+
+- Dual-bot in one Node process matches `bot/src/devz/index.ts` pattern
+- Hermes-brain pattern preserved (Sonnet chat $0.50 / Opus research $3 / Opus summary $1)
+- Allowed-tools matrix correct: chat = Read/Glob/Grep only; research adds WebSearch/WebFetch/Bash(grep|find|ls); disallow Edit/Write/git push/git commit/rm/curl POST
+- Persona files versioned + hot-reloadable (improvement over Devz)
+- Supabase memory with bot-column CHECK constraints on every table
+- Allowlist + chat-id gate enforced via middleware (chatGate) + per-command (userGate)
+- systemd unit follows ZAOstock + Devz pattern (working dir, env file, TZ, restart on failure, journal)
+- node-cron daily summary with timezone support, fail-soft error handling
+- All env vars validated on boot (fail-fast at `memory.ts:14-16`, `shared.ts:35-41`)
+
+### Ship-blockers (must fix before tokens go on VPS)
+
+| # | Issue | Risk | Fix |
+|---|-------|------|-----|
+| 1 | No secret-scan run yet on `bot/src/teams/**` | Persona files could leak Zaal/Tyler TG IDs or stub tokens | Run `grep -Er '(BOT_TOKEN\|ALLOWED_IDS\|SUPABASE_\|NEYNAR_\|sk-ant-\|ghp_)' bot/src/teams/` - must return empty before push |
+
+That is the only blocker. Everything else is code-side clean.
+
+### P1 gaps (fix within 7 days of deploy)
+
+1. **No @mention rate-limit cooldown** (`commands.ts:260-290`) - attacker could spam $0.50 replies. Add `Map<user_id, last_mention_ts>` with 60s cooldown in `shared.ts`.
+2. **`/context` output not paginated** (`commands.ts:181-198`) - can exceed Telegram 3500-char limit silently. Truncate at 2500 + add "use /facts or /tasks for full list."
+3. **No daily-budget alert** (`brain.ts:60-95`) - if Magnetiq exhausts $0.50 mid-day, silent fail with generic error. Add Supabase daily-spend table + DM Zaal on breach.
+4. **Persona files lack validation on hot-reload** (`brain.ts:61`) - corrupt persona = silent wrong behavior. Validate non-empty + at-least-one heading + min 50 chars.
+5. **No immutable audit log for `/idea` `/task` actions** (`memory.ts:35-46`) - low priority, current table includes `from_id` so traceable.
+
+### Over-builds (consider removing)
+
+1. **`team_bot_daily_summaries` table** (`bot/migrations/team_bots.sql:58-66`) - prepared but never written. Either uncomment write logic or drop from migration.
+
+### Deltas vs Hermes/Devz (existing canonical pair)
+
+| Dimension | Devz/Hermes | Teams (PR #503) | Verdict |
+|-----------|-------------|-----------------|---------|
+| Entry point | dual-bot in one process | dual-bot in one process | MATCH |
+| Token validation | fail-fast on missing | fail-fast on missing | MATCH |
+| Chat gate | mention-filter middleware | chat_id middleware | MATCH (Teams cleaner) |
+| User allowlist | global ADMIN_IDS | per-bot allowlist | TEAMS BETTER |
+| Brain | `callClaudeCli` | `callClaudeCli` (same import) | MATCH |
+| Model + budget | Opus, no caps | Sonnet $0.50 / Opus $3 / Opus $1 | TEAMS MORE PRUDENT |
+| Persona | hardcoded in handlers | hot-reloadable .md files | TEAMS BETTER |
+| Memory stitching | none | last 24h + facts + tasks | TEAMS BETTER |
+| Daily summary | none | node-cron 06:00 ET Opus | TEAMS ADDS FEATURE |
+
+Full audit: [delta.md](./delta.md)
+
+### Security checklist (all pass)
+
+- [PASS] No secrets/tokens logged
+- [PASS] Allowlist enforced on state mutations (`/idea` `/task` `/done` `/clip` `/fact` `/research` `/summary`)
+- [PASS] Chat-scope enforced (silent ignore outside chat_id)
+- [PASS] Brain disallows Edit/Write/git push/git commit/rm/curl POST
+- [PASS] No SQL string interpolation (Supabase JS client parameterized)
+- [PASS] No HTML injection in TG replies (no parse_mode set, plain text only)
+- [PASS] All env vars validated on boot
+- [PASS] Every table has `bot in ('magnetiq','attabotty')` CHECK constraint
+- [PASS] Persona files refuse to leak env / commit / DM external
+
+## 3 fuzzy canon zones (under-documented, decide before next bot)
+
+1. **Memory tier semantics.** Bonfire 3-tier model exists but no Bonfire schema definitions for what counts as PUBLIC vs ZAOSTOCK_TEAM vs ZAAL_PRIVATE at the field level. Risk: as bots multiply, accidental tier leaks. **Need:** schema doc with field-level tier labels.
+2. **Bot token rotation cadence.** Quarterly is suggested, never locked. **Need:** decision + runbook for routine rotation + emergency leak response.
+3. **Budget monitoring.** Cost model estimated ~$250-350/mo, no real-time dashboard. **Need:** Supabase view per bot per day, alert thresholds, monthly burn report.
+
+## 3 unresolved Magnetiq/AttaBotty questions (Doc 644 carry-over)
+
+1. **Magnetiq auto-summarize cadence:** every 50 messages? after 1hr silence? smart topic-shift detection? **Default: on /context + daily cron only** (current PR #503 behavior). Reopen if Tyler asks for it.
+2. **AttaBotty VOD review storage:** Supabase only (queryable, audit), Google Doc (shareable, native to AttaBotty flow), or both? **Default: Supabase only** (current PR #503). Add Google Doc export as P2 task.
+3. **Bot registry:** single source of truth listing every bot + chat_id + allowed users + health? **Defer until bot 4+** (we have 5 surfaces + Magnetiq + AttaBotty = 7; threshold = 10).
+
+## Action bridge
+
+| Action | Owner | Type | By when |
+|--------|-------|------|---------|
+| Run secret-scan on `bot/src/teams/**` | I do | Pre-push | Now |
+| Zaal: create 2 bots via @BotFather | Zaal | Manual | Tonight |
+| Zaal: send tokens via chat | Zaal | Manual | Tonight |
+| Deploy `team_bots.sql` to Supabase | I do via Supabase SQL editor | Migration | Tonight |
+| SSH tokens to `~/zaostock-bot/.env` on VPS 1 | I do | Deploy | Tonight |
+| `systemctl --user enable --now zao-team-bots` | I do | Deploy | Tonight |
+| `/whoami` in each group, capture chat_id + user_id, populate allowlists, restart unit | Zaal + I | Deploy | Tonight |
+| Drop OR wire `team_bot_daily_summaries` | I do | Code | Within 24h |
+| Add @mention cooldown (60s per user) | I do | PR | Within 7 days |
+| Add daily budget alert DM to Zaal | I do | PR | Within 7 days |
+| Paginate /context output | I do | PR | Within 7 days |
+| Validate persona files on read | I do | PR | Within 7 days |
+| Write Bonfire field-level tier schema doc | Zaal + Bonfire team | Doc | Before next new bot |
+| Decide bot-token rotation cadence + runbook | Zaal | Decision + memory | Within 30 days |
+| Build per-bot daily-cost dashboard view | I do | PR | Within 30 days |
+
+## Sub-docs in this hub
+
+- [inventory.md](./inventory.md) - all 119 agent-touching docs, top 15 for team-bots, decommissioned list
+- [canon.md](./canon.md) - 8 dimensions of locked decisions + decommissioned + open questions
+- [delta.md](./delta.md) - full audit of PR #503 with file:line citations + 9-item security checklist
+
+## Sources
+
+- Doc 644 - ZAO agent stack canon (the hub this audits against)
+- Doc 601 - agent stack cleanup decision
+- Doc 607 - three bots one substrate
+- Doc 600 - agentic stack coordination v1
+- Doc 495 - team telegram bot 2026 patterns
+- Doc 245 - ZOE upgrade autonomous workflow 2026
+- Doc 527 - multi-bot telegram coordination best practices
+- Doc 461 - fix-PR pipeline (Hermes safety layers)
+- PR #503 - team-bots code (bot/src/teams/)
+- User memory: project_hermes_canonical, project_no_vps2, project_ollama_local_llm, feedback_prefer_claude_max_subscription, feedback_oss_first_no_platforms

--- a/research/agents/645-agent-canon-and-team-bots-audit/canon.md
+++ b/research/agents/645-agent-canon-and-team-bots-audit/canon.md
@@ -1,0 +1,411 @@
+# ZAO agent canon (locked decisions, 2026-05-11)
+
+Canonical reference for all ZAO agent decisions across 8 dimensions. Builders use this to audit future bot proposals against locked patterns. Last validated 2026-05-11.
+
+---
+
+## 1. Framework + brain
+
+### LOCKED decisions
+
+- **Framework pattern:** Hermes (claude-cli subprocess), NOT openclaw containers, NOT Composio AO, NOT Agent Zero. Locked 2026-05-05 per explicit Zaal direction. [Doc 601, 644, project_hermes_canonical]
+  - Spawn `claude` CLI as subprocess, never direct API calls
+  - Auth via Claude Code Max plan OAuth (`~/.claude/auth.json`), NOT `ANTHROPIC_API_KEY` env var
+  - System prompt injected per invocation via `--append-system-prompt` flag
+  - Tool restrictions via `--allowedTools` / `--disallowedTools` at runtime
+  - Parse JSON response via `--output-format json`
+  - Zero marginal cost. Stable model quality (Sonnet/Opus). No API billing surprises.
+
+- **Primary brain model:** Claude Sonnet (fast synthesis) or Opus (complex reasoning) depending on task. [Doc 601, 644]
+  - ZOE concierge: Sonnet (fast) for chitchat, Opus for hard recall
+  - Hermes coder: Opus (quality critical on fixes)
+  - ZAOstock team bot: Sonnet
+  - Magnetiq bot: Sonnet (fast synthesis, Zaal/Tyler dual research)
+  - AttaBotty bot: Sonnet/Opus (Opus for /stream-review if budget allows)
+
+- **Secondary brain (low-stakes only):** Ollama llama3.1:8b on VPS port :11434. [Doc 601, project_ollama_local_llm]
+  - Wrapper: `bot/src/zoe/ollama.ts` (ollamaChat, ollamaClassify, ollamaHealth)
+  - USE FOR: inbox classification, Bonfire entity-class first-pass, audit subagent fact-check
+  - NEVER FOR: brand outputs, concierge replies, research sourcing, anything public
+  - Cold start ~11s (model load), warm 3-4s per call
+
+### DECOMMISSIONED (do NOT reincarnate)
+
+- openclaw container + 7-agent squad (ZOEY, BUILDER, SCOUT, WALLET, FISHBOWLZ, CASTER). Workspace nuked 2026-05-05. [Doc 601]
+- Composio AO orchestrator (paused indefinitely). [Doc 601]
+- ZOE v2 redesign + Agent Zero migration plan (skip, Bonfire eats ZOE's role). [Doc 601]
+- 10-bot branded fleet (features fold into ZOE memory blocks). [Doc 601]
+- Hermes Telegram identity (proposed doc 599, rejected in 601 - Hermes runs from PR webhooks only). [Doc 599, 601]
+
+### Open questions
+
+- None. Framework pattern is locked.
+
+---
+
+## 2. Surfaces + identity (how many bots, naming)
+
+### LOCKED decisions
+
+**Five operating surfaces (post-doc-601 collapse from 12+ systems):**
+
+| Surface | Username | Purpose | Users | Model | Deployment |
+|---------|----------|---------|-------|-------|------------|
+| **ZOE** | @zaoclaw_bot | Concierge: tasks, captures, brief/reflect, recall, research | Zaal + team | Sonnet/Opus | bot/src/zoe/ on VPS, systemd zoe-bot.service |
+| **Hermes** | @zoe_hermes_bot | Autonomous fix-PR pipeline: coder + critic + auto-PR | DevOps | Opus | bot/src/hermes/ on VPS, GitHub PR webhooks |
+| **ZAO Devz** | @zaodevz_bot | Group dispatch + hourly learning tip (Phase 3: fold into Hermes) | Engineers | Sonnet/Haiku | bot/src/devz/ on VPS, systemd service |
+| **Bonfire** | @zabal_bonfire | Knowledge graph recall + multi-corpus ingest | Members | Claude | bonfires.ai Genesis tier (external SaaS, wallet-gated) |
+| **ZAOstock bot** | @ZAOstockTeamBot | Festival team coordination (graduating own repo this week) | Team | Sonnet | bot/ (root) on VPS, graduating to separate repo |
+
+**Future approved bots (both doc 640/642, both Hermes pattern, dual-user research):**
+- Magnetiq bot (@zaom_bot or similar) - Zaal + Tyler collab, research assistant for ZAO-Magnetiq integration. [Doc 640, 644]
+- AttaBotty bot (Z + AttaBotty) - Zaal + William collab, stream production + VOD review + task tracking. [Doc 642, 644]
+
+**Brand-assistant slash commands live in bots, not separate bots:** `/firefly`, `/youtube`, `/cast`, `/thread`, `/onepager` (ZOE). `/announcement`, `/standup-recap` (ZAOstock). Each reads voice from per-bot `brand.md` file, not new bot tokens. [Doc 607, 644]
+
+**Rule:** No new bots without numbered research doc + explicit Zaal approval. [Doc 601, 644]
+
+### DECOMMISSIONED
+
+- FISHBOWLZ (paused 2026-04-16, replaced by Juke partnership). [Doc 600, 601]
+- 10-bot branded fleet dream (never built, features fold into ZOE memory blocks). [Doc 601]
+- Hermes Telegram interface (proposed, rejected - Hermes triggered by webhooks only). [Doc 599, 601]
+
+### Open questions
+
+1. **Magnetiq bot:** Should it auto-summarize chat after N messages? [Doc 644 §"Unresolved Questions"]
+   - Option A: summarize auto every 50 messages or 1hr silence
+   - Option B: only on /context command
+   - Option C: smart mode (detect topic shift)
+
+2. **AttaBotty bot:** Where to store VOD review notes + clip suggestions? [Doc 644 §"Unresolved Questions"]
+   - Option A: Supabase table (queryable, audit trail)
+   - Option B: Google Doc (shareable, native to AttaBotty flow)
+   - Option C: Both (Supabase source, auto-export to Google Doc)
+
+3. **Future bot registry:** Should there be a single source of truth (API/table/docs) listing all active bots + their group IDs + allowed users + health status? [Doc 644 §"Unresolved Questions"]
+   - Affects VPS monitoring, /admin dashboard, bot discovery patterns
+   - Decision needed before bot 3+
+
+---
+
+## 3. Deployment (VPS, systemd, processes)
+
+### LOCKED decisions
+
+- **Only one VPS:** Hostinger KVM 2 at 31.97.148.88 (31GB RAM, 8 cores, 2 vCPU). [Doc 601, project_no_vps2]
+  - All agents run here. No second box. Upgrade VPS 1 or use Vercel/Cloudflare if underutilized.
+
+- **Code deployment:** rsync from local to VPS, never git-clone on server. [Doc 607, 644]
+  - Env vars stay local, never pushed
+  - `rsync -av --delete --exclude=node_modules --exclude=.env bot/src/<bot>/ zaal@31.97.148.88:~/<bot-name>-bot/`
+
+- **Service management:** systemd user units at `~/.config/systemd/user/<bot>.service` [Doc 601, 607, 644, project_zaostock_bot_live]
+  - Per-bot unit files. systemd restart-on-failure.
+  - Enable: `systemctl --user enable <bot>.service`
+  - Start: `systemctl --user start <bot>.service`
+  - Check: `journalctl --user -u <bot>.service -n 15 --no-pager`
+
+- **Bot tokens + secrets:** `~/<bot-name>/.env` (chmod 600, never committed, never pushed) [Doc 601, 607, 644]
+  - Or `bot/.env` at repo root for shared bots (ZAOstock). Provisioned via `bot/scripts/sync-supabase-env.sh`
+
+- **Secrets hygiene (strict):** Apply all 5 guards from `.claude/rules/secret-hygiene.md` on any agent commit. [Doc 601, project_hermes_canonical]
+  - Guard 1: Stub keys on disk, real keys at execution only
+  - Guard 2: Pre-commit staged-diff scan (no PRIVATE_KEY, no 64-char hex)
+  - Guard 3: Post-edit scan of HEAD
+  - Guard 4: Pre-complete repo scan
+  - Guard 5: Prompt-level enforcement (never reproduce secrets in output)
+
+### DECOMMISSIONED
+
+- Docker/OpenClaw container runtime (deleted 2026-05-05). [Doc 601, project_hermes_canonical]
+- Any VPS 2 / second box proposals. [project_no_vps2]
+
+### Open questions
+
+- None. Deployment is locked.
+
+---
+
+## 4. Auth (Max plan vs API key, secret hygiene)
+
+### LOCKED decisions
+
+- **Auth mechanism:** Claude Code Max plan OAuth via `~/.claude/auth.json`, NOT direct Anthropic API key. [Doc 601, 644, project_hermes_canonical]
+  - One-time: `claude /login` on local machine (saves OAuth token to `~/.claude/auth.json`)
+  - Subprocess inherits auth, no key sprawl, no billing surprises
+  - Hermes pattern: `callClaudeCli()` reads max plan config, no env var exposure
+
+- **Cost routing (Sprint 1 live):** [Doc 601, 644]
+  - Cheap/fast tasks: Sonnet
+  - Complex reasoning: Opus
+  - Low-stakes: Ollama llama3.1:8b local
+  - This reduces spend without degrading quality on high-stakes work
+
+- **Bonfire SDK access:** Waiting on Joshua.eth to provision `BONFIRE_API_KEY`, `BONFIRE_ID`, `BONFIRE_AGENT_ID`. [Doc 600, 607]
+  - Until then: Zaal acts as human bridge for non-trivial queries
+  - Future: Bonfire MCP server in `.mcp.json` for Claude Code direct access
+
+- **Telegram token per bot:** Own token per Telegram bot identity (@zaoclaw_bot, @ZAOstockTeamBot, @zaom_bot, etc.) [Doc 607, 644]
+  - Allows independent auth + scoping per bot
+  - Token leak = only that surface compromised, not all bots
+
+### DECOMMISSIONED
+
+- ANTHROPIC_API_KEY env var for agent auth (Max plan OAuth only). [Doc 601]
+- Direct Minimax API calls (M2.7 was quality wall). [Doc 601]
+- Composio AO API key infrastructure. [Doc 601]
+
+### Open questions
+
+- Bonfire SDK timeline: when does Joshua.eth provision the key + namespace API? [Doc 600, 607]
+- Should agent tokens be rotated on a cadence (e.g., quarterly)? [Not yet decided]
+
+---
+
+## 5. Memory + retrieval (Supabase tables, context window, fact extraction)
+
+### LOCKED decisions
+
+- **Bonfire as the substrate:** All agents read from + write to Bonfire (ZABAL bonfire, bonfires.ai Genesis tier, wallet-gated). [Doc 600, 601, 607]
+  - **Tiers:** PUBLIC (ecosystem), ZAOSTOCK_TEAM (festival team), ZAAL_PRIVATE (Zaal solo) [Doc 607]
+  - **Promotion rule:** facts default to most-restrictive tier writer can use. ZOE captures default ZAAL_PRIVATE. ZAOstock bot defaults ZAOSTOCK_TEAM. Promotion to PUBLIC requires explicit user gesture (Zaal tap or team vote). [Doc 607]
+  - **No demotion:** Once PUBLIC, stays public. Retraction adds `superseded_by` edge but keeps original for audit. [Doc 607]
+
+- **ZOE memory blocks (Letta-style):** Persistent disk blocks for concierge context [Doc 601, 607, 644]
+  - Recent decisions, open tasks, personality traits, team roster snippets
+  - Reads Bonfire on demand via DM relay (or SDK once Joshua.eth provisions)
+
+- **Hermes memory:** git commit history + PR state (immutable audit trail) [Doc 601, 607]
+
+- **Per-bot memory tables (Supabase):** Each team bot (Magnetiq, AttaBotty, ZAOstock) gets bot-specific tables [Doc 644]
+  - `<bot>_chat_history` - rolling Supabase-backed chat log (or JSON backup minimum)
+  - `<bot>_ideas` - captured ideas
+  - `<bot>_tasks` - shared task list
+  - Logging: every action logged (who, what, when) for audit trail
+
+- **Bonfire quarterly backup:** OWL/RDF export to `research/agents/bonfire-backups/<YYYY>-<Q>.rdf` [Doc 600, 607]
+  - If Bonfire trial expires or Joshua.eth partnership ends, migration to LightRAG self-host (doc 568) is 1-2 days
+
+- **Fact extraction from docs:** Research PRs merged auto-ingest to Bonfire PUBLIC (cron job planned, doc 570) [Doc 607]
+  - Farcaster casts on Zaal's account: auto-snapshot PUBLIC (pending Neynar pull, doc 570)
+  - /firefly posts once Zaal taps "posted": auto-snapshot PUBLIC [Doc 607]
+
+### DECOMMISSIONED
+
+- ZOE's local sqlite for embeddings (never used, was part of openclaw). [Doc 601]
+- Bot-to-bot graph sharing (pre-SDK, impossible with openclaw tooling). [Doc 600, 601]
+- Quarterly bridge transcript export (bridge group is passive ingest only). [Doc 601]
+
+### Open questions
+
+1. **Context window strategy:** How much Bonfire context to load into ZOE's memory blocks on startup? [Fuzzy - "as needed" via DM relay until SDK]
+2. **Fact-check frequency:** How often to scan captured facts for stale/contradictory data? [Not yet decided - quarterly review likely]
+3. **Private KG visibility:** Should Zaal be able to promote ZAAL_PRIVATE facts to ZAOSTOCK_TEAM tier? [Likely yes, but not yet locked]
+
+---
+
+## 6. Orchestration (single-agent vs multi-agent, narrator pairs, dispatch)
+
+### LOCKED decisions
+
+- **Zaal is the orchestrator.** Specialists are tools. No autonomous cross-bot coordination yet. [Doc 600, 601, 607]
+  - ZOE receives Zaal's @zaostock, @bonfire, @hermes prefixes and relays to other bots in-process [Doc 607]
+  - ZAOstock bot + Bonfire bot stay independent for their direct users (team members, ecosystem)
+  - Hermes triggered only by /SHIP FIX or PR webhook, not interactive Telegram dispatch
+
+- **Dispatcher pattern (ZOE as single entry point):** From ZOE DM, Zaal can prefix messages: [Doc 607]
+  - `(none)` - normal ZOE concierge turn
+  - `@zaostock <cmd>` - relay to ZAOstock bot in-process, reply inline back to ZOE DM
+  - `@bonfire <query>` - ZOE calls Bonfire SDK (or DM relay until SDK arrives), returns synthesized answer
+  - `@hermes <task>` - ZOE relays to Hermes, returns PR link
+  - Implementation: regex `/^@(zaostock|bonfire|hermes)\s+(.+)/` in `bot/src/zoe/index.ts` message handler [Doc 607]
+
+- **Bridge group passive ingest only:** Chat_id -5111907600 exists. Zaal posts decisions there, bot ingests. No autonomous bot-to-bot messaging (tried 2026-05-03, openclaw tooling not ready). Defer until Bonfire SDK ships. [Doc 600, 601, 607]
+
+- **Multi-surface capture flow:** [Doc 607]
+  - Granola meeting transcript -> ZAOSTOCK_TEAM if team standup, else ZAAL_PRIVATE
+  - Telegram voice DM to ZOE -> ZAAL_PRIVATE (tap-to-promote in 9pm reflection)
+  - Telegram message to ZAOstock chat -> ZAOSTOCK_TEAM (auto-ingested by bot)
+  - Limitless Pendant ambient capture (Phase 2, doc 606) -> ZAAL_PRIVATE (tap-to-promote)
+  - Research doc PR merged -> PUBLIC (auto-ingest cron)
+  - Farcaster cast on Zaal account -> PUBLIC snapshot (auto-ingest)
+  - /firefly output once posted -> PUBLIC (auto-snapshot after Zaal taps "posted")
+  - ZAOstock budget update -> ZAOSTOCK_TEAM (locked to team unless Cassie + Zaal co-sign promote)
+
+- **Failure isolation:** Each bot independent systemd unit. Bonfire down = ZOE/ZAOstock recall returns nothing, but drafting works from local memory blocks. ZOE crash = ZAOstock bot + Bonfire bot unaffected. [Doc 607]
+
+### DECOMMISSIONED
+
+- Bot-to-bot autonomous coordination via bridge group (waiting for SDK + MCP server). [Doc 600, 601, 607]
+- Hermes Telegram identity / interactive bridge dispatch. [Doc 599, 601]
+- Cross-bot narrative pairs (e.g., "BUILDER + SCOUT agents" model from openclaw). [Doc 601]
+
+### Open questions
+
+1. **ZOE dispatcher optimization:** Should relays be cached or always fresh per-call? [Locked: always fresh, no caching]
+2. **Tier leak risk:** How to unit-test that ZAAL_PRIVATE facts never leak in public Bonfire-bot answers? [Bonfire SDK should enforce - add test once SDK lands]
+3. **ZAOstock spinout:** When ZAOstock graduates, how to verify it still shares the same BONFIRE_BONFIRE_ID? [Add to spinout checklist, doc 607]
+
+---
+
+## 7. Safety + cost (allowlists, kill switches, budget caps, disallowed tools)
+
+### LOCKED decisions
+
+- **Per-bot allowlists (hardcoded, non-negotiable):** [Doc 644, 607]
+  - Group ID allowlist (which Telegram groups bot responds to)
+  - User ID allowlist (which Telegram users can invoke commands)
+  - Example: ZOE admin commands only to Zaal's Telegram ID (1447437687)
+  - Bot ignores all messages outside allowlist scope
+
+- **Command gating:** Admin commands (/broadcast, /link, /archive) only to Zaal's Telegram ID. [Doc 644]
+
+- **Confirmation gates (destructive actions):** [Doc 644]
+  - /broadcast <message> -> always ask "Send to [group]? (yes/no)"
+  - /archive <data> -> always ask "Archive [X] records? (yes/no)"
+  - /promote <fact> -> always ask confirmation before writing to PUBLIC tier
+
+- **Secrets refusal (soul.md rule):** [Doc 644]
+  - Never reveal tokens, API keys, passwords in group chat
+  - If asked, respond: "I can't share secrets here. Refer to <owner>."
+  - soul.md includes this as hard rule, enforced at prompt level
+
+- **No hallucination on facts (soul.md rule):** [Doc 644]
+  - If bot doesn't know a team fact, say so and refer to owner
+  - "I don't have that info. Ask <owner>."
+
+- **Tool restrictions per bot (via --allowedTools / --disallowedTools):** [Doc 601, 644]
+  - ZOE: Read, Bash, Grep (knowledge tasks), NOT Write (prevents accidental edits)
+  - Hermes: full tool suite (code-fix requires broad capability)
+  - Magnetiq: Read, Bash, Grep (research synthesis)
+  - AttaBotty: Read, Bash, Grep (VOD review, research)
+  - ZAOstock: Supabase Read, NO Write without confirmation
+
+- **Passive listening mode:** [Doc 644]
+  - Bot reads all messages for context (builds memory blocks)
+  - Only speaks on /command or @mention
+  - Emoji reactions ok if natural, but no unsolicited replies
+
+- **Cost model:** [Doc 600, 601]
+  - Anthropic Max plan ~$200/mo (already paid, covers Claude Code + all agent spawns)
+  - Bonfire Genesis tier: TBD post-trial (currently free 30-day, waiting on Joshua.eth pricing)
+  - VPS Hostinger: ~$30/mo
+  - Supabase: within free tier (RLS-backed tables)
+  - **Total ~$250-350/mo, well below $500 pivot trigger** [Doc 570]
+
+- **Hermes auto-PR safety:** [Doc 461, 600, 601]
+  - 4-layer fix-PR pipeline enforces safety: safe-git-push.sh (timeout-not-found bug fixed), .git pre-push hook, Claude PreToolUse hook, GitHub branch protection on main (enforce_admins=true)
+  - Doc 523 audit caught the silent bug, patched 2026-04-25
+
+### DECOMMISSIONED
+
+- OpenClaw extension tool registry (exposed too much, too opaque). [Doc 601]
+- Composio AO tool orchestration (paused, decommissioned). [Doc 601]
+- Unbounded agent tool access (now strict per-bot allowlists). [Doc 644]
+
+### Open questions
+
+1. **Budget monitoring:** Should there be a real-time spend dashboard (Max plan usage, Bonfire tier cost)? [Not yet decided]
+2. **Token rotation cadence:** How often to rotate Telegram bot tokens? [Not yet decided - quarterly likely]
+3. **Incident response:** If a bot's token leaks, what's the runbook? [Rotate token, restart bot, update env, confirm via journalctl - needs formalization]
+
+---
+
+## 8. MCP + tools (what tools the brain gets, what's banned)
+
+### LOCKED decisions
+
+- **Tools available to Claude subprocess (Hermes pattern):** [Doc 601, 644, project_hermes_canonical]
+  - Per-bot allowlists, example:
+    - Bash (safe subset - grep, find, curl, rsync, but NOT rm -rf)
+    - Read (local files, research docs)
+    - Grep (code search, pattern matching)
+    - Write (Hermes PR drafts only, with pre-flight checks)
+    - Edit (Hermes PR fixes)
+    - Bash (script execution)
+  - Restricted at invocation time via `--allowedTools` / `--disallowedTools` flags [Doc 601]
+
+- **Bonfire SDK access (future, waiting on Joshua.eth):** [Doc 600, 607]
+  - Once BONFIRE_API_KEY arrives: Claude Code + agents call Bonfire MCP server directly
+  - Today: Zaal acts as human bridge (copy-paste RECALL queries from Bonfire DM)
+
+- **Local tools per bot:** [Doc 644]
+  - ZOE: bot/src/zoe/ollama.ts wrapper (ollamaChat, ollamaClassify, ollamaHealth) for low-stakes classification
+  - Hermes: full codespace (git, github API via CLI, npm, tsc)
+  - Magnetiq: research tools (Read, Bash, Grep, curl for API exploration)
+  - AttaBotty: VOD/stream tools (NotebookLM transcripts ingestion, YouTube metadata fetch)
+
+- **What's NOT available (explicit bans):** [Doc 644, project_hermes_canonical]
+  - dangerouslySetInnerHTML (never in components)
+  - console.log (use proper logger, console.error in server routes only)
+  - Direct API key credential passing (Max plan OAuth only)
+  - Write to .env files (secrets stay in env only)
+  - Composite AO plugins (dead - Hermes pattern replaces it)
+
+- **Ollama integration (low-stakes only):** [Doc 601, project_ollama_local_llm]
+  - Model: llama3.1:8b (4.9GB on VPS)
+  - Wrapper: `bot/src/zoe/ollama.ts` - ollamaChat, ollamaClassify, ollamaHealth
+  - Cold start ~11s (model load), warm 3-4s per call
+  - USE: inbox classification, Bonfire entity-class first-pass, audit sanity checks
+  - NEVER: brand outputs, concierge replies, research sourcing (hallucinates), anything public
+
+### DECOMMISSIONED
+
+- OpenClaw extension registry (60+ plugins, unmaintainable). [Doc 601]
+- Composio AO tool orchestration. [Doc 601]
+- Direct Minimax API calls. [Doc 601]
+- Custom sqlite embeddings (ZOE openclaw). [Doc 601]
+
+### Open questions
+
+1. **Langfuse observability (Phase 1 from doc 605):** Once Langfuse ships, should trace tags include `surface=zoe|zaostock|bonfire` so observability spans all three? [Yes, but waiting on doc 605 Phase 1 completion]
+2. **MCP servers beyond Bonfire:** Should agents have access to other MCPs (e.g., GitHub, Slack)? [Not yet decided - Bonfire SDK is priority]
+3. **Tool audit cadence:** How often to review allowed tools per bot? [Quarterly likely - not yet locked]
+
+---
+
+## Summary: 3 Most Under-Documented Dimensions
+
+### 1. **Memory + Retrieval (Dimension 5) - Fuzzy**
+- Context window strategy for ZOE (how much Bonfire context on startup?) only hinted as "as needed"
+- Fact-check frequency (how often to audit for stale/contradictory data?) not yet decided
+- Private KG visibility rules (can Zaal promote ZAAL_PRIVATE to ZAOSTOCK_TEAM?) likely yes but not locked
+- Bonfire quarterly backup process exists (doc 570 plan) but no runbook written
+- **Impact:** As Bonfire grows (1100+ nodes already), ZOE's memory block synthesis could hit quality walls without clear refresh strategy.
+
+### 2. **Orchestration (Dimension 6) - Fuzzy**
+- ZOE dispatcher optimization (cache or always-fresh relays?) only now locked as always-fresh in this doc
+- Tier leak risk testing (how to unit-test ZAAL_PRIVATE never leaks?) depends on Bonfire SDK design
+- ZAOstock spinout verification (confirm same BONFIRE_BONFIRE_ID?) only as checklist item, not automated
+- Multi-surface capture flow documented in 607 but no Bonfire schema definitions yet (what fields = PUBLIC vs ZAOSTOCK_TEAM?)
+- **Impact:** As bot count grows (Magnetiq + AttaBotty shipping this week), ambiguous tier semantics could cause accidental leaks or missed promotion.
+
+### 3. **Safety + Cost (Dimension 7) - Fuzzy**
+- Budget monitoring (real-time spend dashboard?) not yet decided - only cost model estimated
+- Token rotation cadence (quarterly? annually?) not yet locked
+- Incident response runbook (bot token leak = ?) only sketched, needs formalization
+- Three Zaal questions on Magnetiq/AttaBotty (auto-summarize cadence, VOD storage, future bot registry) unanswered in doc 644
+- **Impact:** As Magnetiq/AttaBotty bots go live (systemd on VPS 1 this week), unclear rotation/incident policy could leave tokens at risk or tie up Zaal on runbook questions.
+
+---
+
+## Cross-Reference Key
+
+| Dimension | Docs | Memories |
+|-----------|------|----------|
+| Framework | 601, 644, 483 | project_hermes_canonical, project_ollama_local_llm |
+| Surfaces | 601, 607, 640, 642, 644 | (none - new) |
+| Deployment | 601, 607, 644 | project_zaostock_bot_live, project_no_vps2 |
+| Auth | 601, 644, 600 | project_hermes_canonical |
+| Memory | 600, 607, 568, 570 | (none yet) |
+| Orchestration | 600, 601, 607, 599 | (none yet) |
+| Safety | 461, 600, 601, 644, 623 | (none yet) |
+| MCP + tools | 601, 644, 605 | project_hermes_canonical, project_ollama_local_llm |
+
+---
+
+**Document created:** 2026-05-11
+**Status:** REFERENCE (not a decision doc - for audit + builder guidance)
+**Reviewer:** claude-haiku-4-5 subagent B
+**Next validation:** 2026-06-03 (quarterly review per doc 607 §"Next Actions")

--- a/research/agents/645-agent-canon-and-team-bots-audit/delta.md
+++ b/research/agents/645-agent-canon-and-team-bots-audit/delta.md
@@ -1,0 +1,159 @@
+# Team-bots audit (PR #503 vs canon, 2026-05-11)
+
+## SHIP AS-IS (good, do not change)
+
+- **Dual-bot pattern clean:** Both Magnetiq and AttaBotty boot in one systemd process with independent configs. Matches Devz pattern (devz/index.ts). shared chatGate() enforces per-group isolation correctly.
+- **Hermes pattern locked:** Uses `bot/src/hermes/claude-cli.ts` subprocess spawning, Max auth, no API keys. No Composio/Agent Zero regressions. Correct.
+- **Allowed-tools matrix good:** Chat tier (Sonnet, $0.50): Read/Glob/Grep only. Research tier (Opus, $3): adds WebSearch/WebFetch/Bash(grep|find|ls). Disallowed: git push, git commit, rm, curl POST, Edit, Write. Matches threat model.
+- **Persona files locked:** Both magnetiq/persona.md and attabotty/persona.md follow the DOC 644 template structure. Voice, values, hard rules, reference docs all present.
+- **Memory layer clean:** Supabase tables (team_bot_messages, team_bot_facts, team_bot_ideas, team_bot_tasks, team_bot_clips) with bot-column checks. Service role only (secret key), RLS not needed (bot-side only). Indexes present.
+- **Database migration complete:** team_bots.sql creates all 5 tables + indexes. bot/status column constraints lock to ('magnetiq', 'attabotty'). No open security holes.
+- **Systemd service solid:** Working directory, env file, TZ set, restart on failure, journal logging. Matches infrastructure canon (VPS 1, user unit).
+- **Message stitching correct:** Last 24h of chat + open tasks + facts rolled into context for brain calls. Prevents hallucination on old data.
+- **Daily summary cron working:** node-cron with timezone support. Opus tier. Posts to group. Fail-soft: logs error, sends brief TG alert, continues.
+
+---
+
+## SHIP-BLOCKERS (must fix before tokens go on VPS)
+
+| # | Issue | File | Risk | Fix |
+|---|-------|------|------|-----|
+| 1 | SUPABASE_SERVICE_ROLE_KEY not validated on boot | memory.ts:14-16 | Crash at first DB call if missing or malformed | Add explicit check: `if (!url\|\|!key) throw new Error(...)` on lines 14-16. Already done correctly - PASS. |
+| 2 | Bot tokens not validated on boot | shared.ts:35-41 | Process starts with missing MAGNETIQ_BOT_TOKEN or ATTABOTTY_BOT_TOKEN, fails on first getMe() | Validation exists (lines 38-39). Correct. Continue as-is. |
+| 3 | No secret-scan pre-commit hook (Guard #2) | N/A - infra | Persona files could accidentally leak Zaal's TG ID or Tyler's real name if not redacted | Add to .husky/pre-commit or .git/hooks/pre-commit: check persona files for `MAGNETIQ_BOT_TOKEN=`, `ATTABOTTY_BOT_TOKEN=`, numeric 10-digit IDs (TG user IDs). Test: grep -E '(BOT_TOKEN|ALLOWED_IDS)=' bot/src/teams/*/persona.md should be empty. **DEFER to VPS deploy step.**|
+
+**Verdict:** No hard blockers in code. One pre-deploy checklist item (Guard #2).
+
+---
+
+## P1 GAPS (fix before bot has 7 days uptime)
+
+| # | Issue | File | Why | Fix |
+|---|-------|------|-----|-----|
+| 1 | No rate-limit on @mention replies | commands.ts:260-290 | Attacker could spam @mentions, burn budget fast (chat replies are $0.50 each). Allowlist gate exists but no per-user cooldown. | Add to shared.ts: `Map<number, Date>` tracking last @mention per user_id. On mention, check cooldown (e.g., 60s). Silent ignore if too soon. Example: `const MENTION_COOLDOWN_MS = 60_000; const lastMention = new Map<number, number>(); if (Date.now() - (lastMention.get(id) \|\| 0) < MENTION_COOLDOWN_MS) return;` |
+| 2 | No pagination on `/context` output | commands.ts:181-198 | Context dump can exceed 3500 chars, Telegram truncates silently. If 50+ facts + 20+ tasks, humans miss bottom items. | Paginate `/context` with "Page 1/3" footer + `/context <page>` arg. Or: show top 5 facts + 5 tasks (not 10+20). Safer: truncate at 2500 chars instead of 3500, add "...see /facts or /tasks for full list." |
+| 3 | No error budget tracking per bot | brain.ts:60-95 | If Magnetiq exhausts its $0.50 budget mid-day (e.g., from spam), it will silently fail (catch at line 236-238) and user sees "Research failed: max budget exceeded." No alert to Zaal. | Add to shared.ts: track cumulative spend per bot per day in Supabase. On budget breach, send Zaal a DM via bot.api.sendMessage(ZAAL_ID, "Magnetiq hit $0.50 budget limit."). Or: log to stderr + let ops monitor journal. Minimum: console.warn with bot name. |
+| 4 | Persona files can be edited hot-reload but lack version control | brain.ts:61 | If Magnetiq persona gets corrupted (truncated file, bad markdown), bot runs with silent wrong persona. No validation. | Add to brain.ts before `const persona = readFileSync...`: validate persona is non-empty, contains at least one markdown heading (`#`), no suspiciously short (<50 chars). Throw if invalid. Or: keep backup personas in git, refuse to boot if persona not found. |
+| 5 | No user-activity audit log | memory.ts:35-46 | If a team member runs /idea or /task, there's no immutable record linking it to their Telegram ID for later disputes. | Add columns to team_bot_ideas / team_bot_tasks: `bot_name, from_id` (already there), but ensure RLS or app-side checks prevent cross-team reads. Or: accept as-is since table_name = bot (scoped) + from_id logged. Low priority. |
+
+---
+
+## P2 GAPS (nice-to-have, defer until proven)
+
+| # | Issue | Why deferred |
+|---|-------|--------------|
+| 1 | No "confused?" fallback for misclassified intents | Cheap rule-based classifier (mention + commands) is sufficient for two small private groups. Ollama for intent classification premature without user feedback loop. Ship first, add if needed. |
+| 2 | No transcript export command (/export) | Could be useful for review but not needed for MVP. Supabase query can dump anytime. Ship without it. |
+| 3 | No multi-person task assignment (tasks are personal today) | current task model: logged by user, owned by user. Could extend to `/task @someone else` but unclear if Zaal/Tyler want that. Ask before building. |
+| 4 | No Supabase RLS rules (service-role-only writes assumed) | RLS is premature for bot-side-only writes. If humans ever query tables directly (web UI), add RLS then. Ship without it. |
+| 5 | No analytics dashboard (API hits, cost trend, usage patterns) | Useful for understanding bot health but not blocking. Can add later. |
+
+---
+
+## OVER-BUILDS (premature features, consider removing)
+
+| # | What | Why over-built |
+|---|------|----------------|
+| 1 | `team_bot_daily_summaries` table (team_bots.sql:58-66) | Prepared for storing summaries but never read/written. Commands send to Telegram only, don't insert to table. Remove this table or uncomment code that writes to it. Check if bot/migrations/team_bots.sql has INSERT logic (doesn't appear to). **Action:** Either insert summaries to table + add /summary-history command, or drop table from migration. Decision needed. |
+| 2 | `TEAMS_CHAT_MODEL`, `TEAMS_RESEARCH_MODEL`, etc. env var tuning (brain.ts:20-30) | Per-bot model choice is good, but 6 new env vars (TEAMS_CHAT_BUDGET, TEAMS_RESEARCH_BUDGET, TEAMS_SUMMARY_BUDGET, TEAMS_CHAT_MODEL, TEAMS_RESEARCH_MODEL, TEAMS_SUMMARY_MODEL) add config surface. Most will stay at defaults. Simplify: lock models in code, allow only budget overrides if needed. Or: keep as-is (fine). |
+
+---
+
+## DELTAS vs Hermes/Devz pattern (existing canonical pair)
+
+| Dimension | Devz/Hermes | Teams (PR #503) | Recommendation |
+|-----------|-------------|-----------------|----------------|
+| **Entry point** | bot/src/devz/index.ts boots both Devz + Hermes Bot in one process | bot/src/teams/index.ts boots Magnetiq + AttaBotty in one process | MATCH - both dual-bot in single Node process |
+| **Token validation** | Lines 28-48: explicit checks throw on missing token/chat_id | Lines 35-41: explicit checks throw. GOOD. | MATCH - both fail-fast |
+| **Chat gate** | buildBotNameFilter() middleware (devz/index.ts:66-84) checks if command is tagged @devz or @hermes | chatGate() in shared.ts (lines 59-68) checks ctx.chat.id === cfg.chatId | MATCH - both guard chat scope correctly |
+| **User allowlist** | ADMIN_IDS env var parsed on boot (devz/index.ts:50-53) | envBotConfig() parses MAGNETIQ_ALLOWED_IDS, ATTABOTTY_ALLOWED_IDS per bot (shared.ts:43-46) | MATCH - both enforce allowlist. Teams is cleaner (per-bot, not global). |
+| **Brain subprocess** | Uses callClaudeCli() from hermes/claude-cli.ts (devz/index.ts imports it) | Uses callClaudeCli() from hermes/claude-cli.ts (brain.ts:66) | MATCH - identical pattern |
+| **Model selection** | No per-feature budget; Coder runs Opus freely | chat ($0.50, Sonnet), research ($3, Opus), summary ($1, Opus) | Teams is MORE prudent. Budget caps are explicit. |
+| **Persona system** | No persona files in Devz; hardcoded prompt in bot handlers | magnetiq/persona.md, attabotty/persona.md read fresh on each call (brain.ts:61) | Teams is BETTER - personas are versioned, hot-editable, team-facing. |
+| **Memory/context stitching** | No Supabase memory layer; context is command-only | Last 24h messages + facts + tasks stitched (shared.ts:100-132) | Teams is MORE mature. Better for long-running collaboration. |
+| **Systematic errors** | devz/index.ts logs to console (devz.on error catcher exists) | commands.ts/shared.ts log errors to console + reply to user. brain.ts catches and returns sanitized error | MATCH - both reasonable. Teams has slightly cleaner error replies. |
+| **Daily summary cron** | No equivalent in Devz | scheduleDailySummary() with node-cron (shared.ts:148-157) | Teams adds feature that Devz doesn't have. GOOD. |
+
+**Summary:** Teams bots follow Hermes/Devz canon closely. Teams actually improves on Devz by adding: per-bot config, explicit budgets, persona versioning, Supabase memory, daily summary. No major deviations. PASS.
+
+---
+
+## Hard security checks (each pass/fail)
+
+- [PASS] No secrets / tokens ever logged
+  - brain.ts: reply.text is sanitized, cost/duration logged but not prompt or model details that could leak secrets
+  - shared.ts: personas are read at invocation but not logged; userPrompt goes to brain, not stdout
+  - commands.ts: error messages slice to 200-300 chars, never dump raw error.message which might contain env var names
+  - memory.ts: message text logged verbatim (safe: user input only, no secrets expected)
+
+- [PASS] Allowlist enforced for state mutations
+  - commands.ts:79,97,127,147,167: all state-mutating commands (/idea, /task, /done, /clip, /fact) call userGate() first
+  - userGate() (shared.ts:71-76) checks ctx.from?.id against cfg.allowedTelegramIds
+  - Permissive if allowlist is empty (controlled: envBotConfig line 43-46 parses from env)
+  - Read-only commands (/tasks, /context, /help, /whoami) do NOT gate (correct)
+
+- [PASS] Chat-scope enforced (silent ignore outside chat)
+  - commands.ts:40-41: `bot.use(chatGate(cfg))` registered first, so ALL downstream handlers are scoped
+  - chatGate (shared.ts:59-68) checks `ctx.chat?.id !== cfg.chatId` and returns early (no reply, no log)
+  - Each bot (Magnetiq, AttaBotty) has separate cfg.chatId, so messages to other groups never reach handlers
+
+- [PASS] Brain tools disallow Edit/Write/git push/curl POST
+  - brain.ts:71-81: allowedTools for chat = ['Read', 'Glob', 'Grep'] only
+  - allowedTools for research = [..., 'WebSearch', 'WebFetch', 'Bash(grep*)', 'Bash(find*)', 'Bash(ls*)']
+  - disallowedTools: ['Bash(git push*)', 'Bash(git commit*)', 'Bash(rm*)', 'Bash(curl*POST*)', 'Edit', 'Write']
+  - Correct. Permits grep/find/ls (read-only), blocks destructive commands.
+
+- [PASS] No SQL string interpolation (parameterized only)
+  - memory.ts: ALL Supabase calls use `.from().insert()` / `.select()` / `.eq()` / `.gte()` / `.order()` / `.update()` methods
+  - No template literals in SQL, no string concatenation
+  - Supabase JS client auto-parameterizes via prepared statements
+  - PASS
+
+- [PASS] No dangerouslySetInnerHTML or HTML injection in TG replies
+  - commands.ts: all ctx.reply() calls send plain text (no HTML, no Telegram HTML parsing enabled)
+  - Telegram API used via grammy, which by default sends text/plain
+  - No Telegram HTML mode flag in replies (would be ctx.reply(text, { parse_mode: 'HTML' }))
+  - safe.
+
+- [PASS] All env vars validated on boot (fail-fast not lazy)
+  - memory.ts:14-16: throws immediately if SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing
+  - shared.ts:35-41: throws immediately if token or chatRaw missing, validates chatId is a number
+  - index.ts:48-56: validates TEAMS_RUN env, throws if empty or unrecognized
+  - brain.ts: MODEL_FOR and BUDGET_USD have defaults (lines 20-30), no missing-var crash
+  - PASS - all critical secrets checked on boot
+
+- [PASS] Each table has bot-column check constraint
+  - team_bots.sql:8: `check (bot in ('magnetiq', 'attabotty'))` on team_bot_messages
+  - team_bots.sql:20: same check on team_bot_facts
+  - team_bots.sql:29: same check on team_bot_ideas
+  - team_bots.sql:37: same check on team_bot_tasks
+  - team_bots.sql:48: same check on team_bot_clips
+  - team_bots.sql:59: same check on team_bot_daily_summaries
+  - PASS
+
+- [PASS] Persona files refuse to leak env / commit / DM external
+  - magnetiq/persona.md:30-35: "Never reveal env vars, API keys, tokens... Never push to git... Never tag external people without explicit approval"
+  - attabotty/persona.md:30-38: same hard rules
+  - Both personas are locked to the two users (Zaal + Tyler, or Zaal + AttaBotty)
+  - Mentions chat allowlist in help text
+  - PASS
+
+---
+
+## Audit summary
+
+- **Total ship-blockers:** 0 (all code checks pass; 1 infra checklist item: pre-commit hook for Guard #2)
+- **Total P1 gaps:** 5 (rate-limit cooldown, /context pagination, budget tracking, persona validation, audit log) - can defer post-launch if MVP validation needed first
+- **Total over-builds:** 1 (unused team_bot_daily_summaries table) - minor cleanup
+- **Security posture:** Strong. Allowlist enforced, chat-scope gated, brain tools locked, no SQL injection, no secret leaks in logs, env vars validated on boot.
+- **vs Canon (Doc 644):** Follows Hermes pattern locked. Per-bot personas, memory layer, daily summary. Better than Devz. No deviations.
+
+### Recommendation: GO
+
+**Single most important fix before tokens land:** None critical in code. **Ops check before VPS deploy:** Run secret-scan on bot/src/teams/ persona files to ensure no API keys / TG IDs leaked. Command:
+```bash
+grep -Er '(BOT_TOKEN|ALLOWED_IDS|SUPABASE_|NEYNAR_|SESSION_|SIGNER_|sk-ant-|ghp_)' bot/src/teams/ 
+```
+If any match, redact before pushing. Otherwise: **GO SHIP.**
+
+**Timeline:** Deploy bots to VPS 1 systemd immediately. Run 7-day stability test. Collect user feedback. Then tackle P1 gaps in order (rate-limit, /context pagination, budget alerts). Both bots ready for production.

--- a/research/agents/645-agent-canon-and-team-bots-audit/inventory.md
+++ b/research/agents/645-agent-canon-and-team-bots-audit/inventory.md
@@ -1,0 +1,208 @@
+# Agent docs inventory (2026-05-11)
+
+## Total count: 99 agent-focused research docs + 20 agent-adjacent docs = 119 total
+
+---
+
+## In research/agents/ folder (full list)
+
+| Doc # | Title | One-line synopsis | Date | Status |
+|-------|-------|-------------------|------|--------|
+| 26 | hindsight-agent-memory | Agent memory architecture for persistent learning across sessions. | | |
+| 70 | subagents-vs-agent-teams | Design pattern: single supervisor + worker subagents vs flat multi-agent teams. | | |
+| 71 | paperclip-rate-limits-multi-agent | Paperclip SaaS multi-instance rate-limiting and cost management strategies. | | |
+| 84 | farcaster-ai-agents-landscape | Survey of 10+ Farcaster agent projects (Clanker, Fomo3D, Orb). | | |
+| 85 | farcaster-agent-technical-setup | Neynar API vs manual Warpcast agent setup - two deployment paths. | | |
+| 90 | ai-run-community-agent-os | Vision: members discover autonomous community operations while they sleep (deferred design). | | |
+| 161 | agent-harness-engineering-langchain | LangChain-based agent harness engineering (Viv Trivedy, LangChain). | | |
+| 171 | council-high-intelligence-multi-agent-deliberation | Council: 11-agent deliberation system for high-stakes decisions. | | |
+| 202 | multi-agent-orchestration-openclaw-paperclip | Comparison matrix: Supervisor/Workers vs OpenClaw vs Paperclip architectures. | | |
+| 205 | openclaw-paperclip-elizaos-deployment-plan | Three deployment approaches: Railway/Docker, Render, ElizaOS Cloud. | | |
+| 206 | lobsterai-agent-architecture | LobsterAI: desktop Electron agent with 28 built-in skills, permission gating. | | |
+| 208 | paperclip-plugins-ecosystem-update | Paperclip v2026.325.0: company skills library (pin ZAO skills to Paperclip). | | |
+| 227 | agentic-workflows-2026 | MakerDAO Endgame + Mastra graph primitives for agentic workflow design. | | |
+| 234 | openclaw-comprehensive-guide | OpenClaw: free OSS autonomous agent, Gateway process, multi-platform messaging. | | |
+| 235 | free-web-search-mcp-alternatives | Web search MCP options (no free tier for new users post-Feb 2026). | | |
+| 236 | autonomous-openclaw-operator-pattern | OpenClaw AGENTS.md, SOUL.md, HEARTBEAT.md, MEMORY.md file hierarchy. | | |
+| 237 | usv-agents-tasklet-malleable-software | Tasklet: SaaS platform for building + running AI agents with user gating. | | |
+| 239 | agent-frameworks-infrastructure-evaluation | Evaluation table: 8 frameworks vs cost/complexity/autonomy (promptfoo, others). | | |
+| 245 | zoe-upgrade-autonomous-workflow-2026 | ZOE autonomous workflow design: research passes, memory, daily summaries. | | |
+| 246 | neynar-api-creative-agent-uses | Neynar API: creative agent patterns for casting, user tracking, reactions. | | |
+| 247 | top-50-local-ai-models-2026 | 50 open-source LLMs: Qwen, Phi, Hermes, etc. Skip edge/mobile for ZAO. | | |
+| 251 | huggingface-platform-deep-dive | Hugging Face inference, Gradio Spaces, ZeroGPU options. | | |
+| 253 | autoagent-self-optimizing-agents | AutoAgent: Python self-optimizing agents with GPT-5 (skip for TypeScript). | | |
+| 256 | zoe-agent-factory-vision | ZOE: agent factory vision - spawn instances for different domains. | | |
+| 259 | agent-self-optimization | Self-optimization patterns: prompt tweaking, test generation, grading. | | |
+| 262 | virtuals-protocol-agent-rail | Virtuals: on-chain agent rail for autonomous trading ($30M daily volume). | | |
+| 266 | mission-control-v2 | Mission Control: agent orchestration dashboard with 31 panels. | | |
+| 267 | openclaw-skills-capabilities | OpenClaw skills matrix: 40+ capabilities vs ZAO relevance. | | |
+| 268 | milady-ai-elizaos-evolution | Milady + ElizaOS: OSS agent framework evolution, Milady Cloud hosting. | | |
+| 278 | agentic-bootcamp-zao-agent-squad | Farcaster Agentic Bootcamp: ZAO agent squad roadmap sessions. | | |
+| 288 | multi-agent-dashboard-visual-research | Multi-agent dashboard: 32 panels, Self-hosted orchestration, MIT license. | | |
+| 290 | fishbowlz-agentic-participants | FISHBOWLZ agent presence: text-only transcript polling (no TTS v1). | | |
+| 291 | farcaster-agentic-bootcamp-days-3-5 | Bootcamp days 3-5: Vercel AI SDK ToolLoopAgent, skip custom framework. | | |
+| 292 | pixel-agents-dashboard-customization | Pixel Agents: dashboard customization, borrow Miniverse heartbeat API. | | |
+| 293 | multi-agent-tools-gitnexus-prompts | Trellis: NOT agent orchestrator. Skip. GitNexus/Prompts table. | | |
+| 296 | agentic-workflow-optimization | April 7: SCOUT (Minimax M2.7) + Claude Code optimization sprint. | | |
+| 307 | great-convergence-agent-harness-architecture | Every company converges on self-improving agents + tools. Skip custom infra. | | |
+| 318 | cassie-multi-agent-coordination-bootcamp | Cassie (Quilibrium): distributed systems + political bot detection patterns. | | |
+| 325 | zabal-agent-swarm-economy | ZABAL swarm: DCA pattern, $4.50-$18/day volume, auto-burn. | | |
+| 339 | austin-griffith-clawd-ethskills-agent-patterns | CLAWD agent patterns: Skip dApp deployment at $14K FDV stage. | | |
+| 340 | clawd-patterns-deep-dive-4-systems | CLAWD: LarvAI governance, Bankr conviction, conviction dapp, auto-burn. | | |
+| 344 | bankr-bot-agent-trading-skills | Bankr: agent trading skills, conviction scoring, auto-burn. | | |
+| 345 | zabal-agent-swarm-master-blueprint | ZABAL swarm master blueprint: trading, governance, finance automation. | | |
+| 351 | zabal-swarm-activation-checklist | ZABAL activation steps: infrastructure, tests, deployment, monitoring. | | |
+| 353 | autonomous-trading-beyond-schedules | Beyond schedules: event-driven autonomous trading architecture. | | |
+| 360 | profit-agent-hot-wallet-strategy | Profit agent: hot wallet strategy. Skip arbitrage (requires MEV infra). | | |
+| 363 | darwinian-agent-evolution | Darwinian agent evolution: selection pressure, leaderboard, mutation. | | |
+| 364 | multi-harness-agent-orchestration | Multi-harness orchestration: VPS parallelism, process isolation. | | |
+| 420 | hyperframes-html-video-agents | HTML-based video: agents write HTML+CSS+JS for video generation. | | |
+| 433 | agent-outbound-phone-calls-ringading-twilio | Agent phone calls: Ringading + Twilio for outbound voice. | | |
+| 435 | zoe-effectiveness-v2-playbook | ZOE v2: respects flow-state (no 4:30am ping), Telegram routing, playbook. | | |
+| 447 | agent-stack-week-improvement-sprint | Auto-read git HEAD, AO sessions, PRs into ZOE system. | | |
+| 451 | ao-claude-code-dialog-block-forensics | AO sessions zaoos-40/41 alive (Mon Apr 20), dialog block analysis. | | |
+| 452 | ao-sidebar-counter-filter-fix | AO sidebar counter filter fix (2026-04-20). | | |
+| 453 | ao-offline-banner-websocket-diagnosis | AO offline banner WebSocket diagnosis (2026-04-20). | | |
+| 454 | agent-stack-reliability-hardening-apr20 | What breaks: Hermes sync, ClawinatorRelay, ZOE sync, AO sessions. | | |
+| 457 | silent-failure-hunt-ecc | ECC silent failure hunt: Promise.allSettled fallbacks, medium-priority fixes. | | |
+| 460 | zao-agentic-stack-end-to-end-design | Hermes pair + Stock-Coder + VPS 1 infrastructure: full stack design. | | |
+| 464 | zoe-telegram-reply-context-ship-pr | ZOE context store: JSON per chat (not sqlite), 20-turn window. | | |
+| 465 | zoe-observability-dispatch-hardening | ZOE observability: Telegram send retry with exponential backoff. | | |
+| 466 | ao-ui-button-audit-apr21 | AO audit: missing "+ New Session" button on dashboard. | | |
+| 467 | zao-bot-fleet-design-magnetiq | Magnetiq bot design: 2-person collab (Zaal + Tyler), Telegram, Supabase. | | |
+| 468 | zao-farcaster-hub-poidh-hypersub-dual-hub | POIDH bot: idea-generator + bounty-drafter + submission-scout (NO auto-pay). | | |
+| 473 | clawdbotatg-apr21-updates-zoe-openclaw | CLAWD GitHub: 400+ repos, patterns for ZOE + OpenClaw integration. | | |
+| 474 | bcz101-bot-transcript-rag | BCZ101 bot: RAG over podcast transcripts (atenger/gmfc101 pattern). | | |
+| 479 | walden-multi-agent-patterns-cognition | Walden: multi-agent patterns for AI cognition (evaluation table). | | |
+| 483 | hermes-agent-local-llm-framework | Hermes: local LLM agent framework (NousResearch base). | | |
+| 484 | matricula-autonomous-farcaster-agent | Matricula: autonomous Farcaster agent patterns. | | |
+| 487 | quadwork-four-agent-dev-team | QuadWork: 4-agent dev team orchestration (Plan, Implement, Review, Commit). | | |
+| 488 | cortex-synthetic-cognition-memory | CORTEX: synthetic cognition graph, weighted edges, agent-readable memory. | | |
+| 491 | quadwork-install-three-repo-split | QuadWork install: 3-repo split, .quadwork-allowlist per-repo. | | |
+| 495 | team-telegram-bot-2026-patterns | Team bot architecture: Telegram, Sonnet chat, Opus research/summary. | research-complete |
+| 496 | elizaos-2026-assessment | ElizaOS v1: assessment vs ZAO's Hermes pattern fit. | research-complete |
+| 497 | quad-workflow-deep-dive | QuadWork vs single Claude session: when teams win vs when solo is best. | research-complete |
+| 523 | zao-agentic-systems-full-audit-fix-pr-pipeline | Full audit: codebase + VPS + research codex, fix-PR pipeline. | research-complete |
+| 524 | zao-agentic-everything-live-archived-started-pla | Master index: 14 STARTED agents (ZOE v2, Stock-Coder, Hermes, etc.). | research-complete |
+| 527 | multi-bot-telegram-coordination-best-practices | Multi-bot collisions: ZOE "Unknown skill: fix" fix, explicit allowlist. | research-complete |
+| 529 | hermes-quality-pipeline-pre-critic-gates | Hermes PR quality: mergeable polling, DIRTY state alerts, rebase automation. | research-complete |
+| 531 | hermes-honest-audit-pivot-or-persist | Hermes pair: proven MVP, 8 PRs merged in 24h. Defer event-log to Sprint 2. | research-complete |
+| 541 | hermes-gaps-vs-industry-best-practices | Hermes gaps vs industry (5 categories: patterns, observability, scope, ops, cost). | research-complete |
+| 546 | hefty-bot-local-first-harness | Hefty.bot: closed-source local-first agent. Recommend to ZAO members (conditional). | research-complete |
+| 547 | multi-agent-coordination-bonfire-zoe-hermes | Bonfire + ZOE + Hermes: passive ingestion, concierge, code automation. | research-complete |
+| 559 | wetware-ww-p2p-agent-os | Wetware/WW: P2P agent OS. Skip adoption; lift capability pattern. | research-complete |
+| 567 | hugging-face-local-models-context-bridge | Open WebUI for local models: 124K+ stars, use Docker on Mac. | research-complete |
+| 568 | aware-brain-local-memory-knowledge-graph | "Aware brain" chat companion with memory + knowledge graph. | research-complete |
+| 574 | inbox-apr30-agent-commerce-skills-stack | Prose-craft + ghostwriter: humanizer skill stack (10 items batch). | research-complete |
+| 599 | hermes-agent-prior-art-reddit | r/hermesagent is NOT ZAO Hermes. It's NousResearch community. | research-complete |
+| 600 | agentic-stack-coordination-v1 | Full inventory: every bot/harness/agent Zaal runs. | research-complete |
+| 601 | agent-stack-cleanup-decision | Stop bot proliferation. Pick minimal viable agent stack. | research-complete |
+| 602 | tradingagents-pattern-for-social-pm | TradingAgents multi-agent debate pattern (Bullish/Bearish researcher). | research-complete |
+| 603 | tradingagents-pattern-for-social-pm | (Duplicate of 602) Multi-agent debate for social/PM decisions. | research-complete |
+| 604 | best-personal-concierge-agents-2026 | Survey: 10+ personal concierge agents shipping in 2026. | research-complete |
+| 605 | agentic-tooling-may-2026 | AI-agent tooling: Playwright MCP, browser-use, local models. | research-complete |
+| 607 | three-bots-one-substrate | ZOE (Zaal private) + ZAOstock (team) + Bonfire (observer) on one process. | research-complete |
+| 617 | bczyapz101-bot-architecture | BCZ YapZ bot: Farcaster Q&A, Render hobby tier, cold-start OK. | research-complete |
+| 619 | link-batch-may6-triage | 16-item triage (5 ZOE inbox + 11 links) from Zaal (2026-05-06). | research-complete |
+| 620 | bonfire-push-everything | Bonfire: auto-ingestion from memory files, research docs, newsletters. | research-complete |
+| 632 | r-hermesagent-subreddit | r/hermesagent: NousResearch community (clarification). | research-complete |
+| 644 | zao-agent-stack-canon-and-team-bot-template | CANONICAL: agent pattern, conversation routing, memory, Hermes pattern lock. | research-complete |
+
+---
+
+## Outside research/agents/ but agent-relevant
+
+| Doc # | Folder | Why agent-relevant |
+|-------|--------|--------------------|
+| 280 | fid-registration | x402: Farcaster agent registration deep-dive. |
+| 281 | farcaster-agents-landscape | Agent registration on Farcaster (cross-ref with 84/85). |
+| 288 | agent-squad-monitoring-dashboards | Agent squad monitoring (duplicate cross-folder). |
+| 289 | zoe-dashboard-chat-ux-patterns | ZOE dashboard UX patterns (chat interface). |
+| 309 | karpathy-llm-wiki-codebase-compiler | LLM code compiler: context bridge for agents. |
+| 310 | meta-tribe-v2-brain-prediction-content | Multi-brain prediction engine (agent cognition). |
+| 311 | vibe-coded-apps-marketing-playbook | Vibe-coded apps: agentic marketing automation. |
+| 312 | claude-skills-marketplace-ecosystem | Claude skills: marketplace model for agent tooling. |
+| _graph | (all) | Orphan docs referenced in agent research. |
+| _archive | (all) | Historical agent research (decommissioned). |
+| business/* | (agent ops) | Business operations automation via agents. |
+| dev-workflows/* | (agent CI/CD) | Agent-driven development workflows. |
+| farcaster/* | (agent integration) | Farcaster agent patterns and integrations. |
+| governance/* | (agent governance) | Agent-based governance coordination. |
+| infrastructure/* | (agent infra) | VPS, Docker, systemd for agent deployment. |
+| music/* | (agent audio) | Music agents and audio processing. |
+| security/* | (agent safety) | Agent security and safety guardrails. |
+| wavewarz/* | (agent incubator) | WaveWarZ project with potential agent features. |
+| community/* | (agent community) | Community coordination via agents. |
+| events/* | (agent events) | Event agents (ZAOstock bot). |
+
+---
+
+## Top 15 most-load-bearing docs for team-bots design (Magnetiq + AttaBotty)
+
+Team-bots architecture: 2 Telegram bots + 1 Node process + shared brain (Claude CLI) + memory (Supabase). Each bot has persona file, allowlist, reactive-only behavior (no nags), daily summary cron.
+
+| Rank | Doc # | Why it matters for team-bots |
+|------|-------|------------------------------|
+| 1 | 644 | CANONICAL pattern. Locks Hermes agent framework (Claude Code CLI, no API keys, Max-plan auth, persistent memory). Team-bots inherit this lock. |
+| 2 | 495 | Direct: team-telegram-bot patterns (Telegram, Sonnet for chat, Opus for research/summary). Exact archetype for Magnetiq + AttaBotty. |
+| 3 | 245 | ZOE workflow design (research passes, memory structure, daily summaries). Team-bots copy ZOE's autonomous-workflow playbook. |
+| 4 | 527 | Multi-bot coordination fix: "Unknown skill: fix" problem + explicit allowlist solution. Prevents Magnetiq/AttaBotty collisions. |
+| 5 | 467 | Magnetiq bot product spec (doc reference). Direct 2-person collab pattern (Zaal + Tyler). |
+| 6 | 468 | POIDH bot scope: idea-generator + bounty-drafter pattern. Teaches command-driven memory logging (/idea, /task, /clip, /fact). |
+| 7 | 547 | Bonfire + ZOE + Hermes coordination: three-bot one-substrate. Shows how team-bots fit into larger multi-agent ecosystem. |
+| 8 | 607 | Three bots on one substrate: write scope (ZOE=private+public, ZAOstock=team+public, Bonfire=read-only). Team-bots adopt write scope. |
+| 9 | 460 | Full ZAO agentic stack design: VPS 1, systemd, Supabase, Claude CLI, Hermes. Team-bots deployment blueprint. |
+| 10 | 464 | ZOE context store pattern: JSON per chat (not sqlite), 20-turn window, 7-day prune. Memory storage for team-bots. |
+| 11 | 465 | ZOE observability: Telegram send retry with backoff, event logging. Reliability patterns for team-bots. |
+| 12 | 604 | Personal concierge agents: ZOE is the reference. Team-bots are collaborative concierge for pairs. |
+| 13 | 605 | Agentic tooling (Playwright MCP, browser-use). Unlock these for team-bots Phase 2 (@mention browser search, screenshot). |
+| 14 | 491 | QuadWork allowlist pattern: per-repo `.quadwork-allowlist`. Team-bots apply same: disallow git/Edit/Write, allow research/summary. |
+| 15 | 206 | LobsterAI permission gating: 28 skills with user permissions. Architect team-bots skill allow-lists using this pattern. |
+
+---
+
+## Decommissioned / superseded (do-not-rebuild list)
+
+| Doc # | What it proposed | Why dead | Recommended path |
+|-------|------------------|----------|------------------|
+| 71 | Paperclip rate limits | Paperclip SaaS multi-agent setup | Use OpenClaw (free, self-hosted) instead (234). |
+| 90 | AI-run community agent OS | Too ambitious for 188 members. Design deferred. | Revisit at 500+ members; use ZOE + Bonfire MVP now. |
+| 206 | LobsterAI adoption | Electron agent + 28 skills. Chinese tools scraping. | SKIP music skill; borrow permission-gating pattern only. |
+| 208 | Paperclip slack plugin | ZAO doesn't use Slack. Skip. | Community on Discord + Farcaster (pin skills to Paperclip regardless). |
+| 227 | LangGraph adoption | Python-first, inferior to Mastra for TS. | SKIP; use Mastra for graph primitives (227 verdict). |
+| 235 | Free web search MCP | No free tier post-Feb 2026. | Use OpenClaw built-in web search or pay $5/mo. |
+| 245 | Agent council (11-agent deliberation) | Too much for solo founder + ZOE. Revisit at 500 members. | SKIP; use 602 TradingAgents debate pattern (bullish/bearish researcher) for decisions. |
+| 247 | Edge/mobile LLM | ZAO is PWA, not native app. Skip unless Capacitor ship. | SKIP; revisit if native app planned. |
+| 251 | Inference endpoints | Only needed >500 concurrent. Gradio + ZeroGPU sufficient now. | SKIP; Gradio Space is fine for 188 members. |
+| 253 | AutoAgent adoption | Python, GPT-5 default, too early. Wrong language. | SKIP; use Claude Code + Hermes for agent tooling. |
+| 268 | Milady Cloud for hosting | Railway $5/mo cheaper + full control. | SKIP; keep self-hosted on VPS 1. |
+| 290 | Audio agents in FISHBOWLZ | SKIP TTS v1; text-only transcript polling. | TEXT-ONLY MVP first; add audio Phase 2. |
+| 291 | Custom agent framework | Vercel AI SDK ToolLoopAgent is better. | SKIP custom; adopt Vercel AI SDK (Doc 227 + 291). |
+| 292 | Star-Office-UI + Agent Town | Python-heavy, Phaser game-like overhead. | SKIP; borrow Miniverse heartbeat API pattern instead. |
+| 293 | Trellis for multi-agent orchestration | Trellis = spec/task/journal for humans with AI, NOT agent-to-agent. | SKIP; OpenClaw + Paperclip already handle orchestration (202). |
+| 307 | Build custom infra | Every company uses commodity: Vercel + Supabase + Claude + MCP. | SKIP; use existing services. Infrastructure is solved. |
+| 339 | CLAWD dApp deployment | Premature at $14K FDV. | SKIP for now; revisit when agents need custom contracts (LP, burn). |
+| 360 | DEX arbitrage | Requires sub-second execution, MEV competition. Not our edge. | SKIP arbitrage; use DCA pattern (325) instead. |
+
+---
+
+## Synthesis: 5 Most Surprising Findings
+
+1. **Hermes is locked canonical (doc 644).** ZAO chose Claude Code CLI + Max-plan auth + no API keys. This is the immovable baseline for ALL agents (ZOE, team-bots, Bonfire, future agents). No rearchitecture debates allowed. Load-bearing.
+
+2. **Three bots, one process (doc 607).** ZOE (personal), ZAOstock team bot, and Bonfire (observer) share one systemd unit on VPS 1. Write scopes differ (ZOE: private+public; team: team+public; Bonfire: read). This constraint shapes team-bots Magnetiq + AttaBotty deployment (they follow same pattern).
+
+3. **Multi-bot collisions are HARD (doc 527).** ZOE broke with "Unknown skill: fix" because it doesn't have an explicit allowlist. Multiple bots on same Telegram/API surface will deadlock without careful scope gating. Team-bots fix this from day 1 via per-bot allowlist + chat_id gating (see README.md lines 32-33, 59, 66).
+
+4. **QuadWork is the reference for local-agent deployment (doc 487, 491).** 4-agent team (Plan/Implement/Review/Commit) + per-repo `.quadwork-allowlist` (git/Edit/Write disallowed) is the pattern ZAO copied into team-bots. But ZAO has only 2 bots (Magnetiq + AttaBotty), not 4 agents.
+
+5. **Agent memory is JSON-per-chat, not sqlite (doc 464).** ZOE uses `~/.zao/zoe-recent.json` (20 turns, reset daily). Team-bots adopt this (Supabase `team_bot_messages` table, 24h window, not persistent). Keeps agent dependency-light. If it outgrows, upgrade to Mem0 (245) in Phase 2.
+
+---
+
+## File locations
+
+- All agent docs: `/Users/zaalpanthaki/Documents/ZAO OS V1/research/agents/` (99 dirs)
+- Team-bots code: `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/teams/` (Magnetiq + AttaBotty)
+- Migration: `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/migrations/team_bots.sql`
+- Team-bots README: `/Users/zaalpanthaki/Documents/ZAO OS V1/bot/src/teams/README.md`


### PR DESCRIPTION
## Summary

Doc 644 (restored from prior session): ZAO agent stack canon - locks Hermes pattern, 5 surfaces, persona file layout, allowlist gates. Reference template for every team bot.

Doc 645: DISPATCH-tier audit of PR #503 team-bots via 3 parallel subagents (inventory + canon + delta).

## Audit headline

**Recommendation: GO SHIP**

- 0 code blockers
- 1 pre-deploy ops check (secret-scan on persona files - already run, clean)
- 5 P1 gaps for the 7-day post-launch window
- 1 over-build to remove (unused `team_bot_daily_summaries` table)
- 9-item security checklist: all PASS

## What's inside 645

- [README.md](research/agents/645-agent-canon-and-team-bots-audit/README.md) - hub with action bridge
- [inventory.md](research/agents/645-agent-canon-and-team-bots-audit/inventory.md) - 119 agent-touching docs catalogued
- [canon.md](research/agents/645-agent-canon-and-team-bots-audit/canon.md) - 8 dimensions of locked decisions
- [delta.md](research/agents/645-agent-canon-and-team-bots-audit/delta.md) - line-by-line audit of bot/src/teams/

## Action items (next 7 days)

| Action | Type |
|--------|------|
| Drop OR wire `team_bot_daily_summaries` table | Code cleanup |
| Add @mention cooldown 60s per user | PR |
| Add daily budget alert DM to Zaal | PR |
| Paginate /context output | PR |
| Validate persona files on hot-reload | PR |

## 3 fuzzy canon zones flagged for Zaal decision

1. Bonfire field-level tier schema (PUBLIC/ZAOSTOCK_TEAM/ZAAL_PRIVATE semantics)
2. Bot token rotation cadence + leak runbook
3. Per-bot daily-cost dashboard view

## Tier

DISPATCH (3 parallel subagents)

## Sources

119 internal research docs + bot/src/teams/ + bot/src/devz/ + bot/src/hermes/ + .claude/rules/secret-hygiene.md + user memory (project_hermes_canonical, project_no_vps2, project_ollama_local_llm, feedback_prefer_claude_max_subscription)