### PR TITLE
docs(events): doc 678 - ZAOstock advisor call recap (May 19)

### DIFF
--- a/research/events/678-zaostock-advisor-call-may19/README.md
+++ b/research/events/678-zaostock-advisor-call-may19/README.md
@@ -1,0 +1,142 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-19
+related-docs: 473, 476, 654, 670, 673
+tier: STANDARD
+---
+
+# 678 - ZAOstock Advisor Call (May 19)
+
+> **Goal:** Capture decisions + action items from the 2026-05-19 advisor call between Zaal and failoften. Covered: Maine venue locked, ZABAL Games 3-month tournament, the Discord scribe bot, Zao Festivals long-term company structure, and a strong advisor push on documentation + retrospectives + sponsorship clarity.
+
+## Key Decisions
+
+| # | Decision | Owner | Status | Confidence |
+|---|----------|-------|--------|-----------|
+| 1 | **Maine venue + stage + tent LOCKED** - verbal confirm from the Parks & Rec director, ZAOstock name written on the calendar. Cost under $1000, likely under $500 (vs $15k Miami). Paperwork not yet signed. | Zaal | WIP | high |
+| 2 | **ZABAL Games = 3-month tournament** - June bootcamp/workshop month, July open build-a-thon + admissions, August 8 curated builders picked by 8 finals leaders. | Zaal | TODO | high |
+| 3 | **Zao Festivals -> long-term company** - next call brings in Adam (SongJam) + Tyler Stambaugh to form a 4-person strategic group (Zaal, Adam, Tyler, failoften) on company structure + startup best-practices. | Zaal | TODO | high |
+| 4 | **Bring the whole team to the non-profit meeting** (~4-5 weeks out, Tue 10:30am) with the art-conference organizers - everyone listens in + captures value. | Zaal | TODO | high |
+| 5 | **Run a Zaalpalooza retrospective** - who got paid, how, who showed up, what broke - to build a repeatable event pattern. Zaal agreed to add as a to-do. | Zaal | TODO | high |
+| 6 | **Build a Discord scribe bot** - kill the manual Craig download/upload/transcript-copy loop. The bot consumes raw meeting data, organizes it, distributes action items. | Zaal | TODO | high |
+| 7 | **Formalize sponsorship tiers + volunteer expectations** - tier 1/2/3 packages (~$10k/$25k/$75k) with explicit deliverables; document volunteer room/board terms upfront. Advisor-pushed, Zaal agreed in principle. | Zaal | TODO | medium |
+| 8 | **Brand strategy: the Maine event is the engine** - every dollar funds the yearly Maine event; partner with other conferences only if they bring money; cut any side idea that does not funnel back into the engine. | Zaal | TODO | high |
+
+## Who
+
+- **Zaal** - running ZAOstock / Zao Festivals.
+- **failoften** - advisor to Zaal on ZAOstock + Zao Festivals operations + strategy. Pushed hard on documentation, retrospectives, role integrity, and sponsorship/volunteer clarity this call.
+- Referenced, not present: **Adam (SongJam)** + **Tyler Stambaugh** (Magnetic content portal, doc 473) - joining the next strategic call.
+
+## Thread 1 - Maine venue locked
+
+ZAOstock has verbal confirmation of venue + stage + tent in Maine. The Parks & Rec director has written the ZAOstock date on the city calendar. The city itself runs a 10-week concert series; ZAOstock is an add-on concert at the end, so the city wants them there - a sharp contrast to New York / Miami ("please let us in for $15,000").
+
+Cost: the city rents the setup for the whole summer (~$7k); ZAOstock adds 3 extra days, so its share is well under $1000, possibly under $500. Miami's venue alone was $15k. The Maine number covers venue + stage + tent together.
+
+**Not signed.** Advisor's tactic: keep talking to the city as if it is already happening ("you're on the schedule, you're doing this"), then send paperwork framed as just formalizing what is already agreed - avoids the end-of-process document avalanche.
+
+## Thread 2 - ZABAL Games 3-month tournament
+
+A 3-month run to generate attention + content:
+- **June** - workshop / bootcamp month. People instruct in 30-second teacher slots. Zaal also writes the ZABAL Games "prompt" (all team + project context) this month.
+- **July** - the prompt is released for an open build-a-thon + admissions.
+- **August** - 8 curated builders, each picked + championed by one of 8 finals leaders who help them stream + gain awareness.
+
+ZAOstock context will be embedded in the prompt and suggested as a build target - but it is 1 of ~4-5 projects, so participation is optional. Consistent with doc 654's June/July/August calendar.
+
+## Thread 3 - The scribe bot + project-management automation
+
+Zaal's current meeting flow: Craig records -> download audio -> upload -> pull transcript -> copy into Skills. He wants a custom Discord scribe bot to remove all that manual handoff - consume raw meeting data, organize it, distribute action items. (This is the doc 670 ZAO Craig concept; this very recap was produced by the `/meeting` skill, the workflow-layer version of the same idea.)
+
+Also: Iman is onboarding as an intern with a separate action-item tracker; Zaal wants it integrated into the main system soon. ZAO Devz ("Zaal Dabs") = a vibe-coding agency angled at giving vibe-coders a crew of testers - testers who can push PR fixes and act as first users. The thesis: most vibe-coded projects fail for lack of testing (~300k vibe-coded projects ship daily, ~0.5% get used).
+
+## Thread 4 - Zao Festivals as a company + tokenomics
+
+Adam (SongJam) has been pushing to structure Zao Festivals into a long-term company. Next call adds Adam + Tyler Stambaugh; the 4-person group (incl. failoften) brings 4 views on how startups run + fail.
+
+Tokenomics: Zaal will eventually create a token - primarily to capture attention at the right time, not to raise money. Done right, it could crowdfund musicians. Zaal wants a "fractal game" where humans only share contributions and the AI does the algorithmic valuation - so any airdrop is contribution-validated and explainable retroactively.
+
+## Thread 5 - The advisor's documentation push
+
+failoften's core advice this call:
+- **Role integrity** - write down your actual role + what is delegated, so an idea is not just "I came up with it" but has an owner, budget, deliverable, timeline.
+- **Minimal documents** - ask an AI for the minimum document set for the event (invoice, etc.), then hand each to whoever owns it.
+- **Retrospective** - document Zaalpalooza so the event becomes a repeatable pattern.
+- **Sponsorship tiers** - tier 1/2/3 with explicit deliverables removes ambiguity; corporate sponsors want to know what they get for $10k / $25k / $75k, not judge the music.
+- **Volunteer clarity** - document room/board + pay expectations upfront instead of resolving them in the moment.
+- Praise: Zaal's recent prep (e.g. honest "budget: zero", "confirmed musicians: zero") is the right move - expectations + transparency are what prevent things from ruining.
+
+## Action Items
+
+All owner Zaal. Routed to the ZAOstock tracker (@ZAOstockTeamBot), not cowork-zaodevz.
+
+| # | Action | Category | Due | Confidence |
+|---|--------|----------|-----|-----------|
+| 1 | Add + run a Zaalpalooza retrospective (talk it through with AI - who paid, who showed, what broke) | Ops | TBD | high |
+| 2 | Schedule the next call with Adam SongJam (8am M/W/F, bump 1-2h for timezone) | Ops | TBD | high |
+| 3 | Prep a summary + agenda of all action items for the Adam 3-way brainstorm | Ops | TBD | high |
+| 4 | Build the Discord scribe bot (replace the Craig manual flow) | Site / Tech | TBD | high |
+| 5 | Write the ZABAL Games "prompt" - all team + project context | Bounty | June 2026 | medium |
+| 6 | Formalize sponsorship packages - tier 1/2/3 with clear deliverables | Ops | TBD | medium |
+| 7 | Document volunteer expectations (room/board, pay) upfront | Ops | TBD | medium |
+| 8 | Define the minimal event document set (ask AI for the list - invoice etc.) | Ops | TBD | medium |
+| 9 | Get the venue paperwork signed - formalize the Parks & Rec verbal | Ops | TBD | high |
+| 10 | Bring the team to the non-profit meeting (~4-5 weeks out, Tue 10:30am) | Ops | TBD | high |
+| 11 | Integrate Iman's separate action-item tracker into the main system | Site / Tech | TBD | medium |
+| 12 | Send failoften the recap of this call | Ops | TBD | high |
+
+## Key Quotes
+
+> "Expectations and transparency are the two hardest things - that's what ruins everything." - Zaal
+
+> "Where we started for Miami was $15,000 for the venue. Where we've started here... it's gonna be less than 1,000, might be less than 500 bucks." - Zaal
+
+> "Every money dollar is gonna be focused on doing [the yearly Maine event] for the next year." - Zaal
+
+> "How did the last project go? What do we need to change for the next one to go better? That's all." - failoften
+
+> "They start to frame it in their minds as it's already done, then you send them the paperwork - this is just formalizing it." - failoften (on getting the venue signed)
+
+> "My goal is to ultimately do a fractal game, but the humans aren't doing the consensus part - the AI is capturing everyone's contributions." - Zaal
+
+## Research Seeds
+
+- Discord scribe bot design - overlaps doc 670 (ZAO Craig) + doc 673 (the `/meeting` skill). Decide bot vs skill boundary.
+- Zaalpalooza retrospective - its own doc once Zaal runs it.
+- ZAOstock sponsorship-tier package spec (tier 1/2/3, deliverables).
+- Karpathy "wiki for LLMs" vault system - Zaal is applying it in Bonfire for ZABAL-specific content.
+- Zao Festivals long-term company structure - 4-person strategic group output.
+- Tokenomics for Zao Festivals - attention-first token, contribution-validated airdrops, musician crowdfunding.
+
+## Memory Updates
+
+- `project_failoften.md` - new person: advisor to Zaal on ZAOstock / Zao Festivals ops + strategy.
+
+## Also See
+
+- [Doc 473 - Magnetic Portal](../473-road-to-zaostock-magnetic-portal/) - Tyler Stambaugh's content portal
+- [Doc 476 - ZAOstock Apr 22 team recap](../476-zaostock-apr22-team-recap/)
+- [Doc 654 - ZABAL Games + Empire V3 (yerbearzerker)](../654-zabal-games-empire-v3-yerbearzerker-meeting/) - ZABAL Games calendar
+- [Doc 670 - Iman call (ZAO Craig)](../670-iman-call-may18-craig-pizzadao/) - the scribe-bot concept
+- [Doc 673 - Meeting Capture Skill](../../dev-workflows/673-meeting-capture-skill/) - the `/meeting` skill that produced this recap
+
+## Distribution Log
+
+- Recap doc: this file (`research/events/678-zaostock-advisor-call-may19/`)
+- ZAOstock actions: 12-item paste-block printed for @ZAOstockTeamBot (ZAOstock tasks live in its Supabase, not cowork-zaodevz)
+- Telegram: recap block printed in session
+- Memory: `project_failoften.md` written
+- Clipboard: next-actions list opened via /clipboard
+- Cross-link: `research/events/_zaostock-hub/` is a festival-ops dimension hub, not a meeting index - no meeting-recap slot there; this doc links it instead
+
+## Transcript
+
+<details>
+<summary>Full transcript - 2026-05-19, ~31 min (12:23-12:54 PM)</summary>
+
+Provided by Zaal as a Gemini-summarized transcript of a video call (Google Meet, with mid-call connectivity issues). Raw transcript retained in the session that produced this doc; not re-pasted here to keep the doc lean. Key spans are quoted verbatim above.
+
+</details>


### PR DESCRIPTION
## Summary

Meeting recap produced by the `/meeting` skill (test run #1 of the v2 skill). Zaal x failoften advisor call, 2026-05-19.

## Distributed

- Recap doc: `research/events/678-zaostock-advisor-call-may19/README.md`
- ZAOstock actions: 12-item paste-block for @ZAOstockTeamBot (printed in session - ZAOstock tasks live in its Supabase, not cowork-zaodevz)
- Telegram: recap block printed in session
- Memory: `project_failoften.md`
- Clipboard: next-actions list

## Captured

8 decisions, 12 actions, 6 quotes. Maine venue locked, ZABAL Games 3-month tournament, Discord scribe bot, Zao Festivals -> company, advisor documentation push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)