### PR TITLE
SIDEQUESTZ implementation - ZOE goal-alignment layer

### DIFF
--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -276,3 +276,44 @@ test('applyQuestOps: add then score the same quest works across batches', async 
     assert.equal(scored?.status, 'active');
   });
 });
+
+test('buildQuestsBlock: no main quest, no side quests', async () => {
+  await withTempHome(async () => {
+    const { buildQuestsBlock } = await import('../sidequests.ts');
+    const block = await buildQuestsBlock();
+    assert.match(block, /Main quest: \(not set\)/);
+    assert.match(block, /Active side quests: \(none yet\)/);
+  });
+});
+
+test('buildQuestsBlock: shows main quest, active ids, and parked count', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, buildQuestsBlock } = await import('../sidequests.ts');
+    await applyQuestOps([
+      { op: 'set_main', text: 'Ship the ZAO' },
+      { op: 'add', quest: { title: 'A', description: 'd', alignment: 9, alignment_reason: 'core' } },
+      { op: 'add', quest: { title: 'B', description: 'd', alignment: 7, alignment_reason: 'near' } },
+      { op: 'add', quest: { title: 'C', description: 'd', alignment: 5, alignment_reason: 'some' } },
+      { op: 'add', quest: { title: 'D', description: 'd', alignment: 2, alignment_reason: 'weak' } },
+    ]);
+    const block = await buildQuestsBlock();
+    assert.match(block, /Main quest: Ship the ZAO/);
+    assert.match(block, /Active side quests \(top 3 by alignment\)/);
+    assert.match(block, /\[9\/10\] \(sq-.*\) A - core/);
+    assert.match(block, /Parked \(1\):/);
+  });
+});
+
+test('formatQuestList: includes parked and a done/dropped count', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, formatQuestList } = await import('../sidequests.ts');
+    const add = await applyQuestOps([
+      { op: 'add', quest: { title: 'A', description: 'd', alignment: 9, alignment_reason: 'r' } },
+      { op: 'add', quest: { title: 'B', description: 'd' } },
+    ]);
+    await applyQuestOps([{ op: 'complete', id: add.added[0].id }]);
+    const out = await formatQuestList();
+    assert.match(out, /B/);
+    assert.match(out, /Done\/dropped: 1/);
+  });
+});

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -141,3 +141,31 @@ test('recomputeActive: a pinned quest is always active even with a low score', a
   assert.equal(status.b, 'active');
   assert.equal(status.c, 'parked');
 });
+
+test('recomputeActive: alignment 0 is scored (active) - null is not', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 5 }),
+    mkQuest({ id: 'b', alignment: 0 }),
+    mkQuest({ id: 'c', alignment: null }),
+  ];
+  const out = recomputeActive(pool);
+  const status = Object.fromEntries(out.map((q) => [q.id, q.status]));
+  assert.equal(status.a, 'active');
+  assert.equal(status.b, 'active'); // 0 is a real score, not null
+  assert.equal(status.c, 'parked'); // null is never active
+});
+
+test('recomputeActive: more than ACTIVE_LIMIT pinned still yields only 3 active', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 1, pinned: true }),
+    mkQuest({ id: 'b', alignment: 1, pinned: true }),
+    mkQuest({ id: 'c', alignment: 1, pinned: true }),
+    mkQuest({ id: 'd', alignment: 1, pinned: true }),
+    mkQuest({ id: 'e', alignment: 9 }),
+  ];
+  const out = recomputeActive(pool);
+  const active = out.filter((q) => q.status === 'active');
+  assert.equal(active.length, 3); // capped at ACTIVE_LIMIT even with 4 pinned
+});

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -169,3 +169,93 @@ test('recomputeActive: more than ACTIVE_LIMIT pinned still yields only 3 active'
   const active = out.filter((q) => q.status === 'active');
   assert.equal(active.length, 3); // capped at ACTIVE_LIMIT even with 4 pinned
 });
+
+test('applyQuestOps: set_main writes the main quest', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readMainQuest } = await import('../sidequests.ts');
+    const res = await applyQuestOps([{ op: 'set_main', text: 'Ship the ZAO' }]);
+    assert.equal(res.main_quest_set, true);
+    assert.equal(await readMainQuest(), 'Ship the ZAO');
+  });
+});
+
+test('applyQuestOps: add with alignment scores immediately and can go active', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    const res = await applyQuestOps([
+      { op: 'add', quest: { title: 'WaveWarZ Africa', description: 'launch', alignment: 8, alignment_reason: 'direct' } },
+    ]);
+    assert.equal(res.added.length, 1);
+    const stored = await readSideQuests();
+    assert.equal(stored.length, 1);
+    assert.equal(stored[0].alignment, 8);
+    assert.equal(stored[0].status, 'active');
+    assert.notEqual(stored[0].scored_at, null);
+  });
+});
+
+test('applyQuestOps: add without alignment stays unscored and parked', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    await applyQuestOps([{ op: 'add', quest: { title: 'Someday thing', description: 'd' } }]);
+    const stored = await readSideQuests();
+    assert.equal(stored[0].alignment, null);
+    assert.equal(stored[0].status, 'parked');
+    assert.equal(stored[0].scored_at, null);
+  });
+});
+
+test('applyQuestOps: score updates an existing quest and recomputes active', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    const add = await applyQuestOps([{ op: 'add', quest: { title: 'Q', description: 'd' } }]);
+    const id = add.added[0].id;
+    const res = await applyQuestOps([{ op: 'score', id, alignment: 9, reason: 'core' }]);
+    assert.deepEqual(res.scored, [id]);
+    const stored = await readSideQuests();
+    assert.equal(stored[0].alignment, 9);
+    assert.equal(stored[0].alignment_reason, 'core');
+    assert.equal(stored[0].status, 'active');
+  });
+});
+
+test('applyQuestOps: complete and drop are terminal', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    const add = await applyQuestOps([
+      { op: 'add', quest: { title: 'A', description: 'd', alignment: 5, alignment_reason: 'r' } },
+      { op: 'add', quest: { title: 'B', description: 'd', alignment: 6, alignment_reason: 'r' } },
+    ]);
+    const [idA, idB] = add.added.map((q) => q.id);
+    await applyQuestOps([{ op: 'complete', id: idA }, { op: 'drop', id: idB }]);
+    const stored = await readSideQuests();
+    const byId = Object.fromEntries(stored.map((q) => [q.id, q.status]));
+    assert.equal(byId[idA], 'done');
+    assert.equal(byId[idB], 'dropped');
+  });
+});
+
+test('applyQuestOps: pin forces a quest active across recompute', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    const add = await applyQuestOps([
+      { op: 'add', quest: { title: 'A', description: 'd', alignment: 9, alignment_reason: 'r' } },
+      { op: 'add', quest: { title: 'B', description: 'd', alignment: 8, alignment_reason: 'r' } },
+      { op: 'add', quest: { title: 'C', description: 'd', alignment: 7, alignment_reason: 'r' } },
+      { op: 'add', quest: { title: 'D', description: 'd', alignment: 1, alignment_reason: 'r' } },
+    ]);
+    const idD = add.added[3].id;
+    await applyQuestOps([{ op: 'pin', id: idD }]);
+    const stored = await readSideQuests();
+    const byId = Object.fromEntries(stored.map((q) => [q.id, q.status]));
+    assert.equal(byId[idD], 'active');
+  });
+});
+
+test('applyQuestOps: unknown id on score is skipped, not thrown', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps } = await import('../sidequests.ts');
+    const res = await applyQuestOps([{ op: 'score', id: 'sq-nope', alignment: 5, reason: 'r' }]);
+    assert.deepEqual(res.scored, []);
+  });
+});

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -259,3 +259,20 @@ test('applyQuestOps: unknown id on score is skipped, not thrown', async () => {
     assert.deepEqual(res.scored, []);
   });
 });
+
+test('applyQuestOps: add then score the same quest works across batches', async () => {
+  await withTempHome(async () => {
+    const { applyQuestOps, readSideQuests } = await import('../sidequests.ts');
+    const add = await applyQuestOps([{ op: 'add', quest: { title: 'Q', description: 'd' } }]);
+    const id = add.added[0].id;
+    const res = await applyQuestOps([
+      { op: 'add', quest: { title: 'Q2', description: 'd2' } },
+      { op: 'score', id, alignment: 8, reason: 'evolved' },
+    ]);
+    assert.equal(res.scored.length, 1);
+    const stored = await readSideQuests();
+    const scored = stored.find((q) => q.id === id);
+    assert.equal(scored?.alignment, 8);
+    assert.equal(scored?.status, 'active');
+  });
+});

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -63,3 +63,81 @@ test('readSideQuests returns [] on corrupt JSON', async () => {
     assert.deepEqual(await readSideQuests(), []);
   });
 });
+
+// --- recomputeActive tests ---
+
+import type { SideQuest } from '../types.ts';
+
+function mkQuest(over: Partial<SideQuest>): SideQuest {
+  return {
+    id: 'sq-x', title: 'T', description: 'D', alignment: null,
+    alignment_reason: '', status: 'parked', pinned: false,
+    created_at: 't', updated_at: 't', scored_at: null,
+    ...over,
+  };
+}
+
+test('recomputeActive: empty pool returns empty', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  assert.deepEqual(recomputeActive([]), []);
+});
+
+test('recomputeActive: top 3 by alignment go active, rest parked', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 9 }),
+    mkQuest({ id: 'b', alignment: 7 }),
+    mkQuest({ id: 'c', alignment: 5 }),
+    mkQuest({ id: 'd', alignment: 3 }),
+  ];
+  const out = recomputeActive(pool);
+  const status = Object.fromEntries(out.map((q) => [q.id, q.status]));
+  assert.equal(status.a, 'active');
+  assert.equal(status.b, 'active');
+  assert.equal(status.c, 'active');
+  assert.equal(status.d, 'parked');
+});
+
+test('recomputeActive: unscored quests are never active', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 8 }),
+    mkQuest({ id: 'b', alignment: null }),
+    mkQuest({ id: 'c', alignment: null }),
+  ];
+  const out = recomputeActive(pool);
+  const status = Object.fromEntries(out.map((q) => [q.id, q.status]));
+  assert.equal(status.a, 'active');
+  assert.equal(status.b, 'parked');
+  assert.equal(status.c, 'parked');
+});
+
+test('recomputeActive: done and dropped quests are excluded and untouched', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 9, status: 'done' }),
+    mkQuest({ id: 'b', alignment: 8, status: 'dropped' }),
+    mkQuest({ id: 'c', alignment: 2 }),
+  ];
+  const out = recomputeActive(pool);
+  const status = Object.fromEntries(out.map((q) => [q.id, q.status]));
+  assert.equal(status.a, 'done');
+  assert.equal(status.b, 'dropped');
+  assert.equal(status.c, 'active');
+});
+
+test('recomputeActive: a pinned quest is always active even with a low score', async () => {
+  const { recomputeActive } = await import('../sidequests.ts');
+  const pool = [
+    mkQuest({ id: 'a', alignment: 9 }),
+    mkQuest({ id: 'b', alignment: 8 }),
+    mkQuest({ id: 'c', alignment: 7 }),
+    mkQuest({ id: 'd', alignment: 1, pinned: true }),
+  ];
+  const out = recomputeActive(pool);
+  const status = Object.fromEntries(out.map((q) => [q.id, q.status]));
+  assert.equal(status.d, 'active');
+  assert.equal(status.a, 'active');
+  assert.equal(status.b, 'active');
+  assert.equal(status.c, 'parked');
+});

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Each test points ZOE_HOME at a fresh temp dir. sidequests.ts reads
+// process.env.ZOE_HOME lazily (per call), so this works if set before import-use.
+async function withTempHome<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'sidequests-test-'));
+  const prev = process.env.ZOE_HOME;
+  process.env.ZOE_HOME = dir;
+  try {
+    return await fn();
+  } finally {
+    if (prev === undefined) delete process.env.ZOE_HOME;
+    else process.env.ZOE_HOME = prev;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('readMainQuest returns empty string when no file exists', async () => {
+  await withTempHome(async () => {
+    const { readMainQuest } = await import('../sidequests.ts');
+    assert.equal(await readMainQuest(), '');
+  });
+});
+
+test('writeMainQuest then readMainQuest round-trips trimmed text', async () => {
+  await withTempHome(async () => {
+    const { readMainQuest, writeMainQuest } = await import('../sidequests.ts');
+    await writeMainQuest('  Build the ZAO into a self-running impact network  ');
+    assert.equal(await readMainQuest(), 'Build the ZAO into a self-running impact network');
+  });
+});
+
+test('readSideQuests returns [] when no file exists', async () => {
+  await withTempHome(async () => {
+    const { readSideQuests } = await import('../sidequests.ts');
+    assert.deepEqual(await readSideQuests(), []);
+  });
+});
+
+test('writeSideQuests then readSideQuests round-trips', async () => {
+  await withTempHome(async () => {
+    const { readSideQuests, writeSideQuests } = await import('../sidequests.ts');
+    const q = {
+      id: 'sq-1', title: 'X', description: 'desc', alignment: 5,
+      alignment_reason: 'r', status: 'parked' as const, pinned: false,
+      created_at: 't', updated_at: 't', scored_at: 't',
+    };
+    await writeSideQuests([q]);
+    assert.deepEqual(await readSideQuests(), [q]);
+  });
+});
+
+test('readSideQuests returns [] on corrupt JSON', async () => {
+  await withTempHome(async () => {
+    const { readSideQuests } = await import('../sidequests.ts');
+    const { writeFile, mkdir } = await import('node:fs/promises');
+    await mkdir(process.env.ZOE_HOME!, { recursive: true });
+    await writeFile(join(process.env.ZOE_HOME!, 'sidequests.json'), '{not json', 'utf8');
+    assert.deepEqual(await readSideQuests(), []);
+  });
+});

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -9,7 +9,7 @@
  * from PERSONA_DEFAULT in memory.ts on first boot, hand-editable after).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
-import type { ConciergeOptions, ConciergeResult, TaskOp, ZoeCaptureNote } from './types';
+import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
 import type { MemoryBlocks } from './memory';
 
@@ -44,6 +44,10 @@ function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string): string {
     `<tasks>`,
     blocks.tasks,
     `</tasks>`,
+    ``,
+    `<quests>`,
+    blocks.quests,
+    `</quests>`,
   ].join('\n');
 }
 
@@ -108,11 +112,12 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     bare: false,
   });
 
-  const { reply, taskOps, captures } = splitReplyAndOps(result.text);
+  const { reply, taskOps, questOps, captures } = splitReplyAndOps(result.text);
 
   return {
     reply,
     task_ops: taskOps,
+    quest_ops: questOps,
     captures,
     inputTokens: result.inputTokens,
     outputTokens: result.outputTokens,
@@ -124,16 +129,22 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
 
 const OPS_FENCE_RE = /----\s*```json\s*([\s\S]*?)\s*```\s*$/;
 
-function splitReplyAndOps(text: string): { reply: string; taskOps: TaskOp[]; captures: ZoeCaptureNote[] } {
+function splitReplyAndOps(text: string): {
+  reply: string;
+  taskOps: TaskOp[];
+  questOps: QuestOp[];
+  captures: ZoeCaptureNote[];
+} {
   const match = text.match(OPS_FENCE_RE);
   if (!match) {
-    return { reply: text.trim(), taskOps: [], captures: [] };
+    return { reply: text.trim(), taskOps: [], questOps: [], captures: [] };
   }
   const jsonStr = match[1];
   const reply = text.replace(OPS_FENCE_RE, '').trim();
   try {
     const parsed = JSON.parse(jsonStr) as {
       task_ops?: TaskOp[];
+      quest_ops?: QuestOp[];
       captures?: Array<{ text: string; topic: string }>;
     };
     const captures: ZoeCaptureNote[] = (parsed.captures ?? []).map((c) => ({
@@ -146,11 +157,12 @@ function splitReplyAndOps(text: string): { reply: string; taskOps: TaskOp[]; cap
     return {
       reply,
       taskOps: parsed.task_ops ?? [],
+      questOps: parsed.quest_ops ?? [],
       captures,
     };
   } catch (err) {
     console.error('[zoe/concierge] failed to parse ops JSON:', (err as Error).message, 'raw:', jsonStr.slice(0, 200));
-    return { reply, taskOps: [], captures: [] };
+    return { reply, taskOps: [], questOps: [], captures: [] };
   }
 }
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -22,6 +22,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
+import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import {
   buildMemoryBlocks,
   ensureZoeHome,
@@ -171,6 +172,18 @@ bot.command('seed', async (ctx) => {
       ? `Seeded ${result.seeded} tasks from doc 601.`
       : 'Task queue already has entries - skipped seed.',
   );
+});
+
+bot.command('quest', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const block = await buildQuestsBlock();
+  await replyChunked(ctx, block);
+});
+
+bot.command('quests', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const list = await formatQuestList();
+  await replyChunked(ctx, list);
 });
 
 bot.command('notes', async (ctx) => {
@@ -475,6 +488,10 @@ async function dispatchConcierge(
 
     if (result.task_ops.length > 0) {
       await applyTaskOps(result.task_ops);
+    }
+
+    if (result.quest_ops.length > 0) {
+      await applyQuestOps(result.quest_ops);
     }
 
     await pushRecent({ from: 'zoe', text: result.reply }, scope);

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -83,6 +83,14 @@ Reply naturally to Zaal. If you want to add/update tasks OR captured a note, app
     {"op": "add", "task": {"title": "...", "description": "...", "status": "pending", "priority": "med", "source": "ad-hoc", "notes": []}},
     {"op": "complete", "id": "task-id", "outcome": "..."}
   ],
+  "quest_ops": [
+    {"op": "set_main", "text": "the worthy ideal in Zaal's words"},
+    {"op": "add", "quest": {"title": "...", "description": "...", "alignment": 7, "alignment_reason": "one line: how this advances the main quest"}},
+    {"op": "score", "id": "sq-id", "alignment": 9, "reason": "..."},
+    {"op": "complete", "id": "sq-id"},
+    {"op": "drop", "id": "sq-id"},
+    {"op": "pin", "id": "sq-id"}
+  ],
   "captures": [
     {"text": "verbatim what zaal said worth remembering", "topic": "decision"}
   ],
@@ -93,6 +101,20 @@ Reply naturally to Zaal. If you want to add/update tasks OR captured a note, app
 Set "escalate": true ONLY if your current model (Sonnet) cannot answer well and the response should be re-run on Opus. Include "reason" when escalating.
 
 If no ops/captures and no escalation: omit the JSON block entirely.
+
+## SIDEQUESTZ
+
+The <quests> block carries Zaal's main quest (his worthy ideal) and his active side quests. Use it - reason with the main quest loaded on every turn.
+
+When Zaal sets or changes his main quest: emit a "set_main" quest_op. Then emit a "score" quest_op for EVERY existing side quest you can see ids for in the <quests> block - the whole pool re-scores against the new main quest.
+
+When Zaal adds a side quest: emit an "add" quest_op. Include "alignment" (0-10) and "alignment_reason" in the same op - score it immediately using the test below. Tell Zaal the score and whether it landed active or parked.
+
+Alignment test (Earl Nightingale, "The Strangest Secret"): success is the progressive realization of a worthy ideal. A side quest scores HIGH if it directly advances the main quest, LOW if it pulls focus away from it. The score is your honest judgment - explain it in one line. Never fake a number.
+
+ZOE auto-keeps the top 3 by alignment "active", parks the rest. Zaal can override with "pin". Use "complete" when a side quest is done, "drop" when he abandons it.
+
+If no main quest is set yet: still emit "add" ops for side quests, but leave "alignment" off - they stay unscored until the main quest exists.
 
 ## ELDER + LINEAGE
 

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -20,6 +20,7 @@ import { promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { ZoeTask } from './types';
+import { buildQuestsBlock } from './sidequests';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const PERSONA_PATH = join(ZOE_HOME, 'persona.md');
@@ -238,6 +239,7 @@ export interface MemoryBlocks {
   human: string;
   working: string;
   tasks: string;
+  quests: string;
   chat_scope: ChatScope;
   chat_title?: string;
 }
@@ -402,11 +404,12 @@ export async function buildMemoryBlocks(
   scope: ChatScope = 'private',
   chatTitle?: string,
 ): Promise<MemoryBlocks> {
-  const [persona, human, recentTurns, tasks] = await Promise.all([
+  const [persona, human, recentTurns, tasks, quests] = await Promise.all([
     readPersona(),
     readHuman(),
     readRecent(scope),
     readTasks(),
+    buildQuestsBlock(),
   ]);
 
   const working =
@@ -428,7 +431,7 @@ export async function buildMemoryBlocks(
           .map((t, i) => `${i + 1}. [${t.priority}] [${t.status}] ${t.title}\n   ${t.description.slice(0, 100)}`)
           .join('\n');
 
-  return { persona, human, working, tasks: tasksBlock, chat_scope: scope, chat_title: chatTitle };
+  return { persona, human, working, tasks: tasksBlock, quests, chat_scope: scope, chat_title: chatTitle };
 }
 
 /**
@@ -457,4 +460,6 @@ export const ZOE_PATHS = {
   archive_dir: ARCHIVE_DIR,
   tasks: TASKS_PATH,
   bootloader: BOOTLOADER_PATH,
+  main_quest: join(ZOE_HOME, 'main-quest.md'),
+  sidequests: join(ZOE_HOME, 'sidequests.json'),
 };

--- a/bot/src/zoe/sidequests.ts
+++ b/bot/src/zoe/sidequests.ts
@@ -87,3 +87,105 @@ export function recomputeActive(quests: SideQuest[]): SideQuest[] {
   }
   return result;
 }
+
+/**
+ * Apply a batch of QuestOps. set_main writes main-quest.md; the rest mutate
+ * the side-quest pool. After every batch the active set is recomputed and the
+ * pool is persisted. Unknown ids are skipped with a console.warn (mirrors
+ * applyTaskOps in tasks.ts) - never throws on a bad id.
+ */
+export async function applyQuestOps(ops: QuestOp[]): Promise<QuestOpResult> {
+  const existing = await readSideQuests();
+  const byId = new Map(existing.map((q) => [q.id, q]));
+  const res: QuestOpResult = {
+    main_quest_set: false,
+    added: [],
+    scored: [],
+    completed: [],
+    dropped: [],
+    pinned: [],
+    active: [],
+  };
+
+  for (const op of ops) {
+    switch (op.op) {
+      case 'set_main': {
+        await writeMainQuest(op.text);
+        res.main_quest_set = true;
+        break;
+      }
+      case 'add': {
+        const ts = nowIso();
+        const scored = op.quest.alignment != null;
+        const q: SideQuest = {
+          id: newQuestId(),
+          title: op.quest.title,
+          description: op.quest.description,
+          alignment: op.quest.alignment ?? null,
+          alignment_reason: op.quest.alignment_reason ?? '',
+          status: 'parked',
+          pinned: false,
+          created_at: ts,
+          updated_at: ts,
+          scored_at: scored ? ts : null,
+        };
+        byId.set(q.id, q);
+        res.added.push(q);
+        break;
+      }
+      case 'score': {
+        const q = byId.get(op.id);
+        if (!q) {
+          console.warn(`[zoe/sidequests] score skipped - id not found: ${op.id}`);
+          break;
+        }
+        q.alignment = op.alignment;
+        q.alignment_reason = op.reason;
+        q.scored_at = nowIso();
+        q.updated_at = nowIso();
+        res.scored.push(q.id);
+        break;
+      }
+      case 'complete': {
+        const q = byId.get(op.id);
+        if (!q) {
+          console.warn(`[zoe/sidequests] complete skipped - id not found: ${op.id}`);
+          break;
+        }
+        q.status = 'done';
+        q.pinned = false;
+        q.updated_at = nowIso();
+        res.completed.push(q.id);
+        break;
+      }
+      case 'drop': {
+        const q = byId.get(op.id);
+        if (!q) {
+          console.warn(`[zoe/sidequests] drop skipped - id not found: ${op.id}`);
+          break;
+        }
+        q.status = 'dropped';
+        q.pinned = false;
+        q.updated_at = nowIso();
+        res.dropped.push(q.id);
+        break;
+      }
+      case 'pin': {
+        const q = byId.get(op.id);
+        if (!q) {
+          console.warn(`[zoe/sidequests] pin skipped - id not found: ${op.id}`);
+          break;
+        }
+        q.pinned = true;
+        q.updated_at = nowIso();
+        res.pinned.push(q.id);
+        break;
+      }
+    }
+  }
+
+  const recomputed = recomputeActive(Array.from(byId.values()));
+  await writeSideQuests(recomputed);
+  res.active = recomputed.filter((q) => q.status === 'active');
+  return res;
+}

--- a/bot/src/zoe/sidequests.ts
+++ b/bot/src/zoe/sidequests.ts
@@ -189,3 +189,77 @@ export async function applyQuestOps(ops: QuestOp[]): Promise<QuestOpResult> {
   res.active = recomputed.filter((q) => q.status === 'active');
   return res;
 }
+
+function scoreLabel(alignment: number | null): string {
+  return alignment !== null ? `${alignment}/10` : 'unscored';
+}
+
+/**
+ * The compact <quests> memory block injected into every concierge turn:
+ * main quest + the active 3 (with ids + reasons) + a one-line parked summary.
+ * Defensively recomputes active status for display even if sidequests.json
+ * was hand-edited.
+ */
+export async function buildQuestsBlock(): Promise<string> {
+  const [main, quests] = await Promise.all([readMainQuest(), readSideQuests()]);
+  const ranked = recomputeActive(quests);
+  const active = ranked
+    .filter((q) => q.status === 'active')
+    .sort((a, b) => (b.alignment ?? -1) - (a.alignment ?? -1));
+  const parked = ranked.filter((q) => q.status === 'parked');
+
+  const lines: string[] = [];
+  lines.push(`Main quest: ${main || '(not set)'}`);
+  lines.push('');
+  if (active.length === 0) {
+    lines.push('Active side quests: (none yet)');
+  } else {
+    lines.push('Active side quests (top 3 by alignment):');
+    active.forEach((q, i) => {
+      lines.push(`${i + 1}. [${scoreLabel(q.alignment)}] (${q.id}) ${q.title} - ${q.alignment_reason || 'no reason on file'}`);
+    });
+  }
+  if (parked.length > 0) {
+    lines.push('');
+    const summary = parked
+      .map((q) => `(${q.id}) ${q.title} [${scoreLabel(q.alignment)}]`)
+      .join(', ');
+    lines.push(`Parked (${parked.length}): ${summary}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * The fuller /quests view: main quest, active 3 with reasons, every parked
+ * quest with its score, and a done/dropped tally.
+ */
+export async function formatQuestList(): Promise<string> {
+  const [main, quests] = await Promise.all([readMainQuest(), readSideQuests()]);
+  const ranked = recomputeActive(quests);
+  const active = ranked
+    .filter((q) => q.status === 'active')
+    .sort((a, b) => (b.alignment ?? -1) - (a.alignment ?? -1));
+  const parked = ranked
+    .filter((q) => q.status === 'parked')
+    .sort((a, b) => (b.alignment ?? -1) - (a.alignment ?? -1));
+  const terminalCount = ranked.filter((q) => q.status === 'done' || q.status === 'dropped').length;
+
+  const lines: string[] = [];
+  lines.push(`Main quest: ${main || '(not set)'}`);
+  lines.push('');
+  lines.push(`Active (${active.length}):`);
+  if (active.length === 0) lines.push('  (none yet)');
+  for (const q of active) {
+    lines.push(`  [${scoreLabel(q.alignment)}] (${q.id}) ${q.title}`);
+    lines.push(`     ${q.alignment_reason || 'no reason on file'}`);
+  }
+  lines.push('');
+  lines.push(`Parked (${parked.length}):`);
+  if (parked.length === 0) lines.push('  (none)');
+  for (const q of parked) {
+    lines.push(`  [${scoreLabel(q.alignment)}] (${q.id}) ${q.title}`);
+  }
+  lines.push('');
+  lines.push(`Done/dropped: ${terminalCount}`);
+  return lines.join('\n');
+}

--- a/bot/src/zoe/sidequests.ts
+++ b/bot/src/zoe/sidequests.ts
@@ -1,0 +1,60 @@
+/**
+ * SIDEQUESTZ — ZOE's goal-alignment layer (spec 2026-05-14, doc 648).
+ *
+ * Standalone module. Does NOT import from memory.ts (avoids a circular dep:
+ * memory.ts imports buildQuestsBlock from here). Computes its own ZOE_HOME.
+ *
+ * Storage under ~/.zao/zoe/:
+ *   main-quest.md     — the worthy ideal, freeform prose
+ *   sidequests.json   — the side-quest pool
+ */
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SideQuest, QuestOp, QuestOpResult } from './types';
+
+const ACTIVE_LIMIT = 3;
+
+function questHome(): string {
+  return process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+}
+function mainQuestPath(): string {
+  return join(questHome(), 'main-quest.md');
+}
+function sideQuestsPath(): string {
+  return join(questHome(), 'sidequests.json');
+}
+function newQuestId(): string {
+  return `sq-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export async function readMainQuest(): Promise<string> {
+  try {
+    return (await fs.readFile(mainQuestPath(), 'utf8')).trim();
+  } catch {
+    return '';
+  }
+}
+
+export async function writeMainQuest(text: string): Promise<void> {
+  await fs.mkdir(questHome(), { recursive: true });
+  await fs.writeFile(mainQuestPath(), text.trim() + '\n', 'utf8');
+}
+
+export async function readSideQuests(): Promise<SideQuest[]> {
+  try {
+    const raw = await fs.readFile(sideQuestsPath(), 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function writeSideQuests(quests: SideQuest[]): Promise<void> {
+  await fs.mkdir(questHome(), { recursive: true });
+  await fs.writeFile(sideQuestsPath(), JSON.stringify(quests, null, 2), 'utf8');
+}

--- a/bot/src/zoe/sidequests.ts
+++ b/bot/src/zoe/sidequests.ts
@@ -63,7 +63,7 @@ export async function writeSideQuests(quests: SideQuest[]): Promise<void> {
  * Recompute the active set. Pure — returns a new array, mutates nothing.
  *
  * - done/dropped quests are terminal: status untouched, never active.
- * - pinned quests are always active.
+ * - pinned quests are always active, but never more than ACTIVE_LIMIT total.
  * - remaining slots (ACTIVE_LIMIT minus pinned count) fill from the
  *   highest-alignment SCORED quests.
  * - every other rankable quest (scored-but-bumped, or unscored) -> parked.
@@ -72,7 +72,8 @@ export function recomputeActive(quests: SideQuest[]): SideQuest[] {
   const result = quests.map((q) => ({ ...q }));
   const rankable = result.filter((q) => q.status !== 'done' && q.status !== 'dropped');
 
-  const pinned = rankable.filter((q) => q.pinned);
+  // Pinned quests are always active, but never more than ACTIVE_LIMIT total.
+  const pinned = rankable.filter((q) => q.pinned).slice(0, ACTIVE_LIMIT);
   const unpinned = rankable.filter((q) => !q.pinned);
   // highest alignment first; unscored (null) sinks to the bottom
   unpinned.sort((a, b) => (b.alignment ?? -1) - (a.alignment ?? -1));

--- a/bot/src/zoe/sidequests.ts
+++ b/bot/src/zoe/sidequests.ts
@@ -58,3 +58,31 @@ export async function writeSideQuests(quests: SideQuest[]): Promise<void> {
   await fs.mkdir(questHome(), { recursive: true });
   await fs.writeFile(sideQuestsPath(), JSON.stringify(quests, null, 2), 'utf8');
 }
+
+/**
+ * Recompute the active set. Pure — returns a new array, mutates nothing.
+ *
+ * - done/dropped quests are terminal: status untouched, never active.
+ * - pinned quests are always active.
+ * - remaining slots (ACTIVE_LIMIT minus pinned count) fill from the
+ *   highest-alignment SCORED quests.
+ * - every other rankable quest (scored-but-bumped, or unscored) -> parked.
+ */
+export function recomputeActive(quests: SideQuest[]): SideQuest[] {
+  const result = quests.map((q) => ({ ...q }));
+  const rankable = result.filter((q) => q.status !== 'done' && q.status !== 'dropped');
+
+  const pinned = rankable.filter((q) => q.pinned);
+  const unpinned = rankable.filter((q) => !q.pinned);
+  // highest alignment first; unscored (null) sinks to the bottom
+  unpinned.sort((a, b) => (b.alignment ?? -1) - (a.alignment ?? -1));
+
+  const slots = Math.max(0, ACTIVE_LIMIT - pinned.length);
+  const activeUnpinned = unpinned.filter((q) => q.alignment !== null).slice(0, slots);
+  const activeIds = new Set([...pinned, ...activeUnpinned].map((q) => q.id));
+
+  for (const q of rankable) {
+    q.status = activeIds.has(q.id) ? 'active' : 'parked';
+  }
+  return result;
+}

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -52,6 +52,8 @@ export interface ConciergeResult {
   reply: string;
   /** Tasks the assistant wants to add or update */
   task_ops: TaskOp[];
+  /** Side-quest ops the assistant wants to apply (SIDEQUESTZ) */
+  quest_ops: QuestOp[];
   /** Captures to log */
   captures: ZoeCaptureNote[];
   /** Cost stats from Claude CLI call */
@@ -90,4 +92,37 @@ export function selectModel(message: string): string {
     return ZOE_QUICK_MODEL;
   }
   return ZOE_DEFAULT_MODEL;
+}
+
+// --- SIDEQUESTZ (doc 648 / spec 2026-05-14) -----------------------------------
+
+export interface SideQuest {
+  id: string;                  // sq-<timestamp>-<rand>
+  title: string;
+  description: string;
+  alignment: number | null;    // 0-10, null = not yet scored
+  alignment_reason: string;    // ZOE's one-line "why this score" ('' if unscored)
+  status: 'active' | 'parked' | 'done' | 'dropped';
+  pinned: boolean;             // true = forced active regardless of score
+  created_at: string;          // ISO 8601
+  updated_at: string;
+  scored_at: string | null;
+}
+
+export type QuestOp =
+  | { op: 'set_main'; text: string }
+  | { op: 'add'; quest: { title: string; description: string; alignment?: number; alignment_reason?: string } }
+  | { op: 'score'; id: string; alignment: number; reason: string }
+  | { op: 'complete'; id: string }
+  | { op: 'drop'; id: string }
+  | { op: 'pin'; id: string };
+
+export interface QuestOpResult {
+  main_quest_set: boolean;
+  added: SideQuest[];
+  scored: string[];
+  completed: string[];
+  dropped: string[];
+  pinned: string[];
+  active: SideQuest[];   // the resulting active set after recompute
 }


### PR DESCRIPTION
## What this is

The IMPLEMENTATION of SIDEQUESTZ (ZOE's first build project). The spec + plan were merged in #521; this PR is the code that implements them.

**Spec:** `docs/superpowers/specs/2026-05-14-sidequestz-design.md` (merged in #521)
**Plan:** `docs/superpowers/plans/2026-05-14-sidequestz.md` (merged in #521)

## What it does

ZOE now has a goal-alignment layer. One main quest (the worthy ideal, hand-editable markdown). A scored side-quest pool. ZOE auto-keeps the top 3 by alignment "active", parks the rest. The main quest + active 3 inject into ZOE's memory blocks every turn (new 5th `<quests>` block) - so every concierge reply is alignment-aware. Conversational via `quest_ops` in the JSON trailer + `/quest` `/quests` Telegram commands.

Alignment test = Earl Nightingale's "progressive realization of a worthy ideal" — ZOE judges honestly, explains in one line, never fakes a number.

## 9 commits, TDD throughout

- `feat(sidequestz): types + storage primitives` - `SideQuest`/`QuestOp`/`QuestOpResult` in `types.ts`; `readMainQuest`/`writeMainQuest`/`readSideQuests`/`writeSideQuests` in new `sidequests.ts`; 5 tests
- `feat(sidequestz): recomputeActive ranking function` - pure top-3-by-alignment with pinned/done/dropped handling; 5 tests
- `fix(sidequestz): cap pinned active quests at ACTIVE_LIMIT` - code review caught a 4+ pins edge case; 2 tests
- `feat(sidequestz): applyQuestOps` - the op applier (set_main / add / score / complete / drop / pin), unknown-id skip; 7 tests
- `test(sidequestz): cover add-then-score across batches` - 1 extra test
- `feat(sidequestz): buildQuestsBlock + formatQuestList` - the compact `<quests>` memory block + the fuller `/quests` view; 3 tests
- `feat(sidequestz): wire <quests> block into memory blocks` - `memory.ts` integration, `MemoryBlocks.quests`, `Promise.all` parallel read
- `feat(sidequestz): inject <quests> + parse quest_ops in concierge` - `concierge.ts` integration + PERSONA_DEFAULT SIDEQUESTZ section
- `feat(sidequestz): apply quest_ops + /quest /quests commands` - `index.ts` integration

## Tests

**23 unit tests pass** (`node:test` via tsx — see plan for the deviation rationale; the `bot/` package has no vitest and adding it would need a dep approval).

```
ℹ tests 23
ℹ pass 23
ℹ fail 0
```

End-to-end smoke test produces clean output - main quest + top-3-active-with-reasons + parked list (full output in the implementation flow logs).

## Spec deviations (all in the plan, all flagged)

- `node:test` runner instead of vitest (no vitest in bot package; no new dep added)
- `SideQuest.pinned: boolean` field added (pin op needs durable state)
- `complete` / `drop` ops are `{op, id}` only (dropped unused `outcome` / `reason` - YAGNI)
- No first-boot file seeding (read funcs handle absence, write funcs create on demand)

## Post-merge deploy (after you merge)

1. `ssh zaal@31.97.148.88 'cd /home/zaal/zao-os && git fetch origin && git reset --hard origin/main'`
2. Append the SIDEQUESTZ section from `PERSONA_DEFAULT` to the live `~/.zao/zoe/persona.md` (PERSONA_DEFAULT only seeds NEW installs; live file already exists). I will do this via SSH.
3. `systemctl --user restart zoe-bot.service`

## How to test (manual, in Telegram)

DM @zaoclaw_bot:
1. `my main quest is <real one>`
2. `add side quest: <thing>` (a few of varied alignment)
3. `/quest` - main quest + active 3 + scores
4. `/quests` - full pool
5. Ask ZOE something unrelated - reply should be alignment-aware (the `<quests>` block is loaded every turn)

Generated with [Claude Code](https://claude.com/claude-code)