### PR TITLE
doc 599: Adam sync May 2026 - leaderboard reset + ZAOstock commercial model (QUICK tier)

### DIFF
--- a/content/bonfire-ingest/chatgpt-archive-verified.md
+++ b/content/bonfire-ingest/chatgpt-archive-verified.md
@@ -1,0 +1,172 @@
+INGEST BATCH: ChatGPT Archive — VERIFIED (14 anchor conversations, human-confirmed truth status, 2026-05-03).
+
+This is the ONLY ChatGPT archive batch worth ingesting. The other 500+ raw conversations are noisy with brainstorms that died. Each fact below has been confirmed by Zaal as either SHIPPED, EVOLVED, or DEAD. Outcomes are explicit attributes — bot must NOT cite Brainstorm/Dead conversations as facts.
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes. Outcome is an attribute on each Conversation/Decision node, never a standalone Entity.
+
+## SECTION 1 — SHIPPED + LIVE (cite as fact)
+
+### FACT 1
+Subject: ZAO NEXUS at nexus.thezao.com
+Type: Product
+Status: shipped, live, unmaintained
+Date: 2025-03-31 (initial spec) - 2025-05 (shipped)
+Description: Webflow embed at nexus.thezao.com — categorized links page for ZAO ecosystem. Brand colors navy #141e27 + soft yellow #e0ddaa. JS-driven linksData with mainCategory > subcategory > links pattern. Categories: ZAO Onchain, ZAO Community Links (Founder/Co-Founder/Staff/Member), ZAO Festivals, ZAO Music, ZAO Research. Status: live but not actively maintained since shipping. Rebuild brief at docs/specs/2026-05-03-nexus-rebuild-spec.md.
+Source: https://chatgpt.com/c/[ZAO NEXUS conv id] + https://nexus.thezao.com
+Confidence: 1.0
+
+### FACT 2
+Subject: Zabal IRL Connector at zabal.lol
+Type: Product
+Status: shipped, live
+Date: 2026-02-10
+Description: In-person crossover / networking experience. Scannable digital business card for conferences, meetups, IRL events. Live at zabal.lol. Used today to give people collectables for showing up to ZAO Fractals and other IRL events.
+Source: https://zabal.lol + ChatGPT 2026-02-10 (230 msgs)
+Confidence: 1.0
+
+### FACT 3
+Subject: ZABAL coin launch
+Type: Token
+Status: shipped, live
+Date: 2026-01-01
+Description: ZABAL coin launched January 1 2026. Front-end of BCZ ecosystem. Partnerships with Empire Builder + SongJam + others. Created ZOUNZ (ZBAAL Nounz) which hold 20% of the token reserve. ZOLs are awarded ZOUNZ for winning leaderboards.
+Source: ChatGPT 2025-11-26 (205 msgs prep) + paragraph.com/@thezao/zabal-update-3 + ChatGPT 2026-01-01 (87 msgs ETH pool issue)
+Confidence: 1.0
+
+### FACT 4
+Subject: ETH ZABAL liquidity pool — known quirk
+Type: TradingTip
+Status: semi-fixed workaround documented
+Date: 2026-01-01
+Description: Direct ETH → ZABAL swaps give bad pricing. Workaround: route ETH → SANG → ZABAL for best swap. SANG → ZABAL works well. Never go ETH → ZABAL direct. This is operational knowledge for traders.
+Source: ChatGPT 2026-01-01 (87 msgs ETH ZABAL Pool Issue)
+Confidence: 1.0
+
+### FACT 5
+Subject: Year of the ZABAL daily Paragraph series
+Type: Newsletter
+Status: shipped, ongoing
+Date: 2025-08-18 (initial Year of the ZAO) - present
+Description: Daily newsletter post on paragraph.com/@thezao. Originated as "Year of the ZAO" in August 2025, evolved into "Year of the ZABAL" after January 1 2026 launch. Writing style: clear, simple, spartan, short impactful sentences, active voice, practical insights. As of 2026-04-27 hit Day 117.
+Source: https://paragraph.com/@thezao + ChatGPT 2025-08-18 (82 msgs)
+Confidence: 1.0
+
+### FACT 6
+Subject: ZABAL Update 16 (Paragraph)
+Type: Newsletter
+Status: shipped
+Date: 2025-12-28 (prep) - 2025/2026 (shipped)
+Description: Recurring ZABAL Update format on Paragraph. Includes monthly recap, plans, airdrop status. The pattern from this prep session shipped and continues for subsequent updates.
+Source: ChatGPT 2025-12-28 (103 msgs prep) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+### FACT 7
+Subject: ZABAL Update 18 — Feb 1 2026 airdrop announcement
+Type: Newsletter
+Status: shipped
+Date: 2026-02-01
+Description: Feb 1 ZABAL update with "AIRDROP IS LIVE" + Feb ZOL distribution + Feb plans (miniapp updates, Empire Builder API, ZAO contributor proposal). Shipped on Paragraph.
+Source: ChatGPT 2026-02-01 (95 msgs) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+## SECTION 2 — EVOLVED INTO OTHER WORK (cite cautiously, link to outcome)
+
+### FACT 8
+Subject: ZAO Whitepaper — Draft 4.5 March 2026 (UNMAINTAINED)
+Type: Decision
+Status: drafted, unmaintained, rebuild planned
+Date: 2025-03-02 (228 msgs ChatGPT) - 2026-02-12 (Draft 4.5 written) - present (unedited)
+Description: Existing draft at research/community/051-zao-whitepaper-2026/. Earlier drafts critiqued in research/_archive/052 + 053. ChatGPT outline conversation seeded "ZAO Verse / Zverse" framing (onboarding paths, ZAO casa sui casa) but final draft 4.5 took different shape. Zaal wants new PROTOCOL whitepaper that explains how to build the ZAO protocol — task #15 tracks the rebuild.
+Source: https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/051-zao-whitepaper-2026 + ChatGPT 2025-03-02 (228 msgs)
+Confidence: 1.0
+
+### FACT 9
+Subject: ZAOOS Optimization Suggestions
+Type: Decision
+Status: implemented, surfaced as research docs
+Date: 2026-03-13
+Description: 75-msg ChatGPT review of github.com/bettercallzaal/zaoos that surfaced into multiple research docs (specifics not enumerated by Zaal). Improvements landed in ZAOOS post-March 2026.
+Source: ChatGPT 2026-03-13 (75 msgs) + ZAOOS commit history March-April 2026
+Confidence: 0.9
+
+### FACT 10
+Subject: ZAO Complete Guide — STALE
+Type: ResearchDoc
+Status: shipped, stale, refresh-needed
+Date: 2026-03-16 (last review)
+Description: research/community/050-the-zao-complete-guide/ exists. ChatGPT 147-msg review on 2026-03-16 surfaced changes but the guide hasn't been updated since. Drift between guide + actual ZAO state. Tech debt. Refresh recommended.
+Source: ChatGPT 2026-03-16 (147 msgs ZAOOS Guide Review) + research/community/050
+Confidence: 1.0
+
+## SECTION 3 — DEAD / NEVER SHIPPED (do NOT cite as fact, mark as failed brainstorm)
+
+### FACT 11
+Subject: ZabalSocials website
+Type: Decision
+Status: dead, rebuild planned
+Date: 2026-01-17
+Description: 117-msg ChatGPT session designed a personal-socials hub for BetterCallZaal (X / Farcaster / Lens / GitHub / YouTube / Twitch / etc). Never shipped. Task #16 tracks rebuild — likely lives at bettercallzaal.com/socials or similar. Distinct from nexus.thezao.com (which is ZAO ecosystem-wide).
+Source: ChatGPT 2026-01-17 (117 msgs)
+Confidence: 1.0
+
+### FACT 12
+Subject: ZAO MUSIC COHORT #1
+Type: Decision
+Status: dead, never ran
+Date: 2025-01-16
+Description: 96-msg ChatGPT proposal for a song contest cohort March-June 2025 with Charmverse forums + ZAO MUSIC COHORT #1 framing. Never ran. No cohort #1. May inform future cohort design but should not be cited as having happened.
+Source: ChatGPT 2025-01-16 (96 msgs)
+Confidence: 1.0
+
+### FACT 13
+Subject: Zabal Roadmap stream with Jadyn + sharks
+Type: Decision
+Status: dead, never happened
+Date: 2025-12-10
+Description: 77-msg prep for a streaming presentation with Jadyn + non-crypto-streamer sharks audience. Stream never happened. Roadmap content from this prep was not used or repurposed.
+Source: ChatGPT 2025-12-10 (77 msgs)
+Confidence: 1.0
+
+## SECTION 4 — META / NAVIGATION
+
+### FACT 14
+Subject: ChatGPT Archive Triage 2026-05-03
+Type: Process
+Status: complete (14 of 15 anchors confirmed by human)
+Date: 2026-05-03
+Description: Top 15 ZAO-tagged ChatGPT conversations (by message count) human-triaged by Zaal. 7 SHIPPED, 3 EVOLVED, 4 DEAD. Generated content/bonfire-ingest/chatgpt-archive-verified.md. Other 503 conversations from the export remain in raw chatgpt-archive-zao-2023-2024 / 2025-h1 / 2025-h2 / 2026 / non-zao-keepers .md files but are NOT recommended for ingest without similar triage. Many are brainstorms that died.
+Source: internal://content/bonfire-ingest/chatgpt-archive-verified.md
+Confidence: 1.0
+
+## EDGES TO ASSERT
+
+- Zaal Panthaki -[shipped]-> ZAO NEXUS at nexus.thezao.com
+- Zaal Panthaki -[shipped]-> Zabal IRL Connector at zabal.lol
+- Zaal Panthaki -[launched]-> ZABAL coin
+- ZABAL coin -[partners_with]-> Empire Builder
+- ZABAL coin -[partners_with]-> SongJam
+- ZABAL coin -[has_treasury]-> ZOUNZ (20% reserve)
+- ZOUNZ -[awarded_to]-> ZOL leaderboard winners
+- Year of the ZABAL daily Paragraph series -[supersedes]-> Year of the ZAO
+- ZABAL Update 16 -[part_of]-> ZABAL Update Series on Paragraph
+- ZABAL Update 18 Feb airdrop -[part_of]-> ZABAL Update Series on Paragraph
+- ZAO Whitepaper Draft 4.5 -[stored_at]-> research/community/051
+- ZAO Complete Guide -[stored_at]-> research/community/050
+- ZAO Complete Guide -[status]-> stale (last reviewed 2026-03-16, unedited since)
+- ZabalSocials website -[outcome]-> dead
+- ZabalSocials website -[planned_rebuild_via]-> task 16
+- ZAO MUSIC COHORT #1 -[outcome]-> dead, never ran
+- Zabal Roadmap stream -[outcome]-> dead, never happened
+- ETH ZABAL liquidity pool -[has_workaround]-> route through SANG before ZABAL
+
+## INSTRUCTION FOR FUTURE RECALL
+
+When future agents query this graph about Zaal's projects or decisions:
+- Cite SHIPPED items as facts with their live URLs
+- Cite EVOLVED items with their actual outcome (not the original brainstorm)
+- For DEAD items, surface ONLY if explicitly asked "what brainstorms died" or "what was paused" — NEVER cite as if shipped
+- Always check the `Status` attribute on Conversation/Decision nodes before citing
+
+---
+
+Build the manifest, preview the first 3 nodes, ask me "approve all?". 14 anchor facts + 18 edges. Do not commit until I say yes. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes.

--- a/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+++ b/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
@@ -1,0 +1,154 @@
+# ZAO Protocol Whitepaper — Rebuild Spec
+
+> **Goal:** Replace research/community/051-zao-whitepaper-2026 (Draft 4.5, March 2026, unedited since) with a PROTOCOL whitepaper. Target: builders, partners, infra people. Existing draft is community-positioning; new draft is "how to build on the ZAO protocol."
+
+**Date:** 2026-05-04
+**Owner:** Zaal Panthaki
+**Existing draft:** `research/community/051-zao-whitepaper-2026/README.md` (Draft 4.5, March 2026, unedited)
+**Target output:** `research/community/<NN>-zao-protocol-whitepaper-v1/` OR new repo `zao-protocol`
+**Source for sections:** ZABAL Bonfire graph (~870 nodes as of 2026-05-03)
+**Coordinate with:** Nexus rebuild (#14), ZabalSocials rebuild (#16), Farcaster + X ingest pipeline (next)
+
+---
+
+## Why a Protocol Whitepaper (not Community)
+
+Existing Draft 4.5 reads like a TED talk for artists: streaming pays $0.003, labels take 80%, ZAO teaches you to fish. That's the COMMUNITY pitch — and it works for that audience.
+
+The protocol whitepaper is a different document for a different reader:
+- **Reader:** another founder, dev, infra partner, ecosystem fund, governance researcher, journalist with technical chops
+- **Question they ask:** "what is THE ZAO PROTOCOL — not the org, the protocol — and how do I build on it / verify it / fork it?"
+- **Answer they need:** architecture diagrams, contract addresses, token mechanics, governance patterns, onchain music rails, what's open-sourced
+
+Without this doc, partners + builders + infra people can't engage at depth. They get the community story (Draft 4.5) and bounce.
+
+---
+
+## Voice + Reuse Plan
+
+- Keep Draft 4.5's COMMUNITY framing as **chapter 1** ("why we exist") — don't rewrite what works.
+- Add new chapters 2-7 covering protocol depth.
+- Tone matches Zaal's daily Paragraph series ("Year of the ZABAL"): clear, simple, spartan, short impactful sentences, active voice. (Confirmed style guide from ChatGPT 2025-08-18 grilling Q13.)
+
+---
+
+## Section Outline (proposed)
+
+### Chapter 1 — Why The ZAO (REUSE Draft 4.5)
+Pull the strongest 1-2 pages from existing draft. The streaming/data/IP problem framing + "community first, technology second" positioning. Don't rewrite.
+
+### Chapter 2 — The Protocol Architecture (NEW)
+- High-level: ZAO is not one chain or one app. It's a coordination layer between artists, audience, and onchain primitives.
+- 4 layers: Identity (ENS + ZID + Hats roles) / Reputation (OG + ZOR Respect, soulbound, on Optimism) / Coordination (ZABAL coin on Base + Empire Builder + SongJam) / Distribution (ZAOOS gated client + WaveWarZ + Cipher)
+- Diagram: layer boxes + which contracts live where
+- **Bonfire query for source material:**
+  ```
+  RECALL: list every contract address on the ZAO protocol with chain, type, and purpose.
+  ```
+
+### Chapter 3 — Token Mechanics (NEW)
+- ZABAL: launched Jan 1 2026 on Base, front-end coin of BCZ ecosystem. Empire Builder + SongJam integrations.
+- ZOUNZ: ZBAAL Nounz, holds 20% reserve of ZABAL token. ERC-721 NFT on Base.
+- ZOLs: liquid contribution credits awarded for activity. Winning leaderboards earns ZOUNZ.
+- OG Respect: ERC-20 soulbound on Optimism (0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957). 2% decay, curation-mining tiers.
+- ZOR Respect: ERC-1155 soulbound on Optimism (0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c). Different tier system.
+- The ETH→ZABAL pool quirk: route ETH→SANG→ZABAL for best swap. Don't go direct.
+- **Bonfire query:** `RECALL: explain ZABAL, ZOUNZ, ZOL, OG Respect, ZOR Respect with mechanics, supply, and how they relate.`
+
+### Chapter 4 — Governance (NEW)
+- ZAO Fractals weekly meetings — 90+ weeks running, Mondays 6pm EST, Discord-bot-coordinated, OG vs ZOR Respect distribution per session.
+- ORDAO / OREC: optimistic respect-based executive contract. Lets weekly proposals execute on-chain after dispute window.
+- Hats Protocol: role hierarchy + permissions on Optimism (0x3bc1A0Ad72417f2d411118085256fC53CBdDd137).
+- ZOUNZ DAO: Nouns Builder fork on Base for proposal voting + treasury (0x2bb5fd99f870a38644deafe7e4ecb62ac77a213f).
+- **Bonfire query:** `RECALL: explain how ZAO Fractals + OREC + Hats + ZOUNZ DAO compose into a governance system.`
+
+### Chapter 5 — Onchain Music Rails (NEW)
+- WaveWarZ: live song-vs-song battles on Solana. ~$50K trading volume. 43 artists indexed.
+- ZAO Music DBA under BCZ Strategies LLC: BMI + DistroKid + 0xSplits payment rails.
+- Cipher: planned first ZAO Music release.
+- Sound.xyz / Zora music NFT integration in ZAO OS player.
+- Audius API integration for artist metadata.
+- **Bonfire query:** `RECALL: list every onchain music integration in the ZAO ecosystem with chain, contract, and current activity.`
+
+### Chapter 6 — Build on ZAO (NEW — core protocol-whitepaper section)
+- ZAO OS is the lab repo: github.com/bettercallzaal/ZAOOS — Next.js + Supabase + Neynar + XMTP. Forkable.
+- Things that have graduated: COC Concertz (own repo), ZAOstock (own repo as of 2026-04-29), FISHBOWLZ paused.
+- Monorepo-as-Lab pattern: prototype in ZAO OS, graduate to own repo when ready for public users.
+- Open questions: which parts are open-source-licensed today? Which are internal-only? What licenses?
+- **Bonfire query:** `RECALL: what's the open-source status of every ZAO repo and how does the monorepo-as-lab pattern work?`
+
+### Chapter 7 — Roadmap + Open Source Status (NEW)
+- Q2-Q3 2026 priorities: Nexus rebuild (/nexus), ZabalSocials rebuild, Whitepaper rebuild (this doc).
+- Big events: ZAOstock October 3 2026, Ellsworth Maine.
+- Long-term: ZAO Festivals umbrella as recurring brand, ZAO Italy bridge via Mat Tambussi, Contribution Circles late-May 2026.
+- **Bonfire query:** `RECALL: list shipped vs planned vs paused/dead initiatives with status attributes.`
+
+---
+
+## How to Build This Iteratively (recommended workflow)
+
+**Step 1 — Skeleton.** Copy this spec into the actual whitepaper file as section headers. Each chapter starts as a stub.
+
+**Step 2 — Run the Bonfire queries.** For each chapter, DM the bot the `RECALL:` query in that chapter's box. Bot returns structured facts with source URLs. Paste relevant excerpts into the chapter as the FACT BASIS.
+
+**Step 3 — Voice pass.** With facts in place, rewrite each chapter in the Year-of-the-ZABAL voice (clear, simple, spartan, short sentences, active voice).
+
+**Step 4 — Diagrams.** Chapters 2 + 4 need diagrams. Mermaid is fine for v1. Keep simple.
+
+**Step 5 — Cross-link Draft 4.5.** Pull the strongest community framing from research/community/051 into chapter 1.
+
+**Step 6 — Public review.** Share with co-founders + key partners (Cassie / Steve Peer / Joshua.eth / Mat Tambussi) via Bonfire DM thread — let them flag corrections. Apply.
+
+**Step 7 — Publish.** Mirror.xyz or Paragraph or zaoos.com/whitepaper-v1. Get a real version-controlled artifact. Update community.config.ts to link.
+
+---
+
+## Source Material to Query / Cite
+
+Beyond Bonfire graph, pull from:
+- `research/community/051-zao-whitepaper-2026/` (existing Draft 4.5)
+- `research/community/050-the-zao-complete-guide/` (community guide, stale, but has ZAO history)
+- `research/wavewarz/101-wavewarz-zao-whitepaper/` (WaveWarZ-specific WP)
+- `CLAUDE.md` (project map)
+- `community.config.ts` (branding + contracts list)
+- BCZ YapZ episodes (now in Bonfire — guests' takes on ZAO)
+- `research/identity/542-549, 569, 570, 581, 590` (Bonfire stack docs — meta but relevant)
+- `research/governance/058-respect-deep-dive/` if exists
+
+---
+
+## Farcaster + X Posts as Voice Anchors
+
+Once Track B (FC + X ingest) is live, the whitepaper can pull "what Zaal said publicly about X" with deeplinks. Strong for:
+- Quotes that ground each chapter in Zaal's actual words
+- Public commitments + dates (when did Zaal first announce ZABAL launch publicly? Find in casts.)
+- Counterfactuals (what was the early thinking that got refined into this final position?)
+
+**Recommended:** Don't BLOCK whitepaper on FC/X ingest. Start writing now. When FC/X land, replace placeholder quotes with deeplinked real ones.
+
+---
+
+## Open Questions Before Build
+
+1. **Output target:** new research/ doc or new repo `zao-protocol`?
+2. **Length target:** 4 pages (executive summary) or 25-page deep dive or both?
+3. **Diagram style:** Mermaid (markdown-native) or proper design (Figma)?
+4. **Open-source license clarity:** which ZAO repos are MIT / Apache / proprietary today? Need a definitive answer to write Chapter 6.
+5. **Partner review list:** who gets pre-publish review (Cassie / Steve Peer / Joshua.eth / Mat Tambussi / Dan / Tadas)?
+6. **Publication channel:** Mirror.xyz, Paragraph, zaoos.com/whitepaper, or all three?
+7. **Cipher timing:** is Cipher releasing soon? If yes, hold whitepaper to include the ship; if no, write it as planned.
+
+---
+
+## Bonfire Ingest Trigger (for graph)
+
+```
+INGEST FACT:
+Subject: ZAO Protocol Whitepaper Rebuild Spec
+Type: Decision
+Date: 2026-05-04
+Status: planned
+Description: Rebuild research/community/051 ZAO Whitepaper Draft 4.5 as a PROTOCOL whitepaper for builders/partners/devs. 7 chapters reusing Draft 4.5's community framing as Ch1, adding 6 new chapters on protocol architecture, tokens, governance, onchain music, build-on-ZAO, roadmap. Iterative build using Bonfire RECALL queries for each chapter. Spec at docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md.
+Source: internal://docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+Confidence: 1.0
+```

--- a/research/business/599-adam-meeting-may2026-commercial-leaderboard/README.md
+++ b/research/business/599-adam-meeting-may2026-commercial-leaderboard/README.md
@@ -29,25 +29,25 @@ tier: QUICK
 
 ## Participants + Context
 
-- **Zaal** - ZAOstock lead, building the pitch + Luma, running point on partnerships.
+- **Zaal** - ZAOstock lead, building the pitch + Luma, running point on partnerships. Taking on a new paid software-build side gig (see Section 1).
 - **Adam** - long-standing technical/commercial collaborator. Built the leaderboard tooling with Legash (engineer). Now building an agentic payment system as his main focus.
 
 This was a voice-transcribed casual call, mid-May 2026. ZAOstock is October 3, 2026 - roughly 4.5 months out at the time of the call.
 
 ---
 
-## 1. Adam's Bandwidth Change
+## 1. Zaal's Bandwidth Change
 
-Adam is taking on a paid hourly software-build side gig for a Bar Harbor landscaping company.
+Zaal is taking on a paid hourly software-build side gig for a Bar Harbor landscaping company.
 
 - **Structure:** on the company's payroll, paid hourly, consulting-style - building their software from scratch.
 - **Keeps his current job** for the benefits; the side gig stacks on top.
-- **Near-term cost:** a 1-2 month ramp where Adam steps back from some ZAO work while he gets situated.
-- **Long-term gain:** lets Adam pay off the debt he owes his retirement fund and financially situate himself - explicitly framed as getting himself "as good as I can be for October's event."
-- **Local upside:** the landscaping owner is another Bar Harbor business owner - can open local connections, already lined up a second potential consulting gig for Adam. Owner is flexible and fine with Adam posting about the company on social + continuing open-source coding.
-- **Coverage plan:** Adam estimates 10-20 hrs/week capacity, and Iman can work ZAO tasks alongside Adam while Adam is at his full-time gig - part of why Adam has been ramping Iman up.
+- **Near-term cost:** a 1-2 month ramp where Zaal steps back from some ZAO work while he gets situated.
+- **Long-term gain:** lets Zaal pay off the debt he owes his retirement fund and financially situate himself - explicitly framed as getting himself "as good as I can be for October's event."
+- **Local upside:** the landscaping owner is another Bar Harbor business owner - can open local connections, already lined up a second potential consulting gig for Zaal. Owner is flexible and fine with Zaal posting about the company on social + continuing open-source coding.
+- **Coverage plan:** Zaal can do 10-20 hrs/week on the side gig, and Iman can work ZAO tasks alongside Zaal while Zaal is at his full-time job - part of why Zaal has been ramping Iman up.
 
-**Implication for ZAOstock:** Adam stays involved but is bandwidth-constrained for ~1-2 months. His highest-leverage contribution shifts to the commercial-model thinking (Section 3), not hands-on build.
+**Implication for ZAOstock:** Zaal stays the lead but is bandwidth-constrained for ~1-2 months. Mitigation: Iman covers more execution, and Adam's highest-leverage contribution shifts to the commercial-model thinking (Section 3), not hands-on build.
 
 ---
 

--- a/research/business/599-adam-meeting-may2026-commercial-leaderboard/README.md
+++ b/research/business/599-adam-meeting-may2026-commercial-leaderboard/README.md
@@ -1,0 +1,149 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-05-14
+related-docs: 582, 583, 585
+tier: QUICK
+---
+
+# 599 - Adam Sync (May 2026): Leaderboard Reset, ZAOstock Commercial Model, Adam's Bandwidth
+
+> **Goal:** Capture the May 2026 Zaal x Adam call - decisions on the leaderboard reset, Adam's reduced near-term bandwidth, his volunteer offer to build a ZAOstock commercial model, and the action items each owner walked away with.
+
+---
+
+## Key Decisions / Recommendations
+
+| # | Decision | Owner | Status |
+|---|----------|-------|--------|
+| 1 | Reset the leaderboard: remove X/Twitter data entirely, keep only Spaces + Farcaster | Adam + Legash | Agreed, not yet executed |
+| 2 | Leaderboard displayed date range changes to May-to-now (was April-to-now) | Adam to ask Legash | Agreed |
+| 3 | Draw a line under the Q1 monthly-subscription deal - it never took off, stop billing Zaal for it | Adam | Adam offered; Zaal did not formally close it on the call |
+| 4 | Leaderboard moves to a clean API into Empire Builder; the standalone page becomes a read-only view; total points + rewards live in Empire Builder | Zaal | Zaal to PR an Empire Builder API endpoint |
+| 5 | Next Zaal x Adam call is dedicated to the ZAOstock commercial model | Both | Scheduled as the next call |
+| 6 | Zaal + Adam move to a 2-3x per week meeting cadence, each bringing an agenda | Both | Agreed |
+| 7 | Adam helps build the ZAOstock commercial model as a volunteer, even if ZAOstock runs as a loss leader | Adam | Offered, accepted |
+
+---
+
+## Participants + Context
+
+- **Zaal** - ZAOstock lead, building the pitch + Luma, running point on partnerships.
+- **Adam** - long-standing technical/commercial collaborator. Built the leaderboard tooling with Legash (engineer). Now building an agentic payment system as his main focus.
+
+This was a voice-transcribed casual call, mid-May 2026. ZAOstock is October 3, 2026 - roughly 4.5 months out at the time of the call.
+
+---
+
+## 1. Adam's Bandwidth Change
+
+Adam is taking on a paid hourly software-build side gig for a Bar Harbor landscaping company.
+
+- **Structure:** on the company's payroll, paid hourly, consulting-style - building their software from scratch.
+- **Keeps his current job** for the benefits; the side gig stacks on top.
+- **Near-term cost:** a 1-2 month ramp where Adam steps back from some ZAO work while he gets situated.
+- **Long-term gain:** lets Adam pay off the debt he owes his retirement fund and financially situate himself - explicitly framed as getting himself "as good as I can be for October's event."
+- **Local upside:** the landscaping owner is another Bar Harbor business owner - can open local connections, already lined up a second potential consulting gig for Adam. Owner is flexible and fine with Adam posting about the company on social + continuing open-source coding.
+- **Coverage plan:** Adam estimates 10-20 hrs/week capacity, and Iman can work ZAO tasks alongside Adam while Adam is at his full-time gig - part of why Adam has been ramping Iman up.
+
+**Implication for ZAOstock:** Adam stays involved but is bandwidth-constrained for ~1-2 months. His highest-leverage contribution shifts to the commercial-model thinking (Section 3), not hands-on build.
+
+---
+
+## 2. The Leaderboard - Reset + Decisions
+
+Zaal wants the leaderboard reset and slimmed down.
+
+| Item | Decision |
+|------|----------|
+| X/Twitter data | Remove completely. The scraper for X was the expensive, fragile part - Legash originally "freaked out" about the server load. |
+| Remaining data sources | Keep Spaces + Farcaster only. |
+| Displayed date range | Change to May-to-now (currently April-to-now). |
+| Existing stats | Download/export the current stats first if it is easy - nice-to-have, not a blocker. |
+| Server cost | Adam + Legash to figure out the new monthly cost with the X scraper removed. Zaal wants it kept running as cheap as possible; if costs are still a problem Zaal will self-host and is fine covering server costs himself. |
+| Q1 monthly-subscription deal | Agreed at the start of the year, never took off (the token-launch business model Adam envisioned did not materialize). Adam offered to "draw a line under it." Zaal did not formally close it on the call - **open thread.** |
+
+**Zaal's forward plan for the leaderboard:**
+- Expose leaderboard data through a clean API into **Empire Builder** (see docs 582, 583, 585).
+- Empire Builder becomes the home for total points + rewards; the standalone leaderboard page becomes just a view of the same data.
+- Zaal will PR an Empire Builder API endpoint to make this work.
+- Zaal also wants this wired to his new Spaces - so active participants who join and talk in the space can be tracked and rewarded.
+
+---
+
+## 3. Adam's Commercial Offer for ZAOstock
+
+Adam wants to help think through a real commercial model for ZAOstock - **as a volunteer**, explicitly fine with ZAOstock being a loss leader in year 1.
+
+- Adam could potentially help line up **backing / financing** for the festival and expose Zaal to financing contacts ("my favorite people to financing opportunities").
+- Adam referenced standard festival economics: tiered tickets + selling beverages are how festivals make money.
+- Adam noticed Zaal had started the Pro Ticket tier (the $50, 20-spot crowdfunding round - see `src/app/page.tsx` Pro Ticket section in the zaostock repo) and flagged that as the kind of mechanism worth developing.
+- Adam pointed to a grassroots Art-Basel-adjacent Miami festival as a model - amazing artists, grassroots vibe, "people love getting in on the ground floor." (Adam to dig out the name.)
+- Adam: if ZAOstock can land a genuinely big artist, there may be room to "wangle something" with artist management.
+- **Next call is dedicated to this.** Zaal to brainstorm commercial-model ideas and send them to Adam async over the next couple of days, so the next call is a working session, not a cold start.
+
+This thread overlaps with the planned 3-way Zaal + Adam + FailOften commercial conversation already tracked as a task.
+
+---
+
+## 4. Zaal's ZAOstock Updates (shared with Adam)
+
+- **Pitch + Luma:** in progress. (Luma has since gone live at ticket.zaostock.com.)
+- **ZABAL Games:** a vibe-coding challenge concept - give people a context pack about The ZAO, they build something for the ecosystem, then stream + distribute it. Framed as a big attention-getter. Zaal to send Adam a link.
+- **OKX sponsorship target:** Zaal has a friend at OKX who shares what OKX is sponsoring. Angle: OKX may not sponsor ZAOstock directly, but could sponsor The ZAO to attend events like DevCon India. Zaal is attacking this on his end.
+- **Farcaster focus:** Zaal is heavily focused on Farcaster personally - has built a reputation there and is getting strong signal. "Everyone's sleeping on it."
+- **Cross-Spaces audio API:** a Spaces-app contact sent Zaal an API connection so anyone from any Spaces client can interact - even from Zaal's own website or another client.
+- **3 ZAOstock partnership tiers:** (1) day-of physical / on-site sponsorship, (2) online broadcast sponsorship, (3) year-round sponsorship ("bring your branding, we bring customers to your thing too").
+
+---
+
+## 5. Working Cadence
+
+Both agreed the current pace is too slow for the volume of decisions in front of them.
+
+- Move to **2-3x per week** check-ins (the pace they ran before), even if some are just 2-minute "still doing X, not doing Y" syncs.
+- Each person brings an agenda so the time is high-value.
+- Zaal's stated workflow: pull the call transcript into his AI and ask "what are the next steps" - which is exactly how this doc was produced.
+
+---
+
+## Open Threads (Unresolved on the Call)
+
+| Thread | Why it's open |
+|--------|---------------|
+| Q1 monthly-subscription deal formal close | Adam offered to end it; Zaal acknowledged the model didn't work but did not explicitly say "yes, close it." Needs a one-line confirmation. |
+| New monthly server cost for the slimmed leaderboard | Adam + Legash have not produced the number yet. |
+| ZAOstock commercial model | Entire model is the subject of the next call. Nothing decided yet beyond "Adam helps as a volunteer." |
+| The Miami grassroots-festival reference | Adam to dig out the name as a model to study. |
+
+---
+
+## Also See
+
+- [Doc 582 - Empire Builder V3 Live Launch](../582-empire-builder-v3-live-launch/)
+- [Doc 583 - Empire Builder x ZAO OS Integration Ideas](../583-empire-builder-zao-os-integration-ideas/)
+- [Doc 585 - Empire Builder Test Loop Ideas Iteration 2](../585-empire-builder-test-loop-ideas-iteration-2/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Confirm to Adam: formally close the Q1 monthly-subscription deal | @Zaal | Message | Next call |
+| Ask Legash: remove X scraper, change leaderboard display to May-to-now, export current stats if easy | @Adam | Task | This week |
+| Produce the new monthly server cost for the slimmed leaderboard | @Adam + Legash | Task | Before next call |
+| PR an Empire Builder API endpoint to expose leaderboard data | @Zaal | PR | TBD |
+| Brainstorm ZAOstock commercial-model ideas, send to Adam async | @Zaal | Doc | Next couple of days |
+| Bring commercial-model thinking to the next call | @Adam | Meeting prep | Next call |
+| Dig out the name of the grassroots Art-Basel-adjacent Miami festival | @Adam | Lookup | Next call |
+| Send Adam the ZABAL Games concept link | @Zaal | Message | This week |
+| Pursue OKX sponsorship via the OKX-friend contact (angle: sponsor ZAO to attend DevCon India etc.) | @Zaal | Outreach | Ongoing |
+| Submit bio + photo for the team dashboard | @Adam | Task | ASAP |
+| Move Zaal x Adam syncs to 2-3x per week with agendas | @Both | Calendar | Starting now |
+
+## Sources
+
+- Zaal x Adam call, voice-transcribed, mid-May 2026 (primary source).
+- ZAOstock Luma event: [ticket.zaostock.com](https://ticket.zaostock.com) (302 -> luma.com/vhwv9n2h)
+- ZAOstock festival page: [zaostock.com](https://zaostock.com)
+- Empire Builder integration context: research docs 582, 583, 585 in this library.


### PR DESCRIPTION
## Summary
Captures the mid-May 2026 Zaal x Adam call. Three threads: (1) the leaderboard gets reset - X/Twitter data removed, Spaces + Farcaster kept, moving to an Empire Builder API; (2) Adam's near-term bandwidth drops 1-2 months as he takes a paid landscaping-software side gig, but he is healthier for October as a result; (3) Adam offers to build the ZAOstock commercial model as a volunteer - next call is dedicated to it.

## Tier
QUICK - meeting capture, no web research.

## Sources
1 primary (voice-transcribed call) + 3 cross-referenced internal docs (582, 583, 585) + 2 live URLs.

## Next Actions
See the Next Actions table in the doc - 11 action items split across Zaal, Adam, Legash. Key ones: Zaal confirms closing the dead Q1 subscription deal, Adam + Legash produce the slimmed server cost, Zaal brainstorms commercial-model ideas before the next call.