### PR TITLE
docs(agents): doc 683 - ZOE troubles analysis + Ryan followup

### DIFF
--- a/research/agents/683-zoe-troubles-analysis-ryan-followup/README.md
+++ b/research/agents/683-zoe-troubles-analysis-ryan-followup/README.md
@@ -1,0 +1,130 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 647, 648, 669, 672, 676, 680, 682
+tier: STANDARD
+---
+
+# 683 - ZOE Troubles Analysis + Ryan Kagy Followup
+
+> **Goal:** Deep analysis of the ZOE agent troubles visible in the 2026-05-20 "ZAO Civilization" Telegram thread, with code evidence from `bot/src/zoe/`, plus the followup package Ryan Kagy needs to ship the compiled new ZOE without inheriting the same bugs.
+
+## Key Findings
+
+| # | Trouble | Root cause | Code evidence | Severity |
+|---|---------|-----------|---------------|----------|
+| 1 | **ZOE has a permanent archive it never reads** | `pushRecent()` writes every turn to `archive/<scope>/<month>.jsonl` AND a 8-turn ring buffer. `loadMemory()` only loads the ring buffer into `<working_memory>`. `readArchive()` exists but no caller wires it into context. | `memory.ts:388 pushRecent` writes both; `memory.ts:429 loadMemory` calls `readRecent` only, never `readArchive`; `readArchive` defined `memory.ts:361` with zero callers in the context path | **P0** |
+| 2 | **Long replies 400 on non-concierge sends** | `chunkMessage()` + chunked `ctx.reply` exist for concierge replies. `scheduler.ts` sends the morning brief, prompts, and nudges via raw `bot.api.sendMessage` - no chunking. | `index.ts:61 chunkMessage` good; `scheduler.ts:67,86,115` raw `sendMessage`, no chunk | **P1** |
+| 3 | **ZOE tells people it has no long-term memory** | Its persona/export text says "there is no archive of older conversations" - stale. The archive shipped (doc 648 item 4). | The 2026-05-14 soul export says "no archive"; `memory.ts:30,352` archive is live | **P1** |
+| 4 | **Group-chat context loss** | 8-turn ring buffer is the whole window. A busy group (Zaal + Ryan + Iman + bot) blows past 8 turns in ~2 minutes. ZOE could not see Ryan's earlier questions ("answer Ryan's original questions" -> ZOE asked for them to be pasted). | `memory.ts:34 RECENT_MAX = 8`; same root as #1 | **P1** |
+| 5 | Project-context gaps (Infanity, SongJam, Ansuz, Recoup) | `human.md` block lacked them. | ZOE export marked them `[not in context]` | Resolved - Zaal added them 2026-05-20 |
+| 6 | "Got it. Working on this one - reply incoming." then a thin answer | Ack-then-reply pattern; the real reply sometimes lands weak when the question depends on context ZOE cannot see (#1/#4). | thread, multiple occurrences | P2 - downstream of #1 |
+
+## The core problem - a write-only memory
+
+ZOE's memory has three tiers and reads only the smallest one:
+
+```
+pushRecent(turn)                          memory.ts:388
+  -> appendArchive(turn)                  memory.ts:352  PERMANENT, every turn, archive/<scope>/<month>.jsonl
+  -> ring buffer, last 8 turns            memory.ts:400-403  recent/<scope>.json
+
+loadMemory(scope)                         memory.ts:429
+  -> readRecent(scope)   [8 turns]        LOADED into <working_memory>
+  -> readArchive(scope)  [everything]     EXISTS (memory.ts:361) - NEVER CALLED
+```
+
+ZOE writes a perfect lifelong record and then operates as if it does not exist. Effective memory = 8 turns. Everything ZOE said in the thread about "[not in context]", "truncated in my working memory", "I have no prior session history in this window" traces to this one gap. The data is on disk; the agent never loads it.
+
+This is the single highest-leverage fix and it is small: wire `readArchive` (a recency-bounded tail, or a rolling summary to control token cost) into `loadMemory` so a `<long_memory>` block sits alongside `<working_memory>`.
+
+## Trouble detail + fix
+
+### P0 - wire the archive into context
+
+`loadMemory()` (`memory.ts:429`) builds the prompt blocks. Add a fourth read:
+
+- Cheap v1: `readArchive(scope)` then take the last ~40-60 turns beyond the ring buffer, into a `<recent_history>` block. Bounded token cost.
+- Better v2: a rolling summary - after each session, summarise the archive tail to `archive/<scope>/summary.md`, load that. Keeps cost flat as the archive grows.
+- The 8-turn ring buffer stays as the verbatim short window. The archive read is the long memory.
+
+Without this, every other ZOE fix is cosmetic - the agent is functionally amnesiac past 8 turns.
+
+### P1 - chunk all sends, not just concierge replies
+
+`index.ts` has `chunkMessage()` + a chunked send loop, used by `ctx.reply`. `scheduler.ts:67,86,115` bypass it with raw `bot.api.sendMessage`. Extract the chunked-send into a shared `sendChunked(api, chatId, text)` helper in `index.ts` or a small `send.ts`, and route the scheduler's three sends through it. Same 4096-char `TELEGRAM_MAX` constant.
+
+### P1 - fix ZOE's self-description
+
+ZOE's `human.md` / persona / export template still says it has no archive. It does (since 2026-05-14). Update the text so ZOE stops telling collaborators - including Ryan, mid-partnership - that it is more amnesiac than it is. Add the 4 closed-gap projects (SongJam/$SANG doc 079, Recoup learning path, Infanity external, Ansuz external) which Zaal already supplied.
+
+## What this means for Ryan's compiled new ZOE
+
+Ryan is building a "compiled new ZOE" on his agentic SDK with a "lifestream" memory format, and asked Zaal to send everything so his side handles compression + formatting. Two things matter:
+
+1. **Do not inherit the write-only-archive design.** The new lifestream must be LOADED, not just appended. ZOE's current bug is precisely a lifestream that is written and never read. The compiled version's whole value is fixing that.
+2. **The corpus to compress already exists in two places** - the `archive/*.jsonl` files (every turn ZOE ever logged) and the ZABAL Bonfire (Ryan's own product - 57 meeting episodes loaded via the `/meeting` skill + ~780 prior). Ryan does not need Zaal to hand-curate; he needs the raw archive + repo + bonfire read access.
+
+## The Ryan followup package
+
+What to send Ryan, and from where:
+
+| Item | Where | How |
+|------|-------|-----|
+| ZOE soul files | `~/.zao/zoe/persona.md`, `human.md`, `bootloader-template.md`, `brand.md`, `groups.json`, `tasks.json` | zip the dir, send |
+| The lifestream corpus | `~/.zao/zoe/archive/<scope>/*.jsonl` | zip + send - this is the actual conversation history |
+| Agent source | `bot/src/zoe/` | public: github.com/bettercallzaal/ZAOOS |
+| Research library | `research/` - 202 docs, 13 folders | public: same repo, clone it |
+| Key docs to fold | 050, 051, 460, 483, 601, 647, 648, 669, 673, 676, 680, 682, 683 | in the repo |
+| ZAO context, pre-extracted | ZABAL Bonfire knowledge graph | Ryan's own product - 57 meeting episodes + ~780 prior; run labeling to unlock vector read |
+| Troubles to fix | this doc (683) | the design notes above |
+
+The followup message text to drop in the thread is in the next section.
+
+## Followup message for Ryan (copy-paste)
+
+This goes in the "ZAO Civilization" Telegram thread, addressed to Ryan. It is also reproduced as a clipboard block by the session that generated this doc.
+
+---
+
+Ryan - did a deep pass on where ZOE actually struggles, so the compiled version fixes it rather than inherits it.
+
+The core bug: ZOE writes a permanent archive of every turn (`~/.zao/zoe/archive/*.jsonl`) but never reads it back. Context assembly only loads an 8-turn ring buffer. So ZOE has a complete lifelong record and operates amnesiac past 8 turns - that is why she kept saying "[not in context]" and lost your earlier questions. The fix on our side is one wiring change; on your side, the compiled ZOE's lifestream must be LOADED, not just appended. That is the whole point of the rebuild.
+
+Three other issues: long replies 400 on the scheduler's sends (the brief/nudges bypass the chunker), her persona text wrongly says she has no archive, and the 8-turn window means group chats lose context fast. All four are in the analysis doc.
+
+For the compiled version, send everything - you said let your side handle compression, so here is the full manifest:
+
+1. Soul files: zip of `~/.zao/zoe/` - persona.md, human.md, bootloader-template.md, brand.md, groups.json, tasks.json.
+2. The lifestream corpus: `~/.zao/zoe/archive/<scope>/*.jsonl` - every turn ZOE ever logged. This is the raw history to compress.
+3. Agent source + research library: public at github.com/bettercallzaal/ZAOOS - `bot/src/zoe/` is the runtime, `research/` is 202 docs. Clone it.
+4. Key docs to fold: 050 (ZAO guide), 051 (whitepaper), 460 (agentic stack), 483 (Hermes), 601 (5 surfaces), 647 (agent quality), 648 (our call), 669 (Bonfires), 683 (this analysis).
+5. You already have a pre-extracted corpus: the ZABAL Bonfire - your product. The `/meeting` skill has been auto-posting ZAO meetings into it; 57 episodes are in plus the ~780 prior. Run the labeling pass and the compiled ZOE can read ZAO context straight from the graph.
+
+human.md now has the 4 gaps closed (SongJam/$SANG, Recoup, Infanity external, Ansuz external). Soul gets context, not blanks.
+
+Full analysis: research/agents/683 in the repo.
+
+---
+
+## Next Actions
+
+| # | Action | Owner | Type | By When |
+|---|--------|-------|------|---------|
+| 1 | Wire `readArchive` tail into `loadMemory()` - the P0 fix | Zaal / Hermes | Code | This week |
+| 2 | Extract `sendChunked` helper, route `scheduler.ts` sends through it | Zaal / Hermes | Code | This week |
+| 3 | Update ZOE `human.md` + persona - drop the stale "no archive" text, keep the 4 closed-gap projects | Zaal | Code | This week |
+| 4 | Send Ryan the followup message + the soul/archive zip | Zaal | Comms | Now |
+| 5 | Ask Ryan / Joshua to run Bonfire labeling so vector read unlocks | Zaal | Partner | Next Ryan sync |
+
+## Sources
+
+- `bot/src/zoe/memory.ts` - `pushRecent` (388), `appendArchive` (352), `readArchive` (361), `loadMemory` (429), `RECENT_MAX = 8` (34)
+- `bot/src/zoe/index.ts` - `chunkMessage` (61), chunked `ctx.reply` loop (88-95)
+- `bot/src/zoe/scheduler.ts` - raw `bot.api.sendMessage` at 67, 86, 115
+- `bot/src/zoe/concierge.ts` - ops-JSON parse + reply path
+- 2026-05-20 "ZAO Civilization" Telegram thread - ZOE session export + the troubles in situ
+- [Doc 648](../648-ryan-kagy-zao-civilization-sync/), [Doc 669](../669-bonfires-everything-we-know/), [Doc 682](../../events/682-ryan-kagy-limitless-call-may12/) - the Ryan partnership thread
+- [Doc 672](../672-zaocoworking-bot-audit-postv213/) - same message-too-long bug class in the sibling bot

--- a/research/agents/683-zoe-troubles-analysis-ryan-followup/ryan-context-handoff.md
+++ b/research/agents/683-zoe-troubles-analysis-ryan-followup/ryan-context-handoff.md
@@ -1,0 +1,144 @@
+# ZAO Context Handoff - for Ryan Kagy + the compiled new ZOE
+
+> One file. Hand it to your bots, or have them fetch it. Every link resolves. This is everything they need to ingest ZAO context and rebuild ZOE without inheriting her current bugs.
+
+Prepared 2026-05-20 for the Bonfires / ZAO agent partnership (docs 648, 682).
+
+---
+
+## 1. The one move that matters
+
+The whole ZAOOS repo is public. Your bots can clone it and have the agent runtime + 200+ research docs in one shot:
+
+```
+git clone https://github.com/bettercallzaal/ZAOOS
+```
+
+Raw single-file fetch (for bots that pull URLs, not git):
+
+```
+https://raw.githubusercontent.com/bettercallzaal/ZAOOS/main/<path>
+```
+
+Browse: https://github.com/bettercallzaal/ZAOOS
+
+---
+
+## 2. ZOE the runtime - what to rebuild
+
+Source: https://github.com/bettercallzaal/ZAOOS/tree/main/bot/src/zoe
+
+| File | What |
+|------|------|
+| `index.ts` | Telegram entrypoint, command routing, `chunkMessage` |
+| `concierge.ts` | the LLM turn - persona + memory + reply + task-op parse |
+| `memory.ts` | the memory system - ring buffer + archive + context assembly |
+| `types.ts` | `selectModel()` tiered routing (Sonnet/Opus/Haiku) |
+| `recall.ts` | the Bonfire read/write bridge (your product) |
+| `scheduler.ts` | morning brief + nudges crons |
+| `brief.ts` / `reflect.ts` / `tasks.ts` / `sidequests.ts` / `groups.ts` | features |
+| `persona.md` / `brand.md` / `README.md` / `USERGUIDE.md` | the written soul + docs |
+
+### The bug to NOT inherit
+
+ZOE's `memory.ts` writes every turn to a permanent archive (`appendArchive` -> `~/.zao/zoe/archive/<scope>/<month>.jsonl`) but `loadMemory()` only loads an 8-turn ring buffer into context. `readArchive()` exists and is never wired in. ZOE has a complete lifelong record and runs amnesiac past 8 turns.
+
+**For the compiled ZOE: the lifestream must be LOADED, not just appended.** That single property is the point of the rebuild. Full analysis: README.md in this folder (doc 683).
+
+---
+
+## 3. ZOE's soul files - Zaal sends these directly
+
+Not in the public repo (they hold Zaal's personal context). Zaal zips `~/.zao/zoe/` and sends:
+
+| File | What |
+|------|------|
+| `persona.md` | voice, anti-patterns, format rules, elder/lineage |
+| `human.md` | who Zaal is - now with the 4 closed gaps (SongJam/$SANG, Recoup, Infanity external, Ansuz external) |
+| `bootloader-template.md` | the child-bot seed |
+| `brand.md` | brand voice |
+| `groups.json` | registered Telegram groups |
+| `tasks.json` | open task queue |
+| `archive/<scope>/*.jsonl` | **the lifestream corpus - every turn ZOE ever logged. This is the raw history to compress.** |
+| `recent/<scope>.json` | the 8-turn ring buffer (the prompt window) |
+
+---
+
+## 4. Key research docs - verified links
+
+The canonical ZAO context. All on `main`:
+
+| Doc | Topic | Link |
+|-----|-------|------|
+| 050 | The ZAO complete guide | https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/050-the-zao-complete-guide |
+| 051 | ZAO whitepaper 2026 | https://github.com/bettercallzaal/ZAOOS/tree/main/research/community/051-zao-whitepaper-2026 |
+| 079 | SongJam / $SANG | https://github.com/bettercallzaal/ZAOOS/tree/main/research/music/079-songjam-music-player-research |
+| 460 | ZAO agentic stack end-to-end design | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/460-zao-agentic-stack-end-to-end-design |
+| 483 | Hermes agent + local-LLM framework | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/483-hermes-agent-local-llm-framework |
+| 601 | Agent stack cleanup - the 5 operating surfaces | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/601-agent-stack-cleanup-decision |
+| 647 | Agent quality deep research (persona decay, evals) | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/647-agent-quality-deep-research |
+| 648 | Ryan Kagy sync (the May 13/14 call) | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/648-ryan-kagy-zao-civilization-sync |
+| 669 | Bonfires - everything we know | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/669-bonfires-everything-we-know |
+| 673 | Meeting capture skill | https://github.com/bettercallzaal/ZAOOS/tree/main/research/dev-workflows/673-meeting-capture-skill |
+| 680 | Meeting skill - Bonfire bridge | https://github.com/bettercallzaal/ZAOOS/tree/main/research/agents/680-meeting-skill-bonfire-bridge |
+
+Pending on open PRs (not on `main` yet):
+
+- **682** - Ryan Kagy Limitless call (May 12, the origin call): https://github.com/bettercallzaal/ZAOOS/pull/581
+- **683** - ZOE troubles analysis (this folder): https://github.com/bettercallzaal/ZAOOS/pull/582
+
+Whole research library (202 docs, 13 folders): https://github.com/bettercallzaal/ZAOOS/tree/main/research
+
+> Note: the research library has a few duplicate doc numbers from parallel work (601, 676, 683 each appear twice). Always resolve a doc by its folder path, not the bare number.
+
+---
+
+## 5. The Bonfire - you already have a pre-extracted corpus
+
+The ZABAL Bonfire is your product. ZAO context is already flowing into it:
+
+- **bonfires.ai** | dashboard: **app.bonfires.ai/dashboard** | the ZAO bonfire: **zabal.bonfires.ai**
+- API base: `https://tnt-v2.api.bonfires.ai`
+- Write: `POST /knowledge_graph/episode/create` (works, non-admin key)
+- Read: `POST /vector_store/search` (returns empty until labeling runs - admin-gated, `/labeling/hybrid` is 403 for the non-admin key)
+
+What is in it: ~780 prior episodes, plus **57 meeting episodes** the ZAO `/meeting` skill auto-posted (Iman call, Tanja call, ZAOstock advisor, your May 12 Limitless call - all decisions + actions as episodes).
+
+**Ask: run a labeling pass on the ZABAL bonfire.** That unlocks `vector_store/search`, and the compiled ZOE - and your bots - can read ZAO context straight from the graph you control. Right now everything is write-only on the non-admin key.
+
+The ZOE-side Bonfire bridge that proves the API: https://github.com/bettercallzaal/ZAOOS/blob/main/bot/src/zoe/recall.ts
+
+---
+
+## 6. The ZAO agent stack - the map
+
+5 operating surfaces (doc 601), Hermes locked as THE framework (2026-05-05):
+
+| Bot | Role | Source |
+|-----|------|--------|
+| ZOE `@zaoclaw_bot` | concierge - tasks, captures, brief/reflect, recall | `bot/src/zoe/` |
+| Hermes `@zoe_hermes_bot` | autonomous fix-PR pipeline (coder + critic + auto-PR) | `bot/src/hermes/` |
+| ZAO Devz `@zaodevz_bot` | group dispatch + learning tips | `bot/src/devz/` |
+| Bonfire `@zabal_bonfire` | knowledge graph (your product) | bonfires.ai |
+| ZAOstock bot `@ZAOstockTeamBot` | festival team coordination | `bot/` root |
+
+ZOE is the lineage elder - child bots inherit her voice + anti-patterns verbatim. The compiled ZOE inherits that role.
+
+---
+
+## 7. What the compiled ZOE needs to fix (from doc 683)
+
+1. **Load the lifestream.** Not just append. The P0 bug.
+2. **Chunk every send.** ZOE 400s on long scheduler sends (brief/nudges bypass the chunker).
+3. **Honest self-description.** ZOE's persona text wrongly says it has no archive - it does.
+4. **A real context window.** 8 turns loses group chats in ~2 minutes.
+
+---
+
+## 8. Stack reference
+
+Next.js 16 / React 19 / TypeScript / Tailwind v4 / Supabase (RLS) / Neynar / XMTP / Stream.io / Wagmi + Viem / iron-session / Vitest / Biome. Bot runtime: Node + grammY (Telegram), Claude via CLI, tiered model routing. VPS: `31.97.148.88`.
+
+---
+
+That is the full handoff. Clone the repo, pull the soul zip from Zaal, run Bonfire labeling, and your bots have all of ZAO context. Questions -> the thread.


### PR DESCRIPTION
## Summary

Deep analysis of ZOE's agent troubles (from the 2026-05-20 ZAO Civilization Telegram thread) with code evidence, plus the followup package for Ryan Kagy's compiled new ZOE.

## Core finding (P0)

ZOE writes a permanent per-turn archive (`appendArchive` -> `~/.zao/zoe/archive/*.jsonl`) but `loadMemory()` only loads the 8-turn ring buffer. `readArchive()` exists and is never called by the context path. ZOE is functionally amnesiac past 8 turns despite a complete on-disk record - that is the root of every "[not in context]" in the thread.

## Also flagged

- P1: `scheduler.ts` sends (brief/nudges/prompts) bypass the message chunker -> 400 "message too long"
- P1: ZOE's persona text wrongly claims it has no archive
- P1: 8-turn window loses group-chat context fast

## Fix plan + Ryan package

Doc has the local fix plan (wire `readArchive` into `loadMemory`, shared `sendChunked` helper, persona update) and the full manifest + copy-paste message for Ryan so the compiled ZOE loads the lifestream instead of inheriting the write-only-archive bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)