### PR TITLE
feat(skill): /meeting - capture transcripts + distribute (doc 673)

### DIFF
--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: meeting
+description: Capture meeting transcripts (voice memo, Craig recording, Fathom URL, paste-in-chat) and distribute extracted decisions, action items, and key quotes to the right ZAO surfaces - cowork-zaodevz actions.json, a research/events/NNN-* recap doc, Bonfire ingest queue, Telegram copy-paste block, memory, and calendar. Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or types "/meeting <path-or-url>". Always fires on meeting context - undertriggering wastes the capture.
+allowed-tools: Read Write Edit Bash WebFetch
+---
+
+# /meeting - ZAO Meeting Capture
+
+Turn any meeting recording or transcript into:
+- Action items in [cowork-zaodevz `actions.json`](https://github.com/songchaindao-dot/cowork-zaodevz/blob/main/data/actions.json)
+- A research recap doc in `research/events/NNN-<slug>/README.md` (always, per doc 673 decision)
+- A copy-paste Telegram bubble for sharing
+- Optional Bonfire ingest, memory write, calendar update
+
+One command, six inputs, six output targets. User-gated per run.
+
+Doc 673 has full design + decisions. Read it if context is needed beyond this file.
+
+## When to fire
+
+- Zaal pastes a transcript, meeting notes, or "Iman just said X, Y, Z" dump
+- Zaal types `/meeting <path-or-url>`
+- Zaal says "I just had a call with...", "process this recording", "extract todos from this call", "recap that meeting"
+- Zaal shares a `craig.horse`, `fathom.video`, voice memo path, or audio file path
+
+Undertriggering is the bigger risk. Fire on weak signal; ask one clarifier before doing destructive writes.
+
+## Input detection
+
+Detect mode from `$ARGUMENTS`:
+
+| If `$ARGUMENTS` matches | Mode |
+|---|---|
+| starts with `https://craig.horse/` | craig_url |
+| starts with `https://fathom.video/` | fathom_url |
+| ends with `.m4a`, `.mp3`, `.wav`, `.mp4`, `.opus` and file exists | local_audio |
+| empty (no args) AND last user message is >200 chars of text | paste |
+| anything else | ask user to clarify |
+
+If user just talks about the meeting in chat ("Iman said X then Zaal said Y..."), treat as paste mode using the conversation context as transcript.
+
+## Phase 1 - Acquire transcript
+
+### Mode: paste
+Use the pasted text directly. Skip Phase 1.
+
+### Mode: local_audio
+Audio file is on Zaal's mac. Transcribe via Iman's VPS (per doc 673 decision).
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/transcribe.sh "$AUDIO_PATH"
+```
+
+The script:
+1. Checks Whisper is installed on VPS. If not, prints install command and exits.
+2. SCPs the audio file to `root@187.77.3.104:/tmp/meeting-input.<ext>`
+3. Runs `whisper --model base --language en /tmp/meeting-input.<ext> --output_dir /tmp/meeting-output/`
+4. SCPs the `.txt` back, prints transcript path.
+
+### Mode: craig_url
+Download Craig recording, transcribe.
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/fetch-craig.sh "$CRAIG_URL"
+# outputs /tmp/craig-<id>.flac
+bash ${CLAUDE_SKILL_DIR}/scripts/transcribe.sh "/tmp/craig-<id>.flac"
+```
+
+### Mode: fathom_url
+Use WebFetch on the share URL to extract transcript JSON from the page. Fathom share pages typically embed transcript in JSON-LD or a script tag. If WebFetch returns no transcript, ask Zaal to paste it manually.
+
+## Phase 2 - Extract structure
+
+Read the transcript. Output JSON matching the schema in [references/output-schema.md](references/output-schema.md):
+
+```json
+{
+  "meeting": {
+    "date": "YYYY-MM-DD",
+    "duration_min": 0,
+    "title": "...",
+    "attendees": ["..."],
+    "platform": "Telegram voice | Google Meet | Zoom | in-person | Discord/Craig | Fathom"
+  },
+  "decisions": [
+    {"id": 1, "text": "...", "owner": "Zaal|Iman|Both|ThyRev|Samantha", "status": "TODO"}
+  ],
+  "actions": [
+    {"title": "...", "owner": "...", "due": "YYYY-MM-DD or empty", "category": "Site / Tech|Ops|WaveWarZ Zambia|ZAO Devz|Bounty|Social|Other"}
+  ],
+  "quotes": [
+    {"speaker": "...", "text": "..."}
+  ],
+  "research_seeds": ["topic 1", "topic 2"],
+  "memory_updates": [{"slug": "project_xyz", "what": "what changed and why"}]
+}
+```
+
+**Rules for extraction:**
+- Verbatim where possible for quotes. No paraphrasing of decisions.
+- If owner is ambiguous, set `owner: "Both"` and surface in the user-confirm step.
+- If due date is ambiguous, leave empty. Never invent.
+- Category must come from the enum above (matches actions.json schema).
+- 3-8 quotes max - pick load-bearing ones (decisions, commitments, surprising info).
+- `memory_updates` only if a NEW person, project, or strategy decision appeared (not for things already in `~/.claude/projects/.../memory/MEMORY.md`).
+
+## Phase 3 - Present + confirm
+
+Show the extracted JSON inline as a markdown table for each section. Ask Zaal:
+
+> "Extracted N decisions, M actions, K quotes. Edits? If clean, which targets fire?"
+>
+> Targets:
+> - [x] actions.json bulk append (default ON)
+> - [x] research/events/NNN-<slug>/README.md (default ON, every meeting per doc 673)
+> - [ ] Bonfire ingest queue (opt-in)
+> - [ ] Telegram copy-paste block (opt-in, default OFF - print only on request)
+> - [ ] Memory writes (opt-in, confirm each)
+> - [ ] Calendar event update (opt-in if title matches a Google Cal event)
+
+Wait for Zaal's reply before any destructive write.
+
+## Phase 4 - Distribute
+
+For each enabled target, follow the playbook in [references/distribution-targets.md](references/distribution-targets.md). Summary:
+
+### actions.json (cowork-zaodevz)
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/append-actions.sh /tmp/extracted-actions.json
+```
+Script reads the actions array, fetches current `data/actions.json` from GitHub, appends new items starting at `max(existing.id) + 1`, PUTs back via `gh api` with sha. One commit per meeting.
+
+### research/events/NNN-<slug>/README.md
+- Find next number: `find research -maxdepth 3 -type d -name '[0-9]*' | grep -oE '/[0-9]+' | tr -d '/' | sort -n | tail -1`
+- Slug from meeting title: lowercase, hyphens, no special chars, max 50 chars.
+- Use the template at [references/meeting-recap-template.md](references/meeting-recap-template.md). Doc 670 is the gold-standard worked example.
+- Write file, do NOT commit yet - leave for Zaal review in current `ws/` branch.
+
+### Bonfire ingest queue
+- Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
+- Run `python3 scripts/bonfire-ingest/secret_scan.py <file>` to filter secrets.
+- Do NOT run `bonfire_client.py` ingest automatically - Zaal triggers when ready (PR #568 just shipped, integration still warm).
+
+### Telegram copy-paste block
+Print a single fenced block ready for long-press-copy. No header/footer (per `feedback_copyable_content_own_bubble`). Format:
+
+```
+[Meeting] <title> · YYYY-MM-DD · <attendees>
+
+Decisions:
+1. <text> (owner: X)
+2. ...
+
+Actions:
+- <title> (owner: X, due: YYYY-MM-DD)
+- ...
+
+Key quotes:
+"<quote>" - speaker
+```
+
+### Memory writes
+For each `memory_updates` entry, show the proposed memory file content first. Get Zaal's OK per entry. Then write to `~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/<slug>.md` with proper frontmatter (see existing memories for format). Update `MEMORY.md` index with one-line entry.
+
+### Calendar event update
+Use `mcp__claude_ai_Google_Calendar__list_events` to find an event matching `meeting.title` and `meeting.date`. If found, `update_event` to append "Recap: <link to research doc on GitHub>" to description. If not found, skip silently.
+
+## Phase 5 - Report
+
+Print to user a one-line per-target summary:
+
+```
+[OK] actions.json - 7 items appended (commit abc1234)
+[OK] research/events/674-iman-call-may18 - draft written, review before commit
+[--] Bonfire - skipped
+[OK] Telegram - block printed above
+[OK] Memory - 1 entry written (project_zao_craig.md)
+[--] Calendar - no matching event
+```
+
+Then suggest the natural next step: "Review research doc at <path>. Commit + PR when ready, or want me to ship it as a PR off ws/<branch> now?"
+
+## Hard guardrails
+
+- **Never auto-write to actions.json without Phase 3 user-confirm.** The 67-item bulk fix (commit `c80caff8`) was authorized explicitly; default skill behavior must always confirm.
+- **Never invent owners, dates, or decisions not present in the transcript.** If unclear, surface as "ambiguous - need clarification" in Phase 3.
+- **Never commit a research doc without Zaal's review.** Write the file, leave on `ws/` branch, Zaal commits or asks for edits.
+- **Run secret-scan on Bonfire ingest input** before any write to `content/bonfire-ingest/`. Pattern from `.claude/rules/secret-hygiene.md`.
+- **Allowlist for owner field** in actions: Zaal, Iman, Both, ThyRev, Samantha. Anything else surfaces as "unknown owner".
+
+## Anti-patterns
+
+- Do NOT propose a new Telegram bot for meeting capture (= ZAO Craig, separate doc 670 work).
+- Do NOT replace `bot/src/capture.ts` `/gemba /idea /note` (ZAOstock bot, different DB, different scope).
+- Do NOT use Deepgram (ZAOstock-only per doc 12; this skill stays free for personal use).
+- Do NOT install Whisper locally on Zaal's mac - all transcription runs on Iman's VPS (per doc 673 decision).
+- Do NOT use emojis in any output (per global `feedback_no_emojis`).
+- Do NOT use em dashes (per global `feedback_no_em_dashes`).
+
+## References
+
+- [output-schema.md](references/output-schema.md) - JSON schema + worked example from doc 670
+- [distribution-targets.md](references/distribution-targets.md) - per-target API/file shapes
+- [meeting-recap-template.md](references/meeting-recap-template.md) - research doc template (doc 670 distilled)
+
+## Scripts
+
+- `scripts/transcribe.sh` - SCP to VPS, run Whisper, SCP back
+- `scripts/fetch-craig.sh` - curl Craig recording URL, extract audio
+- `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append

--- a/.claude/skills/meeting/references/distribution-targets.md
+++ b/.claude/skills/meeting/references/distribution-targets.md
@@ -1,0 +1,211 @@
+# Distribution Targets - /meeting
+
+How each target gets the extracted output. Skill reads this when Phase 3 confirm flips a target ON.
+
+## 1. actions.json (cowork-zaodevz)
+
+**Target:** `data/actions.json` on `main` of `songchaindao-dot/cowork-zaodevz`.
+**Method:** GitHub Contents API PUT via `gh api`. Bulk append in one commit.
+**Auth:** `gh auth token` (verified push perm `c80caff8` 2026-05-18).
+
+### Script call
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/append-actions.sh /tmp/meeting-extracted.json
+```
+
+Where `/tmp/meeting-extracted.json` is the full extraction JSON. The script reads `.actions[]`, maps to actions.json schema, appends, commits.
+
+### Per-item mapping
+
+Extracted -> actions.json item:
+
+| Extracted field | actions.json field | Default |
+|---|---|---|
+| `title` | `title` | - |
+| `owner` | `owner` | - |
+| `due` | `due` | "" |
+| `category` | `category` | "Other" |
+| (computed) | `id` | `String(max(existing.id) + index + 1)` |
+| (constant) | `createdBy` | `"Claude (/meeting skill)"` |
+| (constant) | `status` | `"TODO"` |
+| (constant) | `important` | `false` |
+| (computed) | `urgent` | `due == today OR due within 3 days` |
+| (constant) | `phase` | `"Define"` |
+| (constant) | `notes` | `""` |
+| (now) | `createdAt` | ISO |
+| (now) | `updatedAt` | ISO |
+| (constant) | `priority` | `"P2"` (or P1 if urgent) |
+
+Also bump top-level `actions.json.updatedAt`.
+
+### Commit message format
+
+```
+chore(actions): meeting recap YYYY-MM-DD <title slug> (+N items)
+
+Source: research/events/NNN-<slug>/README.md
+```
+
+## 2. Research doc (research/events/NNN-<slug>/README.md)
+
+**Target:** New folder + README.md in this repo.
+**Method:** `Write` tool to filesystem. NOT committed by skill - leave on `ws/` branch.
+
+### Numbering
+
+```bash
+NEXT=$(find research -maxdepth 3 -type d -name '[0-9]*' \
+  | grep -oE '/[0-9]+' | tr -d '/' | sort -n | tail -1)
+NEXT=$((NEXT + 1))
+```
+
+### Slug
+
+From `meeting.title`:
+- Lowercase
+- Replace spaces + `+` + special chars with `-`
+- Max 50 chars
+- Trim trailing dashes
+
+Example: `Iman call - ZAO Craig + PizzaDAO Zambia` -> `iman-call-zao-craig-pizzadao-zambia`.
+
+### Template
+
+Use `references/meeting-recap-template.md` filled with extracted data. Doc 670 is the reference example.
+
+### Frontmatter
+
+```yaml
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: YYYY-MM-DD
+related-docs: <comma-separated based on memory_updates linked memories + research_seeds matches>
+tier: STANDARD
+---
+```
+
+## 3. Bonfire ingest queue
+
+**Target:** `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
+**Method:** Write file, run secret-scan, do NOT trigger ingest client (Zaal triggers when ready).
+
+### File structure
+
+```markdown
+# Meeting: <title>
+
+**Date:** YYYY-MM-DD
+**Attendees:** <comma-separated>
+**Platform:** <platform>
+
+## Transcript
+
+<full transcript here>
+
+## Recap
+
+(insert recap doc body here from template)
+```
+
+### Secret-scan gate
+
+```bash
+python3 scripts/bonfire-ingest/secret_scan.py content/bonfire-ingest/meeting-<date>-<slug>.md
+```
+
+If exit code != 0, abort write + surface to Zaal. Reference `.claude/rules/secret-hygiene.md`.
+
+## 4. Telegram copy-paste block
+
+**Target:** chat output only (no API call in v1).
+**Method:** Print to console, user long-press-copies into Telegram.
+
+### Format
+
+NO header text. NO footer. Single fenced block. Per `feedback_copyable_content_own_bubble`:
+
+```
+[Meeting] <title> | YYYY-MM-DD | <attendees>
+
+Decisions
+1. <text> (X)
+2. <text> (Y)
+
+Actions
+- <title> (X, due YYYY-MM-DD)
+- <title> (Y)
+
+Quotes
+"<quote>" - X
+"<quote>" - Y
+```
+
+Use pipes `|` not em-dashes (per global feedback). No emojis (per global feedback). No "GM" / "GN" prefixes.
+
+## 5. Memory writes
+
+**Target:** `~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/<slug>.md`.
+**Method:** Write tool. CONFIRM-FIRST per entry. Update `MEMORY.md` index.
+
+### Pre-flight per entry
+
+For each `memory_updates[i]`:
+1. Check `~/.claude/projects/.../memory/MEMORY.md` for existing slug. If exists, show diff vs new content + confirm Edit.
+2. If new, propose file content + one-line MEMORY.md entry. Get OK.
+3. Write file + Edit MEMORY.md.
+
+### Frontmatter pattern
+
+```yaml
+---
+name: <slug>
+description: <one-line, 80-150 chars>
+metadata:
+  node_type: memory
+  type: project | feedback | user | reference
+  originSessionId: <current session id if available>
+---
+
+<body>
+```
+
+### MEMORY.md index line
+
+```
+- [<title>](<slug>.md) - <one-line hook under 150 chars>
+```
+
+## 6. Calendar event update
+
+**Target:** Google Calendar event matching `meeting.title` + `meeting.date`.
+**Method:** `mcp__claude_ai_Google_Calendar__*` tools.
+
+### Find event
+
+```
+mcp__claude_ai_Google_Calendar__list_events(
+  calendar_id="primary",
+  time_min="<meeting.date>T00:00:00Z",
+  time_max="<meeting.date>T23:59:59Z",
+  q="<first 3 words of meeting.title>"
+)
+```
+
+If 0 matches: skip silently.
+If 1 match: proceed.
+If >1: surface to Zaal, ask which.
+
+### Update
+
+Append to existing description:
+
+```
+---
+Recap: https://github.com/bettercallzaal/ZAOOS/blob/main/research/events/NNN-<slug>/README.md
+Actions filed: <count> items to cowork-zaodevz
+```
+
+Use `mcp__claude_ai_Google_Calendar__update_event` with the event_id + appended description.

--- a/.claude/skills/meeting/references/meeting-recap-template.md
+++ b/.claude/skills/meeting/references/meeting-recap-template.md
@@ -1,0 +1,112 @@
+# Meeting Recap Template
+
+Use this as the body of `research/events/NNN-<slug>/README.md`. Distilled from doc 670 (the gold-standard worked example).
+
+Fill placeholders `{LIKE_THIS}`. Drop empty sections.
+
+```markdown
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: {YYYY-MM-DD}
+related-docs: {comma-separated doc numbers from memory_updates linked entries + research_seed matches}
+tier: STANDARD
+---
+
+# {NNN} - {Meeting Title}
+
+> **Goal:** Lock in action items + decisions from {YYYY-MM-DD} {platform} call with {attendees} covering {topic 1}, {topic 2}, {topic 3}.
+
+## Key Decisions
+
+| # | Decision | Owner | Status |
+|---|----------|-------|--------|
+| 1 | **{Decision text - bolded short version}** - {expanded context if useful} | {Owner} | {TODO|WIP|DONE} |
+| 2 | ... | ... | ... |
+
+## Thread {N} - {Topic Name}
+
+### The Idea
+
+{1-3 paragraphs from transcript about what was discussed.}
+
+### Why It Matters
+
+{Why this is on the docket. From transcript context.}
+
+### Decisions Pending
+
+{Things explicitly flagged as not-decided.}
+
+### Next Step
+
+{What the owner committed to as the next move.}
+
+(Repeat per major thread.)
+
+## Action Items
+
+| # | Action | Owner | Category | Due |
+|---|--------|-------|----------|-----|
+| 1 | {title} | {Owner} | {category} | {YYYY-MM-DD or "TBD"} |
+| 2 | ... | ... | ... | ... |
+
+## Key Quotes
+
+> "{quote text}" - {speaker}
+
+> "{quote text}" - {speaker}
+
+## Research Seeds
+
+{Topics worth a doc later. Each as a bullet.}
+
+- {seed 1}
+- {seed 2}
+
+## Memory Updates
+
+Files written to `~/.claude/projects/.../memory/`:
+
+- `{slug}.md` - {what changed}
+
+## Also See
+
+- [Doc {N}](../../{folder}/{N}-{slug}/) - {one-line context}
+- [Doc {N}](../../{folder}/{N}-{slug}/) - {one-line context}
+
+## Distribution Log
+
+- actions.json: {N} items appended (commit `{sha}`)
+- Bonfire ingest: {queued | skipped}
+- Telegram: {block printed | skipped}
+- Calendar: {event updated | no match | skipped}
+- Memory writes: {count} entries
+
+## Transcript
+
+<details>
+<summary>Full transcript ({duration_min} min)</summary>
+
+\`\`\`
+{full transcript text - paste from Whisper output or original paste}
+\`\`\`
+
+</details>
+```
+
+## Style notes
+
+- No emojis. No em-dashes (use hyphens).
+- Bold the load-bearing word in each decision.
+- Pull quotes from the transcript verbatim - never paraphrase.
+- If a decision is conditional ("we do X only if Y"), state the condition in the decision row.
+- Owner column uses canonical first-names matching memory slugs.
+- Due column: absolute dates only. "TBD" if transcript was vague.
+
+## Length target
+
+- 400-1200 lines for a 30-60 min meeting.
+- 1500+ if the call spanned 3+ major threads.
+- Less than 300 = probably not worth a doc; reconsider whether `--doc` flag should be off.

--- a/.claude/skills/meeting/references/output-schema.md
+++ b/.claude/skills/meeting/references/output-schema.md
@@ -1,0 +1,135 @@
+# Output Schema - /meeting Extraction
+
+Single JSON object. All fields required except where noted optional.
+
+## Schema
+
+```json
+{
+  "meeting": {
+    "date": "YYYY-MM-DD",
+    "duration_min": 47,
+    "title": "Iman call - ZAO Craig + PizzaDAO Zambia",
+    "attendees": ["Zaal", "Iman"],
+    "platform": "Telegram voice"
+  },
+  "decisions": [
+    {
+      "id": 1,
+      "text": "Build ZAO Craig bot - live audio + Whisper + auto-extract todos",
+      "owner": "Zaal",
+      "status": "TODO"
+    }
+  ],
+  "actions": [
+    {
+      "title": "Iman to study RSVPizza repo + build PizzaDAO Zambia brand on top",
+      "owner": "Iman",
+      "due": "2026-05-22",
+      "category": "WaveWarZ Zambia"
+    }
+  ],
+  "quotes": [
+    {
+      "speaker": "Iman",
+      "text": "The code is ready for phase two in behavior"
+    }
+  ],
+  "research_seeds": [
+    "ZAO Craig live audio + Whisper + autotodo bot",
+    "PizzaDAO sponsorship proposal format"
+  ],
+  "memory_updates": [
+    {
+      "slug": "project_zao_craig",
+      "what": "Concept seed - live audio capture + Whisper + autotodo. Hermes pattern bot. Doc 670."
+    }
+  ]
+}
+```
+
+## Enums
+
+### `owner` (decisions + actions)
+- `Zaal`
+- `Iman`
+- `Both`
+- `ThyRev` (Thy Revolution / COC Concertz)
+- `Samantha` (candytoybox / WaveWarZ)
+
+Anything else: surface as `unknown` in Phase 3 confirm, ask Zaal.
+
+### `category` (actions)
+Must match cowork-zaodevz actions.json enum:
+- `Site / Tech`
+- `Ops`
+- `Other`
+- `WaveWarZ Zambia`
+- `ZAO Devz`
+- `Bounty`
+- `Social`
+
+### `status` (decisions)
+- `TODO`
+- `WIP`
+- `DONE`
+
+### `platform`
+Free text. Examples: `Telegram voice`, `Google Meet`, `Zoom`, `Discord/Craig`, `Fathom`, `Riverside`, `in-person`, `phone call`.
+
+## Field rules
+
+| Field | Rule |
+|---|---|
+| `meeting.date` | ISO YYYY-MM-DD. If transcript has no clear date, use file mtime or ask user. Never invent. |
+| `meeting.duration_min` | Integer. From Whisper duration or Fathom metadata. 0 if unknown. |
+| `meeting.title` | 5-80 chars. Format: `<who> - <topic 1> + <topic 2>`. Use doc 670 as template. |
+| `meeting.attendees` | Array of canonical first-names. `Zaal`, `Iman`, `Cassie`, `Hannah`, etc. Match existing memory slugs where possible. |
+| `decisions[].text` | Verbatim where possible. No paraphrasing. Past tense for things decided in the call. |
+| `actions[].title` | Imperative verb-first. "Iman to X" or just "X". 10-120 chars. |
+| `actions[].due` | YYYY-MM-DD or empty string. Never invent. If transcript says "by Thursday", convert to absolute date using meeting.date as anchor. |
+| `quotes[].text` | Verbatim. 5-200 chars. Pick the load-bearing 3-8 quotes total. |
+| `quotes[].speaker` | Match attendees list. |
+| `research_seeds` | Topic strings (5-80 chars each). New ideas, follow-up questions, things worth a doc later. |
+| `memory_updates` | Only NEW entities/concepts. Skip if it's already in `MEMORY.md`. Slug format: `project_<kebab-case>` or `feedback_<kebab-case>` or `user_<kebab-case>`. |
+
+## Worked example - doc 670 (Iman call May 18)
+
+Real example of what extraction looks like, sourced from `research/events/670-iman-call-may18-craig-pizzadao/README.md`:
+
+```json
+{
+  "meeting": {
+    "date": "2026-05-18",
+    "duration_min": 47,
+    "title": "Iman call - ZAO Craig + PizzaDAO Zambia + ZABAL Games",
+    "attendees": ["Zaal", "Iman"],
+    "platform": "Telegram voice"
+  },
+  "decisions": [
+    {"id": 1, "text": "Build ZAO Craig bot - live audio + Whisper + auto-extract todos", "owner": "Zaal", "status": "TODO"},
+    {"id": 2, "text": "ZAO Devz fronts PizzaDAO drinks budget (~$120) only if needed - WaveWarZ cannot wire in 5 days", "owner": "Iman", "status": "TODO"},
+    {"id": 3, "text": "Iman studies RSVPizza repo - builds PizzaDAO Zambia / Kingston brand identity on top", "owner": "Iman", "status": "WIP"},
+    {"id": 4, "text": "ZABAL Games signup drops Wednesday 2026-05-20, NOT Friday - Friday becomes live signup moment", "owner": "Both", "status": "TODO"}
+  ],
+  "actions": [
+    {"title": "Pitch PizzaDAO HQ for ~$120 drinks add-on for Zambia event", "owner": "Iman", "due": "2026-05-22", "category": "WaveWarZ Zambia"},
+    {"title": "Dive into github.com/PizzaDAO/rsv-pizza, feed to Claude, build PizzaDAO Zambia brand", "owner": "Iman", "due": "", "category": "WaveWarZ Zambia"},
+    {"title": "Make and ship ZAO flyer for PizzaDAO Zambia (Fri May 23)", "owner": "Iman", "due": "2026-05-18", "category": "WaveWarZ Zambia"},
+    {"title": "ZABAL Games signup form + group chat live", "owner": "Iman", "due": "2026-05-20", "category": "Bounty"}
+  ],
+  "quotes": [
+    {"speaker": "Iman", "text": "The code is ready for phase two in behavior"},
+    {"speaker": "Zaal", "text": "Imma make that bot after this meeting"},
+    {"speaker": "Zaal", "text": "Zambia for $100 more is high-leverage vs $2-3k they spend on bigger cities"}
+  ],
+  "research_seeds": [
+    "ZAO Craig live audio + Whisper + autotodo bot design",
+    "PizzaDAO sponsorship proposal format / pitch-deck system",
+    "RSVPizza repo patterns - what to clone for ZAO brands"
+  ],
+  "memory_updates": [
+    {"slug": "project_zao_craig", "what": "Concept seed - live audio capture + Whisper + autotodo. Hermes pattern bot. Doc 670."}
+  ]
+}
+```

--- a/.claude/skills/meeting/scripts/append-actions.sh
+++ b/.claude/skills/meeting/scripts/append-actions.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# append-actions.sh - Bulk-append meeting actions to cowork-zaodevz data/actions.json.
+# Usage: append-actions.sh <extracted-json-path> [--commit-msg "msg"]
+#
+# Input JSON must match the /meeting output schema (see references/output-schema.md).
+# We only consume the `.actions[]` array + `.meeting.title` + `.meeting.date` for the commit msg.
+#
+# Auth: gh auth token (verified push perm on songchaindao-dot/cowork-zaodevz 2026-05-18).
+# Confirms commit hash + item ID range on success.
+
+set -euo pipefail
+
+INPUT="${1:?missing extracted-json path}"
+COMMIT_MSG_FLAG=""
+if [[ "${2:-}" == "--commit-msg" && -n "${3:-}" ]]; then
+  COMMIT_MSG_FLAG="$3"
+fi
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "ERROR: extracted JSON not found: $INPUT" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null; then echo "ERROR: jq required" >&2; exit 3; fi
+if ! command -v gh >/dev/null; then echo "ERROR: gh CLI required" >&2; exit 3; fi
+
+TOKEN=$(gh auth token 2>/dev/null) || { echo "ERROR: gh auth token failed - run gh auth login" >&2; exit 4; }
+
+REPO="songchaindao-dot/cowork-zaodevz"
+PATH_F="data/actions.json"
+BRANCH="main"
+
+# Preflight - verify push perm
+PERM=$(gh api "repos/$REPO" --jq '.permissions.push' 2>/dev/null || echo "false")
+if [[ "$PERM" != "true" ]]; then
+  echo "ERROR: gh auth lacks push permission on $REPO" >&2
+  exit 5
+fi
+
+WORK=$(mktemp -d)
+trap "rm -rf $WORK" EXIT
+
+# Fetch current actions.json + sha
+echo "[append] fetching current actions.json" >&2
+RESP=$(curl -fsSL -H "Authorization: Bearer $TOKEN" \
+  "https://api.github.com/repos/$REPO/contents/$PATH_F?ref=$BRANCH")
+SHA=$(echo "$RESP" | jq -r '.sha')
+echo "$RESP" | jq -r '.content' | base64 -d > "$WORK/current.json"
+
+# Sanity check
+if ! jq -e '.items' "$WORK/current.json" >/dev/null; then
+  echo "ERROR: fetched actions.json has no .items array" >&2
+  exit 6
+fi
+
+NEXT_ID=$(jq '[.items[] | .id | tonumber] | max + 1' "$WORK/current.json")
+NOW=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+TODAY=$(date -u +%Y-%m-%d)
+TITLE=$(jq -r '.meeting.title // "meeting"' "$INPUT")
+DATE=$(jq -r '.meeting.date // empty' "$INPUT")
+[[ -z "$DATE" ]] && DATE="$TODAY"
+
+# Build new items
+N_NEW=$(jq '.actions | length' "$INPUT")
+if [[ "$N_NEW" -eq 0 ]]; then
+  echo "[append] no actions to append, skipping" >&2
+  exit 0
+fi
+
+echo "[append] mapping $N_NEW extracted actions starting at id=$NEXT_ID" >&2
+
+jq --slurpfile new "$INPUT" --argjson startId "$NEXT_ID" --arg now "$NOW" --arg today "$TODAY" '
+  $new[0].actions | to_entries | map({
+    id: (($startId + .key) | tostring),
+    title: .value.title,
+    createdBy: "Claude (/meeting skill)",
+    owner: (.value.owner // "Both"),
+    status: "TODO",
+    category: (.value.category // "Other"),
+    priority: (if (.value.due // "") == $today then "P1" else "P2" end),
+    important: false,
+    urgent: ((.value.due // "") == $today),
+    phase: "Define",
+    notes: "",
+    due: (.value.due // ""),
+    createdAt: $now,
+    updatedAt: $now
+  })
+' "$INPUT" > "$WORK/new-items.json"
+
+# Merge
+jq --slurpfile new "$WORK/new-items.json" --arg now "$NOW" '
+  .items = (.items + $new[0]) | .updatedAt = $now
+' "$WORK/current.json" > "$WORK/merged.json"
+
+OLD_N=$(jq '.items | length' "$WORK/current.json")
+NEW_N=$(jq '.items | length' "$WORK/merged.json")
+echo "[append] $OLD_N -> $NEW_N items (+$((NEW_N - OLD_N)))" >&2
+
+# Encode + PUT
+CONTENT_B64=$(base64 < "$WORK/merged.json" | tr -d '\n')
+
+if [[ -n "$COMMIT_MSG_FLAG" ]]; then
+  MSG="$COMMIT_MSG_FLAG"
+else
+  MSG="chore(actions): meeting recap $DATE $TITLE (+$N_NEW items)
+
+Source: /meeting skill, extracted from transcript."
+fi
+
+PAYLOAD=$(jq -n --arg msg "$MSG" --arg content "$CONTENT_B64" --arg sha "$SHA" --arg branch "$BRANCH" \
+  '{message: $msg, content: $content, sha: $sha, branch: $branch}')
+
+echo "[append] PUT $REPO contents/$PATH_F (sha=${SHA:0:7})" >&2
+RESULT=$(curl -fsSL -X PUT \
+  "https://api.github.com/repos/$REPO/contents/$PATH_F" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  -d "$PAYLOAD")
+
+NEW_SHA=$(echo "$RESULT" | jq -r '.commit.sha')
+URL=$(echo "$RESULT" | jq -r '.commit.html_url')
+
+echo "[append] OK commit $NEW_SHA" >&2
+echo "$URL"

--- a/.claude/skills/meeting/scripts/fetch-craig.sh
+++ b/.claude/skills/meeting/scripts/fetch-craig.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# fetch-craig.sh - Download Craig recording from craig.horse share URL.
+# Usage: fetch-craig.sh "https://craig.horse/rec/<id>?key=<key>"
+# Outputs: prints local path to downloaded audio (.flac) on stdout.
+
+set -euo pipefail
+
+URL="${1:?missing craig URL}"
+
+if [[ ! "$URL" =~ ^https://craig\.horse/rec/ ]]; then
+  echo "ERROR: not a craig.horse URL: $URL" >&2
+  exit 2
+fi
+
+# Extract id from URL
+ID=$(echo "$URL" | sed -E 's|.*craig\.horse/rec/([^/?]+).*|\1|')
+KEY=$(echo "$URL" | sed -nE 's|.*[?&]key=([^&]+).*|\1|p')
+
+if [[ -z "$ID" ]]; then
+  echo "ERROR: could not parse recording id from URL" >&2
+  exit 3
+fi
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+OUT="/tmp/craig-$ID-$STAMP.flac"
+
+# Craig download endpoint: /rec/<id>.flac?key=<key>&container=flac
+DL_URL="https://craig.horse/rec/${ID}.flac?key=${KEY}&container=flac"
+
+echo "[craig] downloading $DL_URL -> $OUT" >&2
+
+if ! curl -fsSL -A "Mozilla/5.0 ZAO-meeting-skill" "$DL_URL" -o "$OUT"; then
+  echo "ERROR: download failed. Recording may be expired (Craig keeps 7 days) or key wrong." >&2
+  rm -f "$OUT"
+  exit 4
+fi
+
+if [[ ! -s "$OUT" ]]; then
+  echo "ERROR: download was empty" >&2
+  rm -f "$OUT"
+  exit 5
+fi
+
+echo "[craig] done ($(du -h "$OUT" | cut -f1)) -> $OUT" >&2
+echo "$OUT"

--- a/.claude/skills/meeting/scripts/transcribe.sh
+++ b/.claude/skills/meeting/scripts/transcribe.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# transcribe.sh - SCP audio file to Iman VPS, run Whisper, SCP transcript back.
+# Usage: transcribe.sh <local-audio-path> [--model base|small|medium]
+# Outputs: prints local path to .txt transcript on success.
+
+set -euo pipefail
+
+VPS_HOST="${ZAOCOWORKING_VPS:-root@187.77.3.104}"
+MODEL="${WHISPER_MODEL:-base}"
+SRC="${1:?missing audio path}"
+
+if [[ ! -f "$SRC" ]]; then
+  echo "ERROR: audio file not found: $SRC" >&2
+  exit 2
+fi
+
+# Parse optional model flag
+if [[ "${2:-}" == "--model" && -n "${3:-}" ]]; then
+  MODEL="$3"
+fi
+
+# Preflight - verify whisper installed on VPS
+PREFLIGHT=$(ssh -o ConnectTimeout=8 -o BatchMode=yes "$VPS_HOST" \
+  'command -v whisper >/dev/null 2>&1 && command -v ffmpeg >/dev/null 2>&1 && echo OK || echo MISSING' 2>/dev/null || echo "SSH_FAIL")
+
+if [[ "$PREFLIGHT" == "SSH_FAIL" ]]; then
+  echo "ERROR: cannot SSH to $VPS_HOST. Check SSH key + host." >&2
+  exit 3
+fi
+
+if [[ "$PREFLIGHT" != "OK" ]]; then
+  cat >&2 <<EOF
+ERROR: Whisper or ffmpeg not installed on $VPS_HOST.
+
+One-time install (run from your mac):
+
+  ssh $VPS_HOST 'apt-get update && apt-get install -y ffmpeg python3-pip && pip install openai-whisper'
+
+Then re-run this script.
+EOF
+  exit 4
+fi
+
+BASENAME=$(basename "$SRC")
+EXT="${BASENAME##*.}"
+STAMP=$(date +%Y%m%d-%H%M%S)
+REMOTE_DIR="/tmp/meeting-$STAMP"
+REMOTE_AUDIO="$REMOTE_DIR/input.$EXT"
+LOCAL_OUT="/tmp/meeting-$STAMP.txt"
+
+echo "[transcribe] uploading $SRC ($(du -h "$SRC" | cut -f1)) to $VPS_HOST:$REMOTE_AUDIO" >&2
+
+ssh "$VPS_HOST" "mkdir -p $REMOTE_DIR"
+scp -q "$SRC" "$VPS_HOST:$REMOTE_AUDIO"
+
+echo "[transcribe] running whisper --model $MODEL --language en (this can take minutes for long audio)" >&2
+
+ssh "$VPS_HOST" "cd $REMOTE_DIR && whisper input.$EXT --model $MODEL --language en --output_format txt --output_dir . 2>&1 | tail -5" >&2
+
+# Pull transcript back
+scp -q "$VPS_HOST:$REMOTE_DIR/input.txt" "$LOCAL_OUT"
+
+# Cleanup remote
+ssh "$VPS_HOST" "rm -rf $REMOTE_DIR" || true
+
+echo "[transcribe] done -> $LOCAL_OUT" >&2
+echo "$LOCAL_OUT"

--- a/research/dev-workflows/673-meeting-capture-skill/README.md
+++ b/research/dev-workflows/673-meeting-capture-skill/README.md
@@ -1,0 +1,202 @@
+---
+topic: dev-workflows
+type: decision
+status: draft
+last-validated: 2026-05-18
+related-docs: 012, 433, 448, 539, 552, 650, 661, 662, 670, 672
+tier: STANDARD
+---
+
+# 673 - Meeting Capture Skill Design
+
+> **Goal:** Spec a Claude Code skill that ingests meeting transcripts/recordings (Craig, Fathom, Google Meet, Zoom, Riverside, voice memo, paste), extracts actions + decisions + key quotes, and distributes to the right ZAO surfaces (cowork-zaodevz actions.json, research docs, Bonfire ingest, Telegram, calendar, memory).
+
+## Key Decisions
+
+| # | Decision | Reason |
+|---|---|---|
+| 1 | **Build as a Claude Code skill at `.claude/skills/meeting/SKILL.md`** — NOT a new bot, NOT a fork of capture.ts | Bot = ZAO Craig (doc 670, separate runtime). Skill = workflow orchestrator that Claude already runs. Reuse existing Claude Code session, zero new infra. |
+| 2 | **v1 transcription: Whisper.cpp local OR direct paste** | Free, runs on VPS already. Deepgram (doc 12) is ZAOstock-specific. For Zaal personal/Iman use, Whisper.cpp is enough. Defer Deepgram unless transcript quality blocks. |
+| 3 | **v1 distribution: 6 named targets, user-gated per run** | `actions.json` (cowork-zaodevz), research doc (`research/events/NNN-*`), Bonfire ingest queue, Telegram summary DM, memory write, calendar link. Each is optional per meeting. |
+| 4 | **Skill scope: single `/meeting` skill with phases (capture → extract → present → distribute)** | NOT 4 sub-skills. Anthropic best practice = one progressive-disclosure entry point; load supporting files as needed (`scripts/transcribe.sh`, `references/output-schemas.md`). |
+| 5 | **Project-scoped (`.claude/skills/meeting/`), not personal (`~/.claude/skills/`)** | Distribution targets are ZAO-specific (cowork-zaodevz repo, ZAOOS research dir, ZAOcoworkingBot Telegram). Lives in this repo, version-controlled, ships via PR like other ZAO skills. |
+| 6 | **Frontmatter: model-invocable + user-invocable, no auto-trigger gates** | "Pushy" description so Claude fires on "I just had a meeting", "here's a transcript", "process this recording". Per Anthropic doc, undertriggering is the bigger risk. |
+
+## Input modes (v1)
+
+| Mode | Trigger | Pipeline |
+|---|---|---|
+| Paste-in-chat | Zaal pastes raw text or copies from Fathom/Granola/Zoom summary | skip transcription, go straight to extract |
+| Local audio file | `/meeting /path/to/file.m4a` | Whisper.cpp via `${CLAUDE_SKILL_DIR}/scripts/transcribe.sh` → text → extract |
+| Voice memo path | `/meeting ~/Documents/voice-memos/2026-05-18.m4a` | same as above |
+| Craig URL | `/meeting craig.horse/rec/<id>?key=<key>` | curl download → Whisper → extract |
+| Fathom URL | `/meeting fathom.video/share/<id>` | WebFetch to get share-page transcript JSON → extract |
+| Telegram voice-note saved to disk | drop into watched folder | same as local audio |
+| Discord voice-channel via Craig recording | export through Craig dashboard | same as Craig URL |
+
+Out of scope for v1: live audio capture (= ZAO Craig bot, doc 670), Zoom-native, Riverside cloud (no public transcript API), Google Meet directly (use Fathom or Craig as the recording layer).
+
+## Output schema (extraction)
+
+Claude extracts structured JSON before distribution:
+
+```json
+{
+  "meeting": {
+    "date": "2026-05-18",
+    "duration_min": 47,
+    "title": "Iman call - ZAO Craig + PizzaDAO Zambia",
+    "attendees": ["Zaal", "Iman"],
+    "platform": "Telegram voice"
+  },
+  "decisions": [
+    {"id": 1, "text": "Build ZAO Craig bot", "owner": "Zaal", "status": "TODO"},
+    {"id": 2, "text": "ZAO Devz fronts $120 if needed", "owner": "Iman", "status": "TODO"}
+  ],
+  "actions": [
+    {"title": "Iman to study RSVPizza repo", "owner": "Iman", "due": "2026-05-22", "category": "WaveWarZ Zambia"},
+    {"title": "Pitch PizzaDAO HQ for drinks add-on", "owner": "Iman", "due": "2026-05-22", "category": "WaveWarZ Zambia"}
+  ],
+  "quotes": [
+    {"speaker": "Iman", "text": "The code is ready for phase two in behavior"},
+    {"speaker": "Zaal", "text": "Imma make that bot after this meeting"}
+  ],
+  "research_seeds": ["ZAO Craig live audio + Whisper + autotodo", "PizzaDAO sponsorship proposal format"],
+  "memory_updates": [{"slug": "project_zao_craig", "what": "Concept seed - live audio - autotodo bot, doc 670"}]
+}
+```
+
+## Distribution matrix
+
+For each run, skill asks Zaal which targets to fire. Defaults marked.
+
+| Target | What lands there | Method | Default? |
+|---|---|---|---|
+| `actions.json` (cowork-zaodevz) | Each `action` becomes an item under correct owner/category | GitHub Contents API PUT (`gh auth token`), bulk append, 1 commit per meeting | YES |
+| Research doc (`research/events/NNN-<slug>/README.md`) | Full structured recap (decisions, actions, quotes, context) using doc 670 as the template | Write to repo on a `ws/` branch + PR | YES if >=3 decisions OR explicit ask |
+| Bonfire ingest queue | Transcript + recap markdown, secret-scan filtered | Drop file in `content/bonfire-ingest/`, run `scripts/bonfire-ingest/bonfire_client.py` (already exists, PR #568) | OPT-IN |
+| Telegram summary | One copyable-bubble msg (no header/footer per `feedback_copyable_content_own_bubble`) to ZAOcoworkingBot DM | bot REST endpoint TBD (Phase 3 doc 672), v1 = manual paste from skill output | OPT-IN |
+| Memory write | `project_*` memory for new entities/concepts surfaced | Write to `~/.claude/projects/-Users.../memory/` per existing pattern | OPT-IN |
+| Calendar event link | If `meeting.title` matches a Google Cal event, attach recap link in event description | `mcp__claude_ai_Google_Calendar__update_event` | OPT-IN |
+
+## Skill file layout
+
+```
+.claude/skills/meeting/
+├── SKILL.md                           # 200-300 lines, the entrypoint
+├── references/
+│   ├── output-schema.md               # full JSON schema + example
+│   ├── distribution-targets.md        # how to call each target (actions.json PUT shape, research doc frontmatter, Bonfire format)
+│   └── meeting-recap-template.md      # doc 670 distilled as a fillable template
+└── scripts/
+    ├── transcribe.sh                  # Whisper.cpp wrapper (mac local, or ssh to VPS)
+    ├── fetch-craig.sh                 # curl Craig URL + extract audio
+    └── append-actions.sh              # Octokit-equivalent in bash (gh api PUT data/actions.json)
+```
+
+## Frontmatter (proposed)
+
+```yaml
+---
+name: meeting
+description: Capture meeting transcripts (voice memo, Craig, Fathom, paste) and distribute extracted decisions + action items + quotes to the right ZAO surfaces (cowork-zaodevz actions.json, research docs, Bonfire, Telegram, memory, calendar). Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or pastes meeting content for analysis.
+allowed-tools: Read Write Bash(gh *) Bash(curl *) Bash(whisper *) WebFetch
+---
+```
+
+`when_to_use` phrases that should fire it (per doc preference: pushy):
+- "I just had a meeting"
+- "here's the transcript"
+- "process this recording"
+- "extract todos from this call"
+- "recap that meeting"
+- "/meeting <path-or-url>"
+
+## Pareto: 3 wires that move 80%
+
+1. **Paste-in-chat → actions.json bulk-append** (zero infra, ships today). The exact path we used at 21:30 UTC to fix the 67-item backlog. Skill formalizes this as a one-command flow.
+2. **Local voice-memo → Whisper.cpp → research doc 670-style recap**. Eliminates the manual upload-download-paste loop.
+3. **`/meeting` slash-command surface across all input modes**. One command, six inputs, six output targets, user-gated per run.
+
+Everything else (live audio, speaker diarization, calendar auto-link, Bonfire watch folder) is v2.
+
+## What we are NOT building
+
+- Live audio capture bot (= ZAO Craig, doc 670, separate Hermes-pattern runtime).
+- Replacing `bot/src/capture.ts` `/gemba /idea /note` (ZAOstock-bot, different surface, different DB).
+- Deepgram cloud transcription (doc 12 ZAOstock-only, skill stays free for personal use).
+- Real-time speaker diarization in v1 (defer, manual review faster for <10 meetings/wk).
+- Auto-create new memories without confirmation (memory writes always confirm).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Whisper local install friction (mac dependencies) | `scripts/transcribe.sh` checks `whisper-cpp` binary, prompts brew install if missing |
+| Hallucinated action items (LLM invents owners/dates) | Mandatory user-confirm step before any `actions.json` write. Show extracted JSON in chat first, get OK. |
+| Secret leakage via Bonfire ingest | `scripts/bonfire-ingest/secret_scan.py` already filters (PR #568 shipped today) |
+| Skill drifts vs ZAO Craig bot when both exist | `references/distribution-targets.md` documents both paths; bot calls skill internally once live |
+| `gh auth token` lacks write to cowork-zaodevz | Verified today: `push: true` (commit `c80caff8`) |
+
+## Comparison: 4 reference patterns
+
+| Skill | Pattern Used | What ZAO Borrows | What ZAO Drops |
+|---|---|---|---|
+| **Anthropic `skill-creator`** | progressive disclosure, references/ scripts/ assets/ | Folder layout, frontmatter format | n/a |
+| **dgalarza `process-meeting-transcript`** (Granola-focused) | structured frontmatter output, action item extraction, "capture commitments + technical details" | Output JSON schema, commitment-capture prompt | Granola-only assumption |
+| **ComposioHQ `meeting-insights-analyzer`** | 6-step workflow (discover→clarify→analyze→examples→synthesize→follow-up), pattern recognition (conflict avoidance, speaking ratios) | 6-step workflow scaffold; quote-with-context pattern | Behavioral analysis (overkill for ZAO use case) |
+| **ZAOOS `/inbox`** (existing sibling) | sender whitelist + label-folder routing | Routing logic per output target | Email-only triggers |
+
+## Also See
+
+- [Doc 012 - ZAOstock meeting AI](../../events/_zaostock-hub/12-meeting-ai.md) - Deepgram + Claude + Telegram Pareto for ZAOstock; this skill is the personal/Iman complement
+- [Doc 433 - ZAO media capture pipeline spec](../433-zao-media-capture-pipeline-spec/) - upstream concept (empty stub, this doc supersedes for skill scope)
+- [Doc 539 - grill-me skill specs-to-code](../539-grill-me-claude-skill-specs-to-code/) - skill design methodology
+- [Doc 552 - ZAO skill library audit](../552-zao-skill-library-audit/) - sibling skill inventory; new skill slots in alongside /inbox /reflect /morning
+- [Doc 661 - ZAOcoworkingBot go-live](../../agents/661-zaocoworkingbot-go-live/) - downstream Telegram surface
+- [Doc 670 - Iman call May 18 (ZAO Craig)](../../events/670-iman-call-may18-craig-pizzadao/) - bot version of this idea (live audio); this skill is the workflow version, ZAO Craig is the live-capture runtime
+- [Doc 672 - ZAOcoworkingBot post-v2.13 audit](../../agents/672-zaocoworking-bot-audit-postv213/) - downstream consumer of actions.json bulk-append pattern proven 2026-05-18
+
+## Next Actions
+
+| # | Action | Owner | Type | By When |
+|---|---|---|---|---|
+| 1 | Confirm v1 scope (this doc) + answer 5 open questions below | Zaal | Decision | This session |
+| 2 | Write `.claude/skills/meeting/SKILL.md` + 3 reference files + 3 scripts | Claude | Code | After Q1 answered |
+| 3 | Test on doc 670 transcript (replay May 18 Iman call as input) | Both | QA | After build |
+| 4 | Ship PR off `ws/meeting-capture-skill` | Claude | PR | After QA |
+| 5 | Deferred: ZAO Craig live-audio bot (doc 670) - separate doc + branch | Zaal | Bot | Sprint+1 |
+| 6 | Deferred: hook to ZAOcoworkingBot Telegram for one-tap distribution | Zaal | Bot Phase 4 | After bot v2.14 |
+
+## Locked decisions (2026-05-18)
+
+| Q | Decision |
+|---|---|
+| Skill name | `/meeting` |
+| Research-doc trigger | Always (every meeting → `research/events/NNN-*`) |
+| Telegram method v1 | Print copy-paste block (no bot API dep) |
+| Whisper host | Iman's VPS via SSH (no local mac install) |
+| Memory writes | Confirm-before-write on every memory (safe default) |
+
+## VPS bootstrap (one-time)
+
+Whisper not yet installed on Iman VPS as of 2026-05-18. Skill preflights, prints exact install:
+
+```bash
+ssh root@187.77.3.104 'apt-get install -y ffmpeg && pip install openai-whisper'
+```
+
+Then warm cache:
+```bash
+ssh root@187.77.3.104 'whisper --model base --language en /dev/null 2>/dev/null || echo "model download starts on first real run"'
+```
+
+## Sources
+
+- [Claude Code skills docs](https://code.claude.com/docs/en/skills) - SKILL.md structure, frontmatter, progressive disclosure (last-checked 2026-05-18)
+- [Anthropic skill-creator on GitHub](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) - reference implementation patterns
+- [The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf) - Anthropic official guide
+- [ComposioHQ meeting-insights-analyzer SKILL.md](https://github.com/ComposioHQ/awesome-claude-skills/blob/master/meeting-insights-analyzer/SKILL.md) - 6-step workflow + pattern recognition reference
+- [dgalarza process-meeting-transcript](https://claude-plugins.dev/skills/@dgalarza/claude-code-workflows/process-meeting-transcript) - Granola → structured notes pattern
+- [glebis/claude-skills](https://github.com/glebis/claude-skills) - skill collection
+- ZAOOS internal: [bot/src/capture.ts](../../../bot/src/capture.ts), [scripts/bonfire-ingest/](../../../scripts/bonfire-ingest/), [Doc 670](../../events/670-iman-call-may18-craig-pizzadao/README.md), [Doc 672](../../agents/672-zaocoworking-bot-audit-postv213/README.md)


### PR DESCRIPTION
## Summary

New `/meeting` Claude Code skill - one command, six inputs, six output targets. Built today after the bot's auto-write flow died at the 4096-char Telegram limit; this skill is the workflow layer that bypasses the bot entirely.

## What ships

- `.claude/skills/meeting/SKILL.md` (210 lines) - phased workflow: detect input - transcribe - extract - user-confirm - distribute - report
- 3 references (output schema, distribution targets per playbook, recap template distilled from doc 670)
- 3 scripts (transcribe.sh via Iman VPS Whisper, fetch-craig.sh for craig.horse, append-actions.sh for cowork-zaodevz bulk add)
- Design doc 673 (STANDARD tier zao-research, references existing docs 012/433/670/672 + ComposioHQ + dgalarza + Anthropic skill-creator)

## Locked decisions (Zaal-confirmed in session)

| Q | A |
|---|---|
| Skill name | /meeting (pushy description, undertriggering > overtriggering) |
| Doc trigger | Always write research/events/NNN-* recap |
| Telegram method | Print copy-paste block (no bot-API dep) |
| Whisper host | Iman VPS via SSH |
| Memory writes | Confirm-each-entry (safe default) |

## Test plan

- [ ] Run /meeting with a pasted transcript fragment, verify Phase 2 extraction shape matches schema
- [ ] Run /meeting <path-to-voice-memo.m4a>, VPS install path triggers if Whisper missing
- [ ] Smoke-test append-actions.sh with 1-item synthetic input on a sandbox before live cowork-zaodevz commit (jq pipeline already passed)
- [ ] Verify /meeting shows up in skill list (confirmed in-session)
- [ ] Replay doc 670 Iman call as input, check output matches what was hand-built today

## Out of scope (deferred)

- Live audio capture bot (= ZAO Craig, doc 670, separate Hermes-pattern runtime)
- ZAOcoworkingBot Telegram API integration (= bot Phase 3, doc 672 P3.5)
- Deepgram cloud transcription (= ZAOstock-only per doc 012; this skill stays free)
- Speaker diarization

## Notes

Branch was rebuilt from scratch after a parallel-Claude-Code-session branch collision (my commit landed on someone else's ws/research-674-edge-esmeralda-telamon branch). Recovery: cherry-pick + delete-remote + fresh push. Lesson: doc 663/674 collision-tolerance system should also detect cross-branch HEAD switches mid-commit.

Bot fix items (doc 672 P1.1-P1.6 + the 4096-char chunking issue found in logs today) are tracked as items #46 + #90 in the cowork-zaodevz actions.json (commit c80caff8). Will batch as bot v2.14 in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)