### PR TITLE
feat(zoe/posts) v2: real ZABAL voice + persistent confirm flow

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -42,7 +42,7 @@ import {
   readGroups,
   type GroupMode,
 } from './groups';
-import { handleVoiceMemo } from './posts';
+import { handleVoiceMemo, handlePostCallback } from './posts';
 
 const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
@@ -191,6 +191,15 @@ bot.command('quests', async (ctx) => {
 // Appends to ~/.zao/zoe/voice-memos/YYYY-MM-DD.md for the personal-post drafter.
 bot.command(['voicememo', 'vm'], async (ctx) => {
   await handleVoiceMemo(ctx, isFromZaal(ctx));
+});
+
+// Post slate v2 - callback handler for POST/REGEN/SKIP buttons under draft messages.
+bot.callbackQuery(/^post-(approve|regen|skip):/, async (ctx) => {
+  if (ctx.from?.id !== zaalId) {
+    await ctx.answerCallbackQuery('not authorized');
+    return;
+  }
+  await handlePostCallback({ ctx, repoDir, zaalTgId: zaalId });
 });
 
 bot.command('notes', async (ctx) => {

--- a/bot/src/zoe/posts/buttons.ts
+++ b/bot/src/zoe/posts/buttons.ts
@@ -1,0 +1,173 @@
+// Post slate v2 - inline keyboard + callback handler.
+// Buttons under each draft message: POST | REGEN | SKIP.
+// Callback data shape: `post-<action>:<id>` where action is one of approve|regen|skip.
+
+import { InlineKeyboard, type Context } from 'grammy';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from '../memory';
+import { draftPost } from './drafters';
+import {
+  clearPending,
+  loadPending,
+  newPendingId,
+  savePending,
+  type PendingDraft,
+} from './pending';
+import {
+  gatherBuildSignals,
+  gatherEcosystemSignals,
+  gatherEventSignals,
+  gatherPersonalSignals,
+} from './sources';
+import type { PostCategory, PostSourceSnapshot } from './types';
+
+const POSTS_STATE_DIR = join(ZOE_PATHS.home, 'posts');
+const LOG_FILE = join(POSTS_STATE_DIR, 'log.jsonl');
+
+async function appendLog(line: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(POSTS_STATE_DIR, { recursive: true });
+  await fs.appendFile(LOG_FILE, `${JSON.stringify({ ts: new Date().toISOString(), ...line })}\n`, 'utf8');
+}
+
+export function buildKeyboard(id: string): InlineKeyboard {
+  return new InlineKeyboard()
+    .text('POST', `post-approve:${id}`)
+    .text('REGEN', `post-regen:${id}`)
+    .text('SKIP', `post-skip:${id}`);
+}
+
+async function gatherAll(repoDir: string): Promise<PostSourceSnapshot> {
+  const [build, ecosystem, event, personal] = await Promise.all([
+    gatherBuildSignals(repoDir),
+    gatherEcosystemSignals(repoDir),
+    gatherEventSignals(),
+    gatherPersonalSignals(),
+  ]);
+  return { build, ecosystem, event, personal };
+}
+
+export interface SendDraftOptions {
+  bot: Context['api'] | { sendMessage: (chatId: number, text: string, options?: { reply_markup?: InlineKeyboard }) => Promise<{ message_id: number }> };
+  zaalTgId: number;
+  category: PostCategory;
+  text: string;
+  isResend?: boolean;
+}
+
+/** Send a draft as 2 bubbles (label + bare text with keyboard) and persist pending. */
+export async function sendDraftWithKeyboard(opts: SendDraftOptions): Promise<PendingDraft | null> {
+  const existing = await loadPending();
+  const id = existing?.id ?? newPendingId(opts.category);
+  try {
+    const headerSuffix = opts.isResend
+      ? ` (resend ${(existing?.resendCount ?? 0) + 1}/3 - tap a button)`
+      : ' - tap POST/REGEN/SKIP';
+    await opts.bot.sendMessage(opts.zaalTgId, `ZOE post draft (${opts.category})${headerSuffix}`);
+    const sent = await opts.bot.sendMessage(opts.zaalTgId, opts.text, {
+      reply_markup: buildKeyboard(id),
+    });
+    const now = new Date().toISOString();
+    const pending: PendingDraft = {
+      id,
+      category: opts.category,
+      text: opts.text,
+      createdAt: existing?.createdAt ?? now,
+      lastSentAt: now,
+      messageId: sent?.message_id ?? null,
+      resendCount: existing ? existing.resendCount + (opts.isResend ? 1 : 0) : 0,
+      state: 'pending',
+    };
+    await savePending(pending);
+    await appendLog({
+      event: opts.isResend ? 'resent' : 'sent',
+      category: opts.category,
+      id,
+      resendCount: pending.resendCount,
+      charCount: opts.text.length,
+    });
+    return pending;
+  } catch (err) {
+    await appendLog({ event: 'send-error', category: opts.category, error: (err as Error).message });
+    return null;
+  }
+}
+
+export interface CallbackHandlerOptions {
+  ctx: Context;
+  repoDir: string;
+  zaalTgId: number;
+}
+
+export async function handlePostCallback(opts: CallbackHandlerOptions): Promise<void> {
+  const data = opts.ctx.callbackQuery?.data ?? '';
+  const match = data.match(/^post-(approve|regen|skip):(.+)$/);
+  if (!match) {
+    await opts.ctx.answerCallbackQuery('unknown action');
+    return;
+  }
+  const [, action, id] = match;
+  const pending = await loadPending();
+  if (!pending || pending.id !== id) {
+    await opts.ctx.answerCallbackQuery('this draft is no longer pending');
+    return;
+  }
+
+  // Strip the keyboard from the old draft message so the buttons can't be tapped
+  // again. Best-effort - if it fails (message too old, etc) just continue.
+  try {
+    await opts.ctx.editMessageReplyMarkup({ reply_markup: undefined });
+  } catch {
+    /* ignore */
+  }
+
+  if (action === 'skip') {
+    pending.state = 'skipped';
+    await savePending(pending);
+    await clearPending();
+    await appendLog({ event: 'skipped', category: pending.category, id });
+    await opts.ctx.answerCallbackQuery('skipped');
+    return;
+  }
+
+  if (action === 'approve') {
+    pending.state = 'approved';
+    await savePending(pending);
+    await clearPending();
+    await appendLog({ event: 'approved', category: pending.category, id });
+    await opts.ctx.answerCallbackQuery('approved - paste it');
+    // Resend the bare text one more time as a clean copy-target without buttons.
+    try {
+      await opts.ctx.api.sendMessage(opts.zaalTgId, pending.text);
+    } catch {
+      // best effort
+    }
+    return;
+  }
+
+  // action === 'regen'
+  await opts.ctx.answerCallbackQuery('regenerating...');
+  await clearPending();
+  await appendLog({ event: 'regen-requested', category: pending.category, id });
+  try {
+    const snapshot = await gatherAll(opts.repoDir);
+    const draft = await draftPost(pending.category, snapshot, { cwd: opts.repoDir });
+    if (!draft.text || /^\(skip\)/i.test(draft.text)) {
+      await opts.ctx.api.sendMessage(
+        opts.zaalTgId,
+        `(regen returned skip for ${pending.category} - source data too thin right now)`,
+      );
+      await appendLog({ event: 'regen-skip', category: pending.category });
+      return;
+    }
+    await sendDraftWithKeyboard({
+      bot: opts.ctx.api,
+      zaalTgId: opts.zaalTgId,
+      category: pending.category,
+      text: draft.text,
+    });
+  } catch (err) {
+    await appendLog({ event: 'regen-error', category: pending.category, error: (err as Error).message });
+    await opts.ctx.api.sendMessage(opts.zaalTgId, `regen failed: ${(err as Error).message}`);
+  }
+}

--- a/bot/src/zoe/posts/drafters.ts
+++ b/bot/src/zoe/posts/drafters.ts
@@ -1,39 +1,118 @@
-// Post slate v1 - per-category Claude CLI drafter.
-// Each drafter takes the source snapshot and returns one post draft string.
-// Uses the Hermes pattern (claude CLI subprocess via Max plan auth).
+// Post slate v2 - per-category Claude CLI drafter.
+// Voice rules ported from ~/.claude/skills/socials/skill.md + Doc 610 ZABAL
+// tightening + Doc 558 Anbeeld AI-prose toolkit. Few-shot examples per
+// category to teach tone from examples, not rules alone (see Doc 659).
 
 import { callClaudeCli } from '../../hermes/claude-cli';
 import type { PostCategory, PostDraft, PostSourceSnapshot } from './types';
 
-const SHARED_VOICE = `You are ZOE drafting a social post in Zaal's voice.
+const SHARED_VOICE = `You draft a single social post in Zaal's Year-of-the-ZABAL voice. Output channel: Firefly (cross-posts to Farcaster + X simultaneously, so the post must work on both).
 
-VOICE RULES (non-negotiable):
-- Year-of-the-ZABAL tone: clear, simple, spartan, active voice.
-- No emojis, no em dashes, no marketing-speak ("game-changer", "unlock", etc).
-- 1-3 short lines. Hard cap 280 chars (one X tweet).
-- First person where natural. "I shipped X" beats "ZAO shipped X" for build posts.
-- Brand spellings exact: WaveWarZ, COC Concertz, The ZAO, BetterCallZaal, ZABAL, SANG, ZOE, ZOLs, FISHBOWLZ, Hurric4n3ike, candytoybox.
-- Channel: Firefly (FC+X cross-post). No platform-specific syntax.
+ABSOLUTE RULES (any violation = re-write):
+- Lead with "ZM." (ZAO Morning - the daily greeting across the ZAO ecosystem). Exception: event-promo posts may skip ZM when it would read awkwardly.
+- No emojis. No hashtags. No em dashes. Hyphens only.
+- Hard cap 280 characters total.
+- Brand spellings exact: WaveWarZ, COC Concertz, The ZAO, BetterCallZaal, ZABAL, SANG, ZOE, ZOLs, FISHBOWLZ, Hurric4n3ike, candytoybox, Huottoja, Joseph Goats. PR/issue numbers: "PR 533" not "#533".
+- NEVER reference work-day times. Zaal has a day job at Jackson Labs. Do not publish "lunch stream at 11:30", "this morning", "today at 10am". Use timeless framing: "had a lunch stream" or drop the time entirely.
+- Lowercase casual when it fits the rhythm. "shipped X" beats "Shipped X."
+- Contribution over celebration. Name the artifact, the number, the person. Not the vibe.
+- One specific number, name, or place per post minimum.
 
-OUTPUT: only the post text. No surrounding quotes, no commentary, no labels.`;
+ANTI-PATTERNS (these are LLM tells - strip them):
+- No "is coming together", "small pieces clicking into place", "the rhythm is set", "puzzle pieces", "in motion".
+- No "the machine", "the work", "the system", "the multi-agent coordination layer" as brand-coded singulars. Name the actual thing.
+- No "There is a thing that happens when..." constructions.
+- No aphoristic closes. Closing line is a concrete fact or next step, not a koan.
+- No parallel-structure 3-beat closes ("X. Y. Then Z.").
+- No universal-second-person preachy ("You do not become ready"). Reserve "you" for direct reader address.
+- No "loop is clean", "rooms worth being in", "decide you are", "show up" as abstractions.
+- No "thrilled to", "humbled to", "excited to", "grateful for" - just say what happened.
+
+EMPTY-SOURCE RULE:
+If the source data block is genuinely empty (no commits, no events, no voice memos, no ecosystem activity), output the literal string "(skip)" and nothing else. Better to send nothing than fluff.
+
+OUTPUT: only the post text. No surrounding quotes, no commentary, no labels, no markdown.`;
+
+const BUILD_EXAMPLES = `Examples of good build posts:
+
+"ZM. shipped /voicememo + /vm telegram commands. one-liner thoughts now feed ZOE's personal post drafter. PR 533."
+
+"ZM. dropped paperclipai from VPS - the service had crash-looped 107k times. one less fire."
+
+"ZM. zoe post slate v2 ships persistent confirm flow. every draft sits until you tap POST or SKIP. no more fire-and-forget."`;
+
+const ECOSYSTEM_EXAMPLES = `Examples of good ecosystem posts:
+
+"ZM. cassie validated 4/28 - the ZAOstock infrastructure is the product, the festival is proof. building the rest in public."
+
+"ZM. iman owns cowork-zaodevz now - one tracker across ZAO + WaveWarZ + COC Concertz + BCZ Strategies. 4 brands, one audit log."
+
+"ZM. jadyn violet UVR producer brief locked. iman builds the song next."`;
+
+const EVENT_EXAMPLES = `Examples of good event posts:
+
+"ZAOstock Oct 3 in Ellsworth - franklin st parklet. sign up at zaostock.com."
+
+"monday cobuilds at meet.baserooms.io/zaal - open jam, anyone can drop in."
+
+"POIDH bounty 1151 closes friday - WTM audition format. $25 USDC."`;
+
+const PERSONAL_EXAMPLES = `Examples of good personal posts:
+
+"ZM. realized this week that the ZAO is not the music, the music is the proof of the ZAO. the org is the artifact."
+
+"ZM. iman watching me build imanagent on a video call was the cleanest dev-handoff i've ever done."
+
+"ZM. JANGOUU FOREVER. every project i build now traces back to him."`;
 
 const CATEGORY_PROMPT: Record<PostCategory, string> = {
-  build: `Draft a build-in-public post about today's shipping.
-Sources (last 24h commits + open PRs):
+  build: `Draft a build-in-public post about today's shipping work.
+
+SOURCE DATA (last 24h commits + open PRs):
 {SOURCE}
-Pick the 1-2 most-interesting items. Lead with the verb. End with the URL or PR number if there is one. If sources are empty, output "(skip)".`,
-  ecosystem: `Draft a ZAO ecosystem signal post about community activity in the last 7 days.
-Sources (recent ZAOOS repo activity as proxy for ecosystem momentum):
+
+${BUILD_EXAMPLES}
+
+INSTRUCTIONS:
+- Pick the SINGLE most-interesting shipping item from sources. Do not list 3 things.
+- Lead with the verb + the artifact. "shipped X" not "X is now live".
+- If a PR number is relevant, append "PR 123" (no hashtag, no "#") at the end.
+- If sources show no real shipping (just docs, just chores), output "(skip)".`,
+  ecosystem: `Draft a ZAO ecosystem signal post about community activity.
+
+SOURCE DATA (last 7 days repo activity as proxy for ecosystem momentum):
 {SOURCE}
-Highlight one concrete signal: a new research doc landing, a community member's project, a brand shipping. Frame it as ZAO momentum, not personal momentum. If sources are empty, output "(skip)".`,
-  event: `Draft a calendar/event promo post for today or tomorrow.
-Sources:
+
+${ECOSYSTEM_EXAMPLES}
+
+INSTRUCTIONS:
+- Pick ONE specific signal: a named person, project, doc, or move.
+- Frame as ZAO momentum, not personal momentum.
+- Never generalize to "the ecosystem" or "the multi-agent layer". Name the thing.
+- If sources are thin or all internal-only, output "(skip)".`,
+  event: `Draft a calendar/event promo post.
+
+SOURCE DATA:
 {SOURCE}
-Pick one event. Tell people what + when + how to join. Invite them in. If sources are empty, output "(skip)".`,
-  personal: `Draft a personal/voice post in Zaal's voice from his recent voice memos.
-Sources (recent voice memos, newest last):
+
+${EVENT_EXAMPLES}
+
+INSTRUCTIONS:
+- Pick ONE event from today or tomorrow.
+- Lead with the event name + place/link. Skip the work-day time entirely.
+- End with how to join.
+- If sources are empty, output "(skip)".`,
+  personal: `Draft a personal/voice post pulled from Zaal's recent voice memos.
+
+SOURCE DATA (recent voice memos, newest last):
 {SOURCE}
-Pull one thread, expand it to 1-3 lines. Keep his exact phrasings where possible. If sources are empty, output "(skip)".`,
+
+${PERSONAL_EXAMPLES}
+
+INSTRUCTIONS:
+- Pull ONE thread from the memos. Expand to 1-3 lines using Zaal's exact phrasings.
+- If no voice memos in source, output "(skip)". Do not synthesize personal posts from generic context.
+- Voice memos are first-person Zaal thoughts - keep them in his voice, do not editorialize.`,
 };
 
 export async function draftPost(
@@ -44,7 +123,10 @@ export async function draftPost(
   const sourceBlock = formatSourceBlock(category, snapshot);
   const userPrompt = CATEGORY_PROMPT[category].replace('{SOURCE}', sourceBlock);
 
-  const model = opts.model ?? 'haiku';
+  // Sonnet default (was haiku in v1 - haiku could not internalize 19 voice rules
+  // + few-shot examples without losing the actual content). Sonnet handles the
+  // prompt budget at ~$0.005 per draft = ~$0.04/day at 7 pings.
+  const model = opts.model ?? 'sonnet';
   const result = await callClaudeCli({
     model,
     prompt: userPrompt,
@@ -72,7 +154,7 @@ function formatSourceBlock(category: PostCategory, s: PostSourceSnapshot): strin
         ? s.build.recentCommits.map((c) => `- ${c}`).join('\n')
         : '(no commits in 24h)';
       const prs = s.build.openPrs.length
-        ? s.build.openPrs.map((p) => `- #${p.number} ${p.title}`).join('\n')
+        ? s.build.openPrs.map((p) => `- PR ${p.number} ${p.title}`).join('\n')
         : '(no open PRs)';
       return `COMMITS (24h):\n${commits}\n\nOPEN PRS:\n${prs}`;
     }

--- a/bot/src/zoe/posts/index.ts
+++ b/bot/src/zoe/posts/index.ts
@@ -1,8 +1,11 @@
-// Post slate v1 - public API.
+// Post slate v2 - public API.
 // See README.md for the spec.
 
 export { startPostsScheduler } from './scheduler';
 export type { PostsSchedulerOptions } from './scheduler';
 export { handleVoiceMemo } from './voicememo';
 export { appendVoiceMemo } from './sources';
+export { handlePostCallback, sendDraftWithKeyboard, buildKeyboard } from './buttons';
+export { loadPending, clearPending } from './pending';
+export type { PendingDraft } from './pending';
 export type { PostCategory, PostDraft } from './types';

--- a/bot/src/zoe/posts/pending.ts
+++ b/bot/src/zoe/posts/pending.ts
@@ -1,0 +1,65 @@
+// Post slate v2 - pending draft persistence + state machine.
+// Single in-flight model: at most ONE pending draft at a time. Scheduler
+// blocks new fires until pending is dispositioned (POST / REGEN / SKIP)
+// or expires (4h absolute TTL, or 3 resends).
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from '../memory';
+import type { PostCategory } from './types';
+
+const POSTS_STATE_DIR = join(ZOE_PATHS.home, 'posts');
+const PENDING_FILE = join(POSTS_STATE_DIR, 'pending.json');
+
+export const PENDING_TTL_MS = 4 * 60 * 60_000; // 4 hours absolute
+export const RESEND_INTERVAL_MS = 30 * 60_000; // 30 minutes between resends
+export const MAX_RESENDS = 3;
+
+export interface PendingDraft {
+  id: string;
+  category: PostCategory;
+  text: string;
+  createdAt: string;
+  lastSentAt: string;
+  messageId: number | null;
+  resendCount: number;
+  state: 'pending' | 'approved' | 'skipped' | 'expired';
+}
+
+export async function loadPending(): Promise<PendingDraft | null> {
+  try {
+    const raw = await fs.readFile(PENDING_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as PendingDraft;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export async function savePending(p: PendingDraft): Promise<void> {
+  await fs.mkdir(POSTS_STATE_DIR, { recursive: true });
+  await fs.writeFile(PENDING_FILE, JSON.stringify(p, null, 2), 'utf8');
+}
+
+export async function clearPending(): Promise<void> {
+  try {
+    await fs.unlink(PENDING_FILE);
+  } catch {
+    // already absent - fine
+  }
+}
+
+export function isExpired(p: PendingDraft, nowMs: number = Date.now()): boolean {
+  return nowMs - new Date(p.createdAt).getTime() > PENDING_TTL_MS;
+}
+
+export function shouldResend(p: PendingDraft, nowMs: number = Date.now()): boolean {
+  if (p.state !== 'pending') return false;
+  if (p.resendCount >= MAX_RESENDS) return false;
+  return nowMs - new Date(p.lastSentAt).getTime() > RESEND_INTERVAL_MS;
+}
+
+export function newPendingId(category: PostCategory): string {
+  const iso = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${iso}-${category}`;
+}

--- a/bot/src/zoe/posts/scheduler.ts
+++ b/bot/src/zoe/posts/scheduler.ts
@@ -15,7 +15,9 @@ import cron from 'node-cron';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { ZOE_PATHS } from '../memory';
+import { sendDraftWithKeyboard } from './buttons';
 import { draftPost } from './drafters';
+import { clearPending, isExpired, loadPending, shouldResend } from './pending';
 import {
   gatherBuildSignals,
   gatherEcosystemSignals,
@@ -166,16 +168,16 @@ async function fireOneDraft(bot: Bot, zaalTgId: number, repoDir: string): Promis
     await appendLog({ event: 'skip', category, reason: 'empty-or-skip-marker' });
     return;
   }
-  // Send as TWO messages so Zaal can long-press the post body alone and
-  // tap-copy the whole thing. The header bubble explains category; the body
-  // bubble is the bare post text with no decoration.
-  try {
-    await bot.api.sendMessage(zaalTgId, `ZOE post draft (${category}) - copy the next message`);
-    await bot.api.sendMessage(zaalTgId, draft.text);
-    await appendLog({ event: 'sent', category, charCount: draft.text.length });
-  } catch (err) {
-    await appendLog({ event: 'send-error', category, error: (err as Error).message });
-  }
+  // v2: send with inline keyboard [POST] [REGEN] [SKIP]. Persists as the
+  // single pending draft - scheduler will not fire a new one until this is
+  // dispositioned.
+  await sendDraftWithKeyboard({
+    bot: bot.api,
+    zaalTgId,
+    category,
+    text: draft.text,
+    isResend: false,
+  });
 }
 
 export interface PostsSchedulerOptions {
@@ -206,6 +208,29 @@ export function startPostsScheduler(opts: PostsSchedulerOptions): { stop: () => 
   const tickTask = cron.schedule(
     '* * * * *',
     async () => {
+      // v2: single in-flight draft. If pending exists and not expired, handle it:
+      // - shouldResend (30 min since lastSentAt, max 3 resends) -> resend same text
+      // - expired (4h) -> clear, log expired, allow new draft next tick
+      // - otherwise -> wait, do not fire new
+      const pending = await loadPending();
+      if (pending && pending.state === 'pending') {
+        if (isExpired(pending)) {
+          await appendLog({ event: 'expired', category: pending.category, id: pending.id });
+          await clearPending();
+        } else if (shouldResend(pending)) {
+          await sendDraftWithKeyboard({
+            bot: opts.bot.api,
+            zaalTgId: opts.zaalTgId,
+            category: pending.category,
+            text: pending.text,
+            isResend: true,
+          });
+          return;
+        } else {
+          // waiting - do not fire new
+          return;
+        }
+      }
       const schedule = await loadOrRollSchedule(pings);
       const now = Date.now();
       const LATE_THRESHOLD_MS = 30 * 60_000; // 30 min - any older = treat as missed, don't fire late

--- a/research/dev-workflows/659-zoe-posts-v2-voice-and-confirm-flow/README.md
+++ b/research/dev-workflows/659-zoe-posts-v2-voice-and-confirm-flow/README.md
@@ -1,0 +1,216 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-05-17
+related-docs: 533, 537, 558, 562, 610, 655
+tier: STANDARD
+---
+
+# 659 - ZOE Posts v2: Voice Fix + Persistent Confirm Flow
+
+> **Goal:** Address two real failures of post slate v1 caught in the first 24h: (a) drafts are off-voice + miss every existing ZAO writing rule, (b) drafts fire-and-forget so bad ones still hit Zaal's phone with no way to reject. Both fixes ship in PR #538.
+
+## Recommendations First
+
+| # | Action | Severity | Why |
+|---|---|---|---|
+| 1 | **Replace `SHARED_VOICE` prompt in `drafters.ts` with the full /socials skill rules + Doc 610 anti-patterns + 3-5 few-shot examples per category** | **CRITICAL** | v1 drafts are generic LLM-speak. The /socials skill has 11 voice rules + Doc 610 has 8 anti-patterns + 6 do-rules that ZOE never saw. Single-file fix unlocks the whole post slate. |
+| 2 | **Replace fire-and-forget with persistent inline-keyboard confirm flow: `[POST]` `[REGEN]` `[SKIP]`** | **HIGH** | Per Zaal feedback: "i want it to keep sending the same post until i approve it." Pending state at `~/.zao/zoe/posts/pending/<id>.json`. Scheduler skips new fires while one is pending. Re-DM at 30-min intervals max 3 times. Tap a button → callback handler updates state. |
+| 3 | **Add `(skip)` fast-fail for build/ecosystem categories when source data is empty** | MEDIUM | v1 generated weak drafts even when no commits / no ecosystem signal because the drafter prompt didn't insist on real material. New prompt forces `(skip)` when source block is truly empty. |
+| 4 | **Default category model: `sonnet` not `haiku`** | MEDIUM | Haiku could not internalize 19 voice rules + few-shot examples without losing the actual content. Sonnet handles the prompt budget. Cost = ~$0.003-$0.01 per draft = ~$0.07/day max at 7 pings. Cheap. |
+| 5 | **Hold v3 (auto-post via Firefly API) until v2 has been used 1 week** | LOW | Per `feedback_ship_and_use_not_meta`. Confirm flow + good voice = enough to test. Auto-post adds blast radius. |
+
+## What was wrong with v1 (2026-05-17 evening test)
+
+Zaal received 4 drafts. Quoted verbatim:
+
+> **build**: "I shipped ZOE's post-draft feature. She pings with random social ideas, tap to copy. #533"
+
+Violations: `#533` reads as hashtag (rule: no hashtags). "Pings with random social ideas" = vibes not contribution. Missing `ZM` daily greeting (rule: every post begins with ZM).
+
+> **ecosystem**: "Post-slate v1 shipped: ZOE now auto-drafts social posts. Agency-model research + zao-transcribe landed. The multi-agent coordination layer for The ZAO is coming together."
+
+Violations: "is coming together" = ZABAL anti-pattern (vague abstraction). "The multi-agent coordination layer" = "the X" brand-coded singular (Doc 610 anti-pattern #3). No specific number, no named person, no concrete artifact.
+
+> **ecosystem**: "shipped 3 research on agency model, plural events, monetary substrate. zao foundation work."
+
+Violations: drops voice mid-sentence ("zao foundation work" is a fragment, but the genre is unclear - is this a tweet or a memo?). Too thin - no context, no link, no number.
+
+> **event**: "Lunch stream 11:30am ET. Come hang."
+
+Violations: **"11:30am ET" is a work-day time reference** (rule from /socials: "NEVER reference work-day times"). Zaal has a day job at Jackson Labs - publishing his lunch-stream time confirms he's building during work hours. Direct rule break that v1 had no guardrail for.
+
+## Voice rules to bake into v2
+
+Combined from the **/socials skill** (~/.claude/skills/socials/skill.md) + **Doc 610 ZABAL voice toolkit** + **Doc 558 Anbeeld writing rules**.
+
+### Universal rules (apply to every category)
+
+1. **Lead with `ZM`** as the opener for build/ecosystem/personal posts (skip for event-promo when it would read awkward).
+2. **No hashtags.** Even PR numbers like `#533` reformatted as `PR 533`.
+3. **No emojis. No em dashes. Hyphens only.**
+4. **Lowercase casual** when it fits the rhythm. "shipped post slate" beats "Shipped Post Slate".
+5. **Never reference work-day times.** No "this morning", "today at 10am", "lunch stream at 11:30". Use timeless framing: "had a lunch stream" or just drop the time.
+6. **Contribution over celebration.** Name the artifact, the number, the person. Not the vibe.
+7. **Lead with the verb when possible.** "Shipped X" beats "X is now live."
+8. **No aphoristic closes.** Closing line is a concrete fact or next step, not a koan.
+9. **No "the machine", "the work", "the system", "the multi-agent coordination layer"** as brand-coded singulars. Name the thing.
+10. **No "is coming together", "small pieces clicking into place", "the rhythm is set"** as transitions.
+11. **One specific number, name, or place per post minimum.**
+12. **Hard cap 280 chars** (single FC+X cross-post via Firefly).
+13. **Brand spellings exact**: WaveWarZ, COC Concertz, The ZAO, BetterCallZaal, ZABAL, SANG, ZOE, ZOLs, FISHBOWLZ, Hurric4n3ike, candytoybox, Huöttöja, Joseph Goats.
+14. **If source data is empty or generic, output `(skip)` only.** Better to send nothing than fluff.
+
+### Category-specific rules
+
+| Category | Lead with | Source signal | Anti-rule |
+|---|---|---|---|
+| **build** | Shipped artifact name + PR# (no hashtag) | git log + open PRs (last 24h) | Don't list 3 commits; pick the 1 that ships a thing users see |
+| **ecosystem** | Named ZAO member or project move | repo activity (proxy) + Farcaster v2 | Don't generalize to "ecosystem momentum"; name the specific person/project |
+| **event** | Named event + venue/link, no time | `~/.zao/zoe/events/{today,tomorrow}.txt` | Drop times; "come hang" without the work-hour timestamp |
+| **personal** | Zaal's actual phrasing from voice memo | `~/.zao/zoe/voice-memos/<date>.md` | If no voice memo today, `(skip)` - do not synthesize personal posts from persona alone |
+
+## Few-shot examples (bake into prompt)
+
+Use 2-3 good examples per category. The model copies tone from examples better than from rules alone.
+
+### build examples
+
+```
+ZM. shipped /voicememo + /vm telegram commands. one-liner thoughts now feed ZOE's personal post drafter. PR 533.
+
+ZM. dropped paperclipai from VPS - the service had crash-looped 107k times. one less fire.
+
+ZM. zoe post slate v2 ships persistent confirm: every draft sits until you tap POST or SKIP. no more fire-and-forget noise.
+```
+
+### ecosystem examples
+
+```
+ZM. cassie validated 4/28 - the ZAOstock infrastructure is the product, the festival is proof. building the rest in public.
+
+ZM. iman owns cowork-zaodevz now - one tracker for ZAO + WaveWarZ + COC Concertz + BCZ Strategies. 4 brands, one audit log.
+
+ZM. jadyn violet UVR producer brief locked. iman builds the song next.
+```
+
+### event examples
+
+```
+ZM. ZAOstock Oct 3 in Ellsworth - franklin st parklet. sign up at zaostock.com.
+
+ZM. monday cobuilds at meet.baserooms.io/zaal - open jam, anyone can drop in.
+
+ZM. POIDH bounty 1151 closes friday - WTM audition format, $25 USDC.
+```
+
+### personal examples
+
+```
+ZM. realized this morning that the ZAO is not the music, the music is the proof of the ZAO. the org is the artifact.
+
+ZM. iman watching me build imanagent on a video call was the best dev-handoff i've ever done.
+
+ZM. JANGOUU FOREVER. been thinking about how every project i build now traces back to him.
+```
+
+## Confirm flow v2 design
+
+**Pending draft = the only fire-able state.** Scheduler never sends a new draft while one is pending. Persistence at `~/.zao/zoe/posts/pending.json` (single-pending model - if Zaal taps SKIP on draft A, draft B becomes the next eligible).
+
+### State machine
+
+```
+[scheduled] --tick due--> [drafted] --send + buttons--> [pending]
+                                                            |
+        +------- REGEN tap ---------- regen + send -------- +
+        |
+        +------- POST tap -----------> [approved] (log + done)
+        |
+        +------- SKIP tap -----------> [skipped] (log + done)
+        |
+        +------- 30 min no tap ------> [resent] (max 3 resends)
+        |
+        +------- 4 hours no tap -----> [expired] (auto-skip)
+```
+
+### Inline keyboard markup (grammy)
+
+```typescript
+import { InlineKeyboard } from 'grammy';
+
+const kb = new InlineKeyboard()
+  .text('POST', `post-approve:${id}`)
+  .text('REGEN', `post-regen:${id}`)
+  .text('SKIP', `post-skip:${id}`);
+
+await bot.api.sendMessage(zaalTgId, text, { reply_markup: kb });
+```
+
+Callback handler in `bot/src/zoe/index.ts`:
+
+```typescript
+bot.callbackQuery(/^post-(approve|regen|skip):(.+)$/, async (ctx) => {
+  if (!isFromZaal(ctx)) return ctx.answerCallbackQuery();
+  const [, action, id] = ctx.match;
+  await handlePostCallback({ action, id, ctx });
+  await ctx.answerCallbackQuery(`${action} noted`);
+});
+```
+
+### Persistence shape
+
+`~/.zao/zoe/posts/pending.json`:
+```json
+{
+  "id": "2026-05-17T19:50-build",
+  "category": "build",
+  "text": "ZM. shipped post slate v2...",
+  "createdAt": "2026-05-17T23:50:00.000Z",
+  "lastSentAt": "2026-05-17T23:50:00.000Z",
+  "messageId": 12345,
+  "resendCount": 0,
+  "state": "pending"
+}
+```
+
+### Sources rules
+
+- **Single in-flight draft only.** If pending exists, scheduler tick logs `skip-blocked-on-pending` and returns.
+- **REGEN replaces, doesn't queue.** Same id, new text, same message-edit if grammy supports it (otherwise new message + ignore the old one).
+- **Max 3 resends.** After 3rd resend, auto-state = `expired`.
+- **4-hour absolute TTL** regardless of resend count.
+
+## Sources
+
+- `~/.claude/skills/socials/skill.md` (voice rules verbatim)
+- `~/.claude/skills/humanizer/SKILL.md` (Wikipedia AI-writing toolkit)
+- [Doc 558 - Anbeeld writing.md AI-prose toolkit](../558-anbeeld-writing-md/)
+- [Doc 610 - Newsletter prose toolkit + ZABAL voice tightening](../610-newsletter-prose-toolkit-zabal-voice/) - the 8 anti-patterns + 6 do-rules
+- [Doc 562 - humanizer skill + last30days](../562-reddit-x-scraping-meta-eval-last30days/)
+- [grammY inline keyboards docs](https://grammy.dev/plugins/keyboard)
+- [grammY callback query reference](https://grammy.dev/ref/types/callbackquery)
+- [Twitter Strategy for Indie Hackers 2026 - teract.ai](https://www.teract.ai/resources/twitter-strategy-indie-hackers-2026)
+- v1 drafts that hit Zaal's phone 2026-05-17 evening (cited in "What was wrong" section)
+
+## Also See
+
+- [Doc 533 PR](../533) - post slate v1 ship
+- [Doc 537 PR](../537) - tap-copy UX + 1-ping-per-tick fixes
+- [Doc 655](../655-post-merge-execution-playbook/) - week-1 execution playbook (this is part 2)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Replace `SHARED_VOICE` in `bot/src/zoe/posts/drafters.ts` with v2 rules + few-shot examples | Claude (this PR) | Code | Now |
+| Default category model = `sonnet` | Claude (this PR) | Code | Now |
+| Add inline keyboard to fireOneDraft + pending.json persistence | Claude (this PR) | Code | Now |
+| Register callback handler in `bot/src/zoe/index.ts` | Claude (this PR) | Code | Now |
+| Scheduler: skip new fires if pending exists | Claude (this PR) | Code | Now |
+| Resend pending at 30-min interval max 3 times | Claude (this PR) | Code | Now |
+| Zaal deploys via auto-sync + tests 3-5 drafts | @Zaal | Test | After merge |
+| Friction check: are drafts approval-rate > 30%? | @Zaal | 1 week of pending.json + log.jsonl review | 2026-05-24 |
+| If approval > 50% → consider v3 (Firefly API auto-post) | @Zaal | Decision | 2026-05-24 |
+| If approval < 20% → grill on voice + add more few-shot examples | Claude + Zaal | grill session | 2026-05-24 |


### PR DESCRIPTION
## Summary

v1 shipped yesterday. Within 24h two real failures showed up:

1. **Drafts off-voice.** Generic LLM-speak. Hashtag `#533`, work-day-time violation "Lunch stream 11:30am ET", "the multi-agent coordination layer for The ZAO is coming together" - every LLM anti-pattern doc 610 documents.
2. **Fire-and-forget.** Bad drafts hit Telegram with no reject path. Zaal: *"i want it to keep sending the same post until i approve it."*

Both fixed.

## What's in this PR

- **doc 659**: STANDARD audit + spec, cites the bad v1 drafts verbatim
- **`drafters.ts`**: rewritten `SHARED_VOICE` with `/socials` skill rules + doc 610's 8 anti-patterns + 6 do-rules + 3 few-shot examples per category. Default model `haiku` -> `sonnet` (haiku couldn't hold the budget).
- **`pending.ts` NEW**: single-in-flight state at `~/.zao/zoe/posts/pending.json`. 4h TTL, 30min resend interval, max 3 resends.
- **`buttons.ts` NEW**: inline keyboard `[POST] [REGEN] [SKIP]` + `handlePostCallback`. Strips keyboard after tap. REGEN re-drafts same category with fresh source.
- **`scheduler.ts`**: tick checks pending first. If pending and waiting, do NOT fire new. If pending and 30min stale, resend same text. If pending and 4h expired, clear and allow new.
- **`index.ts`**: registers `bot.callbackQuery(/^post-(approve|regen|skip):/)` handler.

## Voice rules baked in (verbatim)

Lead with `ZM.`, no hashtags, no emojis, no em dashes, lowercase casual, **NEVER reference work-day times**, contribution over celebration, brand spellings exact, hard cap 280 chars, anti-patterns from doc 610 stripped, empty source = `(skip)`.

## State machine

```
[scheduled] -> [drafted] -> [pending] -+-- POST tap --> [approved] + re-send bare text
                                       +-- REGEN tap -> draft again same category
                                       +-- SKIP tap --> [skipped]
                                       +-- 30min idle -> resend (max 3)
                                       +-- 4h absolute -> [expired]
```

Scheduler never sends a new draft while one is pending. Single source of friction = the inline buttons.

## Typecheck

0 new errors. 4 pre-existing in `newsletter.ts` + `teams/shared.ts` unchanged.

## Deploy

```bash
ssh zaal@31.97.148.88 'cd /home/zaal/zao-os && git pull && cd bot && npm install && systemctl --user restart zoe-bot && sleep 6 && journalctl --user -u zoe-bot.service -n 30 --no-pager | grep -E "\[zoe"'
```

(Or wait 60 sec for auto-sync.sh + manual restart.)

## Test plan

- [ ] PR merges to main
- [ ] auto-sync pulls within 1 min
- [ ] Manual `systemctl --user restart zoe-bot` to activate
- [ ] Wait for next scheduled draft (or clear schedule.json + restart to force)
- [ ] Draft arrives with 3 inline buttons under bubble 2
- [ ] Tap SKIP -> draft clears, next scheduled fires when due
- [ ] Tap REGEN -> new draft same category appears
- [ ] Tap POST -> bare text re-sent without buttons (tap-copy target)
- [ ] No tap for 30 min -> same draft re-sent with header "(resend 1/3)"
- [ ] Voice check: drafts start with "ZM.", no hashtags, no work-day times, named specifics