### PR TITLE
docs 684-686: agent dispatch, code-on-incus, Kane Brown festival

### DIFF
--- a/research/dev-workflows/684-claude-code-agent-dispatch-parallelization/README.md
+++ b/research/dev-workflows/684-claude-code-agent-dispatch-parallelization/README.md
@@ -1,0 +1,59 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 685
+tier: QUICK
+---
+
+# 684 - Claude Code Agent Dispatch + Parallelization
+
+> **Goal:** Answer the r/ClaudeCode question "is there a Cowork Dispatch for Claude Code?" and map it to what ZAO already runs (QuadWork).
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | KEEP using QuadWork as ZAO's agent dispatcher - do not adopt a new tool | QuadWork (local 4-agent Head/Dev/RE1/RE2 dashboard, http://127.0.0.1:8400) already solves the parallelization the Reddit thread is asking for |
+| 2 | STEAL the adversarial-review phase from `dangeresque` if QuadWork lacks it | dangeresque bakes automatic adversarial review + human merge control into each pass - that is a concrete upgrade pattern |
+| 3 | USE `cmux` only if QuadWork's dashboard view is insufficient | cmux ("tmux for Claude Code", 537 stars) is terminal-multiplexer visibility; QuadWork already gives a web dashboard |
+| 4 | The native primitive is enough for ad-hoc work | Claude Code's Spawn-agent + git worktrees handles one-off parallel tasks without any external tool |
+
+## Source: Inbox Item (r/ClaudeCode)
+
+Forwarded by Zaal to ZOE's inbox. Thread "Claude Code agent dispatcher!" (r/ClaudeCode, 4 upvotes, 4 comments): asks for "the equivalent of Cowork Dispatch but for Claude Code, with a focus on making it easy to parallelize agents."
+
+## Findings
+
+| Tool / Pattern | What it does | Maturity | Fit for ZAO |
+|----------------|--------------|----------|-------------|
+| **QuadWork** (ZAO's own) | Local 4-agent dev team dashboard, auto-dispatching, agents run on Claude Max auth | In use | Already the answer - keep |
+| **dangeresque** (slikk66) | Claude/Codex headless task-worker dispatch; isolated git worktrees, multi-phase passes, automatic adversarial review, human merge control; host-native | Active OSS | Steal the adversarial-review + phased-pass pattern |
+| **cmux** (craigsc, 537 stars) | "tmux for Claude Code" - terminal multiplexing for many parallel sessions | Active OSS | Optional - QuadWork dashboard covers visibility |
+| **Native Spawn-agent + git worktrees** | Orchestrator reads a task list, spins scoped subagents, each in its own worktree | Built into Claude Code | Use for ad-hoc parallel tasks |
+
+The Reddit thread's own top answers converge on the same three things: dangeresque, cmux/tmux for visibility, and "Spawn agent already does this." ZAO is ahead of the question - QuadWork is the productized version.
+
+## Staleness Notes
+
+- Reddit thread + star counts: captured 2026-05-20. cmux at 537 stars; star counts drift.
+- dangeresque is a thin wrapper under active development; verify the feature set on the repo before adopting any pattern.
+
+## Sources
+
+- [r/ClaudeCode - "Claude Code agent dispatcher!"](https://www.reddit.com/r/ClaudeCode/comments/1tiopk3/claude_code_agent_dispatcher/)
+- [slikk66/dangeresque (GitHub)](https://github.com/slikk66/dangeresque)
+- [craigsc/cmux (GitHub)](https://github.com/craigsc/cmux)
+
+## Also See
+
+- [Doc 685](../685-code-on-incus-agent-sandbox/) - code-on-incus: the sandboxing layer that pairs with a dispatcher
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Compare QuadWork's review step to dangeresque's adversarial-review pass | @Zaal | Decision | Next QuadWork iteration |
+| File the inbox message under `research` + `processed` | @Claude | Bot task | This session |
+| If QuadWork lacks phased multi-pass, scope it as a QuadWork feature | @Zaal | Todo | After comparison |

--- a/research/dev-workflows/685-code-on-incus-agent-sandbox/README.md
+++ b/research/dev-workflows/685-code-on-incus-agent-sandbox/README.md
@@ -1,0 +1,78 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 684
+tier: STANDARD
+---
+
+# 685 - code-on-incus: Isolated Machines for AI Agents
+
+> **Goal:** Evaluate code-on-incus (each AI agent gets its own isolated Linux machine) for ZAO's autonomous agent stack.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | INVESTIGATE code-on-incus for the Hermes autonomous PR pipeline - does each Hermes run get a clean sandbox? | Hermes writes code + opens PRs autonomously; an isolated machine per run contains blast radius if an agent goes wrong |
+| 2 | code-on-incus is Linux-only; on Zaal's Mac it needs a Linux VM. USE it on the VPS, not the laptop | Incus is a Linux container manager; QuadWork runs locally on macOS where Incus is not native |
+| 3 | code-on-incus directly enforces `.claude/rules/secret-hygiene.md` at the OS layer | Host SSH keys, env vars, and Git tokens stay on the host - this is the secret-hygiene rule made structural instead of procedural |
+| 4 | SKIP it for QuadWork's local 4-agent loop for now | QuadWork agents are trusted local dev work; the git-worktree isolation it already uses is proportionate |
+
+## What code-on-incus Is
+
+CLI tool (`coi`) by **mensfeld**, **MIT** licensed, open-source (not commercial). Tagline: "gives each AI agent its own isolated machine with root, Docker, and systemd." Built on **Incus** - a Linux system-container manager forked from LXD - not Docker.
+
+## Why It Exists
+
+| Problem | How code-on-incus answers it |
+|---------|------------------------------|
+| Credential exposure | Host SSH keys, env vars, Git tokens stay on the host; agent only sees its container |
+| Cross-session interference | Each agent gets its own sandboxed full-OS environment; parallel agents do not collide |
+| Agent goes rogue | Kernel-level monitoring (nftables) detects reverse shells, data exfiltration, credential scanning; auto-pauses or kills the container |
+| Permission hacks | System containers give proper file ownership without UID-mapping workarounds |
+
+Supports **Claude Code** (default) and **OpenCode**. Sessions persist with full conversation history; credentials restore automatically. Setup: `curl ... install.sh | bash`, then `coi build` (~5-10 min), then `coi shell` in a project.
+
+## Why System Containers (Incus) over Docker
+
+Docker = application containers (one process). Incus = system containers (full OS with init/systemd). For an agent that needs root, Docker-in-the-box, and systemd, a system container behaves like a real machine - which is what an autonomous coding agent expects.
+
+## ZAO Fit
+
+| ZAO surface | Sandbox needed? | Verdict |
+|-------------|-----------------|---------|
+| **Hermes** autonomous fix-PR pipeline (`bot/src/hermes/`) | High - it writes code + pushes PRs unattended | INVESTIGATE code-on-incus on the VPS |
+| **QuadWork** local 4-agent loop | Low - trusted local dev, git-worktree isolation already used | SKIP for now |
+| **ZOE / ZAO Devz** Telegram bots | Low - they dispatch + classify, do not run arbitrary code | SKIP |
+
+ZAO's existing isolation is procedural: `.claude/rules/secret-hygiene.md` (stub keys on disk, pre-commit scans, post-edit HEAD scans). code-on-incus makes that structural - the agent physically cannot read host secrets. That is the upgrade path if Hermes ever runs untrusted or community-submitted tasks.
+
+## Community Signal
+
+Agent sandboxing is an active 2026 topic. A competing approach - **Elvean** (macOS-native AI client with a Linux sandbox via Apple's Containerization framework) - drew **66 upvotes / 15 comments** on r/ollama. Different stack (Apple Containerization vs Incus), same thesis: AI agents need a real isolated OS, not just a process jail. code-on-incus is the Linux/VPS-native answer; Elvean is the Mac-native one.
+
+## Staleness Notes
+
+- code-on-incus is a young single-maintainer OSS project - verify the threat-detection feature set on the repo before relying on it in production.
+- `coi build` time (~5-10 min) and install method from the repo README, captured 2026-05-20.
+- Incus continues active development post-LXD-fork; no version pinned here.
+
+## Sources
+
+- [mensfeld/code-on-incus (GitHub)](https://github.com/mensfeld/code-on-incus)
+- [Incus - Linux container manager](https://linuxcontainers.org/incus/)
+- [r/ollama - "Local Linux sandbox for AI agents on macOS - no Docker" (Elvean, 66 upvotes)](https://www.reddit.com/r/ollama/comments/1tg7nih/local_linux_sandbox_for_ai_agents_on_macos_no/)
+
+## Also See
+
+- [Doc 684](../684-claude-code-agent-dispatch-parallelization/) - agent dispatch/parallelization; code-on-incus is the isolation layer beneath a dispatcher
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Decide whether Hermes runs need per-run Incus sandboxes on the VPS | @Zaal | Decision | Next Hermes hardening pass |
+| If yes, spike `coi` on VPS 1 and run one Hermes job inside a container | @Zaal | Todo | After decision |
+| Cross-check code-on-incus threat detection against `.claude/rules/secret-hygiene.md` guards | @Claude | Audit | When Hermes sandbox is scoped |

--- a/research/events/686-kane-brown-miles-on-it-automotive-festival/README.md
+++ b/research/events/686-kane-brown-miles-on-it-automotive-festival/README.md
@@ -1,0 +1,82 @@
+---
+topic: events
+type: market-research
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 547
+tier: STANDARD
+---
+
+# 686 - Kane Brown "Miles On It Tour": The Artist-Branded Passion Festival Model
+
+> **Goal:** Break down Kane Brown's automotive festival as an event-design model and pull what is useful for ZAO Festivals / ZAOstock.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | STUDY this as a model, do NOT copy it - ZAOstock stays a music festival | Kane Brown built a festival around cars, not concerts; ZAOstock's core is music. The transferable idea is the *structure*, not the theme. |
+| 2 | The transferable move: anchor a future ZAO event on what the community DOES, not just who performs | Kane Brown's fans are gearheads; the festival is participatory (they bring builds, compete). ZAO's community builds - a "builders expo" event is the parallel. |
+| 3 | STEAL the prize-competition spine: $85,000 in cash prizes makes attendees into participants | A festival where attendees compete (and the founder hands out prizes) converts a crowd into a program. ZAOstock could add a build/music competition track. |
+| 4 | KEEP this for post-ZAOstock-debrief discussion, not the Oct 3 plan | ZAOstock Oct 3 2026 is locked; this is input for ZAO Festivals event #2+, not a Oct 3 change. See [Doc 547](../547-zaostock-master-strategy-cassie-debrief/). |
+
+## The Event
+
+| Field | Value |
+|-------|-------|
+| Name | Miles On It Tour: The Ultimate Automotive Experience |
+| Artist | Kane Brown (country superstar) |
+| Venue | Nashville Superspeedway, Lebanon TN (motorsports venue infield) |
+| Dates | 2026-04-10 and 2026-04-11 (2 days, doors 10am CT) |
+| Tickets | $49 to $350 by access tier; kids 12 and under free with paid adult; general parking free |
+| Prizes | $85,000 in cash prizes + trophies, presented by Kane Brown |
+| Channels | MilesOnItAutoTour.com, AXS.com, Facebook (Milesonittour) |
+
+## What Makes The Model Interesting
+
+It is **not a concert**. Kane Brown does not headline a set - he is the celebrity gravitational center and prize presenter, appearing throughout both days. The festival is built around **car and truck culture**, a passion he shares with his fanbase. The infield fills with custom builds, drift and burnout exhibitions, drag and autocross, dyno pulls, audio competitions, a vendor midway, food trucks, and brand activations.
+
+The attendees are not spectators - they **bring their builds and compete**. The artist's brand is the magnet; the attendees are the program.
+
+## Kane Brown Model vs ZAOstock Model
+
+| Dimension | Miles On It Tour | ZAOstock 2026 (current plan) |
+|-----------|------------------|------------------------------|
+| Core activity | Car culture - attendees bring + compete | Live music - artists perform |
+| Artist role | Celebrity draw + prize presenter, not performer | Performers are the show |
+| Attendee role | Participant (brings a build, competes) | Audience (watches sets) |
+| Revenue spine | Tiered tickets $49-$350 + vendor midway + brand activations | Sponsorship tiers + tickets (Doc 547) |
+| Engagement hook | $85k prize competition | Festival lineup (open-call submissions) |
+| Venue logic | Repurposed motorsports venue infield | Franklin St Parklet, Ellsworth ME |
+
+## Takeaways For ZAO Festivals
+
+1. **Participation beats spectation.** The strongest idea here is attendees-as-program. ZAO's community are builders; a future ZAO event could center a build/hack showcase where members bring work and compete - the music is the soundtrack, not the only act.
+2. **The founder as prize presenter is a real role.** Kane Brown is not on stage all day - he is the recurring presence handing out recognition. Zaal can occupy that exact role at a ZAO event without having to perform.
+3. **A passion adjacency can expand the audience.** Kane Brown reached gearheads via country music. ZAO's adjacency is the builder/web3/AI crowd - an event themed on that passion (not just music) widens the funnel beyond musicians, matching the doc 678/12-month "primitive toolkit for any digital creator" framing.
+
+## Staleness Notes
+
+- All event facts (dates, prices, prize pool) from Nashville Superspeedway press release + AXS listings, captured 2026-05-20. The event runs 2026-04-10/11 - it has already occurred by the time this doc is read; treat it as a completed case study, not an upcoming event.
+- No Reddit/HN discussion exists for a country-music automotive festival; the Facebook fan page (Milesonittour) is the active community channel and is cited as the community source.
+
+## Sources
+
+- [Nashville Superspeedway - press release](https://www.nashvillesuperspeedway.com/media/news/kane-brown-brings-miles-tour-ultimate-automotive-experience-nashville-superspeedway.html)
+- [Miles On It Auto Tour - official site](https://milesonitautotour.com/)
+- [Miles On It Tour - The Experience page](https://milesonitautotour.com/pages/the-experience)
+- [AXS event listing - Apr 10-11 2026](https://www.axs.com/events/1241066/miles-on-it-tour-tickets)
+- [Country Music On Tour - launch coverage](https://countrymusicontour.com/kane-brown-launches-miles-on-it-tour-the-ultimate-automotive-experience-in-nashville/)
+- [Miles On It Tour - Facebook (community channel)](https://www.facebook.com/Milesonittour/)
+
+## Also See
+
+- [Doc 547](../547-zaostock-master-strategy-cassie-debrief/) - ZAOstock master strategy: festival-as-prototype framing this doc feeds into
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Raise the "attendees-as-program" model at the ZAOstock Oct 10 debrief | @Zaal | Calendar | 2026-10-10 |
+| Decide if a ZAO builders-expo / competition track fits ZAO Festivals event #2 | @Zaal | Decision | Post-ZAOstock |
+| Note the "founder as prize presenter" role for Zaal at future ZAO events | @Zaal | Todo | Event #2 planning |


### PR DESCRIPTION
## Summary
Three research docs from one batch: ZOE inbox item + 2 URLs Zaal sent.

- **684 (QUICK)** Claude Code agent dispatch/parallelization - r/ClaudeCode inbox item. QuadWork already solves it; steal dangeresque's adversarial-review pass.
- **685 (STANDARD)** code-on-incus - isolated Linux machine per AI agent (Incus system containers, MIT). Investigate for the Hermes autonomous PR pipeline on the VPS; makes secret-hygiene structural.
- **686 (STANDARD)** Kane Brown "Miles On It Tour" - artist-branded passion-festival model. Transferable idea = attendees-as-program; input for ZAO Festivals event #2, not the Oct 3 ZAOstock plan.

## Tier
QUICK + STANDARD x2

## Sources
~13 unique: r/ClaudeCode, r/ollama, GitHub (code-on-incus, dangeresque, cmux), Nashville Superspeedway, AXS, Miles On It official, country-music press

## Inbox
ZOE inbox item (r/ClaudeCode dispatcher thread) processed + filed under research/processed.

## Next Actions
See each doc's Next Actions table.