### PR TITLE
doc 701: ZABAL Games canonical-state research (STANDARD tier)

### DIFF
--- a/research/events/630-zabal-games-claude-code-hackathon-v0/PROMPT_CONTEXT.md
+++ b/research/events/630-zabal-games-claude-code-hackathon-v0/PROMPT_CONTEXT.md
@@ -610,7 +610,7 @@ By the T+24h ship deadline, you must have all four:
 1. **Live deployed URL** (working, not 404). Vercel free tier is fine.
 2. **Public GitHub repo link** (MIT or similar permissive license). Verifiable empty git log at T+0 (no pre-built code).
 3. **60-second demo video link** (Loom, YouTube, or self-hosted). Show the thing working.
-4. **Tweet/cast on /zabalgames channel** announcing your ship. Tag `@bettercallzaal` so we see it.
+4. **Tweet/cast on /zabal channel** announcing your ship. Tag `@bettercallzaal` so we see it.
 
 PLUS during the 24h build, your declared **show-your-work visibility mode** must be active:
 - Mode 1 (Live Twitch stream): stream archive available afterward
@@ -646,7 +646,7 @@ Hour 0-1 (12:00-13:00 PT)
   Pick your build path - adopt a ZAO project or build from scratch
   Start your Twitch stream
   Read JUDGING.md (voting mechanism)
-  Cast on /zabalgames "I'm in - building [option] - watch at twitch.tv/[me]"
+  Cast on /zabal "I'm in - building [option] - watch at twitch.tv/[me]"
 
 Hour 1-2 (13:00-14:00 PT)
   Sketch what you're building - just a single doc/whiteboard
@@ -704,8 +704,8 @@ Hour 23-24 (11:00-12:00 PT)
 | Need | Where |
 |------|-------|
 | Stuck on Claude Code | Stream chat (your viewers may know) + Anthropic docs |
-| ZAO infra question | /zabalgames Farcaster channel - tag @bettercallzaal |
-| Stream tech issue | StreamElements support docs + /zabalgames channel |
+| ZAO infra question | /zabal Farcaster channel - tag @bettercallzaal |
+| Stream tech issue | StreamElements support docs + /zabal channel |
 | Wallet / gas / Empire Builder issue | DM @bettercallzaal directly |
 | Real emergency (laptop dies, internet dies) | Text Zaal at the number in your onboarding email |
 
@@ -752,13 +752,13 @@ Voting:      ZAO members who have earned Respect through fractals
             1-person-1-vote, NOT token-weighted
             Curated voter set, snapshot at T+0
 
-Stream:      Twitch primary, ZAO restreams every finalist to /zabalgames
+Stream:      Twitch primary, ZAO restreams every finalist to /zabal
 
 Submit by the T+24h ship deadline:
   1. Live deployed URL
   2. Public GitHub repo (MIT)
   3. 60-second demo video
-  4. Cast announcing ship on /zabalgames
+  4. Cast announcing ship on /zabal
 ```
 
 ---
@@ -766,7 +766,7 @@ Submit by the T+24h ship deadline:
 ## Appendix B - Key Links
 
 - ZABAL Games landing page: https://bettercallzaal.com/zabalgames.html
-- /zabalgames Farcaster channel: https://farcaster.xyz/~/channel/zabalgames
+- /zabal Farcaster channel: https://farcaster.xyz/~/channel/zabal
 - $ZABAL Empire leaderboard: https://songjam.space/zabal
 - $ZABAL creative hub: https://zabal.art/
 - Empire Builder: https://empirebuilder.world
@@ -799,4 +799,4 @@ Tech docs:
 
 ---
 
-*This CONTEXT.md is the Season 1 player primer for ZABAL Games. If you see something missing or wrong, flag it in /zabalgames channel before T+0 and we'll fix it. After T+0, this version is sealed for the duration of the August Finals to keep all finalists on equal context footing.*
+*This CONTEXT.md is the Season 1 player primer for ZABAL Games. If you see something missing or wrong, flag it in /zabal channel before T+0 and we'll fix it. After T+0, this version is sealed for the duration of the August Finals to keep all finalists on equal context footing.*

--- a/research/events/630-zabal-games-claude-code-hackathon-v0/PROMPT_CONTEXT.md
+++ b/research/events/630-zabal-games-claude-code-hackathon-v0/PROMPT_CONTEXT.md
@@ -1,8 +1,8 @@
-# ZABAL Games v0 - Player Context Bundle
+# ZABAL Games Season 1 - Player Context Bundle
 
-> **You received this because you got accepted to ZABAL Games v0.** This file is the comprehensive context primer for the ZAO ecosystem. Read it once cover to cover, then load it into your AI coding tool's context (Claude Code uses `CLAUDE.md`, Cursor uses `.cursorrules`, Windsurf uses `.windsurfrules`, Aider supports conventions files, etc.).
+> **This is the comprehensive context primer for the ZAO ecosystem.** July builders get a lighter cut; August Finalists get the full bundle as their sealed prompt. Read it once cover to cover, then load it into your AI coding tool's context (Claude Code uses `CLAUDE.md`, Cursor uses `.cursorrules`, Windsurf uses `.windsurfrules`, Aider supports conventions files, etc.).
 
-> **Status:** Draft v0 (last updated 2026-05-11). Will be locked + sealed in the prompt drop bundle at T+0 on 2026-06-27.
+> **Status:** Updated 2026-05-21 to the June/July/August Season 1 model (see ZAO research Doc 701). Calendar runs June prep / July open build-a-thon / August Finals - exact dates lock once cohort + mentors are known. The August Finals bundle is sealed at T+0 so all finalists start on equal footing.
 
 > **Tool-agnostic:** This Game is harness-agnostic. Use Claude Code, Cursor, Windsurf, Aider, Cline, Bolt, v0, Lovable, or hand-roll your own pipeline - whatever fits your style. The constraint isn't the tool, it's **show your work in public** via at least one primary visibility mode (live Twitch / recorded screen sessions / public AI prompt logs / frequent build casts).
 
@@ -19,9 +19,11 @@
    - **Cline / Continue:** add to `.cline/instructions/` or via continue.dev config
    - **Other harnesses:** check your tool's docs for project-level context file
 3. Reference it actively - if your tool autoloads project context, great. If not, paste relevant sections when prompting
-4. Treat sections as menu items - when building Option A (Empire Booster Workshop), your tool needs the Empire Builder section more than the WaveWarZ section. Tell it what you're building so it focuses
+4. Treat sections as menu items - if you are building an Empire Builder tool, your agent needs the Empire Builder section more than the WaveWarZ section. Tell it what you're building so it focuses
 
-**The single most important thing:** every prompt option in `OPTIONS.md` ties to existing ZAO rails. Use the SDKs, APIs, and patterns documented here. Don't reinvent. Composability is the point.
+**The single most important thing:** whether you adopt a started ZAO project or build from scratch, tie it to existing ZAO rails. Use the SDKs, APIs, and patterns documented here. Don't reinvent. Composability is the point.
+
+**Two build paths.** You can adopt a started / in-progress ZAO project from the curated list ZAO provides and run with it, or build something new from scratch with just this ecosystem context. Both are equally valid. There are no fixed Option A-E tracks.
 
 ---
 
@@ -240,7 +242,7 @@ Contract reads are FREE via any Base RPC - skip API keys for read paths if all y
 **ZOE:** The concierge AI (Telegram `@zaoclaw_bot`). After Doc 601 decision: ZOE backend is being rewritten to mirror Hermes's runtime pattern. Same Claude Code CLI brain, different system prompt for concierge personality. Connects to Bonfire (the memory graph) via DM relay.
 
 **Where YOU might plug in:**
-- New ZOE skill (Option D in OPTIONS.md)
+- New ZOE skill
 - Extension to Hermes (e.g. integrate it with a different code-host)
 - Build-in-public infra (e.g. a builder dashboard for `/zao-devz` Farcaster channel)
 
@@ -339,8 +341,8 @@ Hats are ERC-1155 role NFTs on Base. ZAO uses Hats for:
 - ZAO Music label member
 - COC Concertz promoter
 - ZAOstock team member (4 team-specific roles)
-- ZABAL Games v0 Champion (1st place winner - if collectible spec lands on Hats)
-- ZABAL Games v0 Finisher (every finisher)
+- ZABAL Games S1 Champion (1st place - if collectible spec lands on Hats)
+- ZABAL Games S1 Finisher (every finisher)
 
 **Hats contract on Base:** `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137`
 
@@ -468,20 +470,20 @@ Google Fonts CDN:
 
 ## Part 7 - Useful Research Docs (Curated)
 
-You have read-only access to the full ZAO research library (~630 docs as of 2026-05-10). Don't try to read all of them - here's the curated subset relevant to ZABAL Games builds.
+You have read-only access to the full ZAO research library (~700 docs as of 2026-05-21). Don't try to read all of them - here's the curated subset relevant to ZABAL Games builds.
 
 ### Foundation reading (read first)
 
 | Doc | Topic | Why |
 |-----|-------|-----|
-| 630 (this folder) | ZABAL Games v0 spec | The event rules itself |
+| 630 (this folder) | ZABAL Games Season 1 spec | The event rules itself |
 | 627 | Twitch + StreamElements integration | Your streaming infra |
 | 628 | Web3 streaming + ZABAL Empire bridge | Score feeds, tip flow, Hypersub, EAS |
 | 629 | Streaming as main media source | The auto-clip flywheel |
-| 626 | Empire Builder + ZABAL POIDH airdrop | apiLeaderboards pattern (Option A + B use this) |
+| 626 | Empire Builder + ZABAL POIDH airdrop | apiLeaderboards pattern (any leaderboard build uses this) |
 | 361 | Empire Builder v3 deep dive | Multiplier mechanics, distribute API |
 
-### For Option A (ZABAL Empire Booster Workshop)
+### If you're building Empire Builder / token tooling
 
 | Doc | Topic |
 |-----|-------|
@@ -491,7 +493,7 @@ You have read-only access to the full ZAO research library (~630 docs as of 2026
 | 258 | ZABAL/SANG buyback |
 | 573 | ZABAL AVAX surfaces - Arena Music |
 
-### For Option B (Twitch -> Empire Stream Feed)
+### If you're building streaming / live tooling
 
 | Doc | Topic |
 |-----|-------|
@@ -499,7 +501,7 @@ You have read-only access to the full ZAO research library (~630 docs as of 2026
 | 628 | Full pipeline (Part 1 has the diagram you'll implement) |
 | 626 | apiLeaderboards JSON contract |
 
-### For Option C (ZAO Farcaster Mini App)
+### If you're building a Farcaster mini app
 
 | Doc | Topic |
 |-----|-------|
@@ -507,7 +509,7 @@ You have read-only access to the full ZAO research library (~630 docs as of 2026
 | 627 | Streaming surface (for stream-tracker variant) |
 | 545 | ZABAL knowledge graph ontology |
 
-### For Option D (New ZOE Skill)
+### If you're building agent / ZOE tooling
 
 | Doc | Topic |
 |-----|-------|
@@ -516,7 +518,7 @@ You have read-only access to the full ZAO research library (~630 docs as of 2026
 | 524 | ZAO agentic everything - live/archived/started/planned |
 | 322 | Paragraph publish.new newsletter agent commerce |
 
-### For Option E (Bonfire / Hats Role Automation)
+### If you're building identity / reputation tooling
 
 | Doc | Topic |
 |-----|-------|
@@ -603,9 +605,9 @@ Voters will NOT see (and don't care about):
 
 ## Part 9 - The Submission Bar (Hit ALL Four)
 
-By T+48h (Sun 2026-06-28 12:00 PT), you must have all four:
+By the T+24h ship deadline, you must have all four:
 
-1. **Live deployed URL** (working, not 404). Vercel free tier is fine. `<player>.zabalgames.dev` subdomain provided.
+1. **Live deployed URL** (working, not 404). Vercel free tier is fine.
 2. **Public GitHub repo link** (MIT or similar permissive license). Verifiable empty git log at T+0 (no pre-built code).
 3. **60-second demo video link** (Loom, YouTube, or self-hosted). Show the thing working.
 4. **Tweet/cast on /zabalgames channel** announcing your ship. Tag `@bettercallzaal` so we see it.
@@ -641,7 +643,7 @@ This is a recommended pacing, not a requirement. Adjust to your style.
 ```
 Hour 0-1 (12:00-13:00 PT)
   Read this CONTEXT.md (you should have done this already)
-  Read OPTIONS.md and pick your option
+  Pick your build path - adopt a ZAO project or build from scratch
   Start your Twitch stream
   Read JUDGING.md (voting mechanism)
   Cast on /zabalgames "I'm in - building [option] - watch at twitch.tv/[me]"
@@ -711,11 +713,11 @@ Hour 23-24 (11:00-12:00 PT)
 
 ## Part 14 - Final Thoughts
 
-This is v0. The Games will get better with each iteration. Your role in v0 is to ship something real, get distribution from ZAO accounts, build your audience, and become part of the founding cohort.
+This is Season 1. The Games will get better with each iteration. Your role in Season 1 is to ship something real, get distribution from ZAO accounts, build your audience, and become part of the founding cohort.
 
 Whatever you build belongs to you. ZAO doesn't take IP. If it succeeds, you own that success. If it dies, you keep the learning, the footage, the audience, the collectible.
 
-Win-win-win means: even if you finish 8th, you walk away with:
+Win-win-win means: even if you place last, you walk away with:
 - Permanent onchain proof you shipped at the inaugural Games
 - 24h of Claude Code live-coding footage as a content asset
 - ~20 short-form clips of your build auto-generated by the ZAO streaming flywheel
@@ -730,29 +732,33 @@ Now go build something the community would actually use.
 ## Appendix A - Quick Reference Card
 
 ```
-T+0  :  2026-06-27 12:00 PT  -  Prompt drops + voter snapshot
-T+24h:  2026-06-28 12:00 PT  -  Ship deadline
-T+48h:  2026-06-29 12:00 PT  -  Voting opens (Snapshot)
-T+72h:  2026-06-30 12:00 PT  -  Reveal stream + USDC + collectibles
+CALENDAR (exact dates lock once cohort + mentors are known)
+  June     -  Prep month. Recorded sessions, tool walkthroughs, context.
+  July     -  Open build-a-thon. Ship a build = your application.
+  August   -  The Finals. 72-hour main event for the curated cohort.
 
-Prize pool:  $500 USDC tiered with floor (everyone selected gets paid)
+AUGUST FINALS - 72-HOUR TIMELINE (relative to T+0)
+  T+0    -  Prompt drops + voter snapshot
+  T+24h  -  Ship deadline
+  T+48h  -  Voting opens
+  T+72h  -  Reveal stream + USDC + collectibles
+
+Prize pool:  $500 USDC tiered with floor - every finalist who ships gets paid
             1st $150 / 2nd $100 / 3rd $75 / 4th-8th $35 each
             + Participation collectible (every finisher)
-            + Up to $20/mo covered for your vibe-coding tool of choice
-              (Claude Pro / Cursor Pro / Windsurf Pro / etc.)
+            (No tooling subsidy - bring your own vibe-coding tool.)
 
-Voting:      ZAO DAO members with 3-year earned vote
-            (Hats DAO Hat + Respect threshold, snapshot at T+0)
-            1-person-1-vote, vote-for-1 mechanism
-            NOT open ZABAL holder voting - this is a curated voter set
+Voting:      ZAO members who have earned Respect through fractals
+            1-person-1-vote, NOT token-weighted
+            Curated voter set, snapshot at T+0
 
-Stream:      Twitch primary, ZAO restreams all 8 to /zabalgames
+Stream:      Twitch primary, ZAO restreams every finalist to /zabalgames
 
-Submit by T+48h:
+Submit by the T+24h ship deadline:
   1. Live deployed URL
   2. Public GitHub repo (MIT)
   3. 60-second demo video
-  4. Tweet/cast announcing ship on /zabalgames
+  4. Cast announcing ship on /zabalgames
 ```
 
 ---
@@ -793,4 +799,4 @@ Tech docs:
 
 ---
 
-*This CONTEXT.md is the v0 player primer for ZABAL Games. If you see something missing or wrong, flag it in /zabalgames channel before T+0 and we'll fix it. After T+0, this version is sealed for the duration of the Games to keep all 8 players on equal context footing.*
+*This CONTEXT.md is the Season 1 player primer for ZABAL Games. If you see something missing or wrong, flag it in /zabalgames channel before T+0 and we'll fix it. After T+0, this version is sealed for the duration of the August Finals to keep all finalists on equal context footing.*

--- a/research/events/630-zabal-games-claude-code-hackathon-v0/README.md
+++ b/research/events/630-zabal-games-claude-code-hackathon-v0/README.md
@@ -3,7 +3,7 @@ topic: events
 type: guide
 status: draft
 last-validated: 2026-05-14
-related-docs: 646, 629, 628, 627, 626, 584, 361, 324, 322, 311
+related-docs: 701, 654, 646, 629, 628, 627, 626, 584, 361, 324, 322, 311
 tier: STANDARD
 ---
 
@@ -13,7 +13,9 @@ tier: STANDARD
 
 > **Status:** DRAFT - working spec, designed in the open. Heavily iterated 2026-05-08 through 2026-05-14. The shareable public summary lives at `bettercallzaal.com/zabalgames.html` (with live Supabase-backed submission tech). This doc is the source-of-truth working spec + decision log.
 
-> **Naming note:** Earlier drafts called this "v0" and "Claude Code Hackathon." Current framing: "Season 1" + "Farcaster Vibe-Coding Challenge" (tool-agnostic). Earlier drafts also referenced a person as "Aiman" - that was a phonetic misspelling of Iman, mentor #5, already on the roster.
+> **Naming note:** Earlier drafts called this "v0" and "Claude Code Hackathon." Current framing: "Season 1" + "Farcaster Vibe-Coding Challenge" (tool-agnostic).
+
+> **State note (2026-05-21):** Doc 701 is now canonical for FORMAT, CALENDAR, MENTOR MODEL, and INFRA STATE. Changes since this doc: the named 8-mentor roster is removed (mentors openly recruited, finalist count decided after July), the calendar is June prep / July build / August Finals (Doc 654), and the build prompt drops fixed Option A-E tracks for an adopt-a-started-project-or-build-from-scratch model. This doc stays the long-form spec + decision log; where it conflicts with Doc 701, Doc 701 wins.
 
 ---
 

--- a/research/events/630-zabal-games-claude-code-hackathon-v0/README.md
+++ b/research/events/630-zabal-games-claude-code-hackathon-v0/README.md
@@ -24,7 +24,7 @@ tier: STANDARD
 **What:** A Farcaster-creator onboarding event for the ZAO. Bring hungry, Farcaster-active vibe-coders into ZAO by having them build something real, in public, with a ZAO mentor in their corner.
 
 **Two phases:**
-- **Phase 1 - Open Build-a-Thon:** Anyone applies by building something with the ZAO context prompt + shipping it publicly (live URL + open-source repo + 60s demo + /zabalgames cast). Use any vibe-coding harness.
+- **Phase 1 - Open Build-a-Thon:** Anyone applies by building something with the ZAO context prompt + shipping it publicly (live URL + open-source repo + 60s demo + /zabal cast). Use any vibe-coding harness.
 - **Phase 2 - The Finals:** 8 builders curated from Phase 1, each paired with a ZAO mentor as embedded teammate. 24h build + 24h promote + 24h ZAO governance vote + reveal stream.
 
 **Who decides:** Mentors pick their champions from Phase 1 (first-come-first-served, rolling). Then the ZAO DAO (Respect-earning members, 1-person-1-vote) votes on Finals builds.
@@ -70,7 +70,7 @@ T+0->T+24h BUILD WINDOW. Mentor embedded as teammate (Discord/Meet,
            live with the player). Build in public via declared
            visibility mode. Open repos.
 T+24h      Ship deadline: live URL + open-source repo + 60s demo +
-           ship cast on /zabalgames
+           ship cast on /zabal
 T+24h->48h PROMOTE WINDOW. Cast it, demo it. ZAO accounts amplify all 8.
 T+48h->72h ZAO GOVERNANCE VOTING WINDOW. Respect-earning members cast
            1-person-1-vote ballots onchain. Live tally.
@@ -128,7 +128,7 @@ Players use whatever vibe-coding harness fits them - Claude Code, Cursor, Windsu
 
 ### 4 Visibility Modes
 
-Each player picks at least one primary mode + supplements with ongoing /zabalgames casts:
+Each player picks at least one primary mode + supplements with ongoing /zabal casts:
 
 1. **Live Twitch stream** - the default. ZAO restreams all 8 to one hub.
 2. **Recorded screen sessions** - upload to YouTube/Loom within 1h of each session.
@@ -260,7 +260,7 @@ Blocking step: Zaal creates the Supabase project, runs the schema, pastes the UR
 - $500 USDC tiered pool; all 8 Finalists get paid + collectible
 - ZAO governance vote: Respect-earning members, 1-person-1-vote, not token-weighted
 - Applications public by default
-- Submission bar: live URL + open-source repo + 60s demo + /zabalgames cast
+- Submission bar: live URL + open-source repo + 60s demo + /zabal cast
 - Season 1 framing - recurring format
 - Tooling subsidy dropped
 - Submission tech built (Supabase form + public board + starter projects)

--- a/research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/README.md
+++ b/research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/README.md
@@ -51,7 +51,7 @@ The prior framing in Doc 630 had Phase 1 building + Phase 2 Finals compressed in
 ### July - Submissions Month 1 (Open Build-a-Thon)
 
 - **Purpose:** Anyone with the chops to ship can submit a build aligned with ZABAL, ZAO, or WaveWarZ.
-- **Format:** Same as Doc 630 Phase 1 - the build IS the application. Live URL + open-source repo + 60s demo + /zabalgames cast.
+- **Format:** Same as Doc 630 Phase 1 - the build IS the application. Live URL + open-source repo + 60s demo + /zabal cast.
 - **Empire requirement:** Every submission creates a **tokenless Empire** as its public home. This gives them a leaderboard + treasury surface from day 1.
 - **Mentors watching:** 8 ZAO mentors monitor submissions rolling. Already-known champions can be picked early; surprise breakouts get picked late. First-come-first-served per mentor.
 

--- a/research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/README.md
+++ b/research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/README.md
@@ -3,7 +3,7 @@ topic: events
 type: guide
 status: research-complete
 last-validated: 2026-05-16
-related-docs: 630, 646, 631, 584, 599, 498, 505, 527, 322, 324
+related-docs: 701, 630, 646, 631, 584, 599, 498, 505, 527, 322, 324
 tier: STANDARD
 ---
 
@@ -12,6 +12,8 @@ tier: STANDARD
 > **Goal:** Capture decisions + new direction from the 2026-05-16 working session with Jordan (Empire Builder) + Iman + Zaal. Two big shifts: (1) ZABAL Games timeline moves to June prep / July submissions / August finals, (2) every Phase 2 finalist creates a tokenless Empire as their pre-launch home, then optionally Ascends with a token + Clanker airdrop using their own leaderboard as the airdrop list.
 
 > **Status:** research-complete. Supersedes the "all-in-June" framing from Doc 630. Doc 630 spec stays canonical for format; this doc updates the calendar + adds the Empire V3 mechanic.
+
+> **State note (2026-05-21):** Doc 701 is the current canonical state - it carries this doc's calendar pivot forward plus the mentor-roster-open decision. Where this doc conflicts with Doc 701, Doc 701 wins.
 
 ---
 
@@ -156,7 +158,7 @@ Jordan's framing for Farcaster's role in the ecosystem - "Farcaster is the estua
 | `/Users/zaalpanthaki/Documents/BetterCallZaal/zabalgames.html` | Replace any all-June timeline with June prep / July submissions / August finals 3-column structure. Add Empire Builder tokenless-then-Ascend mechanic to the "How it works" section. |
 | `/Users/zaalpanthaki/Documents/BetterCallZaal/zabalgames-brand-context.md` | Add the master context prompt section + Empire-as-build-home requirement. |
 | `/Users/zaalpanthaki/Documents/BetterCallZaal/zabalgames-schema.sql` | Add `empire_url` field to submissions table (optional in July, required for Phase 2 finalists). |
-| `research/events/630-zabal-games-claude-code-hackathon-v0/README.md` | Add front-matter note: "Calendar updated by Doc 653 - June prep / July build / August finals." |
+| `research/events/630-zabal-games-claude-code-hackathon-v0/README.md` | Add front-matter note: "Calendar updated by Doc 654 - June prep / July build / August finals." |
 
 ---
 
@@ -178,7 +180,7 @@ Jordan's framing for Farcaster's role in the ecosystem - "Farcaster is the estua
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
 | Update `bettercallzaal.com/zabalgames.html` to June/July/August timeline | @Zaal | Edit | This session |
-| Update Doc 630 with calendar-superseded note pointing to Doc 653 | @Zaal | PR | This week |
+| Update Doc 630 with calendar-superseded note pointing to Doc 654 | @Zaal | PR | This week |
 | Ship "ZABAL/ZAO/WaveWarZ context skill" v0 for vibe-coding agents | @Zaal | Build | End of May 2026 |
 | Get Empire Builder API key from Jordan | @Zaal | DM | Next 7 days |
 | Build Empire Builder API leaderboard for Songjam migration | @Adam + @Zaal | Build | Before June 1 |

--- a/research/events/701-zabal-games-canonical-state/README.md
+++ b/research/events/701-zabal-games-canonical-state/README.md
@@ -32,7 +32,7 @@ Recommendations and locked calls first.
 | 6 | **Tokenless Empire** | OPTIONAL mention, NOT a gate. A July build without an Empire still counts if it has live URL + repo + demo + cast. Empire Builder is presented as an available tool, not a requirement. |
 | 7 | **Prize pool** | UNCHANGED. $500 USDC, tiered 1st $150 / 2nd $100 / 3rd $75 / 4th-8th $35 each, all finalists paid. NOTE: tier table assumes 8 finalists - if Finals size lands below 8 (Decision #2), the 4th-8th band needs re-cutting. |
 | 8 | **Voting** | OPEN. Locked: Respect-earning members, 1-person-1-vote, NOT token-weighted. Still undecided: mechanism (Snapshot vs onchain) and the Respect threshold N for voter eligibility. |
-| 9 | **Participation collectible** | OPEN. "Likely a Hats Protocol role NFT" per Doc 630, spec deferred until closer to August. |
+| 9 | **Participation collectible** | LOCKED (2026-05-22). A Hats Protocol role NFT on Base. Every finisher gets one - every July build that hits the bar, plus every August finalist. |
 | 10 | **Context skill** | Does NOT exist (filesystem-verified). Status was unknown to Zaal; now confirmed. Doc 654's "ship by end of May" deadline has zero skill behind it as of 2026-05-21. |
 | 11 | **PROMPT_CONTEXT.md** | REWRITE to the June/July/August open-roster model now. The current file is stale (v0 naming, T+0 2026-06-27, dropped $20/mo subsidy, all-in-June framing). |
 | 12 | **Infra** | The `/zabal` Farcaster channel is live (created 2026-05-22). Everything else is still ahead: no Supabase backend, no `$500 USDC` secured, no `zabalgames.dev` domain. |
@@ -151,9 +151,9 @@ Pulled from Doc 654 action items + Doc 630 PROMPT_CONTEXT Part 7. Zaal to confir
 
 Every finalist who ships gets paid - tiering is recognition of standout work, not win/lose. **Open risk:** the table assumes 8 finalists. If Finals size lands below 8 (Decision #2), the 4th-8th band must be re-cut before the Finals.
 
-### Participation collectible - open
+### Participation collectible - locked
 
-Doc 630: "likely a Hats Protocol role NFT, spec TBD." Deferred (Decision #9). Who gets it (finalists only vs every July ship) is part of the deferred decision.
+A Hats Protocol role NFT on Base (Decision #9, locked 2026-05-22). Every finisher gets one: every July build that hits the submission bar, plus every August finalist. It is the universal "I shipped at ZABAL Games S1" credential, sitting alongside the Respect every July ship earns.
 
 ### Respect
 
@@ -203,12 +203,12 @@ ZABAL itself is an Ascended Empire, launched via Clanker 2026-01-01. Token contr
 | **WaveWarZ** | **Yes - the loud arena brand.** Competitive, sports-energy, stats-forward (W/L records, SOL volume). Deliberately the opposite of the warm ZAO-umbrella tone. | Partner-built (Ikechi). Pull from `wavewarz-intelligence.vercel.app` - Next Action. |
 | **ZAO Festivals / ZAOstock** | Confirmed: "Partiful warmth + Luma competence," first-person, community-rooted. | **Carries a Maine/local visual influence** - Ellsworth, Art of Ellsworth, Northeast indie. |
 | **ZAO Music** | The **artist-collective** voice - members making music together (not a label voice). | Rides the ZAO umbrella visual - no separate identity. |
-| **COC Concertz** | NEEDS INPUT - voice still blank. | NEEDS INPUT - visual still blank. |
+| **COC Concertz** | Warm, communal, builder-energy - same family as the ZAO umbrella (confirmed 2026-05-22). | Its own distinct brand - colors, logo, vibe separate from the umbrella. Spec pending - Zaal to describe. |
 | **Respect + Fractals** | Confirmed: ritual, earned, communal - reputation-with-weight, not gamified-points. | **Has a visual motif** tied to the Fibonacci ranking / fractal sessions. |
 
 **COC Concertz mission line** (was blank): **"Give virtual concerts a real home"** - a real home for virtual + metaverse concerts and the promoters who run them (Decision #13).
 
-Still open after interview: COC Concertz voice + visual; the concrete ZABAL wordmark/zabal.art palette spec; the WaveWarZ palette spec.
+Still open: COC Concertz visual spec (Zaal to describe - it is its own distinct brand); the concrete ZABAL wordmark/zabal.art palette spec; the WaveWarZ palette spec.
 
 ---
 
@@ -235,12 +235,11 @@ The `/zabal` channel exists; everything else is still ahead.
 - Exact dates for all three windows + August Finals T+0.
 - August Finals size / finalist count.
 - Voting mechanism (Snapshot vs onchain) + Respect threshold N for voter eligibility.
-- Participation collectible spec + who receives it.
 
 ### Still needs Zaal input
 
 - The confirmed adoptable-project list for the build prompt (Part 4).
-- COC Concertz voice + visual identity.
+- COC Concertz visual identity (voice locked 2026-05-22 - warm + communal).
 - The concrete ZABAL wordmark + zabal.art palette spec.
 - The WaveWarZ palette spec (extract from the live UI).
 - Per-mentor category 1-liners (collected as the open roster fills).

--- a/research/events/701-zabal-games-canonical-state/README.md
+++ b/research/events/701-zabal-games-canonical-state/README.md
@@ -2,7 +2,7 @@
 topic: events
 type: guide
 status: research-complete
-last-validated: 2026-05-21
+last-validated: 2026-05-22
 related-docs: 630, 654, 646, 626, 584, 631, 666
 original-query: "zabal games in its interity and then grill me on anything thats not defined yet"
 tier: STANDARD
@@ -35,7 +35,7 @@ Recommendations and locked calls first.
 | 9 | **Participation collectible** | OPEN. "Likely a Hats Protocol role NFT" per Doc 630, spec deferred until closer to August. |
 | 10 | **Context skill** | Does NOT exist (filesystem-verified). Status was unknown to Zaal; now confirmed. Doc 654's "ship by end of May" deadline has zero skill behind it as of 2026-05-21. |
 | 11 | **PROMPT_CONTEXT.md** | REWRITE to the June/July/August open-roster model now. The current file is stale (v0 naming, T+0 2026-06-27, dropped $20/mo subsidy, all-in-June framing). |
-| 12 | **Infra** | NOTHING is live: no Supabase backend, no `/zabalgames` Farcaster channel, no `$500 USDC` secured, no `zabalgames.dev` domain. |
+| 12 | **Infra** | The `/zabal` Farcaster channel is live (created 2026-05-22). Everything else is still ahead: no Supabase backend, no `$500 USDC` secured, no `zabalgames.dev` domain. |
 | 13 | **Brand context** | The 7 `[TBD-Zaal]` voice/visual gaps in `zabalgames-brand-context.md` resolved in interview - see Part 7. |
 | 14 | **This session scope** | Full sweep: this doc + fix `zabalgames.html` mentor copy + rewrite `PROMPT_CONTEXT.md` + draft a public recruitment post. |
 
@@ -61,7 +61,7 @@ Three months. Pivoted from the original all-June compression in the 2026-05-16 m
 | Month | Phase | What runs |
 |-------|-------|-----------|
 | **June** | Prep | Recorded Far-Hack-style sessions. ZAO teachers cover governance, Respect, ZOLs, fractals. Vibe-coding instructors cover Claude Code, Cursor, MCP, agent harnesses. Tool walkthroughs: Empire Builder V3, zlank.online, POIDH bounties, Juke, Songjam. Watchable live or after. The ZAO context skill is meant to go live here for any agent to load. |
-| **July** | Open build-a-thon | Anyone with the chops ships a build aligned to ZABAL / ZAO / WaveWarZ. The build IS the application. Bar: live URL + open-source repo + 60s demo + `/zabalgames` cast. Mentors watch rolling and claim champions. Every July ship earns Respect (Decision #4). |
+| **July** | Open build-a-thon | Anyone with the chops ships a build aligned to ZABAL / ZAO / WaveWarZ. The build IS the application. Bar: live URL + open-source repo + 60s demo + `/zabal` cast. Mentors watch rolling and claim champions. Every July ship earns Respect (Decision #4). |
 | **August** | The Finals | Mentor-champion pairs lock. Same Finals prompt for all. 24h build (mentor embedded as teammate) + 24h promote + 24h ZAO governance vote + live reveal stream. Finalists who want a token Ascend their Empire via Clanker with an airdrop. |
 
 **Why three months:** the original ~30-day all-June plan compressed teach + build + judge too tightly. June-prep solves "people show up cold." July-as-open-month lets builds breathe and lets mentors evaluate a real submission pool. August gets the Finals' focused energy.
@@ -129,7 +129,7 @@ Pulled from Doc 654 action items + Doc 630 PROMPT_CONTEXT Part 7. Zaal to confir
 - zlank.online "Today's Empire Builder Stats" daily Snap template (kmac.eth template collab).
 - Twitch -> Empire Builder stream score feed.
 - New ZOE skill(s).
-- The `/zabalgames` Farcaster mini app itself (submission board, starter board).
+- The `/zabal` Farcaster mini app itself (submission board, starter board).
 - COC Concertz content-pipeline automation (record -> Descript -> newsletter -> cross-post).
 - Streaming auto-clip flywheel (30+ hours of Games stream -> 150+ short clips).
 
@@ -214,12 +214,12 @@ Still open after interview: COC Concertz voice + visual; the concrete ZABAL word
 
 ## Part 8 - Infrastructure Status
 
-Nothing is live (Decision #12). Full build-out is still ahead.
+The `/zabal` channel exists; everything else is still ahead.
 
 | Item | Status | Notes |
 |------|--------|-------|
 | Supabase submission backend | NOT LIVE | `zabalgames-schema.sql` exists (5.2 KB). Project not created, schema not run, no URL/anon key in `zabalgames.html`. The form + board are non-functional. |
-| `/zabalgames` Farcaster channel | NOT LIVE | Referenced everywhere as the cast destination. Does not exist yet. |
+| `/zabal` Farcaster channel | LIVE | The cast destination - farcaster.xyz/~/channel/zabal. Created 2026-05-22. All copy uses `/zabal` (the page stays `zabalgames.html`). |
 | `$500 USDC` prize wallet | NOT SECURED | No dedicated wallet funded. |
 | `zabalgames.dev` domain | NOT REGISTERED | `PROMPT_CONTEXT.md` promises `<player>.zabalgames.dev` subdomains. |
 | ZAO context skill | DOES NOT EXIST | Filesystem-verified - no skill folder in `~/.claude/skills`, `.agents/skills`, or ZAO OS. Raw material only: `zabalgames-brand-context.md` (7 gaps) + `PROMPT_CONTEXT.md` (stale). |
@@ -291,7 +291,6 @@ Nothing is live (Decision #12). Full build-out is still ahead.
 | Pull ZABAL wordmark + zabal.art palette into brand-context | @Zaal | Research | Before context skill ships |
 | Build the ZAO context skill (does not exist) | @Zaal | Build | Re-baseline the end-of-May deadline |
 | Create Supabase project + run schema + wire `zabalgames.html` | @Zaal | Build | Before July open call |
-| Create the `/zabalgames` Farcaster channel | @Zaal | Config | Before June bootcamp |
 | Secure $500 USDC in a dedicated wallet | @Zaal | Treasury | Before August Finals |
 | Decide: Finals size, voting mechanism, Respect threshold, collectible spec | @Zaal | Decision | After July submissions land |
 | Lock exact dates once cohort + mentor availability known | @Zaal | Decision | When open call closes |

--- a/research/events/701-zabal-games-canonical-state/README.md
+++ b/research/events/701-zabal-games-canonical-state/README.md
@@ -1,0 +1,310 @@
+---
+topic: events
+type: guide
+status: research-complete
+last-validated: 2026-05-21
+related-docs: 630, 654, 646, 626, 584, 631, 666
+original-query: "zabal games in its interity and then grill me on anything thats not defined yet"
+tier: STANDARD
+---
+
+# 701 - ZABAL Games: Canonical State (post mentor-open pivot)
+
+> **Goal:** One consolidated source of truth for ZABAL Games as of 2026-05-21. Folds Doc 630 (Season 1 spec), Doc 654 (Empire V3 / June-July-August calendar pivot), and Doc 646 (Clanker token mechanic) into a single state-of-the-event, then records 24 decisions taken in a structured decision interview with Zaal on 2026-05-21.
+
+> **Status:** research-complete. This doc is canonical for FORMAT, CALENDAR, MENTOR MODEL, and INFRA STATE. Where it conflicts with Doc 630 or Doc 654, this doc wins (it is later and reflects live decisions). Doc 630 stays the long-form spec and decision log; Doc 654 stays the meeting record. Both get a superseded-for-state note pointing here.
+
+> **Method note:** This is an internal consolidation, not a web-research doc. "Research" here = full read of the four canonical internal docs + the live `zabalgames.html` + filesystem verification of skill/infra claims, followed by a 6-round / 24-question decision interview with Zaal. No external web sources - the event is internal to the ZAO ecosystem. Sources are marked FULL/internal accordingly.
+
+---
+
+## Key Decisions (2026-05-21 interview)
+
+Recommendations and locked calls first.
+
+| # | Area | Decision |
+|---|------|----------|
+| 1 | **Mentor roster** | REMOVE the named 8-mentor roster from Doc 630 (ohnahji, candytoybox, eduard, freezetheverse, Iman, Thy Revolution, Tom Fellenz, Adam SongJam). Mentors are now **openly recruited** via the public form. The embedded-teammate mechanic STAYS - a mentor still embeds as a builder's teammate during the August Finals. |
+| 2 | **Finals size** | OPEN. Doc 630 hard-tied 8 finalists to 8 mentors. With the roster open, the August Finals size is decided AFTER July, once submission volume and mentor signups are both known. |
+| 3 | **Calendar** | June prep / July build / August Finals stays as three loose MONTHS. Exact dates (bootcamp open, July window, August Finals week, T+0) stay OPEN - they lock once cohort + mentor availability are known. |
+| 4 | **July non-finalist reward** | Every July submission that hits the bar **earns Respect** in ZAO governance. Not just finalists. This pulls non-selected builders into the community regardless of Finals outcome. |
+| 5 | **Build prompt** | No fixed Option A-E tracks (the never-written `OPTIONS.md` is dropped). Builders get TWO paths: (a) **adopt a started/in-progress ZAO project** from a curated list and run with it, or (b) **build from scratch** with just the platform context. |
+| 6 | **Tokenless Empire** | OPTIONAL mention, NOT a gate. A July build without an Empire still counts if it has live URL + repo + demo + cast. Empire Builder is presented as an available tool, not a requirement. |
+| 7 | **Prize pool** | UNCHANGED. $500 USDC, tiered 1st $150 / 2nd $100 / 3rd $75 / 4th-8th $35 each, all finalists paid. NOTE: tier table assumes 8 finalists - if Finals size lands below 8 (Decision #2), the 4th-8th band needs re-cutting. |
+| 8 | **Voting** | OPEN. Locked: Respect-earning members, 1-person-1-vote, NOT token-weighted. Still undecided: mechanism (Snapshot vs onchain) and the Respect threshold N for voter eligibility. |
+| 9 | **Participation collectible** | OPEN. "Likely a Hats Protocol role NFT" per Doc 630, spec deferred until closer to August. |
+| 10 | **Context skill** | Does NOT exist (filesystem-verified). Status was unknown to Zaal; now confirmed. Doc 654's "ship by end of May" deadline has zero skill behind it as of 2026-05-21. |
+| 11 | **PROMPT_CONTEXT.md** | REWRITE to the June/July/August open-roster model now. The current file is stale (v0 naming, T+0 2026-06-27, dropped $20/mo subsidy, all-in-June framing). |
+| 12 | **Infra** | NOTHING is live: no Supabase backend, no `/zabalgames` Farcaster channel, no `$500 USDC` secured, no `zabalgames.dev` domain. |
+| 13 | **Brand context** | The 7 `[TBD-Zaal]` voice/visual gaps in `zabalgames-brand-context.md` resolved in interview - see Part 7. |
+| 14 | **This session scope** | Full sweep: this doc + fix `zabalgames.html` mentor copy + rewrite `PROMPT_CONTEXT.md` + draft a public recruitment post. |
+
+---
+
+## Part 1 - What ZABAL Games Is
+
+ZABAL Games is **not a generic hackathon**. It is a **Farcaster-creator onboarding event for the ZAO ecosystem** - a structured way to bring hungry, Farcaster-active vibe-coders into ZAO by having them build something real, in public, with a ZAO mentor in their corner.
+
+- **Host:** Zaal / BetterCallZaal (FID 19640).
+- **Framing:** "Season 1" - a recurring format. Earlier drafts called it "v0" / "Claude Code Hackathon"; current framing is Season 1 + "Farcaster Vibe-Coding Challenge" (tool-agnostic).
+- **Thesis:** The builds matter, but the people matter more. Bring talented builders in, give them deep ZAO context, let them ship something useful for the community with a ZAO mentor as embedded teammate, and have them earn governance during the event itself. Stay after - great. Leave - they still walk away with a real artifact, a real relationship, and a real onchain credential.
+- **What success looks like:** A cohort of new builders who understand ZAO from the inside, a stack of real artifacts shipped for the ecosystem, and a repeatable format that compounds the builder network each Season.
+
+Public landing page: `bettercallzaal.com/zabalgames.html`.
+
+---
+
+## Part 2 - The Calendar (June / July / August)
+
+Three months. Pivoted from the original all-June compression in the 2026-05-16 meeting with Jordan/yerbearzerker (Doc 654). Dates stay at month granularity - exact dates lock once cohort + mentor availability are known (Decision #3).
+
+| Month | Phase | What runs |
+|-------|-------|-----------|
+| **June** | Prep | Recorded Far-Hack-style sessions. ZAO teachers cover governance, Respect, ZOLs, fractals. Vibe-coding instructors cover Claude Code, Cursor, MCP, agent harnesses. Tool walkthroughs: Empire Builder V3, zlank.online, POIDH bounties, Juke, Songjam. Watchable live or after. The ZAO context skill is meant to go live here for any agent to load. |
+| **July** | Open build-a-thon | Anyone with the chops ships a build aligned to ZABAL / ZAO / WaveWarZ. The build IS the application. Bar: live URL + open-source repo + 60s demo + `/zabalgames` cast. Mentors watch rolling and claim champions. Every July ship earns Respect (Decision #4). |
+| **August** | The Finals | Mentor-champion pairs lock. Same Finals prompt for all. 24h build (mentor embedded as teammate) + 24h promote + 24h ZAO governance vote + live reveal stream. Finalists who want a token Ascend their Empire via Clanker with an airdrop. |
+
+**Why three months:** the original ~30-day all-June plan compressed teach + build + judge too tightly. June-prep solves "people show up cold." July-as-open-month lets builds breathe and lets mentors evaluate a real submission pool. August gets the Finals' focused energy.
+
+### August Finals 72-hour timeline (relative; absolute T+0 open)
+
+```
+T-3 days   Onboarding call: rules, infra, wallet linkage, visibility-mode
+           lock-in, voting walkthrough
+T+0        Prompt drops to all finalists simultaneously. Voter snapshot taken.
+T+0..24h   BUILD WINDOW. Mentor embedded as teammate. Build in public.
+T+24h      Ship deadline: live URL + open-source repo + 60s demo + ship cast
+T+24..48h  PROMOTE WINDOW. ZAO accounts amplify all builds.
+T+48..72h  ZAO GOVERNANCE VOTE. Respect-earning members, 1-person-1-vote.
+T+72h      Live results-reveal stream. Recognition order announced.
+           USDC + collectibles distributed.
+```
+
+---
+
+## Part 3 - Format
+
+### Two-phase model
+
+| Phase | What |
+|-------|------|
+| **Phase 1 - July open build-a-thon** | Anyone can enter by building. Vibe-code something with the ZAO context, ship it publicly. The build is the application. Genuinely open - curation happens on demonstrated work, not bios. |
+| **Curation window** | As July builds ship, ZAO mentors watch rolling. Each mentor claims one champion - first-come-first-served per mentor. Mentor-champion pairs lock the August Finals roster. |
+| **Phase 2 - August Finals** | Same Finals prompt for all finalists. 24h build with mentor embedded + 24h promote + 24h governance vote + reveal stream. |
+
+### Mentors - open roster (CHANGED 2026-05-21)
+
+The named 8-mentor roster from Doc 630 is **removed** (Decision #1). Mentors are now openly recruited through the public form on `zabalgames.html`. What stays:
+
+- The **embedded-teammate mechanic**: a mentor pairs with a champion and is live with them through the August Finals (Discord/Meet, DMs, on-call) - handling project management, ZAO connections, and distribution while the player codes.
+- The mentor is as important as the player - the connection point that keeps the player locked in.
+- **Mentor incentive ("on the team"):** a Hats Protocol "ZAO Mentor S1" role NFT (permanent onchain role), a private mentor channel, public cast credit, ongoing ZAO ops involvement, auto-eligibility for future Seasons. No cash - team membership + status.
+- **Per-mentor categories:** each mentor still defines their own search style (the builder archetype they want) before the open call. Collected as the roster fills.
+
+### Finalist count - open
+
+Doc 630 fixed 8 finalists because there were 8 mentors. With the roster open, **the Finals size is decided after July** (Decision #2), keyed off submission volume and how many mentors sign up. The "all finalists win" principle holds regardless of count: the competition is in Phase 1 selection; the Finals are a collaboration.
+
+### Tooling + visibility
+
+- **Tool-agnostic.** Claude Code, Cursor, Windsurf, Aider, Cline, Bolt, v0, Lovable, or a hand-rolled pipeline. The constraint is not the tool - it is **show your work in public**.
+- **4 visibility modes**, pick at least one primary: (1) live Twitch stream, (2) recorded screen sessions uploaded within 1h, (3) public AI prompt logs every 1-2h, (4) frequent build casts every 1-2h.
+- **Anti-cheat:** empty starter repo at T+0 (verified empty git log) + visibility-mode timestamps cross-checked against git commit times.
+
+---
+
+## Part 4 - The Build Prompt
+
+No fixed Option A-E tracks. The `OPTIONS.md` referenced by `PROMPT_CONTEXT.md` was never written and is now dropped (Decision #5). Builders get two paths:
+
+1. **Adopt a started ZAO project.** A curated list of started / in-progress ZAO projects is given to builders as ideas they can pick up and run with.
+2. **Build from scratch.** Build anything that helps the ZAO ecosystem, using only the platform context.
+
+### Candidate adoptable-project list (NEEDS ZAAL CONFIRMATION)
+
+Pulled from Doc 654 action items + Doc 630 PROMPT_CONTEXT Part 7. Zaal to confirm which are real, adoptable, and unclaimed, and add what is missing:
+
+- Songjam leaderboard migration - move the leaderboard off the deprecated X scraper onto an Empire Builder API leaderboard.
+- POIDH bounty leaderboard on Empire Builder - counts unique on-chain bounty submitters.
+- zlank.online "Today's Empire Builder Stats" daily Snap template (kmac.eth template collab).
+- Twitch -> Empire Builder stream score feed.
+- New ZOE skill(s).
+- The `/zabalgames` Farcaster mini app itself (submission board, starter board).
+- COC Concertz content-pipeline automation (record -> Descript -> newsletter -> cross-post).
+- Streaming auto-clip flywheel (30+ hours of Games stream -> 150+ short clips).
+
+**This list is a Next Action - it is NOT yet confirmed.**
+
+---
+
+## Part 5 - Prize, Collectible, Respect
+
+### Prize pool - unchanged ($500 USDC)
+
+| Place | USDC |
+|-------|------|
+| 1st | $150 |
+| 2nd | $100 |
+| 3rd | $75 |
+| 4th-8th | $35 each |
+| **Total** | **$500** |
+
+Every finalist who ships gets paid - tiering is recognition of standout work, not win/lose. **Open risk:** the table assumes 8 finalists. If Finals size lands below 8 (Decision #2), the 4th-8th band must be re-cut before the Finals.
+
+### Participation collectible - open
+
+Doc 630: "likely a Hats Protocol role NFT, spec TBD." Deferred (Decision #9). Who gets it (finalists only vs every July ship) is part of the deferred decision.
+
+### Respect
+
+- Every July submission that hits the bar earns Respect (Decision #4).
+- Finalists earn additional Respect during the August Finals.
+- Respect is ZAO's soulbound, peer-validated, Fibonacci-ranked reputation - earned in weekly fractal sessions. It is also what defines the ZABAL Games voter set.
+
+### Total ZAO cost
+
+~$510-525: $500 USDC pool + ~$10 Hats mints on Base. Submission tech (Supabase free tier) and voting infra are $0. Tooling subsidy was dropped 2026-05-11.
+
+---
+
+## Part 6 - Empire Builder + Token Mechanic
+
+### Empire V3 tier stack (Doc 654)
+
+| | Basic Empire (free, tokenless) | Ascended Empire (token launch) |
+|--|------|------|
+| Leaderboards | 2 | 10 |
+| Boosters | 10 | 40 |
+| Ranked spots/leaderboard | 250 | 500 |
+| Cost | Free | Token launch via Empire Builder UI |
+
+### Build-then-airdrop pattern
+
+Optional, finalist-driven. A builder can: build a contribution leaderboard during the Games -> export the CSV -> that IS the airdrop list -> launch a token through Empire Builder's Clanker integration -> Empire instantly Ascends -> airdrop with a vesting schedule to the CSV. Contributors get paid before speculators arrive.
+
+Jordan's framing: "Token is an assist. It serves a role in the ecosystem. We're not optimizing for speculators." The anti-pattern is "launch token first, figure out project later."
+
+### Token mechanic (Doc 646)
+
+Fully opt-in. Default = no token. A finalist who wants "stream tied to a token" mints via Clanker (Farcaster cast, effectively zero cost, LP auto-paired with WETH, 100% creator fees to player wallet). Token volume is a parallel viewer signal displayed alongside the DAO vote - it does NOT influence placement. Recommended surfacing for v0: mention in onboarding only, keep the public page clean.
+
+ZABAL itself is an Ascended Empire, launched via Clanker 2026-01-01. Token contract `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` on Base. Empire address `0xe0faa499d6711870211505bd9ae2105206af1462`.
+
+---
+
+## Part 7 - Brand Context Resolution
+
+`zabalgames-brand-context.md` had 7 `[TBD-Zaal]` voice/visual gaps. Resolved in interview (Decision #13):
+
+| Brand | Voice | Visual |
+|-------|-------|--------|
+| **ZAO OS** | 1:1 with the ZAO umbrella - no distinct tone. | 1:1 with the umbrella - no distinct treatment. |
+| **$ZABAL + Empire Builder** | Mechanism-forward, token-economy-native, transparent, not hype-y (draft confirmed). | **Has its own wordmark/logo and a distinct zabal.art creative-hub aesthetic.** Exact palette + wordmark spec must be pulled from `zabal.art` - flagged as a Next Action, not invented here. |
+| **WaveWarZ** | **Yes - the loud arena brand.** Competitive, sports-energy, stats-forward (W/L records, SOL volume). Deliberately the opposite of the warm ZAO-umbrella tone. | Partner-built (Ikechi). Pull from `wavewarz-intelligence.vercel.app` - Next Action. |
+| **ZAO Festivals / ZAOstock** | Confirmed: "Partiful warmth + Luma competence," first-person, community-rooted. | **Carries a Maine/local visual influence** - Ellsworth, Art of Ellsworth, Northeast indie. |
+| **ZAO Music** | The **artist-collective** voice - members making music together (not a label voice). | Rides the ZAO umbrella visual - no separate identity. |
+| **COC Concertz** | NEEDS INPUT - voice still blank. | NEEDS INPUT - visual still blank. |
+| **Respect + Fractals** | Confirmed: ritual, earned, communal - reputation-with-weight, not gamified-points. | **Has a visual motif** tied to the Fibonacci ranking / fractal sessions. |
+
+**COC Concertz mission line** (was blank): **"Give virtual concerts a real home"** - a real home for virtual + metaverse concerts and the promoters who run them (Decision #13).
+
+Still open after interview: COC Concertz voice + visual; the concrete ZABAL wordmark/zabal.art palette spec; the WaveWarZ palette spec.
+
+---
+
+## Part 8 - Infrastructure Status
+
+Nothing is live (Decision #12). Full build-out is still ahead.
+
+| Item | Status | Notes |
+|------|--------|-------|
+| Supabase submission backend | NOT LIVE | `zabalgames-schema.sql` exists (5.2 KB). Project not created, schema not run, no URL/anon key in `zabalgames.html`. The form + board are non-functional. |
+| `/zabalgames` Farcaster channel | NOT LIVE | Referenced everywhere as the cast destination. Does not exist yet. |
+| `$500 USDC` prize wallet | NOT SECURED | No dedicated wallet funded. |
+| `zabalgames.dev` domain | NOT REGISTERED | `PROMPT_CONTEXT.md` promises `<player>.zabalgames.dev` subdomains. |
+| ZAO context skill | DOES NOT EXIST | Filesystem-verified - no skill folder in `~/.claude/skills`, `.agents/skills`, or ZAO OS. Raw material only: `zabalgames-brand-context.md` (7 gaps) + `PROMPT_CONTEXT.md` (stale). |
+| `zabalgames.html` page | LIVE | Calendar already updated to June/July/August. Mentor copy still says "8 ZAO mentors" in ~15 places - needs the open-roster rewrite. |
+| `OPTIONS.md` | NEVER WRITTEN | Dropped (Decision #5). |
+
+---
+
+## Part 9 - Open Gaps
+
+### Deliberately open (decided to leave open)
+
+- Exact dates for all three windows + August Finals T+0.
+- August Finals size / finalist count.
+- Voting mechanism (Snapshot vs onchain) + Respect threshold N for voter eligibility.
+- Participation collectible spec + who receives it.
+
+### Still needs Zaal input
+
+- The confirmed adoptable-project list for the build prompt (Part 4).
+- COC Concertz voice + visual identity.
+- The concrete ZABAL wordmark + zabal.art palette spec.
+- The WaveWarZ palette spec (extract from the live UI).
+- Per-mentor category 1-liners (collected as the open roster fills).
+- The August Finals prompt content (sealed-until-T+0, still to be written).
+
+### Doc hygiene
+
+- Doc 654's folder is `654-...` but its body twice cites itself as "Doc 653." Cosmetic - fix on next touch.
+
+---
+
+## Part 10 - File + Doc Touch Points
+
+| File / Doc | Action |
+|------------|--------|
+| `BetterCallZaal/zabalgames.html` | Rewrite all "8 ZAO mentors" copy to the open-roster model. Confirm calendar copy. (This session.) |
+| `BetterCallZaal/zabalgames-brand-context.md` | Fill the 7 voice/visual fields with Part 7 resolutions; leave COC + concrete palettes flagged. (This session.) |
+| `ZAO OS V1/research/events/630-.../PROMPT_CONTEXT.md` | Full rewrite to June/July/August open-roster model. (This session.) |
+| `ZAO OS V1/research/events/630-.../README.md` | Add a superseded-for-state note pointing to Doc 701. |
+| `ZAO OS V1/research/events/654-.../README.md` | Add a superseded-for-state note pointing to Doc 701; fix the "Doc 653" self-reference. |
+| `BetterCallZaal/zabalgames-schema.sql` | No change - holds until Supabase project is created. |
+| Recruitment post | Draft a public post to open mentor + builder recruitment. (This session.) |
+
+---
+
+## Also See
+
+- [Doc 630](../630-zabal-games-claude-code-hackathon-v0/) - ZABAL Games Season 1 long-form spec + decision log + `PROMPT_CONTEXT.md`
+- [Doc 654](../654-zabal-games-empire-v3-yerbearzerker-meeting/) - Empire V3 + June/July/August calendar pivot meeting
+- [Doc 646](../../business/646-clanker-empire-builder-zabal-games-promote/) - Clanker + Empire Builder optional token mechanic
+- [Doc 626](../../business/626-empire-builder-zabal-poidh-airdrop/) - Empire Builder apiLeaderboards + POIDH airdrop pattern
+- [Doc 584](../../business/584-empire-builder-farcaster-creator-playbooks/) - Empire Builder creator playbooks + booster stacks
+- [Doc 631](../../business/631-poidh-zabal-sentinel-convergence/) - POIDH x ZABAL on-chain bounty data
+- [Doc 666](../../business/666-zabal-brand-kit-page/) - ZABAL brand kit page
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Rewrite `zabalgames.html` mentor copy to open-roster model | @Zaal | Edit | This session |
+| Fill `zabalgames-brand-context.md` voice/visual fields | @Zaal | Edit | This session |
+| Rewrite `PROMPT_CONTEXT.md` to June/July/August open-roster | @Zaal | Edit | This session |
+| Draft + publish public mentor/builder recruitment post | @Zaal | Cast | This session draft; publish when ready |
+| Confirm the adoptable-project list (Part 4) | @Zaal | Decision | Before June bootcamp |
+| Define COC Concertz voice + visual | @Zaal | Decision | Before context skill ships |
+| Pull ZABAL wordmark + zabal.art palette into brand-context | @Zaal | Research | Before context skill ships |
+| Build the ZAO context skill (does not exist) | @Zaal | Build | Re-baseline the end-of-May deadline |
+| Create Supabase project + run schema + wire `zabalgames.html` | @Zaal | Build | Before July open call |
+| Create the `/zabalgames` Farcaster channel | @Zaal | Config | Before June bootcamp |
+| Secure $500 USDC in a dedicated wallet | @Zaal | Treasury | Before August Finals |
+| Decide: Finals size, voting mechanism, Respect threshold, collectible spec | @Zaal | Decision | After July submissions land |
+| Lock exact dates once cohort + mentor availability known | @Zaal | Decision | When open call closes |
+
+---
+
+## Sources
+
+- [FULL] `ZAO OS V1/research/events/630-zabal-games-claude-code-hackathon-v0/README.md` - Season 1 spec, read in full.
+- [FULL] `ZAO OS V1/research/events/630-zabal-games-claude-code-hackathon-v0/PROMPT_CONTEXT.md` - player bundle, read in full; confirmed stale.
+- [FULL] `ZAO OS V1/research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/README.md` - Empire V3 meeting, read in full.
+- [FULL] `ZAO OS V1/research/business/646-clanker-empire-builder-zabal-games-promote/README.md` - token mechanic, read in full.
+- [FULL] `BetterCallZaal/zabalgames-brand-context.md` - brand identity guide, read in full.
+- [FULL] `BetterCallZaal/zabalgames.html` - live landing page, scanned for calendar + mentor copy.
+- [FULL] Filesystem verification 2026-05-21 - context skill absent; `OPTIONS.md` absent; `zabalgames-schema.sql` present.
+- [FULL] Decision interview with Zaal, 2026-05-21 - 6 rounds, 24 questions, recorded as Key Decisions above.


### PR DESCRIPTION
## Summary

Doc 701 is one consolidated source of truth for ZABAL Games as of 2026-05-21 - it folds Doc 630 (Season 1 spec), Doc 654 (Empire V3 calendar pivot), and Doc 646 (Clanker mechanic) into a single state-of-the-event and records 24 decisions from a structured interview with Zaal.

Key decisions captured:
- Named 8-mentor roster removed - mentors now openly recruited; the embedded-teammate mechanic stays
- Finalist count open - decided after July submission volume is known
- Build prompt drops fixed Option A-E tracks for adopt-a-started-project-or-build-from-scratch
- July non-finalists earn Respect
- Calendar stays month-level (June prep / July build / August Finals)
- Infra confirmed at zero (no Supabase, channel, USDC, domain); context skill confirmed nonexistent

## Tier

STANDARD - internal consolidation (4 canonical docs read in full + filesystem verification + 6-round decision interview). No external web sources; ZABAL Games is an internal ZAO event.

## Also in this PR

- `PROMPT_CONTEXT.md` rewritten to the Season 1 / June-July-August open-roster model (dropped v0 naming, dead T+0 dates, $20/mo subsidy, OPTIONS.md Option A-E)
- State notes added to Docs 630 + 654 pointing to Doc 701; fixed Doc 654 self-references to "Doc 653"

## Next Actions

See Doc 701 Part 9 (open gaps) + Next Actions table - confirm the adoptable-project list, define COC Concertz voice/visual, build the context skill, stand up infra.