### PR TITLE
doc 601 v2: Live Más pronunciation fix + annotated liner notes

### DIFF
--- a/research/music/601-suno-music-generation-deep-tooling-2026/02-sponsor-me-liner-notes.md
+++ b/research/music/601-suno-music-generation-deep-tooling-2026/02-sponsor-me-liner-notes.md
@@ -1,0 +1,266 @@
+---
+topic: music
+type: guide
+status: draft
+last-validated: 2026-05-15
+related-docs: 601, 600
+tier: STANDARD
+---
+
+# 601.02 — "Sponsor Me (Live Más)" — Annotated Liner Notes
+
+> **What this is:** the Genius-style breakdown of every line in the song. Every reference is pulled from the verified Jadyn Violet / UVR research in doc 600. Use this as the companion writeup when you drop the track in the UVR Discord, in the Cast description on Farcaster, on YouTube, or anywhere the song goes that needs context.
+
+The song is a real-pitch song. Every TB item is a real TB item. Every UVR / Jadyn detail is a real biographical fact. The premise: Jadyn already has a Suno sponsorship; the song asks Taco Bell to sponsor him next, framed through the UVR aesthetic. Built on doc 600's deep dive.
+
+---
+
+## The premise in one paragraph
+
+Jadyn Violet's recurring half-joke in interviews — most explicitly on Word To Your Mama Ep 167 — is that he wants to own a Taco Bell franchise. The song takes that joke and runs it as a real pitch. UVR is the brand. The 365-day Twitch streak (Jan 1, 2025 -> Jan 1, 2026) is the receipts. The Skid Row shipping container is the proof he'll grind for it. Suno is already on board. The chorus is the literal ask.
+
+---
+
+## INTRO
+
+```
+[Intro]
+[Spoken Word] [Male Vocal]
+(violet synth pad, glitch sweep)
+This one's for Tac' Bell.
+Why not me.
+```
+
+**"Tac' Bell"** — diminutive nickname for Taco Bell, the way Drake says "Tory" or "Dot." Lowering the stakes from corporate pitch to street-level conversation.
+
+**"Why not me."** — Jadyn's actual one-line life lesson. From the Steve Reynoso podcast (July 23, 2025), when asked to sum up his whole journey in one lesson he answered: *"Probably just why not you? You know, why not you?"* And in the 365 Documentary: *"Why not me, bro? Why not now?"* This is the song's thesis statement, planted at second zero.
+
+---
+
+## VERSE 1
+
+```
+[Verse 1]
+[Auto-Tuned] [Melodic Rap]
+Indian kid out the Jersey state
+Trap from a bedroom, ten years late
+Lost the wallet, lost the rave
+Bought a shipping container on the Skid Row pave
+Three months in, half a viewer deep
+Now the violet hits like Diablo on the cheek
+Why not me, bro? Why not now?
+365 days, take a bow
+```
+
+**"Indian kid out the Jersey state"** — Jadyn was born March 26 2001 in Somerset, New Jersey, first-generation Indian American. He self-identifies as "the Indian kid in New Jersey" in the 365 Documentary's opening line. This is the identity hook — the whole song earns its arrival in LA by starting in NJ.
+
+**"Trap from a bedroom, ten years late"** — Jadyn's first SoundCloud single dropped in 2018 when he was 17-18; he calls trap "the foundation of my music career." "Ten years late" plays on the trap timeline — he came up after the Atlanta wave peaked — and on his own self-effacing line that he missed early waves (he passed on minting a Bored Ape for under $1,000). The bedroom production is literal: his Twitch bio reads "I make music in my bedroom, gunna happen one day."
+
+**"Lost the wallet, lost the rave"** — two real biographical events compressed into one line. (1) The **$10,000 crypto wallet drain**: on the Steve Reynoso podcast he says *"I opened my crypto wallet one day and the 10 bands was gone, bro. 10,000 drained from my wallet."* That was two years of his music-NFT earnings, wiped in a day. (2) The **lost UVR community**: in 2024 he spent a year in Thailand training Muay Thai; when he came home the daily-Spaces community he had built had dissolved without him. *"I went to Asia for a year and I lost that entire community... I had it. I built this community... and I left and I lost it all."* Both losses set up why a rebuild was necessary.
+
+**"Bought a shipping container on the Skid Row pave"** — literal. During the 365-day streak he ran out of money in LA, slept in his car, then *"had the brilliant idea of renting a shipping container in Skid Row. I spent $150 and I found a Skid Row in the middle of a Skid Row parking lot."* The whole back half of the streak was streamed from that container. "Skid Row pave" = he lived on Skid Row pavement, literally.
+
+**"Three months in, half a viewer deep"** — exactly true. From the 365 Documentary: *"I streamed for 3 months, 90 days, averaging .5 viewers. Twitch couldn't even give me the one viewer."* Ninety straight days streaming to no one. That is the floor the rest of the song climbs from.
+
+**"Now the violet hits like Diablo on the cheek"** — the fusion line. **Violet** = UVR brand color (deep violet/purple; raverrealm.xyz runs dark-mode violet). **Diablo** = Taco Bell's hottest sauce packet. The hit lands on the cheek because Diablo numbs your face. The UVR aesthetic and the Taco Bell heat collide in one image — it's the cross-brand thesis of the whole song.
+
+**"Why not me, bro? Why not now?"** — direct callback to the 365 Documentary's central line. "Bro" is verbatim Jadyn — he uses it constantly across both the documentary and the podcast.
+
+**"365 days, take a bow"** — the streak. January 1 2025 to January 1 2026, every single day. He released "The 365 Documentary: One Year Can Change Your Life" on YouTube January 30, 2026, documenting it. The "take a bow" is the only allowed moment of arrogance in the verse — earned by the previous seven lines.
+
+---
+
+## PRE-CHORUS
+
+```
+[Pre-Chorus]
+[Build]
+Three AM on the 101
+Hollywood sign in the rearview gun
+All I want is one franchise
+Got the dream and the receipts, son
+```
+
+**"Three AM on the 101"** — the 101 = the Hollywood Freeway, the LA artery. 3am = the late-night-drive-thru hour. This is where the song geographically arrives in LA.
+
+**"Hollywood sign in the rearview gun"** — directly from the 365 Documentary, narrating the cross-country drive: *"finally appearing at the Hollywood sign in Los Angeles. It felt like a dream, bro."* "Rearview gun" is the trap flourish — the LA sign as both arrival and threat (rearview because he's past the postcard moment, into the work moment).
+
+**"All I want is one franchise"** — the literal ask. The Taco Bell franchise dream is a real, recurring Jadyn line, most explicitly on Word To Your Mama Ep 167. Not a metaphor. He genuinely wants a TB franchise.
+
+**"Got the dream and the receipts, son"** — receipts = the 365-day streak, the documentary, the verified Skid Row stretch. He's saying: I'm not asking on vibes, I have proof.
+
+---
+
+## CHORUS
+
+```
+[Chorus]
+[Belted] [Auto-Tuned] [Ad-libs] [Layered Vocals]
+(808 drop, sidechained synths, euphoric)
+Sponsor me, Taco Bell, sponsor me
+I'll put the Crunchwrap on the violet TV
+Cheesy Gordita Crunch, my city, my keys
+Liv Más, baby, liv Más with me
+Sponsor me, Suno, you already did
+Now it's Tac' Bell's turn, yeah I'm not a kid
+I'm the Underground Violet Rave at the drive-thru beep
+Doritos Locos, fire sauce, eternal sleep
+```
+
+**"Sponsor me, Taco Bell, sponsor me"** — the chorus is a literal ask. Repetition = chorus locks the memory of the ask.
+
+**"I'll put the Crunchwrap on the violet TV"** — the Crunchwrap Supreme is TB's hero item. "Violet TV" = the Twitch stream, branded in UVR violet. He's offering the most visible placement he owns.
+
+**"Cheesy Gordita Crunch, my city, my keys"** — Cheesy Gordita Crunch (CGC) is a fan-favorite TB item. "My city, my keys" is a Drake-lineage flex (Drake's "OVO Sound my city") — Jadyn flipping it: the city is mine, the keys are mine, and now the TB items are part of that domain.
+
+**"Liv Más, baby, liv Más with me"** — TB's official tagline since 2012: *Live Más* (Spanish for "live more"). Pronounced **"liv mahss"** — *Live* rhymes with *give*. Phonetically respelled here ("Liv Más") to force Suno's TTS to sing it the right way; the brand-correct spelling is "Live Más."
+
+**"Sponsor me, Suno, you already did"** — Jadyn actually has a Suno sponsorship deal (this is the real-life setup of the whole song). The line breaks the fourth wall: the song is being made with Suno, the sponsor that already said yes, asking the next sponsor to do the same. This is the song's smartest move — it makes the song a working pitch in real time.
+
+**"Now it's Tac' Bell's turn, yeah I'm not a kid"** — he's 24 (born March 26 2001). The line addresses the implicit objection — "you're a kid" — and dismisses it. The Steve Reynoso podcast has him saying *"I'm 24. I could easily go down the belief that, man, I'm too old to do music. I'm too old to stream and stuff. But it's like that identity doesn't benefit me."*
+
+**"I'm the Underground Violet Rave at the drive-thru beep"** — UVR identity at the moment of the TB drive-thru speaker beep. The brand fusion in one image: his community shows up to the late-night drive-thru window.
+
+**"Doritos Locos, fire sauce, eternal sleep"** — Doritos Locos Tacos = arguably TB's most iconic 21st-century item. Fire sauce = the standard hot packet. "Eternal sleep" = trap-aesthetic darkness, gothic UVR underbelly, and a wink at the food coma after a 3am order. The trap closes the chorus on a heavy note so the verse can pick it back up.
+
+---
+
+## VERSE 2
+
+```
+[Verse 2]
+[Auto-Tuned] [Melodic Rap]
+Mama on the phone like you sleeping in the whip
+Yeah ma but the dream's on a steady drip
+365 in a Skid Row tin
+Container singing, gunshots ringing in
+Lacy raid, seven thousand strong
+Comeback Kid but the comeback long
+Got a Suno deal, got a song machine
+Now I need that Cinnamon Twist on the violet screen
+```
+
+**"Mama on the phone like you sleeping in the whip"** — verbatim from the 365 Documentary: *"my mom calling me in the car and she was like, 'Man, like are you sleeping in your car?' And I said, 'Yes.'"* This is the song's most direct biographical line. The "whip" (car) is the LA period before the Skid Row container.
+
+**"Yeah ma but the dream's on a steady drip"** — his answer in the documentary: *"Don't worry about it. We will figure it out."* "Steady drip" is the trap line — drip = swag, drip = IV, the dream is keeping him alive.
+
+**"365 in a Skid Row tin"** — 365 = the streak count. "Skid Row tin" = the shipping container. "Tin" because containers are corrugated steel — and because tin is what a beggar's cup is made of. The Indian-kid-in-LA arc compressed.
+
+**"Container singing, gunshots ringing in"** — direct from the documentary: *"We heard gunshots outside, bro. People knocking, homeless, man. Every single bad thing that you could think of was happening on those streets. But if there's a will, there's a way, bro. And we streamed."* The container is where the music kept getting made.
+
+**"Lacy raid, seven thousand strong"** — Day 100 of the streak: at a 24-hour stream, the streamer Lacy raided him with ~7,000 viewers. From the documentary: *"I started seeing a bunch of people flood my chat. I ended up having 7,000 people in my stream that night because Lacy raided me with this entire community."* This is the song's turning-point moment — and the trackers' lifetime viewer peak.
+
+**"Comeback Kid but the comeback long"** — **Comeback Kid** is a real Jadyn Violet song from the Raver Realm collection (Underground Realm, Common rarity). The character archetype is someone aware they're stuck in a loop and can't break it. The line plays self-aware: I'm literally the Comeback Kid, but the comeback is taking forever. Earned humility.
+
+**"Got a Suno deal, got a song machine"** — the Suno sponsorship + the AI music tool. "Song machine" double-meaning: Suno literally is a song machine, and Jadyn is one too at this point (the streak proves it).
+
+**"Now I need that Cinnamon Twist on the violet screen"** — **Cinnamon Twists** = TB dessert item. The "twist on the violet screen" = his Twitch stream branded UVR, with a TB dessert as the visual. Asking for the deal in food terms.
+
+---
+
+## PRE-CHORUS 2
+
+```
+[Pre-Chorus]
+[Build]
+Baja Blast in the studio
+Crunchwrap on the keyboard
+Got a fire sauce dream from a bedroom door
+Indian rockstar, Tac' Bell tour
+```
+
+**"Baja Blast in the studio"** — Baja Blast = TB's Mountain Dew exclusive. Setting the scene: TB on the studio desk while he makes the song that pitches TB.
+
+**"Crunchwrap on the keyboard"** — the desk-meal trope. Stays in the kitchen/studio bilingual zone — a Crunchwrap on the keys = pitch + production in one frame.
+
+**"Got a fire sauce dream from a bedroom door"** — Fire sauce = TB hot sauce, milder than Diablo. "Bedroom door" = where the dream started. Twitch bio: *"I make music in my bedroom, gunna happen one day."*
+
+**"Indian rockstar, Tac' Bell tour"** — **Rockstar Shit** is a real Jadyn Violet song from the Raver Realm collection (Underground Realm, Rare rarity), about unapologetic ambition. "Indian rockstar" = the identity layer the actual song never explicitly named. "Tac' Bell tour" = the imagined sponsorship outcome — a tour underwritten by TB.
+
+---
+
+## BRIDGE
+
+```
+[Bridge]
+[Breakdown] [Whispered] [Half-Time]
+(strip drums, just pads and vocal)
+One franchise. One franchise.
+Bell tower glowing in the LA night
+One franchise. One franchise.
+Slumdog Billionaire gonna make it right
+[Build]
+Rockstar Shit but I'll trade it for a Liv Más day
+Tac' Bell, hear me out, call my line
+You sponsor the rave, I sponsor the sign
+```
+
+**"One franchise. One franchise."** — mantra repetition, the literal ask reduced to its smallest form. The bridge slows everything down to a heartbeat so this is what stays.
+
+**"Bell tower glowing in the LA night"** — the Taco Bell logo is, literally, a bell. "Bell tower" = the TB sign on the corner, lit up. The LA-night image pairs it with arrival.
+
+**"Slumdog Billionaire gonna make it right"** — **Slumdog Billionaire** is a real Jadyn Violet single (March 14, 2025); the music video was shot in India. The title itself is a play on *Slumdog Millionaire* (the 2008 film about an Indian kid winning everything), with the Indian-American hustle escalating the prize. In the bridge it doubles as: the Indian kid from the slums makes it right — earning the franchise.
+
+**"Rockstar Shit but I'll trade it for a Liv Más day"** — direct callback to Verse 2's "Indian rockstar." "Rockstar Shit" = his own song; "Liv Más day" = a TB-branded day. He's saying he'll trade the rockstar life for the franchise life. The half-joke at the heart of the song made literal.
+
+**"Tac' Bell, hear me out, call my line"** — the polite ask. After the mantra, the breakdown, the proofs, he just opens the line.
+
+**"You sponsor the rave, I sponsor the sign"** — the closing offer of the bridge. They put money on UVR; he puts UVR on their sign. Reciprocity in nine words.
+
+---
+
+## OUTRO
+
+```
+[Outro]
+[Whispered] [Fade Out]
+Why not me. Why not me. Why not me.
+Liv Más on the violet frequency.
+Why not me. Why not me. Why not me.
+Taco Bell, I'll see you eventually.
+```
+
+**"Why not me. Why not me. Why not me."** — the thesis statement closes the song the way it opened it. The mantra version of his actual one-line life lesson.
+
+**"Liv Más on the violet frequency"** — TB tagline (phonetic spelling for Suno's TTS — sung as "liv mahss") + UVR brand sign-off. The two brands ride out together on the same radio dial.
+
+**"Taco Bell, I'll see you eventually."** — patient confidence. From the Steve Reynoso podcast Jadyn says: *"I think Violet Rave and Raver Realm have legs and a lot of room to run. And I'm in it for not the next one or two years, but the next 20, 30 years."* The outro ends the pitch by lowering the urgency: it doesn't have to be now. It's going to happen.
+
+---
+
+## Reference index — every callback, in one table
+
+| Line | What it references | Source |
+|------|--------------------|--------|
+| "Indian kid out the Jersey state" | First-gen Indian American, Somerset NJ; 365 Doc opening | Doc 600 / Apple Music / Doc 600.08 |
+| "Trap from a bedroom" | 2018 first SoundCloud single, age 17-18; Twitch bio | Doc 600.06 / TwitchTracker |
+| "Lost the wallet" | The $10,000 crypto wallet drain | Steve Reynoso Podcast / Doc 600.08 |
+| "Lost the rave" | 2024 Thailand year; UVR community dissolved | Steve Reynoso Podcast / Doc 600.08 |
+| "Shipping container on the Skid Row pave" | $150 Skid Row container during 365-day streak | The 365 Documentary / Doc 600.03 |
+| "Three months in, half a viewer deep" | 90 days at ~0.5 avg viewers | The 365 Documentary |
+| "Hollywood sign in the rearview" | Cross-country drive ending at Hollywood sign | The 365 Documentary |
+| "One franchise" | Taco Bell franchise dream | Word To Your Mama Ep 167 |
+| "Crunchwrap, CGC, Cinnamon Twist, Doritos Locos, Fire sauce, Diablo, Baja Blast" | TB menu items | Taco Bell |
+| "Live / Liv Más" | TB tagline since 2012, pronounced "liv mahss" | Taco Bell |
+| "Sponsor me, Suno, you already did" | Jadyn's real Suno sponsorship | User-confirmed |
+| "Mama on the phone like you sleeping in the whip" | Verbatim doc moment | The 365 Documentary |
+| "Lacy raid, seven thousand strong" | Day 100 raid by Lacy with ~7,000 viewers | The 365 Documentary |
+| "Comeback Kid" | Real Jadyn song, Raver Realm Underground Realm | Doc 600.06 |
+| "Rockstar Shit" | Real Jadyn song, Raver Realm Underground Realm | Doc 600.06 |
+| "Slumdog Billionaire" | Real Jadyn single, March 14 2025, video shot in India | Doc 600.06 |
+| "Why not me / why not you" | Jadyn's stated one-line life lesson | Steve Reynoso Podcast |
+| "I'll see you eventually" | "I'm in it for the next 20, 30 years" | Steve Reynoso Podcast |
+| "Violet" / "violet TV" / "violet frequency" / "violet screen" | UVR brand color | Doc 600 / raverrealm.xyz |
+| "Underground Violet Rave at the drive-thru beep" | UVR self-identification at the TB drive-thru | Doc 600 |
+
+---
+
+## Notes for the writeup, when you post this
+
+If you drop this in the UVR Discord or on Farcaster, the move is probably:
+
+1. The 30-second elevator: "Made a Suno song asking Taco Bell to sponsor UVR. Every line in it is a real Jadyn lore reference — Skid Row container, Lacy raid, the 365, the wallet drain, the Thailand year, his actual songs (Comeback Kid, Rockstar Shit, Slumdog Billionaire). The Live Más tagline is sung correctly (liv mahss). Liner notes attached."
+2. Link to the doc / liner notes file.
+3. Tag projectuvr if appropriate.
+
+Per [feedback_no_unconfirmed_anchor_partners] in the standing rules — don't claim Taco Bell or Jadyn endorsement until they actually engage. The framing is "I made this pitch" not "Jadyn made this" or "TB is in." Stay accurate.

--- a/research/music/601-suno-music-generation-deep-tooling-2026/02-sponsor-me-liner-notes.md
+++ b/research/music/601-suno-music-generation-deep-tooling-2026/02-sponsor-me-liner-notes.md
@@ -21,6 +21,38 @@ Jadyn Violet's recurring half-joke in interviews — most explicitly on Word To 
 
 ---
 
+## Where the lore comes from — UVR research
+
+Every reference in this song is real Jadyn Violet / UVR biography pulled from the verified research dossier: **[Doc 600 — Jadyn Violet & UVR Deep Dive](../../community/600-jadyn-violet-uvr-deep-dive/)**. That folder has the full chronological story, the supporting cast, the music + visual identity, the Twitch-era timeline, the press archive, and cleaned transcripts of "The 365 Documentary" and the Steve Reynoso podcast. The annotations below trace every line in this song back to a specific source in that dossier.
+
+The "where to put what" tactical Suno guide for this song's production is the parent doc: **[601 README](README.md)**. The two A/B cover art prompts are in **[03-cover-art-prompts.md](03-cover-art-prompts.md)**.
+
+---
+
+## The recipe (Suno v5.5) — for anyone who wants to remix
+
+Want to make your own version, swap your own bars, run a different vocal? Here's the full recipe.
+
+**Suno settings:** v5.5, Custom Mode, Weirdness 55%, Style Influence 75%.
+
+**Style Description** (paste into Suno's Style box, ~540 chars):
+
+```
+melodic trap, hyperpop elements, dark and euphoric, breathy auto-tuned male vocals, deep 808s with slides, rolling hi-hats, glitchy textures, dark synths, shimmering ethereal pads, sidechained euphoric drop on chorus, 140 BPM, violet underground rave aesthetic, polished mix, vulnerable yet braggadocio
+```
+
+**Exclude Styles** (Advanced field):
+
+```
+no orchestral strings, no acoustic guitar, no spoken word in chorus, no female vocals, no radio polish, no lo-fi warmth
+```
+
+**Pronunciation note:** Taco Bell's tagline "Live Más" is sung **"liv mahss"** — *Live* rhymes with *give*, not *alive*. Suno's TTS defaults to the wrong "alive" pronunciation if you write it standard, so the lyric block respells it phonetically as **Liv Más** in every sung position. The song title and prose stay "Live Más."
+
+**Full lyrics block** — copy from the appendix at the bottom of this doc, or grab it from the [601 README primary variant](README.md#primary---sponsor-me-live-más---melodic-trap--hyperpop).
+
+---
+
 ## INTRO
 
 ```
@@ -252,6 +284,109 @@ Taco Bell, I'll see you eventually.
 | "I'll see you eventually" | "I'm in it for the next 20, 30 years" | Steve Reynoso Podcast |
 | "Violet" / "violet TV" / "violet frequency" / "violet screen" | UVR brand color | Doc 600 / raverrealm.xyz |
 | "Underground Violet Rave at the drive-thru beep" | UVR self-identification at the TB drive-thru | Doc 600 |
+
+---
+
+## Appendix — full lyrics (paste-ready block)
+
+For Suno's Lyrics box, or just to read straight through. Bracket tags on their own line above the lyrics they govern. "Liv Más" is the phonetic respelling of "Live Más" (sung as "liv mahss").
+
+```
+[Intro]
+[Spoken Word] [Male Vocal]
+(violet synth pad, glitch sweep)
+This one's for Tac' Bell.
+Why not me.
+
+[Verse 1]
+[Auto-Tuned] [Melodic Rap]
+Indian kid out the Jersey state
+Trap from a bedroom, ten years late
+Lost the wallet, lost the rave
+Bought a shipping container on the Skid Row pave
+Three months in, half a viewer deep
+Now the violet hits like Diablo on the cheek
+Why not me, bro? Why not now?
+365 days, take a bow
+
+[Pre-Chorus]
+[Build]
+Three AM on the 101
+Hollywood sign in the rearview gun
+All I want is one franchise
+Got the dream and the receipts, son
+
+[Chorus]
+[Belted] [Auto-Tuned] [Ad-libs] [Layered Vocals]
+(808 drop, sidechained synths, euphoric)
+Sponsor me, Taco Bell, sponsor me
+I'll put the Crunchwrap on the violet TV
+Cheesy Gordita Crunch, my city, my keys
+Liv Más, baby, liv Más with me
+Sponsor me, Suno, you already did
+Now it's Tac' Bell's turn, yeah I'm not a kid
+I'm the Underground Violet Rave at the drive-thru beep
+Doritos Locos, fire sauce, eternal sleep
+
+[Verse 2]
+[Auto-Tuned] [Melodic Rap]
+Mama on the phone like you sleeping in the whip
+Yeah ma but the dream's on a steady drip
+365 in a Skid Row tin
+Container singing, gunshots ringing in
+Lacy raid, seven thousand strong
+Comeback Kid but the comeback long
+Got a Suno deal, got a song machine
+Now I need that Cinnamon Twist on the violet screen
+
+[Pre-Chorus]
+[Build]
+Baja Blast in the studio
+Crunchwrap on the keyboard
+Got a fire sauce dream from a bedroom door
+Indian rockstar, Tac' Bell tour
+
+[Chorus]
+[Belted] [Auto-Tuned] [Ad-libs] [Layered Vocals]
+(808 drop, sidechained synths, euphoric)
+Sponsor me, Taco Bell, sponsor me
+I'll put the Crunchwrap on the violet TV
+Cheesy Gordita Crunch, my city, my keys
+Liv Más, baby, liv Más with me
+Sponsor me, Suno, you already did
+Now it's Tac' Bell's turn, yeah I'm not a kid
+I'm the Underground Violet Rave at the drive-thru beep
+Doritos Locos, fire sauce, eternal sleep
+
+[Bridge]
+[Breakdown] [Whispered] [Half-Time]
+(strip drums, just pads and vocal)
+One franchise. One franchise.
+Bell tower glowing in the LA night
+One franchise. One franchise.
+Slumdog Billionaire gonna make it right
+[Build]
+Rockstar Shit but I'll trade it for a Liv Más day
+Tac' Bell, hear me out, call my line
+You sponsor the rave, I sponsor the sign
+
+[Chorus]
+[Belted] [Auto-Tuned] [Ad-libs] [Layered Vocals]
+(808 drop, sidechained synths, euphoric)
+Sponsor me, Taco Bell, sponsor me
+I'll put the Crunchwrap on the violet TV
+Cheesy Gordita Crunch, my city, my keys
+Liv Más, baby, liv Más with me
+
+[Outro]
+[Whispered] [Fade Out]
+Why not me. Why not me. Why not me.
+Liv Más on the violet frequency.
+Why not me. Why not me. Why not me.
+Taco Bell, I'll see you eventually.
+
+[End]
+```
 
 ---
 

--- a/research/music/601-suno-music-generation-deep-tooling-2026/03-cover-art-prompts.md
+++ b/research/music/601-suno-music-generation-deep-tooling-2026/03-cover-art-prompts.md
@@ -1,0 +1,88 @@
+---
+topic: music
+type: guide
+status: draft
+last-validated: 2026-05-15
+related-docs: 601, 600
+tier: STANDARD
+---
+
+# 601.03 — Cover Art Prompts (A / B for UVR community vote)
+
+> Two distinct ChatGPT image-gen prompts for the "Sponsor Me (Live Más)" cover. Run both, drop both in UVR Discord, let the Ravers pick.
+
+Both target a **1:1 square** (Spotify/Apple/Sound canonical 3000x3000). Both reference the same lore — Skid Row shipping container, violet UVR aesthetic, Taco Bell visual cues, Hollywood sign on the horizon — but the styles are deliberately opposite so the vote has a real choice.
+
+- **A — cinematic photo.** No character on screen. A24-album-cover mood piece.
+- **B — hand-drawn character portrait.** Riffs on Jadyn's own Raver Realm illustration practice.
+
+Both prompts avoid actual face/likeness of any real person (per [feedback_dont_invent_outreach] — this is a pitch song, not a Jadyn-endorsed artifact). Both phrase brand cues descriptively so the image model doesn't refuse on IP grounds.
+
+---
+
+## Prompt A — Cinematic photo
+
+Paste into ChatGPT (or any image model with similar capabilities). Square 1:1.
+
+```
+A square 1:1 song cover art for a melodic trap track titled "Sponsor Me (Live Más)."
+
+Scene: A solitary shipping container parked at night on a cracked, weed-cracked Skid Row asphalt lot in downtown Los Angeles. The container's doors are slightly open and its interior glows deep violet from within - the light of a livestreaming setup inside (faintly visible silhouettes of a laptop, monitor, microphone, RGB strip). In the middle distance, an oversized neon bell-tower sign (in the style of a late-night fast-food chain's bell logo) glows a deeper purple-magenta against a near-black sky. Far on the horizon, very small and hazy, the Hollywood sign is faintly visible. Wet pavement reflects the violet neon. LA haze blurs the stars. A single bird mid-air.
+
+Mood: late-night, vulnerable, cinematic, lonely but determined. The image should feel like a still from an A24 film about an underground musician trying to make it.
+
+Color palette: deep violet (#7A3FBF) and near-black dominant. Warm orange/red accents only from a single streetlight and the bell tower glow. No bright daylight colors anywhere.
+
+Style: photorealistic, anamorphic lens flare, 35mm film grain, slight atmospheric haze, shallow depth of field. Container in sharp focus foreground; bell tower softly bokeh'd in midground.
+
+Composition: rule of thirds. Container left of center foreground, bell tower upper right midground, Hollywood sign tiny upper-left horizon. Bottom-right quadrant relatively empty (for a possible title overlay added later). No on-image text.
+
+Avoid: bright daylight, cheerful saturated colors, any real person's face, cartoon style, generic stock-photo framing, busy background.
+```
+
+---
+
+## Prompt B — Hand-drawn character portrait
+
+Paste into ChatGPT. Square 1:1.
+
+```
+A square 1:1 song cover art for a melodic trap track titled "Sponsor Me (Live Más)."
+
+Scene: A hand-drawn illustration of a young South Asian man in a black hoodie sitting cross-legged on top of a corrugated steel shipping container under a deep violet night sky. His face is partly shadowed by the hood; not a portrait of a recognizable real person. He holds a hexagonal folded fast-food wrap in one hand and a glowing violet smartphone (a livestream interface faintly visible on its screen) in the other. A halo of small floating fast-food items orbits him: a twisted cinnamon pastry, a tall cup of bright electric-blue slush drink, a small red square sauce packet, a vivid orange Doritos-style taco. Behind him, an oversized neon bell-tower silhouette (in the style of a late-night fast-food chain's logo) glows huge in the violet sky like a moon, forming a halo around his head. Far on the horizon, the Hollywood sign tiny and hazy. A few small bats or ravens silhouetted against the violet.
+
+Mood: defiant, prayerful, slightly mythical. Lore-poster energy. Equal parts hip-hop mixtape cover and 1990s anime end-card promo.
+
+Color palette: deep violet (#7A3FBF) dominant sky and atmosphere. Character rim-lit in warm magenta-purple. Small hits of fast-food orange and electric blue as accent colors. No daylight tones.
+
+Style: hand-drawn digital ink with painted shading (intentionally not photorealistic, evoking Paint.NET on a Wacom tablet). Strong inked outlines, mostly flat-shaded base colors, a few painted highlights for volume, slightly grainy paper texture overlay. Influence: contemporary NFT character art meets 1990s anime promotional posters meets hand-drawn variant rap album covers.
+
+Composition: centered character portrait, near-vertical symmetry, bell-tower glow forming a halo behind the head. Character occupies the central two-thirds of the frame. No on-image text.
+
+Avoid: photorealism, AI-glossy plastic look, generic shounen anime style, faces of recognizable real people, brand text that's readable, busy background that competes with the character.
+```
+
+---
+
+## UVR Discord poll post (paste with both generated images attached)
+
+```
+made two cover art directions for the song. dropping both - tell me which one to run.
+
+OPTION A - cinematic photo. late-night Skid Row container glowing violet inside, Bell tower silhouette in the distance, Hollywood sign on the horizon. A24-album-cover energy. no character on screen.
+
+OPTION B - hand-drawn character. hooded kid sitting on top of the container with a Crunchwrap in hand, fast-food items orbiting him, Bell tower as a halo behind his head. riffs on Jadyn's own hand-drawn Raver Realm aesthetic.
+
+prompts in the next message if anyone wants to remix them through their own image gen and submit a third option.
+
+vote: A or B?
+```
+
+---
+
+## Notes
+
+- ChatGPT's image generator may produce slightly different results on identical prompts; run each prompt 2-3 times and pick the best.
+- Brand cues are intentionally descriptive ("late-night fast-food chain's bell logo") rather than naming Taco Bell directly. This usually avoids the model's IP-refusal path. If it still refuses, fall back to "a glowing purple bell shape" without any "fast-food chain" framing.
+- The same prompts work in Midjourney with minor adaptations (drop the "square 1:1" preamble and use `--ar 1:1` instead).
+- If the chosen variant needs a tweak (e.g. swap the cup color, add more bats, brighten the container), iterate on the same chat thread rather than starting fresh — context-aware edits beat from-scratch regens.

--- a/research/music/601-suno-music-generation-deep-tooling-2026/README.md
+++ b/research/music/601-suno-music-generation-deep-tooling-2026/README.md
@@ -138,6 +138,8 @@ This is "Sponsor Me (Live Más)" — the UVR-flavor Taco Bell sponsorship pitch.
 
 ### PRIMARY — "Sponsor Me (Live Más)" — melodic trap × hyperpop
 
+> **Pronunciation note:** Taco Bell's tagline is "Live Más" pronounced **"liv mahss"** — *Live* rhymes with *give*, not with *alive*. Suno's TTS will default to the wrong "alive" pronunciation if you write it standard. The lyric block below uses the phonetic spelling **"Liv Más"** in sung positions to force the right pronunciation. The song title and prose still use "Live Más" — only the sung lyric is respelled. See [02-sponsor-me-liner-notes.md](02-sponsor-me-liner-notes.md) for the full annotated lyric breakdown — every reference, every callback, every TB item explained.
+
 **Style** (paste into Suno's Style Description box, 540 chars):
 ```
 melodic trap, hyperpop elements, dark and euphoric, breathy auto-tuned male vocals, deep 808s with slides, rolling hi-hats, glitchy textures, dark synths, shimmering ethereal pads, sidechained euphoric drop on chorus, 140 BPM, violet underground rave aesthetic, polished mix, vulnerable yet braggadocio
@@ -180,7 +182,7 @@ Got the dream and the receipts, son
 Sponsor me, Taco Bell, sponsor me
 I'll put the Crunchwrap on the violet TV
 Cheesy Gordita Crunch, my city, my keys
-Live Más, baby, live Más with me
+Liv Más, baby, liv Más with me
 Sponsor me, Suno, you already did
 Now it's Tac' Bell's turn, yeah I'm not a kid
 I'm the Underground Violet Rave at the drive-thru beep
@@ -210,7 +212,7 @@ Indian rockstar, Tac' Bell tour
 Sponsor me, Taco Bell, sponsor me
 I'll put the Crunchwrap on the violet TV
 Cheesy Gordita Crunch, my city, my keys
-Live Más, baby, live Más with me
+Liv Más, baby, liv Más with me
 Sponsor me, Suno, you already did
 Now it's Tac' Bell's turn, yeah I'm not a kid
 I'm the Underground Violet Rave at the drive-thru beep
@@ -224,7 +226,7 @@ Bell tower glowing in the LA night
 One franchise. One franchise.
 Slumdog Billionaire gonna make it right
 [Build]
-Rockstar Shit but I'll trade it for a Live Más day
+Rockstar Shit but I'll trade it for a Liv Más day
 Tac' Bell, hear me out, call my line
 You sponsor the rave, I sponsor the sign
 
@@ -234,12 +236,12 @@ You sponsor the rave, I sponsor the sign
 Sponsor me, Taco Bell, sponsor me
 I'll put the Crunchwrap on the violet TV
 Cheesy Gordita Crunch, my city, my keys
-Live Más, baby, live Más with me
+Liv Más, baby, liv Más with me
 
 [Outro]
 [Whispered] [Fade Out]
 Why not me. Why not me. Why not me.
-Live Más on the violet frequency.
+Liv Más on the violet frequency.
 Why not me. Why not me. Why not me.
 Taco Bell, I'll see you eventually.
 


### PR DESCRIPTION
## Summary
Two follow-ups to the merged doc 601 work:

1. **Pronunciation fix.** Taco Bell's tagline "Live Más" is pronounced "liv mahss" - *Live* rhymes with *give*, not with *alive*. Suno's TTS will sing it the wrong way if the lyric is spelled standard. Respelled in sung positions as "Liv Más" to force the correct pronunciation; song title and prose retain "Live Más" with a pronunciation note added to the README.

2. **02-sponsor-me-liner-notes.md** - Genius-style annotated breakdown of every line in the primary variant. Each reference is pulled back to the verified Jadyn Violet / UVR research in doc 600. Includes a full reference index table mapping every callback to its source.

## Next
The user is going to generate the song in Suno using the corrected blocks, then drop it in UVR with the liner notes as the writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)