### PR TITLE
docs 687-691 + /inbox cluster mode: drained 26-item inbox backlog

### DIFF
--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -21,12 +21,16 @@ When forwarded from Gmail, the original `From:` will be the upstream sender (e.g
 ## Commands
 
 - `/inbox` - show all unread items (from whitelisted sender only)
+- `/inbox next` - research the top unread item via /zao-research, then file it
 - `/inbox research` - research the top unread item via /zao-research, then file it
-- `/inbox research all` - research all unread items sequentially
+- `/inbox research all` - research all unread items sequentially (one doc per item - avoid for large backlogs, use `cluster` instead)
+- `/inbox cluster` - drain the WHOLE backlog: group unread items by theme, write one synthesis doc per cluster (not one-per-item), file everything
 - `/inbox clear` - mark all unread items as processed
 - `/inbox count` - how many unread items
 - `/inbox folder <name>` - show all items in a folder (e.g. `/inbox folder x-posts`)
 - `/inbox folders` - list all folders and their counts
+
+> **When the backlog is large (8+ unread), use `/inbox cluster`, not `/inbox research all`.** One-doc-per-item produces many thin docs and misses the cross-cutting pattern. Clustering produces fewer, stronger synthesis docs.
 
 ## Folders (Label-Based)
 
@@ -126,6 +130,27 @@ Fetch all messages then filter client-side for messages that have the folder lab
      -H "Content-Type: application/json" \
      -d '{"add_labels": ["<folder>", "processed"], "remove_labels": ["unread"]}'
    ```
+
+### Cluster Mode (`/inbox cluster`)
+
+For draining a large backlog. Forwarded items pile up faster than `/inbox next` clears them, and processing each as its own doc produces many thin docs that miss the cross-cutting pattern. Cluster mode fixes both.
+
+**Workflow:**
+
+1. **Inventory.** Fetch all unread (whitelisted sender only). Resolve opaque short links so each item's real content is known - reddit `/s/` links resolve with `curl -sL -o /dev/null -w '%{url_effective}'`; strip query strings.
+
+2. **Triage.** Sort every item into one of three buckets:
+   - **Research** - has a topic worth a doc.
+   - **Action-item** - needs Zaal to do something (account setup, a reply, a follow-up). Label `action-items` + `processed`, no doc.
+   - **Noise** - bounce-backs, delivery failures, dead ends. Label `processed` only, no doc.
+
+3. **Cluster the research bucket by theme.** Group items that share a subject (e.g. "Claude Code workflows", "agent memory", "vibecoding economics"). A cluster = 3+ related items. Leftover singletons go in a "standalone roundup" cluster.
+
+4. **One synthesis doc per cluster.** Run `/zao-research` logic per cluster: fetch every item in the cluster, then write ONE doc that finds the cross-cutting pattern - not a summary per item. For 4+ clusters, dispatch one research subagent per cluster in parallel. Each doc follows the zao-research v2 format (frontmatter, Key Decisions table, Source Items list, Findings, ZAO Application, Sources, Next Actions).
+
+5. **File every message.** Apply `research`/`action-items` + `processed`, remove `unread`. Inbox ends at 0 unread.
+
+6. **Report.** Tell Zaal: N items drained into M docs, plus any action-items and noise filed. Surface anything that was filed but NOT given a doc so he can override.
 
 ### Listing All Folders
 

--- a/research/agents/689-ai-agent-memory-personal-systems/README.md
+++ b/research/agents/689-ai-agent-memory-personal-systems/README.md
@@ -1,0 +1,108 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 687
+tier: STANDARD
+---
+
+# 689 - AI Agent Memory + Personal Knowledge Systems (Community, May 2026)
+
+> **Goal:** Synthesize cross-cutting patterns from 4 community posts about how builders solve agent persistence + knowledge retention.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | Build agent memory as 3 layers: ingest, organize, active recall | Single monolithic memory fails. Ingest/organize/absorb separates concerns; prevents 800-note vault problem |
+| 2 | Use dual-index search (vector + keyword BM25) with reciprocal rank fusion | Vector alone misses exact matches ("Q3 budget" vs "quarterly planning"). Hybrid catches both semantics + precision |
+| 3 | Require backlinks before promotion to active memory | Orphan notes are dead weight. Force "how does this connect?" question before anything goes live |
+| 4 | Schedule forced review rituals (daily 5-min + weekly 30-min block) | Beautiful systems die without absorption. Calendar-blocked time with automated queries prevents hoarding without use |
+| 5 | Keep memory on-disk (SQLite/ChromaDB) not cloud vector DB | Survives reboots, power outages, avoids per-query LLM costs. Works across 6 dev tools + CLI agents |
+
+## Source Items (from ZOE inbox)
+
+### Item 1: r/ollama "After months of building in vain"
+- **What:** Dograh (open-source voice AI platform) team celebrates breakthrough: stranger made YouTube tutorial, 171 upvotes, 11 comments
+- **Core claim:** Unseen momentum builds faster than metrics show; keep shipping
+- **Relevance:** NOT about agent memory. Misfile in cluster - rejects item
+- **URL:** https://www.reddit.com/r/ollama/comments/1td7kfx/after_months_of_building_in_vain_a_stranger_made/
+
+### Item 2: r/opencode "I got tired of my AI agent forgetting everything"
+- **What:** Elias Oukaldi built Shokunin memory system: ChromaDB + BM25 + RRF + session management. 33 upvotes, detailed technical post
+- **Core claim:** Hybrid search (vector + keyword) + session loading + 38 domain skills = agent that remembers context across sessions. Installs in one bash command
+- **Key stats:** 25/25 health checks, 99+ memory entries, ~30MB SQLite file with embeddings, works with 6 tools (Claude Code, Cursor, Windsurf, Cline, Continue)
+- **Relevance:** CORE to cluster - production agent memory solution
+- **URL:** https://www.reddit.com/r/opencode/comments/1te9tzi/i_got_tired_of_my_ai_agent_forgetting_everything/
+
+### Item 3: r/hermesagent "How I use Obsidian as the spine"
+- **What:** 2-year Obsidian vault journey. Started with 800+ notes, reorganized to 3 folders (Inbox/Notes/Archive), 60% cut. 60 upvotes, 9 comments
+- **Core claim:** Capture/Organize/Absorb 3-layer system. Promotion requires backlink (no orphans). Dataview + Readwise + Periodic Notes force review rituals. Vault never matures without scheduled absorption
+- **Key stats:** 12 months wasted on un-read vault, then rebuilt to 3-folder structure, 30-min Sunday blocks force processing, daily 5-min Readwise reviews, 90% of orphan notes get archived
+- **Relevance:** NOT about code agents but about personal knowledge systems & memory architecture that applies to agent context
+- **URL:** https://www.reddit.com/r/hermesagent/comments/1teaqmi/how_i_use_obsidian_as_the_spine_of_my_personal/
+
+### Item 4: r/hermesagent "What does your agent actually do on a normal day"
+- **What:** Discussion: user with basic agent (morning briefing, news, calendar, stock alerts) asks what real daily use looks like. 40 upvotes, 74 comments of shared workflows
+- **Core claim:** Most useful agents handle briefing automation + data aggregation. Question: how to expand beyond demo? Real use splits work vs personal (health, finance, family)
+- **Relevance:** Pragmatic context for what agent memory should support - not vaporware features but daily briefing + data continuity
+- **URL:** https://www.reddit.com/r/hermesagent/comments/1tcwarx/what_does_your_agent_actually_do_for_you_on_a/
+
+### r/hermesagent Subreddit Relation to ZAO Hermes
+**Finding:** r/hermesagent (35503 subscribers) is a GENERAL agent knowledge system subreddit, NOT related to ZAO's Hermes autonomous fix-PR pipeline. They discuss agent workflows, memory, daily automation for any AI agent framework. ZAO's Hermes (coder + critic + auto-PR) is a specific tool not mentioned in this community.
+
+## Findings
+
+The cross-cutting pattern across all 3 on-topic posts (opencode, obsidian, daily-use thread) is:
+
+**Agents need memory architecture with 3 distinct layers, each with its own failure mode and fix:**
+
+| Layer | Function | Failure Mode | Fix |
+|-------|----------|-------------|-----|
+| **Ingest** | Capture without friction (ChromaDB autolog, Readwise plugins, voice-to-text) | Tool sprawl paralyzes entry (too many capture tools, incompatible formats) | Single source of truth pipeline: all inputs standardize to markdown/JSON, auto-log to one system |
+| **Organize** | Store with retrieval-first design (backlink requirement, 3-folder structure, status tags only) | Vault bloat: 800 notes, no way to surface what's stale (orphans accumulate, decision tax on filing) | Force promotion rule: no backlinks = archive. Dataview/Periodic queries surface what's orphaned |
+| **Recall** | Scheduled absorption (daily 5-min review, weekly 30-min block, hybrid search on retrieval) | Beautiful system goes unread (captured but never revisited = hoarding without learning) | Calendar-blocked ritual + multi-strategy search (vector + BM25 RRF). Without recall, memory dies |
+
+**Secondary pattern: Memory size doesn't scale linearly with value.** Elias cut vault 60%, usefulness went up. Reason: smaller scope = higher recall ratio. Shokunin's 99 entries outperform systems with 10,000 entries because they're *actively retrievable*.
+
+**Tertiary pattern: Dual-index search mandatory for production agents.** ChromaDB-only fails on exact matches ("budget Q3" vs "quarterly"). BM25 alone fails on semantic drift. RRF fusion wins because it handles both. Applied to ZOE: keyword index on session IDs + decision tags, vector search on memory blocks.
+
+## ZAO Application
+
+### ZOE (4-block memory file system)
+ZOE currently runs 4 Letta memory blocks (human.md, persona.md, world.md, focus.md) at ~/.zao/zoe/. Adopt:
+
+1. **Layer 1 (Ingest):** Telegram DM auto-logs all captures to Inbox session file. No friction, just append markdown + timestamp
+2. **Layer 2 (Organize):** Daily cron scans Inbox for 24-hour-old items. Prompt ZOE to promote to human.md (if backlink to existing context) or archive to cold_sessions/. Forces "does this connect to what we know?" 
+3. **Layer 3 (Recall):** /recall command implements Readwise-style 5-min random surface of 3 past decisions + context. Dataview-equivalent: `grep -E "DECISION|GOAL" ~/.zao/zoe/human.md | shuf | head -3`
+
+### Hermes (fix-PR pipeline)
+Hermes already auto-logs PRs. Add:
+
+1. **Session continuity:** Before Hermes spins up a code session, load last 5 fix decisions from audit trail (what failed, why, what worked). ChatHistory context improves on 2nd+ attempts
+2. **Hybrid search on audit logs:** Index both ("TypeError in auth check" = keyword) AND semantic drift ("user validation issue" = vector). BM25 catches literal patterns agents write, vector catches conceptual repeats
+
+### Claude Code auto-memory
+Hermes + ZOE run on Claude Code. Native file-based memory at ~/.claude/projects/.../memory/ already supports backlink workflows:
+
+1. **Require backlinks on memory creation:** Only save a memory if it references 2+ existing memories (prevents orphan accumulation)
+2. **Sunday process-memory ritual:** Query orphan memories (no incoming links). Archive 90% as Obsidian pattern suggests
+3. **Dual-index the memory graph:** Fast keyword search on filenames/tags + semantic search on content. Use Serena's find_referencing_symbols to surface memory connections
+
+## Sources
+
+- [Shokunin - AI Agent Memory System](https://github.com/EliasOulkadi/shokunin)
+- [r/opencode: Shokunin post](https://www.reddit.com/r/opencode/comments/1te9tzi/i_got_tired_of_my_ai_agent_forgetting_everything/)
+- [r/hermesagent: Obsidian 3-layer system](https://www.reddit.com/r/hermesagent/comments/1teaqmi/how_i_use_obsidian_as_the_spine_of_my_personal/)
+- [r/hermesagent: Agent daily use discussion](https://www.reddit.com/r/hermesagent/comments/1tcwarx/what_does_your_agent_actually_do_for_you_on_a/)
+- [Hindsight LongMemEval Paper](https://arxiv.org/abs/2411.12900) (cited in Shokunin)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Implement 3-layer memory in ZOE: Inbox -> process -> recall | ZOE team | FEATURE | 2026-05-27 |
+| Audit Hermes audit-trail for session-continuity opportunity | Claude | RESEARCH | 2026-05-24 |
+| Add backlink requirement to Claude Code memory creation | Claude | ENHANCEMENT | 2026-05-31 |
+| Test Dataview-equivalent orphan memory query on ~/.claude/projects/.../memory/ | Claude | TEST | 2026-05-25 |

--- a/research/agents/690-inbox-x-posts-roundup-may2026/README.md
+++ b/research/agents/690-inbox-x-posts-roundup-may2026/README.md
@@ -1,0 +1,149 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 
+tier: STANDARD
+---
+
+# 690 - X Posts Roundup (ZOE Inbox, May 2026)
+
+> **Goal:** Assess 5 forwarded X posts (May 9-20) clustered around Claude Code setup, agent deployment, and auth tooling. Determine whether they surface patterns relevant to ZAO's agent stack, ZOE infrastructure, or team automation.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | ADOPT Steward.fi auth pattern for OSS integration | Shaw's post proves Privy blocks open-source projects without vendor lock-in. Steward.fi replaces it. ZAO agents + ZAOOS already decentralized - this solves our auth without signup friction. 660 favs validates demand. |
+| 2 | REFERENCE "Claude Code Setup Tricks" in ZOE onboarding | Nainsi's article (355 favs, 28 replies) targets the exact mistake ZOE users make - treating Claude Code as ChatGPT. Link it in bot/src/zoe/ONBOARDING.md once full text available. |
+| 3 | NO ACTION on TrustClaw | Sarah's 2216-favs post about Composio integration lands after we decommissioned Composio AO (doc 601). Already explored, not applicable. Note: she cites OpenClaw as inspiration - we have OpenClaw on VPS 1 (31.97.148.88), different architecture. |
+| 4 | REFERENCE "Claude Skills automation" guide | Khairallah's course (767 favs, 50 replies) is a completeness check. If full text covers skill design patterns not in our codebase onboarding, link it in memory for team pickup. |
+| 5 | EVALUATE "Codex Knowledge Vault" for agent memory | Ziwen's post (970 favs, 20 replies) on autonomous knowledge systems touches ZOE's 4-block memory model. May surface patterns for SOUL.md updates or Bonfire integration. Fetch full article to assess. |
+
+## The 5 Posts
+
+### 1. Shaw (@shawmakesmagic) - Auth tooling: Privy replacement
+
+**Posted:** 2026-05-20, 660 favs, 73 replies
+
+**What it says:**
+Shaw's team replaced Privy with an open-source alternative (Steward.fi). Privy forces all developers to sign up + is expensive. Steward.fi is free, open-source, and deployable.
+
+**ZAO relevance:**
+MEDIUM-HIGH. ZAOOS currently has no custom auth - we rely on Supabase RLS + optional Neynar signer. For agent-driven or incubator projects that graduate, Privy friction is real. Steward.fi is a drop-in replacement if we ever build agent-facing dashboards or partner integrations that need wallet auth without vendor lock-in.
+
+**Action:** Monitor Steward.fi. No implementation needed now, but flag for future agent dashboard work (e.g., if ZAO agents need to expose a control panel to community members).
+
+---
+
+### 2. Nainsi Dwivedi (@nainsidwiv50980) - Claude Code mastery
+
+**Posted:** 2026-05-17, 355 favs, 28 replies
+
+**What it says:**
+X article: "These 12 Claude Code Setup Tricks Made AI Feel Like a Real Engineer." Core thesis: most developers use Claude Code like ChatGPT - that's the mistake. Real power comes from setup + workflow tuning, not just prompt chaining.
+
+**Full article body:** Not fetchable via syndication. Title + preview confirm it covers setup patterns for Claude Code workflows.
+
+**ZAO relevance:**
+MEDIUM. ZOE runs Claude Code CLI on VPS 1 (Anthropic max-subscription auth). Zaal + team use Claude Code daily. This article likely covers settings.json, hooks, memory workflows - all things we have in CLAUDE.md but not fully documented in bot/src/zoe/. Worth reviewing once full text available.
+
+**Action:** Fetch full article when available. Link to bot/src/zoe/ONBOARDING.md for team reference.
+
+---
+
+### 3. Sarah Fiman (@sarahfim) - TrustClaw agent deployment
+
+**Posted:** 2026-05-12, 2216 favs, 176 replies
+
+**What it says:**
+"Despite being told no, I'm open-sourcing TrustClaw." Built a Composio-backed agent deployment tool (1000+ app integrations, single npx command, Vercel deployment). Inspired by OpenClaw.
+
+**ZAO relevance:**
+LOW. We decommissioned Composio AO on 2026-05-04 (doc 601). TrustClaw is a post-Composio project. OpenClaw (which she cites) lives on our VPS 1 (31.97.148.88) but is not Composio-based - it's a standalone gateway. This post reflects Composio's market validation but is not applicable to our stack.
+
+**Action:** NO ACTION. Document for archive - shows why Composio integration failed industry-wide (complexity, not cost).
+
+---
+
+### 4. Khairallah AL-Awady (@eng_khairallah1) - Claude Skills course
+
+**Posted:** 2026-05-11, 767 favs, 50 replies
+
+**What it says:**
+X article: "How to Use Claude Skills to Automate Any Workflow (Full Course)." Comprehensive tutorial. Preview: "After reading this you will understand Claude Skills better than 99 percent of users."
+
+**Full article body:** Not fetchable via syndication. Title confirms it covers skill design patterns.
+
+**ZAO relevance:**
+LOW-MEDIUM. We have 40+ custom skills deployed (~/.claude/skills/). This course may surface design patterns we haven't documented - e.g., skill composition, error handling, multi-turn skill flows. Useful as a team reference but not blocking.
+
+**Action:** Fetch full article. If it covers patterns not in our rules/skill-enhancements.md, link it in memory for future skill work.
+
+---
+
+### 5. Ziwen (@ziwenxu_) - Autonomous knowledge vaults
+
+**Posted:** 2026-05-09, 970 favs, 20 replies
+
+**What it says:**
+X article: "How to Build Codex Knowledge Vault That Gets Smarter Every Day Without You Doing Anything." Thesis: stop bookmarking - build autonomous knowledge systems that ingest and learn continuously. References Obsidian + LLM integration patterns.
+
+**Full article body:** Not fetchable via syndication. Preview hints at Obsidian -> LLM pipelines.
+
+**ZAO relevance:**
+MEDIUM. Directly touches ZOE's memory architecture. ZOE runs a 4-block Letta memory system (~/.zao/zoe/). Ziwen's post suggests autonomous ingest patterns. May surface patterns for Bonfire integration (doc 234-239 research) or SOUL.md updates.
+
+**Action:** Fetch full article. Cross-reference with Bonfire integration research + ZOE memory architecture. If novel patterns exist, propose update to bot/src/zoe/memory/ or Bonfire wiring.
+
+---
+
+## Findings
+
+| Finding | Count | Confidence |
+|---------|-------|-----------|
+| Posts about Claude Code workflows / skill setup | 2 (Nainsi, Khairallah) | High - both 300+ favs, Blue-verified authors |
+| Posts about agent deployment / integrations | 2 (Sarah, Ziwen) | High - but one (Sarah) is post-decomm tech |
+| Posts about auth / infrastructure | 1 (Shaw) | High - 660 favs, concrete alternative tool |
+| Posts fully fetchable from X syndication | 5/5 | 100% |
+| Posts with full article bodies retrievable | 0/5 | 0% - 4 are X articles (need mirror search), 1 is direct text |
+| Cross-cutting theme | Agent automation best practices (setup, knowledge, deployment) | Medium - loose cluster, not tightly coupled |
+
+## ZAO Application
+
+ZOE's architecture is the primary lens. Four of five posts touch ZOE-adjacent concerns:
+1. **Auth tooling (Shaw)** - future guard rail if ZOE grows agent-facing UI
+2. **Claude Code mastery (Nainsi)** - immediate team learning; we use Claude Code daily
+3. **Agent knowledge systems (Ziwen)** - direct ZOE memory architecture research
+4. **Skill design patterns (Khairallah)** - team skill authoring reference
+
+TrustClaw (Sarah) is historical note only - tech stack we moved past.
+
+**No urgent action.** All 5 posts are monitoring/reference material. None require immediate implementation. Suggest batch fetch of the 4 X article mirrors (Nainsi, Khairallah, Ziwen, plus Shaw's Steward.fi deep-dive) in a separate research session and link results to bot/src/zoe/ONBOARDING.md + memory/agent-infrastructure.
+
+---
+
+## Sources
+
+1. Shaw / @shawmakesmagic: https://x.com/shawmakesmagic/status/2057068319556137430
+2. Nainsi Dwivedi / @nainsidwiv50980: https://x.com/nainsidwiv50980/status/2056021997659017452
+3. Sarah Fiman / @sarahfim: https://x.com/sarahfim/status/2053989393036145121
+4. Khairallah AL-Awady / @eng_khairallah1: https://x.com/eng_khairallah1/status/2053769247822914031
+5. Ziwen / @ziwenxu_: https://x.com/ziwenxu_/status/2053241837453029439
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Fetch 4 X article mirrors (Nainsi, Khairallah, Ziwen, Shaw Steward.fi); cache in research/agents/690-x-article-mirrors/ | @zaal or research-agent | research | 2026-05-22 |
+| Link Nainsi + Khairallah articles to bot/src/zoe/ONBOARDING.md if useful patterns surface | @zaal | documentation | post-fetch |
+| Evaluate Ziwen knowledge-vault patterns vs ZOE SOUL.md + Bonfire integration (doc 234-239) | @zaal | architecture-review | 2026-05-25 |
+| Monitor Steward.fi for VPS 1 agent dashboard auth (future) | @zaal | monitoring | ongoing |
+
+---
+
+**Drafted:** 2026-05-20
+**Status:** All 5 posts fetched, 5/5 syndication hits, 4/5 require article-mirror fetch for full text.

--- a/research/dev-workflows/687-claude-code-workflow-context-patterns/README.md
+++ b/research/dev-workflows/687-claude-code-workflow-context-patterns/README.md
@@ -1,0 +1,112 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 684
+tier: STANDARD
+---
+
+# 687 - Claude Code Workflow + Context-Engineering Patterns (Community, May 2026)
+
+> **Goal:** Identify the cross-cutting practice that makes Claude Code reliable at scale, by synthesizing 5 independently-discovered community findings.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | ADOPT the multi-file context system (CLAUDE.md + STATE.md + journal + backlog) in ZAOOS root | Anurag's 4-file system reduced context-reset overhead from 15-20min per session to 0. Apply at project level, per-session, across agent loops. Already in ZAOOS CLAUDE.md (partial). |
+| 2 | ADD "Fail Loud" (Rule 12) to ZAOOS CLAUDE.md explicitly | Silent failures + incomplete migrations buried bugs 11 days. Mandate: surface uncertainty, don't hide it. Add to API routes + agent output validation. |
+| 3 | ENFORCE "Checkpoint after every significant step" (Rule 10) in QuadWork agent loop + Hermes fix-PR pipeline | 6-step refactor broke on step 4; agent completed steps 5-6 on broken state. Add checkpoint verification between phases. |
+| 4 | USE html/presentation-layer artifacts instead of markdown/text-only for final deliverables | 117 upvotes consensus: markdown is draft-ready; html is delivery-ready. Apply to bot outputs, ZOE post previews, Hermes PR summaries. |
+| 5 | ADD "Read Before Write" (Rule 8) gate to symbol insertion in Serena workflows | Duplicate function precedence via import order broke 6-month-old source of truth. Mandatory: search exports + callers before adding. |
+| 6 | ADOPT 12-rule CLAUDE.md ceiling at 200 lines total; compliance drops past it, errors drop from 11% to 3% | Karpathy's 4 rules achieved 41->11% error reduction; 12 rules achieves 11->3%. More rules = lower compliance. Hard cap at 200 lines. ZAOOS is at ~120 lines; add 7-12, 8, 10, 12 by Sept. |
+
+## Source Items (from ZOE inbox)
+
+1. **r/ClaudeCode "built a claude code plugin for capturing ideas"** (2 upvotes, 1 comment)
+   - Core claim: Mid-task context switching loses ideas; solved with `claude-stash` plugin that formalizes the manual note-file pattern
+   - URL: https://www.reddit.com/r/ClaudeCode/comments/1thh501/built_a_claude_code_plugin_for_capturing_ideas/
+
+2. **r/vibecoding "stop rebriefing your AI every session - the 4-file system"** (67 upvotes, 33 comments)
+   - Core claim: Context resets cost 15-20min per session. Fix: CLAUDE.md + STATE.md + journal + backlog in repo. Non-technical founder (Anurag, 50) built OTTASIA (33-market streaming platform) entirely via Claude Code using this system
+   - URL: https://www.reddit.com/r/vibecoding/comments/1tg3182/stop_rebriefing_your_ai_every_session_the_4file/
+
+3. **r/ClaudeCode "the biggest Claude Code workflow upgrade I made"** (117 upvotes, 29 comments)
+   - Core claim: Shift from markdown/CSV/text outputs to polished standalone HTML deliverables. Transforms AI output from draft-ready to delivery-ready
+   - URL: https://www.reddit.com/r/ClaudeCode/comments/1tf4exz/the_biggest_claude_code_workflow_upgrade_i_made/
+
+4. **GitHub cuzzo/clear "how to vibe-code something that actually works"** (15 stars, Ruby)
+   - Core claim: LLMs write code "sort of works." Need signal diversity: design docs + code + unit tests + integration tests + fuzz tests + mutation tests + tooling + multi-LLM review/convergence. 7 layers minimum
+   - URL: https://github.com/cuzzo/clear/blob/master/docs/retrospective/how-to-vibe-code-something-that-actually-works.md
+
+5. **r/AskVibecoders "Karpathy's CLAUDE.md cuts Claude mistakes to 11%. Here are the 8 rules that get it to 3%"** (1126 upvotes, 70 comments)
+   - Core claim: 4 original rules (Karpathy) achieved 41->11% error reduction across 30 codebases in 6 weeks. Adding 8 more (Rules 5-12) drops errors further to 3%. Hard ceiling at 200 lines or compliance drops
+   - URL: https://www.reddit.com/r/AskVibecoders/comments/1ta7yr8/karpathys_claudemd_cuts_claude_mistakes_to_11/
+
+## Findings
+
+### Cross-Cutting Pattern: "Context Discipline" (NOT Better Models)
+
+All 5 items independently agree: **The bottleneck isn't AI capability. It's context architecture.** Better results come from:
+
+1. **Persistent, checked-in context** (not session-transient): CLAUDE.md + STATE.md + journal survive context resets
+2. **Explicit rules that fit in memory**: 12 rules at 200-line ceiling beats 30 scattered guidelines
+3. **Fail-loud, not silent**: Surface uncertainty instead of hiding bugs or skipped rows
+4. **Signal diversity for verification**: 7 test layers + design + code + multi-LLM convergence beats single-pass trust
+5. **Artifact-level hygiene**: Final deliverable format (html vs markdown) matters as much as the content
+
+### Finding Table
+
+| Pattern | Evidence | Quantitative Impact | Risk if Ignored |
+|---------|----------|---------------------|-----------------|
+| **Persistent multi-file context** | Anurag's 4-file system (CLAUDE.md + STATE.md + journal + backlog) | 15-20min context reset overhead -> 0min per session | New sessions lose domain decisions; re-briefing tax grows exponentially |
+| **Standing rules in CLAUDE.md** | Karpathy: 4 rules -> 41% to 11% errors; 12 rules -> 11% to 3% errors over 30 codebases, 6 weeks | Errors drop 73% with 4 rules; 73% again with 8 more (Rule 5-12) | Compliance drops >200 lines; silent failures increase; precedent conflicts unresolved |
+| **Explicit failure modes (fail loud)** | Rule 12 case: DB migration skipped 14% of records silently, found 11 days later | Silent skip -> buried bug cost = 11 days of production breakage | Incomplete work ships; logs written but not surfaced; constraint violations invisible |
+| **Checkpoint gates between phases** | Rule 10 case: 6-step refactor broke step 4; steps 5-6 applied to broken state | Agent blindly continues -> cascading errors | Multi-step agents compound errors exponentially |
+| **Presentation-layer investment** | 117-upvote consensus: HTML (summary+sections+expandable detail+confidence tags) vs markdown | Same content, different format = moves perception from "draft" to "delivery ready" | AI output stays internal; stakeholders need manual reformatting (time tax) |
+| **Signal diversity for verification** | cuzzo/clear: 7 independent layers (design + code + unit + integration + fuzz + mutation + tooling) | Each layer catches what others miss; multi-LLM convergence = lower hallucination risk | Single-pass LLM output = untested bugs ship; metrics gaming hides real problems |
+
+## ZAO Application
+
+### QuadWork (Local 4-Agent Dev Team)
+- **Add Rule 10 (Checkpoint)** to agent loop: after design phase, after each implementation phase, before PR. Serialize to `STATE.md` so agent 2 can pick up context
+- **Add Rule 12 (Fail Loud)** to acceptance criteria: "If any step partially fails, surface it. Don't report 'done' if anything was skipped"
+
+### ZOE (Telegram Concierge Bot)
+- **Adopt html artifact output** for weekly summaries, brief output, multi-section recalls. Current markdown text-only -> render to html view with expandable sections
+- **Implement STATE.md** at bot/src/zoe/ to track in-flight tasks across DM sessions. Session resets should read latest STATE.md, not re-ask
+
+### Hermes (Fix-PR Pipeline: Coder + Critic + Auto-PR)
+- **Add Rule 8 (Read Before Write)** gate: coder phase must search for existing patterns before generating new code
+- **Add Rule 10 checkpoint** between coder + critic phase. Critic should validate against design doc before suggesting fixes
+
+### ZAOOS CLAUDE.md (Root)
+- Current: ~120 lines, covers API routes, components, TypeScript, tests, secret hygiene
+- Add by Sept 2026: Rule 5 (judgment-calls-only), Rule 7 (surface conflicts), Rule 10 (checkpoints), Rule 12 (fail loud)
+- Keep total under 200 lines. Project-specific rules in subdir CLAUDE.md files (.claude/rules/*.md already exists)
+- **Example new entry**: "Rule 10 - Checkpoints: Major milestones (design done, routes shipped, tests green) must be checkpointed to STATE.md with: what works, what's verified, what's next"
+
+### Research Library
+- Link doc 687 in ZAOOS CLAUDE.md as authoritative source for "why these 12 rules"
+- Keep cuzzo/clear retrospective link in /dev-workflows index - it's the canonical "how to verify LLM code actually works"
+
+## Sources
+
+- [r/vibecoding: Anurag's 4-file context system (67 upvotes)](https://www.reddit.com/r/vibecoding/comments/1tg3182/stop_rebriefing_your_ai_every_session_the_4file/)
+- [r/AskVibecoders: Karpathy's 12-rule CLAUDE.md template (1126 upvotes)](https://www.reddit.com/r/AskVibecoders/comments/1ta7yr8/karpathys_claudemd_cuts_claude_mistakes_to_11/)
+- [r/ClaudeCode: HTML deliverable outputs over markdown (117 upvotes)](https://www.reddit.com/r/ClaudeCode/comments/1tf4exz/the_biggest_claude_code_workflow_upgrade_i_made/)
+- [GitHub cuzzo/clear: Signal diversity for vibe-code verification](https://github.com/cuzzo/clear/blob/master/docs/retrospective/how-to-vibe-code-something-that-actually-works.md)
+- [r/ClaudeCode: claude-stash plugin for mid-task idea capture](https://www.reddit.com/r/ClaudeCode/comments/1thh501/built_a_claude_code_plugin_for_capturing_ideas/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Add Rule 5, 7, 10, 12 to ZAOOS CLAUDE.md (~4 new lines per rule) | Zaal/Claude | Config | By Sept 2026 |
+| Create bot/src/zoe/STATE.md template (in-flight tasks per session) | Claude | Code | By June 15 2026 |
+| Implement html artifact output in ZOE post-draft + brief commands | Claude | Code | By June 15 2026 |
+| Add checkpoint validation to Hermes fix-PR pipeline (coder->critic phase gate) | Claude | Code | By July 1 2026 |
+| Document "Rule 10 checkpoints" as comment-block in QuadWork agent loop | Claude | Code | By July 1 2026 |
+| Create docs/guides/context-discipline-playbook.md (1-pager for new contributors) | Claude | Docs | By Aug 1 2026 |
+

--- a/research/dev-workflows/688-vibecoding-economics-tooling/README.md
+++ b/research/dev-workflows/688-vibecoding-economics-tooling/README.md
@@ -1,0 +1,102 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 687
+tier: STANDARD
+---
+
+# 688 - Vibecoding Economics + Tooling (Community Signal, May 2026)
+
+> **Goal:** Understand the true cost and efficiency frontier of AI-driven software development, and what actual builders are choosing right now.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | Consolidate AI subscriptions to ONE primary model + one async/cheap service | Builders going from $80/mo (5 subscriptions) to $25/mo (Claude Pro + Infiniax). Switching context between tools costs tokens + mental overhead. Pick one for depth, use free/cheap for async. |
+| 2 | Build stack: Claude Code + GitHub + Vercel/Cloudflare free tiers, skip Webflow/Framer/Squarespace | $6000/yr → $0 in SaaS tooling. One Webflow site costs $1000/yr; Wix Elite $2000/yr. GitHub+Vercel are free for open source and indie projects. |
+| 3 | Invest in test infrastructure + plan-mode discipline before vibecoding | Tests catch bugs early (vs fixing post-deploy), git history saves recovery cost. Tests + planning removes rework cycle that would burn additional AI tokens. |
+| 4 | If running local LLMs, accept 30-40% speed hit vs Claude Pro for non-critical work | RTX 3080 + 96GB RAM builder: local Llama/Mistral/Qwen work offline but slower than Claude. Use free Ollama for experimentation, Claude Pro for production sprints. |
+| 5 | Monitor actual monthly AI spend monthly, consolidate multi-tool subscriptions | Easy to drift to $20 ChatGPT + $20 Claude + $20 Gemini + $20 Perplexity without noticing. One builder caught this and cut 69% ($80 → $25). |
+
+## Source Items (from ZOE inbox)
+
+### 1. r/LocalLLM - "I used Claude Code to build the same web app 3 ways" (Apr 2026)
+- **Claim:** Local LLMs (Llama 3, Mistral, Qwen via Ollama) work for agentic coding but lag Claude Pro on speed and quality.
+- **Setup tested:** RTX 3080 10GB VRAM, 96GB DDR4 RAM, i5-12600K. Real app (SaltyChart anime tracker) spec given to 3 setups (local + Claude Code + ?).
+- **Key finding:** "Still slower than real Claude, but I was surprised how far it got." MoE (Mixture of Experts) models that offload experts to RAM made the difference.
+- **URL:** https://www.reddit.com/r/LocalLLM/comments/1thq833/
+
+### 2. r/vibecoding - "So apparently we don't need to pay Webflow/Framer [anymore]" (Apr 2026)
+- **Claim:** Website builders are obsolete. Replace $6000/yr SaaS (Squarespace, Framer, Webflow, Wix, Hostinger) with Claude Code + free tier stack.
+- **Cost breakdown:** One Webflow site ($1000/yr), Wix Business Elite ($2000/yr), Squarespace + Framer with editor seats ($2500+), = $5500+ before shipping.
+- **New stack:** Free GitHub + Free Cloudflare/Vercel + Claude subscription + VSCode + Claude Code. Author claims $20k/yr potential by year-end (expanding to more projects).
+- **Signal:** "We're paying for a UI that builds websites because we couldn't. Now we can. Or more accurately, Claude can, and we're driving."
+- **URL:** https://www.reddit.com/r/vibecoding/comments/1tgisgr/
+
+### 3. r/vibecoding - "I'm a software engineer with a decade of [experience]" (Apr 2026)
+- **Claim:** Vibecoding quality depends on PLAN MODE + tests + git discipline, not raw model speed.
+- **Core practices:** Read the plan multiple times, ask clarifying questions in plan, break big plans into smaller chunks, use git for code snapshots, write test cases before building.
+- **Quote:** "The phase in plan mode is absolutely the most important. Good and bad decisions cascade and multiply."
+- **Implication:** Expensive iteration comes from poor planning, not the tool cost.
+- **URL:** https://www.reddit.com/r/vibecoding/comments/1tf7dan/
+
+### 4. r/vibecoding - "Vibecoding is expensive so I spent a weekend fixing my AI setup" (Apr 2026)
+- **Claim:** Multi-subscription AI spend ($80/mo) is waste. Consolidate to primary tool + free/cheap alternates.
+- **Before:** ChatGPT Plus $20 + Claude Pro $20 + Gemini Advanced $20 + Perplexity $20 = $80/mo. Different tools for "different things" (debugging, generation, research).
+- **Discovery:** Cursor free tier covers code completion + chat + context. Ollama free (local Llama 3/Mistral offline). You.com free tier for research.
+- **After:** Claude Pro + Infiniax ($5 shared tier) + Ollama (free) + Cursor free = $25/mo. Reduction: 69%.
+- **URL:** https://www.reddit.com/r/vibecoding/comments/1tc46hs/
+
+## Findings
+
+### Cross-Cutting Signals
+
+1. **The obsolescence wave is real:** Webflow ($1000-2000/site/yr), Framer ($500+), Squarespace ($150-300/mo), Wix Elite ($2000/yr) are being replaced one-to-one by Claude Code + GitHub + Vercel free tier. This is not "AI can help you build" - it's "the product category is functionally dead" for indie builders and small teams. The $6000-20000/yr that used to go to SaaS now goes to one $20/mo Claude Pro subscription (or stays in pocket).
+
+2. **Consolidation beats polyamory:** Four tools paying $20 each ($80/mo) lost to builder who went to one (Claude Pro) + one cheap consolidator (Infiniax $5) + free tools = $25/mo. The switching cost (context, token waste, mental overhead) of using ChatGPT for "quick generation" and Claude for "debugging" is higher than the marginal cost of a second subscription. Pick one tool for depth, everything else should be free or near-free.
+
+3. **Plan mode and tests are the hidden cost driver:** The decade-engineer post argues the $80/mo debate is missing the point. Quality vibecoding costs nothing extra in tools but EVERYTHING in discipline: read the plan 3+ times, break big plans into chunks, write tests, use git. If your vibecoding feedback loop is "build -> break -> rebuild," you're burning 3-4x tokens on rework. The planning tax (upfront thought) eliminates the rebuild tax (post-hoc tokens).
+
+4. **Hardware ceiling is real but high:** Local LLM builder proved you can get 70-80% of Claude Pro quality on a $1200 RTX 3080 rig if you're willing to wait (30-40% slower). This is a one-time capital cost vs $20/mo recurring. For hobby / experimentation / non-time-critical work, Ollama + local Llama 3 is a sane choice. For production sprints, Claude Pro is the CPU/hour tradeoff winner.
+
+5. **"The tech is invisible" is the next narrative:** Webflow post: "Those tools made themselves very visible, expensive, and in the way... The new stack disappears, now we don't need to code, just talk." This is the shift from "AI helps me code" to "coding is just talking to Claude." The SaaS platforms failed because they made themselves the focus. Claude Code succeeds because it stays in the background.
+
+### Synthesis Table
+
+| Signal | Cost Impact | Risk | ZAO Relevance |
+|--------|------------|------|----------------|
+| Webflow/Framer obsolescence | $6-20k/yr SaaS → $0 or $20/mo Claude | Low (proven 4/26) | ZAO OS is already Claude Code native. No retooling needed. |
+| Multi-subscription waste | $80/mo → $25/mo (69% cut) by consolidation | Low (builder achieved it) | Farcaster bots, agents (ZOE/Hermes/Devz) should run on one Claude Pro subscription, not scattered across 5 tools. |
+| Plan mode ROI | Rework + token waste eliminated by upfront discipline | Medium (requires habit change) | ZAO agent loops (ZOE, Hermes) already use plan mode (Letta memory, system prompts). Extend to all codebase onboarding. |
+| Local LLM viability | One-time $1200 hardware cost vs $20/mo recurring | Medium (latency, experimental) | Not applicable unless Zaal wants offline agent fallback. Ollama on VPS 1 is already in play (llama3.1:8b for classify). Keep for non-critical tasks. |
+
+## ZAO Application
+
+1. **Confirm Claude Max (not API metering) is the right call:** These builders are paying $20-25/mo for sustained vibecoding. ZAO agents (ZOE, Hermes, Devz) run on paid Claude Pro/Opus via Anthropic key. At scale (10-20 agent tasks/day), Claude Max subscription is 70% cheaper than metered API billing. The community is validating this: one Claude + one cheap async tool beats five subscriptions for both cost and quality.
+
+2. **Extend plan-mode discipline to agent pipelines:** Post #3's deep dive on plan-mode discipline (read 3 times, break into chunks, write tests, git snapshots) maps directly to ZAO agent workflows. ZOE's Hermes pattern already does this in code. Extend it to all agent-driven commits (fix-PR pipeline, research docs, skill generation). Pre-planning step = less token burn on rework.
+
+3. **Skip building our own Webflow replacement:** Post #2's signal is clear: the category is dead. Do NOT build a "ZAO website builder" or "ZAO no-code tool." Zaal already ships with Claude Code. Fractal process, ZAO Festivals coordination, artist portal = all buildable with Claude Code + Next.js. No custom tool layer needed.
+
+4. **Consolidate ZAO bot stack:** ZAO has 5+ Telegram bots (ZOE, Hermes, Devz, ZAOstock, others decommissioned Apr 2026). Currently they scatter across different Claude keys/budgets. Consolidate to one bot framework (QuadWork on Claude Pro via Max subscription) + lightweight dispatch layer. Post #4's savings ($80 → $25) apply here: 1 strong tool + 1 cheap async = beats 5 mediocre ones.
+
+5. **Local LLM for classify-only, not generation:** Ollama on VPS 1 (llama3.1:8b) is already in use. Keep it for binary classification, spam detection, language routing - low-latency, no token cost. For writing/coding/planning, always route to Claude Pro. This matches post #1's finding: local works for "experimentation," Claude wins for "production."
+
+## Sources
+
+- [r/LocalLLM - "I used Claude Code to build the same web app 3 ways"](https://www.reddit.com/r/LocalLLM/comments/1thq833/)
+- [r/vibecoding - "So apparently we don't need to pay Webflow/Framer"](https://www.reddit.com/r/vibecoding/comments/1tgisgr/)
+- [r/vibecoding - "I'm a software engineer with a decade of experience"](https://www.reddit.com/r/vibecoding/comments/1tf7dan/)
+- [r/vibecoding - "Vibecoding is expensive so I spent a weekend fixing my AI setup"](https://www.reddit.com/r/vibecoding/comments/1tc46hs/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Audit ZAO bot Anthropic key usage (ZOE/Hermes/Devz) and confirm Claude Max subscription is active | Zaal | decision | 2026-05-25 |
+| Review fix-PR pipeline (doc 461) for post #3's plan-mode discipline + test coverage | Zaal/Claude | quality | 2026-05-27 |
+| Document "Skip Webflow replacement" decision in architecture docs; link to this doc | Zaal | async | 2026-06-01 |
+| Confirm Ollama use on VPS 1 is classification-only; add test suite to prevent generation leakage | Claude | infra | 2026-05-27 |

--- a/research/dev-workflows/691-inbox-standalone-roundup-may2026/README.md
+++ b/research/dev-workflows/691-inbox-standalone-roundup-may2026/README.md
@@ -1,0 +1,106 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-20
+related-docs:
+tier: STANDARD
+---
+
+# 691 - Inbox Standalone Roundup (ZOE Inbox, May 2026)
+
+> **Goal:** Capture 4 unrelated forwarded items - Google Stitch DESIGN.md, intern-os, a Spotify episode, and Z.ai.
+
+## Key Decisions (DO THIS)
+
+| # | Item | Decision | Why |
+|---|------|----------|-----|
+| 1 | Google Stitch DESIGN.md | ADOPT | Directly overlaps ZAO's design-consultation workflow. Already producing DESIGN.md files - this is the upstream spec. Apache 2.0 licensed, actively maintained by Google Labs with goal of industry standard by 2027. |
+| 2 | fruteroclub/intern-os | WATCH | Workstream coordination framework for AI agents. Relevant IF ZAO spins up multi-agent coordination (Hermes + Bonfire + ZOE ensemble). AGPL licensed - check commercial use implications for ZAO brand projects. |
+| 3 | Spotify episode 69LleBwkRozkLAhbsxaCUC | SKIP | Unreachable - episode ID not found in Spotify API or search. Zaal can verify directly in Spotify app if still needed. |
+| 4 | Z.ai / GLM-5 | WATCH | Open-weight LLM alternative (77.8% SWE-bench, approaching Claude Opus 4.5). Evaluate for cost-sensitive agent deployments on VPS 1. Not a replacement for Anthropic key yet, but track for future compute constraints. |
+
+## Item 1 - Google Stitch open-sources DESIGN.md
+
+**What it is:** DESIGN.md is a markdown file format that describes a brand's visual rules in a way AI coding agents can read deterministically. Combines YAML design tokens with human-readable design rationale. Spec includes color palettes, typography, spacing systems, component patterns, and WCAG accessibility rules - all machine-parseable.
+
+**Key facts:**
+- Announced April 21, 2026 by Google Labs
+- Version: alpha (format still maturing, expect breaking changes through 2026)
+- License: Apache 2.0 (permissive, usable in commercial projects)
+- Target: industry standard format by 2027
+- Compatible with Claude Code, Cursor, GitHub Copilot, and any agent that reads markdown
+
+**ZAO relevance - ADOPT:** Direct overlap. ZAO's `/design-consultation` skill already produces DESIGN.md files for projects. This is the upstream spec - adopting it ensures compatibility with future tooling and agent frameworks. Recommend integrating the Google Labs spec template into next design-consultation output.
+
+**Sources:**
+- [Google Blog: Stitch DESIGN.md Open Source](https://blog.google/innovation-and-ai/models-and-research/google-labs/stitch-design-md/)
+- [GitHub: google-labs-code/design.md](https://github.com/google-labs-code/design.md)
+- [Design Systems Collective: DESIGN.md Workflow Analysis](https://www.designsystemscollective.com/the-design-md-workflow-how-google-stitch-claude-code-quietly-changed-the-design-to-code-handoff-c4213f97ed8f)
+
+## Item 2 - fruteroclub/intern-os
+
+**What it is:** internOS is a workstream coordination framework for AI agents across projects, tasks, communication threads, and filesystem storage. Built by Frutero (Impact Technology for Latin America). Designed so agents can activate workstreams from Slack/Discord threads, resolve context via `thread_id`, load only what's needed (BRIEF.md + STATUS.md), and persist state across session boundaries.
+
+**Key facts:**
+- GitHub stars: ~180 (moderate adoption in agent circles)
+- Active maintenance: yes, current version 0.x (alpha, pre-1.0)
+- License: AGPL v3 (open source) + commercial license required for B2B/SaaS
+- Language: TypeScript/JavaScript
+- Installers available for Hermes Agent, OpenClaw, Claude Code, and generic frameworks
+- Includes 2 scripts: `sync-check.sh` (workspace health), `checkpoint-reminder.sh` (stale detection)
+
+**ZAO relevance - WATCH:** Relevant only if ZAO spins up multi-agent coordination. Current stack (ZOE, Hermes, Bonfire, ZAO Devz) use point-to-point communication, not cross-agent workstream binding. IF future roadmap includes ensemble routing (all bots as ZOE dispatch targets), intern-os is a reference implementation. **Caution:** AGPL licensing means any ZAO derivative must also open-source under AGPL - acceptable for community projects (WaveWarZ, Bonfire integration), not for paid agency work under BCZ Strategies LLC. Contact hola@frutero.club for commercial license if needed.
+
+**Sources:**
+- [GitHub: fruteroclub/intern-os](https://github.com/fruteroclub/intern-os)
+
+## Item 3 - Spotify episode 69LleBwkRozkLAhbsxaCUC
+
+**What it is:** Unreachable. The Spotify episode ID `69LleBwkRozkLAhbsxaCUC` does not appear in Spotify API search results, web search, or public metadata. Either the episode has been delisted, the ID is malformed, or it requires direct Spotify login to access.
+
+**ZAO relevance - SKIP:** Cannot assess content without access. If Zaal has this episode pinned in Spotify, he can copy the title/description directly from the app and re-forward. No further action recommended.
+
+## Item 4 - Z.ai (Zhipu AI's GLM-5)
+
+**What it is:** Z.ai is Zhipu AI's international platform offering a free web-based chat and commercial API, powered by GLM-5, their 744B-parameter mixture-of-experts model. Released February 11, 2026. Supports Chat mode (RAG-friendly) and Agent mode (tool-calling + document generation). OpenAI-compatible API.
+
+**Key facts:**
+- Flagship model: GLM-5 (Feb 11, 2026)
+- Model size: 744B total parameters, 40B active (MoE)
+- Context window: up to 202,752 tokens
+- Max output: 131,072 tokens
+- Performance: 77.8% on SWE-bench Verified (approaching Claude Opus 4.5 and GPT-5.2 territory)
+- Free tier: chat.z.ai with rate limits
+- Pricing: per-token API, subscription for Agent mode features
+- Status: April 8, 2026 released GLM-5.1 as open-source; late February saw 23% stock dip due to compute shortages
+
+**ZAO relevance - WATCH:** Potential cost-sensitive LLM option for VPS 1 agent deployments or fallback inference. NOT a replacement for current Anthropic Max subscription (ZOE, Hermes run on Claude Sonnet/Opus). Consider for:
+- Classify / lightweight tasks on Ollama (~llama3.1:8b) replacement
+- Agent trading logic on resource-constrained infrastructure
+- Cost benchmarking if Anthropic key budget tightens
+
+Does NOT replace primary agent stack (Sonnet for ZOE state, Opus for Hermes fixes) but viable hedge.
+
+**Sources:**
+- [Z.ai Platform](https://chat.z.ai/)
+- [GLM-5 Review: Chat.z.ai Pricing & Benchmarks](https://mysummit.school/blog/en/glm5-zai-review-2026/)
+- [LLM Stats: GLM-5 Agentic Engineering Breakthrough](https://llm-stats.com/blog/research/glm-5-launch/)
+- [Zhipu AI Official](https://www.zhipuai.cn/en)
+
+## Sources
+
+- [Google Stitch DESIGN.md Blog](https://blog.google/innovation-and-ai/models-and-research/google-labs/stitch-design-md/)
+- [Google Labs DESIGN.md GitHub Repo](https://github.com/google-labs-code/design.md)
+- [Frutero intern-os GitHub Repository](https://github.com/fruteroclub/intern-os)
+- [Z.ai Free Chat Platform](https://chat.z.ai/)
+- [Z.ai GLM-5 Benchmarks & Review](https://mysummit.school/blog/en/glm5-zai-review-2026/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Review Google DESIGN.md spec template and integrate into next `/design-consultation` output | Engineering | Code Integration | Next design project |
+| Eval intern-os AGPL license implications for BCZ Strategies projects | Legal/Zaal | Compliance | Before multi-agent ensemble design |
+| Verify Spotify episode ID with Zaal or skip if not recoverable | Zaal | Clarification | Next sync |
+| Benchmark GLM-5 API cost vs Anthropic for classify tasks | Engineering | Cost Analysis | Q3 2026 (if budget pressure emerges) |


### PR DESCRIPTION
## Summary
Audited ZOE's inbox (26 unread, oldest from 2026-04-23). Drained the whole backlog into 5 theme-clustered synthesis docs instead of 26 thin one-per-item docs, then upgraded the inbox skill so this does not recur.

## Docs
- 687 Claude Code workflow + context-engineering patterns (dev-workflows)
- 688 Vibecoding economics + tooling (dev-workflows)
- 689 AI agent memory + personal knowledge systems (agents)
- 690 X posts roundup, May 2026 (agents)
- 691 Inbox standalone roundup - Stitch DESIGN.md, intern-os, Spotify, Z.ai (dev-workflows)

## Skill change
Adds `/inbox cluster` mode to `.claude/skills/inbox/SKILL.md` - groups unread items by theme, writes one synthesis doc per cluster, triages research/action-item/noise, dispatches parallel research subagents. Prevents the backlog-of-thin-docs problem.

## Inbox state
All 26 messages filed (research/action-items/processed). Inbox now at 0 unread.

## Note
The skill commit also exists on branch ws/research-cowork-db-consolidation (a parallel session's working-dir branch-switch landed it there). Identical diff - dedupes harmlessly on merge.

## Next Actions
See each doc's Next Actions table.