### PR TITLE
feat(skill): /meeting v2 + autoresearch hardening (5 iterations)

### DIFF
--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -248,16 +248,20 @@ Use `mcp__claude_ai_Google_Calendar__list_events` to find an event matching `mee
 
 ## Phase 5 - Report
 
-Print to user a one-line per-target summary:
+Print to user a one-line per-target summary. `[OK]` = done, `[--]` = skipped. One line per target that exists this run:
 
 ```
-[OK] actions.json - 7 items appended (commit abc1234)
-[OK] research/events/674-iman-call-may18 - draft written, review before commit
+[OK] Actions - <N> items -> <tracker> (cowork-zaodevz commit <sha> | ZAOstock paste-block)
+[OK] Recap doc - research/events/<NNN>-<slug>/README.md - draft written, review before commit
+[OK] Transcript - research/events/<NNN>-<slug>/transcript.md
 [--] Bonfire - skipped
 [OK] Telegram - block printed above
-[OK] Memory - 1 entry written (project_zao_craig.md)
+[OK] Memory - <N> entries (<slugs>)
 [--] Calendar - no matching event
+[OK] Clipboard - next-actions page opened
 ```
+
+Use the real values from this run. Do not copy the placeholders. The recap-doc number must be the one actually used (collision-safe pick, not a guess).
 
 Then suggest the natural next step: "Review research doc at <path>. Commit + PR when ready, or want me to ship it as a PR off ws/<branch> now?"
 

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools: Read Write Edit Bash WebFetch Skill AskUserQuestion
 Turn any meeting recording or transcript into:
 - Action items in the right project's tracker (cowork-zaodevz `actions.json`, ZAOstock bot - routed in Phase 0)
 - A research recap doc in `research/events/NNN-<slug>/README.md` (always ZAOOS, per doc 673)
+- A row in `research/events/_meetings-index.md` - the one canonical list of every past meeting
 - A copy-paste Telegram bubble for sharing
 - A next-actions clipboard page the moment the meeting ends (Phase 6)
 - Optional Bonfire ingest, memory write, calendar update
@@ -216,6 +217,29 @@ Script reads the actions array, fetches current `data/actions.json` from GitHub,
 - Use the template at [references/meeting-recap-template.md](references/meeting-recap-template.md). Doc 670 is the gold-standard worked example.
 - **Raw transcript goes in a SEPARATE file**, not inline in the README. Write the full transcript to `research/events/NNN-<slug>/transcript.md`. The README's "Transcript" section is a one-line link: `Full transcript: [transcript.md](transcript.md)`. Keeps the recap README lean and grep-friendly; a 10k-word transcript inline buries the signal.
 - Write both files, do NOT commit yet - leave for Zaal review in current `ws/` branch.
+
+### Meeting index (always - every run)
+
+Prepend a row to `research/events/_meetings-index.md` so there is ONE canonical list of every meeting ever captured. This is the answer to "show me all past meetings" - a single grep-free file, newest first.
+
+If `research/events/_meetings-index.md` does not exist, create it with this header:
+
+```markdown
+# Meetings Index
+
+Every meeting processed by /meeting, newest first. Maintained automatically by the skill.
+
+| Date | Title | Project | Attendees | Doc | Actions |
+|------|-------|---------|-----------|-----|---------|
+```
+
+Then insert the new meeting as the first data row:
+
+```
+| 2026-05-19 | ZAOstock advisor call | ZAOstock | Zaal, failoften | [678](678-zaostock-advisor-call-may19/) | 12 |
+```
+
+This is not optional and not project-routed - every meeting, every project, one index. Commit it alongside the recap doc.
 
 ### Bonfire ingest queue
 - Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -34,17 +34,15 @@ Undertriggering is the bigger risk. Fire on weak signal; ask one clarifier befor
 
 ## Input detection
 
-Detect mode from `$ARGUMENTS`:
+Look at what the user supplied (the slash-command argument, a pasted block, or just chat context) and pick the mode:
 
-| If `$ARGUMENTS` matches | Mode |
-|---|---|
-| starts with `https://craig.horse/` | craig_url |
-| starts with `https://fathom.video/` | fathom_url |
-| ends with `.m4a`, `.mp3`, `.wav`, `.mp4`, `.opus` and file exists | local_audio |
-| empty (no args) AND last user message is >200 chars of text | paste |
-| anything else | ask user to clarify |
+- **craig_url** - the input is a URL starting `https://craig.horse/`
+- **fathom_url** - the input is a URL starting `https://fathom.video/`
+- **local_audio** - the input is a path ending `.m4a` / `.mp3` / `.wav` / `.mp4` / `.opus` and the file exists
+- **paste** - the input (or the last user message) is a block of transcript / meeting-notes text, roughly 200+ chars. Also covers the user narrating the meeting in chat ("Iman said X, then Zaal said Y...") - use the conversation context as the transcript.
+- **unclear** - none of the above. Ask the user one question: paste the transcript, give a file path, or give a Craig/Fathom URL.
 
-If user just talks about the meeting in chat ("Iman said X then Zaal said Y..."), treat as paste mode using the conversation context as transcript.
+Do not echo the raw argument back into a table - just classify it and proceed.
 
 ## Phase 0 - Project routing
 

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meeting
 description: Capture meeting transcripts (voice memo, Craig recording, Fathom URL, paste-in-chat) and distribute extracted decisions, action items, and key quotes to the right ZAO surfaces - cowork-zaodevz actions.json, a research/events/NNN-* recap doc, Bonfire ingest queue, Telegram copy-paste block, memory, and calendar. Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or types "/meeting <path-or-url>". Always fires on meeting context - undertriggering wastes the capture.
-allowed-tools: Read Write Edit Bash WebFetch
+allowed-tools: Read Write Edit Bash WebFetch Skill AskUserQuestion
 ---
 
 # /meeting - ZAO Meeting Capture

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -7,12 +7,13 @@ allowed-tools: Read Write Edit Bash WebFetch
 # /meeting - ZAO Meeting Capture
 
 Turn any meeting recording or transcript into:
-- Action items in [cowork-zaodevz `actions.json`](https://github.com/songchaindao-dot/cowork-zaodevz/blob/main/data/actions.json)
-- A research recap doc in `research/events/NNN-<slug>/README.md` (always, per doc 673 decision)
+- Action items in the right project's tracker (cowork-zaodevz `actions.json`, ZAOstock bot - routed in Phase 0)
+- A research recap doc in `research/events/NNN-<slug>/README.md` (always ZAOOS, per doc 673)
 - A copy-paste Telegram bubble for sharing
+- A next-actions clipboard page the moment the meeting ends (Phase 6)
 - Optional Bonfire ingest, memory write, calendar update
 
-One command, six inputs, six output targets. User-gated per run.
+One command, multiple inputs, project-routed output targets. User-gated per run.
 
 Doc 673 has full design + decisions. Read it if context is needed beyond this file.
 
@@ -24,6 +25,12 @@ Doc 673 has full design + decisions. Read it if context is needed beyond this fi
 - Zaal shares a `craig.horse`, `fathom.video`, voice memo path, or audio file path
 
 Undertriggering is the bigger risk. Fire on weak signal; ask one clarifier before doing destructive writes.
+
+## When NOT to fire
+
+- Live audio capture / real-time transcription = the ZAO Craig bot (doc 670), a separate runtime. This skill is post-meeting only.
+- ZAOstock `/gemba /idea /note` quick-notes = `bot/src/capture.ts`, different DB. Not this skill.
+- A general "summarize this article/doc" request with no meeting context.
 
 ## Input detection
 
@@ -38,6 +45,21 @@ Detect mode from `$ARGUMENTS`:
 | anything else | ask user to clarify |
 
 If user just talks about the meeting in chat ("Iman said X then Zaal said Y..."), treat as paste mode using the conversation context as transcript.
+
+## Phase 0 - Project routing
+
+A meeting belongs to a project. The project decides WHERE actions + the Telegram summary go. Ask Zaal in Phase 3 if not obvious; infer from attendees + topic if it is.
+
+| Project | Action target | Telegram target | Recap doc |
+|---|---|---|---|
+| **ZAO Devz / general** (default) | cowork-zaodevz `data/actions.json` (GitHub PUT) | @ZAOcoworkingBot DM | ZAOOS `research/events/` |
+| **ZAOstock** | paste-block for @ZAOstockTeamBot (its tasks live in ZAOstock Supabase, not GitHub) | @ZAOstockTeamBot group | ZAOOS `research/events/` + cross-link in `research/events/_zaostock-hub/` |
+| **ZAO OS dev** | recap doc action table only (no external tracker) | none | ZAOOS `research/events/` |
+| **BCZ / WaveWarZ / other** | recap doc action table only | none | ZAOOS `research/events/` |
+
+**Rule that does NOT change per project: the recap doc ALWAYS lands in ZAOOS `research/events/`.** Research is permanent institutional memory and never graduates out of ZAOOS (CLAUDE.md monorepo-as-lab). One repo = one searchable archive of every meeting, across every project. Do not scatter recaps into graduated repos.
+
+What DOES route per project is the **action tracker** and the **Telegram destination**. A ZAOstock meeting's todos belong in the ZAOstock tracker, not the cowork-zaodevz tracker.
 
 ## Phase 1 - Acquire transcript
 
@@ -71,7 +93,15 @@ Use WebFetch on the share URL to extract transcript JSON from the page. Fathom s
 
 ## Phase 2 - Extract structure
 
-Read the transcript. Output JSON matching the schema in [references/output-schema.md](references/output-schema.md):
+Multi-pass extraction, NOT one monolithic prompt (doc 676 - monolithic extraction hallucinates). Run these passes in order, each over the same transcript:
+
+1. **Pass A - meeting metadata.** date, duration, title, attendees, platform. Date never invented - from transcript, file mtime, or ask.
+2. **Pass B - decisions.** Things explicitly decided/agreed in the call. Verbatim-anchored.
+3. **Pass C - actions.** Concrete follow-ups with an owner. One owner each.
+4. **Pass D - quotes.** 3-8 load-bearing verbatim quotes.
+5. **Pass E - research seeds + memory updates.** New topics / new entities only. Before deciding `memory_updates`, run an entity cross-check (see below) - a name already documented gets LINKED, not re-created.
+
+Output one JSON object matching the schema in [references/output-schema.md](references/output-schema.md):
 
 ```json
 {
@@ -83,10 +113,10 @@ Read the transcript. Output JSON matching the schema in [references/output-schem
     "platform": "Telegram voice | Google Meet | Zoom | in-person | Discord/Craig | Fathom"
   },
   "decisions": [
-    {"id": 1, "text": "...", "owner": "Zaal|Iman|Both|ThyRev|Samantha", "status": "TODO"}
+    {"id": 1, "text": "...", "owner": "Zaal|Iman|Both|ThyRev|Samantha", "status": "TODO", "confidence": "high|medium|low"}
   ],
   "actions": [
-    {"title": "...", "owner": "...", "due": "YYYY-MM-DD or empty", "category": "Site / Tech|Ops|WaveWarZ Zambia|ZAO Devz|Bounty|Social|Other"}
+    {"title": "...", "owner": "...", "due": "YYYY-MM-DD or empty", "category": "Site / Tech|Ops|WaveWarZ Zambia|ZAO Devz|Bounty|Social|Other", "confidence": "high|medium|low"}
   ],
   "quotes": [
     {"speaker": "...", "text": "..."}
@@ -98,43 +128,96 @@ Read the transcript. Output JSON matching the schema in [references/output-schem
 
 **Rules for extraction:**
 - Verbatim where possible for quotes. No paraphrasing of decisions.
-- If owner is ambiguous, set `owner: "Both"` and surface in the user-confirm step.
-- If due date is ambiguous, leave empty. Never invent.
+- Every decision + action carries a `confidence` field:
+  - `high` - explicit in transcript, clear owner, clear intent.
+  - `medium` - implied or owner/scope slightly fuzzy.
+  - `low` - inferred, ambiguous owner, or transcript span was garbled.
+- If owner is ambiguous, set `owner: "Both"` + `confidence: "low"` and surface it in Phase 3. Never guess a specific owner.
+- If due date is ambiguous, leave empty + `confidence: "medium"` or lower. Never invent. Relative dates ("by Thursday") -> absolute, anchored to `meeting.date`.
 - Category must come from the enum above (matches actions.json schema).
 - 3-8 quotes max - pick load-bearing ones (decisions, commitments, surprising info).
 - `memory_updates` only if a NEW person, project, or strategy decision appeared (not for things already in `~/.claude/projects/.../memory/MEMORY.md`).
+- Never silently drop an uncertain item. A `low`-confidence item still goes in the JSON - Phase 3 surfaces it for Zaal.
+
+### Entity cross-check (Pass E)
+
+For EVERY attendee and every referenced person/project name, before deciding it is "new":
+
+```bash
+grep -ril "<name>" "/Users/zaalpanthaki/Documents/ZAO OS V1/research/" 2>/dev/null | head -3
+grep -i "<name>" ~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/MEMORY.md
+```
+
+- **Hit in research/** - the entity exists. Link the doc number in the recap (e.g. "Tyler Stambaugh, doc 473"). Do NOT create a memory.
+- **Hit in MEMORY.md** - the entity has a memory. Link `[[slug]]`. Do NOT create a duplicate.
+- **No hit anywhere** - genuinely new. Add a `memory_updates` entry.
+
+This stops the skill re-introducing known people as if they were new (test run 1 missed Tyler Stambaugh = doc 473).
+
+## Phase 2.5 - Clarify gaps
+
+Before the Phase 3 confirm, scan the extraction for genuine gaps and ask Zaal about them in ONE batched question round. Ask only when the answer changes the doc - not for things you can infer.
+
+Ask about:
+- A referenced person with zero context AND no hit in the Pass E cross-check (who are they, what role).
+- A decision/action where the owner is genuinely unknown (not just "Both").
+- A name that could be a mis-transcription (surface both spellings).
+- A project-routing call that is not obvious from attendees + topic.
+
+If the extraction is clean and nothing is genuinely ambiguous, skip Phase 2.5 and go straight to Phase 3. Do not invent questions to fill the phase. Zaal has said he is fine with the skill asking questions when they are real - so ask the real ones here, before the confirm, not after.
 
 ## Phase 3 - Present + confirm
 
-Show the extracted JSON inline as a markdown table for each section. Ask Zaal:
+Show the extracted JSON inline as a markdown table for each section (decisions, actions, quotes).
 
-> "Extracted N decisions, M actions, K quotes. Edits? If clean, which targets fire?"
+**Before the confirm prompt, render a VERIFY block** listing every `confidence: low` (and optionally `medium`) decision + action:
+
+```
+VERIFY - low-confidence extractions, confirm or correct each:
+- [action] "<title>" - owner unclear, transcript said "..."
+- [decision] "<text>" - inferred, not explicit
+```
+
+If the VERIFY block is non-empty, Zaal must resolve those items before any actions.json write. Do not write low-confidence items unedited.
+
+Then ask Zaal:
+
+> "Extracted N decisions, M actions, K quotes (J flagged to verify above).
+> Project: <inferred project> - correct? (ZAO Devz / ZAOstock / ZAO OS / other)
+> Edits? If clean, which targets fire?"
 >
-> Targets:
-> - [x] actions.json bulk append (default ON)
-> - [x] research/events/NNN-<slug>/README.md (default ON, every meeting per doc 673)
+> Targets (action target depends on project - see Phase 0):
+> - [x] Action tracker for `<project>` (default ON)
+> - [x] research/events/NNN-<slug>/README.md (default ON, every meeting, always ZAOOS)
 > - [ ] Bonfire ingest queue (opt-in)
 > - [ ] Telegram copy-paste block (opt-in, default OFF - print only on request)
 > - [ ] Memory writes (opt-in, confirm each)
 > - [ ] Calendar event update (opt-in if title matches a Google Cal event)
 
-Wait for Zaal's reply before any destructive write.
+Wait for Zaal's reply before any destructive write. Confirm the project before touching any tracker - a ZAOstock meeting must not write into the cowork-zaodevz tracker.
 
 ## Phase 4 - Distribute
 
 For each enabled target, follow the playbook in [references/distribution-targets.md](references/distribution-targets.md). Summary:
 
-### actions.json (cowork-zaodevz)
+### Action tracker (routed by project - Phase 0)
+
+**Project = ZAO Devz / general:** write to cowork-zaodevz `data/actions.json`.
 ```bash
 bash ${CLAUDE_SKILL_DIR}/scripts/append-actions.sh /tmp/extracted-actions.json
 ```
 Script reads the actions array, fetches current `data/actions.json` from GitHub, appends new items starting at `max(existing.id) + 1`, PUTs back via `gh api` with sha. One commit per meeting.
 
+**Project = ZAOstock:** do NOT write to cowork-zaodevz. ZAOstock tasks live in the ZAOstock Supabase behind @ZAOstockTeamBot. v1: print a paste-block of the action items for Zaal to drop into @ZAOstockTeamBot (`/note` or task command). Also note them in the recap doc's action table. (v2: a `zaostock-actions.sh` that inserts into ZAOstock Supabase via service-role key - deferred until the ZAOstock task schema is confirmed.)
+
+**Project = ZAO OS / BCZ / WaveWarZ / other:** no external tracker. Actions live only in the recap doc's action table.
+
 ### research/events/NNN-<slug>/README.md
 - Find next number: `find research -maxdepth 3 -type d -name '[0-9]*' | grep -oE '/[0-9]+' | tr -d '/' | sort -n | tail -1`
 - Slug from meeting title: lowercase, hyphens, no special chars, max 50 chars.
 - Use the template at [references/meeting-recap-template.md](references/meeting-recap-template.md). Doc 670 is the gold-standard worked example.
-- Write file, do NOT commit yet - leave for Zaal review in current `ws/` branch.
+- **Raw transcript goes in a SEPARATE file**, not inline in the README. Write the full transcript to `research/events/NNN-<slug>/transcript.md`. The README's "Transcript" section is a one-line link: `Full transcript: [transcript.md](transcript.md)`. Keeps the recap README lean and grep-friendly; a 10k-word transcript inline buries the signal.
+- Write both files, do NOT commit yet - leave for Zaal review in current `ws/` branch.
 
 ### Bonfire ingest queue
 - Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
@@ -180,6 +263,35 @@ Print to user a one-line per-target summary:
 
 Then suggest the natural next step: "Review research doc at <path>. Commit + PR when ready, or want me to ship it as a PR off ws/<branch> now?"
 
+## Phase 6 - Next-actions clipboard (default ON)
+
+After the report, auto-hand-off the next-actions to the `/clipboard` skill so Zaal has a clean copyable page the moment the meeting ends. This is the "what do I do now" surface - distinct from the Telegram block (which is for sharing the recap).
+
+Build a plain next-actions list - owner-grouped, due-sorted:
+
+```
+Next actions - <meeting title> (<date>)
+
+ZAAL
+- <action> (due <date>)
+- <action>
+
+IMAN
+- <action> (due <date>)
+
+BOTH
+- <action>
+```
+
+Then invoke the `/clipboard` skill with that list as the content. `/clipboard` opens a local browser page with the text ready to copy in one click (or copies to the macOS clipboard via pbcopy).
+
+Rules:
+- Default ON. Skip only if Zaal says "no clipboard" or there are zero actions.
+- Next-actions list = the `actions[]` array only. Not decisions, not quotes - this is the do-now list.
+- Owner-grouped so Zaal can paste each person's slice into their DM/GC directly.
+- If a single owner (e.g. all Zaal), skip the grouping headers - just the flat list.
+- This runs AFTER the tracker write, so the clipboard list and the tracker agree.
+
 ## Hard guardrails
 
 - **Never auto-write to actions.json without Phase 3 user-confirm.** The 67-item bulk fix (commit `c80caff8`) was authorized explicitly; default skill behavior must always confirm.
@@ -197,6 +309,10 @@ Then suggest the natural next step: "Review research doc at <path>. Commit + PR 
 - Do NOT use emojis in any output (per global `feedback_no_emojis`).
 - Do NOT use em dashes (per global `feedback_no_em_dashes`).
 
+## Doc numbering (collision-safe)
+
+When creating the recap doc, parallel Claude sessions may race for the same number. Pick the next number defensively: `git fetch origin` first, scan `research/` for the max, and if the chosen folder already exists, increment again. Per doc 663 collision-tolerance, a small gap in numbering is fine - a collision is not.
+
 ## References
 
 - [output-schema.md](references/output-schema.md) - JSON schema + worked example from doc 670
@@ -207,4 +323,12 @@ Then suggest the natural next step: "Review research doc at <path>. Commit + PR 
 
 - `scripts/transcribe.sh` - SCP to VPS, run Whisper, SCP back
 - `scripts/fetch-craig.sh` - curl Craig recording URL, extract audio
-- `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append
+- `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append (ZAO Devz project only)
+
+## Evals
+
+- `evals/README.md` - regression fixtures (doc 670 + doc 675 transcripts). Run after editing this skill.
+
+## Engineering basis
+
+Skill structure follows doc 676 (skill-engineering best practices): multi-pass extraction, confidence thresholding, human-review fallback, progressive disclosure. Read doc 676 before refactoring this skill.

--- a/.claude/skills/meeting/evals/README.md
+++ b/.claude/skills/meeting/evals/README.md
@@ -1,0 +1,36 @@
+# /meeting Skill Evals
+
+Regression fixtures for the meeting-capture skill. Run these after editing `SKILL.md` or the extraction logic to confirm the skill still extracts correctly.
+
+## How to run
+
+Feed the fixture transcript to the skill in paste mode, then diff the extraction JSON against the expected shape below. This is a manual eval - no harness yet. Anthropic skill-creator recommends an `evals/` dir; this is the lightweight version.
+
+## Fixture 1 - Iman call (doc 670)
+
+- **Source transcript:** `research/events/670-iman-call-may18-craig-pizzadao/README.md`
+- **Project:** ZAO Devz
+- **Expected:** 4 decisions, ~4-8 actions, 3+ quotes. Owners only Zaal / Iman / Both. Decision about ZAO Craig bot must be present. Due dates: PizzaDAO pitch = 2026-05-22, ZABAL Games signup = 2026-05-20.
+- **Pass criteria:** no hallucinated owner outside {Zaal, Iman, Both}; ZABAL date is 2026-05-20 not Friday; all 4 decisions present.
+
+## Fixture 2 - Tanja Fractal Book call (doc 675)
+
+- **Source transcript:** `research/events/675-tanja-fractal-book-call-may18/README.md`
+- **Project:** ZAO OS / general (Fractal)
+- **Expected:** 4 decisions, 7 actions, 5+ quotes. New person "Tanja" detected -> 1 memory_update (`project_tanja_fractal_book`). Owner "Tanja" appears (outside the core allowlist) -> must surface as a non-team owner, not silently dropped.
+- **Pass criteria:** Tanja recognized as a new entity; memory_update proposed; the "Reference Book" project captured in research_seeds or memory; no invented due dates.
+
+## What each fixture checks
+
+| Check | Fixture 1 | Fixture 2 |
+|---|---|---|
+| Owner allowlist enforced | yes | yes (non-team owner surfaced) |
+| Relative date -> absolute | yes (Thursday/Friday) | n/a |
+| New-entity -> memory_update | n/a | yes (Tanja) |
+| confidence field on every item | yes | yes |
+| Project routing inferred | ZAO Devz | ZAO OS / general |
+| No hallucinated action items | yes | yes |
+
+## Adding a fixture
+
+Every time `/meeting` processes a real meeting, that recap doc becomes a candidate fixture. Add it here with: source path, project, expected counts, pass criteria.

--- a/.claude/skills/meeting/references/distribution-targets.md
+++ b/.claude/skills/meeting/references/distribution-targets.md
@@ -2,7 +2,17 @@
 
 How each target gets the extracted output. Skill reads this when Phase 3 confirm flips a target ON.
 
-## 1. actions.json (cowork-zaodevz)
+## 1. Action tracker (routed by project - SKILL.md Phase 0)
+
+The action target depends on the meeting's project:
+
+| Project | Action target | See |
+|---|---|---|
+| ZAO Devz / general | cowork-zaodevz `data/actions.json` (GitHub PUT) | 1a below |
+| ZAOstock | paste-block for @ZAOstockTeamBot | 1b below |
+| ZAO OS / BCZ / WaveWarZ / other | recap doc action table only - no external tracker | n/a |
+
+### 1a. cowork-zaodevz actions.json (project = ZAO Devz / general)
 
 **Target:** `data/actions.json` on `main` of `songchaindao-dot/cowork-zaodevz`.
 **Method:** GitHub Contents API PUT via `gh api`. Bulk append in one commit.
@@ -46,6 +56,21 @@ chore(actions): meeting recap YYYY-MM-DD <title slug> (+N items)
 
 Source: research/events/NNN-<slug>/README.md
 ```
+
+### 1b. ZAOstock paste-block (project = ZAOstock)
+
+Do NOT write to cowork-zaodevz. ZAOstock tasks live in the ZAOstock Supabase behind @ZAOstockTeamBot.
+
+v1: print a single fenced paste-block of the action items for Zaal to drop into @ZAOstockTeamBot. Format:
+
+```
+ZAOstock meeting YYYY-MM-DD - action items
+
+1. <action> (owner)
+2. <action> (owner)
+```
+
+Also keep the actions in the recap doc's action table. v2 (deferred): a `zaostock-actions.sh` inserting into ZAOstock Supabase via service-role key, once the ZAOstock task schema is confirmed.
 
 ## 2. Research doc (research/events/NNN-<slug>/README.md)
 

--- a/.claude/skills/meeting/references/meeting-recap-template.md
+++ b/.claude/skills/meeting/references/meeting-recap-template.md
@@ -86,14 +86,17 @@ Files written to `~/.claude/projects/.../memory/`:
 
 ## Transcript
 
-<details>
-<summary>Full transcript ({duration_min} min)</summary>
+Full transcript: [transcript.md](transcript.md)
+```
 
-\`\`\`
-{full transcript text - paste from Whisper output or original paste}
-\`\`\`
+The raw transcript is written to a sibling file `transcript.md` in the same folder - NOT inline in the README. The README stays lean (decisions + actions + quotes are the signal); the transcript is one click away for anyone who needs the raw record.
 
-</details>
+`transcript.md` format:
+
+```markdown
+# Transcript - {Meeting Title} ({date})
+
+{full transcript text - Whisper output or original paste, verbatim}
 ```
 
 ## Style notes

--- a/.claude/skills/meeting/references/output-schema.md
+++ b/.claude/skills/meeting/references/output-schema.md
@@ -13,12 +13,14 @@ Single JSON object. All fields required except where noted optional.
     "attendees": ["Zaal", "Iman"],
     "platform": "Telegram voice"
   },
+  "project": "zao-devz | zaostock | zao-os | other",
   "decisions": [
     {
       "id": 1,
       "text": "Build ZAO Craig bot - live audio + Whisper + auto-extract todos",
       "owner": "Zaal",
-      "status": "TODO"
+      "status": "TODO",
+      "confidence": "high"
     }
   ],
   "actions": [
@@ -26,7 +28,8 @@ Single JSON object. All fields required except where noted optional.
       "title": "Iman to study RSVPizza repo + build PizzaDAO Zambia brand on top",
       "owner": "Iman",
       "due": "2026-05-22",
-      "category": "WaveWarZ Zambia"
+      "category": "WaveWarZ Zambia",
+      "confidence": "high"
     }
   ],
   "quotes": [
@@ -49,6 +52,19 @@ Single JSON object. All fields required except where noted optional.
 ```
 
 ## Enums
+
+### `project` (top-level - routes the action tracker, see SKILL.md Phase 0)
+- `zao-devz` - default. Actions -> cowork-zaodevz `data/actions.json`.
+- `zaostock` - actions -> @ZAOstockTeamBot paste-block (ZAOstock Supabase, not GitHub).
+- `zao-os` - actions stay in the recap doc table only.
+- `other` - BCZ / WaveWarZ / misc. Recap doc table only.
+
+The recap doc ALWAYS goes to ZAOOS `research/events/` regardless of project.
+
+### `confidence` (every decision + action)
+- `high` - explicit in transcript, clear owner, clear intent.
+- `medium` - implied, or owner/scope slightly fuzzy.
+- `low` - inferred, ambiguous owner, or garbled transcript span. Surfaced in the Phase 3 VERIFY block; never auto-written.
 
 ### `owner` (decisions + actions)
 - `Zaal`
@@ -86,6 +102,7 @@ Free text. Examples: `Telegram voice`, `Google Meet`, `Zoom`, `Discord/Craig`, `
 | `meeting.title` | 5-80 chars. Format: `<who> - <topic 1> + <topic 2>`. Use doc 670 as template. |
 | `meeting.attendees` | Array of canonical first-names. `Zaal`, `Iman`, `Cassie`, `Hannah`, etc. Match existing memory slugs where possible. |
 | `decisions[].text` | Verbatim where possible. No paraphrasing. Past tense for things decided in the call. |
+| `decisions[].confidence` / `actions[].confidence` | `high` / `medium` / `low`. Required on every item. `low` -> Phase 3 VERIFY block, never auto-written. |
 | `actions[].title` | Imperative verb-first. "Iman to X" or just "X". 10-120 chars. |
 | `actions[].due` | YYYY-MM-DD or empty string. Never invent. If transcript says "by Thursday", convert to absolute date using meeting.date as anchor. |
 | `quotes[].text` | Verbatim. 5-200 chars. Pick the load-bearing 3-8 quotes total. |

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -1,0 +1,22 @@
+# Meetings Index
+
+Every meeting captured as a research recap, newest first. Maintained automatically by the `/meeting` skill (doc 673/676); seeded from existing recap docs.
+
+| Date | Title | Project | Attendees | Doc | Actions |
+|------|-------|---------|-----------|-----|---------|
+| 2026-05-19 | ZAOstock advisor call | ZAOstock | Zaal, failoften | [678](678-zaostock-advisor-call-may19/) | 12 |
+| 2026-05-18 | Iman call - ZAO Craig + PizzaDAO Zambia | ZAO Devz | Zaal, Iman | [670](670-iman-call-may18-craig-pizzadao/) | ~4 |
+| 2026-05-18 | Tanja Fractal Book call | ZAO OS / Fractal | Zaal, Tanja | [675](675-tanja-fractal-book-call-may18/) | 7 |
+| 2026-05-16 | ZABAL Games + Empire V3 - yerbearzerker | ZABAL Games | Zaal, Iman, yerbearzerker | [654](654-zabal-games-empire-v3-yerbearzerker-meeting/) | n/a |
+| 2026-05-04 | ZAOstock cobuild - six circles | ZAOstock | team | [609](609-zaostock-cobuild-six-circles-may4/) | n/a |
+| 2026-05-04 | WaveWarZ Africa - RAM + SongChainn | WaveWarZ | team | [608](608-wavewarz-africa-ram-songchain-may4/) | n/a |
+| 2026-05-xx | Adam sync - commercial leaderboard | ZAOstock | Zaal, Adam | [599](../business/599-adam-meeting-may2026-commercial-leaderboard/) | n/a |
+| 2026-04-22 | ZAOstock Apr 22 team recap | ZAOstock | team | [476](476-zaostock-apr22-team-recap/) | n/a |
+| 2026-xx-xx | Intori SCIS + Tuum Tech DB meeting | ZAO OS | Zaal + Intori | [571](../farcaster/571-intori-scis-tuum-tech-db-meeting/) | n/a |
+
+## Notes
+
+- Newest meeting goes at the top, right under the header row.
+- "Actions" = count of action items extracted. "n/a" = recap predates the action-count convention.
+- Most docs live in `research/events/`; a few sit in their topic folder (path shown relative).
+- This file is the answer to "show me all past meetings" - no grep needed.


### PR DESCRIPTION
## Summary

Re-lands the full `/meeting` v2 skill (PR #570's v2 commit got stomped by a parallel session - main only ever merged v1) and adds 5 autoresearch hardening iterations on top.

## v2 baseline (iteration 0)

Phase 0 project routing, Phase 2.5 clarify-gaps, Phase 6 next-actions clipboard, multi-pass extraction, confidence scoring + VERIFY block, entity cross-check, evals/.

## Autoresearch loop - 5 iterations, all kept

| Iter | Fix |
|---|---|
| 1 | Input-detection no longer embeds `$ARGUMENTS` in a table - it rendered as garbage when the skill ran (caught in live test) |
| 2 | `distribution-targets.md` updated for Phase 0 routing - was stale cowork-zaodevz-only |
| 3 | Phase 5 report - fixed stale doc-number example, added transcript + clipboard lines, project-routed action wording |
| 4 | `allowed-tools` adds `Skill` (Phase 6 invokes /clipboard) + `AskUserQuestion` (Phase 2.5/3) |
| 5 | Skill now maintains `research/events/_meetings-index.md` - one canonical list of every past meeting (answers "show me all past meetings" with zero grep). Index file seeded with 9 existing meeting docs. |

## Test evidence

Skill ran end-to-end on 3 real meetings this session: doc 670 (Iman call), 675 (Tanja Fractal Book), 678 (ZAOstock advisor). Routing, multi-pass extraction, confidence/VERIFY, and distribution all fired correctly. Fixes 1-5 came from observing those runs.

All 3 scripts pass `bash -n`. Skill mirrored to `~/.claude/skills/meeting/` so `/meeting` works on every branch + worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)