### PR TITLE
fix(docs): renumber fractal docs 698-701 -> 702-705 (resolve collision)

### DIFF
--- a/research/community/105-fractal-key-people/README.md
+++ b/research/community/105-fractal-key-people/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [56, 102, 103, 104, 106, 109, 114, 184, 188, 306, 698, 699]
+related-docs: [56, 102, 103, 104, 106, 109, 114, 184, 188, 306, 702, 703]
 original-query: "Key people in fractal governance ecosystem - who leads Eden Fractal, Optimystics, ORDAO, and how can ZAO connect? (reconstructed)"
 tier: STANDARD
 ---
@@ -219,8 +219,8 @@ tier: STANDARD
 - Doc 114 - [ZAO Fractal Live Infrastructure] (zao.frapps.xyz, bots, current state)
 - Doc 188 - [ZAO Fractal Bot Process] (Hermes + ZOE involvement in governance)
 - Doc 306 - [Respect Game Complete Rules] (detailed gameplay mechanics)
-- Doc 698 - [Fractal Governance Lineage Deep] (history + philosophy)
-- Doc 699 - [ZAO Fractal Current State] (ZAO's specific 90-week implementation)
+- Doc 702 - [Fractal Governance Lineage Deep] (history + philosophy)
+- Doc 703 - [ZAO Fractal Current State] (ZAO's specific 90-week implementation)
 
 ## Next Actions
 

--- a/research/community/106-dan-singjoy-eden-fractal-deep-dive/README.md
+++ b/research/community/106-dan-singjoy-eden-fractal-deep-dive/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [56, 102, 103, 104, 105, 109, 114, 184, 188, 306, 698, 699]
+related-docs: [56, 102, 103, 104, 105, 109, 114, 184, 188, 306, 702, 703]
 original-query: "Complete profile of Dan SingJoy: music background, governance philosophy, Eden Fractal operations, current status May 2026, and ZAO collaboration opportunities (reconstructed)"
 tier: DEEP
 ---
@@ -642,8 +642,8 @@ This positions ZAO as a **compelling case study for Dan's thesis:** music + gove
 - Doc 114 - ZAO Fractal live infrastructure (zao.frapps.xyz, current state)
 - Doc 188 - ZAO Fractal bot process and Discord commands
 - Doc 306 - Eden Fractal and Optimism Fractal deep history
-- Doc 698 - Respect and fractal governance: the complete lineage
-- Doc 699 - ZAO Fractal current state (May 2026)
+- Doc 702 - Respect and fractal governance: the complete lineage
+- Doc 703 - ZAO Fractal current state (May 2026)
 
 ---
 

--- a/research/governance/056-ordao-respect-system/README.md
+++ b/research/governance/056-ordao-respect-system/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [058, 102, 103, 104, 105, 109, 114, 115, 184, 188, 285, 306, 346, 698, 699]
+related-docs: [058, 102, 103, 104, 105, 109, 114, 115, 184, 188, 285, 306, 346, 702, 703]
 original-query: "ORDAO governance toolset, Respect Game mechanics, OREC contract design - how The ZAO uses fractal scoring (reconstructed)"
 tier: DEEP
 ---
@@ -22,7 +22,7 @@ tier: DEEP
 | **Use ZAO's 2x Fibonacci scoring (110/68/42/26/16/10) as standard curve** | Zaal | Live | More reward differentiation than canonical Fibonacci (55/34/21/13/8/5). See Section 4. |
 | **Keep OREC submission gated to experienced 2-3 wallets** | Zaal | Current | Risk mitigation until UI/UX in ZAO OS is finalized. Plan to open via ZAO OS UI (future sprint). |
 | **Sync on-chain Respect state (OG + ZOR) into Supabase `respect_balances` as cache** | Doc 115 owner | In progress | Leaderboard.ts already reads both contracts; cache layer adds decay + tier calculation. |
-| **Document fractal as non-technical onboarding tool** | Zaal + CLAUDE.md | Doc 699 rec | Tanja + non-builders cannot explain the fractal. Skeleton guides + video intros needed. |
+| **Document fractal as non-technical onboarding tool** | Zaal + CLAUDE.md | Doc 703 rec | Tanja + non-builders cannot explain the fractal. Skeleton guides + video intros needed. |
 
 ---
 
@@ -176,7 +176,7 @@ The Respect Game is **fractal** - it repeats at different scales:
 - **Round 2:** Top 8 participants from Round 1 (highest Respect) form a new group of 6-8, evaluate each other again, distribute additional Respect. Repeats Fibonacci per rank.
 - **Round 3+:** Continue until fewer than 6 remain.
 
-**Current ZAO practice:** Single-round (no multi-round cascade). Doc 698 confirms this as best practice for communities under 100 members. Optimism Fractal also uses single-round.
+**Current ZAO practice:** Single-round (no multi-round cascade). Doc 702 confirms this as best practice for communities under 100 members. Optimism Fractal also uses single-round.
 
 ---
 
@@ -212,7 +212,7 @@ The ZAO uses a custom curve - roughly 2x the canonical Fibonacci - to reward dif
 | 6th | 10 | 2x |
 | **Per-group total** | **272** | 2x |
 
-**Rationale:** ZAO prioritizes recognizing top contributors (musicians, builders) over baseline participation. The curve steeper than canonical Fibonacci but still resists gaming (peer-ranked, not tradeable). See doc 699 context for governance decisions on this curve choice.
+**Rationale:** ZAO prioritizes recognizing top contributors (musicians, builders) over baseline participation. The curve steeper than canonical Fibonacci but still resists gaming (peer-ranked, not tradeable). See doc 703 context for governance decisions on this curve choice.
 
 ### Why Fibonacci at All
 
@@ -336,7 +336,7 @@ The modern flow leverages OREC for democratic, automated distribution:
 
 ### Current ZAO Bottleneck (May 2026)
 
-**Note:** Only 2 wallets actively submit on-chain: zaal.eth and civilmonkey.eth. This is a centralization risk. **Recommendation (doc 699):** Expand to 3-5 signers or open via ZAO OS UI in future sprint.
+**Note:** Only 2 wallets actively submit on-chain: zaal.eth and civilmonkey.eth. This is a centralization risk. **Recommendation (doc 703):** Expand to 3-5 signers or open via ZAO OS UI in future sprint.
 
 ---
 
@@ -368,7 +368,7 @@ npm install @ordao/orclient
 |---|---|---|
 | **License** | GPL-3.0 | ZAO OS is MIT. GPL permissive for dependents, but consider license compliance. |
 | **Wallet Requirement** | EIP-1193 provider (MetaMask, Privy) | ZAO uses Farcaster signers. Wallet connection needed for on-chain actions. |
-| **ornode Dependency** | orclient requires ornode backend | ZAO has `zao-ornode.frapps.xyz` (currently down as of May 2026, doc 699 rec: restore it) |
+| **ornode Dependency** | orclient requires ornode backend | ZAO has `zao-ornode.frapps.xyz` (currently down as of May 2026, doc 703 rec: restore it) |
 | **Gas Costs** | Cheap on Optimism | Breakout submission ~$0.02-0.05 at current L2 gas |
 | **Ethers v6** | orclient uses ethers v6 | ZAO OS uses viem. May need wrapper or dual dependency. |
 | **Live Deployment** | OREC + ZOR live | 242+ transactions on OREC as of May 21, 2026. Weekly submissions active. |
@@ -445,7 +445,7 @@ npm install @ordao/orclient
   - Consensus ranking interface (ranking each other 1-6)
   - Auto-proposal generation (orclient.proposeBreakoutResult)
   - Live leaderboard + tier badges
-- **Non-technical onboarding docs** for Tanja + other musicians (doc 699 priority)
+- **Non-technical onboarding docs** for Tanja + other musicians (doc 703 priority)
 
 ### Technical Dependencies
 
@@ -460,8 +460,8 @@ npm install @ordao/orclient
 
 ## Also See
 
-- **Doc 698:** "Respect & Fractal Governance: The Complete Lineage" - full history from Dan Larimer's book through current fractals
-- **Doc 699:** "ZAO Fractal: Current State (May 2026)" - live operational status, recommendations, on-chain metrics
+- **Doc 702:** "Respect & Fractal Governance: The Complete Lineage" - full history from Dan Larimer's book through current fractals
+- **Doc 703:** "ZAO Fractal: Current State (May 2026)" - live operational status, recommendations, on-chain metrics
 - **Doc 114-115:** Respect deep dives and Supabase schema design
 - **Doc 104-109:** Historical fractal governance research and ORDAO adoption patterns
 - **Doc 184-188:** Smart contract addresses and token details
@@ -523,5 +523,5 @@ All sources fetched, read, and cross-verified 2026-05-21:
 - [src/lib/respect/leaderboard.ts (on-chain sync)](https://github.com/bettercallzaal/zaoos/blob/main/src/lib/respect/leaderboard.ts) [FULL]
 
 ### Related Governance Research Docs (This Campaign)
-- Doc 698: Respect & Fractal Governance Lineage (verified May 21, 2026)
-- Doc 699: ZAO Fractal Current State May 2026 (verified May 21, 2026)
+- Doc 702: Respect & Fractal Governance Lineage (verified May 21, 2026)
+- Doc 703: ZAO Fractal Current State May 2026 (verified May 21, 2026)

--- a/research/governance/058-respect-deep-dive/README.md
+++ b/research/governance/058-respect-deep-dive/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [056, 102, 103, 104, 109, 114, 115, 184, 188, 285, 306, 346, 698, 699]
+related-docs: [056, 102, 103, 104, 109, 114, 115, 184, 188, 285, 306, 346, 702, 703]
 original-query: "Respect token mechanics: scoring math, decay equilibrium, tier thresholds, orclient SDK, on-chain state and implications for ZAO Sprint 2 (reconstructed)"
 tier: DEEP
 ---
@@ -170,7 +170,7 @@ When a community grows past 50 members, the Respect Game repeats in rounds:
 - Single-round produces Gini ~0.23 (very fair)
 - Multi-round is fair too (~0.23-0.30 with consistent attendance, but drifts to 0.4-0.5 with varied attendance)
 - Simplicity: less complex, easier for non-technical members to understand
-- Doc 699 confirms single-round as ZAO's model
+- Doc 703 confirms single-round as ZAO's model
 
 ---
 
@@ -307,7 +307,7 @@ npm install @ordao/orclient ethers@6
 |---|---|---|
 | **License** | GPL-3.0 | Permissive for library dependencies. No issues. |
 | **Wallet Requirement** | EIP-1193 provider needed (MetaMask, Privy, etc.) | ZAO uses Farcaster signers. Need wrapper or Privy integration. Privy package exists: @ordao/privy-react-orclient v1.4.4. |
-| **ornode Dependency** | zao-ornode.frapps.xyz currently down | **BLOCKER:** Restore ornode or implement fallback (direct OREC contract reads). Doc 699 priority: restore by 2026-06-15. |
+| **ornode Dependency** | zao-ornode.frapps.xyz currently down | **BLOCKER:** Restore ornode or implement fallback (direct OREC contract reads). Doc 703 priority: restore by 2026-06-15. |
 | **ethers v6 vs viem** | orclient uses ethers v6; ZAO OS uses viem | Need dual dependency or wrapper for compatibility. |
 | **Gas Costs** | Optimism L2 (very cheap) | Breakout submission ~$0.02-0.05 per Respect Game at current gas. Negligible cost. |
 | **Live Deployment** | OREC + ZOR live, 242+ txns as of May 21 | Ready for production use. Weekly submissions active. |
@@ -423,8 +423,8 @@ console.log(zaalsRespect); // e.g., 3,450 Respect (decayed from on-chain)
 ## Also See
 
 - **Doc 056:** ORDAO architecture, OREC contract design, orclient SDK reference
-- **Doc 698:** Fractally lineage, Fibonacci theory, Dan Larimer's philosophy
-- **Doc 699:** ZAO Fractal live state (week 100+, current participants, OREC transaction count)
+- **Doc 702:** Fractally lineage, Fibonacci theory, Dan Larimer's philosophy
+- **Doc 703:** ZAO Fractal live state (week 100+, current participants, OREC transaction count)
 - **Doc 115:** Supabase schema for Respect (respect_balances table, tier_enum)
 - **Doc 104-109:** Historical governance evolution, ORDAO adoption pattern
 
@@ -471,6 +471,6 @@ All sources fetched, read, and cross-verified 2026-05-21:
 
 ### Related Docs (This Campaign, Verified 2026-05-21)
 - Doc 056: ORDAO & Respect Game System (DEEP tier, regenerated 2026-05-21)
-- Doc 698: Respect & Fractal Governance Lineage (DEEP tier)
-- Doc 699: ZAO Fractal Current State May 2026 (DEEP tier)
+- Doc 702: Respect & Fractal Governance Lineage (DEEP tier)
+- Doc 703: ZAO Fractal Current State May 2026 (DEEP tier)
 - Doc 115: Supabase schema planning for Respect (referenced, not verified in this pass)

--- a/research/governance/102-fractals-frapps-ordao-page/README.md
+++ b/research/governance/102-fractals-frapps-ordao-page/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 103, 104, 105, 106, 114, 188, 285, 306, 346, 444, 450, 498, 502, 664, 698, 699
+related-docs: 56, 58, 103, 104, 105, 106, 114, 188, 285, 306, 346, 444, 450, 498, 502, 664, 702, 703
 original-query: "Design a dedicated `/fractals` page in ZAO OS integrating frapps.xyz frontend, ORDAO proposal UI, and ZAO's existing fractal session/respect infrastructure (reconstructed)"
 tier: STANDARD
 ---
@@ -254,7 +254,7 @@ export async function GET(req: Request) {
 
 ## Also See
 
-Related docs in fractal governance campaign: 56, 58, 103, 104, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 698, 699.
+Related docs in fractal governance campaign: 56, 58, 103, 104, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 702, 703.
 
 ---
 

--- a/research/governance/103-fractal-governance-ecosystem/README.md
+++ b/research/governance/103-fractal-governance-ecosystem/README.md
@@ -404,7 +404,7 @@ Explicitly designed for "ranking speeches and musical performances" - this is th
 
 ## Also See
 
-Related fractal governance docs: 56, 58, 102, 104, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 698, 699.
+Related fractal governance docs: 56, 58, 102, 104, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 702, 703.
 
 ---
 

--- a/research/governance/104-fractal-communities-directory/README.md
+++ b/research/governance/104-fractal-communities-directory/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 698, 699
+related-docs: 56, 58, 102, 103, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 702, 703
 original-query: "Comprehensive inventory of every fractal governance community - active, paused, and dormant (reconstructed)"
 tier: STANDARD
 ---
@@ -140,7 +140,7 @@ tier: STANDARD
 
 ## Also See
 
-Related docs: 56, 58, 102, 103, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 698, 699.
+Related docs: 56, 58, 102, 103, 105, 106, 109, 114, 115, 188, 285, 306, 346, 444, 450, 498, 502, 664, 702, 703.
 
 ---
 

--- a/research/governance/109-optimystics-tooling-ecosystem/README.md
+++ b/research/governance/109-optimystics-tooling-ecosystem/README.md
@@ -4,14 +4,14 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [56, 58, 102, 103, 104, 105, 106, 109, 114, 184, 188, 285, 306, 346, 498, 698, 699]
+related-docs: [56, 58, 102, 103, 104, 105, 106, 109, 114, 184, 188, 285, 306, 346, 498, 702, 703]
 original-query: "Optimystics tooling ecosystem status 2026 - ORDAO, orfrapps, Respect.Games, Cignals, fractalgram integration" (reconstructed)
 tier: DEEP
 ---
 
 # 109 - Optimystics Tooling Ecosystem
 
-> **Goal:** Map the current state of all Optimystics tools (ORDAO/OREC, orfrapps, Respect.Games, Cignals, fractalgram, Respect Trees, etc.), verify production readiness, and recommend ZAO OS integration paths. Cross-reference with docs 698 (fractal lineage) and 699 (ZAO Fractal state).
+> **Goal:** Map the current state of all Optimystics tools (ORDAO/OREC, orfrapps, Respect.Games, Cignals, fractalgram, Respect Trees, etc.), verify production readiness, and recommend ZAO OS integration paths. Cross-reference with docs 702 (fractal lineage) and 703 (ZAO Fractal state).
 
 ## Key Decisions (Recommendations First)
 
@@ -88,7 +88,7 @@ Cignals directly aligns with ZAO's music-first positioning:
 - **Respect-weighted voting:** Members with higher Respect get proportional voting weight (phase 2+)
 - **Festival integration:** Use at ZAOstock 2026 (Oct 3) or earlier ZAO events
 
-**Recommendation:** Spec out a ZAO fork of Cignals logic once Optimystics ships the onchain version (target: June 2026). Doc 698 lineage + 699 state provide context for how Respect distribution works.
+**Recommendation:** Spec out a ZAO fork of Cignals logic once Optimystics ships the onchain version (target: June 2026). Doc 702 lineage + 703 state provide context for how Respect distribution works.
 
 ---
 
@@ -234,12 +234,12 @@ ornode is a **Node.js/Express REST API backed by MongoDB** that stores proposal 
 
 ### For ZAO OS
 
-**Current deployment:** `zao-ornode.frapps.xyz` (status: [PARTIAL - endpoint down as of May 2026, per doc 699])
+**Current deployment:** `zao-ornode.frapps.xyz` (status: [PARTIAL - endpoint down as of May 2026, per doc 703])
 
 orclient abstracts ornode + on-chain reads, so integrate via orclient rather than direct HTTP. If ornode is down:
 - orclient.getProposals() will fail until ornode restarts
 - Fallback: Read on-chain state only via viem (proposals hashes, votes, balances)
-- Action: Stand up replacement ornode or formally retire it (see doc 699 recommendations)
+- Action: Stand up replacement ornode or formally retire it (see doc 703 recommendations)
 
 ---
 
@@ -388,7 +388,7 @@ Fractalgram is a **fork of Telegram Web A** tailored for live fractal meetings. 
 "Trust a minority of contributors who take the initiative to act." Security model:
 - Time delay allows easy blocking of bad proposals
 - Asymmetric veto power (No votes count 2x) prevents hostile takeover
-- Works best with stable Respect distribution (monitor via doc 699, 115 reconciliation)
+- Works best with stable Respect distribution (monitor via doc 703, 115 reconciliation)
 
 ---
 
@@ -476,8 +476,8 @@ export async function createORClientForViem(walletClient) {
 - **Doc 102-114 - Fractal governance deep dives:** Respect mechanics, game theory, contract audit
 - **Doc 184 - Superchain ORDAO:** Cross-chain governance planning
 - **Doc 285 - orfrapps Updated Docs:** Deployment, configuration, CLI reference
-- **Doc 698 - Fractal Lineage:** Complete history (Fractally -> Eden -> Optimism -> ZAO)
-- **Doc 699 - ZAO Fractal Current State:** Operational status, recommendations (May 2026)
+- **Doc 702 - Fractal Lineage:** Complete history (Fractally -> Eden -> Optimism -> ZAO)
+- **Doc 703 - ZAO Fractal Current State:** Operational status, recommendations (May 2026)
 
 ---
 
@@ -516,5 +516,5 @@ export async function createORClientForViem(walletClient) {
 - [optimystics.io/tools](https://optimystics.io/tools) - Toolkit overview [FULL]
 
 **Cross-reference docs:**
-- Doc 698 (Fractal Lineage) - History + terminology [FULL]
-- Doc 699 (ZAO Fractal State) - Current ops + recommendations [FULL]
+- Doc 702 (Fractal Lineage) - History + terminology [FULL]
+- Doc 703 (ZAO Fractal State) - Current ops + recommendations [FULL]

--- a/research/governance/114-zao-fractal-live-infrastructure/README.md
+++ b/research/governance/114-zao-fractal-live-infrastructure/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 109, 188, 285, 444, 450, 698, 699
+related-docs: 56, 58, 102, 103, 104, 109, 188, 285, 444, 450, 702, 703
 original-query: "Map what's actually live, what data flows where, and what ZAO OS needs to become the one place for all data (reconstructed)"
 tier: STANDARD
 ---
@@ -319,8 +319,8 @@ respect: {
 - **Doc 285:** (Community governance deep dives)
 - **Doc 444:** (Governance tools audit)
 - **Doc 450:** (Hats Protocol integration)
-- **Doc 698:** ZAO Fractal lineage (post-research renumber)
-- **Doc 699:** ZAO Fractal current state (fresh audit, May 2026)
+- **Doc 702:** ZAO Fractal lineage (post-research renumber)
+- **Doc 703:** ZAO Fractal current state (fresh audit, May 2026)
 
 ---
 

--- a/research/governance/115-zao-data-reconciliation/README.md
+++ b/research/governance/115-zao-data-reconciliation/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 114, 184, 188, 285, 306, 698, 699
+related-docs: 56, 58, 102, 103, 104, 114, 184, 188, 285, 306, 702, 703
 original-query: "How do we unify ZAO's two Respect ledgers (OG ERC-20 fractals 1-73 in Airtable, ZOR ERC-1155 fractals 74+ on-chain) into a single source of truth in Supabase, and what is the reconciliation plan? (reconstructed)"
 tier: STANDARD
 ---
@@ -244,8 +244,8 @@ zorPct = 100 * zor_respect / (sum of all zor_respect)
 
 ## Also See
 
-- **Doc 699** - ZAO Fractal: Current State (May 2026) - operatonal status + open issues
-- **Doc 698** - Respect & Fractal Governance: The Complete Lineage - protocol history
+- **Doc 703** - ZAO Fractal: Current State (May 2026) - operatonal status + open issues
+- **Doc 702** - Respect & Fractal Governance: The Complete Lineage - protocol history
 - **Doc 114** - ZAO Fractal Governance on Optimism - original ORDAO audit
 - **Doc 188** - ZAO Fractal Bot Process - fractalbotmarch2026 design
 - **Doc 56, 58** - ORDAO-Respect system + Respect deep dive - governance mechanics

--- a/research/governance/184-superchain-ordao-crosschain-fractal/README.md
+++ b/research/governance/184-superchain-ordao-crosschain-fractal/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 109, 184, 285, 306, 346, 698, 699
+related-docs: 56, 58, 102, 103, 104, 109, 184, 285, 306, 346, 702, 703
 original-query: Superchain ORDAO cross-chain respect Hats integration Eden Epoch 2 Optimism grants ZAO (reconstructed)
 tier: STANDARD
 ---
@@ -18,7 +18,7 @@ tier: STANDARD
 | Decision | Recommendation | Rationale | Timeline |
 |----------|---|---|---|
 | **Cross-chain Respect model** | ZAO should NOT attempt cross-chain Respect bridging; instead, leverage native Superchain interop for *reading* Respect balances | Respect is soulbound (non-transferable) - bridging it contradicts the design. Hub-and-spoke reads (not transfers) are safe and preserve credible neutrality. | Adopted (no change needed) |
-| **Hats integration for ZAO** | Deploy ERC1155 Eligibility Modules on existing ZAO Hats tree, gated to ZOR Respect thresholds | Automates role assignment (Member/Contributor/Council) based on Respect tiers. Simplifies governance permission checks. | Future sprint (post-Doc-699 bottleneck fix) |
+| **Hats integration for ZAO** | Deploy ERC1155 Eligibility Modules on existing ZAO Hats tree, gated to ZOR Respect thresholds | Automates role assignment (Member/Contributor/Council) based on Respect tiers. Simplifies governance permission checks. | Future sprint (post-Doc-703 bottleneck fix) |
 | **Optimism grant track** | Pursue RetroPGF (Onchain Builders) over Grants Council - ZAO's ORDAO deployment + Respect Games are public goods with retroactive proof | RetroPGF emphasizes impact over ongoing operational need. 30M+ OP allocated; ZAO qualifies as ecosystem diversity (music vertical). | RFP window dependent |
 | **Eden Epoch 2 partnership** | Maintain ZAO as an independent fractal on Optimism; co-brand as "Superchain fractals" when discussing cross-community initiatives | ZAO is now the only active fractal on Optimism (since OP Fractal paused Jan 2026). Don't subsume into Eden; position as parallel hub. | Ongoing |
 
@@ -152,7 +152,7 @@ ZAO already has a Hats tree deployed at `0x3bc1A0Ad72417f2d411118085256fC53CBdDd
 5. Update OREC to gate proposal/execute permissions by hat wearer status
 6. Test with a proposal that requires "Council Member" hat
 
-**Status (May 2026):** Integration not yet deployed. The architecture is documented and technically ready; it awaits a sprint after the OREC submission bottleneck is resolved (doc 699 rec #1).
+**Status (May 2026):** Integration not yet deployed. The architecture is documented and technically ready; it awaits a sprint after the OREC submission bottleneck is resolved (doc 703 rec #1).
 
 ---
 
@@ -277,14 +277,14 @@ The Season 6 grant funded 6 research milestones:
 - [109 - Optimystics Tooling Ecosystem](../109-optimystics-tooling-ecosystem/README.md) - ORDAO/orclient/frapps details
 - [114 - ZAO Fractal Live Infrastructure](../114-zao-fractal-live-infrastructure/README.md) - Current operational state
 - [306 - Eden Fractal & Optimism Fractal: Complete History](../306-eden-fractal-op-fractal-deep-history/README.md) - DEEP history + people + philosophy
-- [698 - Respect & Fractal Governance: The Complete Lineage](../698-respect-fractal-lineage/README.md) - Fractally -> Eden -> OP -> ZAO
-- [699 - ZAO Fractal: Current State (May 2026)](../699-zao-fractal-current-state-may-2026/README.md) - Live operational audit
+- [702 - Respect & Fractal Governance: The Complete Lineage](../702-respect-fractal-lineage/README.md) - Fractally -> Eden -> OP -> ZAO
+- [703 - ZAO Fractal: Current State (May 2026)](../703-zao-fractal-current-state-may-2026/README.md) - Live operational audit
 
 ## Next Actions
 
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
-| Evaluate Hats integration for ZAO Governance | @Zaal or Engineering | Scoping | After Doc 699 bottleneck fix |
+| Evaluate Hats integration for ZAO Governance | @Zaal or Engineering | Scoping | After Doc 703 bottleneck fix |
 | Research and draft RetroPGF application for ZAO | @Zaal | Funding | RFP window TBD |
 | Coordinate with Eden Fractal on cross-chain spoke contracts | @Zaal + Dan SingJoy | Partnership | Q3 2026 |
 | Document Superchain ORDAO pattern for other music communities to fork | @Zaal or Research | Public good | Post-Eden collaboration |
@@ -329,7 +329,7 @@ The Season 6 grant funded 6 research milestones:
 
 ### Internal ZAO Research Sources
 
-9. **Doc 698 - Respect & Fractal Governance: The Complete Lineage** [FULL] - verified lineage, contract addresses, people
-10. **Doc 699 - ZAO Fractal: Current State (May 2026)** [FULL] - OREC 242 txns, infrastructure status, operational issues
+9. **Doc 702 - Respect & Fractal Governance: The Complete Lineage** [FULL] - verified lineage, contract addresses, people
+10. **Doc 703 - ZAO Fractal: Current State (May 2026)** [FULL] - OREC 242 txns, infrastructure status, operational issues
 11. **Doc 306 - Eden Fractal & Optimism Fractal: Complete History** [FULL] - detailed history, philosophy, people, technical stack
 12. **Codebase: community.config.ts** [FULL] - ZAO contract addresses, Hats tree address, respect block configuration

--- a/research/governance/188-zao-fractal-bot-process/README.md
+++ b/research/governance/188-zao-fractal-bot-process/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 109, 114, 285, 444, 450, 698, 699
+related-docs: 56, 58, 102, 103, 104, 109, 114, 285, 444, 450, 702, 703
 original-query: "Document the actual ZAO fractal process, the Discord bot that runs it, and integration opportunities with ZAO OS (reconstructed)"
 tier: STANDARD
 ---
@@ -459,8 +459,8 @@ respect: {
 - **Doc 285:** (Community governance deep dives)
 - **Doc 444:** (Governance tools audit)
 - **Doc 450:** (Hats Protocol integration)
-- **Doc 698:** ZAO Fractal lineage (post-research renumber)
-- **Doc 699:** ZAO Fractal current state (fresh audit, May 2026)
+- **Doc 702:** ZAO Fractal lineage (post-research renumber)
+- **Doc 703:** ZAO Fractal current state (fresh audit, May 2026)
 
 ---
 

--- a/research/governance/285-ordao-orfrapps-updated-docs/README.md
+++ b/research/governance/285-ordao-orfrapps-updated-docs/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: [56, 58, 102, 103, 104, 105, 106, 109, 114, 184, 188, 285, 306, 346, 498, 698, 699]
+related-docs: [56, 58, 102, 103, 104, 105, 106, 109, 114, 184, 188, 285, 306, 346, 498, 702, 703]
 original-query: "ORDAO and ORFrapps updated docs April 2026 - deployment, configuration, CLI" (reconstructed)
 tier: STANDARD
 ---
@@ -249,8 +249,8 @@ From Tadas (sim31) via Eden Fractal Telegram (Feb 2026):
 - **Doc 56 - ORDAO & Respect Game System:** Original design + mechanics
 - **Doc 109 - Optimystics Tooling Ecosystem:** Full tool overview (DEEP tier)
 - **Doc 184 - Superchain ORDAO:** Cross-chain expansion plans
-- **Doc 698 - Fractal Lineage:** Historical context + terminology
-- **Doc 699 - ZAO Fractal State:** Current operational status + recommendations
+- **Doc 702 - Fractal Lineage:** Historical context + terminology
+- **Doc 703 - ZAO Fractal State:** Current operational status + recommendations
 
 ---
 
@@ -284,4 +284,4 @@ From Tadas (sim31) via Eden Fractal Telegram (Feb 2026):
 
 **Cross-reference:**
 - Doc 109 (Optimystics ecosystem) - Full tools overview
-- Doc 698 (Fractal lineage) - Context + history
+- Doc 702 (Fractal lineage) - Context + history

--- a/research/governance/306-eden-fractal-op-fractal-deep-history/README.md
+++ b/research/governance/306-eden-fractal-op-fractal-deep-history/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 109, 184, 285, 346, 698, 699
+related-docs: 56, 58, 102, 103, 104, 109, 184, 285, 346, 702, 703
 original-query: Complete deep history of Eden Fractal and Optimism Fractal - philosophy architecture people chain migrations tooling (reconstructed)
 tier: DEEP
 ---
@@ -450,8 +450,8 @@ Fractals are deeply integrated into ZAO OS. Key file paths:
 - [56 - ORDAO & Respect Game System](../056-ordao-respect-system/README.md) - Weekly mechanics
 - [58 - Respect Deep Dive](../058-respect-deep-dive/README.md) - Token design, decay, tiers
 - [184 - Superchain ORDAO & Cross-Chain Fractal Governance](../184-superchain-ordao-crosschain-fractal/README.md) - Hub-and-spoke architecture
-- [698 - Respect & Fractal Governance: The Complete Lineage](../698-respect-fractal-lineage/README.md) - Full lineage with verified dates
-- [699 - ZAO Fractal: Current State (May 2026)](../699-zao-fractal-current-state-may-2026/README.md) - Live operational audit
+- [702 - Respect & Fractal Governance: The Complete Lineage](../702-respect-fractal-lineage/README.md) - Full lineage with verified dates
+- [703 - ZAO Fractal: Current State (May 2026)](../703-zao-fractal-current-state-may-2026/README.md) - Live operational audit
 
 ## Next Actions
 
@@ -545,11 +545,11 @@ Fractals are deeply integrated into ZAO OS. Key file paths:
 
 ### Internal ZAO Research
 
-16. **Doc 698 - Respect & Fractal Governance: The Complete Lineage (May 21, 2026)** [FULL]
+16. **Doc 702 - Respect & Fractal Governance: The Complete Lineage (May 21, 2026)** [FULL]
     - Cross-references all above sources with ZAO-specific context
     - Unified lineage from Larimer -> Fractally -> Eden EOS -> Genesis -> Eden Fractal -> OP Fractal -> ZAO
 
-17. **Doc 699 - ZAO Fractal: Current State (May 21, 2026)** [FULL]
+17. **Doc 703 - ZAO Fractal: Current State (May 21, 2026)** [FULL]
     - Operational audit of ZAO Fractal as of May 2026
     - OREC contract analysis (242 txns), infrastructure status, participation metrics
 

--- a/research/governance/346-iykyk-fractal-nouns-inter-dao-governance/README.md
+++ b/research/governance/346-iykyk-fractal-nouns-inter-dao-governance/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 115, 184, 188, 306, 345, 547, 698, 699
+related-docs: 115, 184, 188, 306, 345, 547, 702, 703
 original-query: "Deep dive into IYKYK DAO and Fractal Nouns - their governance framework, inter-DAO bridge, community dashboard, and how ZOUNZ treasury can use these patterns for ZABAL agent funding and token cycling (reconstructed)"
 tier: STANDARD
 ---
@@ -333,8 +333,8 @@ Proposal: "Fund VAULT agent with 1B ZABAL"
 
 ## Also See
 
-- **Doc 699** - ZAO Fractal: Current State (May 2026) - operational status
-- **Doc 698** - Respect & Fractal Governance: The Complete Lineage - governance theory
+- **Doc 703** - ZAO Fractal: Current State (May 2026) - operational status
+- **Doc 702** - Respect & Fractal Governance: The Complete Lineage - governance theory
 - **Doc 345** - ZABAL Agent Swarm Master Blueprint - agent funding architecture
 - **Doc 547** - ZAO Stock 2026 Festival + Fundraising Strategy - treasury use case
 - **Doc 115** - ZAO Respect Data Reconciliation Plan - related governance data

--- a/research/governance/702-respect-fractal-lineage/README.md
+++ b/research/governance/702-respect-fractal-lineage/README.md
@@ -4,16 +4,16 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 56, 58, 102, 103, 104, 105, 106, 109, 114, 115, 184, 188, 285, 306, 346, 498, 699
+related-docs: 56, 58, 102, 103, 104, 105, 106, 109, 114, 115, 184, 188, 285, 306, 346, 498, 703
 original-query: "prepare a full summary of respect zao fractal edenfractal optimsm fractal fractally etc"
 tier: DEEP
 ---
 
-# 698 - Respect & Fractal Governance: The Complete Lineage
+# 702 - Respect & Fractal Governance: The Complete Lineage
 
 > **Goal:** One canonical summary of the entire fractal-governance lineage ZAO sits inside - Fractally, Eden Fractal, Optimism Fractal, ZAO Fractal, the Respect token, and the ORDAO/OREC/frapps tooling - synthesized from 16+ governance research docs that currently hold this knowledge scattered across the library, with DEEP-tier verification of external claims against primary web sources.
 
-**Note:** This doc was drafted as 696 on a separate branch; renumbered to 698 because 696 was already assigned to "Zaal Panthaki + The ZAO deep audit" (doc 696).
+**Note:** This doc was drafted as 696; renumbered to 698 due to collision with "Zaal Panthaki + The ZAO deep audit" (doc 696); renumbered again to 702 due to collision with a parallel agent-research session's docs 698-701.
 
 ## What this doc is
 

--- a/research/governance/703-zao-fractal-current-state-may-2026/README.md
+++ b/research/governance/703-zao-fractal-current-state-may-2026/README.md
@@ -4,12 +4,12 @@ type: audit
 status: research-complete
 last-validated: 2026-05-21
 superseded-by: 
-related-docs: 102, 103, 104, 114, 115, 188, 306, 444, 450, 498, 502, 664, 675, 696, 698
+related-docs: 102, 103, 104, 114, 115, 188, 306, 444, 450, 498, 502, 664, 675, 696, 702
 original-query: all fractal stuff - current live state of ZAO Fractal May 2026
 tier: DEEP
 ---
 
-# 699 - ZAO Fractal: Current State (May 2026)
+# 703 - ZAO Fractal: Current State (May 2026)
 
 > **Goal:** Answer one question: what is the actual live operational state of ZAO Fractal right now, May 2026? Is the weekly Respect Game still running? What is the fractal number? What changed since March 2026? What is unresolved? What is next?
 
@@ -263,7 +263,7 @@ Features lost:
 | **How many sessions have occurred since March 22, 2026?** | fractal_sessions table created_at > '2026-03-22' | [FAILED] - cannot authenticate to Supabase; only codebase routes visible | Run /api/fractals/sessions on zaoos.com with valid session |
 | **Has the ZAOstock fractal adapter (doc 498) been deployed?** | Telegram bot logs, Supabase scoring_era='zaostock', OREC event logs tagged with ZAOstock | [PARTIAL] - designed in doc 498 (April 24), first session target May 8, but no public updates found | Check ZAOstock team Telegram, look for zaostock_sessions table, or check May 8/22 session records |
 | **Is the Snapshot cog (bot v2.1 feature) working?** | Discord #fractal-call channel messages from bot with "Snapshot proposal" alerts | [FAILED] - cannot access live Discord without auth | Check Discord bot logs on bot-hosting.net or query bot database |
-| **What is the current state of the web dashboard rebuild?** | GitHub issues in ZAOOS, PRs tagged /fractals, Vercel deployment preview | [PARTIAL] - no fractal page found in src/app/fractals/ as of May 21; codebase is API-ready but UI missing | Check ZAOOS project issues/PRs for doc 699/700 bounty or /fractals task |
+| **What is the current state of the web dashboard rebuild?** | GitHub issues in ZAOOS, PRs tagged /fractals, Vercel deployment preview | [PARTIAL] - no fractal page found in src/app/fractals/ as of May 21; codebase is API-ready but UI missing | Check ZAOOS project issues/PRs for doc 703/704 bounty or /fractals task |
 | **Has Tanja from May 18 call attended a fractal session yet?** | ZAO Discord #fractal-call attendance, fractal_sessions members array | [FAILED] - cannot query Discord or DB live | Follow up with Zaal or check Tanja's ZAO profile in members table |
 | **Are there any signer committee rotation proposals in OREC history?** | OREC contract events + on-chain governance proposals (if any) | [FAILED] - Etherscan page and ornode both unreachable | Restore ornode or use Web3 CLI to query on-chain proposal history |
 
@@ -324,7 +324,7 @@ Features lost:
 - **Doc 103** - Fractal governance ecosystem (Optimism / Eden / ZAO cross-links)
 - **Doc 104** - Fractal communities directory (who runs fractals where)
 - **Doc 306** - Eden Fractal + Optimism Fractal deep history
-- **Doc 698** - Respect & Fractal lineage summary (renumbered DEEP doc)
+- **Doc 702** - Respect & Fractal lineage summary (renumbered DEEP doc)
 - **Doc 664** - Async GitHub-native fractal brainstorm (wedge strategy)
 - **Doc 675** - Tanja fractal book call recap (May 18 decision log)
 

--- a/research/governance/704-eden-creators-media-ecosystem/README.md
+++ b/research/governance/704-eden-creators-media-ecosystem/README.md
@@ -4,12 +4,12 @@ type: guide
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 103, 104, 106, 109, 306, 498, 664, 698, 699
+related-docs: 103, 104, 106, 109, 306, 498, 664, 702, 703
 original-query: "research the Eden Creators Notion (edencreators.notion.site) - the Eden Fractal media and content ecosystem"
 tier: STANDARD
 ---
 
-# 700 - Eden Creators: The Eden Fractal Media Studio and Content Garden
+# 704 - Eden Creators: The Eden Fractal Media Studio and Content Garden
 
 > **Goal:** Document Eden Creators - the media and content arm of the Eden Fractal ecosystem - what it is, what it publishes, the "Garden" knowledge hub, and the practical fetch path for getting at its content.
 
@@ -124,8 +124,8 @@ The working path: `edencreators.com` is the same Notion workspace published on a
 - [Doc 106](../../community/106-dan-singjoy-eden-fractal-deep-dive/) - Dan SingJoy and Eden Fractal deep dive
 - [Doc 109](../109-optimystics-tooling-ecosystem/) - Optimystics tooling (Cignals and other Garden tools appear here)
 - [Doc 306](../306-eden-fractal-op-fractal-deep-history/) - Eden Fractal and Optimism Fractal deep history
-- [Doc 698](../698-respect-fractal-lineage/) - the full Respect and fractal governance lineage
-- [Doc 699](../699-zao-fractal-current-state-may-2026/) - ZAO Fractal current state
+- [Doc 702](../702-respect-fractal-lineage/) - the full Respect and fractal governance lineage
+- [Doc 703](../703-zao-fractal-current-state-may-2026/) - ZAO Fractal current state
 
 ## Next Actions
 

--- a/research/governance/705-fractal-governance-external-deep-research/README.md
+++ b/research/governance/705-fractal-governance-external-deep-research/README.md
@@ -4,14 +4,14 @@ type: market-research
 status: research-complete
 last-validated: 2026-05-21
 superseded-by:
-related-docs: 056, 058, 103, 104, 109, 114, 115, 184, 188, 285, 306, 498, 502, 664, 698, 699, 700
+related-docs: 056, 058, 103, 104, 109, 114, 115, 184, 188, 285, 306, 498, 502, 664, 702, 703, 704
 original-query: "DEEP RESEARCH TASK - definitive reference report on fractal governance and the Respect Game ecosystem (commissioned via ChatGPT deep research, 2026-05-21)"
 tier: DEEP
 ---
 
-# 701 - Fractal Governance and the Respect Game Ecosystem (External Deep-Research Synthesis)
+# 705 - Fractal Governance and the Respect Game Ecosystem (External Deep-Research Synthesis)
 
-> **Goal:** Preserve an external ChatGPT deep-research report on fractal governance, commissioned 2026-05-21, as a library reference and an independent cross-check on the fractal campaign (docs 056-306, 698-700).
+> **Goal:** Preserve an external ChatGPT deep-research report on fractal governance, commissioned 2026-05-21, as a library reference and an independent cross-check on the fractal campaign (docs 056-306, 702-704).
 
 ## Editor's note - provenance and how to read this
 
@@ -286,9 +286,9 @@ Finally, some live apps - especially `zao.frapps.xyz` and `respectgame.app` - ar
 
 ## Also See
 
-- [Doc 698](../698-respect-fractal-lineage/) - the campaign's own lineage synthesis
-- [Doc 699](../699-zao-fractal-current-state-may-2026/) - ZAO Fractal current state
-- [Doc 700](../700-eden-creators-media-ecosystem/) - Eden Creators media ecosystem
+- [Doc 702](../702-respect-fractal-lineage/) - the campaign's own lineage synthesis
+- [Doc 703](../703-zao-fractal-current-state-may-2026/) - ZAO Fractal current state
+- [Doc 704](../704-eden-creators-media-ecosystem/) - Eden Creators media ecosystem
 - [Doc 109](../109-optimystics-tooling-ecosystem/) - Optimystics tooling (the orclient v1.4.4 + respectgame.app status this report corroborates)
 - [Doc 058](../058-respect-deep-dive/) - Respect token deep dive (candidate for the Fractally round-one curve note)
 
@@ -297,7 +297,7 @@ Finally, some live apps - especially `zao.frapps.xyz` and `respectgame.app` - ar
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
 | Fold the Fractally round-one curve (21/13/8/5/3/2) into docs 058 / 698 on next revision | Research | Doc update | Next re-validation |
-| Add the "optimistic governance" philosophical tension (Fractally critique vs OREC) to doc 698 | Research | Doc update | Next re-validation |
+| Add the "optimistic governance" philosophical tension (Fractally critique vs OREC) to doc 702 | Research | Doc update | Next re-validation |
 | Standardize rank-label language to "highest-to-lowest payout order" across fractal docs | Research | Doc update | Next re-validation |
 | Use the adoption blueprint here as the Respect Game starter guide for Tanja's book project | Zaal | Reference | When Tanja is ready |
 
@@ -324,8 +324,8 @@ research/governance/497-sociocracy-circles-small-teams
 research/governance/498-zao-fractal-adapted-for-zaostock
 research/governance/502-zaostock-circles-v1-spec
 research/governance/664-farcaster-fip-pow-tokenization-and-async-github-fractal
-research/governance/698-respect-fractal-lineage
-research/governance/699-zao-fractal-current-state-may-2026
+research/governance/702-respect-fractal-lineage
+research/governance/703-zao-fractal-current-state-may-2026
 research/community/105-fractal-key-people
 research/community/106-dan-singjoy-eden-fractal-deep-dive
 research/events/675-tanja-fractal-book-call-may18


### PR DESCRIPTION
## Problem

PR #599 (fractal campaign) and PRs #600-603 (agent research) both merged with doc numbers 698-701. main now has duplicate doc numbers:

- 698: research/governance/698-respect-fractal-lineage AND research/agents/698-agent-stack-reaudit-...
- 699: research/governance/699-zao-fractal-current-state AND research/agents/699-state-of-agentic-2026
- 700: research/governance/700-eden-creators AND research/events/700-devcon-mumbai
- 701: research/governance/701-fractal-governance-external AND research/agents/701-agent-harness-engineering

## Fix

The agent-research docs keep 698-701 (they are referenced by those numbers in the agent handoff). This campaign's fractal docs move to the free range 702-705:

- 698 -> 702 Respect & fractal governance lineage
- 699 -> 703 ZAO Fractal current state (May 2026)
- 700 -> 704 Eden Creators media ecosystem
- 701 -> 705 fractal governance external deep research

4 folders git-mv'd; cross-references updated across all 19 campaign docs (related-docs, Also See, prose, source URLs). Roy Fractal "700+" member counts left intact.

## Still open (not in this PR)

The library still has other collisions from the same merge wave - 695 is used 3x, and governance/696-respect-fractal-lineage-summary (merged via #597) duplicates/is superseded by doc 702 here. Those need a separate numbering-reconciliation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)