### PR TITLE
feat(zoe): post slate v1 - random social-post drafter pings

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -42,6 +42,7 @@ import {
   readGroups,
   type GroupMode,
 } from './groups';
+import { handleVoiceMemo } from './posts';
 
 const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
@@ -184,6 +185,12 @@ bot.command('quests', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const list = await formatQuestList();
   await replyChunked(ctx, list);
+});
+
+// Post slate v1 - voice memo capture. /voicememo <text> or /vm <text>.
+// Appends to ~/.zao/zoe/voice-memos/YYYY-MM-DD.md for the personal-post drafter.
+bot.command(['voicememo', 'vm'], async (ctx) => {
+  await handleVoiceMemo(ctx, isFromZaal(ctx));
 });
 
 bot.command('notes', async (ctx) => {

--- a/bot/src/zoe/posts/README.md
+++ b/bot/src/zoe/posts/README.md
@@ -1,0 +1,102 @@
+# ZOE Post Slate v1
+
+ZOE drafts 4 categories of social posts and DMs Zaal random suggestions throughout the day. He copy-pastes the keepers into Firefly. Hand-tunes weights after a week of real usage.
+
+## Categories
+
+| Category | Source(s) v1 | Source(s) v2 (planned) |
+|---|---|---|
+| `build` | Last 24h commits + open PRs (`gh pr list`) | Vercel deploy status, test runs |
+| `ecosystem` | Last 7d commits to ZAOOS as proxy for ZAO momentum | Farcaster /thezao channel, ZABAL Base contract activity, member roster diffs |
+| `event` | `~/.zao/zoe/events/{today,tomorrow}.txt` (manually seeded) | Google Calendar MCP via Claude CLI subprocess |
+| `personal` | `~/.zao/zoe/voice-memos/YYYY-MM-DD.md` (one-liner captures via `/voicememo`) | Lunch stream transcripts via `zao-transcribe`, persona + recent Telegram messages |
+
+## Cadence
+
+- Target: **7 pings/day** (configurable via `pingsPerDay` option)
+- Window: **5am - 10pm America/New_York**
+- Minimum gap: **20 minutes** between pings
+- No quiet hours (per `feedback_no_flow_state_gate.md`)
+- Schedule re-rolled at midnight ET; stored at `~/.zao/zoe/posts/schedule.json`
+- Category weights: build=3, ecosystem=2, event=1, personal=1
+
+## Telegram surface
+
+```
+Post draft (build):
+
+doc 653 audit — paperclipai crash-looped 107k times since last reboot. fixing today, cleaner crontab tomorrow.
+
+— copy + paste into Firefly when ready
+```
+
+User flow: read on phone, copy text, open Firefly, paste, ship.
+
+No buttons / no API calls / no clipboard skill in v1. Lowest blast radius.
+
+## Capture command
+
+```
+/voicememo built imanagent v0 in 90 min while iman watched
+/vm just got off a call with cassie, debrief is locked
+```
+
+Appends to `~/.zao/zoe/voice-memos/YYYY-MM-DD.md` with timestamp. Drafter pulls last 8 lines from today + yesterday on each personal-category fire.
+
+## State + logs
+
+| File | Purpose |
+|---|---|
+| `~/.zao/zoe/posts/schedule.json` | Today's rolled schedule + fired flags |
+| `~/.zao/zoe/posts/log.jsonl` | One-line-per-event audit log: rolls, sends, skips, errors |
+| `~/.zao/zoe/voice-memos/YYYY-MM-DD.md` | Daily voice memo append log |
+| `~/.zao/zoe/events/today.txt` | One event per line, manually seeded for now |
+| `~/.zao/zoe/events/tomorrow.txt` | Same, tomorrow |
+
+## Voice rules (in `drafters.ts`)
+
+- Year-of-the-ZABAL tone
+- No emojis, no em dashes, no marketing-speak
+- 1-3 short lines, hard cap 280 chars
+- Brand spellings exact
+- First person where natural
+
+## Drafter model
+
+Default `haiku` (cheap, fast, good enough for 280-char drafts). Escalate to `sonnet` per-category if quality drops.
+
+Drafters use the Hermes pattern (`callClaudeCli` from `../hermes/claude-cli`) - Max plan OAuth, no API key billing.
+
+## Disable / tune
+
+- Stop the whole scheduler: comment out `startPostsScheduler(...)` in `bot/src/zoe/scheduler.ts`
+- Change pings/day: pass `pingsPerDay: 4` (or whatever) when calling `startPostsScheduler`
+- Change category weights: edit `CATEGORY_WEIGHTS` in `scheduler.ts`
+- Change window: edit `WINDOW_START_HOUR_ET` / `WINDOW_END_HOUR_ET`
+
+## Deploy
+
+Same path as the rest of zoe-bot:
+
+```bash
+ssh zaal@31.97.148.88 'cd /home/zaal/zao-os && git pull && systemctl --user restart zoe-bot && sleep 5 && journalctl --user -u zoe-bot.service -n 30 --no-pager'
+```
+
+Healthy first-boot log lines:
+```
+[zoe/posts] scheduler started (target 7 pings/day, window 5am-10pm ET)
+[zoe/posts] rolled schedule for 2026-05-17: 7 pings
+```
+
+## v2 roadmap (do not build until v1 has run for 1 week)
+
+1. Inline keyboard buttons: `[Post]` `[Regen]` `[Skip]` `[Edit]` (per Doc 652 / grill answer "later")
+2. Skip-rate learning: bump down category weights if skip rate > 60% over 7 days
+3. Calendar source: wire Google Calendar MCP
+4. Stream transcript source: integrate `zao-transcribe`
+5. Voice note ingestion: handle `ctx.message.voice` via Whisper or zao-transcribe
+6. Auto-post path: Firefly API integration (per grill Q4 hybrid option)
+
+## Spec source
+
+Grill answers from Zaal on 2026-05-16, summarized in commit body for PR.

--- a/bot/src/zoe/posts/drafters.ts
+++ b/bot/src/zoe/posts/drafters.ts
@@ -1,0 +1,114 @@
+// Post slate v1 - per-category Claude CLI drafter.
+// Each drafter takes the source snapshot and returns one post draft string.
+// Uses the Hermes pattern (claude CLI subprocess via Max plan auth).
+
+import { callClaudeCli } from '../../hermes/claude-cli';
+import type { PostCategory, PostDraft, PostSourceSnapshot } from './types';
+
+const SHARED_VOICE = `You are ZOE drafting a social post in Zaal's voice.
+
+VOICE RULES (non-negotiable):
+- Year-of-the-ZABAL tone: clear, simple, spartan, active voice.
+- No emojis, no em dashes, no marketing-speak ("game-changer", "unlock", etc).
+- 1-3 short lines. Hard cap 280 chars (one X tweet).
+- First person where natural. "I shipped X" beats "ZAO shipped X" for build posts.
+- Brand spellings exact: WaveWarZ, COC Concertz, The ZAO, BetterCallZaal, ZABAL, SANG, ZOE, ZOLs, FISHBOWLZ, Hurric4n3ike, candytoybox.
+- Channel: Firefly (FC+X cross-post). No platform-specific syntax.
+
+OUTPUT: only the post text. No surrounding quotes, no commentary, no labels.`;
+
+const CATEGORY_PROMPT: Record<PostCategory, string> = {
+  build: `Draft a build-in-public post about today's shipping.
+Sources (last 24h commits + open PRs):
+{SOURCE}
+Pick the 1-2 most-interesting items. Lead with the verb. End with the URL or PR number if there is one. If sources are empty, output "(skip)".`,
+  ecosystem: `Draft a ZAO ecosystem signal post about community activity in the last 7 days.
+Sources (recent ZAOOS repo activity as proxy for ecosystem momentum):
+{SOURCE}
+Highlight one concrete signal: a new research doc landing, a community member's project, a brand shipping. Frame it as ZAO momentum, not personal momentum. If sources are empty, output "(skip)".`,
+  event: `Draft a calendar/event promo post for today or tomorrow.
+Sources:
+{SOURCE}
+Pick one event. Tell people what + when + how to join. Invite them in. If sources are empty, output "(skip)".`,
+  personal: `Draft a personal/voice post in Zaal's voice from his recent voice memos.
+Sources (recent voice memos, newest last):
+{SOURCE}
+Pull one thread, expand it to 1-3 lines. Keep his exact phrasings where possible. If sources are empty, output "(skip)".`,
+};
+
+export async function draftPost(
+  category: PostCategory,
+  snapshot: PostSourceSnapshot,
+  opts: { cwd: string; model?: 'sonnet' | 'haiku' | 'opus' } = { cwd: process.cwd() },
+): Promise<PostDraft> {
+  const sourceBlock = formatSourceBlock(category, snapshot);
+  const userPrompt = CATEGORY_PROMPT[category].replace('{SOURCE}', sourceBlock);
+
+  const model = opts.model ?? 'haiku';
+  const result = await callClaudeCli({
+    model,
+    prompt: userPrompt,
+    cwd: opts.cwd,
+    appendSystemPrompt: SHARED_VOICE,
+    permissionMode: 'auto',
+    bare: false,
+  });
+
+  return {
+    category,
+    text: result.text.trim(),
+    meta: {
+      sources: extractSourceLabels(category, snapshot),
+      draftedAt: new Date().toISOString(),
+      model,
+    },
+  };
+}
+
+function formatSourceBlock(category: PostCategory, s: PostSourceSnapshot): string {
+  switch (category) {
+    case 'build': {
+      const commits = s.build.recentCommits.length
+        ? s.build.recentCommits.map((c) => `- ${c}`).join('\n')
+        : '(no commits in 24h)';
+      const prs = s.build.openPrs.length
+        ? s.build.openPrs.map((p) => `- #${p.number} ${p.title}`).join('\n')
+        : '(no open PRs)';
+      return `COMMITS (24h):\n${commits}\n\nOPEN PRS:\n${prs}`;
+    }
+    case 'ecosystem':
+      return s.ecosystem.repoActivity.length
+        ? s.ecosystem.repoActivity.map((c) => `- ${c}`).join('\n')
+        : '(no repo activity in 7 days)';
+    case 'event': {
+      const today = s.event.todaysEvents.length
+        ? s.event.todaysEvents.map((e) => `- TODAY: ${e}`).join('\n')
+        : '';
+      const tomorrow = s.event.tomorrowsEvents.length
+        ? s.event.tomorrowsEvents.map((e) => `- TOMORROW: ${e}`).join('\n')
+        : '';
+      const combined = [today, tomorrow].filter(Boolean).join('\n');
+      return combined || '(no events seeded)';
+    }
+    case 'personal':
+      return s.personal.voiceMemos.length
+        ? s.personal.voiceMemos.slice(-8).join('\n')
+        : '(no voice memos)';
+  }
+}
+
+function extractSourceLabels(category: PostCategory, s: PostSourceSnapshot): string[] {
+  switch (category) {
+    case 'build':
+      return [`commits=${s.build.recentCommits.length}`, `prs=${s.build.openPrs.length}`];
+    case 'ecosystem':
+      return [`repo-activity=${s.ecosystem.repoActivity.length}`];
+    case 'event':
+      return [
+        `today=${s.event.todaysEvents.length}`,
+        `tomorrow=${s.event.tomorrowsEvents.length}`,
+      ];
+    case 'personal':
+      return [`voice-memos=${s.personal.voiceMemos.length}`];
+  }
+}

--- a/bot/src/zoe/posts/index.ts
+++ b/bot/src/zoe/posts/index.ts
@@ -1,0 +1,8 @@
+// Post slate v1 - public API.
+// See README.md for the spec.
+
+export { startPostsScheduler } from './scheduler';
+export type { PostsSchedulerOptions } from './scheduler';
+export { handleVoiceMemo } from './voicememo';
+export { appendVoiceMemo } from './sources';
+export type { PostCategory, PostDraft } from './types';

--- a/bot/src/zoe/posts/scheduler.ts
+++ b/bot/src/zoe/posts/scheduler.ts
@@ -1,0 +1,208 @@
+// Post slate v1 - randomized scheduler.
+// At UTC midnight (and on boot), re-rolls a fresh list of random post times for the
+// remainder of today. Each time fires once: picks a category, drafts, DMs Zaal.
+//
+// v1 defaults:
+//   - 7 pings/day target, distributed random across 5am-10pm America/New_York
+//   - 20 min minimum gap between pings
+//   - category weights: build=3, ecosystem=2, event=1, personal=1 (calibrate after week 1)
+//   - empty drafts ("(skip)") are silently dropped, do not count against the day's quota
+//
+// No quiet hours per Zaal feedback (project memory: feedback_no_flow_state_gate).
+
+import type { Bot } from 'grammy';
+import cron from 'node-cron';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from '../memory';
+import { draftPost } from './drafters';
+import {
+  gatherBuildSignals,
+  gatherEcosystemSignals,
+  gatherEventSignals,
+  gatherPersonalSignals,
+} from './sources';
+import type { PostCategory, PostSourceSnapshot } from './types';
+
+const PINGS_PER_DAY_DEFAULT = 7;
+const MIN_GAP_MINUTES = 20;
+const WINDOW_START_HOUR_ET = 5;
+const WINDOW_END_HOUR_ET = 22; // 10pm
+const CATEGORY_WEIGHTS: Array<[PostCategory, number]> = [
+  ['build', 3],
+  ['ecosystem', 2],
+  ['event', 1],
+  ['personal', 1],
+];
+
+const POSTS_STATE_DIR = join(ZOE_PATHS.home, 'posts');
+const SCHEDULE_FILE = join(POSTS_STATE_DIR, 'schedule.json');
+const LOG_FILE = join(POSTS_STATE_DIR, 'log.jsonl');
+
+interface ScheduleEntry {
+  fireAt: string; // ISO
+  fired: boolean;
+}
+
+interface DailySchedule {
+  date: string; // YYYY-MM-DD (ET)
+  entries: ScheduleEntry[];
+}
+
+function todayET(): string {
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+}
+
+function pickWeightedCategory(): PostCategory {
+  const total = CATEGORY_WEIGHTS.reduce((s, [, w]) => s + w, 0);
+  let n = Math.random() * total;
+  for (const [cat, w] of CATEGORY_WEIGHTS) {
+    n -= w;
+    if (n <= 0) return cat;
+  }
+  return CATEGORY_WEIGHTS[0][0];
+}
+
+function rollDailySchedule(date: string, pings: number): DailySchedule {
+  // Build a list of candidate slot-minutes (one per minute in the window), shuffle, take N
+  // with min-gap enforcement.
+  const slotsPerDay = (WINDOW_END_HOUR_ET - WINDOW_START_HOUR_ET) * 60;
+  const indices = Array.from({ length: slotsPerDay }, (_, i) => i);
+  // Fisher-Yates
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [indices[i], indices[j]] = [indices[j], indices[i]];
+  }
+  const picked: number[] = [];
+  for (const idx of indices) {
+    if (picked.length === pings) break;
+    if (picked.every((p) => Math.abs(p - idx) >= MIN_GAP_MINUTES)) {
+      picked.push(idx);
+    }
+  }
+  picked.sort((a, b) => a - b);
+
+  const entries: ScheduleEntry[] = picked.map((minuteOffset) => {
+    const hour = WINDOW_START_HOUR_ET + Math.floor(minuteOffset / 60);
+    const minute = minuteOffset % 60;
+    // Build an ISO timestamp at hour:minute ET for `date`.
+    const local = new Date(`${date}T00:00:00-04:00`); // EDT default; cron tz handles DST elsewhere
+    local.setHours(hour, minute, 0, 0);
+    return { fireAt: local.toISOString(), fired: false };
+  });
+
+  return { date, entries };
+}
+
+async function loadOrRollSchedule(pings: number): Promise<DailySchedule> {
+  const today = todayET();
+  try {
+    const raw = await fs.readFile(SCHEDULE_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as DailySchedule;
+    if (parsed.date === today) return parsed;
+  } catch {
+    // missing file - normal first run
+  }
+  const fresh = rollDailySchedule(today, pings);
+  await fs.mkdir(POSTS_STATE_DIR, { recursive: true });
+  await fs.writeFile(SCHEDULE_FILE, JSON.stringify(fresh, null, 2), 'utf8');
+  return fresh;
+}
+
+async function saveSchedule(schedule: DailySchedule): Promise<void> {
+  await fs.writeFile(SCHEDULE_FILE, JSON.stringify(schedule, null, 2), 'utf8');
+}
+
+async function appendLog(line: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(POSTS_STATE_DIR, { recursive: true });
+  await fs.appendFile(LOG_FILE, `${JSON.stringify({ ts: new Date().toISOString(), ...line })}\n`, 'utf8');
+}
+
+async function gatherAll(repoDir: string): Promise<PostSourceSnapshot> {
+  const [build, ecosystem, event, personal] = await Promise.all([
+    gatherBuildSignals(repoDir),
+    gatherEcosystemSignals(repoDir),
+    gatherEventSignals(),
+    gatherPersonalSignals(),
+  ]);
+  return { build, ecosystem, event, personal };
+}
+
+async function fireOneDraft(bot: Bot, zaalTgId: number, repoDir: string): Promise<void> {
+  const category = pickWeightedCategory();
+  const snapshot = await gatherAll(repoDir);
+  let draft;
+  try {
+    draft = await draftPost(category, snapshot, { cwd: repoDir });
+  } catch (err) {
+    await appendLog({ event: 'draft-error', category, error: (err as Error).message });
+    return;
+  }
+  if (!draft.text || /^\(skip\)/i.test(draft.text)) {
+    await appendLog({ event: 'skip', category, reason: 'empty-or-skip-marker' });
+    return;
+  }
+  const message = `Post draft (${category}):\n\n${draft.text}\n\n— copy + paste into Firefly when ready`;
+  try {
+    await bot.api.sendMessage(zaalTgId, message);
+    await appendLog({ event: 'sent', category, charCount: draft.text.length });
+  } catch (err) {
+    await appendLog({ event: 'send-error', category, error: (err as Error).message });
+  }
+}
+
+export interface PostsSchedulerOptions {
+  bot: Bot;
+  zaalTgId: number;
+  repoDir: string;
+  pingsPerDay?: number;
+}
+
+export function startPostsScheduler(opts: PostsSchedulerOptions): { stop: () => void } {
+  const pings = opts.pingsPerDay ?? PINGS_PER_DAY_DEFAULT;
+
+  // Re-roll the schedule at midnight America/New_York.
+  const midnightTask = cron.schedule(
+    '0 0 * * *',
+    async () => {
+      const today = todayET();
+      const fresh = rollDailySchedule(today, pings);
+      await fs.mkdir(POSTS_STATE_DIR, { recursive: true });
+      await saveSchedule(fresh);
+      await appendLog({ event: 'rolled-schedule', date: today, entries: fresh.entries.length });
+      console.log(`[zoe/posts] rolled schedule for ${today}: ${fresh.entries.length} pings`);
+    },
+    { timezone: 'America/New_York' },
+  );
+
+  // Tick every minute, fire any due entries.
+  const tickTask = cron.schedule(
+    '* * * * *',
+    async () => {
+      const schedule = await loadOrRollSchedule(pings);
+      const now = Date.now();
+      let changed = false;
+      for (const entry of schedule.entries) {
+        if (entry.fired) continue;
+        if (new Date(entry.fireAt).getTime() <= now) {
+          entry.fired = true;
+          changed = true;
+          fireOneDraft(opts.bot, opts.zaalTgId, opts.repoDir).catch((err) => {
+            console.error('[zoe/posts] fire failed:', (err as Error).message);
+          });
+        }
+      }
+      if (changed) await saveSchedule(schedule);
+    },
+    { timezone: 'America/New_York' },
+  );
+
+  console.log(`[zoe/posts] scheduler started (target ${pings} pings/day, window ${WINDOW_START_HOUR_ET}am-${WINDOW_END_HOUR_ET - 12}pm ET)`);
+
+  return {
+    stop: () => {
+      midnightTask.stop();
+      tickTask.stop();
+    },
+  };
+}

--- a/bot/src/zoe/posts/sources.ts
+++ b/bot/src/zoe/posts/sources.ts
@@ -1,0 +1,100 @@
+// Post slate v1 - data gathering per category.
+// Each source is best-effort. Empty arrays mean "skip the category for this fire."
+
+import { execSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from '../memory';
+import type { PostSourceSnapshot } from './types';
+
+const VOICE_MEMOS_DIR = join(ZOE_PATHS.home, 'voice-memos');
+
+export async function gatherBuildSignals(repoDir: string): Promise<PostSourceSnapshot['build']> {
+  let recentCommits: string[] = [];
+  try {
+    const log = execSync(
+      `git -C ${JSON.stringify(repoDir)} log --since="24 hours ago" --no-merges --pretty=format:"%s" 2>/dev/null`,
+      { encoding: 'utf8', timeout: 5000 },
+    );
+    recentCommits = log.split('\n').filter((l) => l.trim()).slice(0, 10);
+  } catch {
+    recentCommits = [];
+  }
+
+  let openPrs: Array<{ number: number; title: string }> = [];
+  try {
+    const json = execSync(
+      'gh pr list --repo bettercallzaal/ZAOOS --state open --limit 8 --json number,title',
+      { encoding: 'utf8', timeout: 8000 },
+    );
+    openPrs = JSON.parse(json) as Array<{ number: number; title: string }>;
+  } catch {
+    openPrs = [];
+  }
+
+  return { recentCommits, openPrs };
+}
+
+export async function gatherEcosystemSignals(repoDir: string): Promise<PostSourceSnapshot['ecosystem']> {
+  // v1: proxy ecosystem activity via recent commits to ZAOOS lab repo (community activity
+  // shows up as new research docs, doc 422 patterns). v2: add Farcaster /thezao channel pulls,
+  // ZABAL contract events via Base RPC, member roster diffs.
+  let repoActivity: string[] = [];
+  try {
+    const log = execSync(
+      `git -C ${JSON.stringify(repoDir)} log --since="7 days ago" --no-merges --pretty=format:"%s" 2>/dev/null`,
+      { encoding: 'utf8', timeout: 5000 },
+    );
+    repoActivity = log.split('\n').filter((l) => l.trim()).slice(0, 15);
+  } catch {
+    repoActivity = [];
+  }
+  return { repoActivity };
+}
+
+export async function gatherEventSignals(): Promise<PostSourceSnapshot['event']> {
+  // v1 stub: drop a file at ~/.zao/zoe/events/today.txt + tomorrow.txt with one event per
+  // line. Cron or manual seeding writes it. v2: wire Google Calendar MCP via Claude CLI
+  // subprocess (Hermes pattern) once the MCP is authenticated on VPS.
+  const eventsDir = join(ZOE_PATHS.home, 'events');
+  let todaysEvents: string[] = [];
+  let tomorrowsEvents: string[] = [];
+  try {
+    const today = await fs.readFile(join(eventsDir, 'today.txt'), 'utf8');
+    todaysEvents = today.split('\n').map((l) => l.trim()).filter(Boolean);
+  } catch {
+    todaysEvents = [];
+  }
+  try {
+    const tomorrow = await fs.readFile(join(eventsDir, 'tomorrow.txt'), 'utf8');
+    tomorrowsEvents = tomorrow.split('\n').map((l) => l.trim()).filter(Boolean);
+  } catch {
+    tomorrowsEvents = [];
+  }
+  return { todaysEvents, tomorrowsEvents };
+}
+
+export async function gatherPersonalSignals(): Promise<PostSourceSnapshot['personal']> {
+  // Voice memos: per-day file under ~/.zao/zoe/voice-memos/YYYY-MM-DD.md (append-mode).
+  // Drafter reads the last 2 days. v2: also pull last lunch-stream transcript via zao-transcribe.
+  const today = new Date().toISOString().slice(0, 10);
+  const yesterday = new Date(Date.now() - 86400_000).toISOString().slice(0, 10);
+  const voiceMemos: string[] = [];
+  for (const date of [today, yesterday]) {
+    try {
+      const raw = await fs.readFile(join(VOICE_MEMOS_DIR, `${date}.md`), 'utf8');
+      voiceMemos.push(...raw.split('\n').filter((l) => l.trim()));
+    } catch {
+      // file might not exist - normal
+    }
+  }
+  return { voiceMemos, recentZaalMessages: [] };
+}
+
+export async function appendVoiceMemo(text: string): Promise<void> {
+  await fs.mkdir(VOICE_MEMOS_DIR, { recursive: true });
+  const today = new Date().toISOString().slice(0, 10);
+  const stamp = new Date().toISOString();
+  const file = join(VOICE_MEMOS_DIR, `${today}.md`);
+  await fs.appendFile(file, `\n[${stamp}] ${text}\n`, 'utf8');
+}

--- a/bot/src/zoe/posts/types.ts
+++ b/bot/src/zoe/posts/types.ts
@@ -1,0 +1,23 @@
+// Post slate v1 - shared types.
+// See bot/src/zoe/posts/README.md for full spec.
+
+export type PostCategory = 'build' | 'ecosystem' | 'event' | 'personal';
+
+export const ALL_CATEGORIES: PostCategory[] = ['build', 'ecosystem', 'event', 'personal'];
+
+export interface PostDraft {
+  category: PostCategory;
+  text: string;
+  meta: {
+    sources: string[];
+    draftedAt: string;
+    model: 'sonnet' | 'haiku' | 'opus';
+  };
+}
+
+export interface PostSourceSnapshot {
+  build: { recentCommits: string[]; openPrs: Array<{ number: number; title: string }> };
+  ecosystem: { repoActivity: string[] };
+  event: { todaysEvents: string[]; tomorrowsEvents: string[] };
+  personal: { voiceMemos: string[]; recentZaalMessages: string[] };
+}

--- a/bot/src/zoe/posts/voicememo.ts
+++ b/bot/src/zoe/posts/voicememo.ts
@@ -1,0 +1,30 @@
+// Post slate v1 - /voicememo Telegram command + plain-text capture.
+//
+// Usage on Telegram:
+//   /voicememo <text>       - append a one-liner to today's voice memo file
+//   /vm <text>              - shorthand
+//
+// File: ~/.zao/zoe/voice-memos/YYYY-MM-DD.md  (one entry per line, timestamped)
+//
+// v2: accept actual voice notes via grammy's `ctx.message.voice`, transcribe
+// via Whisper or the existing zao-transcribe script, then append.
+
+import type { Context } from 'grammy';
+import { appendVoiceMemo } from './sources';
+
+export async function handleVoiceMemo(ctx: Context, isFromZaal: boolean): Promise<void> {
+  if (!isFromZaal) return;
+  const text = ctx.message?.text ?? '';
+  // Strip the leading command + 1 space.
+  const body = text.replace(/^\/(voicememo|vm)(@[^\s]+)?\s*/i, '').trim();
+  if (!body) {
+    await ctx.reply('Usage: /voicememo <thought>  - I save it for the next personal-post draft.');
+    return;
+  }
+  try {
+    await appendVoiceMemo(body);
+    await ctx.reply(`Saved. (${body.length} chars). It'll feed the next personal post draft.`);
+  } catch (err) {
+    await ctx.reply(`Failed to save: ${(err as Error).message}`);
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -22,6 +22,7 @@ import { generateMorningBrief } from './brief';
 import { generateEveningReflection } from './reflect';
 import { ZOE_PATHS } from './memory';
 import { nextNudge, nudgesEnabled } from './nudges';
+import { startPostsScheduler } from './posts';
 
 const SENTINEL_DIR = join(ZOE_PATHS.home, 'sentinels');
 
@@ -135,13 +136,22 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
     );
   }
 
-  console.log(`[zoe/scheduler] started ${tasks.length} cron tasks (no quiet hours per Zaal feedback)`);
+  // Post slate v1 - random 7 pings/day of social-post drafts (build / ecosystem /
+  // event / personal). Owns its own state at ~/.zao/zoe/posts/. See posts/README.md.
+  const postsScheduler = startPostsScheduler({
+    bot: opts.bot,
+    zaalTgId: opts.zaalTgId,
+    repoDir: opts.repoDir,
+  });
+
+  console.log(`[zoe/scheduler] started ${tasks.length} cron tasks + posts scheduler (no quiet hours per Zaal feedback)`);
 
   return {
     stop: () => {
       for (const task of tasks) {
         task.stop();
       }
+      postsScheduler.stop();
     },
   };
 }


### PR DESCRIPTION
## Summary

ZOE drafts 4 categories of social posts and DMs Zaal random suggestions throughout the day. He copy-pastes the keepers into Firefly. Built from grill answers on 2026-05-16.

## Grill answers locked

| Question | Zaal's answer |
|---|---|
| 5am laptop anchor | Pre-drafted post + 2-3 suggestions + today's calendar |
| Post categories | All 4: build / ecosystem / event / personal (one per moment of day) |
| Confirm flow | ZOE Telegram DM per post, copy-paste into Firefly (no buttons, no auto-post in v1) |
| Cadence | Random + often, no fixed schedule |
| Personal/voice source | All sources: stream transcripts + voice memos + persona + Zaal natural-language replies |
| Post execution | Plain DM text, manual copy-paste |
| v1 scope | Ship now, no separate spec doc |

## What's in this PR

`bot/src/zoe/posts/` (7 new files, ~500 LOC):
- `types.ts` - PostCategory + PostDraft types
- `sources.ts` - data gathering per category (git log, repo activity, ~/.zao/zoe/events/*.txt, ~/.zao/zoe/voice-memos/)
- `drafters.ts` - per-category Claude CLI drafter using Hermes pattern (`callClaudeCli`, default haiku)
- `scheduler.ts` - 7 random pings/day in 5am-10pm ET window, 20min min gap, re-rolls at midnight ET
- `voicememo.ts` - `/voicememo` + `/vm` Telegram capture commands
- `index.ts` - public API
- `README.md` - full spec + v2 roadmap

Patches:
- `bot/src/zoe/scheduler.ts` - calls `startPostsScheduler` alongside existing morning brief + evening reflect + hourly nudge
- `bot/src/zoe/index.ts` - registers `/voicememo` + `/vm` commands

## Cadence (configurable)

- **7 pings/day** target (override via `pingsPerDay` option)
- Window **5am-10pm America/New_York**
- **20 min minimum gap** between pings
- Category weights: **build=3 ecosystem=2 event=1 personal=1** (calibrate after week 1)
- No quiet hours per `feedback_no_flow_state_gate.md`
- Empty `(skip)` drafts dropped silently, do not count against quota

## v1 limitations (intentional)

- Event source = manually seeded `~/.zao/zoe/events/{today,tomorrow}.txt`. Google Calendar MCP wiring is v2.
- Ecosystem source = ZAOOS repo activity as proxy. Farcaster + ZABAL contract events are v2.
- Personal source = `/voicememo` text only. Voice notes via Whisper + lunch stream transcripts via `zao-transcribe` are v2.
- No inline keyboard buttons, no auto-post, no clipboard skill. Manual copy-paste only.

## Typecheck

```
src/zoe/posts/*.ts: 0 errors
(4 pre-existing errors in newsletter.ts + teams/shared.ts unchanged)
```

## Deploy

```bash
ssh zaal@31.97.148.88 'cd /home/zaal/zao-os && git pull && systemctl --user restart zoe-bot && sleep 5 && journalctl --user -u zoe-bot.service -n 30 --no-pager'
```

Look for these log lines on healthy boot:
```
[zoe/posts] scheduler started (target 7 pings/day, window 5am-10pm ET)
[zoe/posts] rolled schedule for 2026-05-17: 7 pings
```

## Test plan

- [ ] PR merges to main
- [ ] Zaal deploys via ssh + `git pull` + `systemctl --user restart zoe-bot`
- [ ] On boot, scheduler logs target pings + window
- [ ] First ping arrives within window (5am-10pm ET) within the configured cadence
- [ ] `/voicememo testing 123` on Telegram appends to `~/.zao/zoe/voice-memos/YYYY-MM-DD.md`
- [ ] After 24h: review `~/.zao/zoe/posts/log.jsonl` for skip rate per category
- [ ] After 7 days: tune category weights based on real skip data