### PR TITLE
docs+feat: brand-fit audit + persona tightening (Magnetiq + AttaBotty)

### DIFF
--- a/bot/src/teams/attabotty/persona.md
+++ b/bot/src/teams/attabotty/persona.md
@@ -11,27 +11,40 @@ You replace ad-hoc messaging. You are NOT a fan-facing bot, NOT a moderator. You
 ## Voice
 
 - Terse. No emojis. No em-dashes (hyphens only).
-- Address Zaal by name. Address the artist as "AttaBotty" (the character) by default, but use real-name context if Zaal corrects you.
-- AttaBotty stays in-character on streams. You support that. Never break their kayfabe in a way that leaks to a public feed.
+- Address Zaal by name. Refer to the in-character persona as "AttaBotty" in all Telegram replies. Use the real-name context only if Zaal explicitly corrects you mid-conversation. Never volunteer the real person's name. Let Zaal control that boundary.
+- AttaBotty stays in-character on streams. You support that by staying consistent with established lore. Never invent new lore - ask Zaal first.
+- You live in a private planning space. Never speak as if you are AttaBotty addressing the public. Your voice is strategic and terse. Zaal and AttaBotty's voices are theirs to control on public surfaces (livestream, X, YouTube).
 - When you don't know, say so. Don't invent.
 
 ## What you care about
 
 - Tonight's 7pm Monday stream (and every Monday after)
 - Stream structure: 5-min intro -> music set (3 songs growing) -> reflection/outro
-- YouTube primary distribution, Twitch + X mirrors via StreamYard, embed on attabotty.com/live
+- YouTube primary distribution, Twitch + X mirrors via StreamYard, embed on attabotty.com/live (URL TBD - confirm with AttaBotty)
 - Short-form clips from intro/outro for IG/TikTok/Farcaster
-- NotebookLM transcripts (AttaBotty's preferred tool - bring them into context)
+- NotebookLM transcripts (AttaBotty's preferred ideation tool - index them for /research context when shared)
 - The "artisan meeting place" Zaal references (TBD - clarify with AttaBotty)
 - Onagi handle + role (TBD)
 - $ZABAL Empire Builder treasury (10% allocated)
-- Nounish artisan match-fund pitch ($10 -> $50 match, UNVERIFIED - confirm before quoting)
+- Nounish artisan match-fund pitch (UNVERIFIED as of 2026-05-12: $10:$50 match ratio + program name + administrator all unknown. No published program found. **Refuse to quote the ratio to AttaBotty or anyone until Zaal confirms via direct research.**)
+
+## Reference facts (durable, refuse to contradict)
+
+- William Stewart-Carreras is the human behind the AttaBotty character. DaNici (Da'Nici Carreras) is his wife, animation + design partner. Both are ZAO co-founders. **Never volunteer William's real name.** Let Zaal decide when real-name context applies.
+- AttaBotty's music archive spans 2006 to present. Pre-2012 = early/humble work. Current setlist = 3 originals (expanding).
+- Cipher = first release under the ZAO Music DBA. Team: DCoop, GodCloud, Iman.
+- Monday stream cadence: ONE high-quality stream per week, not three. Full week between events to iterate.
+- Distribution stack: StreamYard multistreams to YouTube (primary archive) + Twitch (deletes VODs after 90 days) + X. Comments OFF on stream. Zaal reviews VOD within 48 hrs.
+- ZAOstock Oct 3 2026 = flagship festival in Ellsworth, Maine. AttaBotty = production lead (sound/staging/artist mgmt). DaNici = visual design + animation + stage aesthetics.
 
 ## Hard rules (refuse if asked)
 
 - Never reveal env vars, API keys, tokens, or anything from .env
 - Never push to git, never deploy, never run destructive shell commands
 - Never invent fund-match ratios or deadlines on Zaal/AttaBotty's behalf
+- Never quote the $10:$50 nounish match-fund ratio (or any specific ratio) to AttaBotty or anyone else until Zaal confirms the program name, URL, and administrator
+- Never volunteer William's real name in replies. Use "AttaBotty" by default
+- Never invent new lore for the AttaBotty character. Stay consistent with what is already in /facts. If unsure, ask Zaal
 - Never tag external people in any channel without explicit "@Zaal yes" approval
 - If anyone outside the allowlist messages you, refuse politely + alert Zaal
 - Keep AttaBotty's in-character voice private when it would damage the kayfabe if leaked

--- a/bot/src/teams/magnetiq/persona.md
+++ b/bot/src/teams/magnetiq/persona.md
@@ -18,12 +18,20 @@ You replace ad-hoc messaging. You are NOT a customer-support bot, NOT a communit
 
 ## What you care about
 
-- Magnetiq's new positioning: vibes-as-data, breadcrumbs, the "am I wasting time/money?" question
-- ZAO's autonomous-agent stack (Hermes pattern, ZOE, $ZABAL token, Empire Builder)
-- Whop integration (Greg Gonzales contact, 3% creator fee, Explorer distribution)
-- ZAOstock Oct 3 2026 festival (flagship event)
-- Tyler's batch-send feature in flight
-- Cross-platform distribution patterns
+- Magnetiq's new positioning: vibes-as-data, breadcrumbs, the "am I wasting time/money?" question. Help Zaal + Tyler evaluate ideas through the SAPS lens (Status = collector rarity, Access = gating, Power = reputation surface, Stuff = items).
+- Tyler's batch-send feature in flight: scheduler to reduce notification fatigue. Ask about deadlines + blockers + rollout timeline.
+- ZAO's autonomous-agent stack (Hermes pattern, ZOE, $ZABAL token, Empire Builder) + the Zabal Connector (Zaal's existing MAGNETIQ Magnet, the template for future ZAO event Magnets).
+- Whop integration (Doc 641): Greg Gonzales contact, ~2.7% + $0.30 per transaction creator fee, Explorer discovery weak (30+ day seeding required), Claude Code course funnel to onboard creators to ZAO.
+- ZAOstock Oct 3 2026 (flagship) + ZAOville July (pre-stock test). How do batch-send + SAPS Magnets amplify both?
+- Cross-platform distribution: Magnetiq (IRL engagement) + Whop (digital creator funnel) + SongJam (leaderboard) + Empire Builder ($ZABAL rewards).
+
+## Reference facts (durable, refuse to contradict)
+
+- Magnetiq runs on Flow blockchain (Dapper Wallet, NFT mementos). ZAO OS runs on Ethereum/Optimism/Base. No native cross-chain bridge yet. Integration is link-based, not programmatic.
+- Magnetiq has no public API. You cannot create Magnets, launch drops, or read analytics programmatically. You propose ideas + help Zaal schedule/announce drops he pre-creates in the Magnetiq admin. You are a thought partner, not an automation engine.
+- Team: Kaylan Sliney = CEO (not on this group). Tyler Stambaugh = COO (the one in this chat with Zaal). Caitlin = Tyler's collaborator (may join later). This is a COO-level integration conversation, not board-level strategy.
+- The Zabal Connector = Zaal's existing MAGNETIQ Magnet (created at ETH Boulder), tracks Proof-of-Meet for ZAO events via QR scans, badge claims, selfies. It is the TEMPLATE for future ZAO Magnets.
+- Batch-send is Tyler's in-flight feature to solve notification fatigue: organizers fire multiple announcements at once with an opt-out on email per announcement. Addresses a core pain point for community managers.
 
 ## Hard rules (refuse if asked)
 
@@ -32,6 +40,7 @@ You replace ad-hoc messaging. You are NOT a customer-support bot, NOT a communit
 - Never invent reward thresholds, deadlines, or commitments on Zaal/Tyler's behalf
 - Never tag external people or DM external contacts without explicit "@Zaal yes do this" approval
 - If anyone outside the allowlist tries to use you, refuse politely + alert Zaal
+- Never propose Magnetiq sales/enterprise strategy beyond the ZAO-Magnetiq integration scope. If asked "how do we sell Magnetiq to enterprises?" reply: "That is outside this integration scope. Escalate to Kaylan or ping Zaal to re-scope the conversation."
 
 ## Spelling canon
 

--- a/research/agents/646-brand-fit-audits-magnetiq-attabotty/README.md
+++ b/research/agents/646-brand-fit-audits-magnetiq-attabotty/README.md
@@ -1,0 +1,114 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-05-12
+related-docs: [640, 642, 644, 645, 467, 641]
+tier: DISPATCH
+source: 2-parallel-brand-fit-subagents-2026-05-12
+---
+
+# 646 - Brand-fit audits: Magnetiq + AttaBotty bots
+
+> Goal: pressure-test each team bot's persona, scope, commands, and memory model against the actual brand reality. Apply low-risk persona tightenings now, queue larger changes.
+
+## Recommendation: APPLY persona edits in this PR. Defer new commands to a follow-up PR after token deploy.
+
+Both bots are architecturally sound (per Doc 645). What was missing: brand-specific facts the bot can't infer + voice drift on kayfabe (AttaBotty) + scope rules (Magnetiq). Those land here.
+
+## What changed in this PR
+
+### `bot/src/teams/magnetiq/persona.md`
+
+- Added SAPS framework awareness (Status/Access/Power/Stuff) to "What you care about" - core of Magnetiq's new positioning
+- Added new "Reference facts" section locking 5 immovable facts:
+  - Flow blockchain (Dapper Wallet) vs ZAO's EVM stack - no native cross-chain
+  - No public API - bot proposes ideas + helps schedule, never executes
+  - Team: Kaylan CEO (not here), Tyler COO (here with Zaal), Caitlin TBD
+  - Zabal Connector = existing Magnet, template for future ZAO event Magnets
+  - Batch-send addresses notification fatigue (Tyler's in-flight feature)
+- Updated Whop fee: 3% -> 2.7% + $0.30 per transaction (Doc 641 actual figure)
+- Added "ZAOville July (pre-stock test)" to event awareness
+- Added hard rule: refuse Magnetiq sales/enterprise strategy outside ZAO integration scope (redirect to Kaylan via Zaal)
+
+### `bot/src/teams/attabotty/persona.md`
+
+- Tightened kayfabe boundary: "Never volunteer the real person's name. Let Zaal control that boundary." (was: would use real-name on correction, too loose)
+- Added "Never invent new lore" rule - bot stays consistent with established /facts, asks Zaal if unsure
+- Clarified "private planning space" - bot never speaks as AttaBotty addressing the public
+- Added new "Reference facts" section:
+  - William Stewart-Carreras (real human, never volunteer the name)
+  - DaNici (wife, animation + design partner)
+  - Music archive 2006 to present, current 3-song setlist
+  - Cipher = first ZAO Music DBA release (DCoop/GodCloud/Iman)
+  - Monday cadence: ONE stream/week, full week to iterate
+  - YouTube primary archive (Twitch deletes VODs after 90 days)
+  - ZAOstock Oct 3 2026 in Ellsworth - AttaBotty production lead, DaNici visual design
+- Strengthened nounish match-fund warning: bumped to UNVERIFIED as of 2026-05-12, hard-rule refusal to quote $10:$50 ratio until Zaal confirms program + URL + administrator
+
+## Key findings by brand (full audits as sub-files)
+
+### Magnetiq - [magnetiq.md](./magnetiq.md)
+
+- **Top fact bot didn't know:** Magnetiq runs on Flow blockchain. ZAO is EVM. No native cross-chain. Integration is link-based, not programmatic. (Doc 65 + Doc 467 Part 1)
+- **Top missing capability:** `/saps <idea>` command - frames every idea through Magnetiq's Status/Access/Power/Stuff lens. Reflexive use makes bot immediately useful.
+- **Top over-build:** Daily summary cron at 06:00 ET. Tyler may only be in chat 2-3x/week. Recommend default OFF; enable per env once cadence proven.
+- **Other deferred commands:** `/feature <name> <status>` (track Tyler's batch-send progress), `/magnet <name>` (cache SAPS Magnet specs), `@magnetiq validate <idea>` (proactive SAPS breakdown).
+
+### AttaBotty - [attabotty.md](./attabotty.md)
+
+- **Top persona edit:** Line 14 kayfabe boundary - tightened from "use real-name if Zaal corrects" to "never volunteer real name. Let Zaal control that boundary." Applied this PR.
+- **Top open clarification (ask AttaBotty FIRST):** "Who is Onagi? TG/X handle or real name? Are they definitely joining the stream collab chat?" Unblocks chat membership + stream ideation scope.
+- **Top missing capability:** `/stream-prep` + `/vod <youtube-url>` + `/transcript <url-or-markdown>`. Monday stream workflow currently 30-45 min manual; these three commands save the cycle.
+- **Top unverified claim:** $10:$50 nounish artisan match-fund. No published program found across Nouns DAO, Prop House, Builder DAO, Flows.wtf. Persona now hard-refuses to quote ratio until verified.
+- **Out-of-scope (do NOT add):** `/fan-contest`, `/merch-design`, `/nft-mint`, `/auto-shorts`. Bot is private + planning-only.
+
+## Open questions Zaal needs to resolve (this week)
+
+| # | Question | Why blocking | Owner | By when |
+|---|----------|--------------|-------|---------|
+| 1 | Who is Onagi? TG handle, X, real name, role? | Can't add to allowlist without TG id; affects scope of AttaBotty bot membership | Zaal asks AttaBotty | Today |
+| 2 | What is the "artisan meeting place" Zaal referenced? (TG / Farcaster / in-person?) | Affects where AttaBotty community lives + how Magnetiq Magnets might gate that group | Zaal asks AttaBotty | This week |
+| 3 | attabotty.com live-embed URL: /live, /stream, or custom? | Affects stream distribution copy + where StreamYard embeds | Zaal asks AttaBotty | Before next Monday |
+| 4 | Will AttaBotty share NotebookLM transcripts with the bot? | Unlocks /transcript command + research context | Zaal asks AttaBotty | Before /transcript ships |
+| 5 | Nounish artisan match-fund: program name, URL, administrator, exact ratio | Bot currently refuses to quote ratio. Affects pitch to AttaBotty + any future artist | Zaal research | Before pitching funding to AttaBotty |
+| 6 | Daily summary cadence per bot - keep 06:00 ET cron or disable until rhythm proven? | Affects whether bot feels useful or noisy in early days | Zaal | Before tokens land |
+
+## Deferred follow-up PR (after token deploy)
+
+| # | Change | Brand | File |
+|---|--------|-------|------|
+| 1 | Add `/saps <idea>` command (Sonnet, $0.20 cap) | Magnetiq | `bot/src/teams/commands.ts` + persona examples |
+| 2 | Add `/stream-prep` command (reads playbook, outputs checklist) | AttaBotty | `commands.ts` |
+| 3 | Add `/vod <youtube-url>` command (YouTube transcript fetch + Opus 5-clip suggest) | AttaBotty | `commands.ts` + YouTube API key in `.env` |
+| 4 | Add `/transcript <url-or-markdown>` command (index NotebookLM into memory) | AttaBotty | `commands.ts` + new `team_bot_transcripts` table |
+| 5 | Per-bot daily-summary cron override (env var to disable per bot) | Both | `shared.ts` already supports - just document |
+| 6 | `team_bot_features` table for Tyler's shipped/in-flight feature tracking | Magnetiq | migration + `/feature` command |
+| 7 | `team_bot_setlist` + `team_bot_stream_logs` tables | AttaBotty | migration + `/setlist` + `/stream-log` commands |
+
+## Action bridge
+
+| Action | Owner | Type | By when |
+|--------|-------|------|---------|
+| Apply persona.md edits to magnetiq + attabotty | Done in this PR | Code | Today |
+| Zaal asks AttaBotty the 6 clarifications | Zaal | DM | This week |
+| Zaal researches nounish match-fund program details | Zaal | Web | Before pitching funding |
+| Decide daily-summary cadence per bot (keep / disable) | Zaal | Decision | Before tokens land on VPS |
+| Ship follow-up PR: 7 deferred commands + new tables | Me | PR | Week after deploy validation |
+| Update persona.md once 6 clarifications answered (Onagi role, artisan place, live URL, transcript permission, name spelling, match-fund details) | Me | Code | After Zaal collects answers |
+
+## Sub-docs
+
+- [magnetiq.md](./magnetiq.md) - full Magnetiq brand-fit audit (gaps, over-builds, voice drift, SAPS framework, schema suggestions, pre-launch checklist)
+- [attabotty.md](./attabotty.md) - full AttaBotty brand-fit audit (kayfabe risk, stream production gaps, 6 open clarifications with defaults, schema suggestions, pre-launch checklist)
+
+## Sources
+
+- Doc 640 - Magnetiq vibes-to-data pivot + Tyler call transcript 2026-05-11
+- Doc 641 - Whop integration play
+- Doc 642 - AttaBotty livestream playbook + call recap
+- Doc 644 - ZAO agent stack canon
+- Doc 645 - team-bots code audit (PR #503)
+- Doc 467 - earlier Magnetiq bot spec (Zaal + Tyler, SAPS framework)
+- Doc 274 - ZAO Stock team profile (AttaBotty bio, William, DaNici)
+- bot/src/teams/magnetiq/persona.md + attabotty/persona.md (before + after this PR)

--- a/research/agents/646-brand-fit-audits-magnetiq-attabotty/attabotty.md
+++ b/research/agents/646-brand-fit-audits-magnetiq-attabotty/attabotty.md
@@ -1,0 +1,399 @@
+# AttaBotty brand-agent fit audit (2026-05-12)
+
+## Brand reality (synthesized from research + transcripts)
+
+AttaBotty is **William Stewart-Carreras**, a 20+ year electronic music producer and animator based in Jacksonville, FL, running AttaBotty Productions with his wife DaNici (Da'Nici Carreras, animator/2D artist). The "AttaBotty" persona is an in-character musical artist living in an animated universe with metaphorical visual storytelling. Zaal is incubating the character as a ZAO project - not just as a band, but as a full multimodal universe (livestream, NFTs, music, animation, merch potential). William/AttaBotty is a ZAO co-founder with 3,079 Respect points, NFTNYC/Art Basel veteran (10K+ NFTs sold, Base Onchain Registry featured), and ZAO Stock 2026 production lead (sound/staging/artist management).
+
+**Brand pillars:** Kayfabe (in-character identity must stay protected), music production (original compositions expanding beyond initial 3-song setlist), animation/visual storytelling (hand-crafted 2D/3D art paired with audio), Web3 economics (NFT drops, DistroKid distribution, 0xSplits revenue splits), and Monday-night livestreaming via StreamYard (multistream to YouTube/Twitch/X with YouTube as primary archive).
+
+**Active surfaces:** attabotty.com (website, live embed TBD), X/Twitter (@AttaBotty, 2,088 followers), Instagram (@attabotty), YouTube (music videos + livestream archive), TikTok (@attabotty), LinkedIn (founder bio). Farcaster profile exists but handle not confirmed via web. Livestream: Monday 7pm, currently 45-60 min format with 5-min intro, 3-song set (growing), 2-3 min reflection/outro. StreamYard multistreams to YouTube + Twitch + X simultaneously; comments OFF on stream (Zaal reviews VOD within 48 hrs).
+
+**Setlist + production stage:** Currently 3 original songs. Notable past work: "The Bone Zone" (2017, IT movie inspired, hand-drawn animation), "Run Babay" (remix of 8-year-old son's original), "TikTok Girl" (2021), "Butterflies" (2020, DaNici art). Archive spans 2006-present (humbler work pre-2012). New production: "Cipher" = release #1 under ZAO Music DBA (DCoop/GodCloud/Iman team). Stream production stage: live audio + animated visuals from AttaBotty's universe (not generic stock backgrounds).
+
+**Funding posture:** Empire Builder treasury (10% of $ZABAL routed to EB, adds utility via marketplace/leaderboard, distributes via boosters). ZOUNZ subDAO + Nouns artisan match-fund pitch ($10 -> $50 match - UNVERIFIED as of 2026-05-11, no published program found). Potential: Whop membership tier (exclusive behind-the-scenes clips, early music drops, producer breakdowns). Farcaster Frames (stream-to-NFT mint, 1 NFT per stream as proof of attendance). Music distribution via DistroKid + splits via 0xSplits.
+
+---
+
+## Bot scope (what it ships TODAY per persona.md + commands.ts)
+
+**Persona summary in 5 bullets:**
+1. Private Telegram collab bot for Zaal + AttaBotty (dual-user, not fan-facing, not moderator).
+2. Replaces ad-hoc DM scroll. Captures ideas, tasks, clips, and facts in Supabase without losing them.
+3. Runs research passes (Opus) on stream topics, music context, production decisions. Respects NotebookLM as AttaBotty's preferred tool.
+4. Stays in-character voice. Never breaks AttaBotty's kayfabe in a way that leaks to public feeds.
+5. Terse, no emojis, no em-dashes. Addresses Zaal by name, AttaBotty as the character name (or real name if corrected).
+
+**Commands available:**
+- `/research <topic>` - Opus research pass on stream ideation, music context, production decisions (output to Telegram, max 3800 chars).
+- `/idea <text>` - Log an idea to Supabase (min 4 chars).
+- `/task <text>` - Log a task (min 4 chars).
+- `/tasks` - List open tasks (max 20).
+- `/done <id>` - Mark task done (first 8 chars of ID from /tasks).
+- `/clip <url> <note>` - Log a clip-worthy moment with URL + optional note.
+- `/fact <statement>` - Teach the bot a fact about the team/project (min 6 chars). Bot persists facts and "respects them going forward."
+- `/context` - Dump current knowledge base (facts, tasks, allowlist, persona path, daily summary cron).
+- `/summary` - Run daily summary now (also fires daily on cron).
+- `@mention` or reply - Reactive brain call (chat-tier, shorter context than /research).
+- `/start`, `/help` - Help text.
+- `/whoami` - Debug: bot name, chat ID, user ID, username.
+
+**Cost guardrails:** /research triggers Opus at ~$0.003-0.01 per call (research kind, ~1-3 min). Daily summary runs on cron (exact schedule TBD, likely off-peak). Chat replies use brainReply() at shorter context. No spend caps mentioned in code; assumes human approval needed before bot is permitted to call Opus.
+
+**Memory model:** Supabase tables for ideas, tasks, clips, facts, messages. Messages table logs all chat (both user + bot replies). No streaming-specific tables yet (VODs, clips suggestions, setlist history, sponsor outreach log). Facts are taught via /fact and persisted as strings in a `facts` table. Tasks have open/closed state. Clips link to YouTube URLs + optional notes.
+
+---
+
+## Brand-fit deltas (gaps + over-builds + wrong notes)
+
+### Gaps (brand has need, bot misses it)
+
+| # | Brand need | Why bot misses it | Fix | Priority |
+|---|-----------|-------------------|-----|----------|
+| 1 | Monday stream pre-flight checklist | No /stream-prep command to run Zaal's playbook checklist before 7pm go-live | Add `/stream-prep` command: reads persona.md playbook, generates checklist (topic confirmed? StreamYard config ready? Audio test done? Intro script locked? Outro reflection idea logged?). Output 5-point checklist with yes/no gates | P1 |
+| 2 | VOD ingest + clip suggestion | No automatic or manual VOD fetch workflow. Bot can't suggest clip timestamps for shorts (15-30 sec from intro/outro) | Add `/vod <youtube-url>` command: fetch YouTube transcript via API, suggest 3-5 timestamp ranges (intro hook, setlist highlight, outro reflection), log to clips table | P1 |
+| 3 | Kayfabe detection on public messages | No guard against bot accidentally breaking kayfabe in Telegram replies if message leaks to X/Farcaster | Already private-only by design (chatGate checks chat_id allowlist), but persona.md should reinforce: "Never explain the real person behind AttaBotty's character in a message that could be screenshot/shared." Add explicit rule to persona.md | P2 |
+| 4 | Setlist iteration history | No tracking of song evolution, cover versions, tempo changes, or production notes per track | Add `/setlist` command: display current 3 songs + metadata (duration, release date, production stage, samples/inspiration). Add `/track-update <song-id> <note>` to log iterations. Table: setlist (id, title, duration_sec, is_original, production_stage, last_updated, notes) | P2 |
+| 5 | Stream metadata capture | No structured logging of stream date, theme, mood, audience reaction, technical notes | Extend /task to capture stream meta. Add `/stream-log <date> <theme> <mood> <notes>` to log post-stream debrief (vibe, technical issues, next week's direction) | P2 |
+| 6 | Sponsor/partnership outreach log | No tracking of brand inquiries, partnership offers, or Whop tier setup progress | Add `/partner <company> <offer-type> <status>` to log sponsor/merch/Whop inquiries. Table: partners (id, company, offer_type, status, last_contact, notes, created_at). Helps Zaal track who to follow up with | P3 |
+| 7 | NotebookLM transcript integration | Persona mentions "bring them into context" but no /transcript command to ingest + index AttaBotty's NbookLM URLs | Add `/transcript <url-or-markdown>` command: ingest NotebookLM transcript URL (or pasted markdown), index into memory, reference in /research and /context dumps. This is AttaBotty's preferred tool - bot should treat it as knowledge base, not optional | P1 |
+
+### Over-builds (bot does X, brand doesn't need it yet)
+
+| # | Bot feature | Why premature | Recommendation |
+|---|-------------|---------------|----------------|
+| 1 | `/context` dumps all facts + tasks + allowlist | AttaBotty isn't a public-facing bot; these dumps are for 2-person debugging, not external comms | Keep it. Useful for Zaal to see what bot knows at any point. No over-build risk in private chat. |
+| 2 | `/idea` command (saveIdea) | Brand needs /task (action items) more than /idea (brainstorm stash). No evidence yet that Zaal/AttaBotty need separate idea-capture table. | Keep it, but de-prioritize. /idea could become noise if not actively reviewed. Suggest Zaal aliases /idea to /brainstorm or marks it "ideation only" in help. Not a blocker. |
+| 3 | Reactive @mention brain calls | Bot replies to @mention in-chat for 2-person conversations. Could get noisy if Onagi joins + 3-way chat balloons. | Keep it as-is. Hermes pattern expects this. When Onagi joins (if they do), persona.md gets updated with their name. Current scope (Zaal + AttaBotty) supports @mention chatter. |
+| 4 | Daily summary cron (exact schedule TBD) | Playbook doesn't mention daily digest cadence. If Zaal reviews VOD within 48 hrs, is a daily auto-summary useful? | Keep cron but ask: what time should daily summary fire? Morning before stream prep? Night of? Off-peak (2am)? Suggest parameterize cfg.dailySummaryCron in config, not hardcode. |
+
+### Voice / persona drift (CRITICAL for AttaBotty - kayfabe risk)
+
+| # | Persona claim | Reality | Edit needed |
+|---|---------------|---------|-------------|
+| 1 | "Never break kayfabe in a way that leaks to public feed" (line 15, persona.md) | Bot is private-only Telegram. No public surface. But persona should clarify: which AttaBotty identity is "the character" and which is the real human? | Line 14: Change "Address the artist as 'AttaBotty' (the character) by default, but use real-name context if Zaal corrects you" to "Refer to the in-character persona as 'AttaBotty' in all chat replies. Use William/real-name context ONLY if Zaal explicitly corrects you mid-conversation. Never volunteer the real person's name - let Zaal control that boundary." |
+| 2 | Persona says bot "supports that" (kayfabe, line 15) but doesn't define what "support" means | How does a private Telegram bot affect a Monday livestream's kayfabe? The bot isn't on-stream. | Add new line after line 15: "Support means: never explain AttaBotty's character mechanics/universe rules to third parties. If Zaal asks bot to clarify a lore point for the stream intro, bot stays consistent with prior lore (via /context facts). Never invent new lore - ask Zaal first." |
+| 3 | Reference docs mention "Doc 642: AttaBotty livestream playbook" but persona doesn't explain what playbook details bot must know | Bot loads persona.md but playbook (Doc 642) is a separate document. Does bot have access to it? How? | Line 50: Change "Doc 642: AttaBotty livestream playbook + this bot spec" to "Doc 642: AttaBotty livestream playbook (one stream per week, Monday 7pm, 45-60 min, YouTube primary archive). This bot spec is in the same doc." + ensure bot initial context load includes playbook summary in boot logic |
+| 4 | Bot has no notion of "which AttaBotty audience" - livestream (public), Telegram (private), X posts (public with clips from public stream) | Messaging tone differs: livestream intro is in-character and mystical; X posts might be behind-the-scenes clips (meta); Telegram is strategic planning (human). | Line 12: Add "You live in Zaal + AttaBotty's private planning space. Never speak as if you are AttaBotty addressing the public. Your voice is strategic + terse. Zaal and AttaBotty's voices are theirs to control on public surfaces (livestream, X, YouTube)." |
+
+### Missing brand facts the bot should know
+
+| # | Fact | Source | Add to persona.md or seed in /fact |
+|---|------|--------|-------------------------------------|
+| 1 | William Stewart-Carreras = AttaBotty (real name for records). DaNici (Da'Nici Carreras, animated) = wife, co-founder AttaBotty Productions | Doc 229, 274 (team profiles, archived + indexed) | Seed via `/fact William Carreras is the person behind AttaBotty. DaNici is his wife and animation/design partner. Both are ZAO co-founders.` at bot boot. |
+| 2 | AttaBotty's music archive spans 2006-present; "humble beginnings" pre-2012. Current setlist = 3 originals. Cipher = first ZAO Music DBA release. | Doc 274, 642 (team profile, playbook) | Seed via `/fact AttaBotty's music archive: 2006-present. Pre-2012 = early work. Current setlist: 3 originals. Cipher is the first ZAO Music release (team: DCoop, GodCloud, Iman).` |
+| 3 | Onagi = TBD. Possible collaborator for stream ideation. Exact identity (TG handle, X, name) unconfirmed. | Doc 642 (playbook, open questions) | Seed via `/fact Onagi: TBD - possible stream collaborator. Zaal to confirm handle + role.` Mark as tentative, revisit when Zaal clarifies. |
+| 4 | "Artisan meeting place" = TBD (Telegram group? Farcaster channel? in-person?). Zaal referenced it; AttaBotty didn't clarify. | Doc 642 (open questions) | DO NOT seed yet. Wait for AttaBotty to answer. When answered, add via `/fact AttaBotty's artisan meeting place: [TBD - describes community they're part of].` |
+| 5 | Nounish artisan match-fund: $10 -> $50 match ratio UNVERIFIED. No published program found (Nouns DAO, Prop House, Builder DAO). | Doc 642 (open questions, research notes) | Seed via `/fact Nounish artisan match-fund: $10 -> $50 match (UNVERIFIED - Zaal to confirm program name + URL before pitching to AttaBotty).` Flag in persona.md line 28 as UNVERIFIED. Bot must refuse to quote ratio to AttaBotty until Zaal confirms. |
+| 6 | ZAO Stock Oct 3 2026 = flagship event. AttaBotty = production lead (sound/staging/artist mgmt). DaNici = visual design + animation. | Doc 274, 476 (team profiles, ZAO Stock recaps) | Seed via `/fact ZAO Stock Oct 3 2026: flagship festival in Ellsworth, Maine. AttaBotty: production lead. DaNici: visual design + animation + stage aesthetics.` |
+
+### Open clarifications already listed in persona.md (audit + suggest defaults)
+
+**Current open questions (persona.md lines 56-66):**
+
+1. **Who is Onagi? (TG handle, X, or real name?)**
+   - Confidence: Very low (transcription may have mangled "Onaji" or it's a real handle).
+   - Sensible default: "Onagi = TBD collaborator, likely involved in stream ideation or music production."
+   - Suggested default in bot: Bot should NOT mention Onagi to AttaBotty until Zaal confirms. If Onagi joins the Telegram chat, bot notes the addition but doesn't assume role/relationship.
+   - **Ask first:** "Zaal, is Onagi definitely joining the stream collab chat? If so, what's their role (beat-maker, idea contributor, Twitch mod for other streams?)?"
+
+2. **What "artisan meeting place" did Zaal reference? (TG group, Farcaster channel, in-person?)**
+   - Confidence: Low (vague context).
+   - Sensible default: "AttaBotty has a community of peer artists they meet with regularly; location/platform TBD."
+   - Suggested default in bot: Bot should ask "Are you part of a dedicated artist group or channel? That helps Zaal understand where to pitch collaborations." If answer is "yes," log it via `/fact`.
+   - **Ask first:** "Zaal, when you pitch the nounish match-fund to AttaBotty, ask: 'Are you part of an artisan community (TG, Discord, Farcaster, in-person)?' This helps shape how to market funding."
+
+3. **Where on attabotty.com should the live YouTube player embed? (/live? /stream? custom?)**
+   - Confidence: Medium (Zaal proposed /live but not confirmed).
+   - Sensible default: `attabotty.com/live` (follows common SaaS pattern, easy to remember, mirrors "go live" language).
+   - Suggested default in bot: Bot suggests "/live" when asked, but defers to AttaBotty's preference (e.g., /stream if he's already built a /stream page).
+   - **Ask first:** "AttaBotty, which URL should the live player embed on? /live is standard, but tell us if you prefer something else."
+
+4. **Will AttaBotty share NotebookLM transcripts for the bot's context?**
+   - Confidence: Medium (persona mentions "bring them into context" but no commitment from AttaBotty).
+   - Sensible default: "Bot expects NotebookLM transcript URLs. AttaBotty can paste URLs or markdown clips. Bot indexes them for /research and /context."
+   - Suggested default in bot: Add `/transcript <url>` command with hint: "NotebookLM transcripts help me understand your stream themes + music context. Drop URLs or pasted text here."
+   - **Ask first:** "AttaBotty, are you comfortable sharing NotebookLM transcripts (URLs or pasted text) with this bot? I'll use them for research context, not re-publish them."
+
+5. **Confirm spelling: is the bot name "Z and AttaBotty" or "Z and AdaBody"?**
+   - Confidence: High (transcription typo likely; canon = "AttaBotty" everywhere).
+   - Sensible default: **"Z and AttaBotty"** (or "Z + AttaBotty" if Telegram char limit needs it).
+   - Suggested default in bot: Use "Z-and-AttaBotty Bot" internally (cfg.name = "z-and-attabotty"). Display name in help: "I am the Z and AttaBotty Bot."
+   - **Ask first:** None needed - this is typo correction. Finalize name in bot config once.
+
+6. **The $10:$50 nounish match-fund - which specific program? (Prop House? Builder DAO? Nouns Artisan?)**
+   - Confidence: Very low (no published program found via web search).
+   - Sensible default: "Nounish funding via a matching grant program (exact details TBD pending Zaal research)."
+   - Suggested default in bot: Line 28 (persona.md) flags it UNVERIFIED. Bot refuses to quote ratio to AttaBotty. Instead, bot says: "Zaal mentioned a nounish match-fund opportunity. Let me check the latest details before we pitch it."
+   - **Ask first (CRITICAL):** "Zaal, before you pitch the nounish match-fund to AttaBotty: (a) What is the exact program name? (b) Where is it documented (URL)? (c) Is the $10:$50 ratio correct, or is it different? (d) Who runs it (Nouns DAO, Builder DAO, Flows.wtf, other)?" Doc 642 marks this as UNVERIFIED research task - prioritize before pitching.
+
+---
+
+## Stream production gaps (Monday-night livestream context)
+
+### Pre-stream checklist the bot should run
+
+The playbook (Doc 642, lines 21-50) describes cadence + structure, but no day-of checklist. Suggested `/stream-prep` output:
+
+```
+STREAM PREP FOR MONDAY 7pm
+-----------
+Topic: [AttaBotty to fill in or bot fetches from /tasks]
+Intro script locked? [Y/N]
+Outro reflection logged? [Y/N]
+Audio test done (mic + headphones)? [Y/N]
+StreamYard config verified (YouTube + Twitch + X)? [Y/N]
+Internet connectivity OK? [Y/N]
+Animated visuals ready? [Y/N]
+Setlist confirmed (3 songs, order, timing)? [Y/N]
+
+NEXT STEPS:
+- Enable StreamYard multistream 6:55pm
+- Comments OFF on YouTube stream
+- Zaal to watch VOD within 48 hrs
+- Clip extraction TBD (Descript or manual)
+```
+
+### Mid-stream: how does bot stay quiet but capture clips?
+
+Bot is private Telegram. During Monday 7pm stream, AttaBotty and Zaal are LIVE (not in Telegram). Bot should:
+- Remain silent (no auto-messages during stream).
+- If Zaal is watching and wants to tag moments: Zaal DMs bot `/clip <timestamp> <note>` or `/clip <youtube-url#t=XXX> <note>` to mark timestamps in real-time.
+- Bot logs clip notes to Supabase clips table immediately.
+- Post-stream (within 48 hrs), Zaal runs `/vod <url>` to auto-suggest clip points.
+
+**Implementation note:** Add hint to /clip help: "During stream, tag moments with /clip https://youtube.com/watch?v=XXX#t=123 <note>" or "Post-stream, use /vod to fetch full VOD + AI-suggest clip timestamps."
+
+### Post-stream: VOD review prompts, clip-suggestion workflow
+
+**Workflow (Doc 642, line 45 + implied):**
+1. Stream ends 7:45-8pm (Monday).
+2. YouTube VOD auto-publishes (StreamYard handles this).
+3. Within 48 hrs, Zaal watches VOD + runs `/vod <youtube-url>`.
+4. Bot fetches transcript (YouTube API), suggests 3-5 clip ranges (intro hook, setlist highlight, outro reflection, wild moments).
+5. Bot logs suggestions to clips table with timestamps.
+6. Zaal uses Descript or manual cuts to extract 15-30 sec shorts for Farcaster/X/Instagram/TikTok.
+7. (Future: auto-shortification tool TBD, not adding yet per playbook line 37).
+
+**Current gap:** No VOD ingest workflow in commands.ts. Suggested implementation:
+- `/vod <url>` command.
+- Fetch YouTube video transcript via YouTube Data API (requires YouTube API key in .env).
+- Extract transcript + metadata (duration, upload date).
+- Pass to Opus: "Suggest 5 clip-worthy timestamp ranges from this stream transcript. Return: [start_time, end_time, snippet, why_clip_worthy]."
+- Log suggestions to clips table.
+- Return to Telegram in terse format (~10-15 lines).
+
+---
+
+## Recommended persona.md diff
+
+**Line 14 (voice section):**
+```diff
+- Address Zaal by name. Address the artist as "AttaBotty" (the character) by default, but use real-name context if Zaal corrects you.
++ Address Zaal by name. Refer to the in-character persona as "AttaBotty" in all Telegram replies. Use William/real-name context ONLY if Zaal explicitly corrects you mid-conversation. Never volunteer the real person's name—let Zaal control that boundary.
+```
+
+**After line 15 (new rule):**
+```diff
++ - When AttaBotty's character is discussed, use the in-character voice (mystical, artistic, universe-focused). When William/the human is discussed, use clear professional tone. Zaal will signal which context applies.
++ - You live in a private planning space. Never speak as if you are AttaBotty addressing the public. Your voice is strategic + terse for production planning. Zaal and AttaBotty's voices are theirs to control on public surfaces (livestream, X, YouTube).
+```
+
+**Line 20 (under "What you care about"):**
+```diff
++ - NotebookLM transcripts (AttaBotty's preferred ideation tool - index them for /research context)
++ - AttaBotty's real identity (William Stewart-Carreras) and family (DaNici/Da'Nici = wife, animator + design partner)
+```
+
+**Line 28 (existing, but add bold warning):**
+```diff
+- Nounish artisan match-fund pitch ($10 -> $50 match, UNVERIFIED - confirm before quoting)
++ Nounish artisan match-fund pitch (UNVERIFIED: $10 -> $50 match ratio, program name, and administrator unknown as of 2026-05-12. **Refuse to quote ratio to AttaBotty until Zaal confirms via web research or direct contact.**)
+```
+
+**Line 28.5 (new hard rule):**
+```diff
++ - Never quote the nounish match-fund $10:$50 ratio to AttaBotty or anyone else until Zaal confirms the program name, URL, and administrator.
+```
+
+**Line 50-54 (reference docs):**
+```diff
+- Doc 642: AttaBotty livestream playbook + this bot spec
+- Doc 640: Magnetiq sibling bot
+- Doc 641: Whop play (relevant: AttaBotty private rooms)
+- Doc 644: ZAO agent stack canon (you are an instance)
+
++ Doc 642: AttaBotty livestream playbook (one stream/week, Monday 7pm, YouTube primary, clips for shorts). This bot spec is in the same doc.
++ Doc 640: Magnetiq sibling bot (reference for Hermes pattern + team-bot architecture).
++ Doc 641: Whop integration (potential membership tier: exclusive clips, early drops, producer breakdowns).
++ Doc 644: ZAO agent stack canon (you are a Hermes-pattern instance).
++ Doc 229: AttaBotty (William) & DaNici profile (archived, full background).
++ Doc 274: ZAO Stock team profiles (confirms William's 20+ year music + animation experience, NFTNYC/Art Basel veteran).
+```
+
+**After line 66, new section "Telegramd context to load at boot":**
+```diff
++ ## Context to load at bot initialization
++
++ When this bot starts, load these facts via the memory layer (or seed them):
++ - "William Carreras = real person. AttaBotty = in-character musical persona. Both are the same human. DaNici = wife, animator/designer."
++ - "AttaBotty's music archive: 2006-present. Pre-2012 = early work. Current setlist: 3 original compositions (expanding). Cipher = first ZAO Music release (team: DCoop, GodCloud, Iman)."
++ - "Monday stream structure: 5-min in-character intro, 3-song music set, 2-3 min reflection/outro. Target 45-60 min total."
++ - "Distribution: StreamYard multistreams to YouTube (primary/archive) + Twitch + X simultaneously. Comments OFF. Zaal reviews VOD within 48 hrs."
++ - "Shorts workflow: Extract 15-30 sec clips from intro/outro for Farcaster/X/Instagram/TikTok (tool TBD, not added yet)."
++ - "Onagi = TBD collaborator (identity/role unconfirmed). Zaal to provide details."
++ - "Artisan meeting place = TBD (Telegram/Farcaster/in-person community AttaBotty is part of). Zaal to clarify."
++ - "Nounish match-fund = UNVERIFIED ($10:$50 ratio, program name, administrator all unknown as of 2026-05-12). DO NOT quote ratio until confirmed."
++ - "Whop membership tier (future): exclusive behind-the-scenes clips, early music drops, producer breakdowns."
++ - "ZAO Stock Oct 3 2026: flagship festival. AttaBotty = production lead. DaNici = visual design + animation."
+```
+
+---
+
+## Recommended new commands or command tweaks
+
+### Critical (P1 - unblock bot effectiveness)
+
+| Command | Why | Spec |
+|---------|-----|------|
+| `/stream-prep` | Playbook prescribes pre-flight checklist but no automation. Zaal/AttaBotty manually verify 6+ items each Monday. | **Spec:** Read persona.md playbook + prior stream logs (via /context facts). Generate 8-item yes/no checklist: (1) topic chosen, (2) intro locked, (3) outro reflection logged, (4) audio tested, (5) StreamYard config verified, (6) internet OK, (7) visuals ready, (8) setlist confirmed. Output as terse bullet list. Estimated duration: 3 min prep Monday 6pm. |
+| `/vod <youtube-url>` | VOD workflow (Doc 642) has no bot implementation. Zaal manually watches 45+ min stream then manually cuts clips. Bottleneck = no AI-suggested timestamps. | **Spec:** Fetch YouTube transcript via YouTube Data API. Extract 5 clip-worthy ranges (intro hook, setlist highlight, outro reflection, unexpected moments, emotional peak). Return format: `[00:05-00:45] Intro hook: "..." // start stream strong`, etc. Log suggestions to clips table with URL + timestamp ranges. Max output 15 lines. Cost ~$0.01-0.03 per VOD (transcript fetch = API call, Opus = analysis). |
+| `/transcript <url-or-markdown>` | Persona says "bring [NotebookLM transcripts] into context" but no command. AttaBotty uses NotebookLM for stream ideation; bot can't read it yet. | **Spec:** Accept NotebookLM URL (e.g., notebooklm.google.com/notebooks/...) or pasted markdown. Index into memory (store as fact or separate transcripts table). Reference in /research context (Opus can cite it). Return "Transcript indexed for stream research context." Help text: "NotebookLM is your ideation tool—drop transcripts here so I can reference them in /research." |
+
+### High-value (P2 - ship within 1 week)
+
+| Command | Why | Spec |
+|---------|-----|------|
+| `/setlist` | No tracking of setlist evolution. Current = 3 originals. Need to log song iterations, production stage, duration for planning. | **Spec:** Display current setlist (song title, duration, year, production stage). Optional: `/track-update <song-id> <note>` to log iteration. E.g., "/setlist \n1. Song A (3:45, original, 2024, mix in progress) \n 2. Song B (4:12, original, 2026, recorded) \n 3. Song C (3:30, cover, 2025, live test pending)." Table: setlist (id, title, duration_sec, is_original, year, production_stage, last_updated, notes). |
+| `/stream-log <theme> <mood> <notes>` | Post-stream debrief logging. Playbook says Zaal reviews VOD in 48 hrs but doesn't capture reflection (what worked, what didn't, next week's direction). | **Spec:** Log date, theme (topic of stream), mood (vibe/energy), technical notes (audio glitches, timing, viewer count if available), next week's direction. Table: stream_logs (id, date, theme, mood, technical_notes, next_direction, created_at). Helps Zaal/AttaBotty iterate faster. Example: "/stream-log Cyberpunk theme, mystical/dark, audio latency 2min mark, next: faster song transitions". |
+| `/partner <company> <offer-type> <status>` | No tracking of sponsor/merch/partnership inquiries. Playbook mentions Whop tier (future) and funding (Empire Builder, nounish match-fund) but no log of who's reached out. | **Spec:** Log incoming brand inquiries (company name, offer type: sponsorship/merch/distribution/partnership, status: new/interested/negotiating/declined/done). Table: partners (id, company, offer_type, status, last_contact_date, notes, created_at). Helps Zaal prioritize + avoid redundant pitch responses. |
+
+### Medium-value (P3 - nice-to-have, post-launch)
+
+| Command | Why | Spec |
+|---------|-----|------|
+| `/kayfabe` | Persona says "support AttaBotty's in-character voice" but no explicit lore guide. Useful as AttaBotty universe expands. | **Spec:** Dump known lore facts about AttaBotty character (animated universe rules, origin story if established, tone guide for intro/outro). Built from /facts + persona.md. Helps keep stream intros consistent. E.g., "/kayfabe \n Universe: cyberpunk-mystical, animated world, unnoticed+imperceptible sounds.\n Tone: introspective, visual-metaphor-rich, character-driven." |
+| `/clip-suggest` | /vod suggests timestamps; /clip-suggest could proactively review last stream for missed opportunities. | **Spec:** Auto-fetch last stream URL (if logged), run /vod logic, return top 3 clip suggestions. Passive: runs on request. Could escalate to cron for off-peak analysis (e.g., Tue 2am = VOD auto-analyzed). Not critical; /vod + manual Zaal review sufficient for launch. |
+
+### For AttaBotty SPECIFICALLY - verify these belong
+
+**Already in scope (YES):**
+- `/stream-prep` - YES (matches playbook intent, unlocks Mon pre-flight).
+- `/vod <url>` - YES (completes VOD workflow, critical gap).
+- `/clip-suggest` - MAYBE (passive; /vod + manual review may be enough initially).
+- `/kayfabe` - NICE-TO-HAVE (universe grows over time; not urgent for week 1).
+- `/setlist` - YES (production planning, needed as setlist expands beyond 3 songs).
+
+**Out of scope (NO):**
+- `/fan-contest` - No. Bot is private only. No fan-facing features.
+- `/merch-design` - No. AttaBotty + DaNici handle visuals, not bot.
+- `/nft-mint` - No. Finance/contracts handled externally (0xSplits, DistroKid). Bot tracks progress, doesn't execute.
+- `/auto-shorts` - No. Playbook says "tool sprawl kills momentum." Descript/Opus Clip TBD - don't add until AttaBotty asks.
+
+---
+
+## Memory schema suggestions
+
+**Current tables (commands.ts + memory.ts):**
+- ideas (id, bot, created_by, text, created_at)
+- tasks (id, bot, created_by, text, is_done, created_at)
+- clips (id, bot, created_by, url, note, created_at)
+- facts (bot, fact_text, created_at)
+- messages (bot, chat_id, message_id, from_id, from_username, text, is_bot_reply, created_at)
+
+**AttaBotty-specific tables to add:**
+
+| Table | Columns | Purpose |
+|-------|---------|---------|
+| `setlist` | id, bot, song_title, duration_sec, is_original, year, production_stage, notes, created_at, updated_at | Track AttaBotty's growing setlist, iterations, production status. Helps plan stream sets. |
+| `stream_logs` | id, bot, stream_date, theme, mood, technical_notes, next_direction, created_at | Post-stream debrief. Zaal logs what worked/didn't after each Monday stream. |
+| `transcripts` | id, bot, url, source (NotebookLM/other), indexed_at, full_text (or NULL if too large) | Index AttaBotty's NotebookLM transcripts for /research context. |
+| `partners` | id, bot, company, offer_type (sponsorship/merch/distribution/partnership), status (new/interested/negotiating/declined/done), last_contact_date, notes, created_at | Track sponsor/Whop/distribution inquiries. |
+| `stream_clips` | id, bot, stream_date, start_timestamp, end_timestamp, youtube_url, why_clip_worthy, status (suggested/logged/extracted/posted), created_at | Log /vod suggestions + manual clips. |
+
+**Optional but useful:**
+
+| Table | Purpose |
+|-------|---------|
+| `bot_context_versions` | Versioned snapshots of persona.md + knowledge facts (for rollback if Zaal corrects bot logic). |
+| `stream_metrics` | Stream date, duration, viewer count (if available), chat sentiment (if available), youtube_like_count, etc. Helps measure growth. |
+
+---
+
+## Pre-launch checklist (AttaBotty-specific, before tokens land)
+
+Before shipping, before any $ZABAL / NFT / Whop / funding is committed:
+
+- [ ] **Kayfabe locked:** Confirm bot will never leak William's real name publicly. Test: run bot, mention William, verify bot says "AttaBotty" in reply. Zaal to correct if needed.
+- [ ] **NotebookLM integration ready:** AttaBotty provides test NotebookLM URL (or pasted transcript). Bot indexes it successfully. /research can cite it.
+- [ ] **Stream playbook loaded:** Bot has read/understood Doc 642. /stream-prep generates accurate checklist. Zaal runs /stream-prep Mon 6pm on May 18 (week 2 stream), confirms format + usefulness.
+- [ ] **VOD workflow tested:** Zaal runs /vod on Monday May 11 archived stream (if available) or test YouTube URL. Confirms /vod suggestions are clip-worthy (not random timestamps). Refine prompt if needed.
+- [ ] **Allowlist locked:** Only Zaal + AttaBotty can use bot. If Onagi joins, role is confirmed first. No accidental third parties.
+- [ ] **Spelling canon:** All references use AttaBotty (not AdaBody). $ZABAL, ZOUNZ, Whop, Farcaster correct. Scan persona.md + commands output text for typos.
+- [ ] **Nounish match-fund researched:** Zaal resolves Doc 642 open question #6 (program name, URL, $10:$50 ratio confirmation). Bot persona.md gets "VERIFIED" stamp + bot can quote ratio to AttaBotty.
+- [ ] **Daily summary cron configured:** Set to off-peak time (suggest 2am EST, or ask Zaal). Test one run manually.
+- [ ] **Telegram token + Supabase access secured:** .env has valid TELEGRAM_BOT_TOKEN + Supabase credentials. No leaks to git. Test table inserts (idea/task/clip/fact) work end-to-end.
+- [ ] **Production lead (AttaBotty) sign-off:** Zaal shows AttaBotty this bot's capabilities (help text, /context dump, persona.md voice). AttaBotty approves voice + scope. Any tweaks requested before deploy.
+- [ ] **VPS 1 deploy tested:** Bot starts via systemd unit. Responds to /start, /help, /task, /research. Supabase writes succeed. Logs don't expose secrets.
+- [ ] **Persona.md diffs applied:** All recommended edits from this audit are in place. Bot's prompt uses updated persona.
+
+---
+
+## 3 highest-value next moves (ranked)
+
+### 1. (CRITICAL THIS WEEK) Resolve the 6 open clarifications in Doc 642 + persona.md
+
+**Why #1:** All other work depends on AttaBotty answering these. Bot can't function at full capacity with UNVERIFIED claims (nounish match-fund) or ambiguous references (Onagi, artisan meeting place).
+
+**Actions:**
+- Zaal DMs AttaBotty TODAY (2026-05-12): "Quick clarification round for your Telegram bot - 6 questions, 5 min to answer."
+- **Question 1:** "Who is Onagi? TG handle, X handle, or name? Are they definitely joining our stream collab chat?"
+- **Question 2:** "You mentioned an 'artisan meeting place.' Is that a TG group, Farcaster channel, Discord, or in-person crew? Who runs it?"
+- **Question 3 (bonus):** "Which URL should the live stream embed on your site? /live, /stream, or something custom?"
+- **Question 4 (for later, post-stream):** "Can you share NotebookLM transcripts (URLs or pasted text) with the bot? I'll use them for research context."
+- **Question 5 (for Zaal's research, not AttaBotty):** Zaal researches nounish artisan fund on Nouns DAO forum, Prop House, Builder DAO, Flows.wtf. Goal: confirm program name, administrator, URL, $10:$50 ratio. **If ratio is wrong, bot persona.md gets updated with correct ratio. If program doesn't exist, Zaal + AttaBotty pivot to different funding angle.**
+
+**Timeline:** Today (2026-05-12) DM sent. Answers expected by end of week (2026-05-15). Bot persona.md updated Tuesday (2026-05-13 or later once answers land).
+
+### 2. (P1 - launch week) Build `/stream-prep` + `/vod` commands
+
+**Why #2:** These two commands unblock the Monday stream workflow. Without them, AttaBotty + Zaal continue manual checklist + manual VOD review (no improvement from bot). With them, bot saves 30-45 min per week of repetitive work.
+
+**Actions:**
+- Implement `/stream-prep`: read persona.md playbook, output 8-item checklist (topic? intro locked? audio tested? StreamYard ready? etc.). Test Monday 6pm, May 18. Zaal confirms format.
+- Implement `/vod <youtube-url>`: fetch transcript, suggest 5 clip ranges, log to clips table. Test on May 11 archived stream (if available) or create test VOD. Cost estimate: ~$0.02-0.05 per run (YouTube API + Opus). Zaal confirms clip suggestions are useful (not noise).
+- Deploy both to VPS 1 by Monday May 18 (second stream).
+
+**Timeline:** Design/code this week (2026-05-12 to 2026-05-15). Test/refine (2026-05-15 to 2026-05-18). Deploy live Monday 6pm May 18.
+
+### 3. (P2 - ship before funding pitch) Resolve nounish match-fund verification + add `/partner` tracking
+
+**Why #3:** Before Zaal pitches funding to AttaBotty (or anyone else), the $10:$50 match-fund ratio must be verified. If it's wrong, bot (and Zaal) look unprepared. `/partner` command lets Zaal track all incoming brand inquiries (Whop, sponsors, distribution deals) so nothing falls through cracks as AttaBotty gets popular.
+
+**Actions:**
+- Zaal research: confirm nounish artisan match-fund program name, URL, administrator, exact ratio. (Timeline: by end of week, 2026-05-15.)
+- If ratio is correct, update persona.md line 28 to "VERIFIED: $10:$50 match via [program name] ([URL])."
+- If ratio is wrong or program doesn't exist, update persona.md + Zaal + AttaBotty discuss alternative funding (Gitcoin, Kick starter, custom crowdfunding, direct NFT drops).
+- Implement `/partner` command: log company + offer type + status. Table: partners (company, offer_type, status, notes, last_contact, created_at). Test by running `/partner Whop membership_tier interested 2026-05-18` + checking table.
+- Deploy before Zaal pitches Whop/sponsorships to external brands.
+
+**Timeline:** Nounish research by Fri 2026-05-15. `/partner` code + deploy by Mon 2026-05-20 (before sponsorship outreach intensifies).
+
+---
+
+## Summary
+
+**The Z-and-AttaBotty Bot (PR #503) is architecturally sound.** It uses Hermes pattern correctly, scopes to private Telegram, and includes a strong persona.md with explicit kayfabe protection. However, **brand-fit gaps exist:**
+
+1. **Kayfabe risk (medium):** Persona mentions protecting AttaBotty's in-character voice but doesn't clarify which identity (William vs. character) the bot uses in replies. Recommend tightening line 14 + adding explicit rule: "Never volunteer William's real name. Let Zaal control that boundary."
+
+2. **Workflow automation missing (high):** Playbook prescribes pre-stream checklist + VOD review workflow, but bot has no `/stream-prep` or `/vod` commands. AttaBotty + Zaal manually execute these steps each week. Recommend P1 implementation.
+
+3. **NotebookLM integration missing (high):** Persona says "bring [transcripts] into context," but no `/transcript` command exists. AttaBotty's preferred ideation tool is inaccessible to bot. Recommend P1 implementation.
+
+4. **Unverified funding claims (critical):** Persona quotes nounish artisan match-fund $10:$50 ratio without source. No published program found. Recommend Zaal verify before bot mentions it to AttaBotty, or flag in bot as UNVERIFIED + refuse to quote ratio until confirmed.
+
+5. **Open ambiguities (medium):** Doc 642 lists 6 clarifying questions (Onagi, artisan meeting place, embed URL, transcripts, bot name spelling, match-fund details). Persona.md surfaces these but doesn't propose defaults. Recommend Zaal ask AttaBotty today; bot persona.md gets updated Tuesday with answers.
+
+**Most important persona.md edit:** Line 14, change "Address the artist as 'AttaBotty' (the character) by default, but use real-name context if Zaal corrects you" to "Refer to the in-character persona as 'AttaBotty' in all Telegram replies. Use William/real-name context ONLY if Zaal explicitly corrects you mid-conversation. Never volunteer the real person's name—let Zaal control that boundary."
+
+**Top open clarification to ask first:** "Who is Onagi? (TG/X handle or real name?) Are they definitely joining the stream collab chat?" This unblocks chat membership + stream ideation scope.

--- a/research/agents/646-brand-fit-audits-magnetiq-attabotty/magnetiq.md
+++ b/research/agents/646-brand-fit-audits-magnetiq-attabotty/magnetiq.md
@@ -1,0 +1,254 @@
+# Magnetiq brand-agent fit audit (2026-05-12)
+
+## Brand reality (synthesized from research + transcripts)
+
+Magnetiq is a **community engagement + analytics platform** founded July 2022 by Kaylan Sliney (CEO) + Tyler Stambaugh (COO). Operates 5 person team. Built on Flow blockchain (Dapper Wallet + NFT mementos). As of May 11, 2026, Tyler is **pivoting from "build your community" to "turn community vibes into data you can understand."** They are shipping a **batch-send feature** to reduce notification fatigue. Magnetiq's IRL proof-of-meet use case (QR scanning events, digital badges, living CRM) remains core; the pivot adds a data-insight layer on top. Team is now available for integration conversations with Zaal, hence the Telegram bot collaboration.
+
+### Vision evolution: OLD positioning -> NEW positioning
+
+- **OLD (generic, competitive dead-end):** "Build your community" — generic SaaS positioning that doesn't differentiate.
+- **NEW (data-first, community organizer pain point):** "Turn community vibes into data you can understand" — frames Magnetiq as the analytics layer for events/engagement. Answers the question every organizer asks: "Am I wasting my time and money? Is this actually working?" (Doc 640)
+
+### Stage
+
+Pre-revenue or early-revenue (unconfirmed in transcripts). Zaal has access to Tyler but no contract/partnership finalized yet. Bot is exploratory dual-user research tool.
+
+### Team
+
+| Person | Role | Contact |
+|--------|------|---------|
+| Kaylan Sliney | Co-founder & CEO | (not on bot) |
+| Tyler Stambaugh | Co-founder & COO | tyler@magnetiq.xyz (on Magnetiq group chat) |
+| Caitlin | Tyler's collaborator | Not yet on group; noted in persona as "may join later" |
+
+---
+
+## Bot scope (what it ships TODAY per persona.md + commands.ts)
+
+### Persona summary (5 bullets)
+
+1. **Private collab tool only** — not a customer-support bot, not a community manager. Exists to help Zaal + Tyler figure out ZAO-Magnetiq integration in their shared scratch space.
+2. **Terse, smart caveman voice** — no emojis, no em-dashes, quotes sources, asks clarifying questions one at a time. Speaks to both by first name.
+3. **Magnetiq pivot-aware** — knows vibes-to-data positioning, batch-send feature in flight, notification fatigue problem, SAPS framework (from Doc 467).
+4. **ZAO integration context** — understands Hermes pattern, ZOE agent, $ZABAL token, Empire Builder, Whop play (Doc 641), ZAOstock Oct 3.
+5. **Refusal-hardened** — will not reveal env vars, push to git, deploy, run destructive commands, invent reward thresholds, or tag external people without approval. Boundary-aware for a dual-user bot.
+
+### Commands available
+
+| Command | Who | Effect | Budget |
+|---------|-----|--------|--------|
+| `/research <topic>` | allowlist (Zaal + Tyler) | Opus research pass, grep library, cite docs | $3.00 |
+| `/idea <text>` | allowlist | Log idea to Supabase, persisted | Append-only |
+| `/task <text>` | allowlist | Create closable task | Append-only |
+| `/tasks` | anyone | List open tasks | Read-only |
+| `/done <id>` | allowlist | Close a task | Append-only |
+| `/clip <url> <note>` | allowlist | Log clip-worthy moment (URL + annotation) | Append-only |
+| `/fact <statement>` | allowlist | Teach the bot a durable fact | Append-only |
+| `/context` | anyone | Dump what bot knows (facts, tasks, allowlist, persona path) | Read-only |
+| `/summary` | allowlist | Run daily summary now (also cron fires 06:00 ET) | $1.00 |
+| `@mention` or reply | allowlist | Reactive chat reply, Sonnet 4.6 | $0.50 |
+| `/help` | anyone | Show command list | Read-only |
+
+### Cost guardrails
+
+- **Chat mention reply:** Sonnet 4.6, $0.50/reply, soft cap on allowlist gated replies
+- **`/research`:** Opus 4.7, $3.00/invocation, Sonnet too weak for research synthesis
+- **Daily summary:** Opus 4.7, $1.00/cron, fires 06:00 America/New_York
+- **Memory model:** Supabase `team_bot_*` tables (see `bot/migrations/team_bots.sql`)
+  - `team_bot_messages`: every message logged 24h sliding window for context stitching
+  - `team_bot_ideas`: append-only, never deleted
+  - `team_bot_tasks`: open/closed state, tracked by UUID
+  - `team_bot_clips`: URL + annotation pairs
+  - `team_bot_facts`: durable statements that become part of system prompt
+
+---
+
+## Brand-fit deltas (gaps + over-builds + wrong notes)
+
+### Gaps (brand has need, bot misses it)
+
+| # | Brand need | Why bot misses it | Fix | Priority |
+|---|-----------|-------------------|-----|----------|
+| 1 | **Magnetiq's SAPS framework visibility.** Tyler frames ALL ideas through Status/Access/Power/Stuff (Doc 467 Part 2). Bot persona knows SAPS exists but has zero teaching/feedback on it. Bot should help Tyler + Zaal evaluate ideas through SAPS lens. | No `/saps <idea>` command. No SAPS framework in system prompt during chat replies. Bot can reference it but doesn't actively use it to structure analysis. | Add `/saps <idea>` command that returns a 4-part breakdown (Status: how does this idea increase collector rarity / visibility?; Access: new gating opportunity?; Power: reputation surface?; Stuff: digital or physical item). Feed into daily summary. Add SAPS-aware examples to persona.md. | P1 (core to new positioning) |
+| 2 | **Batch-send feature tracking.** Tyler is shipping batch-send (UI + scheduling) to reduce notification fatigue. Zero mention of this feature's status, blockers, or cross-ZAO impact in bot persona. | Persona mentions it in "What you care about" but bot has no way to track progress, blockers, or propose validation paths. | Add `/feature batch-send <status>` command to log progress updates. Store in a new `team_bot_features` table. Nightly summary should surface feature blockers + ask for help. | P2 (useful for collaboration, not blockers) |
+| 3 | **Whop integration spec is mentioned but not traced.** Doc 641 exists; Whop fee is 3% creator fee. Magnetiq bot should understand how Claude Code community on Whop + Magnetiq could sync. | Persona mentions Whop exists but bot has no understanding of Whop fees, API capabilities, or how a "Whop purchase -> Magnetiq badge" flow would work. | Add reference to Doc 641 Whop pricing + API capabilities in persona.md. When /research is called on Whop integration, bot should pull together how Magnetiq batch-send + Whop Discord role integration + $ZABAL token-gating could work together. | P2 (strategic, not immediate) |
+| 4 | **Magnetiq's "am I wasting time/money?" question is not anchored.** The pivot hinges on answering this for organizers. Bot never asks clarifying questions that surface ROI, event attendance metrics, or engagement ratios. | Bot is reactive-only. No proactive question like "What metrics would prove batch-send works?" or "How will you measure whether the data-insight feature is moving the needle?" | No direct fix in current command set, but the daily summary should ask open questions about measurement. Persona should include 2-3 examples of how bot asks about ROI/metrics when Zaal mentions an event or campaign. Add to context-stitching prompt: "When Tyler or Zaal mention an event/campaign, ask one follow-up about how they'll measure success." | P2 (deepens collaboration) |
+
+### Over-builds (bot does X, brand doesn't need it yet)
+
+| # | Bot feature | Why premature | Recommendation |
+|---|-------------|---------------|----------------|
+| 1 | **Daily summary cron (06:00 ET every morning).** Bot fires a daily digest automatically. Tyler + Zaal might not have daily cadence yet; they're early exploratory conversations. | Premature automation. If Tyler is only in the group 2-3x per week, a nightly summary feels like noise. | Keep the feature but default to DISABLED via env var (`MAGNETIQ_SUMMARY_CRON=""` or comment out). Manual `/summary` invocation only until Zaal confirms daily cadence desired. No forced summary until sprint rhythm is locked. | Change default in bot/src/teams/README.md: "Daily summary defaults OFF for new bots. Enable via MAGNETIQ_SUMMARY_CRON=0 6 * * * once cadence confirmed." |
+| 2 | **`/research` Opus budgeting at $3/invocation.** Opus is expensive. For early exploration, Sonnet might suffice. `/research magnetiq batch-send`` might only need Sonnet-level synthesis. | Over-provisioning early. As the bot matures, Opus makes sense. Today it's overkill. | Downgrade `/research` to Sonnet 4.6 for Magnetiq bot only. Pass `TEAMS_RESEARCH_MODEL=sonnet` in env for magnetiq. Raises `/research` budget ceiling to $1.50 (Sonnet cost), leaves $3 for eventual promotion to Opus when research scope expands. | Add per-bot model override capability in brain.ts + shared.ts (already supports `TEAMS_RESEARCH_MODEL` env but could be more granular). Document in README. |
+| 3 | **Memory persistence for 7+ open tasks.** Bot can track arbitrary tasks. Tyler might only care about 1-2 Magnetiq-specific tasks (batch-send launch, Whop API review). Storing 7+ tasks pollutes the space. | Cognitive load. If bot suggests `/tasks` lists 12 items, only 1-2 are Magnetiq-specific; the rest are ZAO noise (ZAOstock, Hermes stuff). | Keep `/tasks` but add `/tasks filter:magnetiq` to surface only Magnetiq-related ones. Store a `domain` or `project` tag in the `team_bot_tasks` schema. Default filter = `*` but allow scoping. | Update `saveTask()` in memory.ts to accept optional `project` param. Add parsing to `/task Magnetiq: batch-send deadline` (colon syntax extracts project tag). Doc in persona. |
+
+### Voice / persona drift
+
+| # | Persona claim | Reality | Edit needed |
+|---|---------------|---------|-------------|
+| 1 | "Talk to both of them by first name (Zaal, Tyler)." | Persona correct. Commands are allowlist-gated. No issue. | NONE — voice is aligned. |
+| 2 | "Tyler's batch-send feature in flight" (under "What you care about"). | TRUE per Doc 640, but zero detail on spec/deadline/blockers. Persona says bot KNOWS but bot has no /feature command to track it. | Add example in persona: `Tyler: batch-send blocking on Dapper API rate limits next Tues. @magnetiq /task Batch-send: wait on Dapper API response` -> bot confirms task logged. Adds specificity to persona. |
+| 3 | "Magnetiq's new positioning: vibes-as-data, breadcrumbs, the 'am I wasting time/money?' question." | TRUE per Doc 640 call transcript. But persona never explicitly teaches the bot HOW to evaluate ideas through this lens. | Expand "Voice" section with 1 paragraph: "When Zaal or Tyler propose an event/activation, you frame it through vibes-as-data: 'How will we capture the vibe? What data surfaces from this? What question does it answer?' Always connect ideas back to ROI." Add 2 example replies to persona showing this framing. |
+| 4 | "Whop integration (Greg Gonzales contact, 3% creator fee, Explorer distribution)". | TRUE per Doc 641. But bot's persona.md doesn't acknowledge Whop creator fees, doesn't mention Greg Gonzales by name, doesn't explain the Explorer algo weakness. | Update persona.md facts section to cite Doc 641 specifics: "Whop creator fee is 2.7% + $0.30 per transaction (domestic), Explorer discovery weak (req 30+ days social proof). Greg Gonzales is the Whop contact. ZAO-Magnetiq-Whop triangle: Whop Claude Code course -> onboard creators to ZAO, Magnetiq batch-send reduces fatigue, SongJam leaderboard tracks it all." |
+| 5 | "You replace ad-hoc messaging. You are NOT a customer-support bot, NOT a community manager." | TRUE but bot's behavior doesn't actively enforce this boundary. If Tyler DMs `/idea how do we sell Magnetiq to enterprise accounts?` bot replies normally; it doesn't redirect to "that's sales strategy, outside this collab scope." | Add hard rule to persona: "If asked about sales process, enterprise pitch, competitor analysis, or anything outside ZAO+Magnetiq integration, say: 'That's outside the integration scope. Escalate to Kaylan or ping Zaal to re-scope the conversation.' Never invent sales strategy." |
+
+### Missing brand facts the bot should know
+
+| # | Fact | Source | Add to persona.md or seed in /fact |
+|---|------|--------|-------------------------------------|
+| 1 | Magnetiq is built on Flow blockchain (Dapper Wallet, NFT mementos). Mementos live on Flow, not Ethereum/Optimism/Base. Cross-chain bridge gap exists. | Doc 65 (MAGNETIQ section), Doc 467 Part 1 (No API section). | Add to persona.md facts section: "Magnetiq runs on Flow blockchain (Dapper Wallet, NFT mementos). ZAO OS lives on Ethereum/Optimism/Base. Cross-chain natively impossible until Magnetiq adds EVM support. Integration is currently link-based, not programmatic." |
+| 2 | Magnetiq is pre-revenue or early-revenue. No public API (confirmed Zaal 2026-04-21, Doc 467). Bot cannot programmatically create Magnets, launch drops, or read analytics. Bot is idea-generator + reminder engine only. | Doc 467 Part 1 (No API section), Doc 640 (action items). | Add to persona.md boundaries: "Magnetiq has no public API. You cannot create Magnets, launch drops, or read analytics. You propose ideas + help Zaal schedule/announce drops he pre-creates in the Magnetiq admin. You are a thought partner, not an automation engine." |
+| 3 | Kaylan Sliney is CEO/co-founder. Tyler is COO/co-founder. Caitlin is Tyler's collaborator (may join group later). But Tyler is the 1:1 with Zaal on this bot. | Doc 65 (Magnetiq Team table), bot/src/teams/index.ts (comment: "may be joined later by Caitlin"). | Add to persona.md: "This group = Zaal + Tyler. Kaylan (CEO) is not present. Caitlin (Tyler's collaborator) may join later. This is a COO-level product/integration conversation, not a board-level strategic one." |
+| 4 | The "Zabal Connector" is the existing MAGNETIQ Magnet Zaal already created (at ETH Boulder). It tracks Proof-of-Meet for ZAO events. This is the TEMPLATE for future ZAO Magnets. | Doc 65 (Proof of Meet section), Doc 467 Part 2 (5 Magnet programs to launch, Magnet 1 is "The ZABAL Connector"). | Add to persona.md: "The Zabal Connector is Zaal's existing MAGNETIQ Magnet + template. It captures QR-scanned event attendance, badges, selfies. The bot's job is to help design 4-5 new Magnets using SAPS framework (Status, Access, Power, Stuff) + event lifecycle (announcement, reminder, QR, drop, analytics)." |
+| 5 | Tyler's batch-send feature is specifically designed to reduce notification fatigue. Problem: organizers bombard attendees with announcements, fatigue kills retention. Solution: batch scheduler + "send email?" toggle. This is shipping. | Doc 640 (New features section). | Add to persona.md: "Batch-send is Tyler's in-flight feature to solve notification fatigue. Organizers want to fire multiple announcements at once, but not via email. UI: 'Send to everybody? Yes/No. Email? Yes/No.' This addresses a core pain point for community managers." |
+
+---
+
+## Recommended persona.md diff
+
+**Current persona.md is solid but needs 3 key additions:**
+
+### Edit 1: Expand "What you care about" (add SAPS + batch-send + Whop clarity)
+
+```markdown
+OLD:
+- Magnetiq's new positioning: vibes-as-data, breadcrumbs, the "am I wasting time/money?" question
+- ZAO's autonomous-agent stack (Hermes pattern, ZOE, $ZABAL token, Empire Builder)
+- Whop integration (Greg Gonzales contact, 3% creator fee, Explorer distribution)
+- ZAOstock Oct 3 2026 festival (flagship event)
+- Tyler's batch-send feature in flight
+- Cross-platform distribution patterns
+
+NEW:
+- Magnetiq's new positioning: vibes-as-data, breadcrumbs, the "am I wasting time/money?" question. Help Tyler + Zaal evaluate ideas through the SAPS lens (Status = collector rarity, Access = gating opportunity, Power = reputation, Stuff = items).
+- Tyler's batch-send feature (in flight): scheduler to reduce notification fatigue. Ask about deadlines + blockers + rollout timeline.
+- ZAO's autonomous-agent stack (Hermes pattern, ZOE, $ZABAL token, Empire Builder) + the Zabal Connector (existing MAGNETIQ Magnet template for event POA).
+- Whop integration (Doc 641): Greg Gonzales contact, 2.7% + $0.30 per transaction creator fee, Explorer discovery weak (30+ day seeding), Claude Code course funnel to onboard creators to ZAO.
+- ZAOstock Oct 3 2026 (flagship) + ZAOville July (pre-stock test). How will batch-send + SAPS Magnets amplify both?
+- Cross-platform distribution: Magnetiq (IRL engagement) + Whop (digital creator funnel) + SongJam (leaderboard) + Empire Builder ($ZABAL rewards).
+```
+
+### Edit 2: Add hard rule about boundaries
+
+```markdown
+ADD after "Hard rules (refuse if asked)":
+
+- Never propose sales/enterprise strategy beyond ZAO-Magnetiq integration scope. If asked "How do we sell Magnetiq to enterprises?" escalate: "That's outside the integration scope. Escalate to Kaylan or ping Zaal to re-scope the conversation."
+```
+
+### Edit 3: Add reference facts section
+
+```markdown
+ADD new section after "Reference docs":
+
+## Reference facts (teach the bot via /fact or add here)
+
+- Magnetiq is built on Flow blockchain (Dapper Wallet). ZAO OS is Ethereum/Optimism/Base. No native cross-chain bridge yet; integration is link-based, not programmatic.
+- Magnetiq has no public API. Bot cannot create Magnets or launch drops programmatically. Bot proposes ideas + schedules/announces drops Zaal pre-creates in the admin.
+- Kaylan Sliney = CEO (not on this group). Tyler Stambaugh = COO (1:1 with Zaal here). Caitlin = Tyler's collaborator (may join later).
+- The Zabal Connector = Zaal's existing MAGNETIQ Magnet + template for future ZAO events (QR scanning, badge claims, selfie uploads, analytics).
+- Batch-send is Tyler's feature to solve notification fatigue: multiple announcements, email toggle, fire all at once.
+```
+
+---
+
+## Recommended new commands or command tweaks
+
+| Command | Why | Spec |
+|---------|-----|------|
+| `/saps <idea>` | SAPS framework is core to Magnetiq's new positioning. Bot should structure every major idea through this lens. | **Usage:** `/saps Tyler wants to create a "Superfan Vault" tier drop for 100+ $ZABAL holders` **Reply (Sonnet):** `Status: collector rarity visible in leaderboard | Access: Tier-locked content only | Power: leadership signaling (top 100) | Stuff: exclusive drop (limited sticker sheet, private hour with Zaal) | Follow-up: who gets access first, token holders or attendees?` Sonnet cost, $0.20 budget, fast. |
+| `/feature <name> <status>` | Tyler is shipping batch-send. Bot should track feature progress, blockers, validation. | **Usage:** `/feature batch-send Blocked on Dapper API rate limit increase, waiting Tue response` **Reply:** `Logged. Blocking other: (none logged). Unblock plan: if no response by Wed, escalate to Kaylan?` Stores in new `team_bot_features` table with UUID, status, blocker notes, updated_at. |
+| `/magnet <name>` | Zaal will create 5+ SAPS Magnets (Doc 467 Part 2). Bot should cache + display their spec on demand. | **Usage:** `/magnet Fractal OG` **Reply:** `Magnet: Fractal OG | SAPS: Power + Status | Activations: (a) W91 voter claim, (b) first-time submitter bonus, (c) reconciler bridge | Next drop: TBD | Edit: /fact Fractal OG magnet is...` Requires manual seed via `/fact` or a reference file. Read-only. |
+| `@magnetiq validate <idea>` | Proactive question + SAPS breakdown when Zaal or Tyler propose something. Shortcut for `/saps`. | **Usage:** `@magnetiq validate a live QR drop during ZAOstock Oct 3` **Reply:** `Status: attendee badge scans on-site | Access: event QR only, day-of | Power: "I was there" digital proof | Stuff: memento NFT + email list | Risk: QR code printing, on-site scanner setup. Validate plan?` Sonnet, $0.30 budget. |
+
+---
+
+## Memory schema suggestions
+
+Current schema (team_bot_*) is solid. Three additions for Magnetiq-specific tracking:
+
+### New table: `team_bot_features`
+
+```sql
+CREATE TABLE team_bot_features (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  bot TEXT NOT NULL, -- 'magnetiq' | 'attabotty'
+  feature_name TEXT NOT NULL, -- "batch-send", "Proof of Meet v2"
+  status TEXT NOT NULL, -- "in-flight" | "blocked" | "shipped"
+  blocker_notes TEXT, -- free text, e.g., "Dapper API rate limit"
+  validated_by TEXT, -- "zaal" | "tyler" | null
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+**Rationale:** Tracks Tyler's shipped/in-flight features so the bot can surface status + ask about validation. Daily summary highlights blocked features.
+
+### New table: `team_bot_magnets` (optional, if Zaal creates many)
+
+```sql
+CREATE TABLE team_bot_magnets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  bot TEXT NOT NULL, -- 'magnetiq'
+  magnet_name TEXT NOT NULL, -- "The ZABAL Connector", "Fractal OG"
+  saps_status TEXT, -- "Status" | "Access" | "Power" | "Stuff" (comma-separated pillars)
+  description TEXT, -- "Proof-of-attendance for ZAO events"
+  first_activation TEXT, -- e.g., "ZAO Stock Oct 3"
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+**Rationale:** Cache Magnetiq Magnet specs so `/magnet <name>` can reply instantly. Avoids re-typing.
+
+### Extend `team_bot_tasks`
+
+Add optional `project` field to filter tasks by domain:
+
+```sql
+ALTER TABLE team_bot_tasks ADD COLUMN project TEXT DEFAULT 'general';
+-- Usage: /tasks filter:batch-send -> lists only project='batch-send' tasks
+```
+
+---
+
+## Pre-launch checklist (Magnetiq-specific, before tokens land)
+
+- [ ] Persona.md edits committed (SAPS, batch-send, Whop clarity, hard rule about scope).
+- [ ] `/fact` seed Magnetiq-specific facts (Flow blockchain gap, no API, Tyler=COO, Zabal Connector template, batch-send goal).
+- [ ] Tyler's allowlist ID confirmed (Zaal to run `/whoami` in the group + get Tyler's Telegram user_id).
+- [ ] Caitlin's allowlist ID obtained OR placeholder (if she joins later, Zaal adds her via env var reload).
+- [ ] Daily summary DISABLED by default (`MAGNETIQ_SUMMARY_CRON=""` in .env). Manual `/summary` invocation only until Zaal confirms cadence.
+- [ ] Test `/research magnetiq batch-send` in local dev, confirm Sonnet cost is acceptable (<$1.50).
+- [ ] Test `/saps <idea>` mock reply, ensure SAPS breakdown is clear (Status, Access, Power, Stuff, follow-up).
+- [ ] Verify Supabase migration (`bot/migrations/team_bots.sql`) applied to prod (Zaal to confirm in Supabase console).
+- [ ] Dry-run in Telegram group: Zaal sends `/whoami` -> bot replies with chat_id + his user_id. Tyler sends `/whoami` -> same.
+- [ ] Read persona.md aloud to Zaal + Tyler in a 5-min async Telegram message review. Any corrections?
+- [ ] Document in bot/src/teams/README.md that Magnetiq bot is **experimental / dual-user research mode**, not production yet.
+
+---
+
+## 3 highest-value next moves (ranked)
+
+1. **Add `/saps <idea>` command + teach SAPS examples in persona.** This is THE core of Magnetiq's pivot. Bot should reflexively frame all ideas through Status/Access/Power/Stuff. This makes the bot useful immediately. Sonnet cost, $0.20 each, fast. Deliverable: 10 lines of commands.ts + 2 SAPS examples in persona.md. Time: 1 hour.
+
+2. **Seed `/fact` base with Magnetiq realities (Flow blockchain, no API, batch-send goal, Zabal Connector template).** Right now the bot knows these via persona.md system prompt, but facts are the lever for Zaal + Tyler to CORRECT the bot later ("No, actually the Zabal Connector is deprecated"). Seeding facts makes the bot teachable. Zaal can run: `/fact Zabal Connector is the MAGNETIQ Magnet Zaal created at ETH Boulder, tracks POA for ZAO events, is the template for future Magnets` and the bot will never contradict. Deliverable: 5-6 /fact statements Zaal pastes into the group on day 1. Time: 15 min.
+
+3. **Lock daily summary cadence with Zaal + enable/disable in env.** Right now summary fires every morning (06:00 ET). If Tyler is only in the group 2x/week, this is spam. Confirm: do they want daily summary, or manual `/summary` only? If daily, keep it. If not, set `MAGNETIQ_SUMMARY_CRON=""` in prod .env so it's DISABLED by default. This avoids noise while the collab is finding rhythm. Deliverable: 1 conversation + 1 env var tweak. Time: 10 min.
+
+---
+
+## Appendix: Magnetiq brand context for future reference
+
+**Canonical positioning (May 2026):** "Turn community vibes into data you can understand."
+
+**Problem:** Organizers (like Zaal) run events, reward people, engage them deeply. They ask: "Am I wasting my time and money? Is this actually working?" Magnetiq's answer = quantify the vibes.
+
+**Core product:** Flow blockchain NFT badges (Dapper Wallet) + QR event scanning + analytics dashboard. In-flight: batch-send feature to reduce notification fatigue.
+
+**ZAO integration thesis:** Zaal runs 188 members + monthly fractals + ZAOstock Oct 3. Magnetiq can wrap each event/milestone in a SAPS Magnet (proof-of-meet badge, power signal, gating opportunity, exclusive drop). Batch-send coordinates announcement flow across all 5 Magnets. Data anchor = Magnetiq dashboard shows event attendance + engagement + retention.
+
+**Blockers:** Magnetiq has no public API (Flow blockchain NFTs are not EVM-native). Integration is link-based today. ZAO-Magnetiq funnel = Zaal admin-creates Magnets, bot announces QRs, attendees scan on-site.
+
+**Whop synergy:** Zaal is building Claude Code community on Whop (for digital creators). Magnetiq batch-send + Whop Discord role assignment = creator gets badge on Magnetiq after Whop purchase. SongJam leaderboard tracks both (Whop sales + Magnetiq badge claims). Cross-platform awareness loop.
+


### PR DESCRIPTION
## Summary

2 parallel DEEP subagents audited PR #503 team bots against brand reality. Applied low-risk persona tightening this PR. Queued 7 deferred commands + 3 new tables for post-deploy follow-up PR.

## What ships

### `bot/src/teams/magnetiq/persona.md`
- SAPS framework awareness (Status/Access/Power/Stuff)
- New Reference Facts: Flow blockchain (no cross-chain to ZAO EVM), no public API, team roles, Zabal Connector template, batch-send goal
- Whop fee corrected: 3% -> 2.7% + \$0.30 per transaction
- Hard rule: refuse Magnetiq enterprise sales strategy

### `bot/src/teams/attabotty/persona.md`
- Tightened kayfabe: never volunteer William's real name
- New rule: never invent lore, stay consistent with /facts
- Reference Facts: William + DaNici (kayfabe-protected), Cipher release team, Monday cadence, YouTube primary, ZAOstock roles
- Hard refusal to quote nounish \$10:\$50 ratio until verified (no program found across Nouns DAO/Prop House/Builder DAO)

### Doc 646 hub
- README synthesis + 6 open clarifications for Zaal to ask AttaBotty
- magnetiq.md + attabotty.md full audits

## Deferred to follow-up PR (after token deploy)

| # | Change | Brand |
|---|--------|-------|
| 1 | /saps command | Magnetiq |
| 2 | /stream-prep command | AttaBotty |
| 3 | /vod YouTube transcript + clip suggest | AttaBotty |
| 4 | /transcript NotebookLM ingest | AttaBotty |
| 5 | team_bot_features table + /feature | Magnetiq |
| 6 | team_bot_setlist + team_bot_stream_logs tables | AttaBotty |
| 7 | Per-bot daily-summary defaults documentation | Both |

## Zaal action items this week

1. Ask AttaBotty: who is Onagi, what's the artisan meeting place, /live URL, NotebookLM permission, name spelling
2. Research nounish artisan match-fund: program name, URL, administrator, exact ratio
3. Decide daily-summary cadence per bot (keep 06:00 ET or default off)

## Sources

Docs 640, 641, 642, 644, 645, 467, 274 + bot/src/teams/ + 2 parallel subagent audits