### PR TITLE
feat(zoe/brief): include AgentMail inbox snapshot in 5am morning brief

### DIFF
--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -36,6 +36,10 @@ LAST 24H COMMITS
 OPEN PRS
 - List of open PRs by number + title.
 
+INBOX
+- {N} unread in zoe-zao@agentmail.to. First 3 subjects: ... (skip line entirely if inbox=null)
+- Reminder: run /inbox in any Claude session to research the queue.
+
 portal.zaoos.com/todos - brain dump
 
 Output the brief in plaintext. NO markdown headers, NO emojis, NO pleasantries.`;
@@ -45,6 +49,54 @@ interface BriefContext {
   open_tasks: Array<{ priority: string; title: string }>;
   commits_24h: string[];
   open_prs: Array<{ number: number; title: string }>;
+  inbox: { unreadCount: number; recentSubjects: string[] } | null;
+}
+
+const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
+
+interface AgentMailMessage {
+  from?: string;
+  subject?: string;
+  labels?: string[];
+}
+
+interface AgentMailFetchResult {
+  unreadCount: number;
+  recentSubjects: string[];
+}
+
+async function fetchInboxSnapshot(): Promise<AgentMailFetchResult | null> {
+  const key = process.env.AGENTMAIL_API_KEY;
+  if (!key) return null;
+  try {
+    const res = await fetch(`https://api.agentmail.to/v0/inboxes/${AGENTMAIL_INBOX}/messages?limit=50`, {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) {
+      console.error('[zoe/brief] agentmail fetch non-ok', res.status);
+      return null;
+    }
+    const body = (await res.json()) as { messages?: AgentMailMessage[] } | AgentMailMessage[];
+    const messages = Array.isArray(body) ? body : (body.messages ?? []);
+    // Whitelist: only count messages that trace back to Zaal (direct or forwarded).
+    const fromZaal = messages.filter((m) => {
+      const f = (m.from ?? '').toLowerCase();
+      // Direct or forwarded - the inbox skill checks Resent-From / X-Forwarded-For at the
+      // full-message endpoint, but for the count we approximate with the displayed From.
+      return f.includes('zaalp99@gmail.com') || f.includes('zaal panthaki');
+    });
+    const unread = fromZaal.filter((m) => (m.labels ?? []).includes('unread'));
+    return {
+      unreadCount: unread.length,
+      recentSubjects: unread
+        .slice(0, 3)
+        .map((m) => (m.subject ?? '(no subject)').slice(0, 70)),
+    };
+  } catch (err) {
+    console.error('[zoe/brief] agentmail fetch failed:', (err as Error).message);
+    return null;
+  }
 }
 
 function todayLabel(): { day: string; date: string } {
@@ -79,11 +131,14 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     prs = [];
   }
 
+  const inbox = await fetchInboxSnapshot();
+
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
     commits_24h: commits24h,
     open_prs: prs,
+    inbox,
   };
 }
 
@@ -91,12 +146,19 @@ export async function generateMorningBrief(opts: { repoDir: string; model?: stri
   const ctx = await loadBriefContext(opts.repoDir);
   const { day, date } = todayLabel();
 
+  const inboxLine = ctx.inbox
+    ? ctx.inbox.unreadCount === 0
+      ? 'INBOX: zero unread - skip the INBOX section'
+      : `INBOX: ${ctx.inbox.unreadCount} unread. Recent subjects: ${ctx.inbox.recentSubjects.join(' | ')}`
+    : 'INBOX: (api unavailable - skip the INBOX section)';
+
   const userPrompt = `Generate the morning brief for ${day} ${date}.
 
 CONTEXT:
 - Open tasks: ${JSON.stringify(ctx.open_tasks, null, 2)}
 - Last 24h commits: ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
+- ${inboxLine}
 
 Output the brief now in the exact format from your system prompt.`;
 


### PR DESCRIPTION
## Summary

Closes a gap from doc 652. PR #530 patched the LOCAL /morning skill to include inbox count, but `zoe-bot.service` runs `bot/src/zoe/brief.ts` (separate code path) which had no inbox awareness. Morning Telegram brief at 5am ET showed zero inbox info even with 14 unread items waiting in AgentMail.

## What this fixes

Tomorrow's 5am brief includes a new section:

```
INBOX
- 14 unread. Recent subjects: From the opencode community on Reddit | From the vibecoding community on Reddit | From the ClaudeCode community on Reddit
- Reminder: run /inbox in any Claude session to research the queue.
```

Skips silently if `AGENTMAIL_API_KEY` env missing or API fails. Skips the INBOX section entirely if zero unread.

## What this does NOT do (intentional, ship-and-use)

- Does NOT autonomously research each inbox item via Hermes (tier-2, follow-up)
- Does NOT commit research docs to the repo
- Does NOT clear the items - they stay unread until Zaal runs `/inbox` manually

Tier-1 surfacing of the queue is enough to validate the loop. If Zaal looks at the brief and wants the bot to do the research itself, that's the next PR.

## VPS deploy

Code lands via auto-sync. THEN add `AGENTMAIL_API_KEY` to VPS .env (it's not currently there):

```bash
ssh zaal@31.97.148.88 'grep AGENTMAIL_API_KEY ~/zao-os/bot/.env || echo "Need to add manually - pull value from local zaoos/.env.local"'
```

Then restart zoe-bot to pick up the new env. First brief that includes the line = tomorrow 5am ET.

## Test plan

- [ ] PR merges to main
- [ ] auto-sync pulls within 1 min
- [ ] Zaal adds `AGENTMAIL_API_KEY` to /home/zaal/zao-os/bot/.env (chmod 600)
- [ ] `systemctl --user restart zoe-bot`
- [ ] At next 5am ET brief: INBOX section appears with real unread count
- [ ] If `AGENTMAIL_API_KEY` not set: brief still generates, INBOX section is omitted (graceful)

## Typecheck

0 new errors. 4 pre-existing in newsletter.ts + teams/shared.ts unchanged.