### PR TITLE
feat(hooks): wire pre-commit + staged-diff secret scan

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,3 +4,6 @@
 # 1. Block new doc-number collisions in research/.
 #    From the 2026-05-18 session that hit 4 collisions in one day.
 bash "$(git rev-parse --show-toplevel)/scripts/check-research-doc-collisions.sh" || exit 1
+
+# 2. Block secrets in the staged diff (.claude/rules/secret-hygiene.md, doc 683).
+bash "$(git rev-parse --show-toplevel)/scripts/git-secret-scan.sh" || exit 1

--- a/scripts/git-secret-scan.sh
+++ b/scripts/git-secret-scan.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pre-commit secret scan. Hard-aborts a commit when the staged diff contains an
+# obvious secret. Mirrors .claude/rules/secret-hygiene.md step 2.
+#
+# Two reasons this exists: a Telegram bot token leaked into a session transcript
+# and a real token leaked into a test fixture, both 2026-05. See doc 683.
+#
+# Invoked from .husky/pre-commit. Standalone-safe: pass repo root as $1 or it
+# falls back to git rev-parse. Override a confirmed false positive with
+# `git commit --no-verify`.
+#
+# Patterns are deliberately PREFIXED tokens only (high precision, near-zero
+# false positives). A bare 64-char-hex check was omitted on purpose - it trips
+# on lockfile hashes and research docs. Every secret type the ZAO stack uses
+# (Anthropic, OpenRouter, OpenAI, GitHub PATs, Telegram, AWS, PEM keys) is
+# prefixed, so the named patterns cover the real risk.
+
+set -uo pipefail
+
+REPO="${1:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+[[ -z "$REPO" ]] && exit 0
+cd "$REPO" || exit 0
+
+# 1. No real .env file staged (.env.example is allowed).
+ENV_STAGED=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
+  | grep -E '(^|/)\.env($|\.local$|\.production$)' || true)
+if [[ -n "$ENV_STAGED" ]]; then
+  echo "" >&2
+  echo "[secret-scan] BLOCKED - an env file is staged:" >&2
+  echo "$ENV_STAGED" | sed 's/^/    /' >&2
+  echo "Unstage it: git restore --staged <file>. Env files must stay gitignored." >&2
+  exit 1
+fi
+
+# 2. Scan ADDED lines of the staged diff for secret patterns.
+DIFF=$(git diff --cached --diff-filter=ACM -U0 2>/dev/null | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+[[ -z "$DIFF" ]] && exit 0
+
+HITS=""
+check() { # $1 = label, $2 = extended-regex
+  local m
+  m=$(printf '%s\n' "$DIFF" | grep -nE "$2" 2>/dev/null || true)
+  [[ -n "$m" ]] && HITS="${HITS}  [$1]
+$(printf '%s\n' "$m" | sed 's/^/      /')
+"
+}
+
+check "private-key assignment with hex value" 'PRIVATE_KEY[A-Z_]*[[:space:]]*=.*[0-9a-fA-F]{32}'
+check "PEM private key block"                  'BEGIN (RSA |EC |OPENSSH |DSA |)PRIVATE KEY'
+check "Anthropic API key"                      'sk-ant-[A-Za-z0-9_-]{20,}'
+check "OpenAI / OpenRouter API key"            'sk-(proj-|or-v1-)?[A-Za-z0-9_-]{32,}'
+check "GitHub classic PAT"                     'gh[pousr]_[A-Za-z0-9]{36,}'
+check "GitHub fine-grained PAT"                'github_pat_[A-Za-z0-9_]{50,}'
+check "Telegram bot token"                     '[0-9]{8,10}:[A-Za-z0-9_-]{35}'
+check "AWS access key id"                      'AKIA[0-9A-Z]{16}'
+
+if [[ -n "$HITS" ]]; then
+  echo "" >&2
+  echo "[secret-scan] BLOCKED - the staged diff looks like it contains a secret:" >&2
+  echo "" >&2
+  printf '%s' "$HITS" >&2
+  echo "" >&2
+  echo "If it is a placeholder/fixture: redact it to [REDACTED] and re-stage." >&2
+  echo "If it is a real secret: rotate it NOW, then commit the redacted version." >&2
+  echo "False positive you are certain about: git commit --no-verify" >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Wire the version-controlled .husky/ hooks into .git/hooks/ so git actually
+# runs them. Run once after cloning ZAOOS:  bash scripts/install-git-hooks.sh
+#
+# Why this exists: core.hooksPath points at .git/hooks (not .husky), so the
+# .husky/ hooks are version-controlled but inert until delegated. This script
+# writes thin delegators into .git/hooks/. It does NOT touch git config.
+#
+# Each delegator is local-only (not committed); the real hook logic lives in
+# .husky/ and propagates through git. See doc 683.
+
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$(git rev-parse --git-path hooks)"
+mkdir -p "$HOOKS_DIR"
+
+MARKER="# zaoos-husky-delegator"
+
+for hook in pre-commit; do
+  src="$REPO/.husky/$hook"
+  [[ -f "$src" ]] || continue
+  dst="$HOOKS_DIR/$hook"
+
+  if [[ -f "$dst" ]] && ! grep -q "$MARKER" "$dst" 2>/dev/null; then
+    cp "$dst" "$dst.bak.$(date +%s)"
+    echo "backed up existing $hook -> $dst.bak.*"
+  fi
+
+  cat > "$dst" <<EOF
+#!/usr/bin/env sh
+$MARKER - delegates to version-controlled .husky/$hook (scripts/install-git-hooks.sh)
+exec "$REPO/.husky/$hook" "\$@"
+EOF
+  chmod +x "$dst"
+  echo "wired .git/hooks/$hook -> .husky/$hook"
+done
+
+echo "done. pre-push is left as-is (safe-git-push wrapper, doc 461)."


### PR DESCRIPTION
## Summary

Doc 683 cheap win #1. The collision-guard hook in `.husky/pre-commit` was inert - `core.hooksPath` points at `.git/hooks` where no `pre-commit` existed, so nothing scanned commits. A Telegram bot token and a test-fixture key both leaked this month.

- `scripts/git-secret-scan.sh` - blocks a commit when the staged diff contains a prefixed secret (Anthropic / OpenRouter / OpenAI keys, GitHub PATs, Telegram token, AWS key, PEM block, hex-valued `PRIVATE_KEY`) or a staged env file. High-precision named patterns only - no bare-hex check, so no false positives on lockfiles or research docs.
- `scripts/install-git-hooks.sh` - wires `.husky/` hooks into `.git/hooks/` without touching git config. Run once per clone.
- `.husky/pre-commit` - now also runs the secret scan; the collision guard is revived as a side effect of wiring.

## Test plan

- [x] Scanner exits 0 on its own staged content (no self-trip)
- [x] Scanner exits 1 on a planted fake GitHub PAT + Telegram token
- [x] `install-git-hooks.sh` creates the `.git/hooks/pre-commit` delegator
- [x] This commit itself passed through the newly-wired hook
- [ ] `pre-push` left as-is (already protected by the doc-461 safe-git-push wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)