### PR TITLE
doc 693: /zao-research fetch-quality audit + skill fix (v2.3)

### DIFF
--- a/research/dev-workflows/693-zao-research-fetch-quality-audit/README.md
+++ b/research/dev-workflows/693-zao-research-fetch-quality-audit/README.md
@@ -1,0 +1,96 @@
+---
+topic: dev-workflows
+type: audit
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 674, 683, 690, 691
+tier: STANDARD
+---
+
+# 693 - /zao-research Fetch-Quality Audit: Why We Miss Info, and the Fix
+
+> **Goal:** Find why links Zaal forwards lose information when researched, and fix the /zao-research skill so a source is fully read before a doc is written.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | DELETE every "firecrawl" reference in the /zao-research skill - it is not installed | The skill names firecrawl as the JS-rendering tool and the paywall fallback. `ToolSearch "firecrawl"` returns nothing. When WebFetch fails on a JS page, the prescribed escalation tool does not exist, so research silently drops to WebSearch snippets. |
+| 2 | REPLACE the tool chain with what is actually installed: WebFetch -> `mcp__plugin_everything-claude-code_exa__web_fetch_exa` -> Playwright MCP / `/browse` skill -> Wayback Machine | These render JavaScript and exist right now. exa web_fetch returns clean markdown and batches URLs; Playwright is a full browser for Notion/X. |
+| 3 | ADD a Fetch-Quality Gate before any doc is written: classify every source FULL / PARTIAL / FAILED; PARTIAL or FAILED must be escalated through the full chain or explicitly marked in the doc | This session shipped 4 docs written off metadata, search snippets, or 404s without escalating. The gate makes that impossible to do silently. |
+| 4 | ADD a per-source fetch-quality marker to every doc's Sources section | A reader cannot currently tell whether a cited source was fully read or just its title. Doc 690 was honest ("0/5 article bodies"); most docs are not. |
+| 5 | ADD a depth rule: a high-signal single source (long technical post, 500+ upvotes, a real playbook/spec) gets its own depth treatment, not one row in a synthesis table | Cluster-and-synthesize (docs 687-691) is right for breadth but compresses a deep source to a sentence. Depth and breadth are different jobs. |
+
+## The Honest Audit: What This Session Missed
+
+Reviewing docs 674-691 (this session's output) against what was actually fetched:
+
+| Doc | Source that was NOT fully read | What happened | What should have happened |
+|-----|-------------------------------|---------------|---------------------------|
+| 674 Edge Esmeralda | The Edge Esmeralda Notion wiki (the actual link Zaal sent) | WebFetch returned an empty Notion app shell. Doc was written from WebSearch results instead. The wiki's schedule, sessions, participation details, attendee list - never read. | exa web_fetch_exa or Playwright renders Notion. Not tried. |
+| 683 Artizen | The "Artizen Playbook" + "Guide to Raising Money" (news.artizen.fund) | Both URLs 404'd on WebFetch; artizen.fund 403'd. Doc was synthesized from Gitcoin + search snippets. The playbook - a guide to the exact platform Zaal runs a fund on - went unread. | Wayback Machine for the 404s; exa fetch for the 403. Not tried. |
+| 690 X posts | 4 of 5 forwarded X posts | Only tweet titles + favorite counts came through the syndication endpoint. The doc itself states "Posts with full article bodies retrievable: 0/5". It is a doc about 5 headlines. | X long-form articles need a headless browser (Playwright). zao-fetch-x.sh gets tweet text only, not article bodies. Not escalated. |
+| 691 Spotify episode | open.spotify.com episode 69LleBwkRozkLAhbsxaCUC | Reported "unreachable, episode ID not found" and SKIP. A podcast episode Zaal flagged - zero capture. | Playwright loads the Spotify web player; episode metadata is also searchable by ID. Not tried. |
+| 687-689 Reddit clusters | Deep comment threads | post selftext + top ~5 comments parsed. Nested threads where dissent and nuance live - only partially walked. | zao-fetch-reddit.sh returns the full tree; walk it, do not stop at top-level. |
+
+## Root Cause
+
+Two compounding failures:
+
+1. **The escalation path is broken.** The skill's "MCP Tool Order" lists firecrawl as step 3 (JS rendering, paywalls) and the failure-mode table says "Use firecrawl MCP with JS rendering fallback." Firecrawl is not installed. So the documented escalation is a dead end - and with no live escalation, the researcher falls back to WebSearch snippets and writes the doc anyway.
+
+2. **No gate forces full retrieval before synthesis.** Nothing in the skill says "you may not write the doc until every source is FULL or explicitly marked." So a thin fetch flows straight into a thin doc. The skill's hallucination check (Step 6) checks whether URLs *resolve* - not whether their *content was actually read*.
+
+The result: when a fetch is hard, the doc gets written off whatever scraps came back. The information loss is invisible because the doc still cites the URL.
+
+## External Best Practices (2026)
+
+- **Verification catches AI research errors 15-20% of the time** - multi-step verification is not optional; standard LLM synthesis forms echo chambers around whatever the first fetch returned.
+- **Even the best deep-research agents have a citation-content gap** - OpenAI Deep Research: ~95% of citations identifiable, only ~70% completely correct. Citing a URL is not the same as having read it.
+- **JS-rendered pages require headless browser rendering** (waitForSelector / DOM-ready). React/Vue/Angular sites and Notion return an empty shell to plain HTTP fetches.
+- **X is a full React SPA behind Cloudflare + a login wall** - headless browser rendering is called "non-negotiable" for X article bodies. Syndication endpoints expose tweet text, not long-form articles.
+
+## The Real Tool Chain (Installed + Verified 2026-05-20)
+
+| Need | Tool | Status |
+|------|------|--------|
+| Plain article / HTML | WebFetch | installed |
+| JS-rendered page, clean markdown, batch URLs | `mcp__plugin_everything-claude-code_exa__web_fetch_exa` | installed - this is the real firecrawl replacement |
+| Semantic web search | `mcp__plugin_everything-claude-code_exa__web_search_exa` + WebSearch | installed |
+| Full browser render (Notion, X articles, Spotify, login walls) | Playwright MCP (`mcp__playwright__*`) or `/browse` + `/gstack` skills | installed |
+| Reddit | `~/bin/zao-fetch-reddit.sh` (full post + comment tree as JSON) | installed |
+| X / Twitter tweets | `~/bin/zao-fetch-x.sh` (syndication -> nitter -> wayback) | installed - tweets only, NOT article bodies |
+| Dead / 404 / moved URLs | Wayback Machine (`web.archive.org/web/<url>`) | available |
+| firecrawl | - | NOT installed - remove from skill |
+
+## The Fix: /zao-research Skill Changes
+
+Applied to `~/.claude/skills/zao-research/SKILL.md` in this session:
+
+1. **New Step 4.5 - Fetch-Quality Gate.** After fetching, before writing: classify each source FULL (content fully read) / PARTIAL (some content, some missing) / FAILED (nothing). Any PARTIAL or FAILED must be escalated through the full tool chain. Only after escalation is exhausted may a source stay PARTIAL/FAILED - and then it must be marked in the doc.
+2. **Rewritten MCP Tool Order** - firecrawl removed; exa web_fetch + Playwright + Wayback put in its place, with a per-source-type escalation ladder (Notion/JS -> exa fetch or Playwright; X articles -> Playwright; dead URLs -> Wayback; Reddit -> full comment tree; media -> Playwright or metadata search).
+3. **New Hard Requirement #11** - Sources section marks each source `[FULL]`, `[PARTIAL - what is missing]`, or `[FAILED - what was tried]`.
+4. **Depth rule** added to tier guidance - a high-signal single source is not compressed into a synthesis-table row.
+
+## Sources
+
+- [The 2026 Deep Research AI Protocol](https://zeroskillai.com/deep-research-ai-protocol-2026/)
+- [Best AI Deep Research Tools in 2026 (DeepWriter)](https://deepwriter.com/blog/best-ai-deep-research-tools-in-2026/)
+- [Best Ways to Scrape JavaScript-Heavy Sites in 2026 (Bright Data)](https://brightdata.com/blog/web-data/scraping-js-heavy-websites)
+- [How to Scrape X.com in 2026 (Scrapfly)](https://scrapfly.io/blog/posts/how-to-scrape-twitter)
+- [Comprehensive Guide to Twitter/X Scraping 2026 (DEV)](https://dev.to/ashish_soni08/comprehensive-guide-to-twitterx-scraping-frameworks-and-tools-in-2026-37p2)
+
+## Also See
+
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Notion wiki never read
+- [Doc 683](../../business/683-artizen-platform-fund-director-guide/) - Artizen Playbook 404'd, not recovered
+- [Doc 690](../../agents/690-inbox-x-posts-roundup-may2026/) - 0/5 X article bodies fetched
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Apply the 4 skill changes to ~/.claude/skills/zao-research/SKILL.md | @Claude | Skill edit | This session |
+| Re-research the 3 thin docs with the real tool chain: 674 Notion wiki, 683 Artizen Playbook, 690 X article bodies | @Zaal decision | Re-research | On approval |
+| Add the same Fetch-Quality Gate to the /inbox cluster workflow | @Claude | Skill edit | After this doc |
+| Spot-check: did installing exa MCP remove the need for the `/fetch` skill's manual routing? | @Zaal | Decision | Next research session |

--- a/research/dev-workflows/694-research-library-audit/README.md
+++ b/research/dev-workflows/694-research-library-audit/README.md
@@ -1,0 +1,113 @@
+---
+topic: dev-workflows
+type: audit
+status: research-complete
+last-validated: 2026-05-20
+related-docs: 693
+tier: DISPATCH
+---
+
+# 694 - Research Library Audit: All 649 Live Docs Scored
+
+> **Goal:** Score every live research doc for quality, find where information was lost or never finished, and produce a triage plan.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | RUN a scripted metadata pass on the 111 REVALIDATE docs - refresh `last-validated`, fill missing frontmatter | The single most common defect is metadata debt, not bad research. It is cheap to fix in bulk and does not need re-research. |
+| 2 | RE-RESEARCH the ~40 HIGH-priority thin docs in batches, using the doc 693 fixed fetch chain | These are genuinely incomplete - stubs, missing Sources, info loss. They are the real "missed info." |
+| 3 | MOVE the 12 ARCHIVE docs to `research/_archive/` and set `superseded-by` where applicable | They are superseded or about killed projects (FISHBOWLZ etc) - clear them out of the live set. |
+| 4 | DEFER the ~77 MED/LOW RE-RESEARCH docs - do them after the HIGH batch or when their topic next comes up | Re-researching all 117 at once is not worth it; the HIGH subset is where the value is. |
+| 5 | START the next research sprint with farcaster/ - it is the worst folder (23 of 59 thin) | 39% of the Farcaster docs are RE-RESEARCH; the foundational ones (Hub API, Neynar onboarding) have no Sources. |
+
+## The Numbers (649 live docs, _archive's 80 excluded)
+
+| Verdict | Count | Share | Meaning | Fix |
+|---------|-------|-------|---------|-----|
+| FINE | 408 | 63% | Solid, current, well-sourced | None |
+| REVALIDATE | 111 | 17% | Good content, stale or missing dates | Scripted metadata refresh |
+| RE-RESEARCH | 117 | 18% | Thin: stubs, missing Sources, info loss | Real re-research (doc 693 tool chain) |
+| ARCHIVE | 12 | 2% | Superseded / dead project | Move to _archive |
+
+**The honest headline:** the library is 63% solid. The problem Zaal felt is real but it splits in two - most of it is **metadata debt** (cheap), and a real **~117-doc thin tier** (the actual missed info). It is NOT 649 docs of lost information.
+
+## What "Thin" Actually Means Here
+
+The audit expected the doc 693 failure mode (info lost in fetching) to dominate. It does not. The dominant defect across all 8 folders is **unfinished structure**:
+
+- **Missing frontmatter / no `last-validated`** - whole ranges (dev-workflows 500-600, agents 026-247) created in research sprints without standardized frontmatter.
+- **No Goal statement** - business/identity alone had 7 of 12 RE-RESEARCH docs with no `> Goal` line.
+- **No Sources section** - identity docs 544, 545, 570; farcaster docs 2, 17, 173, 295.
+- **Stubs** - docs that promise a lot in the title and deliver ~50-80 lines (music 333/334, agents 262/266, community 624).
+
+True fetch-loss (the doc 693 problem) is the minority: farcaster 505/589 ("info_loss_thin_sources"), community 590 ("sources lost to 404s"), agents 466 ("6 info-loss signals"). Real, but not the bulk.
+
+## Worst Folders (re-research density)
+
+| Folder | Total | RE-RESEARCH | Density |
+|--------|-------|-------------|---------|
+| farcaster + cross-platform | 59 | 23 | 39% |
+| dev-workflows | 122 | 32 | 26% |
+| community + governance | 75 | 20 | 27% |
+| infrastructure + security | 56 | 16 | 29% |
+| business + identity | 74 | 12 | 16% |
+| music | 84 | 10 | 12% |
+| agents | 120 | 4 | 3% |
+| events + wavewarz + root | 59 | 0 | 0% |
+
+agents/ and events/ are healthy. farcaster/ is the priority cleanup.
+
+## Consolidated HIGH-Priority RE-RESEARCH List (~40 docs)
+
+Re-research these first. Full per-folder tables in this folder's other files.
+
+| Folder | HIGH-priority docs |
+|--------|--------------------|
+| farcaster | 2 (Hub API), 17 (Neynar FID/signers), 173 (Mini Apps), 260 (Neynar acquisition), 295 (Snaps), 505 (zlank spec), 586-589 (Hypersnap/Cassie), 591a-e (mini-app SDK suite), 594-598 (FIP live activity) |
+| dev-workflows | 196, 238, 362, 506, 507, 549a-549e (21st suite) - 29 HIGH total, see dev-workflows.md |
+| community + governance | 590 (Substack models), 624 (Nexus Portal), 59 (Hats Tree), 500 (DAO events), 502 (ZAOstock Circles) |
+| business + identity | 5 (zao-identity), 258 (SANG buyback), 264 (LinkedIn playbook), 271 (knowledge graph), 333 (music licensing), 352 (paragraph x402 - 2 broken links), 543/544/545/549/570 (Bonfire/KG suite), 641 (Whop) |
+| music | 334 + 333 (AI music speakers - Oct 3 time-sensitive), 601 (Suno tooling), 261 (AI music pipeline), 340 (remote collab tools) |
+| infrastructure + security | 471 (Vercel OAuth breach - P0 security) |
+| agents | 466 (ao-ui-button-audit), 673 (zao-craig-spec) |
+
+Time-sensitive within this list: **music 333/334** (ZAO Stock Oct 3 speaker curation) and **infrastructure 471** (P0 security event).
+
+## Per-Folder Audit Tables
+
+Full triage for every one of the 649 docs is in this folder:
+
+- [dev-workflows.md](./dev-workflows.md) - 122 docs
+- [agents.md](./agents.md) - 120 docs
+- [music.md](./music.md) - 84 docs
+- [business-identity.md](./business-identity.md) - 74 docs
+- [infrastructure-security.md](./infrastructure-security.md) - 56 docs
+- [farcaster-crossplatform.md](./farcaster-crossplatform.md) - 59 docs
+- [events-wavewarz-root.md](./events-wavewarz-root.md) - 59 docs
+- [community-governance.md](./community-governance.md) - 75 docs
+
+## Method + Caveats
+
+- 8 parallel research agents, one per folder group, scored each doc on Sources health, completeness vs Goal, and staleness vs 2026-05-20.
+- `research/_archive/` (80 docs) was excluded by design.
+- Verdicts are a fast scan, not a deep re-read - a doc marked RE-RESEARCH might just need its frontmatter fixed; confirm per-doc before redoing.
+- The audit agents themselves did NOT re-fetch sources - they judged from each doc's own text. A FINE verdict means "looks solid", not "every cited URL re-verified live."
+
+## Sources
+
+This is an internal audit; sources are the 649 research docs themselves under `research/`. Method draws on [Doc 693](../693-zao-research-fetch-quality-audit/) (fetch-quality findings).
+
+## Also See
+
+- [Doc 693](../693-zao-research-fetch-quality-audit/) - the fetch-quality skill fix this audit operationalizes
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Scripted metadata-refresh pass on the 111 REVALIDATE docs | @Zaal decision | Batch fix | On approval |
+| Re-research the ~40 HIGH docs in batches via doc 693 tool chain | @Zaal decision | Re-research | On approval |
+| Prioritize music 333/334 (Oct 3 speakers) + infra 471 (P0 security) in the first batch | @Claude | Re-research | First |
+| Move the 12 ARCHIVE docs to research/_archive/ | @Claude | Cleanup | On approval |
+| Start the re-research sprint with the farcaster/ folder (worst density) | @Zaal | Decision | After HIGH batch |

--- a/research/dev-workflows/694-research-library-audit/agents.md
+++ b/research/dev-workflows/694-research-library-audit/agents.md
@@ -1,0 +1,83 @@
+# Agents Research Audit (120+ docs)
+
+**Summary:** 93 FINE | 21 REVALIDATE | 4 RE-RESEARCH | 2 ARCHIVE
+
+| Doc# | Title | Verdict | Prio | Why |
+|------|-------|---------|------|-----|
+| 466 | ao-ui-button-audit-apr21 | RE-RESEARCH | HIGH | info loss (6 signals) |
+| 673 | zao-craig-spec-live-audio-todo | RE-RESEARCH | HIGH | info loss (3 signals) |
+| 262 | virtuals-protocol-agent-rail | RE-RESEARCH | LOW | stub <80 lines, no sources |
+| 266 | mission-control-v2 | RE-RESEARCH | LOW | placeholder, no goal/sources |
+| 026 | hindsight-agent-memory | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 070 | subagents-vs-agent-teams | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 071 | paperclip-rate-limits-multi-agent | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 084 | farcaster-ai-agents-landscape | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 085 | farcaster-agent-technical-setup | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 090 | ai-run-community-agent-os | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 161 | agent-harness-engineering-langchain | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 171 | council-high-intelligence-multi-agent-deliberation | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 202 | multi-agent-orchestration-openclaw-paperclip | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 205 | openclaw-paperclip-elizaos-deployment-plan | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 206 | lobsterai-agent-architecture | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 208 | paperclip-plugins-ecosystem-update | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 227 | agentic-workflows-2026 | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 234 | openclaw-comprehensive-guide | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 235 | free-web-search-mcp-alternatives | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 236 | autonomous-openclaw-operator-pattern | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 237 | usv-agents-tasklet-malleable-software | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 239 | agent-frameworks-infrastructure-evaluation | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 245 | zoe-upgrade-autonomous-workflow-2026 | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 246 | neynar-api-creative-agent-uses | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 247 | top-50-local-ai-models-2026 | REVALIDATE | LOW | no timestamp, pre-March 2026 |
+| 290 | fishbowlz-agentic-participants | ARCHIVE | - | FISHBOWLZ paused 2026-04-16, killed 2026-05-0 |
+| 679 | coworking-agent-mentions-code-pipeline | ARCHIVE | - | superseded |
+| 251 | huggingface-platform-deep-dive | FINE | - | solid, current |
+| 253 | autoagent-self-optimizing-agents | FINE | - | solid, current |
+| 256 | zoe-agent-factory-vision | FINE | - | solid, current |
+| 259 | agent-self-optimization | FINE | - | solid, current |
+| 267 | openclaw-skills-capabilities | FINE | - | solid, current |
+| 268 | milady-ai-elizaos-evolution | FINE | - | solid, current |
+| 278 | agentic-bootcamp-zao-agent-squad | FINE | - | solid, current |
+| 288 | multi-agent-dashboard-visual-research | FINE | - | solid, current |
+| 291 | farcaster-agentic-bootcamp-days-3-5 | FINE | - | solid, current |
+| 292 | pixel-agents-dashboard-customization | FINE | - | solid, current |
+| 293 | multi-agent-tools-gitnexus-prompts | FINE | - | solid, current |
+| 296 | agentic-workflow-optimization | FINE | - | solid, current |
+| 307 | great-convergence-agent-harness-architecture | FINE | - | solid, current |
+| 318 | cassie-multi-agent-coordination-bootcamp | FINE | - | solid, current |
+| 325 | elevenlabs-agents-voice-ai-platform | FINE | - | solid, current |
+| 325 | zabal-agent-swarm-economy | FINE | - | solid, current |
+| 339 | austin-griffith-clawd-ethskills-agent-patterns | FINE | - | solid, current |
+| 340 | clawd-patterns-deep-dive-4-systems | FINE | - | solid, current |
+| 344 | bankr-bot-agent-trading-skills | FINE | - | solid, current |
+| 345 | zabal-agent-swarm-master-blueprint | FINE | - | solid, current |
+| 351 | zabal-swarm-activation-checklist | FINE | - | solid, current |
+| 353 | autonomous-trading-beyond-schedules | FINE | - | solid, current |
+| 360 | profit-agent-hot-wallet-strategy | FINE | - | solid, current |
+| 363 | darwinian-agent-evolution | FINE | - | solid, current |
+| 364 | multi-harness-agent-orchestration | FINE | - | solid, current |
+| 420 | hyperframes-html-video-agents | FINE | - | solid, current |
+| 433 | agent-outbound-phone-calls-ringading-twilio | FINE | - | solid, current |
+| 435 | zoe-effectiveness-v2-playbook | FINE | - | solid, current |
+| 447 | agent-stack-week-improvement-sprint | FINE | - | solid, current |
+| 451 | ao-claude-code-dialog-block-forensics | FINE | - | solid, current |
+| 452 | ao-sidebar-counter-filter-fix | FINE | - | solid, current |
+| 453 | ao-offline-banner-websocket-diagnosis | FINE | - | solid, current |
+| 454 | agent-stack-reliability-hardening-apr20 | FINE | - | solid, current |
+| 457 | silent-failure-hunt-ecc | FINE | - | solid, current |
+| 460 | zao-agentic-stack-end-to-end-design | FINE | - | solid, current |
+| 464 | zoe-telegram-reply-context-ship-pr | FINE | - | solid, current |
+| 465 | zoe-observability-dispatch-hardening | FINE | - | solid, current |
+| 467 | zao-bot-fleet-design-magnetiq | FINE | - | solid, current |
+| 468 | zao-farcaster-hub-poidh-hypersub-dual-hub | FINE | - | solid, current |
+| 473 | clawdbotatg-apr21-updates-zoe-openclaw | FINE | - | solid, current |
+| 474 | bcz101-bot-transcript-rag | FINE | - | solid, current |
+| 479 | walden-multi-agent-patterns-cognition | FINE | - | solid, current |
+| 483 | hermes-agent-local-llm-framework | FINE | - | solid, current |
+
+... and 50 more FINE docs
+
+## Top 5 RE-RESEARCH (HIGH Priority)
+
+- **466**: ao-ui-button-audit-apr21 (info loss (6 signals))
+- **673**: zao-craig-spec-live-audio-todo (info loss (3 signals))

--- a/research/dev-workflows/694-research-library-audit/business-identity.md
+++ b/research/dev-workflows/694-research-library-audit/business-identity.md
@@ -1,0 +1,80 @@
+# Business & Identity Audit
+
+**Total: 74 docs** - RE-RESEARCH: 12 | REVALIDATE: 10 | FINE: 52 | ARCHIVE: 0
+
+| Doc# | Folder | Title | Verdict | Priority | Why |
+|------|--------|-------|---------|----------|-----|
+|   5 | identity | zao-identity                        | RE-RESEARCH  | HIGH     | No goal statement            |
+| 258 | business | zabal-sang-buyback                  | RE-RESEARCH  | HIGH     | No goal statement            |
+| 264 | business | linkedin-build-in-public-playbook   | RE-RESEARCH  | HIGH     | No goal statement            |
+| 271 | identity | zao-knowledge-graph                 | RE-RESEARCH  | HIGH     | No goal statement            |
+| 333 | business | ai-music-licensing-sync-label-deep- | RE-RESEARCH  | HIGH     | No goal statement            |
+| 352 | business | paragraph-x402-agent-implementation | RE-RESEARCH  | HIGH     | 2 broken sources             |
+| 543 | identity | bonfires-bot-shipping-questions     | RE-RESEARCH  | HIGH     | No goal statement            |
+| 544 | identity | bonfires-sdk-zao-wiring             | RE-RESEARCH  | HIGH     | No sources section           |
+| 545 | identity | zabal-knowledge-graph-ontology      | RE-RESEARCH  | HIGH     | No sources section           |
+| 549 | identity | bonfire-personal-second-brain       | RE-RESEARCH  | HIGH     | No goal statement            |
+| 570 | identity | zaal-personal-kg-agentic-memory     | RE-RESEARCH  | HIGH     | No sources section           |
+| 641 | business | whop-claude-code-community-distribu | RE-RESEARCH  | HIGH     | No goal statement            |
+| 139 | business | trustware-sdk-deep-dive             | REVALIDATE   | -        | Thin content                 |
+| 252 | business | publish-new-agent-marketplace       | REVALIDATE   | -        | Thin content                 |
+| 299 | business | audio-room-best-practices           | REVALIDATE   | -        | 1 bad src                    |
+| 455 | business | bcz-maine-clients-stephen-cameron   | REVALIDATE   | -        | 1 bad src                    |
+| 481 | business | kompreni-quotient-anti-cucktrading- | REVALIDATE   | -        | Thin content                 |
+| 482 | business | digihold-seven-money-rules-founder- | REVALIDATE   | -        | Thin content                 |
+| 485 | business | distribution-is-hard-v3-jlcolton    | REVALIDATE   | -        | Thin content                 |
+| 569 | identity | yapz-bonfire-ingestion-strategy     | REVALIDATE   | -        | 1 bad src                    |
+| 582 | business | empire-builder-v3-live-launch       | REVALIDATE   | -        | 1 bad src                    |
+| 637 | business | emily-sundberg-feed-me-open-tab     | REVALIDATE   | -        | Thin content                 |
+|  29 | business | artist-revenue-ip-rights            | FINE         | -        | Solid                        |
+|  37 | business | bridges-competitors-monetization    | FINE         | -        | Solid                        |
+| 125 | business | coinflow-fiat-checkout              | FINE         | -        | Solid                        |
+| 134 | identity | external-reputation-signals-compreh | FINE         | -        | Solid                        |
+| 135 | identity | exhaustive-profile-enrichment-signa | FINE         | -        | Solid                        |
+| 158 | identity | zao-member-naming-ens-basenames     | FINE         | -        | Solid                        |
+| 191 | identity | reputation-scoring-systems          | FINE         | -        | Solid                        |
+| 203 | identity | nft-gallery-alchemy-integration     | FINE         | -        | Solid                        |
+| 222 | business | payment-infrastructure-stripe-coinb | FINE         | -        | Solid                        |
+| 244 | business | polymarket-claude-api-trading-analy | FINE         | -        | Solid                        |
+| 263 | business | obsidian-lean-team-model            | FINE         | -        | Solid                        |
+| 298 | business | fishbowlz-tokenization              | FINE         | -        | Solid                        |
+| 307 | business | app-monetization-ernesto-lopez-fram | FINE         | -        | Solid                        |
+| 322 | business | paragraph-publishnew-newsletter-age | FINE         | -        | Solid                        |
+| 324 | business | zabal-sang-wallet-agent-tokenomics  | FINE         | -        | Solid                        |
+| 350 | business | viral-engagement-bait-anatomy       | FINE         | -        | Solid                        |
+| 361 | business | empire-builder-deep-dive-v3-integra | FINE         | -        | Solid                        |
+| 362 | business | lean-six-sigma-festival-operations  | FINE         | -        | Solid                        |
+| 406 | business | coinflow-isv-deep-dive-wavewarz-zao | FINE         | -        | Solid                        |
+| 410 | business | polymarket-bot-claude-11k-profit-19 | FINE         | -        | Solid                        |
+| 429 | business | paragraph-agents-launch-apr2026     | FINE         | -        | Solid                        |
+| 470 | business | behavioral-intervention-vs-financia | FINE         | -        | Solid                        |
+| 474 | business | foundercheck-block-icp-resolution   | FINE         | -        | Solid                        |
+| 498 | business | zlank-unified-sdk-concept           | FINE         | -        | Solid                        |
+| 525 | identity | guild-xyz-token-gating-platforms-ev | FINE         | -        | Solid                        |
+| 526 | business | distribution-v3-zao-entity-playbook | FINE         | -        | Solid                        |
+| 542 | identity | bonfires-ai-knowledge-graph-bcz-str | FINE         | -        | Solid                        |
+| 546 | identity | bonfires-real-world-deployments     | FINE         | -        | Solid                        |
+| 547 | business | bcard-bfoundation-black-flag-collec | FINE         | -        | Solid                        |
+| 548 | identity | bonfire-first-week-context-teaching | FINE         | -        | Solid                        |
+| 572 | business | zabal-avalanche-l1-l2-gas-token     | FINE         | -        | Solid                        |
+| 573 | business | zabal-avax-surfaces-arena-music     | FINE         | -        | Solid                        |
+| 581 | business | whop-creator-deep-dive              | FINE         | -        | Solid                        |
+| 581 | identity | bonfire-graph-wipe-bot-hygiene      | FINE         | -        | Solid                        |
+| 583 | business | empire-builder-zao-os-integration-i | FINE         | -        | Solid                        |
+| 584 | business | empire-builder-farcaster-creator-pl | FINE         | -        | Solid                        |
+| 585 | business | empire-builder-test-loop-ideas-iter | FINE         | -        | Solid                        |
+| 592 | business | boring-saas-free-preview-risk-rever | FINE         | -        | Solid                        |
+| 599 | business | adam-meeting-may2026-commercial-lea | FINE         | -        | Solid                        |
+| 602 | business | empire-builder-skill-spec-phase3-un | FINE         | -        | Solid                        |
+| 606 | identity | zaal-second-brain-system            | FINE         | -        | Solid                        |
+| 611 | business | zaostock-brand-patterns-rsvpizza-iy | FINE         | -        | Solid                        |
+| 612 | business | autoco-llc-formation                | FINE         | -        | Solid                        |
+| 626 | business | empire-builder-zabal-poidh-airdrop  | FINE         | -        | Solid                        |
+| 628 | business | web3-streaming-zabal-empire-bridge  | FINE         | -        | Solid                        |
+| 631 | business | poidh-zabal-sentinel-convergence    | FINE         | -        | Solid                        |
+| 646 | business | clanker-empire-builder-zabal-games- | FINE         | -        | Solid                        |
+| 649 | identity | zaal-build-profile-ecosystem-survey | FINE         | -        | Solid                        |
+| 656 | business | aroussi-law-firm-agency-model       | FINE         | -        | Solid                        |
+| 658 | business | takemiya-blockchain-geopolitical-mo | FINE         | -        | Solid                        |
+| 666 | business | zabal-brand-kit-page                | FINE         | -        | Solid                        |
+| 667 | business | brand-kit-completeness-audit        | FINE         | -        | Solid                        |

--- a/research/dev-workflows/694-research-library-audit/community-governance.md
+++ b/research/dev-workflows/694-research-library-audit/community-governance.md
@@ -1,0 +1,138 @@
+# Research Audit: Community & Governance Folders
+
+**Scope:** 42 community docs + 33 governance docs = 75 total research documents
+**Date audited:** 2026-05-20
+**Criteria:** Frontmatter completeness, source health, staleness, goal clarity, completeness
+
+---
+
+## Summary
+
+| Verdict | Count | Notes |
+|---------|-------|-------|
+| **FINE** | 54 | Solid, current, good sources |
+| **REVALIDATE** | 0 | None exceeded 60-day staleness threshold |
+| **RE-RESEARCH** | 20 | Thin sources / stubs / unclear goals / info loss |
+| **ARCHIVE** | 1 | Superseded by doc 427/050/051 |
+
+**Health:** 72% passing (FINE), 27% need rework (RE-RESEARCH), 1% obsolete (ARCHIVE)
+
+---
+
+## Priority RE-RESEARCH Docs (Top 10)
+
+| # | Folder | Status | Title | Reason | Priority |
+|---|--------|--------|-------|--------|----------|
+| 590 | community | research-complete | Substack's Three Models for Building Co... | Sources lost to fetch errors / 404s | HIGH |
+| 624 | community | research-complete | Nexus Portal Canon (May 7 stub) | Stub / incomplete, missing clear goal | HIGH |
+| 59 | governance | research-complete | ZAO Hats Tree: On-Chain State & ZAO OS... | Stub with incomplete integration notes | HIGH |
+| 500 | governance | published | DAO Event Coordination Patterns | Stub / incomplete, missing goal clarity | HIGH |
+| 502 | governance | research-complete | ZAOstock Circles v1 Spec | Thin sources (metadata-only notes) | MED |
+| 567 | governance | research-complete | Nouns DAO Deep Dive: Mechanism Lore | Thin sources (mostly outline, light content) | MED |
+| 635 | community | research-complete | CyrilXBT on Anthropic AI Agents | Very thin (374w) without clear purpose | MED |
+| 60 | community | research-complete | Vitalik's Ethereum Philosophy | Sources marked as "metadata only" | MED |
+| 75 | governance | research-complete | Hats Protocol V2 Updates | Sources marked as "thin / metadata only" | MED |
+| 444 | governance | ready-for-submission | ZAO Fractal Submission: April 20 | Very thin (484w), operational notes only | MED |
+
+---
+
+## Detailed Verdicts
+
+### RE-RESEARCH (HIGH PRIORITY)
+
+**590 — Substack's Three Community Models**
+- **Status:** research-complete
+- **Issue:** Sources section shows fetch failures: "could not parse" on 2 out of 3 sources
+- **Action:** Re-fetch Substack URLs + add 2-3 real case studies (BCZ, Juno, one music creator)
+- **Impact:** Informs future ZAO community models; blockers doc development
+
+**624 — Nexus Portal Canon (May 7)**
+- **Status:** research-complete (marked with quotation error)
+- **Issue:** Frontmatter formatting error (`"2026-05-0`) + content is 40% placeholder ("Add X here", "(pending)")
+- **Action:** Complete canonical Nexus Portal overview by reviewing actual portal.zaoos.com + Quad source code
+- **Impact:** Needed for upcoming portal launch decision
+
+**59 — ZAO Hats Tree: On-Chain State & ZAO OS Integration**
+- **Status:** research-complete
+- **Issue:** Content is ~40% research + 60% unfinished integration spec ("TODO: clarify role hierarchy", stub sections)
+- **Action:** Complete: test live Hats deployment on Base + map ZAO roles → Hats roles + spec ZAO OS integration
+- **Impact:** Blocks governance infrastructure decisions
+
+**500 — DAO Event Coordination Patterns**
+- **Status:** published
+- **Issue:** Stub doc: only 1,858 words, section headers present but no body content ("TBD", gaps)
+- **Action:** Flesh out with 3-5 real DAO event examples (ETHDenver, Ethereum Foundation, etc) + apply to ZAOstock workflow
+- **Impact:** ZAOstock team needs this for Oct 3 execution
+
+---
+
+### RE-RESEARCH (MED PRIORITY)
+
+**502 — ZAOstock Circles v1 Spec**
+- **Issue:** Thin sources (spec pulled from memory/notes, not live research)
+- **Action:** Cross-reference with doc 498 (ZAO Fractal Adapted) + test actual circle workflow
+- **Impact:** Confirms Circles v1 design before Oct event
+
+**567 — Nouns DAO Deep Dive: Mechanism Lore + ZAO Angles**
+- **Issue:** 2,604 words but mostly outline structure; thin on mechanism analysis
+- **Action:** Add: treasury curve analysis, prop voting mechanics, historical failures, ZAO-specific learnings
+- **Impact:** Informs future on-chain governance spec
+
+**60 — Vitalik's Ethereum Philosophy & EF Mandate**
+- **Issue:** Sources marked "metadata only" - no actual fetch of Vitalik blog posts for quotes
+- **Action:** Re-fetch all 6 source blog posts, add direct quotes + analysis
+- **Impact:** Core alignment doc; needs solid sourcing
+
+**75 — Hats Protocol V2 Updates & Tooling**
+- **Issue:** Thin sources section; mostly product review without real integration planning
+- **Action:** Review Hats v2 changelog + plan ZAO-specific role hierarchy
+- **Impact:** Informs identity/governance layer decisions
+
+---
+
+### RE-RESEARCH (LOW PRIORITY)
+
+**635 — CyrilXBT on Anthropic AI Agents Workshop (374w)**
+- **Issue:** Very short, no clear takeaway or how-to-apply section
+- **Action:** Expand: What did Cyril teach? How does ZAO apply this to agent stack?
+- **Impact:** Informational only; lower urgency
+
+**105, 272, 458, 56, 58, 103, 109, 450, 497, 501**
+- **Issue:** Missing or vague Goal lines; unclear why each doc exists or what decision it informs
+- **Action:** Add explicit `> Goal:` line + one-sentence decision context for each
+- **Impact:** Organizational clarity; docs are solid but need better framing
+
+---
+
+## ARCHIVE
+
+**600 — Jadyn Violet & UVR (Underground Violet Review)**
+- **Superseded by:** Doc 427, 050, 051 (all more current and complete)
+- **Action:** Link to doc 427 as canonical source; this doc can be marked historical
+
+---
+
+## Recommendations
+
+1. **Immediate (week of 5/20):** Fix HIGH-priority docs (590, 624, 59, 500). These block ZAOstock + governance work.
+2. **Next sprint:** Complete MED-priority source gaps (60, 75, 502, 567).
+3. **Process improvement:** Add consistent frontmatter template to all new research docs.
+   - Required: `status:`, `last-validated: YYYY-MM-DD`, `> Goal:` (one sentence)
+   - Check: 60-day staleness on "governance/community" topics
+
+---
+
+## Files by Quality Tier
+
+**TIER 1 (Canonical, use freely):**
+530, 533, 547, 577, 621, 625, 634, 640, 642 — all recent (11-26 days), solid sourcing, clear use cases
+
+**TIER 2 (Research-complete, safe with minor updates):**
+023, 050, 051, 060, 061, 065, 094, 105, 106, 110, 169, 200, 229, 249, 287, 289, 348, 352, 358, 363, 415, 419, 427, 432, 449, 458, 538, 547, 56, 58, 102, 103, 104, 109, 111, 114, 115, 132, 133, 140, 149, 188, 285, 299, 306, 346, 347, 349, 497, 498 — known good, low change risk
+
+**TIER 3 (Needs rework before citing):**
+590, 624, 59, 500, 502, 567, 60, 75, 444, 635, 105, 272, 458, 497, 501
+
+**TIER 4 (Retired):**
+600 (superseded)
+

--- a/research/dev-workflows/694-research-library-audit/dev-workflows.md
+++ b/research/dev-workflows/694-research-library-audit/dev-workflows.md
@@ -1,0 +1,93 @@
+# Audit Report: /research/dev-workflows/ (122 docs)
+
+**Summary:** 122 total documents scanned. 36 FINE, 49 REVALIDATE (stale), 32 RE-RESEARCH (incomplete/missing metadata), 5 ARCHIVE (superseded).
+
+## Verdict Summary
+
+| Verdict | Count | Notes |
+|---------|-------|-------|
+| FINE | 36 | Current, complete, well-sourced |
+| REVALIDATE | 49 | Content solid but stale (March-early April 2026) |
+| RE-RESEARCH | 32 | Missing date/status, stubs < 50 lines, or incomplete |
+| ARCHIVE | 5 | Superseded or historical |
+
+---
+
+## RE-RESEARCH (Priority Order)
+
+High-priority re-research docs (load-bearing, active topics, or structural issues):
+
+| Doc# | Title | Priority | Why |
+|------|-------|----------|-----|
+| 196 | solo dev ai coding landscape 2026 | HIGH | Missing date/status |
+| 238 | claude tools top50 evaluation | HIGH | Missing date/status |
+| 362 | caveman token savings analysis | HIGH | Missing date/status |
+| 506 | trae ai solo bytedance coding agent | HIGH | Missing date/status |
+| 507 | claude skills 1116 ecosystem zao picks | HIGH | Missing date/status |
+| 528 | pi dev coding agent mario zechner | HIGH | Missing date/status |
+| 536 | claude dot md best practices | HIGH | Missing date/status |
+| 537 | shann superpowers planning framework | HIGH | Missing date/status, stub (62 lines) |
+| 539 | grill me claude skill specs to code | HIGH | Missing date/status |
+| 545 | mitcheil 6agent viral x content pipeline | HIGH | Missing date/status |
+| 549 | 21st dev component platform | HIGH | Missing date/status |
+| 549a | 21st dev catalog inventory | HIGH | Missing date/status |
+| 549b | 21st dev access patterns | HIGH | Missing date/status |
+| 549d | 21st dev ai features magic | HIGH | Missing date/status |
+| 549e | 21st dev zao skill spec | HIGH | Missing date/status |
+| 550 | gitpitcher evaluation | HIGH | Missing date/status |
+| 551 | research roadmap library audit | HIGH | Missing date/status |
+| 553 | memory file health audit | HIGH | Missing date/status |
+| 554 | worktree collision postmortem | HIGH | Missing date/status |
+| 555 | agent harness shootout | HIGH | Missing date/status |
+| 556 | gasless onboarding stack zaostock | HIGH | Missing date/status |
+| 557 | onchain festival ticketing zaostock | HIGH | Missing date/status |
+| 558 | anbeeld writing md | HIGH | Missing date/status |
+| 560 | openwhisp local speech to text | HIGH | Missing date/status |
+| 562 | reddit x scraping meta eval last30days | HIGH | Missing date/status |
+| 563 | shannholmberg content engine ronin | HIGH | Missing date/status |
+| 564 | reddit x scraping FIXED implementation | HIGH | Missing date/status |
+| 565 | ask gpt claude chatgpt learning loop | HIGH | Missing date/status |
+| 566 | claude reddit gems apr 2026 | HIGH | Missing date/status |
+| 638 | x khairallah eng post | MED | Stub (37 lines) |
+| 639 | x zecheng zhang post | MED | Stub (41 lines) |
+| 633 | r vibecoding thread 2026 05 11 | LOW | No Sources section |
+
+---
+
+## REVALIDATE (Stale, need date/fact refresh)
+
+49 docs from March and early April 2026 (60+ days old):
+
+**March 2026 (15 docs):** 030, 038, 039, 045, 054, 063, 066, 076, 089, 137, 154, 159, 162, 164, 166
+
+**Early April 2026 (34 docs):** 168, 170, 172, 212, 232, 242, 243, 248, 276, 279, 297, 298, 299, 300, 301, 302, 303, 305, 306, 319, 353, 354, 355, 356, 357, 359, 405, 408, 409, 411, 412, 414, 429, 618
+
+---
+
+## ARCHIVE (Superseded or Historical)
+
+| Doc# | Title | Status |
+|------|-------|--------|
+| 225 | fork friendly open source patterns | Superseded |
+| 434 | claude code aux model routing | Superseded (ANTHROPIC_SMALL_FAST_MODEL deprecated) |
+| 508 | creator infra mini apps token burn signals apr25 | Superseded |
+| 552 | zao skill library audit | Superseded |
+| 653 | cron bots audit may2026 | Superseded |
+
+---
+
+## FINE (No action needed)
+
+36 docs with current status, solid sources, and complete content. All dated April 16+ or May 2026.
+
+Includes: 157, 165, 282, 321, 365, 366, 367, 415, 422, 424, 426, 440, 441, 448, 459, 461, 469, 472, 477, 478, 480, 490, 493, 549c, 610, 616, 623, 636, 652, 655, 659, 660, 661, 662, 663, 673.
+
+---
+
+## Key Findings
+
+1. **Metadata debt:** 32 RE-RESEARCH docs (mostly 500-600 range) lack `> Date:` field in frontmatter. Add timestamps on next sweep.
+2. **Staleness:** 49 REVALIDATE docs from March-early April. Core tool/API docs (tools-top50, monorepo-migration, token-optimization) should be refreshed.
+3. **Structural gaps:** Docs 549a-549e (21st dev suite) form a sub-tree with missing dates. Either consolidate or timestamp each.
+4. **Stubs:** Docs 638, 639 (X posts) and 633 (Reddit thread) are < 50 lines. Consider archive or expand.
+

--- a/research/dev-workflows/694-research-library-audit/events-wavewarz-root.md
+++ b/research/dev-workflows/694-research-library-audit/events-wavewarz-root.md
@@ -1,0 +1,91 @@
+# Research Audit: Events + WaveWarZ + Root Docs
+
+**Scope:** `/research/events/` (42 docs), `/research/wavewarz/` (5 docs), `/research/[0-9]*/` root level (12 docs)
+**Total:** 59 docs
+**Audit Date:** 2026-05-20
+
+## Summary
+
+- **FINE:** 54 docs (92%)
+- **REVALIDATE:** 4 docs (7%)
+- **RE-RESEARCH:** 1 doc (2%)
+- **ARCHIVE:** 0 docs
+
+## Detailed Results
+
+| Doc# | Folder | Title | Verdict | Priority | Why |
+|------|--------|-------|---------|----------|-----|
+| 201 | events | AI Creator Economy Landscape (March 2026) | FINE | - | 11 external signals, full sources, codebase mapping, recent validation |
+| 207 | events | ZAO VPS Agent Stack Session Log | FINE | - | Architecture doc, current deployment state, roadmap complete |
+| 240 | events | Farcaster Agentic Bootcamp (Builders Garden) | FINE | - | Live session coverage, comprehensive notes, dates through Apr 10 |
+| 241 | events | Q1 2026 Big Wins | FINE | - | Complete summary, decision table, sources cited |
+| 254 | events | ZOE Agent Ecosystem Status (Apr 3) | FINE | - | Living document snapshot, current state verified |
+| 257 | events | ZOE Ship Log (Apr 3 2026) | FINE | - | Brief but complete shipping record, PRs documented |
+| 265 | events | ClawDown Poker Agent | FINE | - | Technical spec complete, API docs, strategy documented, live |
+| 270 | events | ZAO Stock Planning | FINE | - | Event planning doc, structure complete |
+| 274 | events | ZAO Stock Team Deep Profiles | FINE | - | Comprehensive member profiles, backgrounds documented |
+| 280 | root | FID Registration x402 Deep Dive | FINE | - | Technical deep-dive, multiple paths explored, sources verified |
+| 281 | root | Farcaster Agents Landscape & Registration | FINE | - | Agent taxonomy, registration patterns documented |
+| 282 | root | Privy Auth Integration (FISHBOWLZ) | FINE | - | Complete feature mapping, auth patterns, free-tier confirmed |
+| 283 | root | Privy Embedded Wallets Token Mechanics | FINE | - | Wallet capabilities mapped to use cases, integration pattern clear |
+| 284 | root | Privy Full Feature Set | FINE | - | Comprehensive feature audit, all use cases covered |
+| 288 | root | Agent Squad Monitoring Dashboards | FINE | - | Dashboard design complete, data flow documented |
+| 289 | root | ZOE Dashboard Chat UX Patterns | FINE | - | UX patterns extracted, interaction models defined |
+| 294 | events | Event Coordinator AI Agents | FINE | - | Agent pattern research, use cases documented |
+| 309 | root | Karpathy LLM Wiki Codebase Compiler | FINE | - | Brief but complete, implementations mapped, relevance clear |
+| 310 | root | Meta TRIBE v2 Brain Prediction | FINE | - | Complete explanation, setup documented, caveats noted |
+| 311 | root | Vibe-Coded Apps Marketing Playbook | FINE | - | Marketing patterns documented |
+| 312 | root | Claude Skills Marketplace Ecosystem | FINE | - | Ecosystem overview complete |
+| 314 | root | Music Metadata ISRC AI Distribution | FINE | - | Distribution framework documented |
+| 316 | events | Farcaster Agentic Bootcamp Week 2 Deep Dive | FINE | - | Session transcripts, learnings documented |
+| 317 | events | Farcaster Agentic Bootcamp Week 1 Transcripts | FINE | - | Complete session notes |
+| 326 | events | Agentic Bootcamp Complete Session Guide | FINE | - | Full 10-week curriculum archive |
+| 364 | events | ZAO Festivals Deep Research | FINE | - | Festival strategy documented |
+| 369 | events | DreamEvent Framework Gap Analysis | FINE | - | Framework analysis complete |
+| 418 | events | Birding Man Festival Analysis | FINE | - | Festival model study |
+| 421 | wavewarz | Quotient Anti-Cucktrading AI Superforecaster | FINE | - | Technical spec documented |
+| 423 | events | Music x Crypto Connect Sesh (Apr 17) | FINE | - | Event recap, outcomes documented |
+| 425 | events | ZAOstock Dashboard UI Lean Kanban Patterns | FINE | - | Design patterns extracted |
+| 428 | events | ZAOstock Run-of-Show Program | FINE | - | Full day-of schedule, contingency plans |
+| 433 | events | ZAO Media Capture Pipeline Spec | FINE | - | Spec complete, technical requirements clear |
+| 442 | events | WaveWarZ Sunday Battle Recap Socials | FINE | - | Event recap with social content |
+| 443 | events | ZAO Stock Sponsor Pitch Drafts | FINE | - | 3-tier pitch templates, outreach ready |
+| 445 | events | ZAO Stock Monday Progress Report (Apr 20) | FINE | - | Status summary, 25 PRs documented |
+| 456 | events | FarmDrop Soulbenders May 24 Hannah Interview | FINE | - | Interview notes, collaboration documented |
+| 457 | events | FarmDrop Hannah Voice Memo Event Brief | FINE | - | Event brief from voice notes |
+| 458 | events | FarmDrop Statewide Expansion Sam Lardner Collab | FINE | - | Collaboration framework |
+| 472 | events | ZAOstock Artist Lock-in Timeline | FINE | - | Artist pipeline documented |
+| 473 | events | Road to ZAOstock Magnetic Portal | FINE | - | Portal vision documented |
+| 476 | events | ZAOstock Apr 22 Team Recap | FINE | - | Team progress documented |
+| 477 | events | ZAOstock Dashboard Notion Replacement | FINE | - | Dashboard spec documented |
+| 499 | events | Music Festival Collective Governance | FINE | - | Governance patterns studied |
+| 504 | events | Aug 15 Dryrun Planning | REVALIDATE | - | Plan from Apr, no validation date; Oct 3 main event now primary |
+| 599 | events | Inbox Digest 2026-05-03 | FINE | - | Current status snapshot from May 3 |
+| 608 | wavewarz | WaveWarZ Africa RAM SongChain (May 4) | FINE | - | Event recap documented |
+| 609 | events | ZAOstock Cobuild Six Circles (May 4) | FINE | - | Cobuild session notes |
+| 630 | events | ZABAL Games Claude Code Hackathon v0 | FINE | - | Hackathon spec documented |
+| 654 | events | ZABAL Games Empire v3 YerBearZerker Meeting | FINE | - | Meeting notes, decisions documented |
+| 670 | events | Iman Call (May 18) Craig PizzaDAO | FINE | - | Call notes, partnership discussed |
+| 674 | events | Edge Esmeralda Artizen Telamon Outreach | FINE | - | Outreach notes |
+| 675 | events | Tanja Fractal Book Call (May 18) | FINE | - | Call notes |
+| 678 | events | ZAOstock Advisor Call (May 19) | FINE | - | Fresh advisor feedback |
+| 681 | events | ZAOstock May 19 New Build Initiatives | FINE | - | Latest build ideas |
+| 099 | wavewarz | Prediction Market Music Battles | FINE | - | Design spec complete, Respect integration mapped |
+| 100 | wavewarz | Solana PDA Reading Next.js | FINE | - | Technical guide complete, code examples |
+| 101 | wavewarz | WaveWarZ ZAO Whitepaper | FINE | - | Comprehensive integration strategy |
+| 180 | wavewarz | WaveWarZ Integration Blueprints | FINE | - | Artist discovery pipeline designed |
+
+## Issues Found
+
+**REVALIDATE (stale, but substantive):**
+- **Doc 504** (Aug 15 Dryrun Planning) — No `last-validated` date; April planning for now-superseded dry-run. Oct 3 is primary event. Still useful for May ceremonial/planning reference, but should be reviewed against current ZAOstock timeline.
+
+**RE-RESEARCH (thin/incomplete):**
+- None identified in this pass. All docs deliver on their stated goals or are properly positioned as snapshots/briefs.
+
+## Notes
+
+- Stub docs (50-78 lines) like 257, 309, 310, 312, 445 are intentionally brief but complete — they fully deliver on their stated goals (ship logs, research briefs, status reports).
+- All event docs (201-681) are point-in-time records; past dates do not indicate staleness — these are institutional memory. Verdict judged on completeness + source health, not calendar age.
+- 5 wavewarz docs are all substantive (planning + design specs for the music battle platform).
+- 12 root docs span FID registration, Privy auth, agent architecture, and crypto-music topics — all current and well-sourced.

--- a/research/dev-workflows/694-research-library-audit/farcaster-crossplatform.md
+++ b/research/dev-workflows/694-research-library-audit/farcaster-crossplatform.md
@@ -1,0 +1,82 @@
+# Farcaster & Cross-Platform Research Audit
+
+**Date:** 2026-05-20 | **Scope:** 59 docs (44 farcaster, 15 cross-platform)
+
+## Verdict Summary
+
+- **FINE:** 26 (solid + current)
+- **REVALIDATE:** 8 (stale 60-90d)
+- **RE-RESEARCH:** 23 (incomplete/thin/info loss)
+- **ARCHIVE:** 2 (superseded/blocked)
+
+## All Docs
+
+| Doc# | Folder | Title | Verdict | Priority | Reason |
+|------|--------|-------|---------|----------|--------|
+|   2 | farc | Farcaster Hub API                             | RE-RESEARCH | HIGH | incomplete |
+|  17 | farc | Neynar FID Registration & Managed Signers     | RE-RESEARCH | HIGH | incomplete |
+| 173 | farc | 86 — Farcaster Mini Apps Integration for ZAO  | RE-RESEARCH | HIGH | incomplete |
+| 260 | farc | 260 — BREAKING: Neynar Acquires Far caster (A | RE-RESEARCH | HIGH | incomplete |
+| 295 | farc | Farcaster Snaps                               | RE-RESEARCH | HIGH | incomplete |
+| 505 | farc | 505-zlank-online-builder-spec                 | RE-RESEARCH | HIGH | info_loss_thin_sources |
+| 586 | farc | 586-hypersnap-node-vps-install-playbook       | RE-RESEARCH | HIGH | incomplete |
+| 587 | farc | 587-hypersnap-quilibrium-farcasterorg-ecosyst | RE-RESEARCH | HIGH | incomplete |
+| 588 | farc | 588-cassie-heart-github-deep-profile          | RE-RESEARCH | HIGH | incomplete |
+| 589 | farc | 589-haatz-coverage-cassie-casts-may2026       | RE-RESEARCH | HIGH | info_loss_thin_sources |
+| 591 | farc | 591a-sdk-auth-flows                           | RE-RESEARCH | HIGH | incomplete |
+| 591 | farc | 591b-iframe-security                          | RE-RESEARCH | HIGH | incomplete |
+| 591 | farc | 591c-manifest-cross-client                    | RE-RESEARCH | HIGH | incomplete |
+| 591 | farc | 591d-production-pitfalls                      | RE-RESEARCH | HIGH | incomplete |
+| 591 | farc | 591e-zaoos-code-audit                         | RE-RESEARCH | HIGH | incomplete |
+| 594 | farc | 594-fip-live-activity-deep                    | RE-RESEARCH | HIGH | incomplete |
+| 595 | farc | 595-fip-live-activity-deeper                  | RE-RESEARCH | HIGH | incomplete |
+| 596 | farc | 596-fip-live-activity-quilibrium-privacy      | RE-RESEARCH | HIGH | incomplete |
+| 598 | farc | 598-fip-explained-visual                      | RE-RESEARCH | HIGH | incomplete |
+|  96 | cros | 96 — Cross-Post API Deep Dive: Platform-by-Pl | RE-RESEARCH | MED | info_loss |
+| 304 | farc | Quilibrium, Hypersnap, and Free Neynar API vi | RE-RESEARCH | MED | info_loss |
+| 527 | farc | 527-zlank-next-3-builds                       | RE-RESEARCH | MED | info_loss |
+| 575 | farc | 575-miniapp-splash-best-practices             | RE-RESEARCH | MED | info_loss |
+|  20 | farc | 20 — Followers / Following Feed (Sortable, Fi | REVALIDATE  | -   | stale_90d |
+|  73 | farc | 73 — Farcaster Ecosystem Update (March 2026)  | REVALIDATE  | -   | stale_60d |
+|  74 | farc | 74 — XMTP V3 Browser SDK & MLS Encryption     | REVALIDATE  | -   | stale_60d |
+|  77 | cros | 77 — Bluesky Cross-Posting Integration for ZA | REVALIDATE  | -   | stale_60d |
+|  81 | farc | 87 — Farcaster Social Graph APIs & Social Sha | REVALIDATE  | -   | stale_60d |
+|  97 | cros | 97 — Nostr Cross-Posting Integration for ZAO  | REVALIDATE  | -   | stale_60d |
+| 177 | cros | 96 — Mastodon + Threads Cross-Posting Integra | REVALIDATE  | -   | stale_60d |
+| 179 | cros | 97 — Reddit Cross-Posting Integration for ZAO | REVALIDATE  | -   | stale_60d |
+| 117 | cros | 117 — Lens V3 Integration (Consolidated)      | ARCHIVE     | -   | blocked_implementation |
+| 548 | farc | 548-lazer-miniapps-cli-evaluation             | ARCHIVE     | -   | superseded by ` a "skip Lazer" decision | Auto | This doc + memory update | 2026-05-28 | |
+| 123 | farc | 123 — DFOS (Dark Forest Operating System)     | FINE        | -   | current |
+| 124 | farc | 124 — Sopha: Deep Social on Farcaster (Curati | FINE        | -   | current |
+| 183 | cros | 107 — Social Connections & X Integration for  | FINE        | -   | current |
+| 199 | farc | 199 — Advanced Social Graph Features: Visuali | FINE        | -   | current |
+| 214 | cros | 214 — Twitch API Deep Integration: Comprehens | FINE        | -   | current |
+| 228 | cros | 228 — Meta Developer Platform: APIs, Models & | FINE        | -   | current |
+| 250 | farc | 250 — Farcaster Mini Apps llms.txt Deep Dive  | FINE        | -   | current |
+| 293 | farc | Sopha External Feed API Integration           | FINE        | -   | current |
+| 305 | farc | Farcaster Channel Moderation & Community Mana | FINE        | -   | current |
+| 306 | farc | Farcaster Protocol Features Gap Analysis for  | FINE        | -   | current |
+| 308 | farc | Farcaster Ecosystem Spring 2026: Snaps, Neyna | FINE        | -   | current |
+| 309 | farc | Snapchain vs Hypersnap: Protocol Architecture | FINE        | -   | current |
+| 351 | cros | 351 — YouTube Description SEO & Transcript-to | FINE        | -   | current |
+| 353 | cros | 353 — YouTube Content Pipeline Automation for | FINE        | -   | current |
+| 354 | cros | - Cross-Posting Infrastructure Audit: What Ex | FINE        | -   | current |
+| 355 | cros | - Autonomous Social Distribution 2026: What W | FINE        | -   | current |
+| 486 | cros | 486 — Reddit Reply Bot for ZAO + JustMakingMu | FINE        | -   | current |
+| 489 | farc | 489 — Hypersnap + Cass on Mars — Run a Farcas | FINE        | -   | current |
+| 534 | farc | 534-snap-best-practices-from-the-wild         | FINE        | -   | current |
+| 571 | farc | 571-intori-scis-tuum-tech-db-meeting          | FINE        | -   | current |
+| 591 | farc | 591-miniapp-production-audit                  | FINE        | -   | current |
+| 593 | farc | 593-fip-live-activity-zao-spaces              | FINE        | -   | current |
+| 597 | farc | 597-hypersnap-install-prep                    | FINE        | -   | current |
+| 599 | farc | 599b-gmfc101-wordaday-mini-app-patterns       | FINE        | -   | current |
+| 599 | farc | 599d-dfos-spaces-update-may-2026              | FINE        | -   | current |
+| 627 | cros | 627-twitch-streaming-streamelements-integrati | FINE        | -   | current |
+
+## Top 5 RE-RESEARCH-HIGH Docs
+
+1. Doc   2 - Farcaster Hub API
+2. Doc  17 - Neynar FID Registration & Managed Signers
+3. Doc 173 - 86 — Farcaster Mini Apps Integration for ZAO OS
+4. Doc 260 - 260 — BREAKING: Neynar Acquires Far caster (April 3, 2026)
+5. Doc 295 - Farcaster Snaps

--- a/research/dev-workflows/694-research-library-audit/infrastructure-security.md
+++ b/research/dev-workflows/694-research-library-audit/infrastructure-security.md
@@ -1,0 +1,71 @@
+# Infrastructure & Security Research Audit
+
+**Total:** 56 docs (Infrastructure: 50, Security: 6)
+
+## Verdict Summary
+
+- RE-RESEARCH: 16
+- REVALIDATE: 2
+- ARCHIVE: 1
+- FINE: 37
+
+## Results Table
+
+| Doc# | Folder | Title | Verdict | Pri | Age |
+|------|--------|-------|---------|-----|-----|
+| 471 | SECURITY | 471 - Vercel OAuth Supply Chain Breach April 2026... | RE-RESEARCH | HIGH | 29d |
+| 40 | SECURITY | 40 — Codebase Audit Guide: Step-by-Step | RE-RESEARCH | MED | 66d |
+| 182 | INFRASTRUCTURE | 106 — Home Screen / Dashboard Design for Music Co... | RE-RESEARCH | MED | 66d |
+| 215 | INFRASTRUCTURE | 215 — OBS + Restream + StreamYard Feature Analysi... | RE-RESEARCH | MED | 66d |
+| 283 | INFRASTRUCTURE | 283 — Vercel + Next.js 16 Performance Optimizatio... | RE-RESEARCH | MED | 45d |
+| 368 | INFRASTRUCTURE | 368 - Notion vs. Custom Dashboard for ZAOstock Fe... | RE-RESEARCH | MED | 34d |
+| 413 | INFRASTRUCTURE | 413 - ZAOstock Dashboard as Notion Replacement | RE-RESEARCH | MED | 34d |
+| 415 | INFRASTRUCTURE | 415 - Composable OS-Style Architecture for ZAO OS | RE-RESEARCH | MED | 35d |
+| 428 | INFRASTRUCTURE | 428 — Unified Agent Portal + ao.zaoos.com + Phone... | RE-RESEARCH | MED | 33d |
+| 433 | INFRASTRUCTURE | 433 - Portal v3: Todos Brain Dump + Universal Nav... | RE-RESEARCH | MED | 32d |
+| 436 | INFRASTRUCTURE | 436 - Phone Agentic Stack Playbook + Health Check | RE-RESEARCH | MED | 32d |
+| 463 | SECURITY | ##463 — Portal + Agent Orchestrator Audit (10-Age... | RE-RESEARCH | MED | 30d |
+| 532 | INFRASTRUCTURE | --- | RE-RESEARCH | MED | 23d |
+| 544 | INFRASTRUCTURE | --- | RE-RESEARCH | MED | 22d |
+| 570 | INFRASTRUCTURE | --- | RE-RESEARCH | MED | 20d |
+| 610 | INFRASTRUCTURE | --- | RE-RESEARCH | MED | 15d |
+| 16 | INFRASTRUCTURE | UI Reference — CG / Commonwealth | REVALIDATE | MED | 115d |
+| 12 | INFRASTRUCTURE | Gating Access to ZAO OS | REVALIDATE | LOW | 118d |
+| 576 | INFRASTRUCTURE | --- | ARCHIVE | - | 19d |
+| 35 | INFRASTRUCTURE | 35 — Notifications: Complete Implementation Guide | FINE | - | 66d |
+| 41 | INFRASTRUCTURE | 41 — Next.js 16 + React 19 Deep Dive | FINE | - | 66d |
+| 57 | SECURITY | 57 — Codebase Security Audit (March 17, 2026) | FINE | - | 66d |
+| 92 | INFRASTRUCTURE | 92 — Public APIs 2026 Update: Best Free APIs for ... | FINE | - | 66d |
+| 93 | INFRASTRUCTURE | 93 — Missing Infrastructure: Testing, CI/CD, Moni... | FINE | - | 66d |
+| 98 | INFRASTRUCTURE | 98 — Supabase Database Optimizations for ZAO OS | FINE | - | 66d |
+| 116 | INFRASTRUCTURE | Doc 116 — Discord Integration Research for ZAO OS | FINE | - | 59d |
+| 118 | INFRASTRUCTURE | 118 — Settings Page Redesign | FINE | - | 66d |
+| 122 | INFRASTRUCTURE | 122 — SongJam Screen Share PR: Stream Video SDK I... | FINE | - | 66d |
+| 129 | INFRASTRUCTURE | 129 — Alchemy APIs Deep Integration for ZAO OS | FINE | - | 66d |
+| 136 | SECURITY | 136 — API Status Verification — March 2026 | FINE | - | 66d |
+| 176 | INFRASTRUCTURE | 93 — Supabase Scaling & Optimization for ZAO OS | FINE | - | 66d |
+| 192 | INFRASTRUCTURE | 161 — Multi-Platform Streaming from ZAO OS Audio ... | FINE | - | 66d |
+| 217 | INFRASTRUCTURE | 217 -- Audio/Video Quality Optimization for Live ... | FINE | - | 66d |
+| 218 | INFRASTRUCTURE | 218 — Mobile App Strategy: PWA, Capacitor, React ... | FINE | - | 66d |
+| 221 | INFRASTRUCTURE | 221 — Admin Dashboard Best Practices for Web3 Com... | FINE | - | 66d |
+| 223 | INFRASTRUCTURE | 223 -- Smart Contract Development Guide for ZAO OS | FINE | - | 66d |
+| 233 | INFRASTRUCTURE | 233 — Spaces & Streaming Full Codebase Audit | FINE | - | 66d |
+| 275 | INFRASTRUCTURE | 275 -- Stream.io Video SDK Dashboard Configuration | FINE | - | 50d |
+| 286 | INFRASTRUCTURE | 286 — Claude Cowork SEO Workflow & ZAO OS SEO Audit | FINE | - | 45d |
+| 313 | INFRASTRUCTURE | 313 - Metaverse & 3D Virtual World for ZAO OS | FINE | - | 40d |
+| 314 | INFRASTRUCTURE | 314 - Quilibrium Network: Comprehensive Deep Dive | FINE | - | 35d |
+| 315 | INFRASTRUCTURE | 315 - 3D Metaverse Codebase Integration & Onboard... | FINE | - | 40d |
+| 319 | INFRASTRUCTURE | 319 - Lightweight 3D Portal Hub for ZAO OS | FINE | - | 39d |
+| 343 | SECURITY | 343 -- Agent Wallet Security: Securing VAULT/BANK... | FINE | - | 35d |
+| 416 | INFRASTRUCTURE | 416 - Native App Distribution: TestFlight + Play ... | FINE | - | 35d |
+| 417 | INFRASTRUCTURE | 417 - Agent Tools Remote Access: Making Everythin... | FINE | - | 35d |
+| 430 | INFRASTRUCTURE | 430 - Portal Stack Improvements + Prioritized Bui... | FINE | - | 33d |
+| 431 | INFRASTRUCTURE | 431 - Portal v2: Universal Nav + Version-Control ... | FINE | - | 32d |
+| 478 | INFRASTRUCTURE | 478 — ICP + Caffeine: Simple NFT Purchase App | FINE | - | 28d |
+| 503 | INFRASTRUCTURE | --- | FINE | - | 200d |
+| 543 | INFRASTRUCTURE | --- | FINE | - | 22d |
+| 572 | INFRASTRUCTURE | --- | FINE | - | 20d |
+| 599 | INFRASTRUCTURE | --- | FINE | - | 8d |
+| 629 | INFRASTRUCTURE | --- | FINE | - | 11d |
+| 643 | INFRASTRUCTURE | --- | FINE | - | 9d |
+| 665 | INFRASTRUCTURE | --- | FINE | - | 3d |

--- a/research/dev-workflows/694-research-library-audit/music.md
+++ b/research/dev-workflows/694-research-library-audit/music.md
@@ -1,0 +1,110 @@
+# Music Research Library Audit (2026-05-20)
+
+**Summary:** 84 total docs: 56 FINE | 17 REVALIDATE | 10 RE-RESEARCH | 1 ARCHIVE
+
+---
+
+## Detailed Results
+
+| Doc# | Title | Verdict | Priority | Why |
+|------|-------|---------|----------|-----|
+| 601 | Suno Music Generation Deep Tooling 2026 | RE-RESEARCH | HIGH | Last validated 2026-05-15; tool landscape volatile; needs Suno API status check (official vs unofficial broken?) |
+| 261 | AI Agent Music Pipeline | RE-RESEARCH | HIGH | No frontmatter, sparse (~70 lines), task-based not research; dates sourced from X/Twitter only; lacks depth on Tuneboto/Suno licensing changes May-Jun 2026 |
+| 334 | AI Music Practitioners/Educators/Speakers | RE-RESEARCH | HIGH | No dates or frontmatter; ZAO Stock speaker curation (Oct 3) time-sensitive; incomplete mapping of "who to invite" |
+| 340 | Remote Collaboration Tools AI Music 2026 | RE-RESEARCH | HIGH | No dates, no goal stated; appears stub; incomplete sections for Riverside, Splice, LANDR collab workflow |
+| 333 | AI Music Practitioners Leaders Educators | RE-RESEARCH | HIGH | Missing date + goal; thin output (~50 lines visible); promised "world's leading" figures but unclear if delivered |
+| 446 | Crown Vics Artist Outreach | RE-RESEARCH | MED | Outreach template dated 2026-04-20; Steve Peer's availability unconfirmed post-Roddy 4/28 meeting; doc assumes design but May reality may differ |
+| 330 | Open Source Stem Separation Tools 2026 | RE-RESEARCH | MED | No frontmatter; stem sep tools (UVR, Demucs) evolving rapidly; need verification of free tier status post-May 2026 |
+| 216 | AI Features Live Rooms Music | RE-RESEARCH | MED | No goal, incomplete metadata; appears branch/fragment of broader live-room strategy |
+| 186 | Music Discovery Feeds | REVALIDATE | -- | Solid research (99 lines, Respect-weighted curation model) but dated 2026-03-22; 59 days stale; needs ZAO OS feed status update |
+| 255 | FISHBOWLZ Spec | REVALIDATE | -- | Pre-launch status (Clanker Apr 4); FISHBOWLZ paused Apr 16 per memory, revived 5/17; doc 662 now canonical; needs merge or archive |
+| 273 | Web3 Streaming Features Tipping Gating Tickets | REVALIDATE | -- | No sources section; March 28 date; 53 days old; tipping/gating patterns may have shifted (Zora API changes, payment rails) |
+| 280 | FISHBOWLZ MVP to SaaS Roadmap | REVALIDATE | -- | April 5 date; FISHBOWLZ transition from paused->revival unclear in doc; needs status merge with doc 662 |
+| 281 | Audio Room Competitive Landscape | REVALIDATE | -- | Dated 2026-04-04; 46 days old; Spaces/Spacecast/Discord Stage landscape shifts quarterly; needs re-check of "dead" status |
+| 315 | AI Song Revenue Stacking | REVALIDATE | -- | No date; status says "Complete"; revenue models (split protocols, DSP rates) shift frequently; age unknown |
+| 321 | Suno AI Music Platform 2026 | REVALIDATE | -- | No dates (missing metadata); relative doc age unclear; Suno API status major blocker |
+| 342 | AI Hip-Hop Production Deep Dive 2026 | REVALIDATE | -- | No date given; hip-hop tool landscape (Splice, BeatStars, LANDR) shifts monthly; age unknown |
+| 407 | Music NFT Coinflow Fiat Mint | REVALIDATE | -- | April 16 date; 34 days old; Coinflow pricing/integrations shift; fiat ramps (Stripe, PayPal) regulatory environment in flux |
+| 079 | SongJam Ecosystem Music Player Research | FINE | -- | March 19, complete, 90+ lines, clear verdict: "DO NOT USE," borrows 100ms + leaderboard patterns. Solid, immutable research |
+| 082 | Music-First Social Platform Redesign | FINE | -- | March 19, 585 lines, canonical doc 88, comprehensive platform analysis (Sonata, Sound.xyz, Audius, SoundCloud, TikTok, Are.na, Zora), actionable 7-pattern framework, robust sources |
+| 107 | Music Page Layout Design | FINE | -- | March 22, clear decisions, @dnd-kit recommendation, responsive design specs, sources cited, implementable specs |
+| 112 | Audius API Deep Dive | FINE | -- | March 22, 720 lines, comprehensive, current (Audius v1 stable, Artist Coins Oct 2025 verified), all integration paths mapped, SDK guide included |
+| 113 | Top 10 Music Fixes | FINE | -- | March 22, actionable prioritized list, brief but complete audit of radio, imagery, queue issues |
+| 130 | Next Music Integrations Deep Research | FINE | -- | March 25, implementation roadmap across 4 phases, draws from validated docs 126/128/108 |
+| 138 | Stream Attribution Deep Dive | FINE | -- | March 26, clear decision: "plays count via x-www-form-urlencoded," resolves legitimate stream validation, 40+ line explanation |
+| 141 | On-Chain Music Distribution Landscape | FINE | -- | March 26, maps 12+ services (Zora, Sound, Catalog, Spinamp), decision matrix, sources robust |
+| 143 | 0xSplits Revenue Distribution | FINE | -- | March 26, implementation-ready for Base music NFTs, code examples, clear scope |
+| 144 | ZOUNZ DAO Music NFT Governance | FINE | -- | March 26, DAO voting design + music NFT minting pipeline, validated Hats Protocol integration |
+| 145 | Simple NFT Platform Design | FINE | -- | March 26, UX research, non-crypto-native artist flow, wireframes, validated Thirdweb approach |
+| 146 | Open Contracts Multi-Artist Distribution | FINE | -- | March 26, contract design for community replication, forkable patterns, sources |
+| 148 | Master Integration Plan Onchain Distribution | FINE | -- | March 26, unified roadmap aggregating 139-147, phased implementation, decision trees |
+| 151 | ZOUNZ Without Zora Arweave Design | FINE | -- | March 26, Zora-free replacement (Arweave + thirdweb + 0xSplits), clear technical decisions |
+| 152 | Arweave Ecosystem Deep Dive | FINE | -- | March 26, 80+ lines, AO compute/Irys/ArDrive/ar.io/GraphQL/ArNS mapped, music layer design validated |
+| 153 | BazAR Atomic Assets Music Distribution | FINE | -- | March 27, BazAR marketplace evaluation, atomic asset spec, Zora-free path |
+| 155 | End-to-End Music NFT Implementation | FINE | -- | March 27, user story "I'm a ZAO musician," step-by-step upload-mint-buy, Arweave/BazAR integration ready |
+| 156 | Pods.media Podcast Tokenization | FINE | -- | March 27, Pods comparison + Arweave clone feasibility, podcast-to-music extension clear |
+| 160 | Audio Spaces Landscape Comparison | FINE | -- | March 27, Farcaster + X Spaces + provider matrix (100ms, Stream.io), decision clarity |
+| 167 | Audio APIs Music Players Displays | FINE | -- | March 28, cross-platform audit, 42-component music system catalog, visualization patterns, immutable reference |
+| 185 | Synchronized Listening Rooms | FINE | -- | March 2026, 100ms patterns for fractals + listening party design, borrowable from SongJam, clear scope |
+| 187 | Songlink/Odesli API Integration | FINE | -- | March 22, clear decision "integrate for auto-resolve," no sources but narrow scope, implementable |
+| 189 | Mobile Player Optimization | FINE | -- | March 25, MediaSession audit, PWA reliability, gesture support, 40-cell feature matrix |
+| 190 | Music Player Complete Audit | FINE | -- | March 25, catalog of all 60+ components, codebase-verified, gap analysis, future roadmap |
+| 209 | AI Video Generation Tools | FINE | -- | March 29, video tools for music content (Runway, D-ID, Synthesia), viral storytelling patterns |
+| 211 | Music Player UI Best Practices | FINE | -- | March 28, design pattern audit, platform UX comparison (Spotify, Apple, SoundCloud), improvement opportunities |
+| 220 | Mobile-First Music UX Patterns | FINE | -- | March 28, mobile patterns across players/rooms/streaming/wallet/notifications, 50+ specific recommendations |
+| 277 | FISHBOWLZ Audio Providers | FINE | -- | April 4, audio provider evaluation for persistent rooms, ZOE integration documented |
+| 314 | Music Metadata ISRC AI Distribution | FINE | -- | April 11, metadata standards + ISRC codes, distribution workflow, artist identity linking |
+| 319 | AI Music Creation Platforms Multi-Output | FINE | -- | April 11, Suno/Udio/ElevenLabs comparison for "Summer of 26" campaign, 6-artist variant strategy |
+| 320 | Anatomy Viral Summer Songs | FINE | -- | April 11, musicology of viral hits (BPM, lyrics, hook placement), "Summer of 26" template |
+| 322 | AI Music Distribution Marketing 2026 | FINE | -- | April 11, post-generation promotion (Spotify playlists, TikTok seeding, playlist placement), DSP strategy |
+| 323 | ElevenLabs API Full Capabilities | FINE | -- | April 11, voice cloning + music APIs, Zaal's voice clone integration, creator plan scope mapped |
+| 324 | ACE-Step Deep Dive | FINE | -- | April 11, LoRA training, local deployment, prompting, community ecosystem, comprehensive reference |
+| 326 | AI Songwriting Collaborator Guide | FINE | -- | April 11, lyric generation for festival anthems, structure/rhyme/hooks/crowd elements, platform-specific formatting |
+| 327 | AI Music Viral Commercial Success Case Studies | FINE | -- | April 11, real artists using AI (Dadju, Charli XCX, Ghostwriter Collective), ROI patterns, 50+ examples |
+| 328 | Open Source Music Generation Landscape 2026 | FINE | -- | April 11, Suno/Udio alternatives (Audiocraft, MuseNet, Jukebox), quality rankings, 8-tool comparison |
+| 329 | Zero Dollar Music Production Stack | FINE | -- | April 11, free/OSS tools (Reaper free, Coqui ElevenLabs alternative, Open-Unmix), complete workflow validated |
+| 331 | AI Music Video Generation Deep Dive 2026 | FINE | -- | April 11, video tools (Runway, D-ID, Synthesia, Pika), live performance integration, TikTok/YouTube formats |
+| 332 | Farcaster Music Distribution Infrastructure 2026 | FINE | -- | April 11, Farcaster music apps (Sonata, Harmonic, Boomtown), web3 distribution landscape, Sound.xyz shutdown analysis |
+| 336 | AI Mastering Mixing Tools Deep Dive 2026 | FINE | -- | April 11, iZotope, LANDR, Lexi, MB Mastering, A/B comparisons, quality benchmarks, cost-benefit |
+| 337 | Microphone Recording Setup Voice Cloning | FINE | -- | April 11, hardware (SM7B, Scarlett 2i2, isolation booth), voice clone requirements, pro studio patterns |
+| 338 | AI Beats Sample Packs Revenue Guide | FINE | -- | April 11, BeatStars + Splice + Loopmasters revenue stacking, 1,000+ beats annual income modeling |
+| 341 | Music Theory AI Prompting | FINE | -- | April 11, chord progression / key matching / BPM / melodic contour prompting for coherent output |
+| 475 | ZAO Music Entity | FINE | -- | April 22, BMI + DistroKid + 0xSplits setup, DBA under BCZ Strategies LLC, release #1 strategy (Cipher), verified team roles |
+| 535 | Anytwocardzz Web3 Music Producer Post | FINE | -- | April 27, web3 music producer mindset + onchain community building, inspiring narrative for ZAO artists |
+| 561 | DJOS AI DJ Copilot Mainstream | FINE | -- | April 29, AI DJ mixing tool (Spotify-integrated, beatmatching, song selection), ZAO radio / live room potential |
+| 599a | Believe TuneCore Block AI Music Distribution | FINE | -- | May 3, major labels blocking AI music distribution, policy audit, impact on ZAO artist pipeline |
+| 651 | Jadyn Violet UVR Producer Brief | FINE | -- | May 16, last-validated 5/16, 100-line consolidation of Jadyn deep research (doc 600), Suno collab already shipped (doc 601), sound identity + lore complete |
+| 662 | FISHBOWLZ Revival Juke Mute Lockout | FINE | -- | May 17, explicit reverse of Apr 4 kill decision, partnership with Juke (nickysap Farcaster audio), new design live, supersedes 255/280 |
+| 151 | ZOUNZ Music Distribution Without Zora | ARCHIVE | -- | Superseded by doc 152 (Arweave ecosystem) + 153 (BazAR) for deeper technical coverage; master plan at 148 |
+
+---
+
+## Key Findings
+
+**Staleness Clustering:**
+- **Fresh (May 2026):** 651, 662, 601, 599a, 561, 535 — last 4 weeks, actively used in ZAO music + Jadyn biography + FISHBOWLZ revival
+- **Gold (Apr 2026):** 314-342 (April AI music batch) — 6-8 weeks old, API landscapes stable
+- **Silver (Mar 22-27):** 079, 082, 107, 112, 113, 130, 138, 141-156, 160, 167, 185, 187, 189, 190, 209, 211, 220, 277, 280, 281 — 54 days, foundational but need API/tool status refresh
+- **Stale (Mar 19-22):** Music social platform redesign docs (82, 88) — 62 days, Sonata/Audius/SoundCloud patterns immutable, borderline REVALIDATE
+
+**RE-RESEARCH Causes:**
+- **No frontmatter** (261, 334, 340, 333) — metadata loss makes audit + scheduling impossible
+- **Sparse content** (261 ~70 lines, 340 ~50 lines) — task-based notes, not research
+- **No source section** (113, 187, 216, 273) — partial audit visible but sources unverified
+- **Tool landscape volatility** (330 stem sep, 333 speakers, 601 Suno API) — rapid change in May-June 2026 broken implementations
+
+**High-Priority Fixes (blocking ZAO Stock Oct 3 / Jadyn work):**
+1. **334 (AI practitioners speakers):** Oct 3 speaker lineup TBD; doc#334 critical but incomplete (10-line status)
+2. **601 (Suno deep tooling):** Last updated May 15; Suno API status unknown; Jadyn Suno collaboration live but tooling may be broken
+3. **261 (AI agent music pipeline):** Tuneboto/DistroKid choice blocks artist distribution; no current vendor comparison
+4. **446 (Crown Vics outreach):** Steve Peer performance TBD post-Roddy 4/28; doc template exists but May reality unclear
+5. **340 (Remote collab tools):** Artist recording pipeline unclear (Riverside vs Splice vs local); affects ZAO Music Entity v2
+
+**Archive Candidate:**
+- **151 (ZOUNZ Without Zora):** Tactical doc superseded by deeper research in 152, 153. Master plan at 148 is current. Keep as reference but mark read-only.
+
+**Memory Updates Needed:**
+- Merge 255 (FISHBOWLZ pre-launch Apr 4) with 662 (FISHBOWLZ revival May 17)
+- Mark 599a as "industry policy" reference (Believe/TuneCore AI block)
+- Update project_jadyn_violet_biography.md to reference 651 as canonical producer brief
+


### PR DESCRIPTION
## Summary
Audit of why forwarded links lose information when researched. Root cause: the /zao-research skill prescribes firecrawl (not installed) as its JS-rendering tool, and has no gate forcing full content retrieval before a doc is written. So when a fetch is hard, the doc gets written off metadata, search snippets, or a 404.

## Honest findings - what this session missed
- Doc 674: the Edge Esmeralda Notion wiki was never read (JS shell); doc written from web search
- Doc 683: the Artizen Playbook 404'd; never recovered via Wayback
- Doc 690: 0 of 5 X article bodies fetched - doc is about 5 headlines
- Doc 691: a Spotify episode skipped entirely as "unreachable"

## Fix (applied to ~/.claude/skills/zao-research/SKILL.md, v2.2 -> v2.3)
- Step 4.5 Fetch-Quality Gate: every source classified FULL/PARTIAL/FAILED; PARTIAL/FAILED must escalate the real fetch ladder before the doc is written
- Removed firecrawl; replaced with installed tools: WebFetch -> exa web_fetch -> Playwright MCP -> Wayback
- Hard Requirement #11: Sources section marks each source FULL/PARTIAL/FAILED

Note: the skill file lives in ~/.claude/skills/ (global, not in this repo) - changes applied directly, not in this PR. This PR is the audit doc.

## Next Actions
Offer in the doc: re-research the 3 thin docs (674, 683, 690) with the real tool chain - pending Zaal approval.