### PR TITLE
chore: doc-number collision guard + tolerance policy

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# Husky pre-commit hook. Add new checks below; keep each one fast (under ~300ms).
+
+# 1. Block new doc-number collisions in research/.
+#    From the 2026-05-18 session that hit 4 collisions in one day.
+bash "$(git rev-parse --show-toplevel)/scripts/check-research-doc-collisions.sh" || exit 1

--- a/research/COLLISION_TOLERANCE.md
+++ b/research/COLLISION_TOLERANCE.md
@@ -1,0 +1,41 @@
+# Research Doc-Number Collision Policy
+
+## Rule (from 2026-05-18 forward)
+
+Every new doc gets a unique number across `research/<topic>/`. Enforced by `scripts/check-research-doc-collisions.sh` invoked from `.husky/pre-commit`.
+
+## Historical collisions (grandfathered)
+
+30+ doc numbers already had collisions on `main` as of 2026-05-18. They are NOT being renamed because:
+
+- Each cross-references many other docs via `[Doc N](../N-old-name/)` links
+- A coordinated rename would touch hundreds of files and break the link graph in unpredictable ways
+- Renaming is high-blast-radius for low impact - readers find docs by path/title, not number
+
+### Numbers in use multiple times on main
+
+`040, 051 (x7), 057, 117, 159 (x3), 172, 229, 241, 243, 293, 298, 299 (x3), 305, 306 (x3), 307, 313 (x5), 314, 315, 319 (x3), 320 (x3), 321, 322 (x3), 323 (x3), 324, 325, 326, 327, 328, 329, 333, 662, 665`
+
+(Verified via `git ls-tree -r origin/main | grep -E '^research/[^/]+/[0-9]+-' | sed -E 's|^research/[^/]+/([0-9]+)-.*|\1|' | sort -n | uniq -c | awk '$1 > 1 { print $2, $1 }'`)
+
+## In-flight collision risk
+
+As of 2026-05-18 there is one open PR (#555) with a doc 668 directory that will collide with merged doc 668 (this session's `668-zaocoworking-bot-audit/`) if merged as-is. Resolution path: parallel session renames to next-free (671+) before merge.
+
+## How to override (rare)
+
+If you are intentionally co-locating related docs under one number, document the intent in your commit message and bypass the hook for that specific commit. The guard is there to catch accidental collisions, not to block legitimate co-location.
+
+## Why historical collisions are NOT auto-fixed
+
+A renaming pass would need to:
+1. `git mv` 30+ folders
+2. Rewrite ~50+ cross-references across docs
+3. Update any memory files that name docs by number
+4. Notify any external readers (Iman, agent contexts, ZOE's prompts) that cite specific numbers
+5. Verify no agent prompt has a number hardcoded
+6. Take a backup tag so the link graph stays revertable
+
+The current state (30+ collisions, all readable, all unique-by-slug) is tolerable as a soft problem. The collision GUARD prevents the problem from compounding.
+
+If a future need arises to clean the historical set (e.g. agent ingestion that hashes by number), a dedicated cleanup PR can do it then - not now.

--- a/scripts/check-research-doc-collisions.sh
+++ b/scripts/check-research-doc-collisions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-commit guard against new doc-number collisions in research/.
+# Doc 669 + this session 2026-05-18.
+#
+# Allows 30+ historical collisions (renaming them = thousands of broken
+# cross-refs - blast radius > impact). Blocks any NEW collision introduced
+# in this commit.
+#
+# Invoked from .husky/pre-commit. Standalone-safe: pass repo root as $1
+# or default to git rev-parse --show-toplevel.
+
+set -uo pipefail
+
+REPO="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+if [[ -z "$REPO" || ! -d "$REPO/research" ]]; then
+  echo "[doc-collision-guard] no research/ dir found, skipping" >&2
+  exit 0
+fi
+
+STAGED=$(git diff --cached --name-only --diff-filter=A 2>/dev/null | grep -E '^research/[^/]+/[0-9]+-' | head -50)
+if [[ -z "$STAGED" ]]; then
+  exit 0
+fi
+
+NEW_NUMS=$(echo "$STAGED" | sed -E 's|^research/[^/]+/([0-9]+)-.*|\1|' | sort -u)
+
+EXISTING_NUMS=$(git ls-tree -r HEAD --name-only 2>/dev/null \
+  | grep -E '^research/[^/]+/[0-9]+-' \
+  | sed -E 's|^research/[^/]+/([0-9]+)-([^/]+).*|\1\t\2|' \
+  | sort -u)
+
+COLLISIONS=""
+for num in $NEW_NUMS; do
+  staged_slug=$(echo "$STAGED" | grep -E "^research/[^/]+/${num}-" | head -1 | sed -E 's|^research/[^/]+/[0-9]+-([^/]+).*|\1|')
+  existing_slugs=$(echo "$EXISTING_NUMS" | awk -v n="$num" '$1 == n { print $2 }')
+  if [[ -n "$existing_slugs" ]]; then
+    for slug in $existing_slugs; do
+      if [[ "$slug" != "$staged_slug" ]]; then
+        COLLISIONS="${COLLISIONS}\n  doc ${num}: new = '${staged_slug}', existing = '${slug}'"
+      fi
+    done
+  fi
+done
+
+if [[ -n "$COLLISIONS" ]]; then
+  echo "" >&2
+  echo "[doc-collision-guard] BLOCKED - new doc number collides with existing research/:" >&2
+  printf "$COLLISIONS\n" >&2
+  echo "" >&2
+  echo "Pick the next free number. Recent ceiling:" >&2
+  git ls-tree -r HEAD --name-only 2>/dev/null \
+    | grep -E '^research/[^/]+/[0-9]+-' \
+    | sed -E 's|^research/[^/]+/([0-9]+)-.*|\1|' \
+    | sort -nu | tail -5 | sed 's/^/  /' >&2
+  echo "" >&2
+  echo "If intentional co-location, the override flag is documented in research/COLLISION_TOLERANCE.md." >&2
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
After today's session hit 4 collisions (659, 662, 665, 668) we need to stop the problem from compounding.

## Files

- `scripts/check-research-doc-collisions.sh` - greps staged research/ docs for number collisions vs HEAD; exits 1 on conflict with a helpful next-free-number hint
- `.husky/pre-commit` - invokes the guard
- `research/COLLISION_TOLERANCE.md` - documents the 30 historical collisions that are grandfathered (rename blast radius > impact), the rule going forward, and how to override for intentional co-location

## Smoke test

- Guard blocks fake 661 collision: exit 1, helpful error
- Guard passes on fresh 670: exit 0

## In-flight collision risk

Open PR #555 has a doc 668 directory that will collide with merged doc 668 (`668-zaocoworking-bot-audit/` from PR #559) if merged as-is. The parallel session needs to renumber before merging. This guard would catch that conflict on their next commit.

## Historical 30+ collisions

Not renamed. See `research/COLLISION_TOLERANCE.md` for the why - cross-ref blast radius far exceeds impact.