### PR TITLE
feat(zoe): Bonfire read/write bridge - usable knowledge graph

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -3,3 +3,11 @@ SUPABASE_URL=https://xxxx.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=eyJhbG...
 ANTHROPIC_API_KEY=sk-ant-...   # optional v1; used for natural-language contact-log parsing
 BOT_ADMIN_TELEGRAM_IDS=      # comma-separated Telegram user IDs with full access (e.g. 12345678)
+
+# ZABAL Bonfire knowledge-graph bridge (bot/src/zoe/recall.ts).
+# Absent => ZOE falls back to manual-relay (asks Zaal to query @zabal_bonfire).
+# Present => ZOE mirrors captures/decisions into the bonfire (works today) and
+# attempts vector-store recall (live once an admin runs labeling on the bonfire).
+BONFIRE_API_KEY=             # revealed via signed message at app.bonfires.ai/dashboard
+BONFIRE_ID=                  # the ZABAL bonfire id
+BONFIRE_API_URL=https://tnt-v2.api.bonfires.ai   # optional, this is the default

--- a/bot/src/zoe/agents/newsletter.ts
+++ b/bot/src/zoe/agents/newsletter.ts
@@ -156,7 +156,7 @@ async function loadBonfireContext(topic: string): Promise<string> {
       reason: 'newsletter context grounding',
       expected_kind: 'mixed',
     });
-    if (result.kind === 'sdk_response' || result.kind === 'mcp_response') {
+    if (result.kind === 'sdk_response') {
       return (result.text ?? '').slice(0, 1500) || '(empty Bonfire reply)';
     }
     return '(manual relay path - Bonfire not auto-queryable)';

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -32,6 +32,7 @@ import {
 } from './memory';
 import { startScheduler } from './scheduler';
 import { disableNudges, enableNudges, nudgesEnabled } from './nudges';
+import { mirrorTurn } from './recall';
 import {
   addAllowlistMember,
   getGroupConfig,
@@ -509,6 +510,21 @@ async function dispatchConcierge(
     if (result.quest_ops.length > 0) {
       await applyQuestOps(result.quest_ops);
     }
+
+    // Bonfire: mirror this turn's captures + task/quest changes into the
+    // ZABAL knowledge graph. Best-effort, fire-and-forget — never blocks the
+    // reply, never throws. No-op if BONFIRE_API_KEY/BONFIRE_ID are unset.
+    mirrorTurn({
+      captures: result.captures,
+      task_ops: result.task_ops as unknown as Array<Record<string, unknown>>,
+      quest_ops: result.quest_ops as unknown as Array<Record<string, unknown>>,
+    })
+      .then((m) => {
+        if (m.mirrored > 0) {
+          console.log(`[zoe/index] bonfire mirror — ${m.mirrored} episode(s), ${m.skipped} skipped`);
+        }
+      })
+      .catch((e) => console.error('[zoe/index] bonfire mirror failed:', e));
 
     await pushRecent({ from: 'zoe', text: result.reply }, scope);
 

--- a/bot/src/zoe/recall.ts
+++ b/bot/src/zoe/recall.ts
@@ -1,82 +1,293 @@
 /**
- * Bonfire bridge for ZOE.
+ * Bonfire bridge for ZOE — read (recall) + write (remember).
  *
- * Today (no SDK key from Joshua.eth yet): manual relay pattern. ZOE returns
- * a structured "recall request" signal in its reply that asks Zaal to paste
- * a query into @zabal_bonfire DM and paste back the reply.
+ * Verified against the live Bonfires API 2026-05-19:
+ *   - WRITE  POST /knowledge_graph/episode/create   (works with non-admin key)
+ *   - READ   POST /vector_store/search              (works, but returns []
+ *            until an admin runs labeling on the bonfire)
  *
- * When SDK lands: this module swaps to direct API calls without changing
- * concierge.ts callsite.
+ * The 780 episodes ZAO ingested live in the knowledge graph and show in the
+ * dashboard, but vector search stays empty until labeling runs (admin-gated:
+ * /labeling/hybrid is 403 for non-admin keys). So `recall()` degrades
+ * gracefully: it tries vector search, and if the store is empty it falls
+ * back to the manual-relay pattern (ask Zaal to query @zabal_bonfire).
  *
- * When MCP server lands: Claude CLI invocation gets `mcp__bonfires__recall`
- * tool added, ZOE calls it natively, this module retires.
+ * `remember()` works today — ZOE's captures + decisions get mirrored into
+ * the bonfire as episodes, so the knowledge graph keeps growing from daily
+ * use even before read is unlocked.
+ *
+ * Env:
+ *   BONFIRE_API_KEY  required for any API path; absent => manual relay only
+ *   BONFIRE_ID       the ZABAL bonfire id
+ *   BONFIRE_API_URL  default https://tnt-v2.api.bonfires.ai
  */
 
+const API_URL = process.env.BONFIRE_API_URL ?? 'https://tnt-v2.api.bonfires.ai';
+const API_KEY = process.env.BONFIRE_API_KEY ?? '';
+const BONFIRE_ID = process.env.BONFIRE_ID ?? '';
+const READ_TIMEOUT_MS = 10_000;
+const WRITE_TIMEOUT_MS = 15_000;
+
+export function bonfireConfigured(): boolean {
+  return !!API_KEY && !!BONFIRE_ID;
+}
+
+// --- secret guard for writes -------------------------------------------------
+// ZOE's captures are facts about Zaal/the team — low risk, but never let an
+// API key / private key slip into the knowledge graph. Minimal HIGH-severity
+// check mirroring scripts/bonfire-ingest/secret_scan.py.
+const SECRET_PATTERNS: RegExp[] = [
+  /sk-ant-[A-Za-z0-9_-]{20,}/,
+  /sk-(?:proj-|cp-)?[A-Za-z0-9_-]{30,}/,
+  /ghp_[A-Za-z0-9]{36}/,
+  /github_pat_[A-Za-z0-9_]{60,}/,
+  /-----BEGIN (?:RSA |EC |OPENSSH |ENCRYPTED |PGP )?PRIVATE KEY-----/,
+  /\b0x[0-9a-fA-F]{64}\b/,
+  /\b\d{9,12}:[A-Za-z0-9_-]{30,}\b/, // telegram bot token
+  /xox[bpaors]-[A-Za-z0-9-]{10,}/, // slack
+  /\bAKIA[0-9A-Z]{16}\b/, // aws
+];
+
+export function containsSecret(text: string): boolean {
+  return SECRET_PATTERNS.some((re) => re.test(text));
+}
+
+// --- types -------------------------------------------------------------------
 export interface RecallRequest {
   query: string;
-  reason: string;       // why ZOE needs the answer
+  reason: string; // why ZOE needs the answer
   expected_kind: 'fact' | 'people' | 'event' | 'decision' | 'history' | 'mixed';
 }
 
 export interface RecallResult {
-  kind: 'manual_relay_needed' | 'sdk_response' | 'mcp_response';
+  kind: 'sdk_response' | 'manual_relay_needed';
   query: string;
-  text?: string;          // Bonfire reply text when sdk_response or mcp_response
-  inline_keyboard?: Array<Array<{ text: string; callback_data: string }>>;
+  text?: string; // formatted bonfire reply when sdk_response
+  hits?: number;
+  relay?: string; // Telegram-ready manual-relay text when manual_relay_needed
+}
+
+export interface RememberResult {
+  ok: boolean;
+  skipped?: 'no-config' | 'secret-detected' | 'empty';
+  taskId?: string;
+  error?: string;
+}
+
+// --- write -------------------------------------------------------------------
+/**
+ * Mirror a fact / capture / decision into the ZABAL bonfire as an episode.
+ * Bonfires' auto-extraction turns the natural-language body into KG nodes.
+ * Best-effort: never throws, returns a result the caller can log.
+ */
+export async function remember(opts: {
+  body: string;
+  name: string; // stable-ish episode name, e.g. "zoe-capture:<id>"
+  sourceTag: string; // source_description, e.g. "zoe:capture"
+}): Promise<RememberResult> {
+  if (!bonfireConfigured()) return { ok: false, skipped: 'no-config' };
+  const body = opts.body.trim();
+  if (!body) return { ok: false, skipped: 'empty' };
+  if (containsSecret(body)) {
+    console.warn('[zoe/recall] remember() blocked - body contains a secret-shaped string');
+    return { ok: false, skipped: 'secret-detected' };
+  }
+
+  try {
+    const res = await fetch(`${API_URL}/knowledge_graph/episode/create`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        bonfire_id: BONFIRE_ID,
+        name: opts.name,
+        episode_body: body,
+        source: 'text',
+        source_description: opts.sourceTag,
+        reference_time: new Date().toISOString(),
+      }),
+      signal: AbortSignal.timeout(WRITE_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const detail = (await res.text().catch(() => '')).slice(0, 200);
+      return { ok: false, error: `HTTP ${res.status} ${detail}` };
+    }
+    const json = (await res.json().catch(() => ({}))) as { task_id?: string; success?: boolean };
+    return { ok: json.success !== false, taskId: json.task_id };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// --- read --------------------------------------------------------------------
+interface VectorSearchResponse {
+  success?: boolean;
+  count?: number;
+  results?: Array<Record<string, unknown>>;
+}
+
+/** Query the bonfire vector store. Returns hits (possibly empty). Never throws. */
+async function searchVectorStore(
+  query: string,
+  limit = 5,
+): Promise<{ ok: boolean; results: Array<Record<string, unknown>>; error?: string }> {
+  try {
+    const res = await fetch(`${API_URL}/vector_store/search`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ bonfire_ref: BONFIRE_ID, search_string: query, limit }),
+      signal: AbortSignal.timeout(READ_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      return { ok: false, results: [], error: `HTTP ${res.status}` };
+    }
+    const json = (await res.json()) as VectorSearchResponse;
+    return { ok: true, results: json.results ?? [] };
+  } catch (err) {
+    return { ok: false, results: [], error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function formatHit(hit: Record<string, unknown>): string {
+  const text =
+    (hit.text as string) ??
+    (hit.content as string) ??
+    (hit.chunk as string) ??
+    (hit.snippet as string) ??
+    JSON.stringify(hit);
+  return `- ${String(text).slice(0, 300)}`;
 }
 
 /**
- * Today's behavior: format a "please relay to Bonfire" payload that ZOE can
- * include in its reply to Zaal. Returns a Telegram-ready Markdown string.
+ * Telegram-ready manual-relay text — used when vector search is empty
+ * (labeling not run yet) or the bonfire isn't configured.
  */
 export function formatManualRelay(req: RecallRequest): string {
   return [
-    `_Need bonfire context for: ${req.reason}_`,
+    `_Bonfire vector search is not live yet (needs labeling). Manual relay for: ${req.reason}_`,
     '',
     'Paste into @zabal_bonfire DM:',
     '```',
     `RECALL: ${req.query}`,
     '```',
     '',
-    'Then paste the reply back here. I will continue.',
+    'Then paste the reply back here and I will continue.',
   ].join('\n');
 }
 
 /**
- * Future API call (placeholder).
- * Returns sdk_response when env has BONFIRE_API_KEY + BONFIRE_ID, else manual_relay_needed.
- */
-export async function recallViaSdk(req: RecallRequest): Promise<RecallResult> {
-  const apiKey = process.env.BONFIRE_API_KEY;
-  const bonfireId = process.env.BONFIRE_ID;
-
-  if (!apiKey || !bonfireId) {
-    return { kind: 'manual_relay_needed', query: req.query };
-  }
-
-  // Future: process.env.BONFIRE_AGENT_ID + BONFIRE_API_URL used here.
-
-  // Future implementation when key is provisioned (per doc 569 §9 SDK pattern):
-  //
-  //   const r = await fetch(`${apiUrl}/kg/search`, {
-  //     method: 'POST',
-  //     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
-  //     body: JSON.stringify({ bonfire_id: bonfireId, agent_id: agentId, query: req.query, num_results: 5 }),
-  //   });
-  //   const data = await r.json();
-  //   return { kind: 'sdk_response', query: req.query, text: data.results.map(formatResult).join('\n\n') };
-  //
-  // Intentionally not invoking the API until key is in env — to fail loudly
-  // when called without proper config.
-
-  console.warn('[zoe/recall] SDK path not yet implemented — falling back to manual relay');
-  return { kind: 'manual_relay_needed', query: req.query };
-}
-
-/**
- * Single entry point ZOE concierge calls. Routes to SDK if configured,
- * else manual relay.
+ * Single entry point ZOE's concierge calls. Tries vector search; on empty
+ * result or failure, returns a manual-relay payload. Never throws.
  */
 export async function recall(req: RecallRequest): Promise<RecallResult> {
-  return recallViaSdk(req);
+  if (!bonfireConfigured()) {
+    return { kind: 'manual_relay_needed', query: req.query, relay: formatManualRelay(req) };
+  }
+  const search = await searchVectorStore(req.query, 5);
+  if (search.ok && search.results.length > 0) {
+    return {
+      kind: 'sdk_response',
+      query: req.query,
+      hits: search.results.length,
+      text: search.results.map(formatHit).join('\n'),
+    };
+  }
+  // search ok-but-empty => vector store not labeled yet. Graceful fallback.
+  return {
+    kind: 'manual_relay_needed',
+    query: req.query,
+    hits: 0,
+    relay: formatManualRelay(req),
+  };
+}
+
+// --- turn mirroring ----------------------------------------------------------
+/**
+ * Mirror the meaningful output of a concierge turn into the bonfire as
+ * episodes — captures, new tasks, completed tasks, side-quest changes.
+ * The knowledge graph grows from ZOE's daily use. Best-effort, fire-and-forget.
+ *
+ * Loosely typed on purpose (captures/task_ops/quest_ops) so this stays
+ * decoupled from concierge.ts's exact types — the caller passes the result's
+ * arrays straight through.
+ */
+export async function mirrorTurn(turn: {
+  captures?: Array<{ text: string; topic: string }>;
+  task_ops?: Array<Record<string, unknown>>;
+  quest_ops?: Array<Record<string, unknown>>;
+}): Promise<{ mirrored: number; skipped: number }> {
+  if (!bonfireConfigured()) return { mirrored: 0, skipped: 0 };
+
+  const episodes: Array<{ body: string; name: string; sourceTag: string }> = [];
+  const stamp = Date.now();
+
+  for (const c of turn.captures ?? []) {
+    if (!c.text?.trim()) continue;
+    episodes.push({
+      body: `ZOE captured a ${c.topic || 'note'} from a conversation with the ZAO team: ${c.text}`,
+      name: `zoe-capture:${stamp}:${episodes.length}`,
+      sourceTag: 'zoe:capture',
+    });
+  }
+
+  for (const op of turn.task_ops ?? []) {
+    const kind = String(op.op ?? '');
+    if (kind === 'add') {
+      const task = (op.task ?? {}) as Record<string, unknown>;
+      const desc = String(task.description ?? task.title ?? '').trim();
+      if (desc) {
+        episodes.push({
+          body: `ZOE added a task for the ZAO team: ${desc}.`,
+          name: `zoe-task-add:${stamp}:${episodes.length}`,
+          sourceTag: 'zoe:task-add',
+        });
+      }
+    } else if (kind === 'complete') {
+      const outcome = String(op.outcome ?? '').trim();
+      episodes.push({
+        body: `ZOE marked a ZAO team task complete (id ${op.id})${outcome ? `: ${outcome}` : '.'}`,
+        name: `zoe-task-done:${stamp}:${episodes.length}`,
+        sourceTag: 'zoe:task-done',
+      });
+    }
+  }
+
+  for (const op of turn.quest_ops ?? []) {
+    const kind = String(op.op ?? '');
+    if (kind === 'add') {
+      const quest = (op.quest ?? {}) as Record<string, unknown>;
+      const title = String(quest.title ?? '').trim();
+      const description = String(quest.description ?? '').trim();
+      if (title) {
+        episodes.push({
+          body: `ZOE added a side quest for the ZAO team: ${title}. ${description}`,
+          name: `zoe-quest-add:${stamp}:${episodes.length}`,
+          sourceTag: 'zoe:quest-add',
+        });
+      }
+    } else if (kind === 'set_main') {
+      const text = String(op.text ?? '').trim();
+      if (text) {
+        episodes.push({
+          body: `ZOE set the ZAO team's main quest: ${text}`,
+          name: `zoe-quest-main:${stamp}:${episodes.length}`,
+          sourceTag: 'zoe:quest-main',
+        });
+      }
+    }
+  }
+
+  let mirrored = 0;
+  let skipped = 0;
+  for (const ep of episodes) {
+    const r = await remember(ep);
+    if (r.ok) mirrored += 1;
+    else skipped += 1;
+  }
+  return { mirrored, skipped };
 }


### PR DESCRIPTION
Completes the stubbed `recall.ts` into a working bridge so ZOE reads from + writes to the ZABAL knowledge graph. Part of the "build out a usable bonfires" goal.

## WRITE - works today (non-admin key verified)

- `remember()` posts a fact/capture/decision as an episode to `/knowledge_graph/episode/create`. Bonfires auto-extraction turns it into KG nodes.
- `mirrorTurn()` runs after every concierge turn - captures, new tasks, completed tasks, side-quest changes mirror into the bonfire. The graph grows from ZOE's daily use. Fire-and-forget, never blocks the reply.
- Secret guard: `containsSecret()` blocks any episode body with an API-key / private-key / token shape before it reaches the graph (mirrors the Python `secret_scan.py` HIGH patterns).

## READ - graceful-degrades until labeling runs

- `recall()` tries `POST /vector_store/search`. Results => returns them. Empty => falls back to the manual-relay pattern (ZOE outputs a RECALL query for Zaal to paste into @zabal_bonfire).
- The 780 episodes ZAO ingested today ARE in the KG (dashboard-confirmed) but the vector store needs an admin-gated labeling pass before search returns hits. `/labeling/hybrid` + `/vector_store/setup` are 403 for non-admin keys.
- The moment an admin runs labeling, `recall()` starts returning real hits with **zero code change** - the path is wired.

## Wiring

| File | Change |
|---|---|
| `recall.ts` | rewritten: remember + mirrorTurn + recall + containsSecret + graceful fallback |
| `index.ts` | turn handler fires mirrorTurn() after applyTaskOps/applyQuestOps |
| `newsletter.ts` | dropped removed 'mcp_response' kind from RecallResult check |
| `bot/.env.example` | documents BONFIRE_API_KEY / BONFIRE_ID / BONFIRE_API_URL |

## Verification (live API, 2026-05-19)

- WRITE `POST /knowledge_graph/episode/create` -> 200 with non-admin key
- READ `POST /vector_store/search` -> 200, returns [] (vector store empty until labeling)
- `/labeling/hybrid`, `/vector_store/setup`, `/paid/agents/{id}/chat` -> 403 Admin access required

## Typecheck

`recall.ts` + `index.ts` clean. 4 pre-existing unrelated errors remain in `teams/shared.ts` (unused ts-expect-error) + `newsletter.ts` (module resolution + implicit any) - not introduced here, not in scope.

## To fully unlock READ

An admin (Zaal, via the Bonfires dashboard Clerk login, or Joshua) needs to run labeling on the ZABAL bonfire once. Then vector search is live + ZOE answers from the KG directly instead of manual relay.