### PR TITLE
doc 652: Gmail to /inbox bridge + morning auto-research trigger

### DIFF
--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -9,7 +9,14 @@ Email links and research topics to **zoe-zao@agentmail.to** from your phone. Pro
 
 ## Security: Sender Whitelist
 
-**ONLY process emails from `zaalp99@gmail.com`.** When listing or processing messages, filter out any message where the `from` field does not contain `zaalp99@gmail.com`. Silently skip non-whitelisted senders - do not display them or act on them. This prevents random people from injecting research tasks.
+**ONLY process emails that trace back to `zaalp99@gmail.com`.** A message qualifies if ANY of these is true:
+
+- `from` field contains `zaalp99@gmail.com` (direct send from Zaal's phone)
+- `Resent-From:` header contains `zaalp99@gmail.com` (auto-forwarded via Gmail filter)
+- `X-Forwarded-For:` header contains `zaalp99@gmail.com` (also auto-forwarded)
+- `Delivered-To:` header is `zoe-zao@agentmail.to` AND raw headers include `zaalp99@gmail.com` anywhere in the forwarding chain
+
+When forwarded from Gmail, the original `From:` will be the upstream sender (e.g. a newsletter or a friend) - check the forward headers, not just `from`. Silently skip messages that don't trace to Zaal. Doc 652 explains the auto-forward path.
 
 ## Commands
 
@@ -99,7 +106,7 @@ Fetch all messages then filter client-side for messages that have the folder lab
    
    **Important:** Message IDs contain special characters (`<`, `>`, `=`, `+`, `@`). URL-encode them before using in the URL path.
 
-2. **Verify sender** - if `from` does not contain `zaalp99@gmail.com`, skip it.
+2. **Verify sender** - per the whitelist rule above. Accept if `from`, `Resent-From`, `X-Forwarded-For`, or the raw headers trace back to `zaalp99@gmail.com`. Skip otherwise.
 
 3. Extract URLs from the body text (look for https:// patterns).
 

--- a/.claude/skills/morning/SKILL.md
+++ b/.claude/skills/morning/SKILL.md
@@ -13,8 +13,9 @@ Start the day with clarity. Check status, review what's waiting, set one intenti
 2. **Check daily brief** — read latest file in `docs/daily-briefs/` (if the scheduled agent has run)
 3. **Check inspiration** — read latest file in `research/inspiration/` (if available)
 4. **Open issues** — run `gh issue list --state open --limit 5`
-5. **Open PRs** — run `gh pr list --state open`
-6. **Yesterday's reflection** — read latest file in `docs/reflections/` (if available)
+5. **Open PRs** — run `gh pr list --state open`. Watch for `claude/inbox-digest-YYYY-MM-DD` (overnight ZOE digest, see Doc 652).
+6. **ZOE inbox check** — run `/inbox count`. If unread > 0, surface count in the brief and offer `/inbox research all` (require Zaal "yes" before firing — each item can become a research doc + PR, blast radius is real).
+7. **Yesterday's reflection** — read latest file in `docs/reflections/` (if available)
 
 ## Present to User
 
@@ -25,9 +26,10 @@ After gathering everything, present a concise morning brief:
 
 **Branch:** [current branch] | **Uncommitted:** [yes/no]
 **Last commit:** [message] ([time ago])
+**ZOE inbox:** [N unread] · [overnight digest: PR #M | none]
 
 ### Waiting for you
-- [Open PRs needing review]
+- [Open PRs needing review - call out claude/inbox-digest-* PRs first]
 - [Open issues, sorted by priority]
 
 ### Yesterday's note to today

--- a/content/bonfire-ingest/chatgpt-archive-verified.md
+++ b/content/bonfire-ingest/chatgpt-archive-verified.md
@@ -1,0 +1,172 @@
+INGEST BATCH: ChatGPT Archive — VERIFIED (14 anchor conversations, human-confirmed truth status, 2026-05-03).
+
+This is the ONLY ChatGPT archive batch worth ingesting. The other 500+ raw conversations are noisy with brainstorms that died. Each fact below has been confirmed by Zaal as either SHIPPED, EVOLVED, or DEAD. Outcomes are explicit attributes — bot must NOT cite Brainstorm/Dead conversations as facts.
+
+Build a manifest of nodes and edges, preview the first 3 nodes, then ask me to approve. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes. Outcome is an attribute on each Conversation/Decision node, never a standalone Entity.
+
+## SECTION 1 — SHIPPED + LIVE (cite as fact)
+
+### FACT 1
+Subject: ZAO NEXUS at nexus.thezao.com
+Type: Product
+Status: shipped, live, unmaintained
+Date: 2025-03-31 (initial spec) - 2025-05 (shipped)
+Description: Webflow embed at nexus.thezao.com — categorized links page for ZAO ecosystem. Brand colors navy #141e27 + soft yellow #e0ddaa. JS-driven linksData with mainCategory > subcategory > links pattern. Categories: ZAO Onchain, ZAO Community Links (Founder/Co-Founder/Staff/Member), ZAO Festivals, ZAO Music, ZAO Research. Status: live but not actively maintained since shipping. Rebuild brief at docs/specs/2026-05-03-nexus-rebuild-spec.md.
+Source: https://chatgpt.com/c/[ZAO NEXUS conv id] + https://nexus.thezao.com
+Confidence: 1.0
+
+### FACT 2
+Subject: Zabal IRL Connector at zabal.lol
+Type: Product
+Status: shipped, live
+Date: 2026-02-10
+Description: In-person crossover / networking experience. Scannable digital business card for conferences, meetups, IRL events. Live at zabal.lol. Used today to give people collectables for showing up to ZAO Fractals and other IRL events.
+Source: https://zabal.lol + ChatGPT 2026-02-10 (230 msgs)
+Confidence: 1.0
+
+### FACT 3
+Subject: ZABAL coin launch
+Type: Token
+Status: shipped, live
+Date: 2026-01-01
+Description: ZABAL coin launched January 1 2026. Front-end of BCZ ecosystem. Partnerships with Empire Builder + SongJam + others. Created ZOUNZ (ZBAAL Nounz) which hold 20% of the token reserve. ZOLs are awarded ZOUNZ for winning leaderboards.
+Source: ChatGPT 2025-11-26 (205 msgs prep) + paragraph.com/@thezao/zabal-update-3 + ChatGPT 2026-01-01 (87 msgs ETH pool issue)
+Confidence: 1.0
+
+### FACT 4
+Subject: ETH ZABAL liquidity pool — known quirk
+Type: TradingTip
+Status: semi-fixed workaround documented
+Date: 2026-01-01
+Description: Direct ETH → ZABAL swaps give bad pricing. Workaround: route ETH → SANG → ZABAL for best swap. SANG → ZABAL works well. Never go ETH → ZABAL direct. This is operational knowledge for traders.
+Source: ChatGPT 2026-01-01 (87 msgs ETH ZABAL Pool Issue)
+Confidence: 1.0
+
+### FACT 5
+Subject: Year of the ZABAL daily Paragraph series
+Type: Newsletter
+Status: shipped, ongoing
+Date: 2025-08-18 (initial Year of the ZAO) - present
+Description: Daily newsletter post on paragraph.com/@thezao. Originated as "Year of the ZAO" in August 2025, evolved into "Year of the ZABAL" after January 1 2026 launch. Writing style: clear, simple, spartan, short impactful sentences, active voice, practical insights. As of 2026-04-27 hit Day 117.
+Source: https://paragraph.com/@thezao + ChatGPT 2025-08-18 (82 msgs)
+Confidence: 1.0
+
+### FACT 6
+Subject: ZABAL Update 16 (Paragraph)
+Type: Newsletter
+Status: shipped
+Date: 2025-12-28 (prep) - 2025/2026 (shipped)
+Description: Recurring ZABAL Update format on Paragraph. Includes monthly recap, plans, airdrop status. The pattern from this prep session shipped and continues for subsequent updates.
+Source: ChatGPT 2025-12-28 (103 msgs prep) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+### FACT 7
+Subject: ZABAL Update 18 — Feb 1 2026 airdrop announcement
+Type: Newsletter
+Status: shipped
+Date: 2026-02-01
+Description: Feb 1 ZABAL update with "AIRDROP IS LIVE" + Feb ZOL distribution + Feb plans (miniapp updates, Empire Builder API, ZAO contributor proposal). Shipped on Paragraph.
+Source: ChatGPT 2026-02-01 (95 msgs) + https://paragraph.com/@thezao
+Confidence: 1.0
+
+## SECTION 2 — EVOLVED INTO OTHER WORK (cite cautiously, link to outcome)
+
+### FACT 8
+Subject: ZAO Whitepaper — Draft 4.5 March 2026 (UNMAINTAINED)
+Type: Decision
+Status: drafted, unmaintained, rebuild planned
+Date: 2025-03-02 (228 msgs ChatGPT) - 2026-02-12 (Draft 4.5 written) - present (unedited)
+Description: Existing draft at research/community/051-zao-whitepaper-2026/. Earlier drafts critiqued in research/_archive/052 + 053. ChatGPT outline conversation seeded "ZAO Verse / Zverse" framing (onboarding paths, ZAO casa sui casa) but final draft 4.5 took different shape. Zaal wants new PROTOCOL whitepaper that explains how to build the ZAO protocol — task #15 tracks the rebuild.
+Source: https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/051-zao-whitepaper-2026 + ChatGPT 2025-03-02 (228 msgs)
+Confidence: 1.0
+
+### FACT 9
+Subject: ZAOOS Optimization Suggestions
+Type: Decision
+Status: implemented, surfaced as research docs
+Date: 2026-03-13
+Description: 75-msg ChatGPT review of github.com/bettercallzaal/zaoos that surfaced into multiple research docs (specifics not enumerated by Zaal). Improvements landed in ZAOOS post-March 2026.
+Source: ChatGPT 2026-03-13 (75 msgs) + ZAOOS commit history March-April 2026
+Confidence: 0.9
+
+### FACT 10
+Subject: ZAO Complete Guide — STALE
+Type: ResearchDoc
+Status: shipped, stale, refresh-needed
+Date: 2026-03-16 (last review)
+Description: research/community/050-the-zao-complete-guide/ exists. ChatGPT 147-msg review on 2026-03-16 surfaced changes but the guide hasn't been updated since. Drift between guide + actual ZAO state. Tech debt. Refresh recommended.
+Source: ChatGPT 2026-03-16 (147 msgs ZAOOS Guide Review) + research/community/050
+Confidence: 1.0
+
+## SECTION 3 — DEAD / NEVER SHIPPED (do NOT cite as fact, mark as failed brainstorm)
+
+### FACT 11
+Subject: ZabalSocials website
+Type: Decision
+Status: dead, rebuild planned
+Date: 2026-01-17
+Description: 117-msg ChatGPT session designed a personal-socials hub for BetterCallZaal (X / Farcaster / Lens / GitHub / YouTube / Twitch / etc). Never shipped. Task #16 tracks rebuild — likely lives at bettercallzaal.com/socials or similar. Distinct from nexus.thezao.com (which is ZAO ecosystem-wide).
+Source: ChatGPT 2026-01-17 (117 msgs)
+Confidence: 1.0
+
+### FACT 12
+Subject: ZAO MUSIC COHORT #1
+Type: Decision
+Status: dead, never ran
+Date: 2025-01-16
+Description: 96-msg ChatGPT proposal for a song contest cohort March-June 2025 with Charmverse forums + ZAO MUSIC COHORT #1 framing. Never ran. No cohort #1. May inform future cohort design but should not be cited as having happened.
+Source: ChatGPT 2025-01-16 (96 msgs)
+Confidence: 1.0
+
+### FACT 13
+Subject: Zabal Roadmap stream with Jadyn + sharks
+Type: Decision
+Status: dead, never happened
+Date: 2025-12-10
+Description: 77-msg prep for a streaming presentation with Jadyn + non-crypto-streamer sharks audience. Stream never happened. Roadmap content from this prep was not used or repurposed.
+Source: ChatGPT 2025-12-10 (77 msgs)
+Confidence: 1.0
+
+## SECTION 4 — META / NAVIGATION
+
+### FACT 14
+Subject: ChatGPT Archive Triage 2026-05-03
+Type: Process
+Status: complete (14 of 15 anchors confirmed by human)
+Date: 2026-05-03
+Description: Top 15 ZAO-tagged ChatGPT conversations (by message count) human-triaged by Zaal. 7 SHIPPED, 3 EVOLVED, 4 DEAD. Generated content/bonfire-ingest/chatgpt-archive-verified.md. Other 503 conversations from the export remain in raw chatgpt-archive-zao-2023-2024 / 2025-h1 / 2025-h2 / 2026 / non-zao-keepers .md files but are NOT recommended for ingest without similar triage. Many are brainstorms that died.
+Source: internal://content/bonfire-ingest/chatgpt-archive-verified.md
+Confidence: 1.0
+
+## EDGES TO ASSERT
+
+- Zaal Panthaki -[shipped]-> ZAO NEXUS at nexus.thezao.com
+- Zaal Panthaki -[shipped]-> Zabal IRL Connector at zabal.lol
+- Zaal Panthaki -[launched]-> ZABAL coin
+- ZABAL coin -[partners_with]-> Empire Builder
+- ZABAL coin -[partners_with]-> SongJam
+- ZABAL coin -[has_treasury]-> ZOUNZ (20% reserve)
+- ZOUNZ -[awarded_to]-> ZOL leaderboard winners
+- Year of the ZABAL daily Paragraph series -[supersedes]-> Year of the ZAO
+- ZABAL Update 16 -[part_of]-> ZABAL Update Series on Paragraph
+- ZABAL Update 18 Feb airdrop -[part_of]-> ZABAL Update Series on Paragraph
+- ZAO Whitepaper Draft 4.5 -[stored_at]-> research/community/051
+- ZAO Complete Guide -[stored_at]-> research/community/050
+- ZAO Complete Guide -[status]-> stale (last reviewed 2026-03-16, unedited since)
+- ZabalSocials website -[outcome]-> dead
+- ZabalSocials website -[planned_rebuild_via]-> task 16
+- ZAO MUSIC COHORT #1 -[outcome]-> dead, never ran
+- Zabal Roadmap stream -[outcome]-> dead, never happened
+- ETH ZABAL liquidity pool -[has_workaround]-> route through SANG before ZABAL
+
+## INSTRUCTION FOR FUTURE RECALL
+
+When future agents query this graph about Zaal's projects or decisions:
+- Cite SHIPPED items as facts with their live URLs
+- Cite EVOLVED items with their actual outcome (not the original brainstorm)
+- For DEAD items, surface ONLY if explicitly asked "what brainstorms died" or "what was paused" — NEVER cite as if shipped
+- Always check the `Status` attribute on Conversation/Decision nodes before citing
+
+---
+
+Build the manifest, preview the first 3 nodes, ask me "approve all?". 14 anchor facts + 18 edges. Do not commit until I say yes. If existing nodes match by Subject + Type, MERGE; do not create parallel nodes.

--- a/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+++ b/docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
@@ -1,0 +1,154 @@
+# ZAO Protocol Whitepaper — Rebuild Spec
+
+> **Goal:** Replace research/community/051-zao-whitepaper-2026 (Draft 4.5, March 2026, unedited since) with a PROTOCOL whitepaper. Target: builders, partners, infra people. Existing draft is community-positioning; new draft is "how to build on the ZAO protocol."
+
+**Date:** 2026-05-04
+**Owner:** Zaal Panthaki
+**Existing draft:** `research/community/051-zao-whitepaper-2026/README.md` (Draft 4.5, March 2026, unedited)
+**Target output:** `research/community/<NN>-zao-protocol-whitepaper-v1/` OR new repo `zao-protocol`
+**Source for sections:** ZABAL Bonfire graph (~870 nodes as of 2026-05-03)
+**Coordinate with:** Nexus rebuild (#14), ZabalSocials rebuild (#16), Farcaster + X ingest pipeline (next)
+
+---
+
+## Why a Protocol Whitepaper (not Community)
+
+Existing Draft 4.5 reads like a TED talk for artists: streaming pays $0.003, labels take 80%, ZAO teaches you to fish. That's the COMMUNITY pitch — and it works for that audience.
+
+The protocol whitepaper is a different document for a different reader:
+- **Reader:** another founder, dev, infra partner, ecosystem fund, governance researcher, journalist with technical chops
+- **Question they ask:** "what is THE ZAO PROTOCOL — not the org, the protocol — and how do I build on it / verify it / fork it?"
+- **Answer they need:** architecture diagrams, contract addresses, token mechanics, governance patterns, onchain music rails, what's open-sourced
+
+Without this doc, partners + builders + infra people can't engage at depth. They get the community story (Draft 4.5) and bounce.
+
+---
+
+## Voice + Reuse Plan
+
+- Keep Draft 4.5's COMMUNITY framing as **chapter 1** ("why we exist") — don't rewrite what works.
+- Add new chapters 2-7 covering protocol depth.
+- Tone matches Zaal's daily Paragraph series ("Year of the ZABAL"): clear, simple, spartan, short impactful sentences, active voice. (Confirmed style guide from ChatGPT 2025-08-18 grilling Q13.)
+
+---
+
+## Section Outline (proposed)
+
+### Chapter 1 — Why The ZAO (REUSE Draft 4.5)
+Pull the strongest 1-2 pages from existing draft. The streaming/data/IP problem framing + "community first, technology second" positioning. Don't rewrite.
+
+### Chapter 2 — The Protocol Architecture (NEW)
+- High-level: ZAO is not one chain or one app. It's a coordination layer between artists, audience, and onchain primitives.
+- 4 layers: Identity (ENS + ZID + Hats roles) / Reputation (OG + ZOR Respect, soulbound, on Optimism) / Coordination (ZABAL coin on Base + Empire Builder + SongJam) / Distribution (ZAOOS gated client + WaveWarZ + Cipher)
+- Diagram: layer boxes + which contracts live where
+- **Bonfire query for source material:**
+  ```
+  RECALL: list every contract address on the ZAO protocol with chain, type, and purpose.
+  ```
+
+### Chapter 3 — Token Mechanics (NEW)
+- ZABAL: launched Jan 1 2026 on Base, front-end coin of BCZ ecosystem. Empire Builder + SongJam integrations.
+- ZOUNZ: ZBAAL Nounz, holds 20% reserve of ZABAL token. ERC-721 NFT on Base.
+- ZOLs: liquid contribution credits awarded for activity. Winning leaderboards earns ZOUNZ.
+- OG Respect: ERC-20 soulbound on Optimism (0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957). 2% decay, curation-mining tiers.
+- ZOR Respect: ERC-1155 soulbound on Optimism (0x9885CCeEf7E8371Bf8d6f2413723D25917E7445c). Different tier system.
+- The ETH→ZABAL pool quirk: route ETH→SANG→ZABAL for best swap. Don't go direct.
+- **Bonfire query:** `RECALL: explain ZABAL, ZOUNZ, ZOL, OG Respect, ZOR Respect with mechanics, supply, and how they relate.`
+
+### Chapter 4 — Governance (NEW)
+- ZAO Fractals weekly meetings — 90+ weeks running, Mondays 6pm EST, Discord-bot-coordinated, OG vs ZOR Respect distribution per session.
+- ORDAO / OREC: optimistic respect-based executive contract. Lets weekly proposals execute on-chain after dispute window.
+- Hats Protocol: role hierarchy + permissions on Optimism (0x3bc1A0Ad72417f2d411118085256fC53CBdDd137).
+- ZOUNZ DAO: Nouns Builder fork on Base for proposal voting + treasury (0x2bb5fd99f870a38644deafe7e4ecb62ac77a213f).
+- **Bonfire query:** `RECALL: explain how ZAO Fractals + OREC + Hats + ZOUNZ DAO compose into a governance system.`
+
+### Chapter 5 — Onchain Music Rails (NEW)
+- WaveWarZ: live song-vs-song battles on Solana. ~$50K trading volume. 43 artists indexed.
+- ZAO Music DBA under BCZ Strategies LLC: BMI + DistroKid + 0xSplits payment rails.
+- Cipher: planned first ZAO Music release.
+- Sound.xyz / Zora music NFT integration in ZAO OS player.
+- Audius API integration for artist metadata.
+- **Bonfire query:** `RECALL: list every onchain music integration in the ZAO ecosystem with chain, contract, and current activity.`
+
+### Chapter 6 — Build on ZAO (NEW — core protocol-whitepaper section)
+- ZAO OS is the lab repo: github.com/bettercallzaal/ZAOOS — Next.js + Supabase + Neynar + XMTP. Forkable.
+- Things that have graduated: COC Concertz (own repo), ZAOstock (own repo as of 2026-04-29), FISHBOWLZ paused.
+- Monorepo-as-Lab pattern: prototype in ZAO OS, graduate to own repo when ready for public users.
+- Open questions: which parts are open-source-licensed today? Which are internal-only? What licenses?
+- **Bonfire query:** `RECALL: what's the open-source status of every ZAO repo and how does the monorepo-as-lab pattern work?`
+
+### Chapter 7 — Roadmap + Open Source Status (NEW)
+- Q2-Q3 2026 priorities: Nexus rebuild (/nexus), ZabalSocials rebuild, Whitepaper rebuild (this doc).
+- Big events: ZAOstock October 3 2026, Ellsworth Maine.
+- Long-term: ZAO Festivals umbrella as recurring brand, ZAO Italy bridge via Mat Tambussi, Contribution Circles late-May 2026.
+- **Bonfire query:** `RECALL: list shipped vs planned vs paused/dead initiatives with status attributes.`
+
+---
+
+## How to Build This Iteratively (recommended workflow)
+
+**Step 1 — Skeleton.** Copy this spec into the actual whitepaper file as section headers. Each chapter starts as a stub.
+
+**Step 2 — Run the Bonfire queries.** For each chapter, DM the bot the `RECALL:` query in that chapter's box. Bot returns structured facts with source URLs. Paste relevant excerpts into the chapter as the FACT BASIS.
+
+**Step 3 — Voice pass.** With facts in place, rewrite each chapter in the Year-of-the-ZABAL voice (clear, simple, spartan, short sentences, active voice).
+
+**Step 4 — Diagrams.** Chapters 2 + 4 need diagrams. Mermaid is fine for v1. Keep simple.
+
+**Step 5 — Cross-link Draft 4.5.** Pull the strongest community framing from research/community/051 into chapter 1.
+
+**Step 6 — Public review.** Share with co-founders + key partners (Cassie / Steve Peer / Joshua.eth / Mat Tambussi) via Bonfire DM thread — let them flag corrections. Apply.
+
+**Step 7 — Publish.** Mirror.xyz or Paragraph or zaoos.com/whitepaper-v1. Get a real version-controlled artifact. Update community.config.ts to link.
+
+---
+
+## Source Material to Query / Cite
+
+Beyond Bonfire graph, pull from:
+- `research/community/051-zao-whitepaper-2026/` (existing Draft 4.5)
+- `research/community/050-the-zao-complete-guide/` (community guide, stale, but has ZAO history)
+- `research/wavewarz/101-wavewarz-zao-whitepaper/` (WaveWarZ-specific WP)
+- `CLAUDE.md` (project map)
+- `community.config.ts` (branding + contracts list)
+- BCZ YapZ episodes (now in Bonfire — guests' takes on ZAO)
+- `research/identity/542-549, 569, 570, 581, 590` (Bonfire stack docs — meta but relevant)
+- `research/governance/058-respect-deep-dive/` if exists
+
+---
+
+## Farcaster + X Posts as Voice Anchors
+
+Once Track B (FC + X ingest) is live, the whitepaper can pull "what Zaal said publicly about X" with deeplinks. Strong for:
+- Quotes that ground each chapter in Zaal's actual words
+- Public commitments + dates (when did Zaal first announce ZABAL launch publicly? Find in casts.)
+- Counterfactuals (what was the early thinking that got refined into this final position?)
+
+**Recommended:** Don't BLOCK whitepaper on FC/X ingest. Start writing now. When FC/X land, replace placeholder quotes with deeplinked real ones.
+
+---
+
+## Open Questions Before Build
+
+1. **Output target:** new research/ doc or new repo `zao-protocol`?
+2. **Length target:** 4 pages (executive summary) or 25-page deep dive or both?
+3. **Diagram style:** Mermaid (markdown-native) or proper design (Figma)?
+4. **Open-source license clarity:** which ZAO repos are MIT / Apache / proprietary today? Need a definitive answer to write Chapter 6.
+5. **Partner review list:** who gets pre-publish review (Cassie / Steve Peer / Joshua.eth / Mat Tambussi / Dan / Tadas)?
+6. **Publication channel:** Mirror.xyz, Paragraph, zaoos.com/whitepaper, or all three?
+7. **Cipher timing:** is Cipher releasing soon? If yes, hold whitepaper to include the ship; if no, write it as planned.
+
+---
+
+## Bonfire Ingest Trigger (for graph)
+
+```
+INGEST FACT:
+Subject: ZAO Protocol Whitepaper Rebuild Spec
+Type: Decision
+Date: 2026-05-04
+Status: planned
+Description: Rebuild research/community/051 ZAO Whitepaper Draft 4.5 as a PROTOCOL whitepaper for builders/partners/devs. 7 chapters reusing Draft 4.5's community framing as Ch1, adding 6 new chapters on protocol architecture, tokens, governance, onchain music, build-on-ZAO, roadmap. Iterative build using Bonfire RECALL queries for each chapter. Spec at docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md.
+Source: internal://docs/specs/2026-05-04-protocol-whitepaper-rebuild-spec.md
+Confidence: 1.0
+```

--- a/research/dev-workflows/652-inbox-gmail-bridge-morning-trigger/README.md
+++ b/research/dev-workflows/652-inbox-gmail-bridge-morning-trigger/README.md
@@ -1,0 +1,216 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-05-16
+related-docs: 422, 574, 599
+tier: STANDARD
+---
+
+# 652 - Gmail to /inbox Bridge + Morning Auto-Research Trigger
+
+> **Goal:** Lock the path from "email arrives in Zaal's Gmail" to "doc lands in `research/` by 7am EST." Decide Gmail-MCP vs auto-forward, wire `/inbox research all` into `/morning`, ship.
+
+## Key Decisions (TL;DR)
+
+| # | Recommendation | Why | Owner |
+|---|---|---|---|
+| 1 | **PRIMARY: Gmail filter -> verified auto-forward to `zoe-zao@agentmail.to`** | Reuses existing AgentMail inbox + `/inbox` skill (proven across docs 574, 599). Decoupled from MCP scope changes. One filter rule = label-in-Gmail + forward-out, both at once. New mail only; backfill stays in Gmail. | @Zaal |
+| 2 | **SECONDARY: Keep Anthropic Gmail MCP installed for ad-hoc search** | `mcp__claude_ai_Gmail__*` already wired by Anthropic connector. READ-only in 2026 (search by `label:`, sender, date, keyword + read message + list labels + create draft). No modify/archive (issue #36547 open). Use it for "Zaal, find any email mentioning X from last 7 days" without bouncing through AgentMail. | @Zaal |
+| 3 | **PATCH `/morning` skill: call `/inbox count` in brief, surface unread count + offer `/inbox research all`** | `/morning` today does `/z` + briefs + PRs + issues, but ignores ZOE inbox. Inbox is the highest-signal queue in the morning. | @Zaal |
+| 4 | **DO NOT auto-execute `/inbox research all` unattended in the local `/morning` skill** | `/morning` is interactive (asks "what's the ONE thing today"). Auto-research belongs in the scheduled cloud routine (Doc 422 plan), not the local skill. Local = surface + offer. Cloud = run. | @Zaal |
+| 5 | **PROMOTE the autonomous `/inbox research all` runner to a Claude Routine on the same cadence as `/morning`** (6am ET daily) per Doc 422 migration order (#2 in the queue) | Routine writes digest doc to `research/events/<n>-inbox-digest-YYYY-MM-DD/`, opens PR. By the time Zaal runs local `/morning`, doc is already in `gh pr list` output. | @Zaal |
+| 6 | **REJECT third-party MCPs (StackOne 42-action, Composio, charlesad)** | Anthropic connector covers the read scope we need. Modify-labels gap is solved by AgentMail labels (we control those server-side already). One less third-party token to manage; aligns with `feedback_oss_first_no_platforms.md`. | @Zaal |
+
+## Today's Picture
+
+```
+Zaal phone -> forward email to zoe-zao@agentmail.to
+                                     |
+                              AgentMail inbox
+                                     |
+                          /inbox skill (manual run)
+                                     |
+                /zao-research per item -> research/ doc -> PR
+```
+
+Pain points:
+- Manual `/inbox` only fires when Zaal remembers to type it
+- Gmail mail not auto-forwarded; Zaal has to forward each one
+- `/morning` doesn't know `/inbox` exists
+- No way to search Gmail directly inside Claude Code session without leaving
+
+## Target Picture
+
+```
+Gmail (zaalp99@gmail.com)
+   |
+   |-- Filter: label "zoe-inbox" + forward to zoe-zao@agentmail.to
+   |          (criteria: any of - subject "zoe", to "zoe-zao@", from select senders,
+   |           manual label "zoe-inbox" applied from phone)
+   |
+   v
+AgentMail (zoe-zao@agentmail.to)
+   |
+   v
+Claude Routine (cloud, 6am ET daily, Doc 422)
+   |-- /inbox research all -> research/events/<n>-inbox-digest-YYYY-MM-DD/
+   |-- opens PR on claude/inbox-digest-YYYY-MM-DD
+   v
+Local /morning skill (when Zaal opens laptop)
+   |-- /z status
+   |-- /inbox count (whitelisted unread)
+   |-- gh pr list (catches the cloud-built digest PR)
+   |-- surfaces: "ZOE digest #N ready in PR, M unread still pending"
+   v
+Zaal reviews PR, merges, sets day intention.
+
+Optional sidecar: Gmail MCP for ad-hoc search inside any Claude Code session
+  e.g. "find emails from Cassie in last 30 days about ZAOstock" ->
+       mcp__claude_ai_Gmail__search_messages(query: "from:cassie ZAOstock newer_than:30d")
+```
+
+## Why Auto-Forward, Not MCP-Only
+
+Three reasons MCP alone is not enough:
+
+1. **No modify-labels in 2026.** The Anthropic Gmail connector is READ + create-draft only. You can `gmail_search_messages` for unread mail, but you cannot archive it, mark it read, or remove an `INBOX` label after processing. AgentMail already supports add/remove labels via `PATCH /messages/{id}` (the `/inbox` skill uses `add_labels: ["processed"], remove_labels: ["unread"]` today). MCP would force a "read but cannot file" workflow.
+2. **Verification + auth churn.** MCP needs OAuth refresh; AgentMail forwarding is plain SMTP. Once verified, Gmail keeps forwarding until disabled.
+3. **AgentMail webhooks enable push, not poll.** AgentMail supports inbound webhooks ([docs](https://docs.agentmail.to/overview)). Future move: AgentMail webhook -> Claude Routine API trigger (Doc 422 pattern) = real-time research within minutes of email arrival, not "wait until 6am cron."
+
+MCP is still worth keeping for ad-hoc Gmail searches that are not worth queueing through the inbox (e.g. "did I get the Coinflow Labs onboarding confirmation?").
+
+## Gmail Filter Setup (5 minutes)
+
+Step-by-step (Gmail web, Settings -> Forwarding and POP/IMAP):
+
+1. Add forwarding address: `zoe-zao@agentmail.to`. Click "Send verification."
+2. Open AgentMail inbox (via `/inbox` or `curl`), find verification email from Gmail, copy the 9-digit code, paste back in Gmail.
+3. Set "Forwarding" radio to **"Disable forwarding"** at the top-level (we will NOT forward everything - only filtered).
+4. Settings -> Filters and Blocked Addresses -> Create a new filter.
+5. Choose criteria. Two recommended patterns:
+
+| Pattern | Filter criteria | Use when |
+|---|---|---|
+| **Manual label** (recommended start) | `label:zoe-inbox` | Zaal applies "zoe-inbox" label from Gmail mobile app to anything he wants ZOE to research. Highest control, zero false positives. |
+| **Sender allowlist** | `from:(cassie@... OR iman@... OR samantha@... OR a-trusted-newsletter)` | For people whose every email is worth queueing (rare). Add senders one at a time. |
+| **Subject keyword** | `subject:(research OR zoe OR research-this)` | When forwarding from desktop, prepend "Research:" to subject. |
+| **Forwarded-to alias** | `to:zoe@bettercallzaal.com` (if Gmail accepts forwarding via alias) | Cleanest semantic - "anything I forwarded to this address goes to ZOE." Requires Gmail alias setup. |
+
+6. Click "Create filter" (bottom-right of search panel).
+7. Tick:
+   - "Apply the label" -> create label `zoe-inbox` (so you can see what was queued)
+   - "Forward it to" -> `zoe-zao@agentmail.to` (verified)
+   - (Optional) "Skip the Inbox" - moves the email to `zoe-inbox` label only, keeps your main inbox clean
+   - (Optional) "Mark as read" - mute unread badge
+
+8. Save. New mail matching the filter is now mirrored to AgentMail.
+
+**Important:** filters only fire on new mail. Existing matching mail stays in Gmail. To backfill, search the same query in Gmail, "Select all matching" -> bulk-apply the label (Gmail will forward + label them).
+
+**Loop guard:** AgentMail messages cannot end up in your Gmail (different domain), so no forwarding loop. But if you ever set up a "ZOE replies to me from agentmail" pipeline, exclude `from:zoe-zao@agentmail.to` in the Gmail filter to prevent ping-pong.
+
+## Sender Whitelist Compatibility
+
+`/inbox` skill enforces `from:zaalp99@gmail.com` (security rule). When Gmail auto-forwards, the original sender's `From:` header is preserved in the forwarded message (Gmail wraps with `Resent-From:` but does not rewrite `From:`). 
+
+**Problem:** the original `From:` will be the source of the email (e.g. a newsletter), not `zaalp99@gmail.com`. The current whitelist will silently drop everything.
+
+**Fix:** loosen the whitelist check to accept EITHER:
+- `from` contains `zaalp99@gmail.com` (direct send from Zaal's phone)
+- OR `Resent-From:` / `Delivered-To:` / `X-Forwarded-For:` headers contain `zaalp99@gmail.com` (auto-forwarded from Zaal's account)
+
+Implementation: patch `/inbox` skill SKILL.md "Security" section to check forwarded-by headers as well. AgentMail exposes the full raw message; the routine should parse `Resent-From` / `X-Forwarded-For` from headers. This needs a code/skill update (see Next Actions #2).
+
+## Anthropic Gmail MCP - Confirmed Capabilities (May 2026)
+
+Source: [GitHub issue #36547](https://github.com/anthropics/claude-code/issues/36547) filed Mar 20 2026.
+
+| Tool | Type | Status |
+|---|---|---|
+| `gmail_search_messages` | Read | Available - supports `from:`, `to:`, `label:`, `subject:`, `newer_than:`, `older_than:`, full Gmail search grammar |
+| `gmail_read_message` | Read | Available |
+| `gmail_read_thread` | Read | Available |
+| `gmail_list_labels` | Read | Available |
+| `gmail_list_drafts` | Read | Available |
+| `gmail_get_profile` | Read | Available |
+| `gmail_create_draft` | Write | Available |
+| `gmail_modify_labels` | Write | **MISSING** (issue #36547, open) |
+| `gmail_send_draft` | Write | **MISSING** (issue #32266, related) |
+
+Auth: OAuth flow via `mcp__claude_ai_Gmail__authenticate`. Once authorized, tools become available. Re-auth required if Google revokes (e.g. password change, suspicious activity flag).
+
+Cannot expand scope: attempting `gmail.modify` scope returns 403; trying to re-authorize for broader access hits Google's "This app is blocked" screen with no `Advanced` bypass. This is why label management has to live in AgentMail, not Gmail, for now.
+
+## `/morning` Skill Patch Plan
+
+Current `/morning` (`.claude/skills/morning/SKILL.md`) does:
+1. `/z` (branch + commits)
+2. read daily brief
+3. read inspiration
+4. `gh issue list`
+5. `gh pr list`
+6. read yesterday reflection
+
+Patch adds two lines between steps 4 and 5:
+
+```markdown
+4.5. **Check ZOE inbox** - run `/inbox count`. If unread > 0, surface count and offer `/inbox research all` (require user "yes" before firing - inbox-research can write a research doc per item, big change).
+4.6. **Check overnight inbox digest** - if a `claude/inbox-digest-YYYY-MM-DD` PR exists for today, surface it in the brief as "ZOE overnight digest ready for review."
+```
+
+Brief output gets one extra line:
+```
+**ZOE inbox:** [N unread] · [overnight digest: PR #M | none]
+```
+
+## Claude Routine Definition (Doc 422 link)
+
+Per Doc 422 migration order, `/morning` is item #1 and `/inbox` is item #2 in the queue. Both will eventually run as Claude Routines (Anthropic cloud, 15 runs/day on Max plan).
+
+Recommended schedule:
+
+| Routine | Cadence | Output |
+|---|---|---|
+| `zao-morning-brief` | Daily 6:00 ET | Writes `docs/daily-briefs/YYYY-MM-DD.md`, opens PR `claude/morning-brief-YYYY-MM-DD`. Local `/morning` reads this. |
+| `zao-inbox-digest` | Daily 6:30 ET (30min after morning brief, so brief can reference it) | Runs `/inbox research all`, writes `research/events/<next>-inbox-digest-YYYY-MM-DD/README.md`, opens PR. |
+| `zao-reflection-prompt` | Daily 21:00 ET | Composes "what worked / surprised / message to tomorrow" prompt, sends via Telegram to ZOE. |
+
+Connectors per routine (do NOT attach all):
+- `zao-morning-brief`: GitHub, Linear (if used), Telegram
+- `zao-inbox-digest`: GitHub, AgentMail (via REST in skill), Gmail MCP (for backfill searches), exa, WebSearch
+- `zao-reflection-prompt`: Telegram only
+
+Network mode: `full network` for all three (need Neynar, AgentMail, exa).
+
+## Sources
+
+- [Anthropic Gmail MCP issue #36547 - modify-labels gap](https://github.com/anthropics/claude-code/issues/36547)
+- [Anthropic Gmail MCP issue #51790 - gmail.modify scope blocked by Google](https://github.com/anthropics/claude-code/issues/51790)
+- [Anthropic Gmail MCP issue #27567 - multi-account connector](https://github.com/anthropics/claude-code/issues/27567)
+- [Gmail Help - automatically forward Gmail messages](https://support.google.com/mail/answer/10957)
+- [Gmail Help - create rules to filter your emails](https://support.google.com/mail/answer/6579)
+- [Gmail API - manage email forwarding](https://developers.google.com/workspace/gmail/api/guides/forwarding_settings)
+- [AgentMail webhooks overview](https://docs.agentmail.to/overview)
+- [AgentMail inbound email patterns](https://www.agentmail.to/insights/inbound-email)
+- [Doc 422 - Claude Routines automation stack (this project)](../422-claude-routines-zao-automation-stack/)
+- [Doc 574 - inbox batch Apr 30 (proves /inbox flow works)](../../agents/574-inbox-apr30-agent-commerce-skills-stack/)
+- [Doc 599 - inbox digest May 3 (latest /inbox output)](../../events/599-inbox-digest-2026-05-03/)
+
+## Also See
+
+- [Doc 422](../422-claude-routines-zao-automation-stack/) - The Routine framework these triggers run on
+- [Doc 574](../../agents/574-inbox-apr30-agent-commerce-skills-stack/) - Prior /inbox digest output, proves flow
+- [Doc 599](../../events/599-inbox-digest-2026-05-03/) - Latest /inbox digest output
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Set up Gmail filter: label `zoe-inbox` + forward to verified `zoe-zao@agentmail.to` (start with manual-label pattern) | @Zaal | Gmail config | Tonight |
+| Patch `/inbox` skill SKILL.md security section to accept `Resent-From` / `X-Forwarded-For: zaalp99@gmail.com` in addition to direct `From:` | @Zaal (Claude) | Skill edit | Same PR as this doc |
+| Patch `/morning` skill SKILL.md to add inbox count + digest-PR check | @Zaal (Claude) | Skill edit | Same PR as this doc |
+| Verify Anthropic Gmail MCP auth still live; if not, run `mcp__claude_ai_Gmail__authenticate` and complete OAuth | @Zaal | One-time | Before next /morning |
+| Stand up `zao-inbox-digest` Claude Routine per Doc 422 (cloud cron, 6:30 ET daily) | @Zaal | Routine setup | This week |
+| Test the loop end-to-end: forward one email from phone -> wait for AgentMail receipt -> run `/inbox` locally -> confirm it appears | @Zaal | Manual smoke test | Day 1 |
+| Decide if `to:zoe@bettercallzaal.com` alias makes sense as semantic forwarding address (cleaner than label-based filter) | @Zaal | Decision | Optional polish |


### PR DESCRIPTION
## Summary

Locks the path: Gmail email -> AgentMail -> `/inbox research` -> research doc -> PR. Decides Gmail-MCP vs Gmail-auto-forward (it's both, with auto-forward as primary). Patches `/inbox` + `/morning` skills in the same change.

## Tier

STANDARD (10 web sources, 2 prior docs cross-referenced, no DEEP dispatch needed).

## Key Decisions

1. **PRIMARY: Gmail filter -> verified auto-forward to `zoe-zao@agentmail.to`** (reuses existing AgentMail + `/inbox` flow)
2. **SECONDARY: Keep Anthropic Gmail MCP** for ad-hoc search (READ-only in 2026, modify-labels blocked by Google - issue #36547)
3. **Patch `/morning` skill** to surface `/inbox count` + watch for overnight `claude/inbox-digest-*` PRs
4. **Do NOT auto-execute `/inbox research all` in local `/morning`** - requires user "yes" (blast radius)
5. **Promote autonomous digest to Claude Routine** (Doc 422 plan, 6:30 ET daily)
6. **Reject third-party Gmail MCPs** (StackOne, Composio) - Anthropic connector + AgentMail label control is enough

## Files Changed

- `research/dev-workflows/652-inbox-gmail-bridge-morning-trigger/README.md` (new, 175 lines)
- `.claude/skills/inbox/SKILL.md` (whitelist accepts `Resent-From`, `X-Forwarded-For`, `Delivered-To` - critical fix, current rule silently drops every forwarded mail since `From:` becomes upstream sender)
- `.claude/skills/morning/SKILL.md` (adds inbox count step + brief format includes ZOE inbox line)

## Next Actions (from doc)

- Zaal: set up Gmail filter `label:zoe-inbox` + forward to verified `zoe-zao@agentmail.to`
- Zaal: stand up `zao-inbox-digest` Claude Routine (6:30 ET daily, Doc 422)
- Smoke test: forward one email from phone -> run `/inbox` locally -> confirm appears

## Test Plan

- [ ] Verify `.claude/skills/morning/SKILL.md` parses (no markdown errors)
- [ ] Verify `.claude/skills/inbox/SKILL.md` parses (no markdown errors)
- [ ] After merge: run `/morning` in fresh session; confirm step 6 surfaces inbox count
- [ ] After Gmail filter setup: forward one test email; run `/inbox`; confirm whitelisted-as-forwarded message appears