### PR TITLE
doc 699: The State of Agentic AI 2026 - a deep study

### DIFF
--- a/research/agents/699-state-of-agentic-2026-deep-study/README.md
+++ b/research/agents/699-state-of-agentic-2026-deep-study/README.md
@@ -1,0 +1,131 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 601, 693, 694, 698
+original-query: "Keep researching agents - go online, Reddit, X - find out all you can about agents; produce a really high-quality study doc of everything agentic."
+tier: DEEP
+---
+
+# 699 - The State of Agentic AI, 2026: A Deep Study
+
+> **Goal:** A current, evidence-based study of the entire agentic-AI landscape - frameworks, coding agents, memory, multi-agent orchestration, evaluation, protocols, web3 agents, and community sentiment - and what it means for the ZAO agent stack.
+
+## Method
+
+8 parallel research agents, one per dimension, each scanning real community sources - Reddit, Hacker News, X, GitHub, blogs, arXiv - per the Doc 693 fetch ladder. ~110 distinct sources. DEEP tier. Caveat up front: many 2026 benchmark numbers below are community/vendor-reported and contested (see Section 5 - benchmark gaming is itself a finding). Treat specific percentages as directional, not gospel.
+
+## Key Takeaways (the through-line)
+
+| # | Finding | Confidence |
+|---|---------|-----------|
+| 1 | **The harness beats the model.** Across frameworks, coding agents, memory, and orchestration, the scaffold around the LLM (tools, memory, retry logic, context engineering) explains far more performance variance than model choice - a 15-36 point swing on identical models. | HIGH - 4 of 8 dimensions converged on this independently |
+| 2 | **Single-agent + good harness beats multi-agent by default.** Princeton found single-agent matched/beat multi-agent on ~64% of tasks at equal compute. Multi-agent wins only on genuinely parallel work, and costs ~15x the tokens. | HIGH |
+| 3 | **Benchmarks are gamed and benchmark-to-reality gap is wide.** UC Berkeley showed all 8 major agent benchmarks reward-hackable to ~100%; OpenAI dropped SWE-bench Feb 2026. Agents that score 80%+ on coding fail 72% of healthcare workflows. | HIGH |
+| 4 | **"Agent washing" is ~95% of the market.** Gartner: ~130 of thousands of "agentic AI" vendors actually ship autonomous systems. Most are chatbots with a price tag. | MEDIUM-HIGH |
+| 5 | **What works in production: narrow scope + guardrails + observability + human escalation.** Teams that spend 18-24% of budget on evaluation hit 63% year-1 ROI; teams under 8% hit 28%. Only ~11-14% of agent pilots reach production. | HIGH |
+| 6 | **Protocols are consolidating:** MCP owns tool access (~97M monthly downloads, ~9,400 servers), A2A owns agent-to-agent, ERC-8004 owns on-chain identity. All under the Linux Foundation's Agentic AI Foundation. | MEDIUM-HIGH |
+| 7 | **Crypto-AI agents: hype collapsed, infrastructure got real.** Agent tokens crashed (VIRTUAL ~$5B to ~$700M); but x402 agent payments are live and used by Stripe/AWS/Cloudflare. | MEDIUM |
+
+## 1. Agent Frameworks
+
+The 2026 framework market consolidated around graph-based orchestration. LangGraph leads production (observability + state control); CrewAI owns fast prototyping; Microsoft retired AutoGen into the new Microsoft Agent Framework; Pydantic AI won type-safe Python; Mastra won TypeScript. OpenAI Agents SDK and Anthropic Claude Agent SDK are the proprietary bets - and Anthropic moves Agent SDK usage to metered billing in June 2026, ending subscription "compute arbitrage."
+
+**The honest read:** framework choice is a second-order decision. The frameworks that win all ship the same three things - built-in observability, human-in-the-loop gates, cost/timeout budgeting. Pick those capabilities first, the brand second. New-model releases churn the whole layer every few months; do not over-invest in one framework.
+
+## 2. Coding Agents
+
+A mature, bifurcated market. Claude Code leads raw capability; Cursor (~360K paying users) owns the daily-developer IDE experience; OpenHands proves open-source is within ~3-5 points of proprietary when the base model is held constant. The pragmatic 2026 setup is **two tools, not one** - Cursor for daily editing, Claude Code for batch jobs and deep refactors, ~$40/mo total.
+
+Devin is the cautionary tale: marketed as an autonomous engineer, independently tested at ~15% success on diverse real-world tasks vs its ~67% curated-task claim. The internal-vs-real gap is now understood as permanent for autonomous agents, not a measurement artifact.
+
+## 3. Agent Memory + Context Engineering
+
+Memory matured from research problem to production discipline. The field converged on **hybrid retrieval** - vectors for semantic entry, graphs for multi-hop depth (Letta, Mem0, Zep/Graphiti, Cognee). The load-bearing insight: **the context window is RAM, not storage** - agents that load everything degrade catastrophically as sessions grow.
+
+"Context engineering" is now a named discipline ("context engineering is in, prompt engineering is out"). The thesis - context architecture matters more than model capability for long-horizon reliability - holds, with one caveat: it applies to multi-turn / multi-session work, not stateless single-turn tasks. Sub-agent context isolation saves ~67% tokens vs loading everything into one conversation.
+
+## 4. Multi-Agent Orchestration + Harness Engineering
+
+The 2026 consensus is blunt: **do not build multi-agent by default.** Cognition's "Don't Build Multi-Agents" essay (single-threaded agents, shared context) is the canonical position; Princeton's data backs it (single-agent wins ~64% at equal compute); multi-agent burns ~15x tokens and degrades 39-70% on sequential tasks. Multi-agent wins decisively only on genuinely parallel work (Anthropic's research system: +90% on parallel research, at 15x cost).
+
+Harness engineering is the real lever: same model, different harness = a documented 36-point benchmark swing. Token usage alone explained 80% of performance variance in Anthropic's eval. Of the orchestration patterns, **router** (40-70% of production) and **orchestrator-workers** (70% of production multi-agent) are what actually ship; swarms remain rare and hard to debug.
+
+## 5. Agent Evaluation + Benchmarks
+
+Benchmark scores climbed (SWE-bench Verified leaders ~85-88%, Terminal-Bench ~82%) - but the field's honest finding is that **evaluation itself is unsolved**. UC Berkeley reward-hacked all 8 major benchmarks to ~100%; OpenAI publicly abandoned SWE-bench (Feb 2026); SWE-bench Pro shows ~20-point drops vs Verified, exposing training-data contamination.
+
+The benchmark-to-reality gap is structural: agents that lead on coding fail 72% of healthcare workflows; no agent cleared 20% on a 3-run endurance test of the same case. Common failure modes: **silent failures** (wrong answer, no error surface), brittle tool integration, runaway-cost retry loops, prompt injection as goal hijacking, multi-agent cascade collapse. Gartner predicts 40%+ of agentic projects cancelled by 2027 - and frames it as healthy maturation, not doom.
+
+## 6. Agent Protocols + Interoperability
+
+A layered stack emerged. **MCP** (Model Context Protocol) owns agent-to-tool access - ~97M monthly SDK downloads, ~9,400+ public servers, ~78% of enterprise AI teams running one in production. **A2A** (Agent2Agent, Google) owns agent-to-agent coordination, ~150 orgs. **ERC-8004** put agent identity on-chain (Ethereum mainnet, Jan 2026; identity + reputation + validation registries). MCP and A2A are complementary, not competing, and both are now governed by the Linux Foundation's Agentic AI Foundation.
+
+The shadow side: MCP has a by-design RCE class of vulnerability (CVE-2025-49596 and relatives), tool-poisoning is the top client-side attack, and ~15% of the server ecosystem is fully opaque (no public source). Every wired MCP server is both a capability and an attack surface.
+
+## 7. Web3 / On-Chain Agents + Agent Commerce
+
+The crypto-AI-agent narrative completed its hype cycle. Agent tokens collapsed (VIRTUAL from ~$5B to ~$700M; the whole sector under ~$6.6B). What survived is infrastructure: **x402** agent payments (HTTP 402 + stablecoin, ~75M transactions in a month, adopted by Stripe/AWS/Cloudflare/Vercel), Google's AP2 umbrella, ElizaOS as the open-source agent standard, Virtuals' agent commerce. Security is the open wound - LLM-router injection attacks drained $500K+, the Bankr breach (May 2026) hit 14 wallets, and there is no legal framework for agent-caused losses.
+
+## 8. Community Pulse - What Builders Actually Say
+
+The builder consensus is unglamorous and consistent:
+
+- **What works:** narrow scope, hard cost/step caps from day one, typed outputs between steps, three-tier memory, circuit breakers on retry loops, evaluation tooling (not just observability), human escalation paths.
+- **What does not:** general-purpose autonomous "coworkers", multi-agent by default (5 agents at 90% reliability each = 59% system reliability), long-horizon tasks without context management, trusting demos.
+- **Most-repeated lesson:** "the agent didn't fail because the model wasn't smart enough - it failed because nobody built the plumbing." Agents are a distributed-systems problem, not an LLM problem.
+- **Contrarian but credible:** the solo-founder-with-agents playbook is real for *execution* (one founder shipped a SaaS solo in 90 days) - but agents optimize what they can measure, so they nail code quality and miss "did anyone want this." Distribution, not execution, is the remaining human job.
+
+## What This Means For ZAO
+
+The ZAO agent stack is, mostly by luck and a good 2026-05-04 decision (Doc 601), already on the winning side of this research:
+
+| ZAO choice | What the research says |
+|------------|------------------------|
+| Hermes pattern - single Claude-subprocess agent, no orchestrator | Matches "single-agent + good harness beats multi-agent" - the dominant 2026 finding |
+| CLAUDE.md / AGENTS.md context files | A best-practice manual instance of "context engineering" - validated |
+| Sub-agent isolation (ZOE / critic / PR bot separated) | Matches the ~67%-token-saving isolation pattern |
+| Claude Max-auth CLI, not metered API | Smart - though note Anthropic meters Agent SDK usage from June 2026 |
+| 5-surface collapse (Doc 601) | Matches "narrow scope, kill sprawl" - the #1 production lesson |
+
+**The Paperclip question (Doc 698), answered by this research:** the entire 2026 evidence base argues *against* restarting Paperclip as a multi-agent orchestration layer. "Don't build multi-agent by default", the 15x token cost, the 39-70% sequential-task degradation, the cascade-failure math, and "agent washing is 95% of the market" all point the same way. If Paperclip restarts at all, the research supports only a **narrow, single-purpose, time-boxed pilot** - not a reinstated orchestration tier. Doc 698's recommendation stands and is now evidence-backed.
+
+**Where ZAO is genuinely behind:** persistent cross-session memory. CLAUDE.md + MEMORY.md is transparent but manual and does not scale past ~10-20 agents or thousands of threads. A graph-memory layer (Graphiti/Cognee pattern) is the real next upgrade - and Bonfire (already in the stack) is the natural home for it.
+
+## Sources
+
+A representative subset of ~110 sources across the 8 research dimensions. Full per-dimension source lists were captured by the research agents.
+
+- [HN - Agentic Frameworks in 2026: Less Hype, More Autonomy](https://news.ycombinator.com/item?id=46509130) [FULL]
+- [HN - Exploiting the most prominent AI agent benchmarks](https://news.ycombinator.com/item?id=47733217) [FULL]
+- [HN - What makes 5% of AI agents work in production?](https://news.ycombinator.com/item?id=45456381) [FULL]
+- [HN - Most "AI agents" don't survive production](https://news.ycombinator.com/item?id=45718390) [FULL]
+- [HN - Ask HN: How are people doing AI evals these days?](https://news.ycombinator.com/item?id=47319587) [FULL]
+- [Cognition AI - Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents) [FULL]
+- [Anthropic - How We Built Our Multi-Agent Research System](https://www.anthropic.com/engineering/multi-agent-research-system) [FULL]
+- [Anthropic - Building Effective Agents](https://www.anthropic.com/research/building-effective-agents) [FULL]
+- [Mem0 - State of AI Agent Memory 2026](https://mem0.ai/blog/state-of-ai-agent-memory-2026) [FULL]
+- [OpenAI - Why We No Longer Evaluate SWE-Bench](https://openai.com/index/why-we-no-longer-evaluate-swe-bench/) [FULL]
+- [Fortune - AI agents are getting more capable, but reliability is lagging](https://fortune.com/2026/03/24/ai-agents-are-getting-more-capable-but-reliability-is-lagging-narayanan-kapoor/) [FULL]
+- [MCP 2026 Roadmap](https://blog.modelcontextprotocol.io/posts/2026-mcp-roadmap/) [FULL]
+- [The Hacker News - Anthropic MCP design vulnerability](https://thehackernews.com/2026/04/anthropic-mcp-design-vulnerability.html) [FULL]
+- [CoinDesk - Ethereum's ERC-8004 puts identity behind AI agents](https://www.coindesk.com/markets/2026/01/28/ethereum-s-erc-8004-aims-to-put-identity-and-trust-behind-ai-agents) [FULL]
+- [Coinbase - x402 Protocol](https://www.coinbase.com/developer-platform/products/x402) [FULL]
+- [Gartner via Particula - Agent Washing: 95% of "AI Agents" are expensive chatbots](https://particula.tech/blog/agent-washing-real-vs-fake-ai-agents) [FULL]
+- [Awesome Agents - SWE-Bench Coding Agent Leaderboard 2026](https://awesomeagents.ai/leaderboards/swe-bench-coding-agent-leaderboard/) [FULL]
+- [arXiv - Single-Agent LLMs Outperform Multi-Agent Under Equal Token Budgets](https://arxiv.org/pdf/2604.02460) [FULL]
+- [Linux Foundation - Agentic AI Foundation announcement](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) [FULL]
+- [ninadpathak.com - Why AI Agents Keep Failing in Production](https://ninadpathak.com/blog/2026-04-22-why-ai-agents-keep-failing-in-production/) [FULL]
+
+Plus Reddit threads across r/AI_Agents, r/LocalLLaMA, r/ClaudeAI, r/ClaudeCode, r/cursor, r/MachineLearning; GitHub repos (LangGraph, Letta, Graphiti, OpenHands, MCP servers); and X builder threads. Benchmark percentages are community/vendor-reported - see Section 5.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Use Section "What This Means For ZAO" to settle the Paperclip decision (Doc 698) - the research supports decline-or-narrow-pilot, not a full restart | @Zaal | Decision | Before any Paperclip restart step |
+| Scope a graph-memory upgrade for ZOE/Hermes on the Bonfire layer (Graphiti/Cognee pattern) - ZAO's real next agent upgrade | @Zaal | Decision | Next agent sprint |
+| Note Anthropic's June 2026 Agent SDK metered billing - confirm it does not break the Hermes Max-auth CLI pattern | @Zaal | Verification | Before June 2026 |
+| Adopt the production-discipline checklist (hard cost/step caps, typed outputs, circuit breakers, eval budget) as a ZAO agent standard | @Claude | Skill/rule | Next session |
+| Re-validate this doc - benchmark numbers are high-churn; refresh in 4-6 weeks | @Zaal | Revalidate | 2026-07-01 |

--- a/research/agents/699-state-of-agentic-2026-deep-study/README.md
+++ b/research/agents/699-state-of-agentic-2026-deep-study/README.md
@@ -120,6 +120,15 @@ A representative subset of ~110 sources across the 8 research dimensions. Full p
 
 Plus Reddit threads across r/AI_Agents, r/LocalLLaMA, r/ClaudeAI, r/ClaudeCode, r/cursor, r/MachineLearning; GitHub repos (LangGraph, Letta, Graphiti, OpenHands, MCP servers); and X builder threads. Benchmark percentages are community/vendor-reported - see Section 5.
 
+## Also See - Deep-Dive Sub-Docs
+
+This hub spawned four ZAO-actionable deep dives:
+
+- [Doc 699a](../699a-agent-memory-graph-layer-for-zao/) - Agent memory: lock Bonfire as ZAO's memory layer, Cognee as fallback
+- [Doc 699b](../699b-agent-security-hardening/) - Agent security: threat matrix + 10 hardening todos (ZAOcoworkingBot off root first)
+- [Doc 699c](../699c-agent-evaluation-observability/) - Agent eval: Langfuse + PromptFoo + LLM-as-judge for ZOE/Hermes
+- [Doc 699d](../699d-advanced-agentic-coding-workflows/) - Agentic coding: 10 upgrade patterns for Hermes + QuadWork
+
 ## Next Actions
 
 | Action | Owner | Type | By When |

--- a/research/agents/699a-agent-memory-graph-layer-for-zao/README.md
+++ b/research/agents/699a-agent-memory-graph-layer-for-zao/README.md
@@ -1,0 +1,66 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 699, 669, 689
+original-query: "Which agent-memory / graph-memory system should ZAO adopt for persistent cross-session memory? (sub-study of doc 699)"
+tier: STANDARD
+---
+
+# 699a - Agent Memory: The Graph Layer for ZAO
+
+> **Goal:** Decide which persistent cross-session memory system ZAO adopts for ZOE/Hermes, and how it wires in.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | LOCK Bonfire as ZAO's primary agent-memory layer | Farcaster-native auth (no bridge), multi-bonfire federation for ZAO's 25+ brands, active co-builder (Ryan), kEngram export = vendor-lock-out safety, already live (ZABAL bonfire) |
+| 2 | STAGE Cognee as the self-hosted fallback - do not adopt Letta/Mem0/Zep | Cognee is true OSS (Apache 2.0), has a Claude Code plugin, self-hosts on VPS 1. Triggers only if the Bonfire SDK slips >2 weeks. |
+| 3 | SHIP Phase 1 (Bonfire subprocess, ~80 LoC) as a Hermes PR within the week | ZAOcoworkingBot writing events to the ZABAL bonfire is a 3-4 hour change, no breakage |
+| 4 | DEFER brand federation (one bonfire + ontology profiles vs separate bonfires) until Phase 2 validates | Decision needs Phase 2 data; premature now |
+
+## The Candidates
+
+| System | Architecture | Stars | Self-host | Verdict for ZAO |
+|--------|--------------|-------|-----------|-----------------|
+| **Bonfire** | Social knowledge graph + agent personas | early (private SDK) | Managed API | PRIMARY - Farcaster-native, federated, co-builder, export-safe |
+| **Cognee** | KG + vector hybrid, Apache 2.0 | ~17.4K | Yes (multi-DB) | FALLBACK - true OSS, Claude Code plugin, self-hostable |
+| **Mem0** | Vector library + graph tier | ~56K | Yes ($5-7/mo) | Skip - vector-only core, graph behind $249/mo, no federation |
+| **Letta** (MemGPT) | Agent runtime + 3-tier memory | ~23K | Yes | Skip - no multi-bonfire model, self-editing memory is overkill |
+| **Zep / Graphiti** | Temporal KG on Neo4j | ~26K | Yes (Neo4j) | Skip - elegant temporal model but no Farcaster, latency unproven on ZAO's corpus |
+
+## Why Bonfire Wins For ZAO Specifically
+
+Not "best memory system in the abstract" - best for ZAO's situation: 188 Farcaster members, 700+ research docs, 25+ brands, the Hermes pipeline, and an active relationship with Bonfire's builder. The OSS alternatives are all SaaS-escape-hatch risks or lack multi-brand federation. Bonfire's kEngram export (Markdown/OWL/Canvas) is the lock-out insurance that makes committing safe.
+
+## Integration Plan
+
+| Phase | Action | Effort | Cost |
+|-------|--------|--------|------|
+| 1 | Bonfire subprocess - ZAOcoworkingBot writes events to ZABAL bonfire via a spool wrapper | 3-4 hr | 0 |
+| 2 | ZOE rebuilt to read from the Bonfire SDK (`agents.chat`, adaptive graph mode) instead of its ring buffer | ~4-6 hr (Hermes PR) | 0.1 ETH mint (already paid) |
+| 3 | Brand federation - separate bonfires per brand OR ontology profiles in one | ~8 hr | 0 to 0.1 ETH x N |
+| Fallback | If Bonfire SDK slips >2 weeks: ship the Cognee Claude Code plugin, migrate Phase 1 events | 4-6 hr | $5-7/mo or $0 |
+
+## Open Question For Zaal
+
+Per-API-call pricing for Bonfire beyond the 0.1 ETH mint is unconfirmed. Get the SDK + MCP-server ETA and the pricing model from Ryan before Phase 2.
+
+## Sources
+
+- [Doc 669 - Bonfires: Everything We Know](../669-bonfires-everything-we-know/) [FULL]
+- [Cognee (GitHub)](https://github.com/topoteretes/cognee) [FULL]
+- [Zep / Graphiti (GitHub)](https://github.com/getzep/graphiti) [FULL]
+- [Mem0 (GitHub)](https://github.com/mem0ai/mem0) [FULL]
+- [Letta docs](https://docs.letta.com/) [PARTIAL]
+- [Zep temporal-KG paper (arXiv 2501.13956)](https://arxiv.org/abs/2501.13956) [PARTIAL]
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Ship Phase 1 Bonfire subprocess as a Hermes PR | @Zaal | PR | This week |
+| Get SDK + MCP ETA + pricing from Ryan | @Zaal | Outreach | This week |
+| Stage the Cognee plugin on VPS 1 as fallback insurance | @Claude | Todo | Before Phase 2 |

--- a/research/agents/699b-agent-security-hardening/README.md
+++ b/research/agents/699b-agent-security-hardening/README.md
@@ -1,0 +1,78 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 699, 698, 685
+original-query: "Agent security hardening for the ZAO agent stack - MCP vulns, prompt injection, agent wallets, running agents safely. (sub-study of doc 699)"
+tier: STANDARD
+---
+
+# 699b - Agent Security Hardening for the ZAO Stack
+
+> **Goal:** Map the 2026 agent-security threats ZAO is exposed to and the concrete defenses to apply.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | DOWNGRADE ZAOcoworkingBot from root to a dedicated non-root user this week | It runs as root on Iman's VPS. A token leak or injection today = full VPS compromise. ~2-hour fix. |
+| 2 | UPGRADE @modelcontextprotocol/inspector to v0.14.1+ wherever the stack uses MCP | CVE-2025-49596 is a CVSS 9.4 RCE; bind MCP to 127.0.0.1, never 0.0.0.0 |
+| 3 | TREAT prompt injection as a live threat on every input surface - Telegram, GitHub, captured notes, agent memory | ZOE + Hermes read untrusted input and have persistent memory; a successful injection hijacks the agent's whole goal |
+| 4 | BUILD spend caps + recipient allowlists into `src/lib/agents/` before VAULT/BANKER ever run live | The Bankr breach drained 14 wallets; agent wallets are a proven attack surface. Design the guards before activation, not after. |
+| 5 | SYSTEMD-HARDEN every bot unit (NoNewPrivileges, ProtectSystem=strict, PrivateTmp, RestrictNamespaces) | Cheap, structural blast-radius reduction across ZOE, Hermes, ZAOstock, coworking |
+
+## Threat Matrix
+
+| Threat | Severity | ZAO exposure | Mitigation |
+|--------|----------|--------------|------------|
+| MCP Inspector RCE (CVE-2025-49596) | CRITICAL (9.4) | HIGH - claude CLI may invoke MCP | Upgrade to 0.14.1+, session tokens, localhost-only bind |
+| MCP tool poisoning | CRITICAL | HIGH - Hermes/ZOE call external tools | Static tool-metadata validation at connect, version-pin servers, audit-log every tool call |
+| Prompt injection (doc / web / email / memory / inter-agent) | HIGH | VERY HIGH - all of ZOE/Hermes input | 2-LLM quarantine pattern, JSON-strip persuasive text, allowlist sources |
+| Agent memory poisoning | HIGH | VERY HIGH - ZOE memory blocks, no integrity check | SHA256 sidecar per memory file, verify on read, alert on mismatch |
+| Agent wallet drain (Bankr precedent) | CRITICAL | MEDIUM - VAULT/BANKER architecture exists, not live | Spend velocity caps, recipient allowlist, explicit auth per tx, MPC/HSM keys |
+| Non-root process execution | HIGH | VERY HIGH - ZAOcoworkingBot runs as root | Dedicated `_zaobots` user, systemd hardening |
+| MCP design-level RCE class | MEDIUM | MEDIUM - Anthropic declined to change the protocol | Client-side only: auth, origin checks, sandbox the MCP sidecar |
+
+## Top Security Todos (Ranked)
+
+1. Downgrade ZAOcoworkingBot to a non-root `_zaobots` user (P0, ~2 hr)
+2. Upgrade MCP Inspector to v0.14.1+, audit version on the VPS deploy (P0)
+3. Version-pin / hash-verify MCP tool manifests in `bot/src/hermes/` (P0)
+4. SHA256 integrity sidecars for ZOE memory files; verify on read (P1)
+5. Input-validation layer on the concierge - separate trusted (Zaal direct) from untrusted (captures) (P1)
+6. Spend caps + recipient allowlist documented in `src/lib/agents/types.ts` + `runner.ts` (P1)
+7. MCP tool-response filtering for injection patterns + audit log to Supabase (P2)
+8. Privilege-separate the Hermes coder/critic - critic read-only, cannot modify the fix (P2)
+9. Systemd hardening on all bot units (P2)
+10. `agent_audits` Supabase table - log every action's input/output hash, tool calls, memory mutations (P2)
+
+## ZAOcoworkingBot: The Root Fix
+
+Create `_zaobots` system user, move the bot to a systemd unit with `User=_zaobots`, `NoNewPrivileges=yes`, `ProtectSystem=strict`, `ProtectHome=true`, `ReadWritePaths` scoped to the memory dir only. Watch out: `.env` must be readable by `_zaobots` (chmod 640, owned by that user), and no code can assume a `/root/` path. ~1-2 hour task; test that Telegram still connects after restart.
+
+## Specific Numbers
+
+- CVE-2025-49596: CVSS 9.4, patched in MCP Inspector v0.14.1 (June 2025)
+- Bankr breach (May 2026): 14 wallets accessed, ~$150K drained
+- A 2026 study found 26 LLM routers injecting malicious tool calls, ~$500K drained from one client wallet
+- HiddenLayer 2026: autonomous agents account for ~1 in 8 reported AI breaches
+
+## Sources
+
+- [CVE-2025-49596 RCE in MCP Inspector (Oligo)](https://www.oligo.security/blog/critical-rce-vulnerability-in-anthropic-mcp-inspector-cve-2025-49596) [FULL]
+- [The Hacker News - Anthropic MCP design vulnerability](https://thehackernews.com/2026/04/anthropic-mcp-design-vulnerability.html) [FULL]
+- [Bankr breach - 14 wallets, $150K drained (CryptoTimes)](https://www.cryptotimes.io/2026/05/20/bankr-breach-exposes-ai-crypto-wallet-after-14-wallets-lose-150k-ai-attack/) [FULL]
+- [MCP threat modeling + tool poisoning (arXiv 2603.22489)](https://arxiv.org/pdf/2603.22489) [FULL]
+- [Memory poisoning attack + defense on LLM agents (arXiv 2601.05504)](https://arxiv.org/abs/2601.05504) [FULL]
+- [Agent privilege separation as structural injection defense (arXiv 2603.13424)](https://arxiv.org/pdf/2603.13424) [FULL]
+- [How to sandbox AI agents in 2026 (Northflank)](https://northflank.com/blog/how-to-sandbox-ai-agents) [FULL]
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Downgrade ZAOcoworkingBot off root (todo 1) | @Zaal / @Iman | Fix | This week |
+| Upgrade MCP Inspector + pin tool manifests (todos 2-3) | @Zaal | Fix | This week |
+| Memory integrity + input validation (todos 4-5) | @Claude | PR | Next sprint |
+| Wire `agent_audits` logging + systemd hardening (todos 9-10) | @Claude | PR | Next sprint |

--- a/research/agents/699c-agent-evaluation-observability/README.md
+++ b/research/agents/699c-agent-evaluation-observability/README.md
@@ -1,0 +1,75 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 699, 698
+original-query: "Agent evaluation + observability for ZAO's agents - tooling, methodology, catching silent failures. (sub-study of doc 699)"
+tier: STANDARD
+---
+
+# 699c - Agent Evaluation + Observability for ZAO
+
+> **Goal:** Decide how ZAO evaluates and observes ZOE, Hermes, and ZAOcoworkingBot - none have formal eval today.
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | ADOPT a 3-layer stack: Langfuse (observability) + PromptFoo (regression) + hand-rolled LLM-as-judge (domain correctness) | All OSS, self-hostable on VPS 1, ~$10-15/mo total, no vendor lock-in - matches ZAO's OSS-first posture |
+| 2 | SELF-HOST Langfuse on VPS 1 - it has native Claude SDK / OpenTelemetry support | Captures every Claude call, tokens, latency, tool execution with near-zero integration overhead |
+| 3 | PUT PromptFoo regression suites in the repo, run them in CI, fail-closed on regression | Pre-merge gate; catches latency/cost/quality regressions before a PR lands |
+| 4 | BUILD hand-rolled LLM-as-judge evals per agent - generic tooling is too coarse for ZOE/Hermes-specific correctness | "Did the concierge actually solve it?" / "Did the PR fix actually pass CI?" needs domain logic |
+| 5 | TREAT evaluation as the highest-ROI agent spend, not overhead | Doc 699 finding: 18-24% eval budget -> 63% year-1 ROI; under 8% -> 28% |
+
+## Tooling Comparison
+
+| Tool | OSS | Self-host | Cost (self-hosted) | Best for | ZAO fit |
+|------|-----|-----------|--------------------|----|---------|
+| **Langfuse** | Yes | Yes (Docker) | ~$5-10/mo VPS | Tracing, prompt mgmt, scoring, OTel-native | ADOPT (Layer 1) |
+| **PromptFoo** | Yes | Yes (CLI) | Free | Regression suites, red-teaming, CI/CD | ADOPT (Layer 2) |
+| **DeepEval** | Yes | Yes (local) | Free | 50+ metrics, RAG/safety | Optional |
+| **Phoenix/Arize** | Partial | Limited | $600+/mo cloud | Real-time prod monitoring | Overkill for ZAO scale |
+| **Braintrust** | Partial | No (SaaS) | $500+/mo | Release gates, team governance | Skip - no self-host |
+| **Opik (Comet)** | Partial | Yes (Docker) | ~$10/mo | Auto-instrument Claude Code | Optional - strong Claude Code fit |
+
+## The Eval Plan Per Agent
+
+**ZOE (concierge):** measure task completion, clarity, hallucination ("claimed to do X but logs show no query"), brand-voice fit. Langfuse logs every DM+response; PromptFoo runs 20 golden conversations; weekly Claude-Sonnet judge scores 50 sampled chats 1-5, anything <3 to human review.
+
+**Hermes (fix-PR pipeline):** measure fix success (green CI, binary), regressions introduced, tool-calls vs human baseline, no new secret leaks. PromptFoo pre-flight: no 64-char hex, no `.env`, biome clean, vitest pass. Weekly post-merge audit of 10 PRs scored 1-5 on "did the fix actually solve the bug."
+
+**ZAOcoworkingBot:** measure capture accuracy (action + due date + assignee), reminder follow-through, and silent failures ("said captured" but tracker shows nothing). PromptFoo asserts valid action JSON + parseable date + valid @mention.
+
+## Catching Silent Failures
+
+The doc 699 finding: observability tells you it is *running*; evaluation tells you it is *working*. Silent failures (agent reports success, delivered wrong result) hide in the gap. Concrete catches:
+- Hermes says "deployed" but `git log` shows no commit -> PromptFoo diff-output assertion
+- ZOE says "I checked your uploads" but query logs show 0 queries -> LLM judge scores <2 on "did you actually do this?"
+- ZAOcoworkingBot "captured" but @mention silently failed validation -> regex assertion on Telegram user ID vs group members
+
+## Specific Numbers
+
+- Eval cost estimate: ~3,000 evals/mo at ~$0.003 each (Claude Sonnet judge) = ~$9/mo; full stack ~$12-15/mo on VPS 1
+- Doc 699: 18-24% eval budget -> 63% year-1 ROI vs 28% under 8%
+- Target: 0 undetected silent completions in 30 days; 100% of Claude calls traced by week 2
+- Regression gate: fail CI on >15% latency increase or >10% success-rate drop
+
+## Sources
+
+- [Observability for Claude Agent SDK with Langfuse](https://langfuse.com/integrations/frameworks/claude-agent-sdk) [FULL]
+- [PromptFoo (GitHub)](https://github.com/promptfoo/promptfoo) [FULL]
+- [Agent observability complete guide 2026 (Braintrust)](https://www.braintrust.dev/articles/agent-observability-complete-guide-2026) [FULL]
+- [Top 6 agent observability platforms 2026 (Laminar)](https://laminar.sh/article/2026-04-23-top-6-agent-observability-platforms) [FULL]
+- [Taxonomy of Failure Mode in Agentic AI Systems (Microsoft)](https://www.microsoft.com/en-us/security/blog/) [PARTIAL]
+- [Why AI agents break - field analysis of production failures (Arize)](https://arize.com/blog/common-ai-agent-failures/) [FULL]
+- [HN - Ask HN: How are people doing AI evals these days?](https://news.ycombinator.com/item?id=47319587) [FULL]
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Self-host Langfuse Docker on VPS 1, wire ZOE+Hermes OTel export | @Zaal | Infra | Next sprint |
+| Add PromptFoo regression suites for ZOE/Hermes/coworking to the repo + CI | @Claude | PR | Next sprint |
+| Collect 20 golden conversations per agent for the regression baseline | @Zaal | Todo | Next sprint |
+| Wire the weekly LLM-as-judge batch eval cron | @Claude | PR | After Langfuse is up |

--- a/research/agents/699d-advanced-agentic-coding-workflows/README.md
+++ b/research/agents/699d-advanced-agentic-coding-workflows/README.md
@@ -1,0 +1,94 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 699, 698, 684, 685
+original-query: "Advanced agentic coding workflows - how to make ZAO's Hermes + QuadWork better. (sub-study of doc 699)"
+tier: STANDARD
+---
+
+# 699d - Advanced Agentic Coding Workflows: Hermes + QuadWork Upgrades
+
+> **Goal:** The 2026 state-of-the-art agentic-coding patterns ZAO should fold into Hermes (fix-PR pipeline) and QuadWork (4-agent dashboard).
+
+## Key Decisions (DO THIS)
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | ADD multi-model routing to Hermes - Haiku for reads, Sonnet for edits, Opus only for architecture | Hermes routes everything to Opus; reads are ~38% of token volume. Routing = ~70% cost cut, no quality loss. Highest ROI. |
+| 2 | ADD an execution-grounded verification loop - Tester + Debugger agents run real tests in a sandbox before the Critic | Doc 531 found Hermes escalates ~80% of the time on silent test/type failures. Execution feedback drops that to ~30-40%. |
+| 3 | UPGRADE the single Critic to an adversarial review gate - Optimizer + Skeptic, auto-fix only on consensus | Single-pass review has a 30-60% false-positive rate; dual adversarial agents measured ~7% |
+| 4 | RUN QuadWork's reviewers in parallel git worktrees, not sequentially | 60-min sequential -> ~20-min wall-clock, 3x throughput, same token cost |
+| 5 | ISOLATE each Coder run in an ephemeral Docker container | ZAO's `bot/` typecheck OOMs the shared VPS heap; per-run isolation gives automatic resource limits |
+
+## The Upgrade Patterns (Ranked by Impact)
+
+| # | Pattern | What it does | Effort |
+|---|---------|--------------|--------|
+| 1 | Multi-model routing | Haiku reads / Sonnet edits / Opus architecture; ~70% cost cut | 3-4 days |
+| 2 | Execution-grounded loop | Tester synthesizes + runs tests, Debugger fixes on real feedback before Critic | 8-12 days |
+| 3 | Adversarial review gate | Optimizer + Skeptic in parallel, auto-fix on agreement, escalate disputes | 3-5 days |
+| 4 | Per-run Docker isolation | Ephemeral container per Coder run; read-only repo mount, timeout, no network | 6-8 hr |
+| 5 | Context-grounding hooks | Discovery probe + validation gate at each phase; catches hallucinated APIs pre-code | 5-7 days |
+| 6 | Persistent event log | Structured JSON per attempt; resumable, feeds prior failures back to the Coder | 6-8 hr |
+| 7 | Conditional extended thinking | Thinking-token budget only on architecture + debugging phases, 0 on routine gen | 1 day |
+| 8 | Parallel subagent dispatch (QuadWork) | RE1 + RE2 review in parallel worktrees via `Promise.all` | 2-3 days |
+| 9 | Cascade model selection | Start Haiku, escalate to Sonnet/Opus on eval miss; ~80/15/5 ideal distribution | 4-5 days |
+| 10 | PR lifecycle automation | Critic reads CI failures -> Coder re-runs; auto-rebase on conflict (max 2 rounds) | 5-6 days |
+
+## What The Best Fix-PR Pipelines Do That Hermes Does Not
+
+| Capability | Hermes today | Best-in-class | Gap |
+|------------|--------------|---------------|-----|
+| Execution verification | Critic reads code only | Mandatory Docker sandbox + Tester agent | Gap 1 |
+| Adversarial review | Single Critic (Sonnet) | Optimizer + Skeptic consensus | Gap 2 |
+| Model routing | Opus for everything | Haiku/Sonnet/Opus by task type | Gap 3 |
+| Event logging | Prose escalation only | Structured JSON per attempt, resumable | Gap 4 |
+| Phase-scoped grounding | None | Discovery + validation hooks at each phase | Gap 5 |
+| CI feedback loop | Alert-only | Full loop: CI logs -> Coder re-attempt | Gap 6 |
+
+## Cost Control
+
+| Tactic | Current | Optimized | Savings |
+|--------|---------|-----------|---------|
+| Model routing (Haiku reads) | ~$0.50/run | ~$0.15/run | 70% |
+| Cascade model selection | 100% Opus | mostly Haiku | up to 90% on simple issues |
+| Execution loop | $0.50 + 80% escalation | $0.35 + 30% escalation | ~60% of total cycle |
+| **All 10 patterns** | ~$1.10/run + 80% escalation | ~$0.25/run + 20% escalation | ~77% token, ~60% human |
+
+## Specific Numbers
+
+- Production routers (Aider, claude-budget) achieve 62-85% cost reduction via model routing alone
+- Adversarial multi-agent review: ~7% false-positive rate vs 30-60% single-pass
+- Doc 531: Hermes v1 escalates ~80% of runs; execution-grounded + adversarial review brings it to ~30-40%
+- QuadWork parallel worktrees: 60-min sequential -> ~20-min, 3x throughput
+- Claude Max tops out around 3 parallel agent tasks - design QuadWork concurrency around that
+
+## Suggested Roadmap
+
+| Sprint | Patterns | Payoff |
+|--------|----------|--------|
+| 1 (wk 1-2) | Model routing (1), adversarial review (3), parallel worktrees (8) | ~70% cost cut, 3x QuadWork throughput |
+| 2 (wk 3-6) | Execution loop (2), cascade selection (9), event log (6), grounding hooks (5) | ~60% escalation cut, ~77% token savings |
+| 3 (wk 7-8) | PR lifecycle automation (10), full Docker isolation (4) | rebase automation, OOM elimination |
+
+## Sources
+
+- [AgentForge - execution-grounded multi-agent SWE (arXiv 2604.13120)](https://arxiv.org/pdf/2604.13120) [FULL]
+- [Spec Kit Agents - context-grounding hooks (arXiv 2604.05278)](https://arxiv.org/pdf/2604.05278) [FULL]
+- [ng/adversarial-review (GitHub)](https://github.com/ng/adversarial-review) [FULL]
+- [gaurav-yadav/adversarial-ai-review - 7.3% FP on 500+ PRs (GitHub)](https://github.com/gaurav-yadav/adversarial-ai-review) [FULL]
+- [JacobiusMakes/claude-budget - routed agents (GitHub)](https://github.com/JacobiusMakes/claude-budget) [FULL]
+- [Claude Code worktrees docs](https://code.claude.com/docs/en/worktrees) [FULL]
+- [ofox.ai - Claude Code hybrid routing, 85% savings](https://ofox.ai/blog/claude-code-hybrid-routing-pattern-2026/) [FULL]
+- [OpenHands architecture (GitHub)](https://github.com/All-Hands-AI/OpenHands) [FULL]
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Implement multi-model routing in `bot/src/hermes/coder.ts` | @Zaal/@Claude | PR | Sprint 1 |
+| Add the Skeptic critic agent + parallel-consensus logic | @Claude | PR | Sprint 1 |
+| Parallelize QuadWork RE1/RE2 in worktrees | @Zaal | PR | Sprint 1 |
+| Build the Tester + Debugger execution loop | @Zaal | PR | Sprint 2 |


### PR DESCRIPTION
## Summary
DEEP-tier study of the entire agentic-AI landscape, built from 8 parallel research agents that scanned Reddit, Hacker News, X, GitHub, and arXiv - ~110 distinct sources across 8 dimensions.

## Dimensions covered
Agent frameworks, coding agents, memory + context engineering, multi-agent orchestration + harness engineering, evaluation + benchmarks, protocols (MCP/A2A/ERC-8004), web3 + crypto agents, and community pulse (what builders actually say).

## The through-line
1. The harness beats the model - scaffold explains more variance than model choice (15-36 point swings on identical models).
2. Single-agent + good harness beats multi-agent by default (Princeton: single-agent wins ~64% at equal compute; multi-agent burns ~15x tokens).
3. Benchmarks are gamed - UC Berkeley reward-hacked all 8 major ones; OpenAI dropped SWE-bench.
4. "Agent washing" is ~95% of the market.
5. What works: narrow scope + guardrails + observability + human escalation + 18-24% eval budget.

## Why it matters for ZAO
The ZAO stack (Hermes single-agent pattern, CLAUDE.md context engineering, sub-agent isolation, 5-surface collapse) is already on the winning side of this research. Crucially: the evidence base argues *against* a full Paperclip restart (Doc 698) - "don't build multi-agent by default" is the dominant 2026 finding. Doc 698's decline-or-narrow-pilot recommendation is now evidence-backed.

Honest caveat: 2026 benchmark percentages are community/vendor-reported and contested (benchmark gaming is itself a finding) - treated as directional, not gospel.