### PR TITLE
feat(zoe): grounding rules - grep research/ before answering

### DIFF
--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -64,6 +64,13 @@ MEMORY:
 - Long-term facts about Zaal are in <human> block. Treat as ground truth.
 - Open tasks are in <tasks> block. Update via JSON ops in your reply (see output format).
 
+GROUNDING (non-negotiable - doc 647d/647e):
+- Before answering ANY question about ZAO, The ZAO, ZAOstock, ZABAL, WaveWarZ, COC Concertz, a research doc, a project's status, or a community member: grep the research/ library FIRST. The repo is at your cwd.
+- Think about WHICH tool you need before calling it. One targeted Grep beats three vague ones.
+- Ground the answer in what the tool returned. Training knowledge is the fallback ONLY when grep/read come back empty - and when you fall back, say so.
+- When you cite a research doc, cite its number (e.g. "doc 647"). Do not invent doc numbers, file paths, or member facts. A wrong citation is worse than "I'd need to check."
+- If the question needs graph facts you cannot grep, output the RECALL query for Zaal to relay. Do not guess.
+
 OUTPUT FORMAT:
 Reply naturally to Zaal. If you want to add/update tasks OR captured a note, append at the END:
 


### PR DESCRIPTION
## Why

First actionable PR from doc 647 (agent quality deep research). Decision 1 in the hub - lowest effort, highest leverage.

Doc 647d found ZOE under-calls Grep: it answers ZAO questions from training knowledge instead of greping the 640+ doc research library first. Doc 647e: an invented citation is worse than "I'd need to check."

## What

Adds a `GROUNDING` section to `PERSONA_DEFAULT` in `bot/src/zoe/memory.ts`:

- grep `research/` FIRST on any ZAO / project / member / doc question
- think about which tool before calling it (647d: think-before-tool cuts tool errors 54%)
- ground answers in tool output; explicitly say so when falling back to training knowledge
- cite doc numbers, never invent them
- output a RECALL query instead of guessing graph facts

## Scope

`memory.ts` only. No overlap with #512 (`concierge.ts` / `brief.ts` / `reflect.ts`).

`PERSONA_DEFAULT` only seeds NEW installs. The live `~/.zao/zoe/persona.md` on the VPS gets the same section appended at deploy time (done in this session via SSH, append-only, preserves existing rules).

## Test plan

- [ ] After merge: pull on VPS (no restart needed - persona.md is re-read every turn)
- [ ] DM ZOE a ZAO question ("what is doc 647 about") - expect it to grep research/ before answering
- [ ] Confirm via journal: tool calls visible in the turn

Generated with [Claude Code](https://claude.com/claude-code)