### PR TITLE
fix(zoe): drop --bare so Claude OAuth works (hotfix)

### DIFF
--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -106,7 +106,7 @@ Output the brief now in the exact format from your system prompt.`;
     cwd: opts.repoDir,
     appendSystemPrompt: BRIEF_SYSTEM_PROMPT,
     permissionMode: 'auto',
-    bare: true,
+    bare: false,
   });
 
   return guardEmpty(result.text);

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -99,7 +99,13 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     ],
     permissionMode: 'auto',
     outputFormat: 'json',
-    bare: true,
+    // bare: false on purpose. Claude Code CLI 2.1.140+ explicitly disables
+    // OAuth credential reads under --bare ("Anthropic auth is strictly
+    // ANTHROPIC_API_KEY or apiKeyHelper"). ZOE uses Max-plan OAuth, so we
+    // run without --bare. Cost is ~$0.10 per cold turn for CLAUDE.md auto-
+    // discovery (~26K input tokens) but prompt-cache amortizes that across
+    // a session.
+    bare: false,
   });
 
   const { reply, taskOps, captures } = splitReplyAndOps(result.text);

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -93,7 +93,7 @@ Output the reflection prompt in the exact format from your system prompt. Refere
     cwd: opts.repoDir,
     appendSystemPrompt: REFLECT_SYSTEM_PROMPT,
     permissionMode: 'auto',
-    bare: true,
+    bare: false,
   });
 
   const trimmed = result.text.trim();


### PR DESCRIPTION
## Why

After merging #511, every ZOE concierge turn failed with:
> `(concierge error - claude CLI exited 1. stderr: )`

Root cause: Claude Code CLI v2.1.140+ explicitly disables OAuth/keychain reads under `--bare`. From the CLI's own help: *"Anthropic auth is strictly `ANTHROPIC_API_KEY` or `apiKeyHelper` via `--settings`. OAuth and keychain are never read."*

ZOE runs on Max-plan OAuth (no API key in `bot/.env`). With `bare:true`, the CLI returned `"Not logged in · Please run /login"` and exited 1. Cron tips kept firing because they don't call the CLI.

The break happened between the last successful turn (May 12 12:12 UTC) and 2026-05-13, when CLI auth handling tightened. #511 didn't cause it but exposed it.

## What

Flips `bare: true` → `bare: false` in `concierge.ts`, `brief.ts`, `reflect.ts`. Adds a comment explaining the constraint so this doesn't get flipped back.

## Trade-off

`--bare` skipped CLAUDE.md auto-discovery + hooks + plugin sync. Without it, ZOE picks up the project's `CLAUDE.md` (~26K input tokens) on cold turns at ~$0.10/turn. Prompt-cache amortizes across the session. Acceptable for ZOE volume.

Long-term fix path (if cost becomes an issue): set `ANTHROPIC_API_KEY` in `bot/.env`, keep `bare:true`. List-rate API billing instead of Max subscription. Memory says Zaal prefers Max sub for now, so we stay on OAuth.

## Verified

```
ssh zaal@31.97.148.88 'cd /home/zaal/zao-os && claude -p "reply with literally just PONG" --model sonnet --output-format json --no-session-persistence --permission-mode auto --add-dir /home/zaal/zao-os'
-> is_error:false  result:"PONG"  total_cost_usd:$0.0984
```

## Test plan

- [ ] After merge: pull on VPS + `systemctl --user restart zoe-bot`
- [ ] DM `@zaoclaw_bot` ping
- [ ] Expect normal reply + `turn handled` log line