### PR TITLE
feat(spaces): Juke developer API route (doc 695 Path B)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,3 +142,11 @@ EMPIRE_BUILDER_API_KEY=
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_ORG=
 SENTRY_PROJECT=
+
+# ── Juke Developer API ─────────────────────────────────────────
+# Server-side Juke space creation for recurring ZAO events (doc 695, Path B).
+# Apply at juke.audio/developers — sign in, request access, create an app,
+# generate a key. The secret is shown only once at creation. Server-only,
+# never expose to the browser. Optional: when unset, /api/juke/space returns
+# 503 and the keyless /live iframe embed (Path A) still works.
+JUKE_API_KEY=

--- a/src/app/api/juke/space/__tests__/route.test.ts
+++ b/src/app/api/juke/space/__tests__/route.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  makeRequest,
+  makePostRequest,
+  mockUnauthenticatedSession,
+  mockAuthenticatedSession,
+  mockAdminSession,
+} from '@/test-utils/api-helpers';
+
+const mockEnv = vi.hoisted(() => ({
+  JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+}));
+
+const { mockGetSessionData, mockCreateJukeSpace } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockCreateJukeSpace: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+vi.mock('@/lib/spaces/juke-api', () => ({
+  createJukeSpace: mockCreateJukeSpace,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/juke/space', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+  });
+
+  it('returns 401 when there is no session', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the user is not an admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Admin access required');
+    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when JUKE_API_KEY is not configured', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockEnv.JUKE_API_KEY = undefined;
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toMatch(/not configured/i);
+    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the body is not valid JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const res = await POST(
+      makeRequest('/api/juke/space', { method: 'POST', body: '{not json' }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/valid JSON/i);
+  });
+
+  it('returns 400 when the title is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: '' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid request');
+  });
+
+  it('returns 400 when scheduledAt is not an ISO datetime', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const res = await POST(
+      makePostRequest('/api/juke/space', { title: 'ZAO Live', scheduledAt: 'next tuesday' }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid request');
+  });
+
+  it('creates a space and returns 201 for an admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockCreateJukeSpace.mockResolvedValue({
+      ok: true,
+      space: {
+        id: 'zao-live-1',
+        embedUrl: 'https://juke.audio/embed/zao-live-1',
+        raw: { id: 'zao-live-1' },
+      },
+    });
+
+    const res = await POST(
+      makePostRequest('/api/juke/space', {
+        title: 'ZAOstock Standup',
+        announceCast: true,
+      }),
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.success).toBe(true);
+    expect(body.data.id).toBe('zao-live-1');
+    expect(body.data.embedUrl).toBe('https://juke.audio/embed/zao-live-1');
+    expect(mockCreateJukeSpace).toHaveBeenCalledWith(
+      { title: 'ZAOstock Standup', announceCast: true },
+      'jk_sec_live_test',
+    );
+  });
+
+  it('returns 502 when the Juke API rejects the request', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockCreateJukeSpace.mockResolvedValue({
+      ok: false,
+      status: 401,
+      error: 'Juke API returned 401',
+    });
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Juke API returned 401');
+  });
+
+  it('returns 500 when createJukeSpace throws unexpectedly', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockCreateJukeSpace.mockRejectedValue(new Error('boom'));
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Failed to create Juke space');
+  });
+});

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { createJukeSpace } from '@/lib/spaces/juke-api';
+
+/**
+ * POST /api/juke/space — create a branded Juke space (Path B of doc 695).
+ *
+ * Admin-only. ZAO runs recurring audio-worthy events (ZAOstock standups, the
+ * weekly fractal call, COC Concertz nights); this route mints a Juke space for
+ * one of them on demand and returns the `/live/{id}` embed link to share.
+ *
+ * The `JUKE_API_KEY` secret stays server-side. Until it is configured (apply
+ * at juke.audio/developers), the route reports 503 rather than failing
+ * opaquely — Path A, the keyless iframe embed, keeps working regardless.
+ */
+
+const createSpaceSchema = z.object({
+  /** Space title shown in Juke and on the ZAO `/live` surface. */
+  title: z.string().trim().min(1).max(200),
+  /** ISO-8601 start time; null or omitted opens the space immediately. */
+  scheduledAt: z.string().datetime().nullish(),
+  /** When true, Juke posts an announcement cast for the space. */
+  announceCast: z.boolean().optional(),
+  /** When true, AI agents may join the room. */
+  allowAgents: z.boolean().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSessionData();
+  if (!session) {
+    return NextResponse.json(
+      { success: false, error: 'Unauthorized' },
+      { status: 401 },
+    );
+  }
+  if (!session.isAdmin) {
+    return NextResponse.json(
+      { success: false, error: 'Admin access required' },
+      { status: 403 },
+    );
+  }
+
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          'Juke developer API is not configured. Apply at juke.audio/developers, then set JUKE_API_KEY.',
+      },
+      { status: 503 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Request body must be valid JSON' },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createSpaceSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await createJukeSpace(parsed.data, apiKey);
+    if (!result.ok) {
+      // Upstream Juke failure. Log the real status server-side; report a
+      // single 502 to the client — a Juke 401/400 is an integration problem,
+      // not a signal the ZAO caller is unauthenticated or sent a bad body.
+      logger.error('[juke/space] Juke API failed:', result.status, result.error);
+      return NextResponse.json(
+        { success: false, error: result.error },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json(
+      { success: true, data: result.space },
+      { status: 201 },
+    );
+  } catch (error: unknown) {
+    logger.error('[juke/space] Unexpected error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to create Juke space' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -87,4 +87,9 @@ export const ENV = {
   DEALER_WALLET_ID: optionalEnv('DEALER_WALLET_ID'),
   // 0x Swap API -- swap routing on Base
   ZX_API_KEY: optionalEnv('ZX_API_KEY'),
+
+  // Juke developer API -- server-side Juke space creation (doc 695, Path B).
+  // Apply at juke.audio/developers; secret shown once at key creation.
+  // Absent = /api/juke/space returns 503; the keyless /live embed still works.
+  JUKE_API_KEY: optionalEnv('JUKE_API_KEY'),
 } as const;

--- a/src/lib/spaces/juke-api.test.ts
+++ b/src/lib/spaces/juke-api.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createJukeSpace, extractSpaceId, JUKE_API_ORIGIN } from './juke-api';
+
+describe('extractSpaceId', () => {
+  it('reads a top-level id', () => {
+    expect(extractSpaceId({ id: 'abc123' })).toBe('abc123');
+  });
+
+  it('reads alternate top-level id keys', () => {
+    expect(extractSpaceId({ space_id: 'sp-1' })).toBe('sp-1');
+    expect(extractSpaceId({ spaceId: 'sp-2' })).toBe('sp-2');
+    expect(extractSpaceId({ room_id: 'rm-1' })).toBe('rm-1');
+    expect(extractSpaceId({ roomId: 'rm-2' })).toBe('rm-2');
+  });
+
+  it('reads an id nested one level deep', () => {
+    expect(extractSpaceId({ space: { id: 'nested-1' } })).toBe('nested-1');
+    expect(extractSpaceId({ room: { id: 'nested-2' } })).toBe('nested-2');
+    expect(extractSpaceId({ data: { space_id: 'nested-3' } })).toBe('nested-3');
+  });
+
+  it('prefers a top-level id over a nested one', () => {
+    expect(extractSpaceId({ id: 'top', space: { id: 'deep' } })).toBe('top');
+  });
+
+  it('rejects a structurally invalid id', () => {
+    expect(extractSpaceId({ id: 'abc/def' })).toBeNull();
+    expect(extractSpaceId({ id: '../evil' })).toBeNull();
+    expect(extractSpaceId({ id: '' })).toBeNull();
+    expect(extractSpaceId({ id: 'a'.repeat(129) })).toBeNull();
+  });
+
+  it('rejects a non-string id', () => {
+    expect(extractSpaceId({ id: 42 })).toBeNull();
+    expect(extractSpaceId({ id: null })).toBeNull();
+  });
+
+  it('returns null when no id field is present', () => {
+    expect(extractSpaceId({ title: 'no id here' })).toBeNull();
+  });
+
+  it('returns null for non-object input', () => {
+    expect(extractSpaceId(null)).toBeNull();
+    expect(extractSpaceId(undefined)).toBeNull();
+    expect(extractSpaceId('abc123')).toBeNull();
+    expect(extractSpaceId(42)).toBeNull();
+  });
+});
+
+describe('createJukeSpace', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function mockFetchOnce(init: { ok: boolean; status: number; json: () => unknown }) {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: init.ok,
+      status: init.status,
+      json: async () => init.json(),
+    } as Response);
+  }
+
+  it('posts to the developer endpoint with the API key header', async () => {
+    mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
+
+    await createJukeSpace({ title: 'ZAO Standup' }, 'jk_sec_live_test');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(`${JUKE_API_ORIGIN}/v1/developer/spaces`);
+    expect(options.method).toBe('POST');
+    expect(options.headers['X-Juke-Api-Key']).toBe('jk_sec_live_test');
+    expect(options.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('maps the camelCase input to the snake_case Juke body', async () => {
+    mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
+
+    await createJukeSpace(
+      {
+        title: 'Fractal Call',
+        scheduledAt: '2026-06-01T18:00:00.000Z',
+        announceCast: true,
+        allowAgents: true,
+      },
+      'key',
+    );
+
+    const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      title: 'Fractal Call',
+      scheduled_at: '2026-06-01T18:00:00.000Z',
+      announce_cast: true,
+      allow_agents: true,
+    });
+  });
+
+  it('defaults optional fields when omitted', async () => {
+    mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
+
+    await createJukeSpace({ title: 'Quick Room' }, 'key');
+
+    const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(JSON.parse(options.body)).toEqual({
+      title: 'Quick Room',
+      scheduled_at: null,
+      announce_cast: false,
+      allow_agents: false,
+    });
+  });
+
+  it('returns the space with an embed URL on success', async () => {
+    mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'zao-live-1' }) });
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.space.id).toBe('zao-live-1');
+      expect(result.space.embedUrl).toBe('https://juke.audio/embed/zao-live-1');
+      expect(result.space.raw).toEqual({ id: 'zao-live-1' });
+    }
+  });
+
+  it('fails when the Juke response carries no usable id', async () => {
+    mockFetchOnce({ ok: true, status: 201, json: () => ({ title: 'orphan' }) });
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/space id/i);
+    }
+  });
+
+  it('surfaces a non-2xx Juke response with its status', async () => {
+    mockFetchOnce({ ok: false, status: 401, json: () => ({}) });
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'bad-key');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toMatch(/401/);
+    }
+  });
+
+  it('returns a 502 when the Juke API is unreachable', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/reach/i);
+    }
+  });
+
+  it('reports a timeout distinctly', async () => {
+    const timeout = new Error('aborted');
+    timeout.name = 'TimeoutError';
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(timeout);
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/timed out/i);
+    }
+  });
+
+  it('returns a 502 when the Juke API returns invalid JSON', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error('Unexpected token');
+      },
+    } as Response);
+
+    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(502);
+      expect(result.error).toMatch(/invalid json/i);
+    }
+  });
+});

--- a/src/lib/spaces/juke-api.ts
+++ b/src/lib/spaces/juke-api.ts
@@ -1,0 +1,164 @@
+/**
+ * Juke developer API client — SERVER ONLY (Path B of doc 695).
+ *
+ * Creates branded Juke spaces for recurring ZAO events via the Juke developer
+ * API (`api.juke.audio`). Path A (the iframe embed in `juke.ts`) needs no
+ * keys; Path B does — `POST /v1/developer/spaces` is gated by an
+ * `X-Juke-Api-Key` secret.
+ *
+ * IMPORTANT: never import this module from a client component. The
+ * `JUKE_API_KEY` secret is passed in by the caller (the API route reads it
+ * from the environment), so this file holds no secret literal — but the Juke
+ * developer API surface is server-only regardless.
+ *
+ * The Juke developer API is in beta; its create-space *response* shape is not
+ * publicly documented. `createJukeSpace` parses the response defensively and
+ * only trusts a space id that passes `isValidJukeSpaceId`. See research doc
+ * 695 and juke.audio/llms.txt for the verified request contract.
+ */
+import { isValidJukeSpaceId, jukeEmbedUrl } from './juke';
+
+/** Base origin of the Juke REST API (distinct from the juke.audio web app). */
+export const JUKE_API_ORIGIN = 'https://api.juke.audio';
+
+/** Path of the developer create-space endpoint. */
+const CREATE_SPACE_PATH = '/v1/developer/spaces';
+
+/** Abort the Juke request if it has not responded within this many ms. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/** Input for creating a Juke space — the ZAO-facing, camelCase shape. */
+export interface CreateJukeSpaceInput {
+  /** Human-readable space title, e.g. "ZAOstock Tuesday Standup". */
+  title: string;
+  /**
+   * ISO-8601 start time for a scheduled space, or null/omitted to open the
+   * space immediately.
+   */
+  scheduledAt?: string | null;
+  /** When true, Juke posts an announcement cast for the space. */
+  announceCast?: boolean;
+  /** When true, AI agents are permitted to join the room. */
+  allowAgents?: boolean;
+}
+
+/** A Juke space created through the developer API. */
+export interface JukeSpace {
+  /** Juke space id — validated, safe to interpolate into URLs. */
+  id: string;
+  /** Embed URL for the space; `/live/{id}` renders this iframe. */
+  embedUrl: string;
+  /** The raw, undocumented Juke response, for callers that need more. */
+  raw: unknown;
+}
+
+/** Result of {@link createJukeSpace} — a discriminated union; never throws. */
+export type CreateJukeSpaceResult =
+  | { ok: true; space: JukeSpace }
+  | { ok: false; status: number; error: string };
+
+/** Id fields the Juke response is most likely to use, in priority order. */
+const ID_KEYS = ['id', 'space_id', 'spaceId', 'room_id', 'roomId'] as const;
+/** Nested objects the space id may live under one level deep. */
+const NESTED_KEYS = ['space', 'room', 'data'] as const;
+
+/**
+ * Pull a Juke space id out of the (undocumented) create-space response.
+ * Checks the id fields Juke is most likely to use, at the top level and one
+ * level deep, and returns the first that is a structurally valid space id.
+ *
+ * Exported for unit testing — the defensive parsing is the part most likely
+ * to break when Juke finalises its response shape.
+ */
+export function extractSpaceId(payload: unknown): string | null {
+  if (typeof payload !== 'object' || payload === null) return null;
+  const record = payload as Record<string, unknown>;
+
+  for (const key of ID_KEYS) {
+    if (isValidJukeSpaceId(record[key])) return record[key];
+  }
+
+  for (const nestedKey of NESTED_KEYS) {
+    const nested = record[nestedKey];
+    if (typeof nested === 'object' && nested !== null) {
+      const nestedRecord = nested as Record<string, unknown>;
+      for (const key of ID_KEYS) {
+        if (isValidJukeSpaceId(nestedRecord[key])) return nestedRecord[key];
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a Juke space through the developer API.
+ *
+ * @param input  The space to create.
+ * @param apiKey The `JUKE_API_KEY` secret, passed in by the caller — this
+ *               module never reads it from the environment itself.
+ * @returns A {@link CreateJukeSpaceResult}. This function does not throw:
+ *          network, timeout, and parse failures are returned as
+ *          `{ ok: false }` so callers handle one shape.
+ */
+export async function createJukeSpace(
+  input: CreateJukeSpaceInput,
+  apiKey: string,
+): Promise<CreateJukeSpaceResult> {
+  // Translate the camelCase ZAO shape into Juke's documented snake_case body.
+  const body = JSON.stringify({
+    title: input.title,
+    scheduled_at: input.scheduledAt ?? null,
+    announce_cast: input.announceCast ?? false,
+    allow_agents: input.allowAgents ?? false,
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(`${JUKE_API_ORIGIN}${CREATE_SPACE_PATH}`, {
+      method: 'POST',
+      headers: {
+        'X-Juke-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error: unknown) {
+    const timedOut = error instanceof Error && error.name === 'TimeoutError';
+    return {
+      ok: false,
+      status: 502,
+      error: timedOut ? 'Juke API timed out' : 'Could not reach the Juke API',
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      error: `Juke API returned ${response.status}`,
+    };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    return { ok: false, status: 502, error: 'Juke API returned invalid JSON' };
+  }
+
+  const spaceId = extractSpaceId(payload);
+  if (!spaceId) {
+    return {
+      ok: false,
+      status: 502,
+      error: 'Juke API response did not include a usable space id',
+    };
+  }
+
+  return {
+    ok: true,
+    space: { id: spaceId, embedUrl: jukeEmbedUrl(spaceId), raw: payload },
+  };
+}


### PR DESCRIPTION
## What

Path B of doc 695 (Juke integration). Adds `POST /api/juke/space` so an admin can mint a branded Juke space for a recurring ZAO event and get back the `/live/{id}` embed link.

Path A (the keyless `/live/[spaceId]` iframe embed) shipped in PR #595 + #598. This is the server-side counterpart.

## Changes

- `src/lib/spaces/juke-api.ts` - server-only Juke developer API client. `createJukeSpace()` calls `POST api.juke.audio/v1/developer/spaces` with the `X-Juke-Api-Key` header, maps the camelCase input to Juke's documented snake_case body (`title`, `scheduled_at`, `announce_cast`, `allow_agents`), and parses the response defensively. The create-space response shape is not publicly documented, so `extractSpaceId` walks the likely id fields (top-level and one level deep) and only trusts an id that passes `isValidJukeSpaceId`. Never throws - network, timeout, and parse failures return `{ ok: false }`.
- `src/app/api/juke/space/route.ts` - admin-gated route. `401` no session, `403` non-admin, `503` when `JUKE_API_KEY` is unset, `400` on bad JSON or Zod failure, `201` on success, `502` on any upstream Juke failure.
- `src/lib/env.ts` + `.env.example` - `JUKE_API_KEY` as an optional server-only secret.

Kept separate from `juke.ts` (the client-safe embed module) so no server-only code or secret literal can reach the client bundle.

## Blocked on

`JUKE_API_KEY` is not yet set. Apply at juke.audio/developers (sign in, request access, create app, generate key - secret shown once). Until then the route returns `503` and the Path A keyless embed keeps working.

## QA - Path A (live deploy)

Verified on zaoos.com: `/live` form validation (rejects non-Juke input, routes valid links), `/live/[spaceId]` embeds `juke.audio/embed/{id}` end-to-end inside the ZAO navy/gold shell. Juke's embed allows any `frame-ancestors`, middleware CSP `frame-src` + microphone Permissions-Policy already list `juke.audio`.

## Tests

26 new (17 juke-api client, 9 route). All 48 spaces tests pass. `npm run typecheck` clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)