### PR TITLE
chore(legal): add MIT LICENSE (Doc 663 P0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zaal Panthaki / BCZ Strategies LLC / The ZAO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

Per [Doc 663 P0](research/dev-workflows/663-zao-research-meta-audit-2026-05-17/) audit: 5 of 6 active ZAO products lacked LICENSE. ZAOOS was one of them. `gh api repos/bettercallzaal/ZAOOS/contents/LICENSE` returned HTTP 404 before this commit.

Adds standard MIT LICENSE to repo root. Copyright held by Zaal Panthaki / BCZ Strategies LLC / The ZAO per `project_bcz_strategies_llc.md` memory.

## Autoresearch context
This is Target 1 Iteration 1.1 of the autoresearch loop kicked off after Doc 663 audit. Companion PRs for the other 5 unlicensed repos (zaostock, CoCConcertZ, ZAONEXUS, zao-101, ZAOVideoEditor) follow in subsequent iterations.

## Verify
```
gh api repos/bettercallzaal/ZAOOS/contents/LICENSE
```
returns HTTP 200 after merge.