### PR TITLE
doc 599: podcast MP3 hosting decision (STANDARD)

### DIFF
--- a/content/bonfire-ingest/chatgpt-archive-verified.md
+++ b/content/bonfire-ingest/chatgpt-archive-verified.md
@@ -1,0 +1,172 @@
+INGEST BATCH: ChatGPT Archive — VERIFIED (14 anchor conversations, human-confirmed truth status, 2026-05-03).
+
+This is the ONLY ChatGPT archive batch worth ingesting. The other 500+ raw conversations are noisy with brainstorms that died. Each fact below has been confirmed by Zaal as either SHIPPED, EVOLVED, or DEAD. Outcomes are explicit attributes — bot must NOT cite Brainstorm/Dead conversations as facts.
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes. Outcome is an attribute on each Conversation/Decision node, never a standalone Entity.
+
+## SECTION 1 — SHIPPED + LIVE (cite as fact)
+
+### FACT 1
+Subject: ZAO NEXUS at nexus.thezao.com
+Type: Product
+Status: shipped, live, unmaintained
+Date: 2025-03-31 (initial spec) - 2025-05 (shipped)
+Description: Webflow embed at nexus.thezao.com — categorized links page for ZAO ecosystem. Brand colors navy #141e27 + soft yellow #e0ddaa. JS-driven linksData with mainCategory > subcategory > links pattern. Categories: ZAO Onchain, ZAO Community Links (Founder/Co-Founder/Staff/Member), ZAO Festivals, ZAO Music, ZAO Research. Status: live but not actively maintained since shipping. Rebuild brief at docs/specs/2026-05-03-nexus-rebuild-spec.md.
+Source: https://chatgpt.com/c/[ZAO NEXUS conv id] + https://nexus.thezao.com
+Confidence: 1.0
+
+### FACT 2
+Subject: Zabal IRL Connector at zabal.lol
+Type: Product
+Status: shipped, live
+Date: 2026-02-10
+Description: In-person crossover / networking experience. Scannable digital business card for conferences, meetups, IRL events. Live at zabal.lol. Used today to give people collectables for showing up to ZAO Fractals and other IRL events.
+Source: https://zabal.lol + ChatGPT 2026-02-10 (230 msgs)
+Confidence: 1.0
+
+### FACT 3
+Subject: ZABAL coin launch
+Type: Token
+Status: shipped, live
+Date: 2026-01-01
+Description: ZABAL coin launched January 1 2026. Front-end of BCZ ecosystem. Partnerships with Empire Builder + SongJam + others. Created ZOUNZ (ZBAAL Nounz) which hold 20% of the token reserve. ZOLs are awarded ZOUNZ for winning leaderboards.
+Source: ChatGPT 2025-11-26 (205 msgs prep) + paragraph.com/@thezao/zabal-update-3 + ChatGPT 2026-01-01 (87 msgs ETH pool issue)
+Confidence: 1.0
+
+### FACT 4
+Subject: ETH ZABAL liquidity pool — known quirk
+Type: TradingTip
+Status: semi-fixed workaround documented
+Date: 2026-01-01
+Description: Direct ETH → ZABAL swaps give bad pricing. Workaround: route ETH → SANG → ZABAL for best swap. SANG → ZABAL works well. Never go ETH → ZABAL direct. This is operational knowledge for traders.
+Source: ChatGPT 2026-01-01 (87 msgs ETH ZABAL Pool Issue)
+Confidence: 1.0
+
+### FACT 5
+Subject: Year of the ZABAL daily Paragraph series
+Type: Newsletter
+Status: shipped, ongoing
+Date: 2025-08-18 (initial Year of the ZAO) - present
+Description: Daily newsletter post on paragraph.com/@thezao. Originated as "Year of the ZAO" in August 2025, evolved into "Year of the ZABAL" after January 1 2026 launch. Writing style: clear, simple, spartan, short impactful sentences, active voice, practical insights. As of 2026-04-27 hit Day 117.
+Source: https://paragraph.com/@thezao + ChatGPT 2025-08-18 (82 msgs)
+Confidence: 1.0
+
+### FACT 6
+Subject: ZABAL Update 16 (Paragraph)
+Type: Newsletter
+Status: shipped
+Date: 2025-12-28 (prep) - 2025/2026 (shipped)
+Description: Recurring ZABAL Update format on Paragraph. Includes monthly recap, plans, airdrop status. The pattern from this prep session shipped and continues for subsequent updates.
+Source: ChatGPT 2025-12-28 (103 msgs prep) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+### FACT 7
+Subject: ZABAL Update 18 — Feb 1 2026 airdrop announcement
+Type: Newsletter
+Status: shipped
+Date: 2026-02-01
+Description: Feb 1 ZABAL update with "AIRDROP IS LIVE" + Feb ZOL distribution + Feb plans (miniapp updates, Empire Builder API, ZAO contributor proposal). Shipped on Paragraph.
+Source: ChatGPT 2026-02-01 (95 msgs) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+## SECTION 2 — EVOLVED INTO OTHER WORK (cite cautiously, link to outcome)
+
+### FACT 8
+Subject: ZAO Whitepaper — Draft 4.5 March 2026 (UNMAINTAINED)
+Type: Decision
+Status: drafted, unmaintained, rebuild planned
+Date: 2025-03-02 (228 msgs ChatGPT) - 2026-02-12 (Draft 4.5 written) - present (unedited)
+Description: Existing draft at research/community/051-zao-whitepaper-2026/. Earlier drafts critiqued in research/_archive/052 + 053. ChatGPT outline conversation seeded "ZAO Verse / Zverse" framing (onboarding paths, ZAO casa sui casa) but final draft 4.5 took different shape. Zaal wants new PROTOCOL whitepaper that explains how to build the ZAO protocol — task #15 tracks the rebuild.
+Source: https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/051-zao-whitepaper-2026 + ChatGPT 2025-03-02 (228 msgs)
+Confidence: 1.0
+
+### FACT 9
+Subject: ZAOOS Optimization Suggestions
+Type: Decision
+Status: implemented, surfaced as research docs
+Date: 2026-03-13
+Description: 75-msg ChatGPT review of github.com/bettercallzaal/zaoos that surfaced into multiple research docs (specifics not enumerated by Zaal). Improvements landed in ZAOOS post-March 2026.
+Source: ChatGPT 2026-03-13 (75 msgs) + ZAOOS commit history March-April 2026
+Confidence: 0.9
+
+### FACT 10
+Subject: ZAO Complete Guide — STALE
+Type: ResearchDoc
+Status: shipped, stale, refresh-needed
+Date: 2026-03-16 (last review)
+Description: research/community/050-the-zao-complete-guide/ exists. ChatGPT 147-msg review on 2026-03-16 surfaced changes but the guide hasn't been updated since. Drift between guide + actual ZAO state. Tech debt. Refresh recommended.
+Source: ChatGPT 2026-03-16 (147 msgs ZAOOS Guide Review) + research/community/050
+Confidence: 1.0
+
+## SECTION 3 — DEAD / NEVER SHIPPED (do NOT cite as fact, mark as failed brainstorm)
+
+### FACT 11
+Subject: ZabalSocials website
+Type: Decision
+Status: dead, rebuild planned
+Date: 2026-01-17
+Description: 117-msg ChatGPT session designed a personal-socials hub for BetterCallZaal (X / Farcaster / Lens / GitHub / YouTube / Twitch / etc). Never shipped. Task #16 tracks rebuild — likely lives at bettercallzaal.com/socials or similar. Distinct from nexus.thezao.com (which is ZAO ecosystem-wide).
+Source: ChatGPT 2026-01-17 (117 msgs)
+Confidence: 1.0
+
+### FACT 12
+Subject: ZAO MUSIC COHORT #1
+Type: Decision
+Status: dead, never ran
+Date: 2025-01-16
+Description: 96-msg ChatGPT proposal for a song contest cohort March-June 2025 with Charmverse forums + ZAO MUSIC COHORT #1 framing. Never ran. No cohort #1. May inform future cohort design but should not be cited as having happened.
+Source: ChatGPT 2025-01-16 (96 msgs)
+Confidence: 1.0
+
+### FACT 13
+Subject: Zabal Roadmap stream with Jadyn + sharks
+Type: Decision
+Status: dead, never happened
+Date: 2025-12-10
+Description: 77-msg prep for a streaming presentation with Jadyn + non-crypto-streamer sharks audience. Stream never happened. Roadmap content from this prep was not used or repurposed.
+Source: ChatGPT 2025-12-10 (77 msgs)
+Confidence: 1.0
+
+## SECTION 4 — META / NAVIGATION
+
+### FACT 14
+Subject: ChatGPT Archive Triage 2026-05-03
+Type: Process
+Status: complete (14 of 15 anchors confirmed by human)
+Date: 2026-05-03
+Description: Top 15 ZAO-tagged ChatGPT conversations (by message count) human-triaged by Zaal. 7 SHIPPED, 3 EVOLVED, 4 DEAD. Generated content/bonfire-ingest/chatgpt-archive-verified.md. Other 503 conversations from the export remain in raw chatgpt-archive-zao-2023-2024 / 2025-h1 / 2025-h2 / 2026 / non-zao-keepers .md files but are NOT recommended for ingest without similar triage. Many are brainstorms that died.
+Source: internal://content/bonfire-ingest/chatgpt-archive-verified.md
+Confidence: 1.0
+
+## EDGES TO ASSERT
+
+- Zaal Panthaki -[shipped]-> ZAO NEXUS at nexus.thezao.com
+- Zaal Panthaki -[shipped]-> Zabal IRL Connector at zabal.lol
+- Zaal Panthaki -[launched]-> ZABAL coin
+- ZABAL coin -[partners_with]-> Empire Builder
+- ZABAL coin -[partners_with]-> SongJam
+- ZABAL coin -[has_treasury]-> ZOUNZ (20% reserve)
+- ZOUNZ -[awarded_to]-> ZOL leaderboard winners
+- Year of the ZABAL daily Paragraph series -[supersedes]-> Year of the ZAO
+- ZABAL Update 16 -[part_of]-> ZABAL Update Series on Paragraph
+- ZABAL Update 18 Feb airdrop -[part_of]-> ZABAL Update Series on Paragraph
+- ZAO Whitepaper Draft 4.5 -[stored_at]-> research/community/051
+- ZAO Complete Guide -[stored_at]-> research/community/050
+- ZAO Complete Guide -[status]-> stale (last reviewed 2026-03-16, unedited since)
+- ZabalSocials website -[outcome]-> dead
+- ZabalSocials website -[planned_rebuild_via]-> task 16
+- ZAO MUSIC COHORT #1 -[outcome]-> dead, never ran
+- Zabal Roadmap stream -[outcome]-> dead, never happened
+- ETH ZABAL liquidity pool -[has_workaround]-> route through SANG before ZABAL
+
+## INSTRUCTION FOR FUTURE RECALL
+
+When future agents query this graph about Zaal's projects or decisions:
+- Cite SHIPPED items as facts with their live URLs
+- Cite EVOLVED items with their actual outcome (not the original brainstorm)
+- For DEAD items, surface ONLY if explicitly asked "what brainstorms died" or "what was paused" — NEVER cite as if shipped
+- Always check the `Status` attribute on Conversation/Decision nodes before citing
+
+---
+
+Build the manifest, preview the first 3 nodes, ask me "approve all?". 14 anchor facts + 18 edges. Do not commit until I say yes. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes.

--- a/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+++ b/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
@@ -1,0 +1,154 @@
+# ZAO Protocol Whitepaper — Rebuild Spec
+
+> **Goal:** Replace research/community/051-zao-whitepaper-2026 (Draft 4.5, March 2026, unedited since) with a PROTOCOL whitepaper. Target: builders, partners, infra people. Existing draft is community-positioning; new draft is "how to build on the ZAO protocol."
+
+**Date:** 2026-05-04
+**Owner:** Zaal Panthaki
+**Existing draft:** `research/community/051-zao-whitepaper-2026/README.md` (Draft 4.5, March 2026, unedited)
+**Target output:** `research/community/<NN>-zao-protocol-whitepaper-v1/` OR new repo `zao-protocol`
+**Source for sections:** ZABAL Bonfire graph (~870 nodes as of 2026-05-03)
+**Coordinate with:** Nexus rebuild (#14), ZabalSocials rebuild (#16), Farcaster + X ingest pipeline (next)
+
+---
+
+## Why a Protocol Whitepaper (not Community)
+
+Existing Draft 4.5 reads like a TED talk for artists: streaming pays $0.003, labels take 80%, ZAO teaches you to fish. That's the COMMUNITY pitch — and it works for that audience.
+
+The protocol whitepaper is a different document for a different reader:
+- **Reader:** another founder, dev, infra partner, ecosystem fund, governance researcher, journalist with technical chops
+- **Question they ask:** "what is THE ZAO PROTOCOL — not the org, the protocol — and how do I build on it / verify it / fork it?"
+- **Answer they need:** architecture diagrams, contract addresses, token mechanics, governance patterns, onchain music rails, what's open-sourced
+
+Without this doc, partners + builders + infra people can't engage at depth. They get the community story (Draft 4.5) and bounce.
+
+---
+
+## Voice + Reuse Plan
+
+- Keep Draft 4.5's COMMUNITY framing as **chapter 1** ("why we exist") — don't rewrite what works.
+- Add new chapters 2-7 covering protocol depth.
+- Tone matches Zaal's daily Paragraph series ("Year of the ZABAL"): clear, simple, spartan, short impactful sentences, active voice. (Confirmed style guide from ChatGPT 2025-08-18 grilling Q13.)
+
+---
+
+## Section Outline (proposed)
+
+### Chapter 1 — Why The ZAO (REUSE Draft 4.5)
+Pull the strongest 1-2 pages from existing draft. The streaming/data/IP problem framing + "community first, technology second" positioning. Don't rewrite.
+
+### Chapter 2 — The Protocol Architecture (NEW)
+- High-level: ZAO is not one chain or one app. It's a coordination layer between artists, audience, and onchain primitives.
+- 4 layers: Identity (ENS + ZID + Hats roles) / Reputation (OG + ZOR Respect, soulbound, on Optimism) / Coordination (ZABAL coin on Base + Empire Builder + SongJam) / Distribution (ZAOOS gated client + WaveWarZ + Cipher)
+- Diagram: layer boxes + which contracts live where
+- **Bonfire query for source material:**
+  ```
+  RECALL: list every contract address on the ZAO protocol with chain, type, and purpose.
+  ```
+
+### Chapter 3 — Token Mechanics (NEW)
+- ZABAL: launched Jan 1 2026 on Base, front-end coin of BCZ ecosystem. Empire Builder + SongJam integrations.
+- ZOUNZ: ZBAAL Nounz, holds 20% reserve of ZABAL token. ERC-721 NFT on Base.
+- ZOLs: liquid contribution credits awarded for activity. Winning leaderboards earns ZOUNZ.
+- OG Respect: ERC-20 soulbound on Optimism (0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957). 2% decay, curation-mining tiers.
+- ZOR Respect: ERC-1155 soulbound on Optimism (0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c). Different tier system.
+- The ETH→ZABAL pool quirk: route ETH→SANG→ZABAL for best swap. Don't go direct.
+- **Bonfire query:** `RECALL: explain ZABAL, ZOUNZ, ZOL, OG Respect, ZOR Respect with mechanics, supply, and how they relate.`
+
+### Chapter 4 — Governance (NEW)
+- ZAO Fractals weekly meetings — 90+ weeks running, Mondays 6pm EST, Discord-bot-coordinated, OG vs ZOR Respect distribution per session.
+- ORDAO / OREC: optimistic respect-based executive contract. Lets weekly proposals execute on-chain after dispute window.
+- Hats Protocol: role hierarchy + permissions on Optimism (0x3bc1A0Ad72417f2d411118085256fC53CBdDd137).
+- ZOUNZ DAO: Nouns Builder fork on Base for proposal voting + treasury (0x2bb5fd99f870a38644deafe7e4ecb62ac77a213f).
+- **Bonfire query:** `RECALL: explain how ZAO Fractals + OREC + Hats + ZOUNZ DAO compose into a governance system.`
+
+### Chapter 5 — Onchain Music Rails (NEW)
+- WaveWarZ: live song-vs-song battles on Solana. ~$50K trading volume. 43 artists indexed.
+- ZAO Music DBA under BCZ Strategies LLC: BMI + DistroKid + 0xSplits payment rails.
+- Cipher: planned first ZAO Music release.
+- Sound.xyz / Zora music NFT integration in ZAO OS player.
+- Audius API integration for artist metadata.
+- **Bonfire query:** `RECALL: list every onchain music integration in the ZAO ecosystem with chain, contract, and current activity.`
+
+### Chapter 6 — Build on ZAO (NEW — core protocol-whitepaper section)
+- ZAO OS is the lab repo: github.com/bettercallzaal/ZAOOS — Next.js + Supabase + Neynar + XMTP. Forkable.
+- Things that have graduated: COC Concertz (own repo), ZAOstock (own repo as of 2026-04-29), FISHBOWLZ paused.
+- Monorepo-as-Lab pattern: prototype in ZAO OS, graduate to own repo when ready for public users.
+- Open questions: which parts are open-source-licensed today? Which are internal-only? What licenses?
+- **Bonfire query:** `RECALL: what's the open-source status of every ZAO repo and how does the monorepo-as-lab pattern work?`
+
+### Chapter 7 — Roadmap + Open Source Status (NEW)
+- Q2-Q3 2026 priorities: Nexus rebuild (/nexus), ZabalSocials rebuild, Whitepaper rebuild (this doc).
+- Big events: ZAOstock October 3 2026, Ellsworth Maine.
+- Long-term: ZAO Festivals umbrella as recurring brand, ZAO Italy bridge via Mat Tambussi, Contribution Circles late-May 2026.
+- **Bonfire query:** `RECALL: list shipped vs planned vs paused/dead initiatives with status attributes.`
+
+---
+
+## How to Build This Iteratively (recommended workflow)
+
+**Step 1 — Skeleton.** Copy this spec into the actual whitepaper file as section headers. Each chapter starts as a stub.
+
+**Step 2 — Run the Bonfire queries.** For each chapter, DM the bot the `RECALL:` query in that chapter's box. Bot returns structured facts with source URLs. Paste relevant excerpts into the chapter as the FACT BASIS.
+
+**Step 3 — Voice pass.** With facts in place, rewrite each chapter in the Year-of-the-ZABAL voice (clear, simple, spartan, short sentences, active voice).
+
+**Step 4 — Diagrams.** Chapters 2 + 4 need diagrams. Mermaid is fine for v1. Keep simple.
+
+**Step 5 — Cross-link Draft 4.5.** Pull the strongest community framing from research/community/051 into chapter 1.
+
+**Step 6 — Public review.** Share with co-founders + key partners (Cassie / Steve Peer / Joshua.eth / Mat Tambussi) via Bonfire DM thread — let them flag corrections. Apply.
+
+**Step 7 — Publish.** Mirror.xyz or Paragraph or zaoos.com/whitepaper-v1. Get a real version-controlled artifact. Update community.config.ts to link.
+
+---
+
+## Source Material to Query / Cite
+
+Beyond Bonfire graph, pull from:
+- `research/community/051-zao-whitepaper-2026/` (existing Draft 4.5)
+- `research/community/050-the-zao-complete-guide/` (community guide, stale, but has ZAO history)
+- `research/wavewarz/101-wavewarz-zao-whitepaper/` (WaveWarZ-specific WP)
+- `CLAUDE.md` (project map)
+- `community.config.ts` (branding + contracts list)
+- BCZ YapZ episodes (now in Bonfire — guests' takes on ZAO)
+- `research/identity/542-549, 569, 570, 581, 590` (Bonfire stack docs — meta but relevant)
+- `research/governance/058-respect-deep-dive/` if exists
+
+---
+
+## Farcaster + X Posts as Voice Anchors
+
+Once Track B (FC + X ingest) is live, the whitepaper can pull "what Zaal said publicly about X" with deeplinks. Strong for:
+- Quotes that ground each chapter in Zaal's actual words
+- Public commitments + dates (when did Zaal first announce ZABAL launch publicly? Find in casts.)
+- Counterfactuals (what was the early thinking that got refined into this final position?)
+
+**Recommended:** Don't BLOCK whitepaper on FC/X ingest. Start writing now. When FC/X land, replace placeholder quotes with deeplinked real ones.
+
+---
+
+## Open Questions Before Build
+
+1. **Output target:** new research/ doc or new repo `zao-protocol`?
+2. **Length target:** 4 pages (executive summary) or 25-page deep dive or both?
+3. **Diagram style:** Mermaid (markdown-native) or proper design (Figma)?
+4. **Open-source license clarity:** which ZAO repos are MIT / Apache / proprietary today? Need a definitive answer to write Chapter 6.
+5. **Partner review list:** who gets pre-publish review (Cassie / Steve Peer / Joshua.eth / Mat Tambussi / Dan / Tadas)?
+6. **Publication channel:** Mirror.xyz, Paragraph, zaoos.com/whitepaper, or all three?
+7. **Cipher timing:** is Cipher releasing soon? If yes, hold whitepaper to include the ship; if no, write it as planned.
+
+---
+
+## Bonfire Ingest Trigger (for graph)
+
+```
+INGEST FACT:
+Subject: ZAO Protocol Whitepaper Rebuild Spec
+Type: Decision
+Date: 2026-05-04
+Status: planned
+Description: Rebuild research/community/051 ZAO Whitepaper Draft 4.5 as a PROTOCOL whitepaper for builders/partners/devs. 7 chapters reusing Draft 4.5's community framing as Ch1, adding 6 new chapters on protocol architecture, tokens, governance, onchain music, build-on-ZAO, roadmap. Iterative build using Bonfire RECALL queries for each chapter. Spec at docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md.
+Source: internal://docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+Confidence: 1.0
+```

--- a/research/infrastructure/599-podcast-mp3-hosting-bcz-yapz/README.md
+++ b/research/infrastructure/599-podcast-mp3-hosting-bcz-yapz/README.md
@@ -1,0 +1,108 @@
+---
+topic: infrastructure
+type: decision
+status: research-complete
+last-validated: 2026-05-12
+related-docs: 092, 093
+tier: STANDARD
+---
+
+# 599 - Podcast MP3 Hosting for BCZ YapZ
+
+> **Goal:** Pick the host for ~30 MB MP3 podcast files that the Apple Podcasts and Spotify ingest crawlers will accept. Budget under $20/yr, ~20 eps growing weekly. S3-compatible API preferred (drop-in boto3). Decentralized preferred (matches The ZAO ethos) but compatibility wins.
+
+## Verdict
+
+**USE Cloudflare R2.** Free tier covers BCZ YapZ at current and 10x scale, zero egress fees so Apple/Spotify ingest crawlers cannot cost money, native public bucket with HTTP range request support out of the box. One-line endpoint swap in the existing `scripts/rip-and-upload.py` (boto3).
+
+**2nd choice: Storj DCS.** Decentralized, S3-compatible, byte-range supported - the right ethos match. Deprioritized because the signup verification flow is currently flaky (Zaal blocked at email-verify step 2026-05-12), and the linkshare URL prefix is uglier than R2's `pub-<hash>.r2.dev`. Revisit if Storj signup unblocks and decentralization weighting increases.
+
+## Key Decisions
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Primary host | Cloudflare R2 | $0/month at current scale, zero egress, no signup blockers, S3 API |
+| Fallback | Storj DCS | Decentralized + S3-compatible, matches ZAO ethos when ready |
+| Avoid | Backblaze B2 | Egress fees kick in at 3x stored monthly. Apple ingest can blow past this for a popular pod |
+| Avoid | Filebase | $5/month minimum even for one file - more than R2 will ever charge BCZ |
+| Avoid for now | ArDrive / Turbo | Not S3-compatible, requires script rewrite. Reserve for ZAO music NFTs and permanent artifacts, not weekly podcast eps |
+
+## Comparison
+
+| Option | API | Public URLs | Range Requests | Free Tier Math (20 eps, 30 MB each, ~10k listens/mo) | Apple/Spotify Compat | Decentralized |
+|--------|-----|-------------|----------------|-------------------|--------------------|-----------|
+| **Cloudflare R2** | S3 | `pub-<hash>.r2.dev/<key>` or custom domain | Native | 600 MB / 10 GB free + 0 egress = $0/mo | Validated by Selfhost Podcasting plugin + microfeed | No |
+| **Storj DCS** | S3 (gateway.storjshare.io) | `link.storjshare.io/raw/<grant>/<bucket>/<key>` | Native (HEAD + byte-range per Storj docs) | 600 MB / 25 GB free = $0/mo | Documented in Storj DCS S3 compatibility page | Yes (80-shard erasure coding) |
+| Filebase | S3 | `<bucket>.s3.filebase.com/<key>` | Native | $5/mo min (Starter plan) | Works (S3, public buckets) | Yes (Filecoin/Sia backend) |
+| Backblaze B2 | S3 | Friendly URLs via Bandwidth Alliance + CDN | Native | 10 GB free + 1 GB/day egress free, then $0.01/GB | Works | No |
+| ArDrive / Turbo | Custom SDK (not S3) | `arweave.net/<txid>` | Native | One-time $0.50-1 per upload, $0 ongoing | Works (permanent CDN) | Yes (Arweave) |
+
+## Apple/Spotify Ingest Gotchas
+
+Apple Podcasts Connect and Spotify for Podcasters crawlers stream-read the enclosure URL using HTTP HEAD followed by partial-content GETs (Range requests). Hosts must:
+
+1. Return `200 OK` (or `301`/`302` to a stable URL) on HEAD with `Content-Length` and `Content-Type: audio/mpeg`
+2. Support `Range: bytes=` requests with `206 Partial Content`
+3. Not require auth, cookies, or User-Agent gating
+
+**Flagged risks:**
+- **Cloudflare R2: NO known issues.** The Cloudflare community thread "Apple Podcast is not pulling through my latest episodes" turns out to be about Cloudflare CDN proxy mode in front of a non-R2 podcast host (Buzzsprout style), not R2 itself. R2 origins serve cleanly.
+- **Storj DCS: NO known issues for podcast use case.** Storj rate-limits at <100 RPS on certain endpoints, but that's per-account and only matters if you serve a huge audience from one access grant. Plenty of headroom for BCZ at current scale.
+- **Filebase: NO known issues**, but $5/mo floor makes it worse than R2 at our volume.
+- **ArDrive: works, but the gateway URL (`arweave.net`) is not under Zaal's control.** Apple's RSS validator accepts it, but if Zaal ever wants to swap CDNs, the URLs are immutable. Use only for permanence-required artifacts.
+
+## Migration Path: If Storj Signup Unblocks Later
+
+Switching from R2 to Storj is one env-var change:
+
+```bash
+# Was (R2):
+export STORJ_ENDPOINT="https://<account>.r2.cloudflarestorage.com"
+# Switch to Storj:
+export STORJ_ENDPOINT="https://gateway.storjshare.io"
+# Update STORJ_PUBLIC_PREFIX, re-run rip:audio --all --force.
+```
+
+Frontmatter `audio_url` gets re-patched; commit + Vercel rebuild; Apple/Spotify re-fetch the feed and pick up new URLs. No code changes.
+
+## R2 Setup Steps (Replacement for scripts/PODCAST-SETUP.md)
+
+1. Cloudflare account at https://dash.cloudflare.com (already have one if you use Cloudflare for any DNS - Zaal does).
+2. **R2 > Create bucket** named `bcz-yapz-audio`. Region: Auto.
+3. **Settings > Public access > Allow Access** (the `pub-<hash>.r2.dev` subdomain).
+4. **R2 > Manage API tokens > Create API token**. Permissions: Object Read + Write on `bcz-yapz-audio`. Save Access Key ID, Secret Access Key, **and the S3 endpoint URL** (visible after token creation, format `https://<accountid>.r2.cloudflarestorage.com`).
+5. Set env:
+   ```bash
+   export STORJ_ACCESS_KEY="<r2 access key id>"
+   export STORJ_SECRET_KEY="<r2 secret>"
+   export STORJ_BUCKET="bcz-yapz-audio"
+   export STORJ_PUBLIC_PREFIX="https://pub-<bucket-hash>.r2.dev"
+   export STORJ_ENDPOINT="https://<accountid>.r2.cloudflarestorage.com"
+   ```
+6. Run rip script as documented. (Env var names can stay as `STORJ_*` since boto3 just sees them as S3 credentials; if naming bothers, rename in a follow-up PR.)
+
+## Also See
+
+- [Doc 092](../092-public-apis-2026-update/) - other ZAO ecosystem public infrastructure
+- [Doc 093](../093-missing-infrastructure-gaps/) - prior infrastructure audit
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Switch BCZ YapZ podcast pipeline from Storj to R2 | @Zaal | Code (bcz-yapz repo) | Today |
+| Update scripts/PODCAST-SETUP.md in bcz-yapz with R2 steps | @Claude | PR (bcz-yapz) | Today |
+| Optionally rename env vars from STORJ_* to AUDIO_HOST_* | @Zaal | PR (bcz-yapz) | Follow-up |
+| Revisit Storj when signup is unblocked | @Zaal | Decision review | If R2 ever introduces egress fees |
+
+## Sources
+
+- [Cloudflare R2 Pricing](https://developers.cloudflare.com/r2/pricing/) - $0.015/GB-mo, 10 GB free, zero egress
+- [Cloudflare R2 Overview](https://developers.cloudflare.com/r2/) - product docs
+- [microfeed self-hosted podcast CMS on R2](https://github.com/microfeed/microfeed) - working podcast hosted on R2
+- [Selfhost Podcasting WordPress plugin (R2 integration)](https://wordpress.org/plugins/selfhost-podcasting/) - "fully formatted RSS feed that meets the technical specifications of Apple Podcasts and Spotify"
+- [Storj S3 Gateway docs](https://storj.dev/dcs/api/s3/s3-compatible-gateway) - byte-range and HEAD support confirmed
+- [Storj S3 Compatibility](https://storj.dev/dcs/api/s3/s3-compatibility) - per-operation compatibility matrix
+- [Storj forum: rate limit at <100 RPS](https://forum.storj.io/t/rate-limiting-under-100-rps-http-403-errors/19591) - flagged but not blocking for BCZ scale
+- [Filebase FAQ on public buckets](https://docs.filebase.com/getting-started/faq) - confirms S3 URL format
+- [Filebase pricing context (The New Stack)](https://thenewstack.io/filebases-s3-compatible-api-aims-to-ease-decentralized-storage/) - $5/mo Starter tier floor


### PR DESCRIPTION
## Summary
R2 wins over Storj for BCZ YapZ podcast MP3 hosting. R2 free tier ($0/mo at current scale) + zero egress + working signup. Storj would have been the ethos pick but its signup is currently flaky (Zaal blocked at email verify 2026-05-12), and the migration is a one-env-var swap if that ever unblocks.

## Tier
STANDARD

## Sources
9 unique: 1 Cloudflare R2 docs, 2 R2 community/plugin validations, 4 Storj docs/forum, 2 Filebase docs/article.

## Next Actions
See "Next Actions" table in README - main one is switching bcz-yapz repo's PODCAST-SETUP.md from Storj to R2 immediately so Zaal is unblocked.