### PR TITLE
feat(zoe): append-only conversation archive

### DIFF
--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -18,7 +18,7 @@
  */
 import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import type { ZoeTask } from './types';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
@@ -26,6 +26,7 @@ const PERSONA_PATH = join(ZOE_HOME, 'persona.md');
 const HUMAN_PATH = join(ZOE_HOME, 'human.md');
 const RECENT_DIR = join(ZOE_HOME, 'recent');
 const LEGACY_RECENT_PATH = join(ZOE_HOME, 'recent.json');
+const ARCHIVE_DIR = join(ZOE_HOME, 'archive');
 const TASKS_PATH = join(ZOE_HOME, 'tasks.json');
 const BOOTLOADER_PATH = join(ZOE_HOME, 'bootloader-template.md');
 
@@ -283,9 +284,23 @@ function recentPathFor(scope: ChatScope): string {
   return join(RECENT_DIR, `${scope}.json`);
 }
 
-export async function readRecent(
-  scope: ChatScope = 'private',
-): Promise<Array<{ from: 'zaal' | 'zoe' | 'other'; text: string; ts: string; sender?: string }>> {
+/**
+ * Archive path for a chat, partitioned by month so files stay scannable.
+ * ~/.zao/zoe/archive/<scope>/<yyyy-mm>.jsonl
+ */
+function archivePathFor(scope: ChatScope, when: Date): string {
+  const month = when.toISOString().slice(0, 7); // yyyy-mm
+  return join(ARCHIVE_DIR, String(scope), `${month}.jsonl`);
+}
+
+export interface RecentTurn {
+  from: 'zaal' | 'zoe' | 'other';
+  text: string;
+  ts: string;
+  sender?: string;
+}
+
+export async function readRecent(scope: ChatScope = 'private'): Promise<RecentTurn[]> {
   await ensureZoeHome();
   const path = recentPathFor(scope);
   try {
@@ -296,13 +311,63 @@ export async function readRecent(
   }
 }
 
+/**
+ * Append-only conversation log. Never truncated - this is ZOE's long-term
+ * memory of every turn, the source for soul exports and future retrieval.
+ * The recent.json ring buffer (RECENT_MAX turns) is just the prompt window;
+ * this archive is the permanent record.
+ */
+export async function appendArchive(turn: RecentTurn, scope: ChatScope = 'private'): Promise<void> {
+  const path = archivePathFor(scope, new Date(turn.ts));
+  await fs.mkdir(dirname(path), { recursive: true });
+  await fs.appendFile(path, JSON.stringify(turn) + '\n', 'utf8');
+}
+
+/**
+ * Read archived turns for a chat. Without `month`, concatenates every month
+ * file for the scope in chronological order.
+ */
+export async function readArchive(
+  scope: ChatScope = 'private',
+  month?: string,
+): Promise<RecentTurn[]> {
+  const dir = join(ARCHIVE_DIR, String(scope));
+  let files: string[];
+  try {
+    files = (await fs.readdir(dir)).filter((f) => f.endsWith('.jsonl')).sort();
+  } catch {
+    return [];
+  }
+  if (month) files = files.filter((f) => f === `${month}.jsonl`);
+  const turns: RecentTurn[] = [];
+  for (const file of files) {
+    const raw = await fs.readFile(join(dir, file), 'utf8');
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        turns.push(JSON.parse(line) as RecentTurn);
+      } catch {
+        // skip a corrupt line rather than fail the whole read
+      }
+    }
+  }
+  return turns;
+}
+
 export async function pushRecent(
   turn: { from: 'zaal' | 'zoe' | 'other'; text: string; sender?: string },
   scope: ChatScope = 'private',
 ): Promise<void> {
   await ensureZoeHome();
+  const stamped: RecentTurn = { ...turn, ts: new Date().toISOString() };
+
+  // Permanent append-only archive first - this must not be lost even if the
+  // ring-buffer write below fails.
+  await appendArchive(stamped, scope);
+
+  // Ring buffer: last RECENT_MAX turns, the prompt window.
   const recent = await readRecent(scope);
-  recent.push({ ...turn, ts: new Date().toISOString() });
+  recent.push(stamped);
   while (recent.length > RECENT_MAX) recent.shift();
   await fs.writeFile(recentPathFor(scope), JSON.stringify(recent, null, 2), 'utf8');
 }
@@ -382,6 +447,7 @@ export const ZOE_PATHS = {
   persona: PERSONA_PATH,
   human: HUMAN_PATH,
   recent_dir: RECENT_DIR,
+  archive_dir: ARCHIVE_DIR,
   tasks: TASKS_PATH,
   bootloader: BOOTLOADER_PATH,
 };


### PR DESCRIPTION
## Why

ZOE's only memory of past turns was the `recent.json` ring buffer - 8 turns per chat. Everything older was overwritten and gone forever.

ZOE flagged this herself in the 2026-05-14 session export:
> "anything past 8 turns is gone forever ... all prior conversations cannot be packaged - they were never persisted."

This is the fix that makes "package up all prior conversations" actually possible - going forward.

## What

Append-only archive alongside the ring buffer:

- `~/.zao/zoe/archive/<scope>/<yyyy-mm>.jsonl` - one JSON turn per line, partitioned by month
- `appendArchive()` - never truncates
- `readArchive(scope, month?)` - concatenates month files chronologically, skips corrupt lines rather than failing the whole read
- `pushRecent()` writes the archive FIRST (must not be lost if the ring-buffer write fails), then updates the ring buffer
- `RecentTurn` is now an exported interface

The ring buffer stays the prompt window. The archive is the permanent record - source for soul exports and future retrieval.

## Scope

`memory.ts` only. Overlaps region-wise with #514 (also `memory.ts`, but #514 touches the `PERSONA_DEFAULT` string constant - different region, git auto-merges).

## Deploy

Hotpatched on VPS in this session (scp + restart). This PR makes it durable.

## Note on the soul export

This does NOT recover lost history - turns before this deploy were never persisted and are gone. It stops the bleed from here forward. Aligns with doc 647b (memory architectures) phase 1.

## Test plan

- [ ] DM ZOE - confirm `~/.zao/zoe/archive/private/2026-05.jsonl` gets a line per turn
- [ ] Group turn - confirm `~/.zao/zoe/archive/-5290743750/2026-05.jsonl`
- [ ] `readArchive('private')` returns all turns chronologically

Generated with [Claude Code](https://claude.com/claude-code)