### PR TITLE
doc 700: Devcon 8 Mumbai music stage co-programming brief (STANDARD)

### DIFF
--- a/research/events/700-devcon-mumbai-music-stage-coprogramming/README.md
+++ b/research/events/700-devcon-mumbai-music-stage-coprogramming/README.md
@@ -1,0 +1,151 @@
+---
+topic: events
+type: guide
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 557, 649
+tier: STANDARD
+---
+
+# 700 — Devcon 8 Mumbai Music Stage: co-programming brief + reply kit
+
+> **Goal:** Arm Zaal's reply to a music-stage organizer who asked about (1) his music-curation background, (2) an "Indian element" opportunity, (3) his professional background. Establish what the Devcon music stage actually is, how it gets programmed, and the Indian-artist landscape to pitch into.
+
+> **Trigger:** 2026-05-21 - an organizer DMed Zaal inviting him to co-program "the music stage" and asked three intro questions. This doc supplies the facts; the drafted reply is in Part 5.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Which event is this** | Devcon 8 - Mumbai, India, 3-6 Nov 2026, JIO World Center. The "Indian element" question only makes sense because the event is physically in India. Treat the brief as Devcon 8, not Devconnect ARG (that one already happened, Buenos Aires Nov 2025). |
+| **What the music stage is** | A real, recurring Devcon fixture. At Devcon SEA (Bangkok 2024) the music stage lived in the "Chiva Chillout" social area - community-curated, born from a **Devcon Improvement Proposal (DIP)** by **The Fellowship of Ethereum Musicians**. It is NOT an EF-booked headliner stage; it is community programming. That is exactly the lane Zaal already operates in. |
+| **How to get co-programming traction** | Anchor the pitch to the DIP model + the Fellowship of Ethereum Musicians precedent. Co-programming = curating a slate of ecosystem-aligned artists, not booking commercial headliners. Zaal's ZAO music org IS a curation engine; lead with that. |
+| **The Indian angle** | Strong and real. India has a deep electronic-fusion scene that blends classical/regional Indian music with club electronics - exactly the "Indian element" a Mumbai stage should showcase. Lead names in Part 3. Frame it as: the stage should sound like where it is, not like a generic web3 afterparty. |
+| **Zaal's curation credibility** | Real and specific - he founded and programs a music org + festival. Do NOT undersell as "I'm a fan." See Part 4 for the exact resume beats. |
+| **Reply tone** | Warm, concrete, not a pitch deck. Answer the 3 questions in order, drop 2-3 specific artist names to show he's done the homework, offer a next step (a call). Draft in Part 5. |
+
+## Part 1 — Devcon 8 Mumbai (the event)
+
+| Field | Value |
+|-------|-------|
+| Event | Devcon 8 (Ethereum Foundation flagship developer conference) |
+| Dates | 3-6 November 2026 |
+| Venue | JIO World Center, Mumbai, India |
+| Announced | 2025-12-23 (EF blog) |
+| Predecessor | Devconnect ARG - Buenos Aires, 17-22 Nov 2025, 14,000+ attendees, 130+ countries |
+| Scale precedent | Devcon/Devconnect draw 4,000-15,000+; La Rural (ARG) hosted 8 themed districts, 80+ exhibitors, 40+ in-venue events, 500+ side events |
+
+Devcon is the EF's builder gathering; it alternates years/cities. Devcon 8 in Mumbai is the first flagship in India - which is why a music stage there is actively courting an "Indian element."
+
+## Part 2 — The Devcon Music Stage (how it works)
+
+- Devcon runs a **Music Stage in the social/chillout area** - "live performances curated by talented musicians from the Ethereum ecosystem."
+- At **Devcon SEA (Bangkok, 2024)** the music stage sat in the **Chiva Chillout** zone.
+- It originated as a **Devcon Improvement Proposal (DIP)** - the community-activation mechanism - submitted by **The Fellowship of Ethereum Musicians**, a community group of musicians inside the Ethereum ecosystem.
+- Devconnect ARG 2025 carried the same DNA: inside La Rural, alongside food trucks, a cinema, and a soccer pitch, there was **live music** as part of the venue experience.
+- Separately, the broader scene has crypto-native music collectives - **RaveDAO** (started with a 200-person Devcon Istanbul afterparty, Nov 2023) and big sponsored afterparties (Devcon BKK 2024 had DJ SODA across 2 stages). These are side events, not the in-venue community Music Stage - useful context, not the target.
+
+**Implication:** "Co-programming the music stage" = joining/partnering with the community curation crew (Fellowship-of-Ethereum-Musicians lineage) to build the artist slate. It is curation + community, not a promoter booking job. Zaal's wheelhouse.
+
+## Part 3 — The "Indian element": artist + scene map
+
+India has a mature scene fusing Indian classical/regional music with electronic production. This is the credible "Indian element" - not Bollywood covers, but genuine fusion artists. Names Zaal can drop to show homework:
+
+| Artist | Why they fit a Devcon Mumbai music stage |
+|--------|-------------------------------------------|
+| **Bandish Projekt** (Mayur Narvekar) | The canonical Indian fusion act - classically trained tabla player (20 yrs) building electronica around Indian classical composition ("bandish"). Living proof of "Indian element + electronic." |
+| **Nucleya** (Udyan Sagar) | India's best-known electronic producer; made EDM mainstream in India; has already moved into NFTs - a natural web3-curious headline name. |
+| **Nanditi** (Nanditi Khilnani) | Classically trained Indian musician AND **live-coder** doing raga-based generative electronic music. Ex-Google India. The single most web3/tech-aligned pick - "creative technology" framing maps directly onto an Ethereum crowd. |
+| **Spryk** (Tejas Nair) | Mumbai-based; immersive audio-visual electronic performance; founder of XR studio Vorlds; curates the EyeMyth new-media arts festival. Tech-culture overlap. |
+| **Kratex** | Mumbai DJ; created "M-House" (Marathi music + house/techno); first Marathi track on Spinnin' Records; 100M+ streams. Regional-Indian-fusion at scale. |
+| **Elsewhere in India** (Thiruda + Murthovic) | Indo-futurist duo - electronic music + XR + gaming + modified classical instruments. "Post-heritage India 2079" concept - extremely on-theme for a futures-oriented Ethereum crowd. |
+| **Arushi Jain** | Modular-synth + Indian classical, diaspora "in-betweenness" themes. International festival credibility. |
+| **Three Oscillators** (Brij Dalvi) | Underground producer using regional Indian instruments; explicitly interested in Web 3.0 music platforms. |
+
+Scene infrastructure to name-drop: **Magnetic Fields Festival** (India's forward-thinking electronic festival, Rajasthan) and event company **Krunk**. Mentioning these signals Zaal knows the ecosystem, not just the headliners.
+
+## Part 4 — Zaal's curation resume (the honest version)
+
+From Doc 649 (Zaal build profile). Use these beats - they are real:
+
+- **Founder of The ZAO** - a music-focused decentralized org / impact network, 188 members on Base. Music is the org's spine.
+- **Programs ZAOstock** - a flagship music festival, locked for 3 Oct 2026, Ellsworth, Maine. He is literally curating a live music event right now (see Doc 557 for the build).
+- **WaveWarZ** - music-battle product (Solana); artist pipeline + competitive music format.
+- **COC Concertz** - virtual concert promotion community (13+ promoters) showcasing artists.
+- **ZOUNZ** - a Farcaster music mini-app (AI music, Audius discovery, Zora minting).
+- **DJs himself** - runs DJ sets / "WaveWarZ sets" on Twitch; hosts "Let's Talk About Web3" livestreams and the BCZ YapZ podcast.
+- **Personal India connection** - the surname Panthaki is Parsi (Indian Zoroastrian heritage). Zaal can speak to the Indian-element question from lived background, not just curation - he decides how forward to put this.
+
+Honest framing: Zaal has NOT programmed a Devcon stage before, and probably has not run a 5,000-cap commercial festival. What he HAS done: built music community infrastructure, run recurring music events/competitions, and curated artist slates inside web3. That is the right-sized, true claim. Co-programming (not solo-programming) is the correct ask for his level.
+
+## Part 5 — Drafted reply (paste-ready, edit to taste)
+
+> Hihi! No worries on timing at all - and thanks for thinking of me for this, genuinely excited by the idea.
+>
+> A bit about me on your three questions:
+>
+> **1. Music background.** I run The ZAO, a music-focused community of ~190 people building at the intersection of music and tech. I program our flagship music festival (ZAOstock, this October), run a music-battle format called WaveWarZ, and curate artist showcases through COC Concertz. I also DJ and host a web3 music podcast. So less "industry promoter," more community curator - I build lineups and the scenes around them. Co-programming a stage is squarely the kind of thing I love.
+>
+> **2. The Indian element.** Big yes - and I think a Mumbai Devcon almost demands it. The opportunity I'd chase isn't Bollywood-cover novelty; it's India's genuine electronic-fusion scene - artists building club music out of Indian classical and regional traditions. Acts like Bandish Projekt (tabla-rooted electronica) or Nanditi (a classically trained musician and live-coder doing raga-based generative sets - extremely on-theme for an Ethereum crowd) would make the stage sound like where it actually is. I'd approach it as: curate a slate where every act bridges Indian musical heritage and forward tech, so the stage is a statement, not background noise. [Personal note if you want it: I'm of Parsi/Indian heritage myself, so this one's close to home.]
+>
+> **3. What I do.** I'm a builder - I run BCZ Strategies, a small studio doing web3 product and community work, and I've spent the last ~18 months building music + community tooling across the ZAO ecosystem. Day to day that's product, events, and community programming.
+>
+> Would love to hear how you're thinking about the stage - format, how many slots, how it ties into the Fellowship of Ethereum Musicians / DIP side of things. Happy to jump on a quick call whenever suits you.
+>
+> Looking forward to it!
+
+Notes on the draft:
+- Answers the 3 questions in the asked order.
+- Drops 2 specific, verifiable artist names (Bandish Projekt, Nanditi) - enough to show homework without listing a wall of names.
+- Names the Fellowship of Ethereum Musicians / DIP - signals Zaal knows how the stage actually gets programmed.
+- The Parsi/Indian-heritage line is bracketed - Zaal includes or cuts it.
+- Honest scope: "community curator," "co-programming" - no overclaim.
+
+## Specific Numbers
+
+| Metric | Value |
+|--------|-------|
+| Devcon 8 dates | 3-6 Nov 2026 |
+| Devcon 8 venue | JIO World Center, Mumbai, India |
+| Devconnect ARG 2025 attendees | 14,000+ (130+ countries) |
+| Devconnect ARG in-venue events | 40+ (plus 500+ side events) |
+| Devcon SEA music stage origin | DIP by The Fellowship of Ethereum Musicians (Chiva Chillout zone) |
+| RaveDAO first event | ~200 people, Devcon Istanbul, Nov 2023 |
+| The ZAO members | ~188-190 (on Base) |
+| ZAOstock 2026 | 3 Oct 2026, Ellsworth, Maine |
+| Bandish Projekt formed | 1998 |
+| Kratex streams | 100M+ |
+
+## Sources
+
+- [Devcon 8 is coming to Mumbai - EF Blog](https://blog.ethereum.org/2025/12/23/devcon-mumbai) - dates, venue (verified 2026-05-21)
+- [Devcon official site](https://devcon.org/en/) - Devcon 8 India (verified 2026-05-21)
+- [Devcon 2026 listing - Coinpedia](https://events.coinpedia.org/devcon-2026-8108/) - 3-6 Nov 2026 corroboration
+- [2 weeks to Devconnect - EF Blog](https://blog.ethereum.org/2025/11/04/devconnect-arg) - live music inside La Rural confirmed
+- [Devconnect Argentina Recap - EF Blog](https://blog.ethereum.org/2025/12/04/devconnect-arg-wrap) - 14,000+ attendees, venue programming
+- [Devconnect.org](https://devconnect.org/) - ARG 2025 stats, Devcon 8 Mumbai callout
+- [Alaska @ Devcon SEA - app.devcon.org](https://app.devcon.org/schedule/JWDJNQ) - music stage / Chiva Chillout, Fellowship of Ethereum Musicians DIP
+- [RaveDAO / Devcon Istanbul afterparty origin](https://bitcoinethereumnews.com/crypto/from-dancefloor-to-the-wall-street-journal-how-ravedao-is-making-raves-cryptos-hottest-new-narrative/) - community crypto-rave precedent
+- [Spryk - about](https://spryk.in/about/) - Mumbai electronic artist / new-media curator
+- [Nanditi](https://nanditi.com/) - classically trained Indian musician + live-coder
+- [Kratex press](https://press.kratex.in/) - M-House, Marathi-electronic fusion
+- [Bandish Projekt - Wikipedia](https://en.wikipedia.org/wiki/Bandish_Projekt) - tabla + electronica fusion act
+- [Electronic Fusion in India - Bandcamp Daily](https://daily.bandcamp.com/scene-report/india-electronic-scene-report) - scene report (Magnetic Fields, Krunk, Three Oscillators, Arushi Jain)
+- ZAO internal: Doc 649 (Zaal build profile), Doc 557 (ZAOstock onchain ticketing)
+
+URLs verified live 2026-05-21. Devcon 8 date/venue cross-checked across EF blog + devcon.org + Coinpedia.
+
+## Also See
+
+- [Doc 649 - Zaal Build Profile + ZAO Ecosystem Survey](../../identity/649-zaal-build-profile-ecosystem-survey/) - source for Zaal's curation resume
+- [Doc 557 - Onchain Festival Ticketing for ZAOstock](../../dev-workflows/557-onchain-festival-ticketing-zaostock/) - Zaal's live festival build, evidence of current curation work
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Send the Part 5 reply (edit the heritage line in/out) | @Zaal | DM reply | Today |
+| Confirm with the organizer whether this is the in-venue Music Stage (Fellowship/DIP) or a side-event stage - changes the playbook | @Zaal | Ask on the call | Next reply |
+| If it advances: draft a 6-10 act Indian-fusion curation slate from Part 3 | @Zaal | Curation doc | After call |
+| Check whether The Fellowship of Ethereum Musicians is taking Devcon 8 DIP submissions + how to join | @Zaal | Research | Before pitching a slate |
+| Decide how hard to lean on the Parsi/Indian-heritage angle publicly | @Zaal | Personal call | Before sending |


### PR DESCRIPTION
## Summary

Reply kit for an organizer who DMed Zaal inviting him to co-program the Devcon music stage and asked 3 intro questions (music background, Indian element, professional background).

## Tier
STANDARD

## Key findings
- The event is **Devcon 8 - Mumbai, 3-6 Nov 2026, JIO World Center** (the 'Indian element' ask only makes sense because the event is in India)
- The Devcon Music Stage is a real recurring fixture - community-curated via a **Devcon Improvement Proposal** by **The Fellowship of Ethereum Musicians** (Chiva Chillout zone at Devcon SEA). Co-programming = curation + community, exactly Zaal's lane
- India has a deep electronic-fusion scene - mapped 8 artists (Bandish Projekt, Nucleya, Nanditi, Spryk, Kratex, Elsewhere in India, Arushi Jain, Three Oscillators)
- Zaal's curation resume pulled honest from Doc 649 (The ZAO, ZAOstock festival, WaveWarZ, COC Concertz)
- **Part 5 = paste-ready drafted reply** answering all 3 questions

## Sources
13 sources - EF blog x3, devcon.org, Coinpedia, devconnect.org, app.devcon.org, Bandcamp scene report, 4 artist sites, RaveDAO writeup + 2 internal docs.

## Next Actions
Send the Part 5 reply. See doc's Next Actions table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)