### PR TITLE
fix(bot): evening recap silence-on-empty

### DIFF
--- a/bot/src/digest.ts
+++ b/bot/src/digest.ts
@@ -79,7 +79,11 @@ export async function morningDigest(): Promise<string> {
   return lines.join('\n');
 }
 
-export async function eveningRecap(): Promise<string> {
+// Evening recap. Returns null if there is nothing worth posting -
+// no activity AND no closed todos. The schedule caller skips the post
+// when null is returned (don't spam the team with empty "no activity"
+// pings).
+export async function eveningRecap(): Promise<string | null> {
   const s = db();
   const since = new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString();
   const [activityR, todosClosedR] = await Promise.all([
@@ -95,6 +99,11 @@ export async function eveningRecap(): Promise<string> {
   const activity = activityR.data ?? [];
   const closed = todosClosedR.data ?? [];
 
+  // Skip the post entirely when there is no real activity to recap.
+  if (activity.length === 0 && closed.length === 0) {
+    return null;
+  }
+
   const byActor: Record<string, number> = {};
   for (const a of activity) {
     // @ts-expect-error supabase inferred
@@ -108,13 +117,11 @@ export async function eveningRecap(): Promise<string> {
   const lines: string[] = [];
   lines.push(`Evening recap · ${new Date().toISOString().slice(0, 10)} · ${festivalDaysOut()} days to Oct 3`);
   lines.push('');
-  lines.push(`Moves today (${activity.length} activity entries)`);
-  if (actors.length > 0) {
+  if (activity.length > 0) {
+    lines.push(`Moves today (${activity.length} activity entries)`);
     for (const [name, count] of actors) lines.push(`  · ${name}: ${count}`);
-  } else {
-    lines.push('  (no activity logged)');
+    lines.push('');
   }
-  lines.push('');
   if (closed.length > 0) {
     lines.push(`Todos closed (${closed.length})`);
     for (const t of closed.slice(0, 5)) {

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -463,8 +463,10 @@ bot.command('digest', async (ctx) => {
   const which = (ctx.match ?? '').trim().toLowerCase();
   let text: string;
   try {
-    if (which === 'evening') text = await eveningRecap();
-    else if (which === 'week') text = await weekAheadDigest();
+    if (which === 'evening') {
+      const r = await eveningRecap();
+      text = r ?? 'No activity to recap today. Evening digest is silent when the board is quiet.';
+    } else if (which === 'week') text = await weekAheadDigest();
     else if (which === 'retro') text = await fridayRetro();
     else text = await morningDigest();
   } catch (err) {

--- a/bot/src/schedule.ts
+++ b/bot/src/schedule.ts
@@ -38,11 +38,16 @@ export function scheduleAll(bot: MinimalBot, onError: (err: unknown, label: stri
   );
 
   // Evening: every day 6:00pm America/New_York
+  // Skip if eveningRecap returns null (no activity + no closed todos)
   cron.schedule(
     '0 18 * * *',
     async () => {
       try {
         const text = await eveningRecap();
+        if (text === null) {
+          console.log('[schedule] evening skipped - no activity to recap');
+          return;
+        }
         await postToAllDigestChats(bot, text);
         console.log('[schedule] evening posted');
       } catch (err) {


### PR DESCRIPTION
## Summary
- eveningRecap() returns null when activity AND closed-todos windows are both empty
- 6pm cron in schedule.ts skips post when null
- /digest evening manual command falls back to a friendly message so operator gets feedback

## Why
Per Zaal feedback May 12: empty evening recaps with "(no activity logged)" placeholder are noise. Bot should stay silent when the board is quiet.

## Test plan
- [x] Already deployed to VPS via rsync
- [ ] Tomorrow 6pm cron fires on a day with activity, posts recap as before
- [ ] /digest evening manually run on a quiet day returns the fallback message
- [ ] Empty-state day passes through schedule.ts without posting

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>