### PR TITLE
feat(spaces): Juke Path B - correct auth + password web path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,8 +145,14 @@ SENTRY_PROJECT=
 
 # ── Juke Developer API ─────────────────────────────────────────
 # Server-side Juke space creation for recurring ZAO events (doc 695, Path B).
-# Apply at juke.audio/developers — sign in, request access, create an app,
-# generate a key. The secret is shown only once at creation. Server-only,
-# never expose to the browser. Optional: when unset, /api/juke/space returns
-# 503 and the keyless /live iframe embed (Path A) still works.
+# POST /v1/developer/spaces needs BOTH credentials below. Server-only, never
+# expose to the browser. When either is unset, /api/juke/space returns 503 and
+# the keyless /live iframe embed (Path A) still works.
+#
+# JUKE_API_KEY  — app secret. Apply at juke.audio/developers: sign in, request
+#                 access, create an app, generate a key. Shown only once.
+# JUKE_USER_TOKEN — Juke JWT for the account that hosts created spaces,
+#                 obtained via Sign In With Farcaster. Juke JWTs expire;
+#                 refresh strategy is an open question (see doc 695).
 JUKE_API_KEY=
+JUKE_USER_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -154,5 +154,9 @@ SENTRY_PROJECT=
 # JUKE_USER_TOKEN — Juke JWT for the account that hosts created spaces,
 #                 obtained via Sign In With Farcaster. Juke JWTs expire;
 #                 refresh strategy is an open question (see doc 695).
+# JUKE_CREATE_PASSWORD — shared password that lets the /live/create page and
+#                 the ZAOcoworking bot call /api/juke/space without an admin
+#                 session. Unset = password path disabled. Server-only.
 JUKE_API_KEY=
 JUKE_USER_TOKEN=
+JUKE_CREATE_PASSWORD=

--- a/scripts/test-juke-space.ts
+++ b/scripts/test-juke-space.ts
@@ -1,0 +1,74 @@
+/**
+ * Smoke-test the Juke developer API (research doc 695, Path B).
+ *
+ * Run this ONCE after JUKE_API_KEY + JUKE_USER_TOKEN land in `.env.local`.
+ * It creates a throwaway Juke space and prints the result — confirming the
+ * credentials work end-to-end and revealing the (undocumented) create-space
+ * response shape before the live `/api/juke/space` route is relied on.
+ *
+ * If the response shape differs from what `extractSpaceId` expects, this is
+ * where it shows up first.
+ *
+ *   npx tsx scripts/test-juke-space.ts
+ *
+ * Reads secrets from `.env.local` (gitignored) and prints them only as
+ * "set" / "MISSING" — never the values.
+ */
+import * as fs from 'fs';
+import { createJukeSpace } from '../src/lib/spaces/juke-api';
+
+/** Parse `.env.local` from the repo root into a flat key-value map. */
+function loadEnv(): Record<string, string> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync('.env.local', 'utf8');
+  } catch {
+    console.error('Could not read .env.local — run this from the repo root.');
+    process.exit(1);
+  }
+  const env: Record<string, string> = {};
+  for (const line of raw.split('\n')) {
+    const match = line.match(/^([^#=]+)=(.*)$/);
+    if (match) env[match[1].trim()] = match[2].trim();
+  }
+  return env;
+}
+
+async function main(): Promise<void> {
+  const env = loadEnv();
+  const apiKey = env.JUKE_API_KEY;
+  const userToken = env.JUKE_USER_TOKEN;
+
+  if (!apiKey || !userToken) {
+    console.error('Missing Juke credentials in .env.local:');
+    console.error('  JUKE_API_KEY    ', apiKey ? 'set' : 'MISSING');
+    console.error('  JUKE_USER_TOKEN ', userToken ? 'set' : 'MISSING');
+    console.error('Apply at juke.audio/developers, then add both to .env.local.');
+    process.exit(1);
+  }
+
+  const title = `ZAO smoke test ${new Date().toISOString()}`;
+  console.log('Creating Juke space:', title);
+
+  const result = await createJukeSpace(
+    { title, allowAgents: true },
+    { apiKey, userToken },
+  );
+
+  if (!result.ok) {
+    console.error(`FAILED — status ${result.status} — ${result.error}`);
+    process.exit(1);
+  }
+
+  console.log('OK — space created.');
+  console.log('  id        ', result.space.id);
+  console.log('  embedUrl  ', result.space.embedUrl);
+  console.log('  ZAO route ', `/live/${result.space.id}`);
+  console.log('Raw Juke response:');
+  console.log(JSON.stringify(result.space.raw, null, 2));
+}
+
+main().catch((err: unknown) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/src/app/api/juke/space/__tests__/route.test.ts
+++ b/src/app/api/juke/space/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import {
 
 const mockEnv = vi.hoisted(() => ({
   JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+  JUKE_USER_TOKEN: 'jwt_test' as string | undefined,
 }));
 
 const { mockGetSessionData, mockCreateJukeSpace } = vi.hoisted(() => ({
@@ -36,6 +37,7 @@ describe('POST /api/juke/space', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+    mockEnv.JUKE_USER_TOKEN = 'jwt_test';
   });
 
   it('returns 401 when there is no session', async () => {
@@ -60,7 +62,7 @@ describe('POST /api/juke/space', () => {
     expect(mockCreateJukeSpace).not.toHaveBeenCalled();
   });
 
-  it('returns 503 when JUKE_API_KEY is not configured', async () => {
+  it('returns 503 naming JUKE_API_KEY when only the key is missing', async () => {
     mockGetSessionData.mockResolvedValue(mockAdminSession());
     mockEnv.JUKE_API_KEY = undefined;
 
@@ -68,8 +70,33 @@ describe('POST /api/juke/space', () => {
     const body = await res.json();
 
     expect(res.status).toBe(503);
-    expect(body.error).toMatch(/not configured/i);
+    expect(body.error).toContain('JUKE_API_KEY');
+    expect(body.error).not.toContain('JUKE_USER_TOKEN');
     expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 naming JUKE_USER_TOKEN when only the token is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockEnv.JUKE_USER_TOKEN = undefined;
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toContain('JUKE_USER_TOKEN');
+  });
+
+  it('returns 503 naming both when neither credential is set', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockEnv.JUKE_API_KEY = undefined;
+    mockEnv.JUKE_USER_TOKEN = undefined;
+
+    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toContain('JUKE_API_KEY');
+    expect(body.error).toContain('JUKE_USER_TOKEN');
   });
 
   it('returns 400 when the body is not valid JSON', async () => {
@@ -131,7 +158,7 @@ describe('POST /api/juke/space', () => {
     expect(body.data.embedUrl).toBe('https://juke.audio/embed/zao-live-1');
     expect(mockCreateJukeSpace).toHaveBeenCalledWith(
       { title: 'ZAOstock Standup', announceCast: true },
-      'jk_sec_live_test',
+      { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
     );
   });
 

--- a/src/app/api/juke/space/__tests__/route.test.ts
+++ b/src/app/api/juke/space/__tests__/route.test.ts
@@ -10,6 +10,7 @@ import {
 const mockEnv = vi.hoisted(() => ({
   JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
   JUKE_USER_TOKEN: 'jwt_test' as string | undefined,
+  JUKE_CREATE_PASSWORD: 'ZAO' as string | undefined,
 }));
 
 const { mockGetSessionData, mockCreateJukeSpace } = vi.hoisted(() => ({
@@ -33,160 +34,197 @@ vi.mock('@/lib/logger', () => ({
 
 import { POST } from '../route';
 
+/** A successful Juke create result the mocked client returns. */
+const CREATED = {
+  ok: true,
+  space: {
+    id: 'zao-live-1',
+    embedUrl: 'https://juke.audio/embed/zao-live-1',
+    raw: { id: 'zao-live-1' },
+  },
+};
+
 describe('POST /api/juke/space', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
     mockEnv.JUKE_USER_TOKEN = 'jwt_test';
-  });
-
-  it('returns 401 when there is no session', async () => {
+    mockEnv.JUKE_CREATE_PASSWORD = 'ZAO';
     mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
-
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(401);
-    expect(body.error).toBe('Unauthorized');
-    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
   });
 
-  it('returns 403 when the user is not an admin', async () => {
-    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  describe('authorisation', () => {
+    it('returns 401 with no session and no password', async () => {
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
 
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(403);
-    expect(body.error).toBe('Admin access required');
-    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
-  });
-
-  it('returns 503 naming JUKE_API_KEY when only the key is missing', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockEnv.JUKE_API_KEY = undefined;
-
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(503);
-    expect(body.error).toContain('JUKE_API_KEY');
-    expect(body.error).not.toContain('JUKE_USER_TOKEN');
-    expect(mockCreateJukeSpace).not.toHaveBeenCalled();
-  });
-
-  it('returns 503 naming JUKE_USER_TOKEN when only the token is missing', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockEnv.JUKE_USER_TOKEN = undefined;
-
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(503);
-    expect(body.error).toContain('JUKE_USER_TOKEN');
-  });
-
-  it('returns 503 naming both when neither credential is set', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockEnv.JUKE_API_KEY = undefined;
-    mockEnv.JUKE_USER_TOKEN = undefined;
-
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(503);
-    expect(body.error).toContain('JUKE_API_KEY');
-    expect(body.error).toContain('JUKE_USER_TOKEN');
-  });
-
-  it('returns 400 when the body is not valid JSON', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-
-    const res = await POST(
-      makeRequest('/api/juke/space', { method: 'POST', body: '{not json' }),
-    );
-    const body = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(body.error).toMatch(/valid JSON/i);
-  });
-
-  it('returns 400 when the title is missing', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-
-    const res = await POST(makePostRequest('/api/juke/space', { title: '' }));
-    const body = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(body.error).toBe('Invalid request');
-  });
-
-  it('returns 400 when scheduledAt is not an ISO datetime', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-
-    const res = await POST(
-      makePostRequest('/api/juke/space', { title: 'ZAO Live', scheduledAt: 'next tuesday' }),
-    );
-    const body = await res.json();
-
-    expect(res.status).toBe(400);
-    expect(body.error).toBe('Invalid request');
-  });
-
-  it('creates a space and returns 201 for an admin', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockCreateJukeSpace.mockResolvedValue({
-      ok: true,
-      space: {
-        id: 'zao-live-1',
-        embedUrl: 'https://juke.audio/embed/zao-live-1',
-        raw: { id: 'zao-live-1' },
-      },
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockCreateJukeSpace).not.toHaveBeenCalled();
     });
 
-    const res = await POST(
-      makePostRequest('/api/juke/space', {
-        title: 'ZAOstock Standup',
-        announceCast: true,
-      }),
-    );
-    const body = await res.json();
+    it('returns 401 for an authenticated non-admin with no password', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
 
-    expect(res.status).toBe(201);
-    expect(body.success).toBe(true);
-    expect(body.data.id).toBe('zao-live-1');
-    expect(body.data.embedUrl).toBe('https://juke.audio/embed/zao-live-1');
-    expect(mockCreateJukeSpace).toHaveBeenCalledWith(
-      { title: 'ZAOstock Standup', announceCast: true },
-      { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
-    );
-  });
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
 
-  it('returns 502 when the Juke API rejects the request', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockCreateJukeSpace.mockResolvedValue({
-      ok: false,
-      status: 401,
-      error: 'Juke API returned 401',
+      expect(res.status).toBe(401);
+      expect(mockCreateJukeSpace).not.toHaveBeenCalled();
     });
 
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
+    it('returns 401 when the password is wrong', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/space', { title: 'ZAO Live', password: 'nope' }),
+      );
 
-    expect(res.status).toBe(502);
-    expect(body.success).toBe(false);
-    expect(body.error).toBe('Juke API returned 401');
+      expect(res.status).toBe(401);
+      expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when a password is sent but JUKE_CREATE_PASSWORD is unset', async () => {
+      mockEnv.JUKE_CREATE_PASSWORD = undefined;
+
+      const res = await POST(
+        makePostRequest('/api/juke/space', { title: 'ZAO Live', password: 'ZAO' }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(mockCreateJukeSpace).not.toHaveBeenCalled();
+    });
+
+    it('accepts the correct password without a session', async () => {
+      mockCreateJukeSpace.mockResolvedValue(CREATED);
+
+      const res = await POST(
+        makePostRequest('/api/juke/space', { title: 'Fractal Call', password: 'ZAO' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      // The password must not be forwarded to the Juke client.
+      expect(mockCreateJukeSpace).toHaveBeenCalledWith(
+        { title: 'Fractal Call' },
+        { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
+      );
+    });
+
+    it('accepts an admin session without a password', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockCreateJukeSpace.mockResolvedValue(CREATED);
+
+      const res = await POST(
+        makePostRequest('/api/juke/space', { title: 'ZAOstock Standup', announceCast: true }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.data.id).toBe('zao-live-1');
+      expect(mockCreateJukeSpace).toHaveBeenCalledWith(
+        { title: 'ZAOstock Standup', announceCast: true },
+        { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
+      );
+    });
   });
 
-  it('returns 500 when createJukeSpace throws unexpectedly', async () => {
-    mockGetSessionData.mockResolvedValue(mockAdminSession());
-    mockCreateJukeSpace.mockRejectedValue(new Error('boom'));
+  describe('configuration', () => {
+    it('returns 503 naming JUKE_API_KEY when only the key is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockEnv.JUKE_API_KEY = undefined;
 
-    const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-    const body = await res.json();
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
 
-    expect(res.status).toBe(500);
-    expect(body.success).toBe(false);
-    expect(body.error).toBe('Failed to create Juke space');
+      expect(res.status).toBe(503);
+      expect(body.error).toContain('JUKE_API_KEY');
+      expect(body.error).not.toContain('JUKE_USER_TOKEN');
+    });
+
+    it('returns 503 naming JUKE_USER_TOKEN when only the token is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockEnv.JUKE_USER_TOKEN = undefined;
+
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toContain('JUKE_USER_TOKEN');
+    });
+
+    it('returns 503 naming both when neither credential is set', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockEnv.JUKE_API_KEY = undefined;
+      mockEnv.JUKE_USER_TOKEN = undefined;
+
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toContain('JUKE_API_KEY');
+      expect(body.error).toContain('JUKE_USER_TOKEN');
+    });
+  });
+
+  describe('request validation', () => {
+    it('returns 400 when the body is not valid JSON', async () => {
+      const res = await POST(
+        makeRequest('/api/juke/space', { method: 'POST', body: '{not json' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toMatch(/valid JSON/i);
+    });
+
+    it('returns 400 when the title is missing', async () => {
+      const res = await POST(makePostRequest('/api/juke/space', { title: '', password: 'ZAO' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when scheduledAt is not an ISO datetime', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/space', {
+          title: 'ZAO Live',
+          password: 'ZAO',
+          scheduledAt: 'next tuesday',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+  });
+
+  describe('upstream failures', () => {
+    it('returns 502 when the Juke API rejects the request', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockCreateJukeSpace.mockResolvedValue({
+        ok: false,
+        status: 401,
+        error: 'Juke API returned 401',
+      });
+
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Juke API returned 401');
+    });
+
+    it('returns 500 when createJukeSpace throws unexpectedly', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockCreateJukeSpace.mockRejectedValue(new Error('boom'));
+
+      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create Juke space');
+    });
   });
 });

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -12,9 +12,10 @@ import { createJukeSpace } from '@/lib/spaces/juke-api';
  * weekly fractal call, COC Concertz nights); this route mints a Juke space for
  * one of them on demand and returns the `/live/{id}` embed link to share.
  *
- * The `JUKE_API_KEY` secret stays server-side. Until it is configured (apply
- * at juke.audio/developers), the route reports 503 rather than failing
- * opaquely — Path A, the keyless iframe embed, keeps working regardless.
+ * The `JUKE_API_KEY` + `JUKE_USER_TOKEN` secrets stay server-side. Until both
+ * are configured (apply at juke.audio/developers), the route reports 503
+ * rather than failing opaquely — Path A, the keyless iframe embed, keeps
+ * working regardless.
  */
 
 const createSpaceSchema = z.object({
@@ -43,13 +44,20 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Juke's create-space endpoint needs both the app key and a host JWT.
   const apiKey = ENV.JUKE_API_KEY;
-  if (!apiKey) {
+  const userToken = ENV.JUKE_USER_TOKEN;
+  if (!apiKey || !userToken) {
+    const missing = [
+      !apiKey ? 'JUKE_API_KEY' : null,
+      !userToken ? 'JUKE_USER_TOKEN' : null,
+    ]
+      .filter(Boolean)
+      .join(' and ');
     return NextResponse.json(
       {
         success: false,
-        error:
-          'Juke developer API is not configured. Apply at juke.audio/developers, then set JUKE_API_KEY.',
+        error: `Juke developer API is not configured (missing ${missing}). Apply at juke.audio/developers.`,
       },
       { status: 503 },
     );
@@ -74,7 +82,7 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const result = await createJukeSpace(parsed.data, apiKey);
+    const result = await createJukeSpace(parsed.data, { apiKey, userToken });
     if (!result.ok) {
       // Upstream Juke failure. Log the real status server-side; report a
       // single 502 to the client — a Juke 401/400 is an integration problem,

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -8,9 +8,14 @@ import { createJukeSpace } from '@/lib/spaces/juke-api';
 /**
  * POST /api/juke/space — create a branded Juke space (Path B of doc 695).
  *
- * Admin-only. ZAO runs recurring audio-worthy events (ZAOstock standups, the
- * weekly fractal call, COC Concertz nights); this route mints a Juke space for
- * one of them on demand and returns the `/live/{id}` embed link to share.
+ * Two ways to authorise:
+ *  - an admin ZAO OS session, or
+ *  - a `password` in the body matching `JUKE_CREATE_PASSWORD` — the path the
+ *    `/live/create` page and the ZAOcoworking bot use.
+ *
+ * ZAO runs recurring audio-worthy events (ZAOstock standups, the weekly
+ * fractal call, COC Concertz nights); this route mints a Juke space for one
+ * of them on demand and returns the space id to embed at `/live/{id}`.
  *
  * The `JUKE_API_KEY` + `JUKE_USER_TOKEN` secrets stay server-side. Until both
  * are configured (apply at juke.audio/developers), the route reports 503
@@ -27,20 +32,40 @@ const createSpaceSchema = z.object({
   announceCast: z.boolean().optional(),
   /** When true, AI agents may join the room. */
   allowAgents: z.boolean().optional(),
+  /** Shared create-password — an alternative to an admin session. */
+  password: z.string().optional(),
 });
 
 export async function POST(request: NextRequest) {
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: 'Request body must be valid JSON' },
+      { status: 400 },
+    );
+  }
+
+  const parsed = createSpaceSchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  // Keep the password out of `spaceInput` so it never reaches the Juke API.
+  const { password, ...spaceInput } = parsed.data;
+
+  // Authorised by an admin ZAO OS session OR the shared create-password.
+  // The password path is disabled unless JUKE_CREATE_PASSWORD is configured.
   const session = await getSessionData();
-  if (!session) {
+  const passwordOk =
+    !!ENV.JUKE_CREATE_PASSWORD && password === ENV.JUKE_CREATE_PASSWORD;
+  if (!session?.isAdmin && !passwordOk) {
     return NextResponse.json(
       { success: false, error: 'Unauthorized' },
       { status: 401 },
-    );
-  }
-  if (!session.isAdmin) {
-    return NextResponse.json(
-      { success: false, error: 'Admin access required' },
-      { status: 403 },
     );
   }
 
@@ -63,26 +88,8 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  let raw: unknown;
   try {
-    raw = await request.json();
-  } catch {
-    return NextResponse.json(
-      { success: false, error: 'Request body must be valid JSON' },
-      { status: 400 },
-    );
-  }
-
-  const parsed = createSpaceSchema.safeParse(raw);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { success: false, error: 'Invalid request', details: parsed.error.flatten() },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const result = await createJukeSpace(parsed.data, { apiKey, userToken });
+    const result = await createJukeSpace(spaceInput, { apiKey, userToken });
     if (!result.ok) {
       // Upstream Juke failure. Log the real status server-side; report a
       // single 502 to the client — a Juke 401/400 is an integration problem,

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -1,9 +1,22 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getSessionData } from '@/lib/auth/session';
 import { ENV } from '@/lib/env';
 import { logger } from '@/lib/logger';
 import { createJukeSpace } from '@/lib/spaces/juke-api';
+
+/**
+ * Constant-time string comparison. Both inputs are SHA-256'd to a fixed
+ * 32-byte digest first, so `timingSafeEqual` never throws on a length
+ * mismatch and the comparison leaks neither the length nor the content of
+ * the configured password.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const ah = createHash('sha256').update(a).digest();
+  const bh = createHash('sha256').update(b).digest();
+  return timingSafeEqual(ah, bh);
+}
 
 /**
  * POST /api/juke/space — create a branded Juke space (Path B of doc 695).
@@ -61,7 +74,9 @@ export async function POST(request: NextRequest) {
   // The password path is disabled unless JUKE_CREATE_PASSWORD is configured.
   const session = await getSessionData();
   const passwordOk =
-    !!ENV.JUKE_CREATE_PASSWORD && password === ENV.JUKE_CREATE_PASSWORD;
+    !!ENV.JUKE_CREATE_PASSWORD &&
+    !!password &&
+    constantTimeEqual(password, ENV.JUKE_CREATE_PASSWORD);
   if (!session?.isAdmin && !passwordOk) {
     return NextResponse.json(
       { success: false, error: 'Unauthorized' },

--- a/src/app/live/create/page.tsx
+++ b/src/app/live/create/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+/**
+ * /live/create — create a Juke live audio space from the web (doc 695, Path B).
+ *
+ * Posts to `/api/juke/space`, which is authorised by either an admin session
+ * or the shared `JUKE_CREATE_PASSWORD`. This page uses the password path so
+ * anyone on the ZAO team can spin up a space. On success it shows the
+ * `/live/{id}` link to share.
+ */
+
+interface CreatedSpace {
+  id: string;
+  embedUrl: string;
+}
+
+type Status = 'idle' | 'creating' | 'done' | 'error';
+
+export default function CreateLiveSpacePage() {
+  const [password, setPassword] = useState('');
+  const [title, setTitle] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [space, setSpace] = useState<CreatedSpace | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const liveUrl = space
+    ? `${typeof window !== 'undefined' ? window.location.origin : ''}/live/${space.id}`
+    : '';
+
+  const createSpace = async () => {
+    setStatus('creating');
+    setError(null);
+    try {
+      const res = await fetch('/api/juke/space', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: title.trim(), password }),
+      });
+      const body = await res.json();
+      if (!res.ok || !body.success) {
+        setError(
+          res.status === 401
+            ? 'Wrong password.'
+            : (body.error ?? 'Could not create the space.'),
+        );
+        setStatus('error');
+        return;
+      }
+      setSpace(body.data as CreatedSpace);
+      setStatus('done');
+    } catch {
+      setError('Network error - please try again.');
+      setStatus('error');
+    }
+  };
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(liveUrl).then(
+      () => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      },
+      () => setCopied(false),
+    );
+  };
+
+  const reset = () => {
+    setSpace(null);
+    setTitle('');
+    setStatus('idle');
+    setError(null);
+  };
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628]">
+      <header className="border-b border-white/[0.08] bg-[#0d1b2a]">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Link
+            href="/live"
+            aria-label="Back to ZAO Live"
+            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-800 hover:text-[#f5a623]"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <h1 className="text-sm font-bold text-white sm:text-base">Create a ZAO Live space</h1>
+        </div>
+      </header>
+
+      <main className="flex flex-1 flex-col items-center px-4 py-10">
+        <div className="w-full max-w-md">
+          {status === 'done' && space ? (
+            <div>
+              <h2 className="text-2xl font-bold text-white">Space created</h2>
+              <p className="mt-2 text-sm text-gray-400">
+                Share this link - anyone can listen in. To speak, they sign in
+                with Farcaster inside the space.
+              </p>
+              <div className="mt-6 rounded-xl border border-white/[0.08] bg-[#0d1b2a] p-4">
+                <p className="break-all font-mono text-sm text-[#f5a623]">{liveUrl}</p>
+                <div className="mt-3 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={copyLink}
+                    className="rounded-lg bg-[#f5a623] px-4 py-2 text-sm font-semibold text-[#0a1628] transition-colors hover:bg-[#ffd700]"
+                  >
+                    {copied ? 'Copied' : 'Copy link'}
+                  </button>
+                  <Link
+                    href={`/live/${space.id}`}
+                    className="rounded-lg border border-white/[0.12] px-4 py-2 text-sm font-semibold text-white transition-colors hover:border-[#f5a623]/50"
+                  >
+                    Open space
+                  </Link>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={reset}
+                className="mt-4 text-xs text-gray-500 transition-colors hover:text-[#f5a623]"
+              >
+                Create another
+              </button>
+            </div>
+          ) : (
+            <>
+              <h2 className="text-2xl font-bold text-white">Create a ZAO Live space</h2>
+              <p className="mt-2 text-sm text-gray-400">
+                Spin up a Farcaster-native live audio space on Juke. Enter the
+                team password and a title.
+              </p>
+
+              <form
+                className="mt-6"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  createSpace();
+                }}
+              >
+                <label htmlFor="create-password" className="text-xs font-medium text-gray-400">
+                  Team password
+                </label>
+                <input
+                  id="create-password"
+                  type="password"
+                  autoComplete="off"
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                    if (error) setError(null);
+                  }}
+                  className="mt-1.5 w-full rounded-xl border border-white/[0.08] bg-[#0d1b2a] px-4 py-3 text-sm text-white placeholder:text-gray-600 focus:border-[#f5a623]/50 focus:outline-none"
+                />
+
+                <label htmlFor="create-title" className="mt-4 block text-xs font-medium text-gray-400">
+                  Space title
+                </label>
+                <input
+                  id="create-title"
+                  type="text"
+                  autoComplete="off"
+                  placeholder="ZAOstock Tuesday Standup"
+                  value={title}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    if (error) setError(null);
+                  }}
+                  className="mt-1.5 w-full rounded-xl border border-white/[0.08] bg-[#0d1b2a] px-4 py-3 text-sm text-white placeholder:text-gray-600 focus:border-[#f5a623]/50 focus:outline-none"
+                />
+
+                {error && <p className="mt-3 text-xs text-red-400">{error}</p>}
+
+                <button
+                  type="submit"
+                  disabled={
+                    status === 'creating' ||
+                    password.trim().length === 0 ||
+                    title.trim().length === 0
+                  }
+                  className="mt-4 w-full rounded-xl bg-[#f5a623] py-3 text-sm font-semibold text-[#0a1628] transition-colors hover:bg-[#ffd700] disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {status === 'creating' ? 'Creating...' : 'Create space'}
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -95,4 +95,8 @@ export const ENV = {
   // /api/juke/space returns 503; the keyless /live embed still works.
   JUKE_API_KEY: optionalEnv('JUKE_API_KEY'),
   JUKE_USER_TOKEN: optionalEnv('JUKE_USER_TOKEN'),
+  // Shared password for /api/juke/space — lets the /live/create page and the
+  // ZAOcoworking bot create spaces without an admin session. Unset = the
+  // password path is disabled (admin session still works).
+  JUKE_CREATE_PASSWORD: optionalEnv('JUKE_CREATE_PASSWORD'),
 } as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -89,7 +89,10 @@ export const ENV = {
   ZX_API_KEY: optionalEnv('ZX_API_KEY'),
 
   // Juke developer API -- server-side Juke space creation (doc 695, Path B).
-  // Apply at juke.audio/developers; secret shown once at key creation.
-  // Absent = /api/juke/space returns 503; the keyless /live embed still works.
+  // Needs BOTH: JUKE_API_KEY (app secret, shown once at key creation) and
+  // JUKE_USER_TOKEN (Juke JWT for the host account, from Sign In With
+  // Farcaster). Apply at juke.audio/developers. Either absent =
+  // /api/juke/space returns 503; the keyless /live embed still works.
   JUKE_API_KEY: optionalEnv('JUKE_API_KEY'),
+  JUKE_USER_TOKEN: optionalEnv('JUKE_USER_TOKEN'),
 } as const;

--- a/src/lib/spaces/juke-api.test.ts
+++ b/src/lib/spaces/juke-api.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createJukeSpace, extractSpaceId, JUKE_API_ORIGIN } from './juke-api';
+import {
+  createJukeSpace,
+  extractSpaceId,
+  JUKE_API_ORIGIN,
+  type JukeCredentials,
+} from './juke-api';
+
+/** A complete credentials pair for tests that do not assert on the values. */
+const CREDS: JukeCredentials = { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' };
 
 describe('extractSpaceId', () => {
   it('reads a top-level id', () => {
@@ -64,16 +72,20 @@ describe('createJukeSpace', () => {
     } as Response);
   }
 
-  it('posts to the developer endpoint with the API key header', async () => {
+  it('posts to the developer endpoint with both auth headers', async () => {
     mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
 
-    await createJukeSpace({ title: 'ZAO Standup' }, 'jk_sec_live_test');
+    await createJukeSpace(
+      { title: 'ZAO Standup' },
+      { apiKey: 'jk_sec_live_test', userToken: 'jwt_abc' },
+    );
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(url).toBe(`${JUKE_API_ORIGIN}/v1/developer/spaces`);
     expect(options.method).toBe('POST');
     expect(options.headers['X-Juke-Api-Key']).toBe('jk_sec_live_test');
+    expect(options.headers.Authorization).toBe('Bearer jwt_abc');
     expect(options.headers['Content-Type']).toBe('application/json');
   });
 
@@ -87,7 +99,7 @@ describe('createJukeSpace', () => {
         announceCast: true,
         allowAgents: true,
       },
-      'key',
+      CREDS,
     );
 
     const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -102,7 +114,7 @@ describe('createJukeSpace', () => {
   it('defaults optional fields when omitted', async () => {
     mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
 
-    await createJukeSpace({ title: 'Quick Room' }, 'key');
+    await createJukeSpace({ title: 'Quick Room' }, CREDS);
 
     const [, options] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(JSON.parse(options.body)).toEqual({
@@ -116,7 +128,7 @@ describe('createJukeSpace', () => {
   it('returns the space with an embed URL on success', async () => {
     mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'zao-live-1' }) });
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+    const result = await createJukeSpace({ title: 'ZAO Live' }, CREDS);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -129,7 +141,7 @@ describe('createJukeSpace', () => {
   it('fails when the Juke response carries no usable id', async () => {
     mockFetchOnce({ ok: true, status: 201, json: () => ({ title: 'orphan' }) });
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+    const result = await createJukeSpace({ title: 'ZAO Live' }, CREDS);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -141,7 +153,10 @@ describe('createJukeSpace', () => {
   it('surfaces a non-2xx Juke response with its status', async () => {
     mockFetchOnce({ ok: false, status: 401, json: () => ({}) });
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'bad-key');
+    const result = await createJukeSpace(
+      { title: 'ZAO Live' },
+      { apiKey: 'bad-key', userToken: 'bad-jwt' },
+    );
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -153,7 +168,7 @@ describe('createJukeSpace', () => {
   it('returns a 502 when the Juke API is unreachable', async () => {
     (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('ECONNREFUSED'));
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+    const result = await createJukeSpace({ title: 'ZAO Live' }, CREDS);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -167,7 +182,7 @@ describe('createJukeSpace', () => {
     timeout.name = 'TimeoutError';
     (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(timeout);
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+    const result = await createJukeSpace({ title: 'ZAO Live' }, CREDS);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -185,7 +200,7 @@ describe('createJukeSpace', () => {
       },
     } as Response);
 
-    const result = await createJukeSpace({ title: 'ZAO Live' }, 'key');
+    const result = await createJukeSpace({ title: 'ZAO Live' }, CREDS);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {

--- a/src/lib/spaces/juke-api.ts
+++ b/src/lib/spaces/juke-api.ts
@@ -3,13 +3,14 @@
  *
  * Creates branded Juke spaces for recurring ZAO events via the Juke developer
  * API (`api.juke.audio`). Path A (the iframe embed in `juke.ts`) needs no
- * keys; Path B does — `POST /v1/developer/spaces` is gated by an
- * `X-Juke-Api-Key` secret.
+ * keys; Path B does — `POST /v1/developer/spaces` takes TWO credentials:
+ * `X-Juke-Api-Key` authorises the app, and `Authorization: Bearer <jwt>`
+ * identifies the Juke account that will host the new space.
  *
- * IMPORTANT: never import this module from a client component. The
- * `JUKE_API_KEY` secret is passed in by the caller (the API route reads it
- * from the environment), so this file holds no secret literal — but the Juke
- * developer API surface is server-only regardless.
+ * IMPORTANT: never import this module from a client component. Both secrets
+ * are passed in by the caller (the API route reads them from the
+ * environment), so this file holds no secret literal — but the Juke developer
+ * API surface is server-only regardless.
  *
  * The Juke developer API is in beta; its create-space *response* shape is not
  * publicly documented. `createJukeSpace` parses the response defensively and
@@ -57,6 +58,22 @@ export type CreateJukeSpaceResult =
   | { ok: true; space: JukeSpace }
   | { ok: false; status: number; error: string };
 
+/**
+ * Credentials for a Juke developer API call. BOTH are required: Juke's
+ * `POST /v1/developer/spaces` authorises the *app* with `X-Juke-Api-Key` and
+ * identifies the *host* of the new space with a user JWT.
+ */
+export interface JukeCredentials {
+  /** `JUKE_API_KEY` — the app's static developer secret (juke.audio/developers). */
+  apiKey: string;
+  /**
+   * `JUKE_USER_TOKEN` — a Juke JWT for the account that will host the space,
+   * obtained via Sign In With Farcaster. Juke JWTs expire; refreshing this
+   * server-side is an open question for nickysap — see research doc 695.
+   */
+  userToken: string;
+}
+
 /** Id fields the Juke response is most likely to use, in priority order. */
 const ID_KEYS = ['id', 'space_id', 'spaceId', 'room_id', 'roomId'] as const;
 /** Nested objects the space id may live under one level deep. */
@@ -94,16 +111,17 @@ export function extractSpaceId(payload: unknown): string | null {
 /**
  * Create a Juke space through the developer API.
  *
- * @param input  The space to create.
- * @param apiKey The `JUKE_API_KEY` secret, passed in by the caller — this
- *               module never reads it from the environment itself.
+ * @param input       The space to create.
+ * @param credentials The `JUKE_API_KEY` + `JUKE_USER_TOKEN` pair, passed in by
+ *                    the caller — this module never reads them from the
+ *                    environment itself.
  * @returns A {@link CreateJukeSpaceResult}. This function does not throw:
  *          network, timeout, and parse failures are returned as
  *          `{ ok: false }` so callers handle one shape.
  */
 export async function createJukeSpace(
   input: CreateJukeSpaceInput,
-  apiKey: string,
+  credentials: JukeCredentials,
 ): Promise<CreateJukeSpaceResult> {
   // Translate the camelCase ZAO shape into Juke's documented snake_case body.
   const body = JSON.stringify({
@@ -118,7 +136,9 @@ export async function createJukeSpace(
     response = await fetch(`${JUKE_API_ORIGIN}${CREATE_SPACE_PATH}`, {
       method: 'POST',
       headers: {
-        'X-Juke-Api-Key': apiKey,
+        // App credential + host-identifying user JWT — Juke requires both.
+        Authorization: `Bearer ${credentials.userToken}`,
+        'X-Juke-Api-Key': credentials.apiKey,
         'Content-Type': 'application/json',
       },
       body,


### PR DESCRIPTION
## What

Completes Path B of doc 695 (Juke integration). Two commits:

### 1. Fix - developer API needs both auth headers

PR #608 sent only `X-Juke-Api-Key`. The code sample on juke.audio/developers shows `POST /v1/developer/spaces` requires **two** credentials:

```
Authorization: Bearer ${JUKE_USER_TOKEN}
X-Juke-Api-Key: ${JUKE_API_KEY}
```

`X-Juke-Api-Key` authorises the app; the Bearer JWT identifies the Juke account hosting the space. Without the second header the route would have `401`'d the moment a key landed.

- `createJukeSpace` now takes `JukeCredentials { apiKey, userToken }` and sends both headers.
- `route.ts` reads both, `503`s naming whichever is missing.
- `JUKE_USER_TOKEN` added as a second server-only secret.
- `scripts/test-juke-space.ts` - one-shot smoke test for once both credentials land.

### 2. Feature - password-gated `/live/create` web page

A way to create a Juke space without an admin session.

- `/api/juke/space` - second auth path: admin session **or** a `password` matching `JUKE_CREATE_PASSWORD`. Body parses before auth; password is stripped before the Juke call.
- `/live/create` - client page: team password + space title, returns a copyable `/live/{id}` link. Navy/gold, mobile-first.
- `JUKE_CREATE_PASSWORD` env var (optional, server-only). Set it to enable the password path.

## Open question for nickysap

`JUKE_USER_TOKEN` is a Juke JWT from Sign In With Farcaster, and JWTs expire. Needs a decision: a long-lived developer token, or server-side refresh via `POST /v1/auth/refresh`. Flag this when requesting the API key.

## Env to set when ready

- `JUKE_API_KEY` - waiting on nickysap (juke.audio/developers)
- `JUKE_USER_TOKEN` - Juke JWT, SIWF
- `JUKE_CREATE_PASSWORD` - set to `ZAO` to enable the web/bot password path

## Follow-up

ZAOcoworking bot `/juke` command lands in `ZAODEVZ/ZAOcowork` (separate repo) - it will POST to this route with the password.

## Tests

53 spaces tests pass (route covers both auth paths, wrong password, missing-credential `503`s, upstream failures). `npm run typecheck` + eslint clean.

Note: the repo's `Lint & Typecheck` CI check is red on `main` from pre-existing `require()`-import / JSX-entity errors in unrelated files - not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)