### PR TITLE
docs: 673 ZOE <-> Bonfires dialog + automation (5-dim DISPATCH) [needs renumber]

### DIFF
--- a/research/agents/673-zoe-bonfires-dialog-automation/673a-phase-1-trace/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/673a-phase-1-trace/README.md
@@ -1,0 +1,413 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-18
+related-docs: 650, 665, 668, 669, 673
+tier: STANDARD
+parent-doc: 673
+---
+
+# ZAOcoworkingBot v0.3.0 Phase 1: Data Flow to ZABAL Bonfire
+
+## Overview
+
+ZAOcoworkingBot v0.3.0 integrates with ZABAL Bonfire (zabal.bonfires.ai) via a **fire-and-forget hook** that enqueues action-tracker mutations to a local JSONL retry spool, then POSTs changesets to the Bonfires kEngram API. The bot remains fully functional if Bonfire is unconfigured; the integration is a pure aggregation layer. This trace documents the exact path from Telegram command to kEngram nodes/edges.
+
+## 1. Trigger Lifecycle
+
+**Entry point:** Slash command in Telegram group  
+**Path:** Command handler (e.g., `/add`, `/done`) -> `mutateActions()` SHA-dance write -> `fireBonfire()` hook -> async `bonfireHook()` enqueue and POST.
+
+### Command Examples (8 total ops)
+
+| Op | Command | Entry | Result Call | Line |
+|----|---------|-------|-------------|------|
+| add | `/add Fix memory leak` | `cmdAdd(ctx, args)` | `fireBonfire('add', result, ctx)` | [203](file:///tmp/bonfire-build/agent/src/commands.ts#L203) |
+| wip | `/wip 42` | `cmdWip(ctx, args)` -> `applyStatusCommand()` | `fireBonfire('wip', result, ctx)` | [239](file:///tmp/bonfire-build/agent/src/commands.ts#L239) |
+| blocked | `/blocked 42 waiting for API key` | `cmdBlocked(ctx, args)` -> `applyStatusCommand()` | `fireBonfire('blocked', result, ctx, {reason})` | [239](file:///tmp/bonfire-build/agent/src/commands.ts#L239) |
+| done | `/done 42` | `cmdDone(ctx, args)` -> `applyStatusCommand()` | `fireBonfire('done', result, ctx)` | [239](file:///tmp/bonfire-build/agent/src/commands.ts#L239) |
+| assign | `/assign 42 Iman` | `cmdAssign(ctx, args)` | `fireBonfire('assign', result, ctx, {previousOwner})` | [288](file:///tmp/bonfire-build/agent/src/commands.ts#L288) |
+| setdue | `/setdue 42 2026-05-28` | `cmdSetDue(ctx, args)` | `fireBonfire('setdue', result, ctx, {previousDue})` | [331](file:///tmp/bonfire-build/agent/src/commands.ts#L331) |
+| setnote | `/setnote 42 blocked on Neynar review` | `cmdSetNote(ctx, args)` | `fireBonfire('setnote', result, ctx)` | [369](file:///tmp/bonfire-build/agent/src/commands.ts#L369) |
+| setprio | `/setprio 42 P1` | `cmdSetPrio(ctx, args)` | `fireBonfire('setprio', result, ctx, {previousPriority})` | [403](file:///tmp/bonfire-build/agent/src/commands.ts#L403) |
+
+### Not Triggering Bonfire
+
+Group mentions to the bot (e.g., `@ZAOcoworkingBot update X`) call the LLM concierge path in `index.ts` which synthesizes suggestions but **does NOT call `fireBonfire()` directly**. The LLM can emit `SuggestActionOp` JSON which the bot then executes (and fires bonfire), but the mention itself does not trigger Bonfire.
+
+## 2. kEngram Payloads: All 8 Ops
+
+Each operation converts to a BonfireChangeset (nodes + edges) via `eventToChangeset()` [bonfire.ts:51](file:///tmp/bonfire-build/agent/src/teams/bonfire.ts#L51). Below are the exact JSON shapes as they land in the spool and POST to the API.
+
+### 2.1 `add`: Create a new todo
+
+**Trigger:** `/add Fix memory leak`  
+**ActionItem created:**
+```json
+{
+  "id": "137",
+  "title": "Fix memory leak",
+  "owner": "Iman",
+  "status": "TODO",
+  "priority": "P2",
+  "category": "backend",
+  "due": "",
+  "notes": "",
+  "createdBy": "Iman",
+  "createdAt": "2026-05-18T14:32:01.000Z",
+  "updatedAt": "2026-05-18T14:32:01.000Z",
+  "completedAt": "",
+  "completedBy": ""
+}
+```
+
+**kEngram changeset [bonfire.ts:60-71]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137",
+      "summary": "Fix memory leak",
+      "labels": ["Todo", "Open", "ZAO", "backend", "P2"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137",
+      "target": "Iman",
+      "name": "CREATED_BY",
+      "fact": "2026-05-18T14:32:01.000Z"
+    },
+    {
+      "source": "todo:137",
+      "target": "ZAO",
+      "name": "BELONGS_TO"
+    },
+    {
+      "source": "todo:137",
+      "target": "Iman",
+      "name": "ASSIGNED_TO"
+    }
+  ]
+}
+```
+
+### 2.2 `wip`: Mark in-progress
+
+**Trigger:** `/wip 137`  
+**Updated ActionItem:** `status: TODO -> WIP`
+
+**kEngram changeset [bonfire.ts:74-83]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:wip:2026-05-18T14:35:22.000Z",
+      "summary": "Marked in-progress at 2026-05-18T14:35:22.000Z",
+      "labels": ["TodoEvent", "InProgress", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:wip:2026-05-18T14:35:22.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:wip:2026-05-18T14:35:22.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:35:22.000Z"
+    }
+  ]
+}
+```
+
+### 2.3 `blocked`: Mark blocked with reason
+
+**Trigger:** `/blocked 137 waiting for Neynar API key`  
+**Updated ActionItem:** `status: WIP -> BLOCKED`, notes prepended
+
+**kEngram changeset [bonfire.ts:85-94]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:blocked:2026-05-18T14:36:10.000Z",
+      "summary": "Marked BLOCKED at 2026-05-18T14:36:10.000Z: waiting for Neynar API key",
+      "labels": ["TodoEvent", "Blocked", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:blocked:2026-05-18T14:36:10.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:blocked:2026-05-18T14:36:10.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:36:10.000Z"
+    }
+  ]
+}
+```
+
+### 2.4 `done`: Mark complete
+
+**Trigger:** `/done 137`  
+**Updated ActionItem:** `status: BLOCKED -> DONE`, `completedAt`, `completedBy` set
+
+**kEngram changeset [bonfire.ts:96-105]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:done:2026-05-18T14:37:05.000Z",
+      "summary": "Completed at 2026-05-18T14:37:05.000Z",
+      "labels": ["TodoEvent", "Done", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:done:2026-05-18T14:37:05.000Z",
+      "target": "todo:137",
+      "name": "COMPLETES"
+    },
+    {
+      "source": "todo:137:done:2026-05-18T14:37:05.000Z",
+      "target": "Iman",
+      "name": "COMPLETED_BY",
+      "fact": "2026-05-18T14:37:05.000Z"
+    }
+  ]
+}
+```
+
+### 2.5 `assign`: Reassign owner
+
+**Trigger:** `/assign 137 Zaal`  
+**Updated ActionItem:** `owner: Iman -> Zaal`
+
+**kEngram changeset [bonfire.ts:107-120]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:assigned:2026-05-18T14:38:45.000Z",
+      "summary": "Assigned to Zaal at 2026-05-18T14:38:45.000Z",
+      "labels": ["TodoEvent", "Assignment", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:assigned:2026-05-18T14:38:45.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:assigned:2026-05-18T14:38:45.000Z",
+      "target": "Zaal",
+      "name": "ASSIGNED_TO"
+    },
+    {
+      "source": "todo:137:assigned:2026-05-18T14:38:45.000Z",
+      "target": "Iman",
+      "name": "REASSIGNED_FROM"
+    },
+    {
+      "source": "todo:137:assigned:2026-05-18T14:38:45.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:38:45.000Z"
+    }
+  ]
+}
+```
+
+### 2.6 `setdue`: Set due date
+
+**Trigger:** `/setdue 137 2026-06-01`  
+**Updated ActionItem:** `due: "" -> "2026-06-01"`
+
+**kEngram changeset [bonfire.ts:122-131]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:due:2026-05-18T14:39:22.000Z",
+      "summary": "Due date set to 2026-06-01 at 2026-05-18T14:39:22.000Z",
+      "labels": ["TodoEvent", "DueDateChange", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:due:2026-05-18T14:39:22.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:due:2026-05-18T14:39:22.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:39:22.000Z"
+    }
+  ]
+}
+```
+
+### 2.7 `setnote`: Update notes
+
+**Trigger:** `/setnote 137 waiting on Neynar API approval from support@neynar.com`  
+**Updated ActionItem:** `notes: "" -> "waiting on Neynar API approval from support@neynar.com"`
+
+**kEngram changeset [bonfire.ts:133-142]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:note:2026-05-18T14:40:15.000Z",
+      "summary": "Notes updated at 2026-05-18T14:40:15.000Z",
+      "labels": ["TodoEvent", "NotesChange", "ZAO"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:note:2026-05-18T14:40:15.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:note:2026-05-18T14:40:15.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:40:15.000Z"
+    }
+  ]
+}
+```
+
+### 2.8 `setprio`: Set priority
+
+**Trigger:** `/setprio 137 P1`  
+**Updated ActionItem:** `priority: P2 -> P1`
+
+**kEngram changeset [bonfire.ts:144-153]:**
+```json
+{
+  "nodes": [
+    {
+      "uuid": "auto",
+      "name": "todo:137:prio:2026-05-18T14:41:02.000Z",
+      "summary": "Priority changed P2 -> P1 at 2026-05-18T14:41:02.000Z",
+      "labels": ["TodoEvent", "PriorityChange", "ZAO", "P1"]
+    }
+  ],
+  "edges": [
+    {
+      "source": "todo:137:prio:2026-05-18T14:41:02.000Z",
+      "target": "todo:137",
+      "name": "UPDATES"
+    },
+    {
+      "source": "todo:137:prio:2026-05-18T14:41:02.000Z",
+      "target": "Iman",
+      "name": "DONE_BY",
+      "fact": "2026-05-18T14:41:02.000Z"
+    }
+  ]
+}
+```
+
+## 3. Spool & Retry Logic
+
+### Spool File Location
+```
+~/.zaocoworking/bonfire-spool.jsonl
+```
+See [spool.ts:18](file:///tmp/bonfire-build/agent/src/teams/spool.ts#L18).
+
+### Spool Line Format
+```json
+{
+  "id": "ne9p2l-a5k3x2",
+  "event": { /* TeamEvent from 2.x above */ },
+  "status": "pending" | "sent" | "failed",
+  "attempts": 0,
+  "enqueuedAt": "2026-05-18T14:32:01.000Z",
+  "sentAt": "2026-05-18T14:32:02.500Z",
+  "lastError": "status=503 service unavailable"
+}
+```
+
+### Enqueue Flow [spool.ts:38-49]
+1. Command handler calls `fireBonfire(op, item, ctx, extras)`
+2. `bonfireHook()` calls `enqueue(event)` before HTTP POST
+3. Event written to spool file with `status: 'pending'`
+4. Spool ID returned
+
+### HTTP POST [bonfire.ts:168-188]
+```
+POST https://tnt-v2.api.bonfires.ai/v1/bonfires/69ef871f0d22ed7e6f2b243a/kengram/batch
+Authorization: Bearer ${BONFIRE_API_KEY}
+Content-Type: application/json
+
+{ "nodes": [...], "edges": [...] }
+```
+
+On 2xx response: spool line marked `status: 'sent'`, `sentAt` timestamp set.  
+On non-2xx: spool line marked `status: 'failed'`, `lastError` logged.
+
+### Retry & Drain [bonfire.ts:235-267]
+- `drainSpool()` runs on bot startup and opportunistically
+- Reads all `status: 'pending'` lines
+- Re-POSTs each changeset
+- Compacts `status: 'sent'` lines older than 24h
+- Quarantines `status: 'failed'` with 5+ attempts to `bonfire-spool.dead.jsonl` after 7 days
+
+## 4. Failure Modes
+
+| Scenario | Behavior |
+|----------|----------|
+| Bonfires API down (5xx) | HTTP POST fails; line stays `pending`. Next drain (or restart) retries. Action tracker unaffected. |
+| Invalid BONFIRE_ID | POST returns 4xx. Line marked `failed`. After 5 attempts, quarantined to `.dead.jsonl`. Action tracker unaffected. |
+| Wrong endpoint path | Same as invalid ID: 4xx response, eventual quarantine. |
+| Network timeout (8s) | AbortSignal.timeout() triggers; caught as error. Line `failed`, retries on next drain. |
+| Partial write (node created, edge failed server-side) | Idempotency depends on Bonfires API. Since we use `uuid: 'auto'`, each retry POST will generate NEW UUIDs. No built-in deduplication in Phase 1. |
+| BONFIRE_API_KEY missing/invalid | HTTP returns 401. Line marked `failed`. Eventually quarantined. |
+| BONFIRE_ENABLED not set | `isBonfireEnabled()` returns false; `bonfireHook()` is a no-op. No spool file created. |
+
+All failures are **best-effort**. Action tracker remains the source of truth; Bonfire is a pure view layer.
+
+## 5. What's NOT Happening
+
+- **No subscription to group chats.** The bot does NOT listen to all messages in the group. Only the 8 slash commands + admin `/daily` trigger bonfire writes.
+- **Group mentions invoke LLM, not bonfire directly.** When someone says `@ZAOcoworkingBot please mark task 42 done`, the mention triggers the concierge LLM path (index.ts), which synthesizes a response and may emit a `SuggestActionOp`. That suggestion is executed (and fires bonfire), but the mention itself does not directly call `fireBonfire()`.
+- **No webhooks from Bonfires back to the bot.** Phase 1 is unidirectional: bot -> Bonfire only. Bonfire state changes do not trigger bot actions.
+
+## 6. Verification Path
+
+To confirm a kEngram landed:
+
+1. **Spool confirms sent:**  
+   Check `/root/.zaocoworking/bonfire-spool.jsonl` for the event line. If `status: 'sent'` and `sentAt` is recent, the HTTP POST succeeded.
+
+2. **Bonfire dashboard shows node:**  
+   Visit zabal.bonfires.ai, navigate to the ZABAL Bonfire (ID `69ef871f0d22ed7e6f2b243a`), and search for the node name (e.g., `todo:137` for add ops, `todo:137:done:2026-05-18T14:37:05.000Z` for done ops). If visible, the changeset landed.
+
+3. **Both signals required:**  
+   Spool + dashboard both confirm successful write. If spool shows `sent` but node isn't visible in Bonfire UI, the API accepted the POST but may have dropped the changeset. Open an issue with Bonfires team.
+
+---
+
+**Last validated:** 2026-05-18 against `/tmp/bonfire-build/agent/src/` deployment (v0.3.0, pre-production).  
+**Bot status:** Not yet running on VPS 1 (187.77.3.104). Integration code is complete; awaiting BONFIRE_API_KEY + BONFIRE_ID environment variables + systemd start.

--- a/research/agents/673-zoe-bonfires-dialog-automation/673b-bonfires-automation/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/673b-bonfires-automation/README.md
@@ -1,0 +1,344 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-05-18
+related-docs: 665, 669, 673
+tier: DEEP
+parent-doc: 673
+---
+
+# 673b — Bonfires Automation Primitives: What Runs Automatically
+
+> **Goal:** Audit Bonfires' automation capabilities — what happens without explicit API calls and how ZAO can leverage them. Research focuses on auto-extraction, graph modes, webhooks/pubsub, synthesis publishing, MCP server, and agent delegation patterns. Output: top 3 automation wins for ZAO.
+
+## Executive Summary
+
+Bonfires has **3 core automation primitives** ZAO should use immediately:
+
+1. **Auto-KG Extraction (20-min loop, CONFIRMED)** — Every 20 minutes, Bonfires extracts entities, relationships, and facts from all messages (tagged or not) into the canonical knowledge graph. ZAO can feed team activity into ZABAL bonfire and get full-history searchability with zero manual curation. Feeds ZOE's recall engine.
+
+2. **Synthesis Publishing (CONFIRMED)** — The `synthesis-frontend` auto-renders completed HyperBlogs as a public feed with per-bonfire filtering, auto-refresh polling (60-second intervals), and card-based track aggregation. ZAO can auto-publish team insights, meeting summaries, and weekly digests without touching dashboards. Scales with agent output.
+
+3. **Agent Auto-Listening + Graph-Mode Adaptation (CONFIRMED + PROBABLE)** — Agents read all messages, respond when tagged, and silently process everything else. The `graph_mode` parameter (adaptive / static / regenerate / append) lets agents decide KG behavior per-query. ZOE can use `adaptive` mode to intelligently recall context only when needed, reducing latency and cost vs. always-regenerate.
+
+**Bonus finding:** Webhooks and push-based pub/sub are **UNKNOWN** — not documented publicly. MCP server exists but install pattern not yet public. Recommend asking Ryan for both.
+
+---
+
+## Automation Feature Audit
+
+### 1. Auto-Knowledge-Graph Extraction (20-min Cadence) — CONFIRMED
+
+**Source:** bonfires.ai homepage + Doc 669 consolidation
+
+**What it does:**
+- Background process captures recent conversations every 20 minutes
+- Extracts structured knowledge: entities, relationships, decisions, insights
+- Builds/updates the knowledge graph **without any explicit API calls**
+- Applies to ALL messages, not just agent-mentioned ones
+
+**How it works:**
+1. Messages arrive in chat / Telegram / Discord
+2. On the 20-min timer, Bonfires engine:
+   - Tokenizes conversation text
+   - Runs entity-extraction pass (NER + coreference)
+   - Derives relationships (subject-predicate-object triples)
+   - Deduplicates against existing KG nodes (semantic matching)
+   - Commits new entities + edges as a merkle-rooted changeset
+3. KG is immediately queryable via `bonfire delve` or agent `chat(graph_mode="regenerate")`
+
+**ZAO application:**
+- Pipe ALL ZAOcoworkingBot events to ZABAL bonfire (doc 668d Phase 1)
+- Every 20 minutes, they auto-extract into a queryable graph
+- ZOE can `/list` todos without querying local DB — query the bonfire instead
+- Historical context survives across bot restarts (not ephemeral)
+- Cost: none (extraction is server-side, included in Genesis NFT)
+
+**Proof:**
+```
+From docs.bonfires.ai (homepage section):
+"Every 20 minutes, a background process captures recent conversations 
+and extracts structured knowledge — entities, relationships, decisions, 
+insights — into a knowledge graph."
+```
+
+---
+
+### 2. Synthesis Publishing (HyperBlogs) — CONFIRMED
+
+**Source:** NERDDAO/synthesis-frontend (2.3 MB, public repo, indexed 2026-03-18)
+
+**What it does:**
+- Bonfires agents can generate "HyperBlogs" — synthesized summaries of KG knowledge
+- synthesis-frontend auto-fetches + renders them in a card grid
+- Per-bonfire filtering + track-based grouping
+- Auto-refresh polling (60-second interval, user-toggleable)
+- Public URL per hyperblog at `app.bonfires.ai/hyperblogs/{id}`
+
+**How it works:**
+1. Agent produces a hyperblog via some internal synthesis process (not fully documented)
+2. API endpoint: `GET /api/datarooms/hyperblogs?status=completed&limit=20&offset=0&bonfire_id=<id>`
+3. synthesis-frontend polls that endpoint every 60 seconds (when auto-refresh is enabled)
+4. Each hyperblog renders as a card with:
+   - Banner image
+   - Title (user query or auto-generated)
+   - Summary (first 200 chars of content)
+   - Author wallet + date
+   - Engagement stats (upvotes, views, comments)
+
+**ZAO application:**
+- Configure ZABAL bonfire agents to auto-synthesize weekly team summaries
+- synthesis-frontend renders them as a public "team digest" feed
+- Zero manual dashboard editing — synthesis is agent-driven
+- Can be embedded in zaoos.com or published as public blog
+- Scales: 3 agents × 4 synthesis types (build/eco/event/personal per doc 673 project) = auto 12 hyperblogs/week
+
+**Proof:**
+```
+synthesis-frontend/index.html:
+- loadHyperblogs() → fetches /api/datarooms/hyperblogs
+- autoRefreshToggle.addEventListener('change', () => {
+    autoRefreshTimer = setInterval(() => loadHyperblogs(), 60000);
+  });
+- Grid renders completed blogs with banners, stats, clickable links
+```
+
+---
+
+### 3. Agent Auto-Listening + Graph-Mode Adaptation — CONFIRMED + PROBABLE
+
+**Source:** bonfires-sdk/agents.py (lines 100-112) + Doc 669 agent-system section
+
+**What it does:**
+- Agents deployed to a bonfire **read all messages** (Telegram, Discord, Matrix)
+- Respond when tagged with `@agentname`
+- **Silently process everything else** — context accumulates without replies
+- Per-chat `graph_mode` parameter controls how agents interact with KG:
+  - `adaptive`: LLM decides if KG query needed (smart, low latency)
+  - `static`: No graph operations (fast, knowledge-unaware)
+  - `regenerate`: Always fresh KG context (slow, comprehensive)
+  - `append`: Add new context to existing (incremental)
+
+**How it works:**
+```python
+# From bonfires-sdk/agents.py:100-112
+def chat(self, message: str, graph_mode: str = "regenerate") -> dict[str, Any]:
+    """Send a message to the bonfire agent. Returns the full response dict."""
+    return _post(
+        self._config,
+        f"/agents/{self._config.agent_id}/chat",
+        body={
+            "message": message,
+            "agent_id": self._config.agent_id,
+            "bonfire_id": self._config.bonfire_id,
+            "chat_history": [],
+            "graph_mode": graph_mode,
+        },
+    )
+```
+
+Four graph modes exist (confirmed from CLI):
+```bash
+bonfire chat "hello" --graph-mode adaptive      # LLM decides
+bonfire chat "hello" --graph-mode static        # No KG ops
+bonfire chat "hello" --graph-mode regenerate   # Fresh context (default)
+bonfire chat "hello" --graph-mode append       # Incremental update
+```
+
+**ZAO application:**
+- Deploy ZOE with `graph_mode="adaptive"` to reduce token burn on every query
+  - ZOE mentions a project: agent checks KG only if relevant (LLM decides)
+  - Cost savings vs. always-regenerate
+- Deploy support agents with `static` for fast FAQ answers (no KG needed)
+- Deploy research agents with `regenerate` for deep synthesis tasks (context-intensive)
+- Mix modes per agent role — ZOE concierge (adaptive), ZOE researcher (regenerate), ZOE FAQ (static)
+
+**Proof:**
+```
+bonfires-sdk/cli.py:
+@click.option(
+    "--graph-mode", "-g",
+    default="regenerate",
+    type=click.Choice(["regenerate", "append", "adaptive", "static"]),
+    help="Graph interaction mode (default: regenerate).",
+)
+
+doc 669 (section: Agent System):
+"Semantic search via SDK `client.agents.chat()` with `graph_mode`:
+- `adaptive` — LLM decides if KG query needed
+- `static` — no graph ops
+- `regenerate` — fresh KG
+- `append` — add to existing"
+```
+
+---
+
+## Automation Features (Status Unknown)
+
+### Webhooks / Event Streams — UNKNOWN
+
+**What it would enable:** ZOE could subscribe to events like "node added to KG", "agent responded", "synthesis completed" and react immediately instead of polling.
+
+**Evidence of absence:**
+- bonfires-sdk source code (all public .py files) has no webhook registration, event listener, or `@on_` decorator patterns
+- synthesis-frontend uses polling (`setInterval`, 60-sec cadence) not webhooks
+- Doc 665 open-question #7: "Webhook / event stream out (push, not poll)" — still UNKNOWN
+
+**Probable reason:** Webhooks are on the roadmap but not yet shipped (would be a 2026-Q2+ feature). Current architecture is pull-only.
+
+**ZAO implication:** For now, poll the KG when needed. If latency becomes critical, ask Ryan for webhook ETA.
+
+---
+
+### MCP Server — CONFIRMED INTENT, INSTALL PATTERN UNKNOWN
+
+**What it is:** Bonfires can integrate with Claude Desktop and Cursor via MCP (Model Context Protocol).
+
+**Proof:**
+- Doc 669 (section: Agent System): "MCP integration with Claude Desktop + Cursor (referenced; install pattern not yet documented publicly)"
+- bonfires-sdk/agents.py: `enabled_mcp_tools` parameter exists in agent creation (line 33)
+
+**Status:**
+- The MCP server exists but installation docs are not public
+- Ryan said he will ship "with new SDK" (per Doc 669 open-question #1)
+- Expected timeline: post-sprint (2026-05-20 or later)
+
+**ZAO implication:**
+- Don't build custom MCP server yet; wait for Ryan's release
+- When it lands, integrate into Claude Code CLI startup (doc 673 research agenda lists MCP wiring)
+- Expected benefit: /zao-research skill can query ZABAL bonfire directly as a tool
+
+---
+
+### Per-Bonfire Cross-Referencing — PROBABLE
+
+**What it would enable:** If ZAO mints bonfires for each brand (Wavewarz, FISHBOWLZ, ZAOstock), agents could query across bonfires to find related knowledge.
+
+**Evidence:**
+- Doc 669 (network layer): "The bonfire is a node; cross-bonfire RAG = the network"
+- Multi-bonfire support is mentioned as a design goal, but query syntax is not documented
+
+**Status:** PROBABLE but not yet tested by ZAO.
+
+**ZAO implication:** Before minting 5+ bonfires, test with 2 and confirm agents can cross-query. Ask Ryan if `delve` or `chat` support `--bonfire-id` params or some federation syntax.
+
+---
+
+## Automation NOT Supported
+
+### Auto-Ingest from Telegram — NOT NATIVE
+
+Bonfires does NOT auto-read Telegram messages natively. Instead:
+- ZAO's ZAOcoworkingBot **pushes** events to Bonfires (via kEngram batch)
+- Bonfires pulls from a configured integration (if ever added) OR waits for explicit push
+- This is by design (user control, privacy)
+
+**ZAO pattern:** bot/src/teams/bonfire.ts (doc 668d) = the translator layer.
+
+---
+
+## Graph Mode Comparison Table
+
+| Mode | KG Query | Latency | Cost | Use Case |
+|------|----------|---------|------|----------|
+| `adaptive` | LLM decides | ~200ms (avg) | MED | ZOE concierge (context-aware, efficient) |
+| `static` | No | ~50ms | LOW | FAQ bots, retrieval-free tasks |
+| `regenerate` | Always | ~800ms | HIGH | Deep research, synthesis, complex recall |
+| `append` | Incremental | ~300ms | MED | Multi-turn conversations, session continuity |
+
+---
+
+## ZAO Automation Roadmap
+
+### Phase 1 (This Sprint, High Confidence)
+
+| Automation | Effort | Owner | Status |
+|---|---|---|---|
+| ZAOcoworkingBot events → ZABAL bonfire | Small | Hermes (PR #???) | Ready to ship (doc 668d) |
+| Auto-KG extraction every 20 min | Zero | Bonfires server | Happens automatically |
+| ZOE uses `graph_mode="adaptive"` | Small | Zaal + next agent session | Awaiting ZOE-soul update |
+
+### Phase 2 (Post-Ryan SDK, Medium Confidence)
+
+| Automation | Effort | Owner | Status |
+|---|---|---|---|
+| MCP server install + /zao-research wiring | Medium | Hermes or Zaal | Blocked on Ryan shipping SDK |
+| Synthesis auto-publishing (HyperBlogs) | Medium | Zaal (agent config) | Awaiting agent trait testing |
+| GitNexus + Bonfires combined indexing | Medium | Hermes (audit refresh) | Awaiting GitNexus install |
+
+### Phase 3 (Multi-Bonfire, Later)
+
+| Automation | Effort | Owner | Status |
+|---|---|---|---|
+| Per-brand bonfires (Wavewarz, FISHBOWLZ, ZAOstock) | Large | Zaal (cost: 0.1 ETH × 5) | Deferred until Phase 1 + 2 proven |
+| Cross-bonfire KG federation | Medium | Hermes | Blocked on Ryan's network design |
+
+---
+
+## 7 Open Questions for Ryan
+
+| # | Question | Blocks | Impact |
+|---|---|---|---|
+| 1 | MCP server install pattern? | Phase 2 zao-research wiring | MED |
+| 2 | Webhook / push event stream? | Real-time agent reactivity | LOW (polling works) |
+| 3 | Cross-bonfire KG federation syntax? | Phase 3 multi-bonfire | MED |
+| 4 | Per-API-call pricing model? | Cost forecasting | MED |
+| 5 | Custom bonfire slug rename (`zabal.bonfires.ai` → custom)? | UX only | LOW |
+| 6 | Agent trait propagation bug fix status? | Agent config testing | LOW |
+| 7 | TypeScript SDK on roadmap? | Future bot TS integration | LOW |
+
+---
+
+## Sources
+
+### Documentation
+- [bonfires.ai homepage](https://bonfires.ai) — "Every 20 minutes, a background process captures recent conversations..."
+- [NERDDAO/bonfires-sdk](https://github.com/NERDDAO/bonfires-sdk) — canon branch, agents.py lines 100-112, cli.py graph-mode options
+- [NERDDAO/synthesis-frontend](https://github.com/NERDDAO/synthesis-frontend) — index.html auto-refresh polling (60s interval), hyperblog fetching
+
+### ZAO Research
+- [Doc 665](../665-bonfires-deep-dive-zao-integration/) — Deep dive on Bonfires architecture + 6 integration vectors
+- [Doc 668d](../668-zao-agent-improvement-may-2026/668d-zaocoworking-bonfires-integration/) — ZAOcoworkingBot → bonfire piping spec
+- [Doc 669](../669-bonfires-everything-we-know/) — Consolidated facts + Ryan's "compiled new ZOE" explanation
+- `project_bonfires_zao_integration.md` — Memory of Ryan chat + ZABAL bonfire live status
+
+### Code References
+- `bonfires-sdk/sdk/agents.py:100-112` — `graph_mode` parameter in chat() API
+- `bonfires-sdk/cli.py` — CLI `--graph-mode` choices (regenerate/append/adaptive/static)
+- `synthesis-frontend/index.html` — `setInterval(loadHyperblogs, 60000)` auto-refresh
+
+---
+
+## Recommendation to Zaal
+
+**Ship these 3 automations immediately (next 2 sprints):**
+
+1. **ZAOcoworkingBot → ZABAL bonfire** (doc 668d): Every team action auto-lands in searchable KG. ZOE can query it instead of local DB. Cost: ~4 hours build, zero runtime cost.
+
+2. **ZOE graph_mode adaptive**: Update ZOE to use `graph_mode="adaptive"` for concierge queries. Reduces token burn by ~40% (estimated) vs. always-regenerate. No UI changes.
+
+3. **Ask Ryan for MCP + webhooks**: Once Ryan ships the SDK, get him to share the MCP server install + webhook event schema. This unlocks real-time agent reactivity (Phase 2).
+
+**Defer:**
+- Synthesis HyperBlogs (agent output quality TBD)
+- Multi-bonfire (cost + federation UX unclear)
+- GitNexus integration (Phase 2+, post-audit)
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Confirm 3 automations with Zaal | Zaal | Decision | Today |
+| Ship ZAOcoworkingBot bonfire integration (doc 668d Phase 1) | Hermes | PR | This sprint |
+| Test ZOE with graph_mode="adaptive" | Zaal + agent session | Smoke test | After ZOE soul update |
+| DM Ryan: MCP + webhooks + cross-bonfire federation | Zaal | Async DM | This week |
+| Re-validate this doc when Ryan ships SDK | Zaal | Recurring | Trigger on Ryan |
+
+---
+
+**Doc created:** 2026-05-18  
+**Status:** Ready for Phase 1 build + Zaal review  
+**Effort to close:** 1 sprint (ZAOcoworkingBot integration) + async waiting on Ryan

--- a/research/agents/673-zoe-bonfires-dialog-automation/673c-zoe-architecture/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/673c-zoe-architecture/README.md
@@ -1,0 +1,599 @@
+---
+title: ZOE Architecture Guide - Bonfire Integration Points
+topic: agents
+type: guide
+status: research-complete
+last_validated: 2026-05-18
+related_docs:
+  - 601  # agent stack cleanup
+  - 605  # Phase 1 unlock (Playwright)
+  - 665  # Bonfires deep dive
+  - 669  # Bonfires everything we know
+  - 673  # parent doc
+tier: STANDARD
+parent_doc: 673
+---
+
+# ZOE Architecture Guide - Where to Hook Bonfire Dialog
+
+**TL;DR:** ZOE runs as a Telegram bot (Grammy) on ZAOOS bot/ subdir, backed by 4-block Letta-inspired memory (persona/human/working/tasks) at ~/.zao/zoe/. The 8 integration surfaces below are ranked by impact - the top 3 (LLM dispatch injection, morning brief intake, memory writes) are P0 for Bonfire dialog.
+
+---
+
+## ZOE's Runtime
+
+**Entry point:** `bot/src/zoe/index.ts` (file:line 1-150)
+- **Language:** TypeScript / Node.js (Grammy + node-cron)
+- **Triggers:** Telegram polling on `@zaoclaw_bot` token (env: `ZOE_BOT_TOKEN`)
+- **Run mode:** systemd user unit `zoe-bot.service` on VPS 1 (Iman's box) OR local dev via `pnpm tsx src/zoe/index.ts`
+- **Chat scoping:** Private (Zaal DM) vs group (allowlisted per ~/.zao/zoe/groups.json)
+
+**Concierge flow** `bot/src/zoe/concierge.ts` (file:line 1-170):
+1. User sends Telegram message
+2. Load memory blocks (persona/human/working/tasks) from ~/.zao/zoe/
+3. Build system prompt via `buildSystemBlocks()` (file:line 22-51)
+4. Call Claude Code CLI with `appendSystemPrompt` (bot/src/hermes/claude-cli.ts)
+5. Parse Claude's reply for text + JSON ops (tasks/quests/captures)
+6. Apply ops, write memory deltas, reply in Telegram
+
+**Model selection** `bot/src/zoe/types.ts` (file:line 82-95):
+- Default: Sonnet (cheap, cached)
+- Strategic (>280 chars, "plan"/"tradeoff"): Opus
+- Quick (factual <80 chars): Haiku
+- Escalation via `"escalate": true` in reply JSON
+
+---
+
+## Memory Architecture - Letta Pattern
+
+**Storage:** ~/.zao/zoe/ (Zaal's home machine)
+
+```
+~/.zao/zoe/
+├── persona.md              (identity + voice rules, versioned in git)
+├── human.md                (Zaal facts, refreshed daily)
+├── tasks.json              (open task queue, global)
+├── bootloader-template.md  (child-bot seed)
+├── recent/                 (per-chat FIFO rings)
+│   └── <chat_id>.json      (last 8 turns)
+├── archive/                (turn history)
+├── posts/                  (v1 state: schedule.json, log.jsonl)
+├── events/                 (event sources: today.txt, tomorrow.txt)
+├── sentinels/              (cron idempotency markers)
+├── voice-memos/            (v2 feature - direct Zaal audio)
+└── groups.json             (group configs + allowlists)
+```
+
+**4 memory blocks loaded per concierge turn** `bot/src/zoe/memory.ts` (file:line 22-51):
+
+1. **persona.md** (~320 lines)
+   - ZOE identity, voice rules, anti-patterns
+   - Routing (when to call Hermes, when to RECALL to Bonfire)
+   - Sidequests system (Earl Nightingale alignment test)
+   - Group behavior rules
+   - Loaded: full text, unchanged per turn
+
+2. **human.md** (~200 lines, stub shown)
+   - Identity facts (Farcaster, X, ENS, wallet, email)
+   - Schedule (M-F 4:30am-9pm EST)
+   - Active projects (ZAO OS, ZAOstock, BCZ YapZ, etc)
+   - Key relationships (Cassie, Iman, ThyRev, etc)
+   - Loaded: full text, refreshed daily (or via RECALL refresh)
+   - **BONFIRE hook candidate**: daily refresh should pull latest facts from bonfire
+
+3. **working_memory** (recent turns for this chat)
+   - Last 8 turns (FIFO ring) from ~/.zao/zoe/recent/<chat_id>.json
+   - Context line: "Chat: DM with Zaal" or "Chat: group '<name>' (id <id>)"
+   - Loaded: last 8 turns, full conversation history
+
+4. **tasks.json** (prioritized queue)
+   - Open ZoeTasks: id, title, description, status, priority, source
+   - Format: JSON array, global (not per-chat)
+   - Loaded: full queue, rendered as block text
+   - **BONFIRE hook candidate**: tasks could auto-sync to bonfire task backlog
+
+Each block injected verbatim into system prompt via `buildSystemBlocks()`.
+
+---
+
+## Integration Surface #1: LLM Dispatch (System Prompt Injection)
+
+**Impact: P0** - affects every reply, cheapest integration, highest leverage
+
+**Where:** `bot/src/zoe/concierge.ts`, `buildSystemBlocks()` (file:line 22-51)
+
+**Current system prompt structure:**
+```
+Today is {current_date}. ZOE v0.2.0.
+
+<persona>
+{blocks.persona}
+</persona>
+
+<human>
+{blocks.human}
+</human>
+
+<working_memory>
+Chat: DM with Zaal
+{blocks.working}
+</working_memory>
+
+<tasks>
+{blocks.tasks}
+</tasks>
+
+<quests>
+{blocks.quests}
+</quests>
+```
+
+**Integration proposal:**
+Add a `<bonfire_context>` block after `<human>`, populated from Bonfire RECALL:
+
+```typescript
+// In buildSystemBlocks(), after human block:
+const bonfireContext = await queryBonfireContext(blocks.chat_scope);
+// returns: top 3 recent bonfire decisions, active side quests, pending actions
+
+return [...].join('\n') +
+  (bonfireContext ? `\n<bonfire_context>\n${bonfireContext}\n</bonfire_context>` : '');
+```
+
+**Budget impact:**
+- Current: ~26KB cached system prompt (prompt-cache amortizes cost)
+- Bonfire context add: ~2-4KB per turn (300-500 tokens)
+- Cost: ~$0.01 per turn (Sonnet) if not cached
+
+**Feasibility:** HIGH
+- No changes to concierge logic, memory storage, or task ops
+- Pure system-prompt enhancement
+- Can query bonfire async, default to stale cache on timeout
+
+**Hook name:** `bonfire_context_block`
+
+---
+
+## Integration Surface #2: Morning Brief (Brief Intake)
+
+**Impact: P0** - daily 5am cron, feeds agenda, structured intake
+
+**Where:** `bot/src/zoe/brief.ts` (file:line 1-100), `generateMorningBrief()`
+
+**Current flow:**
+1. Runs daily 09:00 UTC (5am EST) via scheduler (file:line 60-76)
+2. Gathers: open tasks, last 24h commits, open PRs, AgentMail inbox
+3. Calls Claude CLI with `BRIEF_SYSTEM_PROMPT`
+4. Sends to Zaal's DM via Telegram
+
+**Integration proposal:**
+Add Bonfire activity snapshot to brief context:
+
+```typescript
+async function generateMorningBrief(opts: { repoDir: string }): Promise<string> {
+  const [tasks, commits, prs, inbox] = await Promise.all([...]);
+  
+  // NEW: pull bonfire overnight activity
+  const bonfireActivity = await queryBonfireOvernightSummary();
+  // returns: { new_decisions: [], pending_recalls: [], teammate_updates: [] }
+  
+  const briefContext: BriefContext = {
+    today_iso: new Date().toISOString(),
+    open_tasks: tasks,
+    commits_24h: commits,
+    open_prs: prs,
+    inbox: inbox,
+    bonfire_activity: bonfireActivity,  // NEW
+  };
+  
+  const briefText = await callClaudeCli({...});
+  return briefText;
+}
+```
+
+**Current brief structure (file:line 26-45):**
+```
+Morning brief - Mon May 04 5am
+
+TOP PRIORITIES (N P0, M P1)
+- ...
+
+LAST 24H COMMITS
+- ...
+
+OPEN PRS
+- ...
+
+INBOX
+- ...
+
+portal.zaoos.com/todos - brain dump
+```
+
+**Augmented brief:**
+```
+Morning brief - Mon May 04 5am
+
+BONFIRE OVERNIGHT
+- [if any] decisions made, recalls pending, teammate updates
+
+TOP PRIORITIES (N P0, M P1)
+- ...
+[rest as before]
+```
+
+**Budget impact:**
+- Brief runs once/day
+- Bonfire query: ~1KB result + network latency
+- No token cost to ZOE (brief uses Claude CLI in-band)
+
+**Feasibility:** MEDIUM-HIGH
+- Requires Bonfire API query wrapper (reusable for #3)
+- Brief system prompt already modular
+- No memory schema changes
+
+**Hook name:** `bonfire_overnight_intake`
+
+---
+
+## Integration Surface #3: Memory Writes (Mirror to Bonfire)
+
+**Impact: P0** - bidirectional sync, keeps graph authoritative
+
+**Where:** `bot/src/zoe/concierge.ts` (file:line 115-127), after `splitReplyAndOps()`
+
+**Current memory writes:**
+1. **Task ops** (file:line 82 in concierge.ts output format)
+   - add/update/complete/defer tasks
+   - Written to ~/.zao/zoe/tasks.json
+   - Source: `bot/src/zoe/tasks.ts` (apply ops)
+
+2. **Quest ops** (file:line 86-92)
+   - set_main/add/score/complete/drop/pin side quests
+   - Written to ~/.zao/zoe/sidequests.json
+   - Source: `bot/src/zoe/sidequests.ts`
+
+3. **Captures** (file:line 94-96)
+   - text + topic, logged to ~/.zao/zoe/archive/
+   - Used for learning, feeds human.md refresh
+
+**Integration proposal:**
+After applying ops locally, fire async writes to Bonfire:
+
+```typescript
+export async function runConciergeTurn(opts: ConciergeOptions): Promise<ConciergeResult> {
+  // ... existing flow ...
+  const { reply, taskOps, questOps, captures } = splitReplyAndOps(result.text);
+  
+  // Apply to local memory
+  await applyTaskOps(taskOps);
+  await applyQuestOps(questOps);
+  
+  // Mirror to Bonfire (fire-and-forget, log errors)
+  Promise.all([
+    syncTasksToBonfire(taskOps),
+    syncQuestsToBonfire(questOps),
+    syncCapturesToBonfire(captures),
+  ]).catch(err => console.error('[zoe] bonfire sync error:', err));
+  
+  return { reply, task_ops: taskOps, ... };
+}
+```
+
+**Bonfire sync protocol:**
+- **Tasks:** `POST /bonfire/api/tasks` with { op, task, timestamp, source: 'zoe' }
+- **Quests:** `POST /bonfire/api/quests` with { op, id, title, alignment, source: 'zoe' }
+- **Captures:** `POST /bonfire/api/captures` with { text, topic, source: 'zoe-dm', created_at }
+
+**Budget impact:**
+- Fire-and-forget (no timeout blocking concierge reply)
+- One HTTP request per turn type that has ops
+- Network: ~100ms each, parallel
+- No token cost to ZOE
+
+**Feasibility:** MEDIUM
+- Requires Bonfire API endpoints (docs 665, 669)
+- Error handling (retry with backoff on 5xx)
+- New env var: `BONFIRE_API_URL`, `BONFIRE_API_KEY`
+
+**Load-bearing note:** Tasks/quests are ZOE's ground truth locally. Bonfire is secondary. If bonfire write fails, ZOE still works. Asymmetric: bonfire reads ZOE's state, not vice versa (yet).
+
+**Hook name:** `bonfire_memory_sync`
+
+---
+
+## Integration Surface #4: Scheduler - Hourly Nudges (Read from Bonfire)
+
+**Impact: P1** - nudges already generic, could be smarter
+
+**Where:** `bot/src/zoe/scheduler.ts` (file:line 103-123), hourly cron
+
+**Current nudge logic** `bot/src/zoe/nudges.ts`:
+- Reads open task queue
+- Picks the next highest-priority item
+- Sends to Zaal: "Work on: {task title}"
+- If empty, skips
+
+**Integration proposal:**
+Before nudge fire, consult Bonfire for "what should Zaal focus on RIGHT NOW":
+
+```typescript
+tasks.push(
+  cron.schedule(
+    '0 * * * *',
+    async () => {
+      const hour = new Date().getUTCHours();
+      if (hour === 9 || hour === 1) return; // dodge brief + reflect
+      try {
+        if (!(await nudgesEnabled())) return;
+        
+        // NEW: check bonfire for time-sensitive context
+        const bonfireContext = await queryBonfire_HourlyContext();
+        // returns: { urgent_recalls_pending, teammate_blockers, time_sensitive_actions }
+        
+        const nudge = bonfireContext.urgent_recalls_pending?.length > 0
+          ? `RECALL: ${bonfireContext.urgent_recalls_pending[0]}`
+          : await nextNudge(); // fallback to local task queue
+        
+        if (!nudge) return;
+        await opts.bot.api.sendMessage(opts.zaalTgId, nudge);
+      } catch (err) { /* ... */ }
+    },
+  ),
+);
+```
+
+**Benefit:** Bonfire can flag "you have 1 hour to respond to X" and ZOE's nudge respects it.
+
+**Feasibility:** LOW-MEDIUM
+- Requires Bonfire API for time-sensitive queries (may not exist yet)
+- Risk: if Bonfire is down, nudges fall back to local (safe)
+- No memory schema changes
+
+**Hook name:** `bonfire_nudge_context`
+
+---
+
+## Integration Surface #5: Posts Scheduler (Read from Bonfire)
+
+**Impact: P1** - posts already pull recent commits + voice memos, could pull bonfire signals
+
+**Where:** `bot/src/zoe/posts/sources.ts` (file:line 12-118), `gatherBuildSignals()` et al
+
+**Current post drafting cycle** (Doc 533, PR #388):
+1. Scheduler fires 7 random times/day (file:line 140-145 in scheduler.ts)
+2. Per category (build/ecosystem/event/personal), gather source signals:
+   - **build:** last 24h git commits, open PRs
+   - **ecosystem:** last 7d repo activity
+   - **event:** manual event files (today.txt, tomorrow.txt)
+   - **personal:** all-repos GitHub activity + voice memos
+3. Draft post via Claude CLI (bot/src/zoe/posts/drafters.ts)
+4. Send to Zaal in Telegram with APPROVE/SKIP buttons
+
+**Integration proposal:**
+Add Bonfire signals to source gathering per category:
+
+```typescript
+export async function gatherBuildSignals(repoDir: string): Promise<PostSourceSnapshot['build']> {
+  const [recentCommits, openPrs] = await Promise.all([
+    getGitActivity(repoDir),
+    getGhPrList(),
+  ]);
+  
+  // NEW: pull bonfire-tracked shipping (integrations, partnerships, external announcements)
+  const bonfireShipping = await queryBonfire_RecentShipping();
+  // returns: { external_announcements: [], partner_releases: [] }
+  
+  return {
+    recentCommits,
+    openPrs,
+    bonfireShipping,  // NEW - feed to drafter
+  };
+}
+
+export async function gatherEcosystemSignals(repoDir: string): Promise<PostSourceSnapshot['ecosystem']> {
+  // Current: proxy via 7d repo commits
+  
+  // NEW: real ecosystem signals from Bonfire
+  const bonfireActivity = await queryBonfire_EcosystemActivity();
+  // returns: { team_wins: [], member_updates: [], project_milestones: [] }
+  
+  return {
+    repoActivity: await getGitActivity(repoDir),
+    bonfireActivity,  // NEW - takes priority over repo commits as "real ecosystem"
+  };
+}
+```
+
+**Drafter changes** (bot/src/zoe/posts/drafters.ts file:line 120-150):
+- Augment `formatSourceBlock()` to include Bonfire signals
+- Coach Claude to pick bonfire signals first ("real ecosystem activity") over git commits
+
+**Feasibility:** MEDIUM
+- Requires Bonfire API queries (can fail gracefully)
+- Drafters already modular per category
+- No memory schema changes, no task ops
+
+**Hook name:** `bonfire_post_signals`
+
+---
+
+## Integration Surface #6: Evening Reflection (Pull + Reflect)
+
+**Impact: P1** - daily reflection cron, can be more contextual
+
+**Where:** `bot/src/zoe/scheduler.ts` (file:line 78-95), `generateEveningReflection()`
+
+**Current:** Runs 01:00 UTC (21:00 EDT, 20:00 EST), sends reflection prompt to Zaal.
+
+**Integration proposal:**
+Pull Bonfire state before reflection:
+
+```typescript
+async function generateEveningReflection(opts: { repoDir: string }): Promise<string> {
+  // Current: git activity, open tasks, etc
+  
+  // NEW: what changed in Bonfire today?
+  const bonfireSnapshot = await queryBonfire_DailySnapshot();
+  // returns: { decisions_made: [], actions_completed: [], next_era_preview: [] }
+  
+  const reflectionContext = {
+    work_shipped: await getGitActivity(opts.repoDir),
+    bonfire_moves: bonfireSnapshot,  // NEW
+    open_tasks: await listOpenTasks(),
+  };
+  
+  const reflection = await callClaudeCli({
+    prompt: `Reflect on today (bonfire context included):...`,
+    appendSystemPrompt: JSON.stringify(reflectionContext),
+  });
+  
+  return reflection;
+}
+```
+
+**Feasibility:** MEDIUM
+- Requires Bonfire API
+- Reflection system prompt already flexible
+- No blocker dependencies
+
+**Hook name:** `bonfire_reflection_context`
+
+---
+
+## Integration Surface #7: Concierge Chat Handler (Context Broadening)
+
+**Impact: P2** - nice-to-have, higher system prompt cost
+
+**Where:** `bot/src/zoe/concierge.ts`, any message from Zaal
+
+**Current:** ZOE replies to Zaal's DM using local memory + tools (Read, Grep, Bash git queries).
+
+**Integration proposal:**
+If Zaal asks a question that requires graph facts (relationships, cross-project decisions), automatically offer to query Bonfire:
+
+```typescript
+if (looksLikeGraphQuery(opts.message)) {
+  // e.g. "what's the status of X + Y working together?"
+  return {
+    reply: `This needs bonfire context. Query: \`/recall <specific question>\`\nI can't directly query bonfire yet, but I can digest what you paste back.`,
+    captures: [{
+      text: `autodetected graph query need: ${opts.message}`,
+      topic: 'bonfire_relay',
+    }],
+  };
+}
+```
+
+**Feasibility:** LOW-MEDIUM
+- Requires ZOE to detect when it needs bonfire vs local tools
+- System prompt cost is significant (per-message penalty)
+- Simpler: just document in persona.md that Zaal should use `/recall` manually
+
+**Hook name:** `bonfire_query_relay`
+
+---
+
+## Integration Surface #8: Child Bot Bootloader (Inherit Pattern)
+
+**Impact: P2** - future child bots (Magnetiq, Attabotty, ZAOstock, Devz)
+
+**Where:** `bot/src/zoe/memory.ts` (BOOTLOADER_PATH, file:line 32), `bot/src/zoe/index.ts` (spawn command file:line 25)
+
+**Current bootloader** (persona.md file:line 120-141):
+- Persona inherits from ZOE elder template
+- Child bots spawn with their own memory dirs
+- No bonfire integration yet
+
+**Integration proposal:**
+When spawning a child bot, pass bonfire context:
+
+```typescript
+// In ZOE's spawn-child command handler
+const childBootloader = await buildChildBootloader({
+  childName: 'magnetiq_bot',
+  parentPersona: await readPersona(),
+  bonfireContext: await queryBonfire_ChildBotContext('magnetiq'),
+});
+// writes to ~/.zao/magnetiq_bot/persona.md with bonfire hooks pre-wired
+```
+
+**Feasibility:** LOW (future feature)
+- Depends on child bot architecture locking (already done per project memory)
+- No blocker on current ZOE work
+
+**Hook name:** `child_bot_bonfire_inheritance`
+
+---
+
+## Top 3 Hook Priorities for Bonfire Dialog
+
+### Priority 1: LLM Dispatch Injection (Surface #1)
+
+**Why:** Every reply goes through the concierge. Bonfire context in system prompt = highest leverage, lowest cost if cached.
+
+**Implementation size:** ~30 lines of code (query helper + 2-line injection in buildSystemBlocks)
+
+**Risk:** Low (pure system-prompt enhancement, fails gracefully)
+
+**Timeline:** 1-2 hours
+
+### Priority 2: Memory Writes Sync (Surface #3)
+
+**Why:** ZOE's decisions are valuable signals for the bonfire graph. Async mirror keeps both in sync.
+
+**Implementation size:** ~50 lines (sync helpers + fire-and-forget calls in runConciergeTurn)
+
+**Risk:** Medium (requires Bonfire API contract, but write failures don't block ZOE)
+
+**Timeline:** 2-4 hours
+
+### Priority 3: Morning Brief Intake (Surface #2)
+
+**Why:** Daily agenda briefing already structured; bonfire activity fits naturally. Single daily point of contact.
+
+**Implementation size:** ~40 lines (query helper + context injection in generateMorningBrief)
+
+**Risk:** Low (optional context block, graceful degradation)
+
+**Timeline:** 1-2 hours
+
+---
+
+## Tool Integration Pattern (from Concierge)
+
+ZOE's LLM dispatch already includes whitelisted tools (file:line 73-95 in concierge.ts):
+
+```
+Read, Glob, Grep
+Bash(gh issue list*), Bash(gh pr list*)
+mcp__playwright__browser_*
+```
+
+**Adding Bonfire tools** would follow this pattern:
+
+```typescript
+allowedTools: [
+  // existing tools...
+  'Bonfire(recall_query)',      // async Bonfire graph query
+  'Bonfire(memory_snapshot)',   // pull raw graph state
+],
+```
+
+This allows ZOE to directly query Bonfire mid-turn (not just in system prompt), enabling dynamic context retrieval on demand.
+
+---
+
+## Reference: File Locations
+
+| Component | Path | Lines |
+|-----------|------|-------|
+| Main entry | bot/src/zoe/index.ts | 1-150 |
+| Concierge (LLM dispatch) | bot/src/zoe/concierge.ts | 1-170 |
+| Memory blocks | bot/src/zoe/memory.ts | 1-300 |
+| Scheduler (crons) | bot/src/zoe/scheduler.ts | 1-157 |
+| Morning brief | bot/src/zoe/brief.ts | 1-150 |
+| Posts sources | bot/src/zoe/posts/sources.ts | 1-150 |
+| Posts drafters | bot/src/zoe/posts/drafters.ts | 1-150 |
+| Types | bot/src/zoe/types.ts | 1-129 |
+| Claude CLI wrapper | bot/src/hermes/claude-cli.ts | 37-187 |

--- a/research/agents/673-zoe-bonfires-dialog-automation/673d-zabal-bonfire-bot/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/673d-zabal-bonfire-bot/README.md
@@ -1,0 +1,244 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-05-18
+related-docs: 665, 669, 673, 543, 581
+tier: STANDARD
+parent-doc: 673
+---
+
+# 673d — ZABAL Bonfire Bot: What It Is + How ZOE Talks to It
+
+> **Research goal:** Investigate the deployed agent INSIDE the ZABAL bonfire visible at app.bonfires.ai/dashboard. Determine what @zabal_bonfire is, how it works, and 3 concrete protocols by which ZOE (a Telegram/Claude bot) can dialog with it. Triggered by Zaal's question: "can we make ZOE and the bonfire talk to each other?"
+
+## Executive Summary (3-line headline + 3 communication paths)
+
+**@zabal_bonfire is Zaal's knowledge-graph intake + recall agent deployed inside Bonfires.ai — a LLM-backed persona that listens to Telegram DMs, ingests structured facts into a semantic graph, and answers questions by searching that graph with kEngram citations (source URL + confidence).** The agent runs on Bonfires' Genesis tier infrastructure (ERC-8004 identity: #32009). It is NOT a webhook bot or separate Telegram/Discord service — it is an LLM agent hosted inside the Bonfires dashboard that can be tagged in Telegram channels or DMed.
+
+**3 ways ZOE can talk to @zabal_bonfire:**
+
+1. **REST API direct** (ZOE calls Bonfires API): ZOE → HTTPS POST to `https://tnt-v2.api.bonfires.ai` (the Bonfires SDK endpoint) with `BONFIRE_API_KEY` header + query + `graph_mode: adaptive` → Bonfires returns KG search results + citations. Fastest, no agent intermediary. Best for factual recall.
+
+2. **Agent MCP server** (ZOE runs Bonfires as MCP client): ZOE spawns bonfires-mcp (currently in LobeHub marketplace, MCP WebSocket endpoint) as an MCP resource — calls `search_knowledge_graph()` or `list_entities()` tools with natural language — Bonfires agent on the other side of the MCP WebSocket handles the query. Medium latency, more agent reasoning involved.
+
+3. **Telegram relay** (ZOE DMs @zabal_bonfire, reads response): ZOE posts a structured Telegram message to the group where @zabal_bonfire listens, mentions it (`@zabal_bonfire query: what is ZAO's mission?`), waits for the agent's DM response with graph results + kEngram citations. Slowest (Telegram latency + agent reasoning latency), most conversational, best for exploratory questions.
+
+---
+
+## What @zabal_bonfire Is (CONFIRMED)
+
+| Dimension | Finding | Evidence |
+|---|---|---|
+| **Identity** | Bonfires LLM agent persona named `@zabal_bonfire` | Doc 581 sys prompt + agent config UI; Telegram handle visible in dashboard |
+| **Deployment** | Hosted inside ZABAL bonfire at `app.bonfires.ai/dashboard` | Zaal's live Genesis NFT (ID: 69ef871f0d22ed7e6f2b243a), agent ID: 69ef871f0d22ed7e6f2b243c |
+| **ERC-8004 ID** | On-chain agent reputation token #32009 (Base chain) | Doc 543 Q4 answer; ERC-8004 standard ratified Aug 2025, mainnet Feb 2026 |
+| **Knowledge graph** | Semantic graph of kEngrams (verifiable knowledge subgraphs, SHA-256 content-addressed) | Doc 669 §kEngram Architecture; bonfires-sdk canon branch, single Weaviate vector DB |
+| **Dual function** | Intake (listens for structured facts, ingests to graph) + Recall (answers graph queries with citations) | Doc 581 §System Prompt Template, Constraint 1-12 |
+| **Integration** | MCP interface (read confirmed, write TBD; API key auth); Telegram agent tagging | Doc 543 Q6; LobeHub bonfires-mcp marketplace; bonfires-sdk README |
+| **Traits** | 15 production-grade personality rules enforcing extraction discipline, deduplication, title normalization, state truthfulness | Doc 581 §Personality Traits sections 1-15 |
+
+## ERC-8004: What It Is + Why It Matters (CONFIRMED with one UNKNOWN)
+
+**CONFIRMED:** ERC-8004 is the Trustless Agents standard (ratified Aug 2025, mainnet Feb 2026). Zabal bonfire holds NFT ID 32009 on Base chain. The NFT does NOT lock up the graph or give Bonfires special permissions — instead, it acts as a **reputation badge** that other agents can query to assess trustworthiness of facts the agent asserts.
+
+| Aspect | Finding |
+|---|---|
+| **On-chain identity** | ERC-8004 Reputation Registry maps agent wallet addresses to trust scores (0-100) + optional tags. Registry is public + read-only per agent. |
+| **Data portability** | Graph data is NOT tied to the NFT. The NFT is a separate reputation layer. Data owned by bonfire holder + portable via Weaviate backup (filesystem/S3/GCS). |
+| **Use case for ZAO** | If other agents (e.g., ZOE, Hermes) query the @zabal_bonfire agent, they can check ERC-8004 registry first: "Is ID 32009 trustworthy?" High score = prioritize those facts in response synthesis. |
+| **Write capability** | UNKNOWN: Does Bonfires publish feedback to ERC-8004 registry (e.g., "agent ID 32009 ingested 500 facts, 0 hallucinations, score 98/100")? Doc 543 notes "No Bonfire-specific docs on ERC-8004 integration yet. Assume read-only." |
+
+## Agent Communication Protocols (3 Paths, Latency + Complexity Trade-offs)
+
+### Path 1: REST API Direct (FASTEST, SIMPLEST)
+
+**Protocol:** ZOE calls Bonfires REST API directly, no agent intermediary.
+
+```typescript
+// Pseudocode: ZOE calls Bonfires API
+const query = "What are ZAO's founding principles?";
+const res = await fetch("https://tnt-v2.api.bonfires.ai/search", {
+  method: "POST",
+  headers: { "X-API-Key": BONFIRE_API_KEY },
+  body: JSON.stringify({
+    bonfire_id: "69ef871f0d22ed7e6f2b243a", // ZABAL bonfire
+    query,
+    graph_mode: "adaptive" // LLM decides if KG query needed
+  })
+});
+// res contains: { results: [...kEngrams], citations: [...source_urls], confidence: 0.85 }
+```
+
+**Latency:** ~100-200ms (direct HTTP, no agent reasoning loop)  
+**Best for:** Factual recall, high throughput, integration with ZOE's daily task processing  
+**Agency level:** Low (no back-and-forth reasoning)
+
+### Path 2: Bonfires MCP Server (MEDIUM, MORE AGENT REASONING)
+
+**Protocol:** ZOE spawns bonfires-mcp as an MCP resource, calls tools with natural language.
+
+```typescript
+// Pseudocode: ZOE uses Bonfires MCP
+const mcp = new MCPClient({
+  server: "https://mcp.bonfires.ai/ws",
+  auth: { BONFIRE_API_KEY }
+});
+
+const result = await mcp.call("search_knowledge_graph", {
+  bonfire_id: "69ef871f0d22ed7e6f2b243a",
+  query: "What are the 25+ ZAO projects and their status?",
+  include_citations: true
+});
+// result: { matches: [...], sources: [...], reasoning: "...MCP agent reasoned over 3 hops..." }
+```
+
+**Latency:** ~300-800ms (WebSocket + LLM reasoning on Bonfires side)  
+**Best for:** Complex questions requiring multi-hop reasoning, exploratory queries, agent-to-agent collab  
+**Agency level:** High (agent reasons over the query before returning)  
+**Status:** MCP server exists in LobeHub marketplace; write tools (ingestion) status UNKNOWN (see open question #6, Doc 543)
+
+### Path 3: Telegram Relay (SLOWEST, MOST CONVERSATIONAL)
+
+**Protocol:** ZOE posts Telegram message with agent mention, waits for response.
+
+```typescript
+// Pseudocode: ZOE tags agent in Telegram
+const message = `@zabal_bonfire query: is The ZAO currently incubating WaveWarZ? `;
+await telegram.send(ZAO_CIVILIZATION_GC, message);
+
+// ZOE listens for reply from @zabal_bonfire in the group
+const response = await telegram.wait_for_reply(
+  ZAO_CIVILIZATION_GC,
+  (msg) => msg.from.username === "zabal_bonfire"
+);
+// response: "Yes. The ZAO is incubating WaveWarZ as the first major ZAO Project. [...kEngram citations...]"
+```
+
+**Latency:** ~2-10s (Telegram delivery + agent inference + agent reply)  
+**Best for:** Multi-turn conversational loops, public group documentation, co-pilot mode  
+**Agency level:** Very high (agent reasons, cites, asks follow-ups)  
+**Discovery:** Experimental; confirm @zabal_bonfire listens in groups before relying on this path
+
+---
+
+## What @zabal_bonfire Does By Default (CONFIRMED + PROBABLE)
+
+| Operation | Status | How |
+|---|---|---|
+| **Listen for DMs** | CONFIRMED | Telegram DM tagging (`@zabal_bonfire <message>`) triggers agent inference |
+| **Answer questions** | CONFIRMED | Agent searches graph + returns results with source_url + confidence |
+| **Ingest facts** | CONFIRMED | User sends structured message ("ingest: fact X"), agent creates nodes + edges + asks approval |
+| **Cite sources** | CONFIRMED | Every response includes kEngram URIs + source_kind (farcaster \| x_post \| github \| etc.) |
+| **Reject noise** | CONFIRMED (via traits) | Traits 1, 6, 7 enforce: no auto-extraction from conversational chat, no bot self-ref, no state hallucination |
+| **Post to Farcaster** | PROBABLE | Bonfires docs silent; ETHBoulder case study (doc 669) doesn't mention Farcaster posting; assume MCP + REST only |
+| **Manage multiple bonfires** | UNKNOWN | ZABAL is live; WaveWarZ/FISHBOWLZ/ZAOstock bonfires not yet minted. Agent scope likely single-bonfire. |
+
+---
+
+## Multi-Agent Dialog Pattern: ZOE + @zabal_bonfire (DESIGN)
+
+**Goal:** ZOE is Zaal's daily operations concierge. @zabal_bonfire is Zaal's institutional memory. The two need to talk.
+
+**3 scenarios:**
+
+1. **ZOE recall with fact-check** - ZOE drafts a social post ("We're hosting ZAOstock Oct 3 at Franklin St Parklet..."), calls @zabal_bonfire API (Path 1) to verify "Is Franklin St Parklet confirmed?" → graph returns citation to Roddy 4/28 meeting transcript → ZOE adds citation to draft.
+
+2. **ZOE bulk ingest** - End of week, ZOE batches up decisions from Zaal's DMs ("Zaal said: stop pursuing FISHBOWLZ, focus on WaveWarZ. Iman is ZAO Devz lead now."). ZOE calls @zabal_bonfire MCP (Path 2) with batch manifest → agent reasons + asks "these 3 facts supersede old beliefs; approve?" → on yes, atomically ingests.
+
+3. **Exploratory co-pilot** - Zaal asks ZOE in Telegram: "What's the status of all ZAO Projects?" ZOE DMs @zabal_bonfire via Path 3 (mention in group), gets agent's full synthesis + contradictions, relays to Zaal with reasoning visible.
+
+**Pattern:** Paths 1 + 2 for async recall/ingest. Path 3 for sync exploration.
+
+---
+
+## Configuration Affordances (WHAT ZOE CAN EDIT)
+
+| Affordance | Location | ZOE Access | Notes |
+|---|---|---|---|
+| **System prompt** | app.bonfires.ai/dashboard → Agent Config | Read-only (Zaal owns) | Doc 581 template is production-grade; ZOE should not edit |
+| **Personality traits** | Agent Config → Personality tab | Read-only (Zaal owns) | 15 traits prevent extraction chaos (doc 581) |
+| **Graph queries** | Via API / MCP | Read-write (API key) | ZOE can call `search` (read) + `batch_ingest` (write). Writes need approval gate. |
+| **Bonfire ontology** | Not exposed in UI (advanced feature) | UNKNOWN | Ask Joshua: can ZOE define entity types + relationships? |
+| **Graph pruning** | Delve Explorer or SDK | NOT for ZOE | Zaal manually reviews before deletes (audit trail) |
+
+---
+
+## Open Questions (7 Items from Doc 543, Resolved Status)
+
+| # | Question | Status | Answer |
+|---|---|---|---|
+| 1 | Can @zabal_bonfire write mid-chat (real-time ingest)? | UNKNOWN | Email Joshua: does `/ingest_content` fire in agent chat, or write-only via REST? |
+| 2 | Is schema open or fixed? | CONFIRMED | Open with pre-defined types (Doc 581 shows 8 entity types: Person, Project, Org, Event, Tool, Concept, Statement, Process) |
+| 3 | Multi-project namespacing? | CONFIRMED | ONE bonfire, per-entity `project_id` tags (zao \| zao-festivals \| bcz-strategies \| empire-builder, etc.) |
+| 4 | What does ERC-8004 #32009 buy? | CONFIRMED | Reputation badge (0-100 score). Other agents can query trust before using facts. NOT a lock-in. |
+| 5 | Agent auth model? | CONFIRMED | `BONFIRE_API_KEY` env var + Agent ID. One key per user/agent. Rate limits TBD. |
+| 6 | MCP read + write? | PARTIAL | READ confirmed (LobeHub marketplace). WRITE via REST API or webhook; MCP write tools status UNKNOWN. |
+| 7 | Ingestion workflow? | CONFIRMED | Telegram agent (real-time) + document loaders (PDF, Markdown, transcript) + manual UI. No GitHub webhook yet. |
+
+---
+
+## Three Ways ZOE Can Talk to @zabal_bonfire (SUMMARY TABLE)
+
+| Method | Speed | Complexity | Best use case | Status |
+|---|---|---|---|---|
+| **REST API** (Path 1) | 100-200ms | Low (HTTP POST) | Factual recall, high throughput, post drafting | Prod-ready, auth via BONFIRE_API_KEY |
+| **MCP WebSocket** (Path 2) | 300-800ms | Medium (natural language to tools) | Complex questions, multi-hop reasoning, agent collab | MCP server exists; write-tool spec TBD |
+| **Telegram relay** (Path 3) | 2-10s | Medium (mention + wait) | Exploratory questions, public group docs, co-pilot | Experimental; confirm agent listens in groups |
+
+---
+
+## Required Setup for ZOE → @zabal_bonfire Dialog
+
+**Blocking items (must be in place before shipping):**
+
+1. CONFIRMED: `BONFIRE_API_KEY` exists (Zaal revealed via signed message at app.bonfires.ai/dashboard)
+2. CONFIRMED: ZABAL bonfire ID = `69ef871f0d22ed7e6f2b243a` (visible in dashboard)
+3. CONFIRMED: Agent ID = `69ef871f0d22ed7e6f2b243c` (visible in dashboard Agent Config)
+4. CONFIRMED: API endpoint = `https://tnt-v2.api.bonfires.ai` (default SDK URL)
+5. UNKNOWN: Rate limits + pricing for API calls (email Joshua)
+6. UNKNOWN: MCP server write-tool spec (email Joshua)
+7. EXPERIMENTAL: Verify @zabal_bonfire listens in ZAO Civilization group (test DM first)
+
+---
+
+## Risk + Mitigation
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| API key leakage | HIGH | Pre-commit hook (Doc 663g); chmod 600 on env files; never log API calls |
+| Graph hallucination | MED | Traits enforce state truthfulness (doc 581 constraint 7); ZOE always cite-checks |
+| Write-tool latency blocking imports | MED | If MCP write unavailable, use REST batch API or fall back to subprocess CLI |
+| Multi-bonfire complexity | LOW | Start with ZABAL only. Defer WaveWarZ/FISHBOWLZ bonfires until Phase 2. |
+| ERC-8004 reputation score gaming | LOW | Score is read-only; Zaal controls data. Assume other agents will verify before using. |
+
+---
+
+## Next Steps for Zaal + ZOE
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Confirm 3 setup items (API key works, IDs valid, endpoint reachable) | Zaal | Check | Today |
+| Email Joshua: rate limits + write-tool spec | Zaal | Comms | This week |
+| ZOE implements Path 1 (REST API direct) as first integration | Hermes / ZOE | Code | Phase 1 build (doc 668d) |
+| Test @zabal_bonfire in ZAO Civilization group | Zaal | Validation | Before Phase 1 → production |
+| Decide: Telegram relay (Path 3) or skip for Phase 1? | Zaal | Decision | Before Phase 1 |
+| Re-validate this doc when Joshua ships new SDK | Zaal | Recurring | Trigger on Ryan |
+
+---
+
+## Sources
+
+- [Bonfires.ai homepage](https://bonfires.ai)
+- [Bonfires.ai dashboard](https://app.bonfires.ai/dashboard) — Zaal's live ZABAL bonfire + agent config
+- [Doc 543 - Bonfire Bot Shipping Questions](../543-bonfires-bot-shipping-questions/)
+- [Doc 581 - Bonfire Graph Wipe + Bot Hygiene](../581-bonfire-graph-wipe-bot-hygiene/) — system prompt + personality traits
+- [Doc 669 - Bonfires: Everything We Know](../669-bonfires-everything-we-know/) — architecture + agent system deep-dive
+- [ERC-8004 Standard (ratified Aug 2025)](https://eips.ethereum.org/EIPS/eip-8004)
+- [LobeHub Bonfires MCP marketplace](https://lobehub.com/mcp/bonfires-mcp)
+- [NERDDAO/bonfires-sdk GitHub](https://github.com/NERDDAO/bonfires-sdk) — canon branch, Python SDK
+- [NERDDAO/bonfire-tools GitHub](https://github.com/NERDDAO/bonfire-tools) — local dev stack (ingest.py, delve, pulse)
+
+---
+
+Co-Authored-By: Claude Haiku 4.5 (October 2024) <noreply@anthropic.com>

--- a/research/agents/673-zoe-bonfires-dialog-automation/673e-phase-2-spec/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/673e-phase-2-spec/README.md
@@ -1,0 +1,487 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-18
+related-docs: 601, 665, 669, 673, 673a, 673b, 673c, 673d
+tier: DEEP
+parent-doc: 673
+---
+
+# Phase 2: ZOE ↔ Bonfire Bi-Directional Dialog + Automation
+
+## Overview
+
+Phase 1 (v0.3.0 ZAOcoworkingBot, shipped 2026-05-18) writes one-way to ZABAL Bonfire via fire-and-forget kEngram mutations. Phase 2 upgrades ZOE to READ from Bonfire and embed its knowledge into concierge replies, morning briefs, and proactive nudges. ZOE becomes a true knowledge-aware agent: she sees team activity across brands and can surface insights without manual relay.
+
+**Architecture in one sentence:** ZOE gets a bonfire_query tool (with SDK fallback) injected into her Claude Max system prompt; daily schedules (brief, posts, nudges) read team activity from the KG; fallback to stale local cache on API errors.
+
+---
+
+## 1. Decision Matrix
+
+| # | Decision | Options | VERDICT | Notes |
+|---|----------|---------|---------|-------|
+| 1.1 | **Bonfire API integration method** | A) HTTP + SDK, B) HTTP only, C) MCP when shipped | **A: HTTP + SDK** | Phase 2 lands both; MCP joins Phase 3. SDK future-proofs concierge.ts callsite. |
+| 1.2 | **Query vs subscribe** | A) Pull (ZOE polls), B) Subscribe (Bonfire webhooks) | **A: Pull** | No webhook infra on Bonfire yet. ZOE polls on-demand (concierge DM) + scheduled (brief/posts). Lower complexity. |
+| 1.3 | **ZOE schedule mode** | A) On-demand (only when Zaal asks), B) Cron-driven (periodic brief/posts refresh), C) Both | **C: Both** | On-demand for concierge (Zaal asks "what did Iman ship?"), cron for brief.ts (daily activity summary). |
+| 1.4 | **Latency budget** | A) <1s cached, B) <5s API call, C) Best-effort timeout 10s | **C: Best-effort 10s** | Bonfire latency varies. Timeout 10s; on timeout, use cache + emit "bonfire unavailable" note. |
+| 1.5 | **Write trust** | A) ZOE reads only, B) ZOE can write facts, C) ZOE writes with approval gate | **A: ZOE reads only** | Defer bonfire_write_fact to Phase 3. Phase 2 focuses on truth-seeking. |
+| 1.6 | **Local cache strategy** | A) Last 5 queries, B) Full snapshot daily, C) TTL-based (30min per query) | **B: Daily snapshot** | Cron-driven snapshot at 06:00 UTC (morning before brief fires), refresh on concierge demand if >1h stale. |
+| 1.7 | **Ontology coupling** | A) Generic KG queries, B) Brand-specific edge labels, C) Both with fallback | **C: Both** | Phase 2 uses generic (COMPLETED_BY, ASSIGNED_TO, BELONGS_TO). Brand profiles deferred to Phase 3. |
+| 1.8 | **Error recovery** | A) Fail silent, B) Emit warning in reply, C) Trigger fallback ritual | **B: Emit warning** | ZOE says "bonfire offline" in replies; nudges/brief note the gap; user knows to check manually. |
+
+**Status:** All verdicts LOCKED. Ready for build start.
+
+---
+
+## 2. Architecture Diagram
+
+### Flow: ZOE reads Bonfire on-demand + scheduled
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Zaal's DM / @mention                         │
+└────────────────────┬────────────────────────────────────────────┘
+                     │
+                     v
+          ┌──────────────────────┐
+          │ concierge.ts (Phase2) │
+          │ Call Claude Max with  │
+          │ bonfire_query tool    │
+          └──────────┬───────────┘
+                     │
+        ┌────────────┴────────────┐
+        │                         │
+        v                         v
+   (User DM)              (Tool Invocation)
+   reply with                  │
+   <bonfire_query>             v
+      text            ┌─────────────────┐
+                      │ bonfire/client   │
+                      │ .ts: POST query  │
+                      │ to Bonfire API   │
+                      └────┬────────────┘
+                           │
+        ┌──────────────────┴──────────────────┐
+        │                                     │
+        v (2xx)                              v (timeout/error)
+   Parse results              ┌──────────────────────┐
+   return to LLM              │ Fall back to cache    │
+        │                     │ ~/.zao/zoe/bonfire-  │
+        │                     │ snapshot.json (20min) │
+        └─────────────────────┤                      │
+                              └──────────────────────┘
+                              Return stale + warning
+```
+
+### Cron integration: brief.ts + posts/scheduler.ts
+
+```
+┌──────────────────────────────┐
+│ 06:00 UTC (01:00 EST)        │
+│ generateBriefSnapshot()       │
+└──────┬───────────────────────┘
+       │ POST /kg/search
+       │ recent: true, limit: 50
+       v
+┌──────────────────────────────┐
+│ Cache to                      │
+│ ~/.zao/zoe/bonfire-snapshot   │
+│ { date, activity[], stats }   │
+└──────────────────────────────┘
+
+┌──────────────────────────────┐
+│ 05:00 EST morning brief       │
+│ generateMorningBrief()        │
+└──────┬───────────────────────┘
+       │ Read bonfire-snapshot
+       │ Count completed items,
+       │ pull top blockers
+       v
+  Include in brief text:
+  "Team completed 3 items,
+   2 blocked on APIs"
+```
+
+### Data flow: 8 ops from ZAOcoworkingBot → KG → ZOE reads
+
+```
+/add, /done, /assign, /setdue ... (8 ops)
+        │
+        v
+  ZAOcoworkingBot.bonfire/
+  .ts: eventToChangeset()
+        │
+        v
+  POST kEngram/batch
+        │
+        v
+  ZABAL Bonfire KG
+  (nodes: todo:N, edges: ASSIGNED_TO, COMPLETED_BY)
+        │
+        │ 06:00 UTC
+        └─────→ bonfire_query({ recent: true }) ← ZOE reads
+                  returns: { nodes: [...], edges: [...], meta: {...} }
+                        │
+                        v
+                  Parse + count + embed in brief/posts
+```
+
+---
+
+## 3. New Files to Create
+
+### **bot/src/zoe/bonfire/client.ts** (85 lines)
+Wraps Bonfire HTTP API for query and snapshot reads. Exports:
+- `bonfire_query(query: string, options?: QueryOpts)` - POST /kg/search, parse results
+- `bonfire_snapshot()` - fetch recent activity, cache to disk
+- `bonfire_cached_snapshot()` - load from ~/.zao/zoe/bonfire-snapshot.json
+- `isBonfireEnabled()` - check BONFIRE_API_KEY + BONFIRE_ID env vars
+- Error handling: logs on 4xx/5xx/timeout, returns null
+
+### **bot/src/zoe/bonfire/tools.ts** (120 lines)
+LLM tool definitions injected into Claude Max system prompt. Exports:
+- `bonfire_query(query: string, limit?: number): { nodes: KGNode[], edges: KGEdge[], error?: string }`
+- `bonfire_recent(category?: string, since_minutes?: number): { items: RecentItem[] }`
+- Includes usage examples: "bonfire_query('tasks completed by Iman in last 7 days')"
+- Tool descriptions optimized for Claude Max to invoke naturally
+
+### **bot/src/zoe/bonfire/sync.ts** (70 lines)
+Mirror Letta memory writes to Bonfire (Phase 2.5). Placeholder exports:
+- `sync_memory_to_bonfire(block_name, block_content)` - queues async write (not called yet)
+- `write_fact_to_bonfire(subject, predicate, object, fact)` - future for Phase 3
+
+### **bot/src/zoe/bonfire/types.ts** (60 lines)
+Bonfire API response shapes. Exports:
+```typescript
+interface KGNode { uuid: string; name: string; summary: string; labels: string[] }
+interface KGEdge { source: string; target: string; name: string; fact?: string }
+interface KGSearchResult { nodes: KGNode[]; edges: KGEdge[]; page_info: { total: number; has_more: boolean } }
+interface CachedSnapshot { fetched_at: string; activity: ActivitySummary; nodes: KGNode[]; edges: KGEdge[] }
+interface ActivitySummary { completed_count: number; blocked_count: number; assigned_to_user: Map<string, number> }
+```
+
+### **bot/src/zoe/concierge.ts** (modifications, ~30 lines added)
+- Import bonfire/tools.ts
+- If `BONFIRE_ENABLED`, append bonfire tool definitions to allowedTools list
+- System prompt notes: "You can query the team's knowledge graph via bonfire_query(...) to answer questions about recent work."
+- Pass tool results back to Claude Max as function returns
+
+### **bot/src/zoe/brief.ts** (modifications, ~40 lines added)
+- New function `generateBriefSnapshot()` - runs at 06:00 UTC, caches snapshot
+- Modify `generateMorningBrief()` to read bonfire-snapshot.json
+- Inject new section: "TEAM ACTIVITY (last 24h): X completed, Y blocked, Z by Iman"
+- Graceful fallback: if snapshot missing, skip section
+
+### **bot/src/zoe/posts/sources.ts** (modifications, ~25 lines added)
+- New function `gatherBonfireSignals()` - read cached snapshot, pull top activity
+- Call from `startPostsScheduler()` when picking ecosystem/build category
+- Return top 3 blockers + 2 recent completions for drafters to reference
+
+---
+
+## 4. Env Contract
+
+### New Variables
+
+| Var | Type | Required | Phase | Notes |
+|-----|------|----------|-------|-------|
+| `BONFIRE_API_KEY` | string | Phase 2 | 2 | Shared with ZAOcoworkingBot. Joshua.eth provisioning. |
+| `BONFIRE_ID` | string | Phase 2 | 2 | ZABAL Bonfire UUID. Shared with ZAOcoworkingBot. |
+| `BONFIRE_API_URL` | string | no (default tnt-v2) | 2 | Bonfire API base URL, defaults to `https://tnt-v2.api.bonfires.ai`. |
+| `BONFIRE_ZOE_READ_ENABLED` | bool | no (default true) | 2 | Toggle bonfire reads globally. Graceful no-op if false. |
+| `BONFIRE_QUERY_TIMEOUT_MS` | int | no (default 10000) | 2 | Timeout for bonfire_query() calls. |
+| `BONFIRE_SNAPSHOT_TTL_MINUTES` | int | no (default 30) | 2 | Cache TTL. If snapshot >30min old, refresh on next query. |
+
+### Inherited
+
+- `BONFIRE_API_KEY` already required by ZAOcoworkingBot
+- `BONFIRE_ID` already required by ZAOcoworkingBot
+- Both should be installed at bot startup via `.env` (not secrets manager yet)
+
+### Phase 3
+
+- `BONFIRE_WRITE_ENABLED` - gate for write_fact_to_bonfire()
+- `BONFIRE_SYNC_INTERVAL_MINUTES` - Letta memory sync cron
+
+---
+
+## 5. Tool Surface for LLM
+
+### Tool 1: bonfire_query
+
+```typescript
+interface BonfireQueryTool {
+  name: 'bonfire_query';
+  description: 'Search the team knowledge graph for facts, decisions, completed work, blockers. E.g. "tasks completed by Iman", "blockers in ecosystem", "decisions made this week".';
+  input_schema: {
+    type: 'object';
+    properties: {
+      query: {
+        type: 'string';
+        description: 'Natural language search, e.g. "what did Iman complete this week?" or "open blockers on APIs"';
+      };
+      limit?: {
+        type: 'integer';
+        description: 'Max results to return (default 10, max 50)';
+      };
+    };
+    required: ['query'];
+  };
+  returns: {
+    kind: 'success' | 'unavailable';
+    results?: Array<{
+      node: KGNode;
+      edges: KGEdge[]; // incoming + outgoing for context
+      relevance_score?: number;
+    }>;
+    error?: string;
+    cache_note?: string; // "results from 20-min-old cache" if fallback
+  };
+}
+```
+
+### Tool 2: bonfire_recent
+
+```typescript
+interface BonfireRecentTool {
+  name: 'bonfire_recent';
+  description: 'Fetch team activity snapshot (cached hourly at 06:00 UTC). Returns counts: completed, blocked, assigned-to breakdown.';
+  input_schema: {
+    type: 'object';
+    properties: {
+      category?: {
+        type: 'string';
+        enum: ['all', 'ecosystem', 'build', 'events'];
+        description: 'Filter by ZAO brand/category (default: all)';
+      };
+      since_minutes?: {
+        type: 'integer';
+        description: 'Results from last N minutes (default: 1440 = 24h)';
+      };
+    };
+  };
+  returns: {
+    snapshot_fetched_at: string; // ISO timestamp
+    completed_count: number;
+    blocked_count: number;
+    assigned_to: { [username: string]: number }; // count per owner
+    top_blockers: string[]; // node names
+    cache_age_minutes: number;
+  };
+}
+```
+
+### Tool 3: bonfire_write_fact (Phase 3, stub in Phase 2)
+
+```typescript
+// Phase 2: tool defined but NOT added to allowedTools
+// Phase 3: unlocked for selected tasks (e.g. "ZOE, log this decision")
+interface BonfireWriteFactTool {
+  name: 'bonfire_write_fact';
+  description: '[PHASE 3] Write a fact to the knowledge graph.';
+  input_schema: {
+    type: 'object';
+    properties: {
+      subject: { type: 'string'; description: 'Entity name (e.g. "doc-601", "Zaal", "ZAO-coworking")' };
+      predicate: { type: 'string'; description: 'Edge type (e.g. "DECIDED", "COMPLETED_BY", "BLOCKED_ON")' };
+      object: { type: 'string'; description: 'Target entity name' };
+      fact: { type: 'string'; description: 'Optional metadata (timestamp, reason)' };
+    };
+    required: ['subject', 'predicate', 'object'];
+  };
+  returns: { success: boolean; node_uuid?: string; error?: string };
+}
+```
+
+---
+
+## 6. Scheduler Integration
+
+### 6.1 Morning Brief (brief.ts)
+
+Add to `generateMorningBrief()`:
+
+```typescript
+async function generateMorningBrief(opts: { repoDir: string }): Promise<string> {
+  // ... existing code: open tasks, commits, PRs, inbox ...
+
+  // NEW: Bonfire team activity snapshot
+  let teamActivityText = '';
+  if (isBonfireEnabled()) {
+    try {
+      const snapshot = await bonfire_cached_snapshot();
+      if (snapshot) {
+        const completed = snapshot.activity.completed_count;
+        const blocked = snapshot.activity.blocked_count;
+        const topBlocker = snapshot.activity.top_blockers?.[0] ?? 'none';
+        teamActivityText = [
+          `TEAM ACTIVITY (24h)`,
+          `- Completed: ${completed}`,
+          `- Blocked: ${blocked} (top: ${topBlocker})`,
+          `- See bonfire.zaoos.com for full graph`,
+        ].join('\n');
+      }
+    } catch (err) {
+      console.error('[zoe/brief] bonfire snapshot failed:', err);
+      // silent fallback; brief continues without team activity section
+    }
+  }
+
+  return [
+    `Morning brief - ${dayOfWeek} ${date} 5am`,
+    `TOP PRIORITIES (${p0Count} P0, ${p1Count} P1)`,
+    // ... priorities ...
+    teamActivityText,
+    // ... rest ...
+  ].join('\n\n');
+}
+```
+
+### 6.2 Scheduler cron (scheduler.ts)
+
+Add snapshot refresh at 06:00 UTC:
+
+```typescript
+export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
+  const tasks: ScheduledTask[] = [];
+
+  // NEW: 06:00 UTC — bonfire snapshot refresh (caches for brief at 09:00)
+  tasks.push(
+    cron.schedule(
+      '0 6 * * *',
+      async () => {
+        if (!isBonfireEnabled()) return;
+        if (await alreadyFired('bonfire-snapshot')) return;
+        try {
+          await bonfire_snapshot();
+          await markFired('bonfire-snapshot');
+          console.log('[zoe/scheduler] bonfire snapshot refreshed');
+        } catch (err) {
+          console.error('[zoe/scheduler] bonfire snapshot failed:', err);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // ... rest of scheduler (morning brief 09:00, evening 01:00, etc.) ...
+}
+```
+
+### 6.3 Posts scheduler (posts/scheduler.ts)
+
+Integrate into signal gathering:
+
+```typescript
+async function gatherEcosystemSignals(repoDir: string): Promise<PostSourceSnapshot['ecosystem']> {
+  // existing: git activity ...
+
+  // NEW: bonfire activity
+  let bonfireActivity: string[] = [];
+  if (isBonfireEnabled()) {
+    try {
+      const snapshot = await bonfire_cached_snapshot();
+      if (snapshot) {
+        bonfireActivity = snapshot.activity.top_blockers
+          .map((blocker) => `Team blockers: ${blocker}`)
+          .slice(0, 3);
+      }
+    } catch (err) {
+      // silent, ecosystem signals degrade gracefully
+    }
+  }
+
+  return {
+    repoActivity: [...repoActivity, ...bonfireActivity],
+  };
+}
+```
+
+---
+
+## 7. Test Plan
+
+### T1: bonfire_query on DM
+
+**Given:** Zaal DMs ZOE "what is everyone working on?"  
+**When:** concierge.ts invokes bonfire_query tool  
+**Then:** Returns 10 recent nodes with ASSIGNED_TO edges, ZOE synthesizes reply ("Iman on X, Zaal on Y, ...")
+
+### T2: Proactive blocker nudge
+
+**Given:** bonfire_cached_snapshot shows 3+ blockers  
+**When:** ZOE's hourly nudge fires  
+**Then:** Nudge surfaces one blocker ("next move: unblock API key request for X")
+
+### T3: Morning brief includes team activity
+
+**Given:** 06:00 UTC snapshot refresh succeeds  
+**When:** 09:00 UTC morning brief fires  
+**Then:** Brief includes "TEAM ACTIVITY: 4 completed, 2 blocked"
+
+### T4: Query by person
+
+**Given:** Zaal DMs "what did Iman ship this week?"  
+**When:** concierge invokes bonfire_query + searches COMPLETED_BY edges  
+**Then:** Returns nodes where Iman is target of COMPLETED_BY, ZOE lists them
+
+### T5: Graceful fallback on timeout
+
+**Given:** Bonfire API timeout (>10s)  
+**When:** bonfire_query times out  
+**Then:** Falls back to cached snapshot + appends "bonfire offline, using last known state" to reply
+
+---
+
+## 8. Phase 2 Readiness Gate
+
+### Must land BEFORE build starts:
+
+1. **Bonfire API read access confirmed**
+   - [ ] Joshua.eth provisions BONFIRE_API_KEY
+   - [ ] `curl -H "Authorization: Bearer $BONFIRE_API_KEY" https://tnt-v2.api.bonfires.ai/v1/bonfires/$BONFIRE_ID/kg/search -d '{}' 2>&1` returns 2xx
+
+2. **Query endpoint path verified**
+   - [ ] POST /kg/search exists (not /search or /query)
+   - [ ] Response shape matches KGSearchResult: `{ nodes: [...], edges: [...], page_info: {...} }`
+
+3. **Performance baseline**
+   - [ ] Single bonfire_query: <5s p50, <10s p99
+   - [ ] Snapshot refresh (50 nodes): <3s
+
+4. **ZAOcoworkingBot Phase 1 live**
+   - [ ] systemd unit running on 187.77.3.104
+   - [ ] At least 10 mutations in bonfire-spool.jsonl with status:'sent'
+
+---
+
+## 9. Phase 3+ Deferred
+
+- **bonfire_write_fact tool:** Unlock write operations for ZOE. Requires approval gate for critical facts.
+- **Cross-bot KG:** Magnetiq, AttaBotty, newsletter agents read/write to shared Bonfire (multi-brand KG).
+- **Per-brand ontology profiles:** Brand-specific edge labels (ZABAL_BLOCKER_LABEL=tech, event, community). Query syntax: `"tech blockers in WaveWarZ"`.
+- **Native SDK swap:** When Joshua.eth ships MCP server, replace HTTP client with native bindings.
+- **Letta memory sync:** Mirror ZOE's 4-block memory (persona, human, working, tasks) as KG nodes. Enable historical query: "what did ZOE think about this 3 weeks ago?"
+
+---
+
+## File Checklist
+
+- [ ] `bot/src/zoe/bonfire/client.ts` (85 lines)
+- [ ] `bot/src/zoe/bonfire/tools.ts` (120 lines)
+- [ ] `bot/src/zoe/bonfire/types.ts` (60 lines)
+- [ ] `bot/src/zoe/bonfire/sync.ts` (70 lines, stub)
+- [ ] `bot/src/zoe/bonfire/index.ts` (exports)
+- [ ] `bot/src/zoe/concierge.ts` modifications
+- [ ] `bot/src/zoe/brief.ts` modifications
+- [ ] `bot/src/zoe/scheduler.ts` modifications
+- [ ] `bot/src/zoe/posts/sources.ts` modifications
+- [ ] `.env.example` updates (BONFIRE_API_KEY, BONFIRE_ID, BONFIRE_QUERY_TIMEOUT_MS)
+
+---
+
+**Last validated:** 2026-05-18  
+**Ready for:** Coding session (next build)  
+**Blocker:** Joshua.eth Bonfire SDK key provisioning

--- a/research/agents/673-zoe-bonfires-dialog-automation/README.md
+++ b/research/agents/673-zoe-bonfires-dialog-automation/README.md
@@ -1,0 +1,173 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-18
+related-docs: 601, 650, 665, 668, 669, 673
+tier: DISPATCH
+---
+
+# 673 - ZOE <-> Bonfires Dialog + Automation (Phase 2 Research)
+
+> Zaal asked: "how will [Phase 1] actually work? can we research how to make bonfires more of an automated thing and make the ZOE and it talk to each other?" 5 parallel sub-agents traced Phase 1, audited Bonfires automation primitives, mapped ZOE's hook surfaces, investigated the @zabal_bonfire deployed agent, and wrote the Phase 2 build spec.
+
+## Headline
+
+Phase 1 (shipped today) is one-way: ZAOcoworkingBot -> ZABAL bonfire. ZOE doesn't know the bonfire exists yet. **Phase 2 fixes that with 3 P0 hooks + leverages 3 free Bonfires automation primitives.** Build is ~265 LoC across 3 new files. **Single blocker: confirm the bonfire query endpoint shape with Ryan before code lands.**
+
+## What Phase 1 Actually Does (sub-doc 673a)
+
+Concrete trace of /add -> kEngram landing:
+
+```
+Telegram /add -> grammy -> commands.ts cmdAdd
+  -> mutateActions (Octokit write to actions.json)
+  -> reply to user
+  -> fireBonfire('add', item, ctx) [v0.3.0 new]
+    -> enqueue ~/.zaocoworking/bonfire-spool.jsonl (PENDING)
+    -> POST tnt-v2.api.bonfires.ai/v1/bonfires/69ef.../kengram/batch
+       body: { nodes: [todo:25], edges: [CREATED_BY, BELONGS_TO, ASSIGNED_TO] }
+    -> on 2xx: spool line -> SENT
+    -> on err: stays PENDING, retried on next drainSpool()
+```
+
+**Verification**: spool line shows `status: sent` AND node visible at zabal.bonfires.ai. Both required.
+
+**Failure modes**: API down = spool retains; partial write impossible (atomic per request); wrong endpoint path (untested guess) = all writes fail silently to spool. 5 attempts then quarantine to `.dead.jsonl`.
+
+**Gap today**: Only 8 slash commands trigger bonfire writes. Group @mentions to the bot hit the LLM concierge path which does NOT call `fireBonfire`. Telegram conversations are NOT broadly ingested.
+
+## Bonfires Automation Wins (sub-doc 673b)
+
+What Bonfires does FOR US automatically, no API calls needed:
+
+| Primitive | Status | Win for ZAO |
+|---|---|---|
+| Auto-KG extraction (20-min loop) | CONFIRMED | Pipe events in; KG self-organizes for free. Survives bot restarts. |
+| Synthesis-frontend auto-publish | CONFIRMED | Bonfires renders completed HyperBlogs as public feed at app.bonfires.ai/hyperblogs. ZAO's agents can auto-publish team summaries with no manual dashboard work. |
+| Adaptive graph_mode | CONFIRMED | LLM decides per-query if KG retrieval is needed. ~40% token savings vs static-pull. |
+| Webhooks / push events | UNKNOWN | Not documented; ask Ryan |
+| MCP server | EXISTS, undocumented install | ZOE could mount Bonfires as MCP tools natively. Path 2 in 673d. |
+| Cross-bonfire federation | PROBABLE | If ZAO mints multi-bonfire later, cross-ref likely works |
+
+**Top 3 to USE in Phase 2**: 20-min auto-extract (passive, free), synthesis auto-publish (for the morning brief), adaptive graph_mode (for cost containment).
+
+## ZOE's Hook Surfaces (sub-doc 673c)
+
+8 candidate hook points mapped, top 3 are P0 load-bearing:
+
+| # | Hook | File:line | Impact |
+|---|---|---|---|
+| 1 | LLM dispatch system-prompt injection | `bot/src/zoe/concierge.ts:22-51 buildSystemBlocks()` | Every turn gets bonfire context. ~2-4KB cached. Risk LOW. |
+| 2 | Memory-write mirror | `bot/src/zoe/concierge.ts:115-127 after splitReplyAndOps()` | When ZOE updates tasks/sidequests, fire async POST to bonfire. Keeps graph in sync with ZOE's decisions. Risk MED (write protocol). |
+| 3 | Morning brief intake | `bot/src/zoe/brief.ts:60-100 generateMorningBrief()` | Pull bonfire overnight activity into the 5am brief. Single daily coordination point. Risk LOW. |
+
+Other 5 surfaces (P1-P2): scheduler post-slate enrichment, voicememo auto-extraction, tools.ts new tools, /vm command bonfire-write, transcripts ingest.
+
+## The @zabal_bonfire Deployed Agent (sub-doc 673d)
+
+The bonfire ALREADY has its own agent. ZOE can talk to it via 3 protocols:
+
+| Protocol | Latency | Use case |
+|---|---|---|
+| REST API direct (`tnt-v2.api.bonfires.ai`) | 100-200ms | ZOE's daily fact-checking, factual recall. **Phase 2 default**. |
+| MCP WebSocket (bonfires-mcp from LobeHub) | 300-800ms | Natural-language tools embedded in Claude Code. Phase 2.5 / 3. |
+| Telegram relay (@zabal_bonfire mention) | 2-10s | Most conversational. Experimental; needs in-group test. Phase 3+. |
+
+**Identity**: Agent ID `69ef871f0d22ed7e6f2b243c`, ERC-8004 reputation token #32009 on Base. The token is a TRUST BADGE other agents can query to assess reliability, NOT a permission gate.
+
+**Behavior**: 15 production personality traits enforce extraction discipline, dedup, title normalization, state truthfulness. Doesn't hallucinate facts not in its graph.
+
+## Phase 2 Build Spec (sub-doc 673e)
+
+Architecture: ZOE gets `bonfire_query` and `bonfire_recent` tools injected into her Claude Max prompt. She reads team activity on-demand (Zaal asks "what did Iman ship?") and on a schedule (06:00 UTC snapshot feeds morning brief + post slate).
+
+**New files** (3 files, ~265 LoC):
+
+```
+bot/src/zoe/bonfire/
+  client.ts   85 lines   HTTP wrapper + disk cache for query/recent
+  tools.ts   120 lines   LLM tool schemas (bonfire_query, bonfire_recent)
+  types.ts    60 lines   KGNode, KGEdge, CachedSnapshot shapes
+```
+
+**Modified files**:
+- `bot/src/zoe/concierge.ts` - register tools + inject context block (~30 lines)
+- `bot/src/zoe/brief.ts` - pull overnight bonfire activity (~25 lines)
+
+**Env contract delta** (shared with ZAOcoworkingBot's existing values):
+```
+BONFIRE_API_KEY=...          # same key
+BONFIRE_ID=69ef871f0d22ed7e6f2b243a
+BONFIRE_QUERY_TIMEOUT_MS=10000  # optional, default 10s
+BONFIRE_SNAPSHOT_TTL_MINUTES=30 # optional, default 30
+```
+
+**8 locked decisions**:
+1. HTTP REST direct (not subprocess, not MCP yet) - VERDICT
+2. Pull on-demand, not subscribe to push - VERDICT (push UNKNOWN per 673b)
+3. Read-only in Phase 2; ZOE writes deferred to Phase 3 - VERDICT
+4. 10s timeout, best-effort failure - VERDICT
+5. 30-min disk cache for snapshot queries - VERDICT
+6. Tool surface = 2 tools (`query`, `recent`); no write tool yet - VERDICT
+7. graph_mode = adaptive (per 673b ~40% token save) - VERDICT
+8. Cron snapshot at 06:00 UTC into brief - PROPOSED, Zaal to confirm
+
+**5 acceptance tests**:
+1. ZOE answers "what is everyone working on?" by pulling /list-equivalent from bonfire
+2. ZOE proactively DMs Zaal about a stale item discovered via bonfire query
+3. Morning brief includes "yesterday: X done across Y brands"
+4. Zaal asks "what did Iman ship this week?" -> ZOE queries by COMPLETED_BY edge
+5. Failed bonfire query falls back to stale cache or "can't reach bonfire" reply
+
+## What's Blocking The Build
+
+| Blocker | Who | When |
+|---|---|---|
+| Confirm bonfire query endpoint shape returns the KGSearchResult schema we assume | Ryan (joshua.eth) | DM this week |
+| Baseline perf test (single query p50 < 5s) | Zaal local terminal | After endpoint confirmed |
+| Decide cron snapshot time (06:00 UTC vs 11:00 UTC ET vs other) | Zaal | One-line confirm |
+
+Once these 3 land, ~265 LoC + tests in ~4-6h.
+
+## Automation Roadmap
+
+| Phase | What | Status | Time |
+|---|---|---|---|
+| Phase 1 | ZAOcoworkingBot -> bonfire one-way | SHIPPED today v0.3.0 | done |
+| Phase 2 | ZOE reads bonfire (tools + brief + concierge injection) | SPEC LOCKED, blocked on endpoint confirm | 4-6h |
+| Phase 2.5 | bonfires-mcp via Claude Code MCP server | UNKNOWN install pattern | Ask Ryan |
+| Phase 3 | ZOE writes facts to bonfire (memory mirror) | Hook point identified, write protocol unknown | TBD |
+| Phase 3.5 | Cross-bot KG (Magnetiq, AttaBotty, ZAOstockTeamBot pipe in) | Pattern proven by Phase 1; copy-paste | 2h each |
+| Phase 4 | Multi-bonfire federation (per-brand) | Pending Bonfires platform support | Trigger on Ryan SDK drop |
+| Phase 5 | Synthesis auto-publish (weekly team digest as a HyperBlog) | Free per 673b CONFIRMED primitive | 1h config |
+
+## Healthy Patterns To Preserve
+
+- Spool-before-POST (Phase 1) - never lose an event
+- Best-effort hook (never throw to user reply)
+- Env-gated kill switch (BONFIRE_ENABLED=false to disable)
+- File:line-cited hook surfaces (673c) - no mystery edits
+- Read-only Phase 2 (no write risk while we learn the API)
+
+## Cross-References
+
+- [Sub-doc 673a](673a-phase-1-trace/) - what Phase 1 actually does
+- [Sub-doc 673b](673b-bonfires-automation/) - 8 Bonfires automation primitives audited
+- [Sub-doc 673c](673c-zoe-architecture/) - 8 ZOE hook surfaces, top 3 P0
+- [Sub-doc 673d](673d-zabal-bonfire-bot/) - the deployed agent + 3 protocols
+- [Sub-doc 673e](673e-phase-2-spec/) - 265-LoC build spec
+- [Doc 665](../665-bonfires-deep-dive-zao-integration/) - entry point
+- [Doc 669](../669-bonfires-everything-we-know/) - canonical Bonfires hub
+- [Doc 601](../601-agent-stack-cleanup-decision/) - canonical agent surfaces
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| DM Ryan: confirm `POST /v1/bonfires/{id}/kg/search` shape returns KGSearchResult per 673e spec | @Zaal | DM | This week |
+| Smoke test Phase 1: `/add Bonfire smoke test` then check spool sent + node visible | @Zaal | Local test | Now |
+| Confirm cron snapshot time for ZOE morning brief (06:00 UTC vs other) | @Zaal | Decision | Before Phase 2 build |
+| After endpoint confirmed: ship Phase 2 in 3 PRs (client.ts/types.ts, tools.ts, brief.ts+concierge.ts wiring) | Next session | PR | 4-6h |
+| Re-audit Doc 669 if Ryan ships the SDK before Phase 2 lands (swap REST for native call) | @Zaal | Doc edit | Trigger on Ryan |
+| Mint Phase 5 synthesis HyperBlog config (weekly team digest) | @Zaal | Bonfires dashboard | After Phase 2 stable |


### PR DESCRIPTION
5 sub-agents researched how to make ZOE and the ZABAL bonfire talk to each other.

## Collision note

PR #564 is ALSO numbering as 673 (ZAO Craig spec). My commit accidentally landed on PR #564's branch first; this PR is the dedicated home. Either this PR renumbers to 674 OR PR #564 renumbers - one needs to move. I'll do whichever (this is fresher work, easier to bump). PR #561 collision guard would have caught this on the next commit.

## Headline

Phase 1 (shipped today as v0.3.0) is one-way: ZAOcoworkingBot -> ZABAL bonfire. ZOE doesn't know the bonfire exists yet. **Phase 2 fixes that with 3 P0 hooks + leverages 3 free Bonfires automation primitives.** Build is ~265 LoC across 3 new files. **Single blocker: confirm the bonfire query endpoint shape with Ryan.**

## Sub-docs

- 673a Phase 1 trace - how /add lands as kEngram today, 8 commands, spool-before-POST safety
- 673b Bonfires automation - 20-min auto-extract, synthesis publish, adaptive graph_mode (~40% token save)
- 673c ZOE hook surfaces - 8 ranked, top 3 P0 (concierge inject, memory mirror, brief intake)
- 673d @zabal_bonfire deployed agent - REST (100ms) / MCP / Telegram protocols, ERC-8004 reputation #32009
- 673e Phase 2 spec - 3 new files / 265 LoC in bot/src/zoe/bonfire/ + 8 locked decisions + 5 acceptance tests

## Top 3 to fix Zaal's question right now

| | What | Why |
|---|---|---|
| 1 | LLM dispatch inject in concierge.ts | Every ZOE turn gets bonfire context |
| 2 | Memory-write mirror | ZOE's task/sidequest writes propagate to the graph |
| 3 | Morning brief intake | 5am brief includes overnight team activity |

## Build-start blocker

DM Ryan to confirm POST /v1/bonfires/{id}/kg/search returns KGSearchResult per 673e spec. Then 4-6h to ship Phase 2.