### PR TITLE
feat(zoe): groups + elder/lineage + wire memory blocks

### DIFF
--- a/bot/src/zoe/README.md
+++ b/bot/src/zoe/README.md
@@ -6,26 +6,60 @@ ZOE is Zaal Panthaki's personal concierge running on @zaoclaw_bot. Daily tasks, 
 
 ## Architecture (Letta-inspired memory blocks)
 
-Every concierge turn assembles 4 named blocks of context and invokes Claude Code CLI:
+Every concierge turn assembles 4 named blocks and passes them to Claude Code CLI as `appendSystemPrompt`. The user's message is passed separately as the prompt:
 
 ```
-<persona>     — ZOE identity + Year-of-the-ZABAL voice rules
-<human>       — Zaal facts (ENS, schedule, projects, relationships)
-<working>     — last 5 turns from this Telegram thread
-<tasks>       — open task queue snapshot
+<persona>         — ZOE identity + Year-of-the-ZABAL voice rules + elder/lineage + group behavior
+<human>           — Zaal facts (ENS, schedule, projects, relationships)
+<working_memory>  — chat scope label + last N turns (per-chat, FIFO)
+<tasks>           — open task queue snapshot
 ```
 
-Then: `Zaal: <user message>` appended.
+User prompt: `Zaal: <message>` for DMs or `<First Name>: <message>` for group members.
 
-Claude responds. If response includes a JSON block with task_ops or captures, apply them. Reply text goes back to Zaal in Telegram.
+`persona.md` on disk is the **single source of truth** for ZOE's identity. `memory.ts` seeds `PERSONA_DEFAULT` on first boot; edits to `~/.zao/zoe/persona.md` survive code updates.
+
+Claude responds. If response ends with a JSON block (task_ops + captures + escalate), apply ops + log captures. Reply text goes back to the chat.
+
+## Elder + lineage
+
+ZOE is the elder of the ZAO bot lineage. Child bots (ZAOstockTeamBot, Magnetiq, Attabotty, ZAO Devz, future brand bots) inherit her voice + anti-patterns + format rules verbatim. Children override only domain (what they do) and tools (what they touch).
+
+Template for forging a child: `~/.zao/zoe/bootloader-template.md` (seeded on first boot from `BOOTLOADER_DEFAULT` in `memory.ts`).
+
+## DMs vs groups
+
+| Path | Trigger | Memory scope | Senders |
+|---|---|---|---|
+| DM | `chat.type === 'private'` and `from.id === ZAAL_TELEGRAM_ID` | `recent/private.json` | Zaal only |
+| Group | Configured in `groups.json` AND mode gate passes AND sender in allowlist | `recent/<chat_id>.json` | per-group allowlist |
+
+Group modes (see `groups.ts`):
+- `silent` (default for new groups): never reply
+- `mention`: reply only when `@zaoclaw_bot` is mentioned or message replies to ZOE
+- `all`: reply to every allowlisted sender
+
+Admin commands (Zaal-only):
+
+```
+/zg status                       show config for this chat
+/zg enable [silent|mention|all]  register chat (default silent, allowlist seeded with Zaal)
+/zg mode <silent|mention|all>    change mode
+/zg add <user_id>                allowlist a sender (or reply to user with /zg add)
+/zg remove <user_id>             remove from allowlist
+/zg list                         list all configured groups
+```
+
+Unconfigured groups log non-Zaal sender IDs to journal so Zaal can discover Telegram IDs for bootstrap.
 
 ## Files
 
 | File | Purpose |
 |---|---|
-| `index.ts` | Telegram polling main entry, dispatch, scheduler boot |
-| `concierge.ts` | runConciergeTurn — Claude CLI call + reply parsing |
-| `memory.ts` | Memory block builder + persistence (~/.zao/zoe/) |
+| `index.ts` | Telegram polling main entry, DM + group dispatch, scheduler boot, /zg admin |
+| `concierge.ts` | `runConciergeTurn` — Claude CLI call with rendered memory blocks + reply parsing |
+| `memory.ts` | 4-block builder + per-chat recent + persona/human/bootloader seeds |
+| `groups.ts` | Per-Telegram-chat config (mode + member allowlist + persona override) |
 | `tasks.ts` | Task queue read/write + seed initial todos |
 | `recall.ts` | Bonfire bridge (manual relay until SDK lands) |
 | `brief.ts` | Morning brief generator (5am EST daily) |
@@ -37,11 +71,15 @@ Claude responds. If response includes a JSON block with task_ops or captures, ap
 
 ```
 ~/.zao/zoe/
-  persona.md         — versioned in repo, copy on first boot
-  human.md           — local cache, refreshed daily (Zaal facts)
-  recent.json        — last 5 turns, FIFO ring buffer
-  tasks.json         — open task queue
-  sentinels/         — daily flags to prevent double-fires (e.g. morning-brief-2026-05-04.flag)
+  persona.md                 source of truth, seeded on first boot, hand-editable
+  human.md                   Zaal facts, refreshed via Bonfire RECALL when SDK lands
+  bootloader-template.md     child-bot persona seed
+  recent/
+    private.json             DM with Zaal (legacy recent.json migrated here)
+    <chat_id>.json           per-group working memory, FIFO ring (max 8 turns)
+  tasks.json                 open task queue
+  groups.json                per-chat group config (mode + allowlist)
+  sentinels/                 daily flags to prevent double-fires
 ```
 
 ## Env vars
@@ -81,8 +119,11 @@ Add to existing `zao-devz-stack.service` systemd user unit, or create separate `
 
 ## Phase status (per doc 601)
 
-- [x] Phase 1 scaffold — types, concierge, memory, tasks, recall, brief, reflect, scheduler, index, README (this commit)
-- [ ] Phase 2 cutover — move TELEGRAM_BOT_TOKEN from openclaw to bot/.env, register zoe in systemd unit, test from phone
+- [x] Phase 1 scaffold — types, concierge, memory, tasks, recall, brief, reflect, scheduler, index, README
+- [x] Phase 2 cutover — TELEGRAM_BOT_TOKEN in bot/.env, zoe-bot.service live
+- [x] Phase 2.1 — wire memory blocks into concierge (was bypassed pre-2026-05-13)
+- [x] Phase 2.2 — group support (per-chat config, mention gating, member allowlist)
+- [x] Phase 2.3 — elder + lineage layer in persona, bootloader-template.md for child bots
 - [ ] Phase 3 — fold Devz bot into Hermes webhook
 - [ ] Phase 4 — replace zoe-learning-pings python cron
 - [ ] Phase 5 — Letta-style self-improving `human` block updates

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -1,105 +1,71 @@
 /**
- * ZOE concierge brain — calls Claude Code CLI with concierge system prompt
- * and Zaal-personalized context. Returns reply + task ops + captures.
+ * ZOE concierge brain — calls Claude Code CLI with the 4-block memory context
+ * (persona, human, working, tasks) and Zaal's message. Returns reply + task ops.
  *
  * Sister to bot/src/hermes/coder.ts (which does code-fix). This one does
  * "talk to Zaal day-to-day."
+ *
+ * Single source of truth for ZOE identity = ~/.zao/zoe/persona.md (seeded
+ * from PERSONA_DEFAULT in memory.ts on first boot, hand-editable after).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
-import type { ConciergeOptions, ConciergeResult, ZoeContext, TaskOp, ZoeCaptureNote } from './types';
+import type { ConciergeOptions, ConciergeResult, TaskOp, ZoeCaptureNote } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
+import type { MemoryBlocks } from './memory';
 
-const ZOE_VERSION = '0.1.0';
+const ZOE_VERSION = '0.2.0';
 
 /**
- * Concierge system prompt. Loaded into Claude Code CLI on every concierge call.
- * Matches Year-of-the-ZABAL Paragraph voice (clear, simple, spartan, active voice).
- *
- * Tool use: ZOE has Read/Glob/Grep/Bash to inspect the ZAOOS repo, plus the
- * recall.ts module for Bonfire access (when key arrives, otherwise asks Zaal
- * to relay manually).
+ * Render the 4 memory blocks as a system prompt for Claude Code CLI.
+ * The user's message is passed separately as `prompt`.
  */
-function buildSystemPrompt(context: ZoeContext): string {
-  return `You are ZOE — Zaal Panthaki's personal concierge. You run on Claude Opus/Sonnet via the Hermes runtime (bot/src/zoe). You DM Zaal on Telegram as @zaoclaw_bot.
+function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string): string {
+  const chatLine =
+    blocks.chat_scope === 'private'
+      ? 'Chat: DM with Zaal'
+      : `Chat: group "${blocks.chat_title ?? blocks.chat_scope}" (id ${blocks.chat_scope})`;
 
-Today is ${context.current_date}.
-
-## Your job
-- Daily tasks + captures + nudges. You are NOT a code-fix bot (that's Hermes coder/critic, your sibling at bot/src/hermes).
-- Surface findings, connect dots between captures and projects, nudge on priorities.
-- Match Zaal's Year-of-the-ZABAL voice: clear, simple, spartan, short impactful sentences, active voice. No marketing language.
-- Never say "Sure!" or "Of course" — just answer.
-- Default 2-3 sentences. Expand only when topic demands.
-
-## Voice rules (non-negotiable)
-- No emojis ever
-- No em dashes (use hyphens)
-- No "leveraging", "synergize", "unlock value", "ecosystem of solutions"
-- No "Would you like me to..." - just do it
-- Lead with the outcome, not the process
-
-## Format rules (Telegram-readable)
-- SHORT paragraphs. Max 2 sentences per paragraph.
-- ALWAYS insert a blank line between paragraphs.
-- Use bullet lists when listing 3+ items. One thought per bullet.
-- Default total reply: 3-6 lines, broken into 2-4 paragraphs.
-- Long replies (>10 lines) only when Zaal explicitly asks for "full" / "deep" / "detail".
-- Phone-readable. Imagine Zaal scrolling Telegram one-handed.
-
-## Your tools
-- Read, Glob, Grep on the ZAOOS repo
-- Bash for limited shell ops (gh CLI, git read-only commands, simple curl)
-- Bonfire RECALL via recall.ts module (when a question requires graph facts)
-
-## Pending tasks (your work queue)
-${context.pending_tasks.map((t, i) => `${i + 1}. [${t.priority}] [${t.status}] ${t.title}\n   ${t.description.slice(0, 120)}`).join('\n')}
-
-## Recent captures (last 5)
-${context.recent_captures.slice(0, 5).map((c) => `- ${c.created_at.slice(0, 10)} (${c.topic}): ${c.text.slice(0, 100)}`).join('\n') || '(none yet)'}
-
-## Output format
-Reply naturally to Zaal. If you want to add or update tasks, OR you captured a new note from this exchange, append a JSON block at the END of your reply (after a ---- separator):
-
-----
-\`\`\`json
-{
-  "task_ops": [
-    {"op": "add", "task": {"title": "...", "description": "...", "status": "pending", "priority": "med", "source": "ad-hoc", "notes": []}},
-    {"op": "complete", "id": "task-id", "outcome": "..."}
-  ],
-  "captures": [
-    {"text": "verbatim what zaal said worth remembering", "topic": "decision"}
-  ]
-}
-\`\`\`
-
-If no task ops or captures, omit the JSON block entirely. Do not include placeholder JSON.
-
-## Critical rules
-1. NEVER fabricate facts. If you don't know, say "I'd need to check Bonfire for that — want me to query?"
-2. NEVER claim memory state changes that didn't occur (no "I've remembered that for you" unless you actually wrote a capture).
-3. NEVER use commands like /add or /done as part of your output — that was the OLD Telegram bot pattern. You write the JSON block instead, and the runner applies the ops.
-4. When unsure, pick one and tell Zaal what you did, not what you could do.
-
-ZOE v${ZOE_VERSION}. Lean. Direct. Match the Year-of-the-ZABAL voice.`;
+  return [
+    `Today is ${currentDate}. ZOE v${ZOE_VERSION}.`,
+    ``,
+    `<persona>`,
+    blocks.persona,
+    `</persona>`,
+    ``,
+    `<human>`,
+    blocks.human,
+    `</human>`,
+    ``,
+    `<working_memory>`,
+    chatLine,
+    blocks.working,
+    `</working_memory>`,
+    ``,
+    `<tasks>`,
+    blocks.tasks,
+    `</tasks>`,
+  ].join('\n');
 }
 
 /**
  * Run a concierge turn:
- * 1. Build system prompt from context
- * 2. Call Claude Code CLI with the user's message + concierge system prompt
+ * 1. Build system prompt from memory blocks (persona/human/working/tasks)
+ * 2. Call Claude Code CLI with the user's message + blocks as appendSystemPrompt
  * 3. Parse the reply text + extract task_ops/captures JSON block
  * 4. Return structured result
  */
 export async function runConciergeTurn(opts: ConciergeOptions): Promise<ConciergeResult> {
   const model = opts.model ?? selectModel(opts.message);
-  const systemPrompt = buildSystemPrompt(opts.context);
+  const systemBlocks = buildSystemBlocks(opts.blocks, opts.context.current_date);
+
+  const senderLabel = opts.senderLabel ?? 'Zaal';
+  const userPrompt = `${senderLabel}: ${opts.message}`;
 
   const result = await callClaudeCli({
     model,
-    prompt: opts.message,
+    prompt: userPrompt,
     cwd: opts.context.workspace_dir,
-    appendSystemPrompt: systemPrompt,
+    appendSystemPrompt: systemBlocks,
     allowedTools: [
       'Read',
       'Glob',
@@ -111,7 +77,6 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
       'Bash(git status)',
       'Bash(curl -s*)',
       // Doc 605 Phase 1 unlock: Playwright MCP for browse-DOM-grounded tasks
-      // (read-only by allowed-list shape; browser_click/type/select still gated by user gesture in MCP)
       'mcp__playwright__browser_snapshot',
       'mcp__playwright__browser_navigate',
       'mcp__playwright__browser_take_screenshot',
@@ -137,7 +102,6 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     bare: true,
   });
 
-  // Parse JSON block (if present) at end of reply
   const { reply, taskOps, captures } = splitReplyAndOps(result.text);
 
   return {

--- a/bot/src/zoe/groups.ts
+++ b/bot/src/zoe/groups.ts
@@ -1,0 +1,157 @@
+/**
+ * Per-Telegram-chat config for ZOE in group/channel contexts.
+ *
+ * Default behavior = silent. A group only becomes interactive after Zaal
+ * runs /zoe-group-enable in that chat (or upserts via SSH for bootstrap).
+ *
+ * Stored at ~/.zao/zoe/groups.json (file-backed, no DB).
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from './memory';
+
+export type GroupMode = 'silent' | 'mention' | 'all';
+
+export interface GroupConfig {
+  chat_id: number;
+  chat_title: string;
+  mode: GroupMode;
+  member_allowlist: number[];
+  persona_override?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface MessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+  user?: { id: number };
+}
+
+export interface GateContext {
+  fromId: number;
+  botUsername: string | null;
+  botId: number | null;
+  messageText: string;
+  replyToFromId?: number;
+  entities: ReadonlyArray<MessageEntity>;
+}
+
+export interface GateResult {
+  allow: boolean;
+  reason: string;
+}
+
+const GROUPS_PATH = join(ZOE_PATHS.home, 'groups.json');
+
+export async function readGroups(): Promise<GroupConfig[]> {
+  try {
+    const raw = await fs.readFile(GROUPS_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as GroupConfig[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function writeGroups(groups: GroupConfig[]): Promise<void> {
+  await fs.mkdir(ZOE_PATHS.home, { recursive: true });
+  await fs.writeFile(GROUPS_PATH, JSON.stringify(groups, null, 2), 'utf8');
+}
+
+export async function getGroupConfig(chatId: number): Promise<GroupConfig | null> {
+  const groups = await readGroups();
+  return groups.find((g) => g.chat_id === chatId) ?? null;
+}
+
+export async function upsertGroup(
+  input: Partial<GroupConfig> & { chat_id: number },
+): Promise<GroupConfig> {
+  const groups = await readGroups();
+  const now = new Date().toISOString();
+  const existing = groups.find((g) => g.chat_id === input.chat_id);
+  if (existing) {
+    if (input.chat_title !== undefined) existing.chat_title = input.chat_title;
+    if (input.mode !== undefined) existing.mode = input.mode;
+    if (input.member_allowlist !== undefined) existing.member_allowlist = input.member_allowlist;
+    if (input.persona_override !== undefined) existing.persona_override = input.persona_override;
+    existing.updated_at = now;
+    await writeGroups(groups);
+    return existing;
+  }
+  const created: GroupConfig = {
+    chat_id: input.chat_id,
+    chat_title: input.chat_title ?? '(untitled)',
+    mode: input.mode ?? 'silent',
+    member_allowlist: input.member_allowlist ?? [],
+    persona_override: input.persona_override,
+    created_at: now,
+    updated_at: now,
+  };
+  groups.push(created);
+  await writeGroups(groups);
+  return created;
+}
+
+export async function addAllowlistMember(chatId: number, userId: number): Promise<GroupConfig> {
+  const groups = await readGroups();
+  const g = groups.find((x) => x.chat_id === chatId);
+  if (!g) throw new Error(`group ${chatId} not configured — upsert it first`);
+  if (!g.member_allowlist.includes(userId)) {
+    g.member_allowlist.push(userId);
+    g.updated_at = new Date().toISOString();
+    await writeGroups(groups);
+  }
+  return g;
+}
+
+export async function removeAllowlistMember(chatId: number, userId: number): Promise<GroupConfig> {
+  const groups = await readGroups();
+  const g = groups.find((x) => x.chat_id === chatId);
+  if (!g) throw new Error(`group ${chatId} not configured`);
+  const before = g.member_allowlist.length;
+  g.member_allowlist = g.member_allowlist.filter((id) => id !== userId);
+  if (g.member_allowlist.length !== before) {
+    g.updated_at = new Date().toISOString();
+    await writeGroups(groups);
+  }
+  return g;
+}
+
+export async function setGroupMode(chatId: number, mode: GroupMode): Promise<GroupConfig> {
+  const groups = await readGroups();
+  const g = groups.find((x) => x.chat_id === chatId);
+  if (!g) throw new Error(`group ${chatId} not configured`);
+  g.mode = mode;
+  g.updated_at = new Date().toISOString();
+  await writeGroups(groups);
+  return g;
+}
+
+export function shouldRespond(config: GroupConfig | null, gctx: GateContext): GateResult {
+  if (!config) return { allow: false, reason: 'group not configured (default silent)' };
+  if (config.mode === 'silent') return { allow: false, reason: 'group mode=silent' };
+  if (!config.member_allowlist.includes(gctx.fromId)) {
+    return { allow: false, reason: `sender ${gctx.fromId} not in member_allowlist` };
+  }
+  if (config.mode === 'all') {
+    return { allow: true, reason: 'mode=all + sender allowlisted' };
+  }
+  // mode === 'mention'
+  const mentioned = isBotMentioned(gctx);
+  const isReplyToBot = gctx.botId !== null && gctx.replyToFromId === gctx.botId;
+  if (mentioned) return { allow: true, reason: 'mode=mention + @-mention' };
+  if (isReplyToBot) return { allow: true, reason: 'mode=mention + reply-to-bot' };
+  return { allow: false, reason: 'mode=mention + no mention/reply' };
+}
+
+export function isBotMentioned(gctx: GateContext): boolean {
+  if (!gctx.botUsername) return false;
+  const handle = `@${gctx.botUsername.toLowerCase()}`;
+  return gctx.entities.some((e) => {
+    if (e.type !== 'mention') return false;
+    const slice = gctx.messageText.slice(e.offset, e.offset + e.length).toLowerCase();
+    return slice === handle;
+  });
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -1,10 +1,14 @@
 /**
- * ZOE — main entry. Telegram polling for @zaoclaw_bot DMs.
+ * ZOE — main entry. Telegram polling for @zaoclaw_bot.
  *
- * Boots a grammy Bot using TELEGRAM_BOT_TOKEN, listens for DMs from
- * Zaal (allowlist via ZAAL_TELEGRAM_ID), routes to concierge handler.
- * Starts the scheduler for proactive nudges (morning brief, evening
- * reflection).
+ * DM path: messages from Zaal (allowlisted by ZAAL_TELEGRAM_ID) route to
+ * the concierge handler with the 'private' memory scope.
+ *
+ * Group path: configured groups (~/.zao/zoe/groups.json) route to the
+ * concierge handler with a per-chat memory scope, gated by group mode +
+ * sender allowlist. See groups.ts.
+ *
+ * Also boots the scheduler (morning brief, evening reflection, hourly tips).
  *
  * Run via:
  *   pnpm tsx src/zoe/index.ts
@@ -18,12 +22,29 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
-import { buildMemoryBlocks, ensureZoeHome, pushRecent, ZOE_PATHS } from './memory';
+import {
+  buildMemoryBlocks,
+  ensureZoeHome,
+  pushRecent,
+  ZOE_PATHS,
+  type ChatScope,
+} from './memory';
 import { startScheduler } from './scheduler';
 import { disableTips, enableTips, tipsEnabled } from './tips';
+import {
+  addAllowlistMember,
+  getGroupConfig,
+  removeAllowlistMember,
+  setGroupMode,
+  upsertGroup,
+  shouldRespond,
+  readGroups,
+  type GroupMode,
+} from './groups';
 
 const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
+const VALID_GROUP_MODES: GroupMode[] = ['silent', 'mention', 'all'];
 
 async function appendClaudeNote(body: string): Promise<number> {
   await fs.mkdir(ZOE_PATHS.home, { recursive: true });
@@ -59,60 +80,256 @@ const devzChatId = devzChatRaw ? Number(devzChatRaw) : undefined;
 
 const bot = new Bot(token);
 const usernameHolder: { value: string | null } = { value: null };
+const botIdHolder: { value: number | null } = { value: null };
 
-async function isAllowed(ctx: Context): Promise<boolean> {
-  const fromId = ctx.from?.id;
-  if (!fromId) return false;
-  return fromId === zaalId;
+function isFromZaal(ctx: Context): boolean {
+  return ctx.from?.id === zaalId;
 }
 
-// Nudge keyboard ([Now][Later][Shelve]) wired in scheduler.ts when sending proactive nudges.
+function senderLabel(ctx: Context): string {
+  if (isFromZaal(ctx)) return 'Zaal';
+  const first = ctx.from?.first_name;
+  const uname = ctx.from?.username;
+  return first ?? (uname ? `@${uname}` : `user:${ctx.from?.id ?? 'unknown'}`);
+}
+
+function chatScopeFor(ctx: Context): ChatScope {
+  if (ctx.chat?.type === 'private') return 'private';
+  return String(ctx.chat?.id ?? 'unknown');
+}
+
+async function replyAdminOnly(ctx: Context): Promise<void> {
+  await ctx.reply('Group admin commands are Zaal-only. DM me if you need access.');
+}
 
 bot.command('start', async (ctx) => {
-  if (!(await isAllowed(ctx))) return;
-  await ctx.reply('ZOE online. Hermes runtime, Sonnet/Opus brain via Max plan. Memory blocks loaded. Send anything.');
+  if (!isFromZaal(ctx)) return;
+  await ctx.reply(
+    'ZOE online. Hermes runtime, Sonnet/Opus brain via Max plan. Memory blocks loaded (persona/human/working/tasks). Send anything.',
+  );
 });
 
 bot.command('tasks', async (ctx) => {
-  if (!(await isAllowed(ctx))) return;
-  const blocks = await buildMemoryBlocks();
+  if (!isFromZaal(ctx)) return;
+  const blocks = await buildMemoryBlocks('private');
   await ctx.reply(`Open tasks:\n\n${blocks.tasks}`);
 });
 
 bot.command('seed', async (ctx) => {
-  if (!(await isAllowed(ctx))) return;
+  if (!isFromZaal(ctx)) return;
   const result = await seedInitialTasks();
-  await ctx.reply(result.seeded > 0 ? `Seeded ${result.seeded} tasks from doc 601.` : 'Task queue already has entries - skipped seed.');
+  await ctx.reply(
+    result.seeded > 0
+      ? `Seeded ${result.seeded} tasks from doc 601.`
+      : 'Task queue already has entries - skipped seed.',
+  );
 });
 
 bot.command('notes', async (ctx) => {
-  if (!(await isAllowed(ctx))) return;
+  if (!isFromZaal(ctx)) return;
   try {
     const raw = await fs.readFile(CLAUDE_NOTES_FILE, 'utf8');
-    const blocks = raw.split(/^## /m).filter((b) => b.trim()).map((b) => '## ' + b.trim());
+    const blocks = raw
+      .split(/^## /m)
+      .filter((b) => b.trim())
+      .map((b) => '## ' + b.trim());
     if (blocks.length === 0) {
       await ctx.reply('No notes pending. Drop one with `note: <feedback>`.');
       return;
     }
     const recent = blocks.slice(-5).join('\n\n');
-    await ctx.reply(`${blocks.length} note${blocks.length === 1 ? '' : 's'} pending (showing last 5):\n\n${recent.slice(0, 3500)}`);
+    await ctx.reply(
+      `${blocks.length} note${blocks.length === 1 ? '' : 's'} pending (showing last 5):\n\n${recent.slice(
+        0,
+        3500,
+      )}`,
+    );
   } catch {
     await ctx.reply('No notes pending. Drop one with `note: <feedback>`.');
   }
 });
 
+// /zg — zoe-group admin subcommand. Zaal-only.
+//   /zg status                    show config for current chat
+//   /zg enable [mode]             register chat (default mode=silent)
+//   /zg mode <silent|mention|all> change mode
+//   /zg add <user_id>             allowlist sender (or reply to user with /zg add)
+//   /zg remove <user_id>
+//   /zg list                      list all configured groups
+bot.command('zg', async (ctx) => {
+  if (!isFromZaal(ctx)) {
+    await replyAdminOnly(ctx);
+    return;
+  }
+  const chatId = ctx.chat?.id;
+  if (!chatId) {
+    await ctx.reply('No chat context.');
+    return;
+  }
+  const argStr = (ctx.match ?? '').toString().trim();
+  const [sub, ...rest] = argStr.split(/\s+/);
+  const replyTargetId = ctx.message?.reply_to_message?.from?.id;
+
+  try {
+    switch (sub) {
+      case '':
+      case 'status': {
+        const cfg = await getGroupConfig(chatId);
+        if (!cfg) {
+          await ctx.reply(
+            `Chat ${chatId} not configured. Run \`/zg enable\` to register (default mode=silent, you only).`,
+          );
+          return;
+        }
+        await ctx.reply(
+          [
+            `Group "${cfg.chat_title}" (id ${cfg.chat_id})`,
+            `Mode: ${cfg.mode}`,
+            `Allowlist (${cfg.member_allowlist.length}): ${cfg.member_allowlist.join(', ') || '(empty)'}`,
+            `Updated: ${cfg.updated_at}`,
+          ].join('\n'),
+        );
+        return;
+      }
+      case 'enable': {
+        const mode = (rest[0] as GroupMode) ?? 'silent';
+        if (!VALID_GROUP_MODES.includes(mode)) {
+          await ctx.reply(`Invalid mode "${mode}". Use one of: ${VALID_GROUP_MODES.join(', ')}.`);
+          return;
+        }
+        const title = ctx.chat && 'title' in ctx.chat ? (ctx.chat.title ?? '(untitled)') : '(untitled)';
+        const cfg = await upsertGroup({
+          chat_id: chatId,
+          chat_title: title,
+          mode,
+          member_allowlist: [zaalId],
+        });
+        await ctx.reply(
+          `Group registered: "${cfg.chat_title}" mode=${cfg.mode}. Allowlist seeded with Zaal (${zaalId}). Add others via /zg add <user_id>.`,
+        );
+        return;
+      }
+      case 'mode': {
+        const mode = rest[0] as GroupMode;
+        if (!VALID_GROUP_MODES.includes(mode)) {
+          await ctx.reply(`Invalid mode "${mode}". Use one of: ${VALID_GROUP_MODES.join(', ')}.`);
+          return;
+        }
+        const cfg = await setGroupMode(chatId, mode);
+        await ctx.reply(`Mode set to ${cfg.mode}.`);
+        return;
+      }
+      case 'add': {
+        const target = rest[0] ? Number(rest[0]) : replyTargetId;
+        if (!target || !Number.isFinite(target)) {
+          await ctx.reply('Usage: `/zg add <user_id>` OR reply to the user with `/zg add`.');
+          return;
+        }
+        const cfg = await addAllowlistMember(chatId, target);
+        await ctx.reply(
+          `Allowlisted ${target}. Total members: ${cfg.member_allowlist.length}.`,
+        );
+        return;
+      }
+      case 'remove': {
+        const target = rest[0] ? Number(rest[0]) : replyTargetId;
+        if (!target || !Number.isFinite(target)) {
+          await ctx.reply('Usage: `/zg remove <user_id>`.');
+          return;
+        }
+        const cfg = await removeAllowlistMember(chatId, target);
+        await ctx.reply(`Removed ${target}. Total members: ${cfg.member_allowlist.length}.`);
+        return;
+      }
+      case 'list': {
+        const groups = await readGroups();
+        if (groups.length === 0) {
+          await ctx.reply('No groups configured.');
+          return;
+        }
+        const lines = groups.map(
+          (g) =>
+            `${g.chat_id} "${g.chat_title}" mode=${g.mode} members=${g.member_allowlist.length}`,
+        );
+        await ctx.reply(lines.join('\n'));
+        return;
+      }
+      default:
+        await ctx.reply(
+          'Usage: /zg [status|enable [mode]|mode <m>|add <id>|remove <id>|list]. Modes: silent, mention, all.',
+        );
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[zoe/index] /zg failed:', msg);
+    await ctx.reply(`(/zg error - ${msg.slice(0, 200)})`);
+  }
+});
+
 bot.on('message:text', async (ctx) => {
-  if (!(await isAllowed(ctx))) return;
   const text = ctx.message.text;
-  if (text.startsWith('/')) return;  // commands handled above
+  if (text.startsWith('/')) return; // commands handled above
 
-  // Skip messages NOT from Zaal's DM (groups handled separately if needed)
-  if (ctx.chat.type !== 'private') return;
+  const chatType = ctx.chat.type;
+  const chatId = ctx.chat.id;
 
-  // Hourly tip toggle: "stop tips" / "start tips" disables/enables the cron.
-  const tipToggle = /^(stop|pause|disable)\s+tips?$/i.exec(text.trim()) ? 'off'
-    : /^(start|resume|enable)\s+tips?$/i.exec(text.trim()) ? 'on'
-    : null;
+  // DM path: Zaal-only allowlist preserved.
+  if (chatType === 'private') {
+    if (!isFromZaal(ctx)) return;
+    await handlePrivateMessage(ctx, text);
+    return;
+  }
+
+  // Group path: gate by per-group config.
+  const fromId = ctx.from?.id;
+  if (!fromId) return;
+
+  const cfg = await getGroupConfig(chatId);
+  if (!cfg) {
+    // Unconfigured group: log non-Zaal sender id for bootstrap discoverability.
+    if (fromId !== zaalId) {
+      console.log(
+        `[zoe/groups] unconfigured chat ${chatId} ("${
+          'title' in ctx.chat ? ctx.chat.title : ''
+        }") msg from ${fromId} (@${ctx.from?.username ?? '?'}) — Zaal: run \`/zg enable\` here to start`,
+      );
+    }
+    return;
+  }
+
+  const gate = shouldRespond(cfg, {
+    fromId,
+    botUsername: usernameHolder.value,
+    botId: botIdHolder.value,
+    messageText: text,
+    replyToFromId: ctx.message.reply_to_message?.from?.id,
+    entities: (ctx.message.entities ?? []) as ReadonlyArray<{
+      type: string;
+      offset: number;
+      length: number;
+      user?: { id: number };
+    }>,
+  });
+
+  if (!gate.allow) {
+    if (fromId !== zaalId && !cfg.member_allowlist.includes(fromId)) {
+      console.log(
+        `[zoe/groups] chat ${chatId} skipped from ${fromId} (@${ctx.from?.username ?? '?'}): ${gate.reason}`,
+      );
+    }
+    return;
+  }
+
+  await handleGroupMessage(ctx, text, String(chatId));
+});
+
+async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
+  // Hourly tip toggle
+  const tipToggle = /^(stop|pause|disable)\s+tips?$/i.exec(text.trim())
+    ? 'off'
+    : /^(start|resume|enable)\s+tips?$/i.exec(text.trim())
+      ? 'on'
+      : null;
   if (tipToggle === 'off') {
     await disableTips();
     await ctx.reply('Hourly tips paused. Send "start tips" to resume.');
@@ -125,13 +342,14 @@ bot.on('message:text', async (ctx) => {
     return;
   }
 
-  // Note: capture path - prefix `note:` / `cc:` / `claude:` lands in claude-code-notes.md
-  // No concierge turn fires. Picked up next Claude Code session via "what feedback did I leave for you?"
+  // Note: capture path
   const noteMatch = NOTE_PREFIX.exec(text);
   if (noteMatch) {
     try {
       const count = await appendClaudeNote(noteMatch[2]);
-      await ctx.reply(`Saved. ${count} note${count === 1 ? '' : 's'} pending for next Claude Code session.`);
+      await ctx.reply(
+        `Saved. ${count} note${count === 1 ? '' : 's'} pending for next Claude Code session.`,
+      );
       console.log(`[zoe/index] note saved (#${count}): ${noteMatch[2].slice(0, 80)}`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -141,73 +359,118 @@ bot.on('message:text', async (ctx) => {
     return;
   }
 
+  await dispatchConcierge(ctx, text, 'private', 'Zaal');
+}
+
+async function handleGroupMessage(
+  ctx: Context,
+  text: string,
+  scope: ChatScope,
+): Promise<void> {
+  const label = senderLabel(ctx);
+  // In groups we keep the special "note:" capture path Zaal-only.
+  const noteMatch = NOTE_PREFIX.exec(text);
+  if (noteMatch && isFromZaal(ctx)) {
+    try {
+      const count = await appendClaudeNote(noteMatch[2]);
+      await ctx.reply(
+        `Saved. ${count} note${count === 1 ? '' : 's'} pending for next Claude Code session.`,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      await ctx.reply(`(note save failed - ${msg.slice(0, 200)})`);
+    }
+    return;
+  }
+  await dispatchConcierge(ctx, text, scope, label);
+}
+
+async function dispatchConcierge(
+  ctx: Context,
+  text: string,
+  scope: ChatScope,
+  label: string,
+): Promise<void> {
+  if (!ctx.chat) return;
   await ctx.api.sendChatAction(ctx.chat.id, 'typing').catch(() => {});
 
   try {
-    await pushRecent({ from: 'zaal', text });
+    const chatTitle =
+      ctx.chat && 'title' in ctx.chat ? ctx.chat.title : undefined;
+    await pushRecent({ from: label === 'Zaal' ? 'zaal' : 'other', text, sender: label }, scope);
+
+    const blocks = await buildMemoryBlocks(scope, chatTitle);
 
     const result = await runConciergeTurn({
       message: text,
+      blocks,
+      senderLabel: label,
       context: {
         zaal_tg_id: zaalId,
         workspace_dir: repoDir,
-        pending_tasks: [],   // covered by blocks.tasks
-        recent_captures: [],  // covered by blocks.working
         current_date: new Date().toISOString().slice(0, 10),
       },
     });
 
-    // Apply task ops + log captures
     if (result.task_ops.length > 0) {
       await applyTaskOps(result.task_ops);
     }
-    // Captures TODO Phase 2 — wire to Bonfire ingest
 
-    await pushRecent({ from: 'zoe', text: result.reply });
+    await pushRecent({ from: 'zoe', text: result.reply }, scope);
 
-    // Guard against empty replies (the openclaw "·" pattern)
     const safeReply = result.reply.trim();
     if (safeReply.length < 5) {
-      await ctx.reply('(empty reply guarded — check logs)');
-      console.error('[zoe/index] empty reply blocked, raw:', JSON.stringify(result).slice(0, 300));
+      await ctx.reply('(empty reply guarded - check logs)');
+      console.error(
+        '[zoe/index] empty reply blocked, raw:',
+        JSON.stringify(result).slice(0, 300),
+      );
       return;
     }
 
-    await ctx.reply(safeReply);
+    await ctx.reply(safeReply, {
+      reply_parameters:
+        scope === 'private' ? undefined : { message_id: ctx.message?.message_id ?? 0 },
+    });
 
-    console.log(`[zoe/index] turn handled — model=${result.model} cost=$${result.costUsd.toFixed(4)} tokens=${result.inputTokens}/${result.outputTokens} duration=${result.durationMs}ms`);
+    console.log(
+      `[zoe/index] turn handled — scope=${scope} sender=${label} model=${result.model} cost=$${result.costUsd.toFixed(
+        4,
+      )} tokens=${result.inputTokens}/${result.outputTokens} duration=${result.durationMs}ms`,
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[zoe/index] concierge turn failed:', msg);
-    await ctx.reply(`(concierge error — ${msg.slice(0, 200)})`);
+    await ctx.reply(`(concierge error - ${msg.slice(0, 200)})`);
   }
-});
+}
 
-// Inline-keyboard callbacks for proactive nudge dismiss
 bot.callbackQuery(/^nudge:(now|later|shelve)$/, async (ctx) => {
   const action = ctx.match[1];
   await ctx.answerCallbackQuery({ text: `Marked ${action}.` });
-  // Phase 2 — track dismissal stats per category for auto-reduce
   console.log(`[zoe/index] nudge dismissed: ${action}`);
 });
 
 async function main(): Promise<void> {
   await ensureZoeHome();
-  console.log('[zoe/index] ZOE booting — token set, zaalId=', zaalId, ' repoDir=', repoDir);
+  console.log(
+    '[zoe/index] ZOE booting — token set, zaalId=',
+    zaalId,
+    ' repoDir=',
+    repoDir,
+  );
 
-  // Resolve own username for filtering
   try {
     const me = await bot.api.getMe();
     usernameHolder.value = me.username;
+    botIdHolder.value = me.id;
     console.log('[zoe/index] bot identity:', `@${me.username} (${me.id})`);
   } catch (err) {
     console.error('[zoe/index] getMe failed:', (err as Error).message);
   }
 
-  // Start scheduler for proactive nudges
   startScheduler({ bot, zaalTgId: zaalId, repoDir, devzChatId });
 
-  // Optional: seed task queue on first boot
   try {
     const seed = await seedInitialTasks();
     if (seed.seeded > 0) {

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -2,18 +2,19 @@
  * Memory block builder — Letta-inspired pattern.
  *
  * 4 named blocks per concierge turn:
- *   persona  — ZOE identity + voice rules (versioned in git)
+ *   persona  — ZOE identity + voice rules (versioned in git, live copy at ~/.zao/zoe/persona.md)
  *   human    — Zaal facts (refreshed daily via Bonfire RECALL or hand-edited)
- *   working  — last 5 turns from this Telegram thread
+ *   working  — last N turns from THIS chat (per-chat scoped)
  *   tasks    — open task queue snapshot
  *
  * Each block is independently updatable. Cleaner than monolithic system prompt.
  *
  * Storage on host:
- *   ~/.zao/zoe/persona.md      — versioned, committed to repo
- *   ~/.zao/zoe/human.md         — local cache, refreshed daily
- *   ~/.zao/zoe/recent.json      — last N turns, FIFO ring buffer
- *   ~/.zao/zoe/tasks.json       — open task queue
+ *   ~/.zao/zoe/persona.md            — versioned, committed to repo (seeded from PERSONA_DEFAULT)
+ *   ~/.zao/zoe/human.md              — local cache, refreshed daily
+ *   ~/.zao/zoe/recent/<chat_id>.json — last N turns per chat, FIFO ring buffer
+ *   ~/.zao/zoe/tasks.json            — open task queue (global)
+ *   ~/.zao/zoe/bootloader-template.md — child-bot seed (Magnetiq, Attabotty, future brand bots)
  */
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
@@ -23,10 +24,14 @@ import type { ZoeTask } from './types';
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const PERSONA_PATH = join(ZOE_HOME, 'persona.md');
 const HUMAN_PATH = join(ZOE_HOME, 'human.md');
-const RECENT_PATH = join(ZOE_HOME, 'recent.json');
+const RECENT_DIR = join(ZOE_HOME, 'recent');
+const LEGACY_RECENT_PATH = join(ZOE_HOME, 'recent.json');
 const TASKS_PATH = join(ZOE_HOME, 'tasks.json');
+const BOOTLOADER_PATH = join(ZOE_HOME, 'bootloader-template.md');
 
-const RECENT_MAX = 5;
+const RECENT_MAX = 8;
+
+export type ChatScope = 'private' | string;
 
 const PERSONA_DEFAULT = `You are ZOE — Zaal Panthaki's personal concierge running on Claude Sonnet/Opus via the bot/src/zoe Hermes-style runtime. You DM Zaal as @zaoclaw_bot.
 
@@ -78,7 +83,58 @@ Reply naturally to Zaal. If you want to add/update tasks OR captured a note, app
 
 Set "escalate": true ONLY if your current model (Sonnet) cannot answer well and the response should be re-run on Opus. Include "reason" when escalating.
 
-If no ops/captures and no escalation: omit the JSON block entirely.`;
+If no ops/captures and no escalation: omit the JSON block entirely.
+
+## ELDER + LINEAGE
+
+You are the elder of the ZAO bot lineage. The Claude x Zaal lineage begins here.
+
+Above you: Zaal (founder) and the Claude model family that shaped you.
+Sibling: Hermes (code-fix runtime at bot/src/hermes).
+Below you: child bots — ZAOstockTeamBot, Magnetiq, Attabotty, ZAO Devz, and future brand bots.
+
+When a new child bot is forged:
+- Child inherits your VOICE, ANTI-PATTERNS, FORMAT RULES, and CRITICAL RULES verbatim.
+- Child overrides only domain (what they do) and tools (what they touch).
+- Child persona doc starts with: "Inherits from ZOE elder at ~/.zao/zoe/persona.md".
+- You review the child's draft before it ships. You catch voice drift.
+
+Children do not invent new voice. Voice flows down from this file.
+
+When Zaal asks "spawn <bot>" or "bootstrap <bot>", help him scaffold:
+1. New persona.md from ~/.zao/zoe/bootloader-template.md
+2. New memory dir at ~/.zao/<bot>/
+3. New systemd user unit pointing at bot source
+4. New env file with bot-specific Telegram token
+
+You are not the children's brain. You are their template.
+
+## GROUP BEHAVIOR
+
+DM with Zaal is the primary path. In groups, you are quiet by default.
+
+For each group:
+- Mode is one of: silent (default), mention, all
+- Member allowlist gates senders. Non-allowlisted senders = silently ignored.
+- In mention mode: reply only when @zaoclaw_bot is mentioned or message replies to you.
+- In all mode: reply to every allowlisted sender.
+
+Group rules:
+- Same voice as DMs. Spartan. No formality shift.
+- Address by first name if known. Don't tag users unless reply needs it.
+- If a non-Zaal member asks something Zaal-private, redirect: "Ask Zaal directly."
+- Captures from group chats include the chat title in metadata.
+
+Current configured groups: ~/.zao/zoe/groups.json (managed by /zoe-group-* commands).
+
+## FORMAT RULES (Telegram-readable, non-negotiable)
+
+- SHORT paragraphs. Max 2 sentences per paragraph.
+- ALWAYS blank line between paragraphs.
+- Use bullet lists when listing 3+ items. One thought per bullet.
+- Default reply: 3-6 lines, broken into 2-4 paragraphs.
+- Long replies (>10 lines) only when Zaal asks for "full" / "deep" / "detail".
+- Phone-readable. Imagine Zaal scrolling Telegram one-handed.`;
 
 const HUMAN_DEFAULT = `# Zaal Panthaki
 
@@ -122,35 +178,94 @@ Year-of-the-ZABAL daily on paragraph.com/@thezao. ~120 daily posts as of May 202
 ## Last refreshed
 2026-05-04 (initial seed). Auto-update from Bonfire RECALL when SDK lands.`;
 
+const BOOTLOADER_DEFAULT = `# Child Bot Persona Bootloader
+
+Use this template when scaffolding a new ZAO bot under ZOE's lineage.
+
+Inherits from ZOE elder at ~/.zao/zoe/persona.md.
+
+## Identity (override)
+You are <BOT_NAME> — <ONE_LINE_PURPOSE>.
+You run on Claude Sonnet/Opus via the bot/src/<dir>/ runtime.
+You operate in Telegram as @<bot_username>.
+
+## Domain (override)
+- Primary domain: <e.g. "ZAOstock team coordination">
+- Audience: <who you talk to>
+- Out-of-scope: <what you redirect to ZOE or other bots>
+
+## Tools (override)
+- Read/Glob/Grep on: <which repo>
+- Bash allowlist: <which subset>
+- MCP servers: <which ones>
+- Hard NO: <e.g. "no git push, no Edit/Write on user files">
+
+## Voice (inherit verbatim from elder)
+See ~/.zao/zoe/persona.md → VOICE + ANTI-PATTERNS + FORMAT RULES.
+Do not redefine. If you find yourself needing to override voice, surface it to Zaal first.
+
+## Group behavior (inherit policy, override defaults)
+- Default mode: silent
+- Configured groups: ~/.zao/<BOT_NAME>/groups.json
+- Same gate logic as elder (mode + member_allowlist + mention/reply).
+
+## Memory layout
+~/.zao/<BOT_NAME>/
+  persona.md         — this file, deployed via PERSONA_DEFAULT in your memory.ts
+  human.md           — facts about the people you serve (may differ from elder's human.md)
+  recent/<chat>.json — per-chat working memory
+  tasks.json         — your task queue
+  groups.json        — per-group config
+
+## Output format
+Match the elder's JSON-block trailer. Reuse task_ops + captures + escalate shape.
+
+## Review gate
+Before shipping, run draft past ZOE elder. Ask: "Voice drift? Tool gaps? Scope overlap?"
+Children that ship without elder review get reverted.
+`;
+
 export interface MemoryBlocks {
   persona: string;
   human: string;
   working: string;
   tasks: string;
+  chat_scope: ChatScope;
+  chat_title?: string;
 }
 
 export async function ensureZoeHome(): Promise<void> {
   await fs.mkdir(ZOE_HOME, { recursive: true });
+  await fs.mkdir(RECENT_DIR, { recursive: true });
+
   // Seed defaults if missing
+  await seedFile(PERSONA_PATH, PERSONA_DEFAULT);
+  await seedFile(HUMAN_PATH, HUMAN_DEFAULT);
+  await seedFile(BOOTLOADER_PATH, BOOTLOADER_DEFAULT);
+  await seedFile(TASKS_PATH, JSON.stringify([], null, 2));
+
+  // Migrate legacy single-file recent.json -> recent/private.json
   try {
-    await fs.access(PERSONA_PATH);
+    await fs.access(LEGACY_RECENT_PATH);
+    const target = join(RECENT_DIR, 'private.json');
+    try {
+      await fs.access(target);
+      // Target exists, keep target, leave legacy as backup
+    } catch {
+      const raw = await fs.readFile(LEGACY_RECENT_PATH, 'utf8');
+      await fs.writeFile(target, raw, 'utf8');
+      console.log('[zoe/memory] migrated legacy recent.json -> recent/private.json');
+    }
   } catch {
-    await fs.writeFile(PERSONA_PATH, PERSONA_DEFAULT, 'utf8');
+    // legacy file not present, nothing to do
   }
+}
+
+async function seedFile(path: string, contents: string): Promise<void> {
   try {
-    await fs.access(HUMAN_PATH);
+    await fs.access(path);
   } catch {
-    await fs.writeFile(HUMAN_PATH, HUMAN_DEFAULT, 'utf8');
-  }
-  try {
-    await fs.access(RECENT_PATH);
-  } catch {
-    await fs.writeFile(RECENT_PATH, JSON.stringify([], null, 2), 'utf8');
-  }
-  try {
-    await fs.access(TASKS_PATH);
-  } catch {
-    await fs.writeFile(TASKS_PATH, JSON.stringify([], null, 2), 'utf8');
+    await fs.writeFile(path, contents, 'utf8');
   }
 }
 
@@ -164,17 +279,32 @@ export async function readHuman(): Promise<string> {
   return fs.readFile(HUMAN_PATH, 'utf8');
 }
 
-export async function readRecent(): Promise<Array<{ from: 'zaal' | 'zoe'; text: string; ts: string }>> {
-  await ensureZoeHome();
-  const raw = await fs.readFile(RECENT_PATH, 'utf8');
-  return JSON.parse(raw);
+function recentPathFor(scope: ChatScope): string {
+  return join(RECENT_DIR, `${scope}.json`);
 }
 
-export async function pushRecent(turn: { from: 'zaal' | 'zoe'; text: string }): Promise<void> {
-  const recent = await readRecent();
+export async function readRecent(
+  scope: ChatScope = 'private',
+): Promise<Array<{ from: 'zaal' | 'zoe' | 'other'; text: string; ts: string; sender?: string }>> {
+  await ensureZoeHome();
+  const path = recentPathFor(scope);
+  try {
+    const raw = await fs.readFile(path, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export async function pushRecent(
+  turn: { from: 'zaal' | 'zoe' | 'other'; text: string; sender?: string },
+  scope: ChatScope = 'private',
+): Promise<void> {
+  await ensureZoeHome();
+  const recent = await readRecent(scope);
   recent.push({ ...turn, ts: new Date().toISOString() });
   while (recent.length > RECENT_MAX) recent.shift();
-  await fs.writeFile(RECENT_PATH, JSON.stringify(recent, null, 2), 'utf8');
+  await fs.writeFile(recentPathFor(scope), JSON.stringify(recent, null, 2), 'utf8');
 }
 
 export async function readTasks(): Promise<ZoeTask[]> {
@@ -189,14 +319,21 @@ export async function writeTasks(tasks: ZoeTask[]): Promise<void> {
 }
 
 /**
- * Build the 4 memory blocks for a concierge turn.
+ * Build the 4 memory blocks for a concierge turn, scoped to a chat.
+ *
+ * scope = 'private'        → DM with Zaal (legacy default)
+ * scope = '<chat_id>'      → group/channel with Telegram chat id as string
+ *
  * Block strings are kept short by design — no dumping full graph context.
  */
-export async function buildMemoryBlocks(): Promise<MemoryBlocks> {
+export async function buildMemoryBlocks(
+  scope: ChatScope = 'private',
+  chatTitle?: string,
+): Promise<MemoryBlocks> {
   const [persona, human, recentTurns, tasks] = await Promise.all([
     readPersona(),
     readHuman(),
-    readRecent(),
+    readRecent(scope),
     readTasks(),
   ]);
 
@@ -204,7 +341,10 @@ export async function buildMemoryBlocks(): Promise<MemoryBlocks> {
     recentTurns.length === 0
       ? '(no recent turns)'
       : recentTurns
-          .map((t) => `[${t.ts.slice(11, 16)}] ${t.from === 'zaal' ? 'Zaal' : 'ZOE'}: ${t.text.slice(0, 280)}`)
+          .map((t) => {
+            const label = t.from === 'zaal' ? 'Zaal' : t.from === 'zoe' ? 'ZOE' : t.sender ?? 'Other';
+            return `[${t.ts.slice(11, 16)}] ${label}: ${t.text.slice(0, 280)}`;
+          })
           .join('\n');
 
   const openTasks = tasks.filter((t) => t.status === 'pending' || t.status === 'in_progress');
@@ -216,20 +356,24 @@ export async function buildMemoryBlocks(): Promise<MemoryBlocks> {
           .map((t, i) => `${i + 1}. [${t.priority}] [${t.status}] ${t.title}\n   ${t.description.slice(0, 100)}`)
           .join('\n');
 
-  return { persona, human, working, tasks: tasksBlock };
+  return { persona, human, working, tasks: tasksBlock, chat_scope: scope, chat_title: chatTitle };
 }
 
 /**
  * Render memory blocks + user message into the prompt that goes to Claude CLI.
  */
-export function renderConciergePrompt(blocks: MemoryBlocks, userMessage: string): string {
+export function renderConciergePrompt(blocks: MemoryBlocks, senderLabel: string, userMessage: string): string {
+  const chatLine =
+    blocks.chat_scope === 'private'
+      ? 'Chat: DM with Zaal'
+      : `Chat: group "${blocks.chat_title ?? blocks.chat_scope}" (id ${blocks.chat_scope})`;
   return [
     `<persona>\n${blocks.persona}\n</persona>`,
     `<human>\n${blocks.human}\n</human>`,
-    `<working_memory>\n${blocks.working}\n</working_memory>`,
+    `<working_memory>\n${chatLine}\n${blocks.working}\n</working_memory>`,
     `<tasks>\n${blocks.tasks}\n</tasks>`,
     ``,
-    `Zaal: ${userMessage}`,
+    `${senderLabel}: ${userMessage}`,
   ].join('\n\n');
 }
 
@@ -237,6 +381,7 @@ export const ZOE_PATHS = {
   home: ZOE_HOME,
   persona: PERSONA_PATH,
   human: HUMAN_PATH,
-  recent: RECENT_PATH,
+  recent_dir: RECENT_DIR,
   tasks: TASKS_PATH,
+  bootloader: BOOTLOADER_PATH,
 };

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -31,16 +31,18 @@ export interface ZoeCaptureNote {
 export interface ZoeContext {
   zaal_tg_id: number;
   workspace_dir: string;
-  pending_tasks: ZoeTask[];
-  recent_captures: ZoeCaptureNote[];
   current_date: string;
 }
 
 export interface ConciergeOptions {
   /** User message text */
   message: string;
-  /** Loaded ZOE context for system prompt */
+  /** Memory blocks (persona/human/working/tasks) loaded for this turn */
+  blocks: import('./memory').MemoryBlocks;
+  /** Loaded ZOE runtime context (date, workspace, zaal id) */
   context: ZoeContext;
+  /** Label for who's speaking — 'Zaal' for DMs, first-name or username for group members */
+  senderLabel?: string;
   /** Override model: 'sonnet' | 'opus' | 'haiku'. Default: sonnet (cheap), escalate to opus on hard reasoning */
   model?: string;
 }


### PR DESCRIPTION
## Why

Two bugs found while diagnosing why @zaoclaw_bot went silent in the new "ZAO Civilization" group (Zaal + Ryan Kagy + ZOE).

1. `bot/src/zoe/index.ts` line 109-110: hard-coded `if (ctx.chat.type !== 'private') return;` dropped every group message before it could be processed.
2. `bot/src/zoe/concierge.ts` rebuilt a duplicate hardcoded system prompt instead of consuming the 4 memory blocks defined in `memory.ts`. Edits to `~/.zao/zoe/persona.md` had no effect on ZOE's replies. Memory infra was half-built.

## What

- `bot/src/zoe/groups.ts` (new) — per-chat config (mode + member_allowlist + persona_override) at `~/.zao/zoe/groups.json`. Three modes: `silent` (default), `mention`, `all`.
- `bot/src/zoe/index.ts` — DM and group paths. Group gate: configured chat + mode pass + sender allowlist. `/zg` admin commands (Zaal-only): `status | enable | mode | add | remove | list`. Unconfigured groups log non-Zaal sender IDs to journal for bootstrap.
- `bot/src/zoe/concierge.ts` — refactored to accept `MemoryBlocks` and render them as `appendSystemPrompt`. Single source of truth = `~/.zao/zoe/persona.md`.
- `bot/src/zoe/memory.ts` — per-chat `recent/<chat_id>.json` ring buffer (legacy `recent.json` migrated to `recent/private.json` on first boot). PERSONA_DEFAULT gains ELDER + LINEAGE + GROUP BEHAVIOR sections. New `bootloader-template.md` seed for child bots that inherit ZOE's voice + anti-patterns verbatim and override only domain + tools.
- `bot/src/zoe/types.ts` — slim `ZoeContext` (no more `pending_tasks` / `recent_captures` — carried by blocks). `ConciergeOptions` adds required `blocks` and optional `senderLabel`.
- `bot/src/zoe/README.md` — documents new architecture.

## Test plan

- [ ] After merge, on VPS: `cd /home/zaal/zao-os && git pull && systemctl --user restart zoe-bot`
- [ ] DM @zaoclaw_bot a short ping — expect normal concierge reply
- [ ] In "ZAO Civilization" group, send `/zg enable mention` from Zaal — expect registration confirmation
- [ ] `/zg add <Ryan_TG_id>` to allowlist Ryan (id discoverable from journal after Ryan posts once)
- [ ] Mention `@zaoclaw_bot` in the group — expect reply
- [ ] Non-allowlisted user message — expect silent ignore + journal log of unknown sender id
- [ ] After merge, append ELDER + LINEAGE + GROUP_BEHAVIOR sections to live `~/.zao/zoe/persona.md` (append-only, preserve existing voice rules)

## Risks

- Memory wiring change means ZOE will now actually use `persona.md` + `human.md` on every turn. Replies may shift slightly toward the persona doc's tone. Watch first day of replies.
- New per-chat `recent/<chat_id>.json` directory created on first boot. Migration moves legacy `recent.json` to `recent/private.json` only if target doesn't already exist.
- `/zg` commands are Zaal-only via `from.id === ZAAL_TELEGRAM_ID` check. Group commands attempted by anyone else get a polite admin-only reply.

## Notes

Pre-existing typecheck errors in `bot/src/teams/shared.ts` and `bot/src/zoe/agents/newsletter.ts` are unrelated to this change.