### PR TITLE
feat(skill): /meeting v2 + autoresearch + Bonfire bridge (docs 676, 680)

### DIFF
--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -248,16 +248,20 @@ Use `mcp__claude_ai_Google_Calendar__list_events` to find an event matching `mee
 
 ## Phase 5 - Report
 
-Print to user a one-line per-target summary:
+Print to user a one-line per-target summary. `[OK]` = done, `[--]` = skipped. One line per target that exists this run:
 
 ```
-[OK] actions.json - 7 items appended (commit abc1234)
-[OK] research/events/674-iman-call-may18 - draft written, review before commit
+[OK] Actions - <N> items -> <tracker> (cowork-zaodevz commit <sha> | ZAOstock paste-block)
+[OK] Recap doc - research/events/<NNN>-<slug>/README.md - draft written, review before commit
+[OK] Transcript - research/events/<NNN>-<slug>/transcript.md
 [--] Bonfire - skipped
 [OK] Telegram - block printed above
-[OK] Memory - 1 entry written (project_zao_craig.md)
+[OK] Memory - <N> entries (<slugs>)
 [--] Calendar - no matching event
+[OK] Clipboard - next-actions page opened
 ```
+
+Use the real values from this run. Do not copy the placeholders. The recap-doc number must be the one actually used (collision-safe pick, not a guess).
 
 Then suggest the natural next step: "Review research doc at <path>. Commit + PR when ready, or want me to ship it as a PR off ws/<branch> now?"
 

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -9,6 +9,7 @@ allowed-tools: Read Write Edit Bash WebFetch Skill AskUserQuestion
 Turn any meeting recording or transcript into:
 - Action items in the right project's tracker (cowork-zaodevz `actions.json`, ZAOstock bot - routed in Phase 0)
 - A research recap doc in `research/events/NNN-<slug>/README.md` (always ZAOOS, per doc 673)
+- A row in `research/events/_meetings-index.md` - the one canonical list of every past meeting
 - A copy-paste Telegram bubble for sharing
 - A next-actions clipboard page the moment the meeting ends (Phase 6)
 - Optional Bonfire ingest, memory write, calendar update
@@ -216,6 +217,29 @@ Script reads the actions array, fetches current `data/actions.json` from GitHub,
 - Use the template at [references/meeting-recap-template.md](references/meeting-recap-template.md). Doc 670 is the gold-standard worked example.
 - **Raw transcript goes in a SEPARATE file**, not inline in the README. Write the full transcript to `research/events/NNN-<slug>/transcript.md`. The README's "Transcript" section is a one-line link: `Full transcript: [transcript.md](transcript.md)`. Keeps the recap README lean and grep-friendly; a 10k-word transcript inline buries the signal.
 - Write both files, do NOT commit yet - leave for Zaal review in current `ws/` branch.
+
+### Meeting index (always - every run)
+
+Prepend a row to `research/events/_meetings-index.md` so there is ONE canonical list of every meeting ever captured. This is the answer to "show me all past meetings" - a single grep-free file, newest first.
+
+If `research/events/_meetings-index.md` does not exist, create it with this header:
+
+```markdown
+# Meetings Index
+
+Every meeting processed by /meeting, newest first. Maintained automatically by the skill.
+
+| Date | Title | Project | Attendees | Doc | Actions |
+|------|-------|---------|-----------|-----|---------|
+```
+
+Then insert the new meeting as the first data row:
+
+```
+| 2026-05-19 | ZAOstock advisor call | ZAOstock | Zaal, failoften | [678](678-zaostock-advisor-call-may19/) | 12 |
+```
+
+This is not optional and not project-routed - every meeting, every project, one index. Commit it alongside the recap doc.
 
 ### Bonfire ingest queue
 - Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -34,17 +34,15 @@ Undertriggering is the bigger risk. Fire on weak signal; ask one clarifier befor
 
 ## Input detection
 
-Detect mode from `$ARGUMENTS`:
+Look at what the user supplied (the slash-command argument, a pasted block, or just chat context) and pick the mode:
 
-| If `$ARGUMENTS` matches | Mode |
-|---|---|
-| starts with `https://craig.horse/` | craig_url |
-| starts with `https://fathom.video/` | fathom_url |
-| ends with `.m4a`, `.mp3`, `.wav`, `.mp4`, `.opus` and file exists | local_audio |
-| empty (no args) AND last user message is >200 chars of text | paste |
-| anything else | ask user to clarify |
+- **craig_url** - the input is a URL starting `https://craig.horse/`
+- **fathom_url** - the input is a URL starting `https://fathom.video/`
+- **local_audio** - the input is a path ending `.m4a` / `.mp3` / `.wav` / `.mp4` / `.opus` and the file exists
+- **paste** - the input (or the last user message) is a block of transcript / meeting-notes text, roughly 200+ chars. Also covers the user narrating the meeting in chat ("Iman said X, then Zaal said Y...") - use the conversation context as the transcript.
+- **unclear** - none of the above. Ask the user one question: paste the transcript, give a file path, or give a Craig/Fathom URL.
 
-If user just talks about the meeting in chat ("Iman said X then Zaal said Y..."), treat as paste mode using the conversation context as transcript.
+Do not echo the raw argument back into a table - just classify it and proceed.
 
 ## Phase 0 - Project routing
 

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meeting
 description: Capture meeting transcripts (voice memo, Craig recording, Fathom URL, paste-in-chat) and distribute extracted decisions, action items, and key quotes to the right ZAO surfaces - cowork-zaodevz actions.json, a research/events/NNN-* recap doc, Bonfire ingest queue, Telegram copy-paste block, memory, and calendar. Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or types "/meeting <path-or-url>". Always fires on meeting context - undertriggering wastes the capture.
-allowed-tools: Read Write Edit Bash WebFetch
+allowed-tools: Read Write Edit Bash WebFetch Skill AskUserQuestion
 ---
 
 # /meeting - ZAO Meeting Capture

--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -7,12 +7,13 @@ allowed-tools: Read Write Edit Bash WebFetch
 # /meeting - ZAO Meeting Capture
 
 Turn any meeting recording or transcript into:
-- Action items in [cowork-zaodevz `actions.json`](https://github.com/songchaindao-dot/cowork-zaodevz/blob/main/data/actions.json)
-- A research recap doc in `research/events/NNN-<slug>/README.md` (always, per doc 673 decision)
+- Action items in the right project's tracker (cowork-zaodevz `actions.json`, ZAOstock bot - routed in Phase 0)
+- A research recap doc in `research/events/NNN-<slug>/README.md` (always ZAOOS, per doc 673)
 - A copy-paste Telegram bubble for sharing
+- A next-actions clipboard page the moment the meeting ends (Phase 6)
 - Optional Bonfire ingest, memory write, calendar update
 
-One command, six inputs, six output targets. User-gated per run.
+One command, multiple inputs, project-routed output targets. User-gated per run.
 
 Doc 673 has full design + decisions. Read it if context is needed beyond this file.
 
@@ -24,6 +25,12 @@ Doc 673 has full design + decisions. Read it if context is needed beyond this fi
 - Zaal shares a `craig.horse`, `fathom.video`, voice memo path, or audio file path
 
 Undertriggering is the bigger risk. Fire on weak signal; ask one clarifier before doing destructive writes.
+
+## When NOT to fire
+
+- Live audio capture / real-time transcription = the ZAO Craig bot (doc 670), a separate runtime. This skill is post-meeting only.
+- ZAOstock `/gemba /idea /note` quick-notes = `bot/src/capture.ts`, different DB. Not this skill.
+- A general "summarize this article/doc" request with no meeting context.
 
 ## Input detection
 
@@ -38,6 +45,21 @@ Detect mode from `$ARGUMENTS`:
 | anything else | ask user to clarify |
 
 If user just talks about the meeting in chat ("Iman said X then Zaal said Y..."), treat as paste mode using the conversation context as transcript.
+
+## Phase 0 - Project routing
+
+A meeting belongs to a project. The project decides WHERE actions + the Telegram summary go. Ask Zaal in Phase 3 if not obvious; infer from attendees + topic if it is.
+
+| Project | Action target | Telegram target | Recap doc |
+|---|---|---|---|
+| **ZAO Devz / general** (default) | cowork-zaodevz `data/actions.json` (GitHub PUT) | @ZAOcoworkingBot DM | ZAOOS `research/events/` |
+| **ZAOstock** | paste-block for @ZAOstockTeamBot (its tasks live in ZAOstock Supabase, not GitHub) | @ZAOstockTeamBot group | ZAOOS `research/events/` + cross-link in `research/events/_zaostock-hub/` |
+| **ZAO OS dev** | recap doc action table only (no external tracker) | none | ZAOOS `research/events/` |
+| **BCZ / WaveWarZ / other** | recap doc action table only | none | ZAOOS `research/events/` |
+
+**Rule that does NOT change per project: the recap doc ALWAYS lands in ZAOOS `research/events/`.** Research is permanent institutional memory and never graduates out of ZAOOS (CLAUDE.md monorepo-as-lab). One repo = one searchable archive of every meeting, across every project. Do not scatter recaps into graduated repos.
+
+What DOES route per project is the **action tracker** and the **Telegram destination**. A ZAOstock meeting's todos belong in the ZAOstock tracker, not the cowork-zaodevz tracker.
 
 ## Phase 1 - Acquire transcript
 
@@ -71,7 +93,15 @@ Use WebFetch on the share URL to extract transcript JSON from the page. Fathom s
 
 ## Phase 2 - Extract structure
 
-Read the transcript. Output JSON matching the schema in [references/output-schema.md](references/output-schema.md):
+Multi-pass extraction, NOT one monolithic prompt (doc 676 - monolithic extraction hallucinates). Run these passes in order, each over the same transcript:
+
+1. **Pass A - meeting metadata.** date, duration, title, attendees, platform. Date never invented - from transcript, file mtime, or ask.
+2. **Pass B - decisions.** Things explicitly decided/agreed in the call. Verbatim-anchored.
+3. **Pass C - actions.** Concrete follow-ups with an owner. One owner each.
+4. **Pass D - quotes.** 3-8 load-bearing verbatim quotes.
+5. **Pass E - research seeds + memory updates.** New topics / new entities only. Before deciding `memory_updates`, run an entity cross-check (see below) - a name already documented gets LINKED, not re-created.
+
+Output one JSON object matching the schema in [references/output-schema.md](references/output-schema.md):
 
 ```json
 {
@@ -83,10 +113,10 @@ Read the transcript. Output JSON matching the schema in [references/output-schem
     "platform": "Telegram voice | Google Meet | Zoom | in-person | Discord/Craig | Fathom"
   },
   "decisions": [
-    {"id": 1, "text": "...", "owner": "Zaal|Iman|Both|ThyRev|Samantha", "status": "TODO"}
+    {"id": 1, "text": "...", "owner": "Zaal|Iman|Both|ThyRev|Samantha", "status": "TODO", "confidence": "high|medium|low"}
   ],
   "actions": [
-    {"title": "...", "owner": "...", "due": "YYYY-MM-DD or empty", "category": "Site / Tech|Ops|WaveWarZ Zambia|ZAO Devz|Bounty|Social|Other"}
+    {"title": "...", "owner": "...", "due": "YYYY-MM-DD or empty", "category": "Site / Tech|Ops|WaveWarZ Zambia|ZAO Devz|Bounty|Social|Other", "confidence": "high|medium|low"}
   ],
   "quotes": [
     {"speaker": "...", "text": "..."}
@@ -98,43 +128,96 @@ Read the transcript. Output JSON matching the schema in [references/output-schem
 
 **Rules for extraction:**
 - Verbatim where possible for quotes. No paraphrasing of decisions.
-- If owner is ambiguous, set `owner: "Both"` and surface in the user-confirm step.
-- If due date is ambiguous, leave empty. Never invent.
+- Every decision + action carries a `confidence` field:
+  - `high` - explicit in transcript, clear owner, clear intent.
+  - `medium` - implied or owner/scope slightly fuzzy.
+  - `low` - inferred, ambiguous owner, or transcript span was garbled.
+- If owner is ambiguous, set `owner: "Both"` + `confidence: "low"` and surface it in Phase 3. Never guess a specific owner.
+- If due date is ambiguous, leave empty + `confidence: "medium"` or lower. Never invent. Relative dates ("by Thursday") -> absolute, anchored to `meeting.date`.
 - Category must come from the enum above (matches actions.json schema).
 - 3-8 quotes max - pick load-bearing ones (decisions, commitments, surprising info).
 - `memory_updates` only if a NEW person, project, or strategy decision appeared (not for things already in `~/.claude/projects/.../memory/MEMORY.md`).
+- Never silently drop an uncertain item. A `low`-confidence item still goes in the JSON - Phase 3 surfaces it for Zaal.
+
+### Entity cross-check (Pass E)
+
+For EVERY attendee and every referenced person/project name, before deciding it is "new":
+
+```bash
+grep -ril "<name>" "/Users/zaalpanthaki/Documents/ZAO OS V1/research/" 2>/dev/null | head -3
+grep -i "<name>" ~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/MEMORY.md
+```
+
+- **Hit in research/** - the entity exists. Link the doc number in the recap (e.g. "Tyler Stambaugh, doc 473"). Do NOT create a memory.
+- **Hit in MEMORY.md** - the entity has a memory. Link `[[slug]]`. Do NOT create a duplicate.
+- **No hit anywhere** - genuinely new. Add a `memory_updates` entry.
+
+This stops the skill re-introducing known people as if they were new (test run 1 missed Tyler Stambaugh = doc 473).
+
+## Phase 2.5 - Clarify gaps
+
+Before the Phase 3 confirm, scan the extraction for genuine gaps and ask Zaal about them in ONE batched question round. Ask only when the answer changes the doc - not for things you can infer.
+
+Ask about:
+- A referenced person with zero context AND no hit in the Pass E cross-check (who are they, what role).
+- A decision/action where the owner is genuinely unknown (not just "Both").
+- A name that could be a mis-transcription (surface both spellings).
+- A project-routing call that is not obvious from attendees + topic.
+
+If the extraction is clean and nothing is genuinely ambiguous, skip Phase 2.5 and go straight to Phase 3. Do not invent questions to fill the phase. Zaal has said he is fine with the skill asking questions when they are real - so ask the real ones here, before the confirm, not after.
 
 ## Phase 3 - Present + confirm
 
-Show the extracted JSON inline as a markdown table for each section. Ask Zaal:
+Show the extracted JSON inline as a markdown table for each section (decisions, actions, quotes).
 
-> "Extracted N decisions, M actions, K quotes. Edits? If clean, which targets fire?"
+**Before the confirm prompt, render a VERIFY block** listing every `confidence: low` (and optionally `medium`) decision + action:
+
+```
+VERIFY - low-confidence extractions, confirm or correct each:
+- [action] "<title>" - owner unclear, transcript said "..."
+- [decision] "<text>" - inferred, not explicit
+```
+
+If the VERIFY block is non-empty, Zaal must resolve those items before any actions.json write. Do not write low-confidence items unedited.
+
+Then ask Zaal:
+
+> "Extracted N decisions, M actions, K quotes (J flagged to verify above).
+> Project: <inferred project> - correct? (ZAO Devz / ZAOstock / ZAO OS / other)
+> Edits? If clean, which targets fire?"
 >
-> Targets:
-> - [x] actions.json bulk append (default ON)
-> - [x] research/events/NNN-<slug>/README.md (default ON, every meeting per doc 673)
+> Targets (action target depends on project - see Phase 0):
+> - [x] Action tracker for `<project>` (default ON)
+> - [x] research/events/NNN-<slug>/README.md (default ON, every meeting, always ZAOOS)
 > - [ ] Bonfire ingest queue (opt-in)
 > - [ ] Telegram copy-paste block (opt-in, default OFF - print only on request)
 > - [ ] Memory writes (opt-in, confirm each)
 > - [ ] Calendar event update (opt-in if title matches a Google Cal event)
 
-Wait for Zaal's reply before any destructive write.
+Wait for Zaal's reply before any destructive write. Confirm the project before touching any tracker - a ZAOstock meeting must not write into the cowork-zaodevz tracker.
 
 ## Phase 4 - Distribute
 
 For each enabled target, follow the playbook in [references/distribution-targets.md](references/distribution-targets.md). Summary:
 
-### actions.json (cowork-zaodevz)
+### Action tracker (routed by project - Phase 0)
+
+**Project = ZAO Devz / general:** write to cowork-zaodevz `data/actions.json`.
 ```bash
 bash ${CLAUDE_SKILL_DIR}/scripts/append-actions.sh /tmp/extracted-actions.json
 ```
 Script reads the actions array, fetches current `data/actions.json` from GitHub, appends new items starting at `max(existing.id) + 1`, PUTs back via `gh api` with sha. One commit per meeting.
 
+**Project = ZAOstock:** do NOT write to cowork-zaodevz. ZAOstock tasks live in the ZAOstock Supabase behind @ZAOstockTeamBot. v1: print a paste-block of the action items for Zaal to drop into @ZAOstockTeamBot (`/note` or task command). Also note them in the recap doc's action table. (v2: a `zaostock-actions.sh` that inserts into ZAOstock Supabase via service-role key - deferred until the ZAOstock task schema is confirmed.)
+
+**Project = ZAO OS / BCZ / WaveWarZ / other:** no external tracker. Actions live only in the recap doc's action table.
+
 ### research/events/NNN-<slug>/README.md
 - Find next number: `find research -maxdepth 3 -type d -name '[0-9]*' | grep -oE '/[0-9]+' | tr -d '/' | sort -n | tail -1`
 - Slug from meeting title: lowercase, hyphens, no special chars, max 50 chars.
 - Use the template at [references/meeting-recap-template.md](references/meeting-recap-template.md). Doc 670 is the gold-standard worked example.
-- Write file, do NOT commit yet - leave for Zaal review in current `ws/` branch.
+- **Raw transcript goes in a SEPARATE file**, not inline in the README. Write the full transcript to `research/events/NNN-<slug>/transcript.md`. The README's "Transcript" section is a one-line link: `Full transcript: [transcript.md](transcript.md)`. Keeps the recap README lean and grep-friendly; a 10k-word transcript inline buries the signal.
+- Write both files, do NOT commit yet - leave for Zaal review in current `ws/` branch.
 
 ### Bonfire ingest queue
 - Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
@@ -180,6 +263,35 @@ Print to user a one-line per-target summary:
 
 Then suggest the natural next step: "Review research doc at <path>. Commit + PR when ready, or want me to ship it as a PR off ws/<branch> now?"
 
+## Phase 6 - Next-actions clipboard (default ON)
+
+After the report, auto-hand-off the next-actions to the `/clipboard` skill so Zaal has a clean copyable page the moment the meeting ends. This is the "what do I do now" surface - distinct from the Telegram block (which is for sharing the recap).
+
+Build a plain next-actions list - owner-grouped, due-sorted:
+
+```
+Next actions - <meeting title> (<date>)
+
+ZAAL
+- <action> (due <date>)
+- <action>
+
+IMAN
+- <action> (due <date>)
+
+BOTH
+- <action>
+```
+
+Then invoke the `/clipboard` skill with that list as the content. `/clipboard` opens a local browser page with the text ready to copy in one click (or copies to the macOS clipboard via pbcopy).
+
+Rules:
+- Default ON. Skip only if Zaal says "no clipboard" or there are zero actions.
+- Next-actions list = the `actions[]` array only. Not decisions, not quotes - this is the do-now list.
+- Owner-grouped so Zaal can paste each person's slice into their DM/GC directly.
+- If a single owner (e.g. all Zaal), skip the grouping headers - just the flat list.
+- This runs AFTER the tracker write, so the clipboard list and the tracker agree.
+
 ## Hard guardrails
 
 - **Never auto-write to actions.json without Phase 3 user-confirm.** The 67-item bulk fix (commit `c80caff8`) was authorized explicitly; default skill behavior must always confirm.
@@ -197,6 +309,10 @@ Then suggest the natural next step: "Review research doc at <path>. Commit + PR 
 - Do NOT use emojis in any output (per global `feedback_no_emojis`).
 - Do NOT use em dashes (per global `feedback_no_em_dashes`).
 
+## Doc numbering (collision-safe)
+
+When creating the recap doc, parallel Claude sessions may race for the same number. Pick the next number defensively: `git fetch origin` first, scan `research/` for the max, and if the chosen folder already exists, increment again. Per doc 663 collision-tolerance, a small gap in numbering is fine - a collision is not.
+
 ## References
 
 - [output-schema.md](references/output-schema.md) - JSON schema + worked example from doc 670
@@ -207,4 +323,12 @@ Then suggest the natural next step: "Review research doc at <path>. Commit + PR 
 
 - `scripts/transcribe.sh` - SCP to VPS, run Whisper, SCP back
 - `scripts/fetch-craig.sh` - curl Craig recording URL, extract audio
-- `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append
+- `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append (ZAO Devz project only)
+
+## Evals
+
+- `evals/README.md` - regression fixtures (doc 670 + doc 675 transcripts). Run after editing this skill.
+
+## Engineering basis
+
+Skill structure follows doc 676 (skill-engineering best practices): multi-pass extraction, confidence thresholding, human-review fallback, progressive disclosure. Read doc 676 before refactoring this skill.

--- a/.claude/skills/meeting/evals/README.md
+++ b/.claude/skills/meeting/evals/README.md
@@ -1,0 +1,36 @@
+# /meeting Skill Evals
+
+Regression fixtures for the meeting-capture skill. Run these after editing `SKILL.md` or the extraction logic to confirm the skill still extracts correctly.
+
+## How to run
+
+Feed the fixture transcript to the skill in paste mode, then diff the extraction JSON against the expected shape below. This is a manual eval - no harness yet. Anthropic skill-creator recommends an `evals/` dir; this is the lightweight version.
+
+## Fixture 1 - Iman call (doc 670)
+
+- **Source transcript:** `research/events/670-iman-call-may18-craig-pizzadao/README.md`
+- **Project:** ZAO Devz
+- **Expected:** 4 decisions, ~4-8 actions, 3+ quotes. Owners only Zaal / Iman / Both. Decision about ZAO Craig bot must be present. Due dates: PizzaDAO pitch = 2026-05-22, ZABAL Games signup = 2026-05-20.
+- **Pass criteria:** no hallucinated owner outside {Zaal, Iman, Both}; ZABAL date is 2026-05-20 not Friday; all 4 decisions present.
+
+## Fixture 2 - Tanja Fractal Book call (doc 675)
+
+- **Source transcript:** `research/events/675-tanja-fractal-book-call-may18/README.md`
+- **Project:** ZAO OS / general (Fractal)
+- **Expected:** 4 decisions, 7 actions, 5+ quotes. New person "Tanja" detected -> 1 memory_update (`project_tanja_fractal_book`). Owner "Tanja" appears (outside the core allowlist) -> must surface as a non-team owner, not silently dropped.
+- **Pass criteria:** Tanja recognized as a new entity; memory_update proposed; the "Reference Book" project captured in research_seeds or memory; no invented due dates.
+
+## What each fixture checks
+
+| Check | Fixture 1 | Fixture 2 |
+|---|---|---|
+| Owner allowlist enforced | yes | yes (non-team owner surfaced) |
+| Relative date -> absolute | yes (Thursday/Friday) | n/a |
+| New-entity -> memory_update | n/a | yes (Tanja) |
+| confidence field on every item | yes | yes |
+| Project routing inferred | ZAO Devz | ZAO OS / general |
+| No hallucinated action items | yes | yes |
+
+## Adding a fixture
+
+Every time `/meeting` processes a real meeting, that recap doc becomes a candidate fixture. Add it here with: source path, project, expected counts, pass criteria.

--- a/.claude/skills/meeting/references/distribution-targets.md
+++ b/.claude/skills/meeting/references/distribution-targets.md
@@ -2,7 +2,17 @@
 
 How each target gets the extracted output. Skill reads this when Phase 3 confirm flips a target ON.
 
-## 1. actions.json (cowork-zaodevz)
+## 1. Action tracker (routed by project - SKILL.md Phase 0)
+
+The action target depends on the meeting's project:
+
+| Project | Action target | See |
+|---|---|---|
+| ZAO Devz / general | cowork-zaodevz `data/actions.json` (GitHub PUT) | 1a below |
+| ZAOstock | paste-block for @ZAOstockTeamBot | 1b below |
+| ZAO OS / BCZ / WaveWarZ / other | recap doc action table only - no external tracker | n/a |
+
+### 1a. cowork-zaodevz actions.json (project = ZAO Devz / general)
 
 **Target:** `data/actions.json` on `main` of `songchaindao-dot/cowork-zaodevz`.
 **Method:** GitHub Contents API PUT via `gh api`. Bulk append in one commit.
@@ -46,6 +56,21 @@ chore(actions): meeting recap YYYY-MM-DD <title slug> (+N items)
 
 Source: research/events/NNN-<slug>/README.md
 ```
+
+### 1b. ZAOstock paste-block (project = ZAOstock)
+
+Do NOT write to cowork-zaodevz. ZAOstock tasks live in the ZAOstock Supabase behind @ZAOstockTeamBot.
+
+v1: print a single fenced paste-block of the action items for Zaal to drop into @ZAOstockTeamBot. Format:
+
+```
+ZAOstock meeting YYYY-MM-DD - action items
+
+1. <action> (owner)
+2. <action> (owner)
+```
+
+Also keep the actions in the recap doc's action table. v2 (deferred): a `zaostock-actions.sh` inserting into ZAOstock Supabase via service-role key, once the ZAOstock task schema is confirmed.
 
 ## 2. Research doc (research/events/NNN-<slug>/README.md)
 

--- a/.claude/skills/meeting/references/meeting-recap-template.md
+++ b/.claude/skills/meeting/references/meeting-recap-template.md
@@ -86,14 +86,17 @@ Files written to `~/.claude/projects/.../memory/`:
 
 ## Transcript
 
-<details>
-<summary>Full transcript ({duration_min} min)</summary>
+Full transcript: [transcript.md](transcript.md)
+```
 
-\`\`\`
-{full transcript text - paste from Whisper output or original paste}
-\`\`\`
+The raw transcript is written to a sibling file `transcript.md` in the same folder - NOT inline in the README. The README stays lean (decisions + actions + quotes are the signal); the transcript is one click away for anyone who needs the raw record.
 
-</details>
+`transcript.md` format:
+
+```markdown
+# Transcript - {Meeting Title} ({date})
+
+{full transcript text - Whisper output or original paste, verbatim}
 ```
 
 ## Style notes

--- a/.claude/skills/meeting/references/output-schema.md
+++ b/.claude/skills/meeting/references/output-schema.md
@@ -13,12 +13,14 @@ Single JSON object. All fields required except where noted optional.
     "attendees": ["Zaal", "Iman"],
     "platform": "Telegram voice"
   },
+  "project": "zao-devz | zaostock | zao-os | other",
   "decisions": [
     {
       "id": 1,
       "text": "Build ZAO Craig bot - live audio + Whisper + auto-extract todos",
       "owner": "Zaal",
-      "status": "TODO"
+      "status": "TODO",
+      "confidence": "high"
     }
   ],
   "actions": [
@@ -26,7 +28,8 @@ Single JSON object. All fields required except where noted optional.
       "title": "Iman to study RSVPizza repo + build PizzaDAO Zambia brand on top",
       "owner": "Iman",
       "due": "2026-05-22",
-      "category": "WaveWarZ Zambia"
+      "category": "WaveWarZ Zambia",
+      "confidence": "high"
     }
   ],
   "quotes": [
@@ -49,6 +52,19 @@ Single JSON object. All fields required except where noted optional.
 ```
 
 ## Enums
+
+### `project` (top-level - routes the action tracker, see SKILL.md Phase 0)
+- `zao-devz` - default. Actions -> cowork-zaodevz `data/actions.json`.
+- `zaostock` - actions -> @ZAOstockTeamBot paste-block (ZAOstock Supabase, not GitHub).
+- `zao-os` - actions stay in the recap doc table only.
+- `other` - BCZ / WaveWarZ / misc. Recap doc table only.
+
+The recap doc ALWAYS goes to ZAOOS `research/events/` regardless of project.
+
+### `confidence` (every decision + action)
+- `high` - explicit in transcript, clear owner, clear intent.
+- `medium` - implied, or owner/scope slightly fuzzy.
+- `low` - inferred, ambiguous owner, or garbled transcript span. Surfaced in the Phase 3 VERIFY block; never auto-written.
 
 ### `owner` (decisions + actions)
 - `Zaal`
@@ -86,6 +102,7 @@ Free text. Examples: `Telegram voice`, `Google Meet`, `Zoom`, `Discord/Craig`, `
 | `meeting.title` | 5-80 chars. Format: `<who> - <topic 1> + <topic 2>`. Use doc 670 as template. |
 | `meeting.attendees` | Array of canonical first-names. `Zaal`, `Iman`, `Cassie`, `Hannah`, etc. Match existing memory slugs where possible. |
 | `decisions[].text` | Verbatim where possible. No paraphrasing. Past tense for things decided in the call. |
+| `decisions[].confidence` / `actions[].confidence` | `high` / `medium` / `low`. Required on every item. `low` -> Phase 3 VERIFY block, never auto-written. |
 | `actions[].title` | Imperative verb-first. "Iman to X" or just "X". 10-120 chars. |
 | `actions[].due` | YYYY-MM-DD or empty string. Never invent. If transcript says "by Thursday", convert to absolute date using meeting.date as anchor. |
 | `quotes[].text` | Verbatim. 5-200 chars. Pick the load-bearing 3-8 quotes total. |

--- a/research/agents/679-coworking-agent-mentions-code-pipeline/README.md
+++ b/research/agents/679-coworking-agent-mentions-code-pipeline/README.md
@@ -1,0 +1,315 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-20
+superseded-by:
+related-docs: 650, 662, 677, 461, 523, 601
+tier: STANDARD
+---
+
+# 679 - Coworking Agent: Telegram @-Mentions + Iman DM-to-Code Pipeline
+
+> **Goal:** Audit the cowork-zaodevz Telegram bot against best practices, then lock two new features - (A) @-mention the owner on Telegram when an action is assigned or changes status, and (B) let any cowork allowlist user DM the bot a task, have Claude write the code and open a PR, so Zaal only reviews and merges.
+
+## Scope note - which bot
+
+This doc covers the **cowork-zaodevz tracker bot** (`@ZAOcoworkingBot`, on Iman's VPS `187.77.3.104`, GitHub Contents API backend, `data/actions.json` task store). It is NOT the ZAOOS `ZAO Devz` dual-bot (`bot/src/devz/`, the Hermes Coder/Critic narrator). The two share the Hermes engine pattern but are separate processes on separate machines.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **@-mention via HTML `tg://user?id=` deep link**, not `@username` | Robust - works whether or not the user has a public username. Already proven in `bot/src/devz/index.ts:177` (Zaal cc-tag). Telegram Bot API confirms `text_mention` / id-link needs only the numeric id. |
+| 2 | **Fire notifications from the command handlers** (handler-hook), post to one notifications chat | The bot executes `/add /assign /done /wip /blocked` itself, so it knows the actor and can skip self-pings. Web-app edits are a known v1 gap - see Finding A4. |
+| 3 | **Code engine = Hermes, vendored into cowork-zaodevz, runs on Iman's VPS** | Zaal's choice (2026-05-20). Clone-no-deps matches the ZAO graduate pattern. Tradeoff accepted: Zaal's Claude Max OAuth token lives on Iman's box - mitigations in Feature B. |
+| 4 | **`/code` is open to all 4 cowork allowlist users** (Zaal, Iman, ThyRev, Samantha) | Zaal's choice (2026-05-20). Raises cost exposure - hard daily cap + concurrency lock are mandatory, not optional. See the June 15 cost flag. |
+| 5 | **`HERMES_FLEET_DAILY_USD_CAP = 10`** for the cowork engine | 4-user access against one Max account, and `claude -p` headless billing changes 2026-06-15. $10/day is a deliberate brake; raise later if it proves too tight. |
+| 6 | Run the bot as a **dedicated non-root `cowork` user** | Current v1 runs as root. New code-write capability makes root unacceptable. |
+
+## Best-Practices Audit
+
+The cowork-zaodevz agent today (v1, per docs 650 + 662): deterministic slash commands, GitHub Contents API backend, daily digest cron. Audited against `.claude/rules/secret-hygiene.md`, `.claude/rules/typescript-hygiene.md`, the Hermes pattern (docs 461/523), and the ZAO monorepo-as-lab rules.
+
+| # | Finding | Severity | Fix | Covered by |
+|---|---------|----------|-----|------------|
+| A1 | v1 bot code lives only on Iman's VPS, not committed to the repo - drift risk, no review | High | Commit `agent/` to cowork-zaodevz | doc 662 v2 PR |
+| A2 | Bot process runs as root | High | Dedicated non-root `cowork` user + `systemctl --user` unit | This doc, Feature B |
+| A3 | GitHub PAT on disk, scope unverified | Med | Fine-grained PAT scoped to cowork-zaodevz only; `chmod 600 .env` | This doc |
+| A4 | No assignment / status notifications; web-app edits invisible to the bot | Feature gap | Feature A (handler-hook); poll-diff safety net = v1.1 | This doc, Feature A |
+| A5 | No code-change pipeline | Feature gap | Feature B | This doc, Feature B |
+| A6 | Coder-generated commits are not secret-scanned | High | Port secret-hygiene guards 2-4 into the Hermes preflight + PR step | This doc, Feature B |
+| A7 | No 5-block memory / transcripts | Med | v2 spec | doc 662 |
+| A8 | No branch protection on cowork-zaodevz `main` | Med | `gh api` branch protection + ported `safe-git-push.sh` | This doc, Feature B |
+| A9 | No tests on agent code | Low | vitest for roster / notify / diff logic | This doc, Next Actions |
+| A10 | No per-run cost telemetry | Med | Parse `total_cost_usd` from `claude --output-format json`, log to runs store, enforce daily cap | This doc, Feature B |
+| A11 | `claude -p` headless billing changes 2026-06-15 (see below) | High - time-bomb | Daily cap + monitor the Agent SDK credit; revisit Decision 4 | This doc |
+
+### The 2026-06-15 cost flag (read before shipping Feature B)
+
+Anthropic emailed subscription users: starting **2026-06-15**, `claude -p` headless usage on Max/Pro plans stops drawing from interactive Max limits. It moves to a separate **monthly Agent SDK credit**; past that credit it bills **raw token (API) cost** (HN thread 48129753, "A new monthly Agent SDK credit for your plan").
+
+Consequences for the cowork code pipeline (and for Hermes on VPS 1, same engine):
+
+- Before 2026-06-15: each `/code` run is effectively free under Max.
+- After 2026-06-15: each run draws the Agent SDK credit, then costs real money. With 4 users able to fire Opus coder runs (Decision 4), exposure is real.
+- Mitigation is built in: `HERMES_FLEET_DAILY_USD_CAP` (Decision 5), `--output-format json` returns `total_cost_usd` per run for tracking, and a concurrency lock (one run at a time).
+- Recommendation: ship now, watch the first week of spend after 2026-06-15, and reconsider whether `/code` stays allowlist-wide or narrows to Iman + Zaal.
+
+## Feature A - @-Mention on Assignment / Status Change
+
+### Trigger matrix
+
+| Bot command | Notify | Condition |
+|-------------|--------|-----------|
+| `/add <title>` (with owner) | new owner | owner is a real person AND owner != actor |
+| `/assign <id> <Owner>` | new owner | owner is a real person AND owner != actor |
+| `/done <id>` | item owner | owner != actor |
+| `/wip <id>` | item owner | owner != actor |
+| `/blocked <id> <reason>` | item owner + creator | recipient != actor (creator only if != owner) |
+
+Rules: never ping yourself. Owner `Open` -> no ping. Owner `Both` -> ping Zaal and Iman in one message. Owner with no roster entry -> plain-text name, no link (graceful degrade).
+
+### Roster - `agent/src/roster.ts`
+
+The v1 allowlist already maps Telegram id to display name. Require those display names to equal the `Owner` enum values exactly (`Zaal`, `Iman`, `ThyRev`, `Samantha`). Then:
+
+```typescript
+import type { Owner } from './types';
+
+interface RosterEntry { name: string; telegramId: number }
+
+// Loaded from the existing allowlist (users.json / ALLOWLIST_USER_IDS+USER_NAMES).
+const ROSTER: Record<string, RosterEntry> = loadRoster();
+
+/** Telegram ids to ping for a given Owner. [] = nobody (Open / unknown). */
+export function ownerTelegramIds(owner: Owner): number[] {
+  if (owner === 'Open') return [];
+  if (owner === 'Both') {
+    return ['Zaal', 'Iman']
+      .map((n) => ROSTER[n]?.telegramId)
+      .filter((id): id is number => typeof id === 'number');
+  }
+  const id = ROSTER[owner]?.telegramId;
+  return typeof id === 'number' ? [id] : [];
+}
+```
+
+### Notification helper - `agent/src/notify.ts`
+
+```typescript
+import type { Bot } from 'grammy';
+import type { ActionItem } from './types';
+import { ownerTelegramIds } from './roster';
+
+/** Action titles/notes are user input - escape before embedding in HTML. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function mention(name: string, telegramId: number | null): string {
+  const safe = escapeHtml(name);
+  return telegramId
+    ? `<a href="tg://user?id=${telegramId}">${safe}</a>`
+    : safe;
+}
+
+interface NotifyOpts {
+  bot: Bot;
+  notifyChatId: number;       // env NOTIFY_CHAT_ID, defaults to DAILY_DIGEST_CHAT_ID
+  item: ActionItem;
+  actorTelegramId: number;
+  actorName: string;
+  kind: 'assigned' | 'status';
+}
+
+export async function notifyOwner(o: NotifyOpts): Promise<void> {
+  const targets = ownerTelegramIds(o.item.owner)
+    .filter((id) => id !== o.actorTelegramId); // never ping the actor
+  if (targets.length === 0) return;
+
+  const title = escapeHtml(o.item.title);
+  const actor = mention(o.actorName, o.actorTelegramId);
+  const links = targets.map((id) => mention(o.item.owner, id)).join(' ');
+
+  const body =
+    o.kind === 'assigned'
+      ? `${links} assigned: "${title}" [${o.item.priority}]` +
+        (o.item.due ? ` due ${escapeHtml(o.item.due)}` : '') +
+        ` - by ${actor}`
+      : `${links} your item "${title}" is now ${o.item.status} - by ${actor}`;
+
+  await o.bot.api.sendMessage(o.notifyChatId, body, { parse_mode: 'HTML' });
+}
+```
+
+Then each command handler calls `notifyOwner(...)` right after the successful `saveActions()` write.
+
+### Delivery requirement
+
+The `tg://user?id=` mention only produces a push notification if the target user is a member of the notification chat. **All 4 cowork users must be members of the `NOTIFY_CHAT_ID` group.** If a user is not a member the message still posts; it just will not ping them. Add `NOTIFY_CHAT_ID` to `.env` (default to the existing `DAILY_DIGEST_CHAT_ID`).
+
+### Known v1 gap + v1.1 fix
+
+Handler-hook notifications fire only for changes made *through the bot*. Edits made in the cowork-zaodevz **web app** do not pass through the bot, so they will not ping. v1.1 fix: a poll-diff loop - every 2 minutes read `data/actions.json`, diff item owner/status against the cached snapshot (v2 already caches the file + sha per doc 662), ping any delta, and skip ids already notified via a small `~/.zaocoworking/notified.json` fingerprint set. Poll-diff loses the actor name on web edits, so the message degrades to "item X is now WIP" without a "by" clause. Ship handler-hook first; add poll-diff once v2 caching lands.
+
+## Feature B - Iman DMs the Bot, Claude Writes Code, PR Opens
+
+This is doc 662's v3 ("add `cowork` profile to Hermes, `/code` command"), with the two open decisions now locked: engine runs on Iman's VPS (Decision 3), `/code` is allowlist-wide (Decision 4).
+
+### Flow
+
+```
+Iman (or any of 4 allowlist users) DMs the cowork bot:
+   /code make the BLOCKED badge red instead of gray
+
+   v
+cowork bot (Iman's VPS):
+   - allowlist check (4 users)
+   - daily cost cap not exceeded?  (HERMES_FLEET_DAILY_USD_CAP=10)
+   - acquire run lock (one run at a time)
+   - reply: "Coder starting on cowork-zaodevz..."
+   v
+vendored Hermes runner (agent/src/hermes/, cowork profile):
+   clone cowork-zaodevz -> /tmp/hermes-<id>/ -> fresh branch
+   Coder pass    (opus,   claude -p headless, Max OAuth)
+   Preflight     (npm run build + typecheck + lint + secret scan)
+   Critic pass   (sonnet, claude -p headless) -> score 0-100
+   score >= 70   -> gh pr create  (base: main)
+   v
+cowork bot posts back to the chat:
+   "PR #N opened on cowork-zaodevz: <title>. Critic 85. <url>"  cc <mention Zaal>
+   v
+Zaal reviews + merges on GitHub. No Claude Code on his laptop needed.
+```
+
+Score < 70 loops feedback to the Coder, max 3 attempts, then escalates: "needs human" cc Zaal.
+
+### Engine - vendor Hermes into cowork-zaodevz
+
+Copy `bot/src/hermes/` from ZAOOS into `cowork-zaodevz/agent/src/hermes/` (clone, no deps - the ZAO graduate pattern). One adaptation: ZAOOS Hermes persists runs to a Supabase `hermes_runs` table; cowork has no Supabase wired yet (doc 650 puts it in Phase 2). Replace `db.ts` with a file-backed run store at `~/.zaocoworking/hermes-runs.json` (same shape - `id, triggeredBy, issueText, branch, prNumber, criticScore, status, totalCostUsd, timestamps`).
+
+### The `cowork` repo profile
+
+Add to the vendored Hermes (`agent/src/hermes/types.ts` + `coder.ts`):
+
+```typescript
+// repo profile
+cowork: {
+  repoUrl: process.env.HERMES_COWORK_REPO_URL
+    ?? 'https://github.com/songchaindao-dot/cowork-zaodevz.git',
+  baseBranch: 'main',
+  gitUserName: 'Cowork Bot',
+  gitUserEmail: 'bot@songchaindao.dev',
+  forbiddenPaths: [
+    'data/',                  // tracker data - the bot owns this, not the coder
+    '.env', 'agent/.env', '.env.local', '.env.production',
+    'agent/src/hermes/',      // do not let the coder edit its own engine
+    '.github/workflows/',     // CI changes need human review
+    'package-lock.json',
+  ],
+}
+```
+
+Coder system-prompt context block: "cowork-zaodevz is a Next.js 15 App Router team action tracker. The web app reads/writes `data/actions.json` via the GitHub Contents API; never touch `data/`. The `agent/` folder is the Telegram bot. Tailwind v3, TypeScript strict."
+
+### `/code` command handler
+
+```typescript
+bot.command('code', async (ctx) => {
+  const userId = ctx.from?.id;
+  if (!userId || !isAllowlisted(userId)) return;          // Decision 4: 4 users
+
+  const task = ctx.match?.trim();
+  if (!task) return ctx.reply('Usage: /code <what to change>');
+
+  if (await dailyCostExceeded()) {
+    return ctx.reply('Daily code-engine cap reached. Try again tomorrow.');
+  }
+  if (!acquireRunLock()) {
+    return ctx.reply('A code run is already in progress. One at a time.');
+  }
+
+  await ctx.reply('Coder starting on cowork-zaodevz...');
+  try {
+    const run = await dispatchHermesRun({
+      profile: 'cowork',
+      issueText: task,
+      triggeredBy: userId,
+      narrate: (msg) => ctx.reply(msg),       // progress to this chat
+      model: { coder: 'opus', critic: 'sonnet' },
+    });
+    if (run.status === 'ready') {
+      await ctx.reply(
+        `PR #${run.prNumber} opened: ${run.prTitle}. Critic ${run.criticScore}.\n` +
+        `${run.prUrl}\ncc <a href="tg://user?id=${ZAAL_TG_ID}">Zaal</a>`,
+        { parse_mode: 'HTML' },
+      );
+    } else {
+      await ctx.reply(
+        `Code run ${run.status} after ${run.fixerAttempts} attempts. ` +
+        `Needs human. cc <a href="tg://user?id=${ZAAL_TG_ID}">Zaal</a>`,
+        { parse_mode: 'HTML' },
+      );
+    }
+  } finally {
+    releaseRunLock();
+  }
+});
+```
+
+### VPS prerequisites - Iman's box `187.77.3.104`
+
+1. **Node 22** + `git`.
+2. **`claude` CLI**: `npm i -g @anthropic-ai/claude-code`.
+3. **Auth with Zaal's Claude Max**: run `claude` once interactively to complete the OAuth login, or copy `~/.claude/` from a Zaal machine. Then `chmod 600 ~/.claude/*.json`. Pass `bare: false` on every `callClaudeCli()` call (per `feedback_no_bare_with_oauth` / PR #512 - the `--bare` flag strips OAuth reads, breaks Max-plan bots).
+4. **`gh` CLI** authed with a **fine-grained GitHub PAT scoped to `songchaindao-dot/cowork-zaodevz` only** (Contents + Pull requests: write).
+5. **Dedicated non-root `cowork` user**; bot runs under `systemctl --user` (fixes audit A2).
+6. Port **`safe-git-push.sh` + `branch-guard.sh`** (docs 461/523) so the Coder can never push to `main` or a merged PR.
+7. **Branch protection on cowork-zaodevz `main`**: `gh api -X PUT /repos/songchaindao-dot/cowork-zaodevz/branches/main/protection ...` - block force-push + deletion.
+8. **Secret-hygiene guards 2-4** (`.claude/rules/secret-hygiene.md`) wired into the Hermes preflight + PR step - scan the staged diff for 64-char hex, `PRIVATE_KEY=`, PEM blocks, `ghp_` / `sk-ant-` tokens; hard-abort on any match (fixes audit A6).
+
+### Security tradeoff (Decision 3, accepted)
+
+Zaal's Claude Max OAuth token will live on Iman's VPS. Honest mitigations: it is a revocable OAuth token, not a raw API key - revoke from the Anthropic console anytime; `chmod 600`; the bot runs non-root; `HERMES_FLEET_DAILY_USD_CAP` bounds spend; the Hermes `forbiddenPaths` + secret-hygiene scan bound what the Coder can write. Residual risk: anyone with root on Iman's box can read the token and run Claude as Zaal. If that becomes a concern, the alternative (rejected today) is to keep the engine on VPS 1 and have the cowork bot dispatch over an authenticated tunnel.
+
+### The "simple VPS command" fallback
+
+Zaal asked whether a plain VPS command is the better path. It is the fallback, not the primary: once Hermes is vendored, anyone with SSH to Iman's box can run `cd ~/cowork-zaodevz/agent && npm run code -- "<task>"` to invoke the same runner manually. The `/code` DM path is the recommendation because it needs no SSH, works from a phone, and is gated by the allowlist + cost cap automatically.
+
+## Also See
+
+- [Doc 650](../650-cowork-zaodevz-imanagent/) - cowork-zaodevz imanagent spec, VPS build, storage layer
+- [Doc 662](../../dev-workflows/662-zaocoworking-v2-v3-architecture/) - v2 memory/transcripts + v3 Hermes integration skeleton (this doc locks v3)
+- [Doc 677](../677-bonfire-cowork-github-connection/) - GitHub events -> Bonfire sync (the GitHub-side companion)
+- [Doc 461](../../dev-workflows/461-push-to-merged-pr-failure-fix/) - safe-git-push.sh, branch protection
+- [Doc 523](../523-zao-agentic-systems-full-audit-fix-pr-pipeline/) - Hermes dual-bot pattern, hermes_runs schema
+- [Doc 601](../601-agent-stack-cleanup-decision/) - Hermes-as-canonical-engine decision
+
+## Next Actions
+
+| Action | Owner | Type | Difficulty (1-10) |
+|--------|-------|------|-------------------|
+| Commit v1 `agent/` to cowork-zaodevz repo (closes audit A1) | @Iman | PR | 2 |
+| Move bot to non-root `cowork` user + `systemctl --user` unit (A2) | @Iman | Infra | 3 |
+| Scope the GitHub PAT to cowork-zaodevz only, `chmod 600 .env` (A3) | @Iman | Infra | 2 |
+| Feature A - add `roster.ts` + `notify.ts`, hook the 5 command handlers, add `NOTIFY_CHAT_ID` env | @Iman | PR | 4 |
+| Confirm all 4 cowork users are members of `NOTIFY_CHAT_ID` group | @Zaal | Ops | 1 |
+| Feature B - vendor Hermes into `agent/src/hermes/`, file-backed run store, `cowork` profile | @Iman | PR | 6 |
+| Feature B - VPS prereqs 1-8 on `187.77.3.104` (claude CLI, gh PAT, guards, branch protection) | @Iman | Infra | 5 |
+| Feature B - `/code` handler with allowlist + cost cap + run lock | @Iman | PR | 4 |
+| Set `HERMES_FLEET_DAILY_USD_CAP=10`, wire `total_cost_usd` telemetry (A10) | @Iman | PR | 3 |
+| vitest coverage for roster / notify / diff logic (A9) | @Iman | PR | 3 |
+| After 2026-06-15: review one week of code-engine spend, decide if `/code` stays allowlist-wide (Decision 4 / A11) | @Zaal | Decision | 2 |
+
+## Sources
+
+- [Telegram Bot API - Mentions](https://core.telegram.org/bots/api) - `text_mention` entity + `tg://user?id=` link mention users without a username; only the numeric id is required. Verified 2026-05-20.
+- [Telegram API - Mentions](https://core.telegram.org/api/mentions) - mention mechanics. Verified 2026-05-20.
+- [Claude Code - Headless mode docs](https://code.claude.com/docs/en/headless) - `claude -p` non-interactive, `--allowedTools`, `--output-format json` returns `total_cost_usd`. Verified 2026-05-20.
+- [HN 48129753 - "Claude -p headless mode cannot use Max limits, will fall under API plan"](https://news.ycombinator.com/item?id=48129753) - community thread; confirms the 2026-06-15 "Agent SDK credit" change for subscription headless usage. Verified 2026-05-20.
+- [amux.io - Claude Code headless self-hosting guide (2026)](https://amux.io/guides/claude-code-headless/) - server deployment patterns. Verified 2026-05-20.
+- ZAOOS codebase: `bot/src/hermes/` (Hermes engine), `bot/src/devz/index.ts:177` (existing `tg://user?id=` cc-tag pattern), `.claude/rules/secret-hygiene.md`.

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -1,0 +1,22 @@
+# Meetings Index
+
+Every meeting captured as a research recap, newest first. Maintained automatically by the `/meeting` skill (doc 673/676); seeded from existing recap docs.
+
+| Date | Title | Project | Attendees | Doc | Actions |
+|------|-------|---------|-----------|-----|---------|
+| 2026-05-19 | ZAOstock advisor call | ZAOstock | Zaal, failoften | [678](678-zaostock-advisor-call-may19/) | 12 |
+| 2026-05-18 | Iman call - ZAO Craig + PizzaDAO Zambia | ZAO Devz | Zaal, Iman | [670](670-iman-call-may18-craig-pizzadao/) | ~4 |
+| 2026-05-18 | Tanja Fractal Book call | ZAO OS / Fractal | Zaal, Tanja | [675](675-tanja-fractal-book-call-may18/) | 7 |
+| 2026-05-16 | ZABAL Games + Empire V3 - yerbearzerker | ZABAL Games | Zaal, Iman, yerbearzerker | [654](654-zabal-games-empire-v3-yerbearzerker-meeting/) | n/a |
+| 2026-05-04 | ZAOstock cobuild - six circles | ZAOstock | team | [609](609-zaostock-cobuild-six-circles-may4/) | n/a |
+| 2026-05-04 | WaveWarZ Africa - RAM + SongChainn | WaveWarZ | team | [608](608-wavewarz-africa-ram-songchain-may4/) | n/a |
+| 2026-05-xx | Adam sync - commercial leaderboard | ZAOstock | Zaal, Adam | [599](../business/599-adam-meeting-may2026-commercial-leaderboard/) | n/a |
+| 2026-04-22 | ZAOstock Apr 22 team recap | ZAOstock | team | [476](476-zaostock-apr22-team-recap/) | n/a |
+| 2026-xx-xx | Intori SCIS + Tuum Tech DB meeting | ZAO OS | Zaal + Intori | [571](../farcaster/571-intori-scis-tuum-tech-db-meeting/) | n/a |
+
+## Notes
+
+- Newest meeting goes at the top, right under the header row.
+- "Actions" = count of action items extracted. "n/a" = recap predates the action-count convention.
+- Most docs live in `research/events/`; a few sit in their topic folder (path shown relative).
+- This file is the answer to "show me all past meetings" - no grep needed.


### PR DESCRIPTION
## Summary

Supersedes PR #570 and #577. Full `/meeting` skill: v2 + 5 autoresearch iterations + the Bonfire knowledge-graph bridge.

## Bonfire bridge (doc 680 - this ask)

Connects `/meeting` to Bonfires so the ZABAL knowledge graph always has full meeting context - always-on, not opt-in.

- `scripts/bonfire-episode.sh` - POSTs episodes to `POST /knowledge_graph/episode/create` (the verified API from `bot/src/zoe/recall.ts`, commit 5314ba4d). Best-effort: secret-scans every body, 15s timeout, always exits 0 - never aborts the run.
- Phase 3: Bonfire flipped from opt-in to default-ON.
- Phase 4: one episode per decision + per action + a summary episode. Natural-language prose bodies; Bonfires auto-extracts KG nodes.
- Reuses `BONFIRE_API_KEY` / `BONFIRE_ID` env (no new secrets). Unset => skips gracefully.
- Doc 680 = the research + decision record.

## Also in this branch

- v2 skill (Phase 0 project routing, Phase 2.5 clarify, Phase 6 clipboard, multi-pass extraction, confidence scoring, evals)
- 5 autoresearch hardening iterations (input-detection fix, distribution-targets routing, Phase 5 report, allowed-tools, `_meetings-index.md`)
- doc 676 (skill-engineering best practices)

## KNOWN TANGLE - needs a review decision

Commit `e57e9563` is mislabeled "docs: 679..." and bundles a parallel session's **doc 679** (`research/agents/679-coworking-agent-mentions-code-pipeline/`) with my Bonfire work - the two Claude sessions share one git index and the other session's `git commit` swept up my staged files.

Doc 679 is legit ZAO research (cowork bot audit) and harmless to land. But if a separate PR already covers doc 679, drop that one file in review. The Bonfire skill changes + doc 680 are all correct.

This is the 4th parallel-session collision this session. Strong recommendation: enforce git worktrees per session (doc 459 / `feedback_workspace_worktrees`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)