### PR TITLE
feat(zabal): ZABAL hub - per-route embeds + token/ecosystem/about sections

### DIFF
--- a/src/app/og/zabal/route.tsx
+++ b/src/app/og/zabal/route.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from 'next/og';
+
+// OG / Mini App embed image for the ZABAL hub. Referenced by the
+// per-route fc:miniapp embed in src/app/zabal/page.tsx (Research Doc 707/708).
+
+export const runtime = 'edge';
+export const contentType = 'image/png';
+export const size = { width: 1200, height: 800 };
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background:
+            'radial-gradient(circle at 50% 10%, rgba(224,221,170,0.18), transparent 55%), linear-gradient(135deg, #0a0a0a 0%, #141e27 100%)',
+          color: '#ffffff',
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+          padding: 80,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 160,
+            fontWeight: 900,
+            letterSpacing: 12,
+            background: 'linear-gradient(135deg, #ffffff 0%, #e0ddaa 100%)',
+            backgroundClip: 'text',
+            color: 'transparent',
+          }}
+        >
+          ZABAL
+        </div>
+        <div style={{ fontSize: 40, color: '#e0ddaa', marginTop: 16, fontWeight: 700 }}>
+          Vote weekly on ZAO direction
+        </div>
+        <div style={{ fontSize: 28, color: '#a0a0a0', marginTop: 24, display: 'flex', gap: 28 }}>
+          <span>Music</span>
+          <span>Governance</span>
+          <span>Events</span>
+          <span>Build</span>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/src/app/zabal/_components/ZabalHub.tsx
+++ b/src/app/zabal/_components/ZabalHub.tsx
@@ -1,0 +1,273 @@
+// Static hub sections for the ZABAL landing page (zaoos.com/zabal).
+// Server components - no client JS. Spec: research Doc 708.
+
+import React from 'react';
+
+const GOLD = '#e0ddaa';
+const DIM = '#a0a0a0';
+const PANEL = 'rgba(20, 30, 39, 0.6)';
+const BORDER = 'rgba(224, 221, 170, 0.2)';
+
+// ---------------------------------------------------------------
+// Anchored top nav
+// ---------------------------------------------------------------
+
+const NAV = [
+  ['#vote', 'Vote'],
+  ['#token', 'Token'],
+  ['#ecosystem', 'Ecosystem'],
+  ['#spotlight', 'Spotlight'],
+  ['#about', 'About'],
+] as const;
+
+export function ZabalNav() {
+  return (
+    <nav
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+        display: 'flex',
+        gap: '1.25rem',
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        padding: '0.85rem 1rem',
+        background: 'rgba(10, 10, 10, 0.85)',
+        backdropFilter: 'blur(10px)',
+        borderBottom: `1px solid ${BORDER}`,
+      }}
+    >
+      {NAV.map(([href, label]) => (
+        <a
+          key={href}
+          href={href}
+          style={{ color: DIM, fontSize: '0.9rem', fontWeight: 600, textDecoration: 'none' }}
+        >
+          {label}
+        </a>
+      ))}
+    </nav>
+  );
+}
+
+// ---------------------------------------------------------------
+// $ZABAL token panel
+// ---------------------------------------------------------------
+
+export function ZabalTokenPanel() {
+  return (
+    <section id="token" style={{ padding: '2.5rem 2rem', maxWidth: 960, margin: '0 auto' }}>
+      <h2 style={sectionTitle()}>$ZABAL</h2>
+      <div
+        style={{
+          background: PANEL,
+          border: `1px solid ${BORDER}`,
+          borderRadius: 16,
+          padding: '1.75rem',
+        }}
+      >
+        <p style={{ color: '#fff', fontSize: '1rem', marginBottom: '0.75rem' }}>
+          $ZABAL is the token at the center of the ZABAL universe - launched Jan 1 2026 on Base.
+          Holding it and showing up in /zao both feed your weekly vote power.
+        </p>
+        <p style={{ color: DIM, fontSize: '0.9rem', marginBottom: '1.25rem' }}>
+          Vote power = base 1 + /zao cast activity + Neynar score, capped at 6. Hold $ZABAL and
+          stay active to vote heavier.
+        </p>
+        <div style={{ display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+          <a href="https://empirebuilder.world" target="_blank" rel="noopener noreferrer" style={primaryCta()}>
+            Hold $ZABAL
+          </a>
+          <a
+            href="https://songjam.space/zabal"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={secondaryCta()}
+          >
+            $ZABAL Empire leaderboard
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------
+// Ecosystem portals grid
+// ---------------------------------------------------------------
+
+interface Portal {
+  name: string;
+  url: string;
+  blurb: string;
+  badge: string;
+}
+
+const PORTALS: Portal[] = [
+  { name: 'The ZAO', url: 'https://thezao.com', blurb: 'The artist org - ~190 members on Base.', badge: 'Org' },
+  { name: 'ZAO Festivals', url: 'https://zaofestivals.com', blurb: 'ZAOstock, ZAO-PALOOZA, ZAO CHELLA.', badge: 'Events' },
+  { name: 'WaveWarZ', url: 'https://www.wavewarz.com', blurb: 'Onchain music battles.', badge: 'Music' },
+  { name: 'ZAO OS', url: 'https://zaoos.com', blurb: 'The community operating system.', badge: 'Platform' },
+  { name: 'BCZ YapZ', url: 'https://bczyapz.com', blurb: 'The podcast - Web3, music, building.', badge: 'Media' },
+  { name: 'ZAO Nexus', url: 'https://www.thezao.com/nexus', blurb: 'The full ecosystem link directory.', badge: 'Directory' },
+  { name: 'Empire Builder', url: 'https://empirebuilder.world', blurb: 'Where $ZABAL lives onchain.', badge: 'Token' },
+  { name: 'BetterCallZaal', url: 'https://bettercallzaal.com', blurb: 'Zaal’s personal brand + studio.', badge: 'Brand' },
+];
+
+export function ZabalEcosystem() {
+  return (
+    <section id="ecosystem" style={{ padding: '2.5rem 2rem', maxWidth: 960, margin: '0 auto' }}>
+      <h2 style={sectionTitle()}>Ecosystem</h2>
+      <p style={{ color: DIM, fontSize: '0.9rem', marginBottom: '1.5rem' }}>
+        Everything under the ZABAL umbrella - one tap away.
+      </p>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+          gap: '1rem',
+        }}
+      >
+        {PORTALS.map((p) => (
+          <a
+            key={p.name}
+            href={p.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              background: PANEL,
+              border: `1px solid ${BORDER}`,
+              borderRadius: 16,
+              padding: '1.25rem',
+              textDecoration: 'none',
+              color: '#fff',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.4rem',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+              <strong style={{ fontSize: '1.05rem' }}>{p.name}</strong>
+              <span
+                style={{
+                  fontSize: '0.65rem',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  color: GOLD,
+                  border: `1px solid ${BORDER}`,
+                  borderRadius: 999,
+                  padding: '2px 8px',
+                }}
+              >
+                {p.badge}
+              </span>
+            </div>
+            <span style={{ color: DIM, fontSize: '0.85rem' }}>{p.blurb}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------
+// About ZABAL + socials footer
+// ---------------------------------------------------------------
+
+interface Social {
+  label: string;
+  url: string;
+}
+
+const SOCIALS: Social[] = [
+  { label: 'BCZ on X', url: 'https://x.com/BetterCallZaal' },
+  { label: 'BCZ on Farcaster', url: 'https://warpcast.com/bettercallzaal' },
+  { label: 'The ZAO on X', url: 'https://x.com/TheZAODAO' },
+  { label: '/thezao channel', url: 'https://warpcast.com/~/channel/thezao' },
+  { label: 'ZAO Festivals', url: 'https://x.com/ZAOFestivals' },
+  { label: 'WaveWarZ', url: 'https://x.com/WaveWarZ' },
+  { label: 'Discord', url: 'https://discord.gg/thezao' },
+  { label: 'Paragraph', url: 'https://paragraph.xyz/@thezao' },
+];
+
+export function ZabalAbout() {
+  return (
+    <section
+      id="about"
+      style={{
+        padding: '2.5rem 2rem 3.5rem',
+        maxWidth: 960,
+        margin: '0 auto',
+        borderTop: `1px solid ${BORDER}`,
+      }}
+    >
+      <h2 style={sectionTitle()}>About ZABAL</h2>
+      <p style={{ color: '#fff', fontSize: '0.95rem', marginBottom: '0.6rem' }}>
+        ZABAL is the umbrella over everything Zaal builds: BetterCallZaal (the personal brand +
+        studio), The ZAO (the artist org), and incubated projects like WaveWarZ and ZAO Festivals -
+        all tied together by the $ZABAL token.
+      </p>
+      <p style={{ color: DIM, fontSize: '0.9rem', marginBottom: '1.5rem' }}>
+        This page is the front door. Vote weekly on where it goes.
+      </p>
+      <div style={{ display: 'flex', gap: '0.6rem', flexWrap: 'wrap' }}>
+        {SOCIALS.map((s) => (
+          <a
+            key={s.label}
+            href={s.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              color: GOLD,
+              fontSize: '0.82rem',
+              textDecoration: 'none',
+              border: `1px solid ${BORDER}`,
+              borderRadius: 999,
+              padding: '5px 12px',
+            }}
+          >
+            {s.label}
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------
+// shared style helpers
+// ---------------------------------------------------------------
+
+function sectionTitle(): React.CSSProperties {
+  return {
+    fontSize: '1.5rem',
+    fontWeight: 700,
+    marginBottom: '1rem',
+    color: GOLD,
+  };
+}
+
+function primaryCta(): React.CSSProperties {
+  return {
+    background: GOLD,
+    color: '#0a0a0a',
+    fontWeight: 700,
+    fontSize: '0.9rem',
+    padding: '0.65rem 1.4rem',
+    borderRadius: 10,
+    textDecoration: 'none',
+  };
+}
+
+function secondaryCta(): React.CSSProperties {
+  return {
+    background: 'transparent',
+    color: GOLD,
+    fontWeight: 700,
+    fontSize: '0.9rem',
+    padding: '0.65rem 1.4rem',
+    borderRadius: 10,
+    textDecoration: 'none',
+    border: `1px solid ${BORDER}`,
+  };
+}

--- a/src/app/zabal/_components/ZabalVoteClient.tsx
+++ b/src/app/zabal/_components/ZabalVoteClient.tsx
@@ -60,16 +60,20 @@ export function ZabalVoteClient({ initialTotals }: { initialTotals: ModeTotal[] 
       try {
         const ctx = await sdk.context;
         const userFid = ctx?.user?.fid;
-        if (cancelled || !userFid) return;
+        // Base App can report fid -1 when context is not ready (Issue #537);
+        // treat anything < 1 as "no FID yet".
+        if (cancelled || !userFid || userFid < 1) return;
         setFid(userFid);
 
-        // Pre-compute vote power (also primes the cache for /vote acceptance)
+        // Pre-compute vote power (also primes the cache for /vote acceptance).
+        // Note: sdk.actions.ready() is fired globally by <MiniAppReady /> in
+        // the root layout - not called here, so a slow fetch never blocks the
+        // splash from clearing.
         const res = await fetch(`/api/zabal/calculate-vote-power?fid=${userFid}`);
         if (res.ok) {
           const data = (await res.json()) as VotePower;
           if (!cancelled) setVotePower(data);
         }
-        await sdk.actions.ready();
       } catch (err) {
         if (!cancelled) setStatus(`miniapp init failed: ${String(err).slice(0, 80)}`);
       }

--- a/src/app/zabal/page.tsx
+++ b/src/app/zabal/page.tsx
@@ -1,15 +1,37 @@
 import { Metadata } from 'next';
 import { ZabalVoteClient } from './_components/ZabalVoteClient';
+import { ZabalNav, ZabalTokenPanel, ZabalEcosystem, ZabalAbout } from './_components/ZabalHub';
 import { supabaseAdmin } from '@/lib/db/supabase';
+
+// Per-route Mini App embed so a shared zaoos.com/zabal link launches the
+// ZABAL hub - not the root /miniapp. (Research Doc 707 P0.)
+const zabalEmbed = JSON.stringify({
+  version: '1',
+  imageUrl: 'https://zaoos.com/og/zabal',
+  button: {
+    title: 'Vote on ZAO',
+    action: {
+      type: 'launch_miniapp',
+      url: 'https://zaoos.com/zabal',
+      name: 'ZABAL',
+      splashImageUrl: 'https://zaoos.com/splash.png',
+      splashBackgroundColor: '#0a0a0a',
+    },
+  },
+});
 
 export const metadata: Metadata = {
   title: 'ZABAL - Vote on ZAO Direction',
   description:
-    'Weekly community vote on ZAO focus: Music, Governance, Events, Build. Powered by Farcaster + $ZABAL Empire.',
+    'The ZABAL hub - vote weekly on ZAO focus (Music, Governance, Events, Build), hold $ZABAL, and explore the ecosystem.',
   openGraph: {
     title: 'ZABAL - Vote on ZAO Direction',
-    description: 'Weekly community vote: Music, Governance, Events, Build.',
-    url: 'https://thezao.com/zabal',
+    description: 'Weekly community vote, $ZABAL token, and the whole ZABAL ecosystem.',
+    url: 'https://zaoos.com/zabal',
+  },
+  other: {
+    'fc:miniapp': zabalEmbed,
+    'fc:frame': zabalEmbed,
   },
 };
 
@@ -41,23 +63,41 @@ async function getLeaderboard(): Promise<LeaderRow[]> {
   return data as LeaderRow[];
 }
 
+interface WinnerRow {
+  username: string | null;
+  fid: number;
+  wins: number;
+}
+
+async function getTopWinner(): Promise<WinnerRow | null> {
+  const { data, error } = await supabaseAdmin.rpc('get_zabal_spotlight_leaderboard', { p_limit: 1 });
+  if (error || !data || (data as WinnerRow[]).length === 0) return null;
+  return (data as WinnerRow[])[0];
+}
+
 export default async function ZabalPage() {
-  const [totals, leaders] = await Promise.all([getWeekTotals(), getLeaderboard()]);
+  const [totals, leaders, topWinner] = await Promise.all([
+    getWeekTotals(),
+    getLeaderboard(),
+    getTopWinner(),
+  ]);
 
   return (
     <main
       style={{
         minHeight: '100vh',
-        background:
-          'linear-gradient(135deg, #0a0a0a 0%, #141e27 100%)',
+        background: 'linear-gradient(135deg, #0a0a0a 0%, #141e27 100%)',
         color: '#ffffff',
         fontFamily:
           '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif',
       }}
     >
+      <ZabalNav />
+
+      {/* Hero - identity above the fold */}
       <header
         style={{
-          padding: '4rem 2rem 2rem',
+          padding: '3rem 2rem 1.5rem',
           textAlign: 'center',
           maxWidth: 960,
           margin: '0 auto',
@@ -72,19 +112,58 @@ export default async function ZabalPage() {
             WebkitBackgroundClip: 'text',
             WebkitTextFillColor: 'transparent',
             backgroundClip: 'text',
-            marginBottom: '0.5rem',
+            marginBottom: '0.75rem',
           }}
         >
           ZABAL
         </h1>
-        <p style={{ color: '#a0a0a0', fontSize: '1.1rem' }}>
-          Vote weekly on ZAO direction. Mon-Sun in NYC.
+        <p style={{ color: '#a0a0a0', fontSize: '1.05rem', maxWidth: 560, margin: '0 auto' }}>
+          The umbrella over everything Zaal builds - The ZAO, WaveWarZ, ZAO Festivals, and the
+          $ZABAL economy. Vote weekly on where it goes.
         </p>
       </header>
 
-      <ZabalVoteClient initialTotals={totals} />
+      {/* Section 2 - the live weekly vote */}
+      <div id="vote">
+        <ZabalVoteClient initialTotals={totals} />
+      </div>
 
-      <section style={{ padding: '2rem', maxWidth: 960, margin: '0 auto' }}>
+      {/* Section 3 - $ZABAL token */}
+      <ZabalTokenPanel />
+
+      {/* Section 4 - ecosystem portals */}
+      <ZabalEcosystem />
+
+      {/* Section 5 - Member Spotlight summary */}
+      <section id="spotlight" style={{ padding: '2.5rem 2rem', maxWidth: 960, margin: '0 auto' }}>
+        <h2 style={{ fontSize: '1.5rem', fontWeight: 700, marginBottom: '1rem', color: '#e0ddaa' }}>
+          Member Spotlight
+        </h2>
+        <a
+          href="/zabal/spotlight"
+          style={{
+            display: 'block',
+            background: 'rgba(20, 30, 39, 0.6)',
+            border: '1px solid rgba(224, 221, 170, 0.2)',
+            borderRadius: 16,
+            padding: '1.5rem',
+            textDecoration: 'none',
+            color: '#fff',
+          }}
+        >
+          <p style={{ margin: 0, fontSize: '1rem' }}>
+            {topWinner
+              ? `Latest spotlight winner: ${topWinner.username ?? `fid ${topWinner.fid}`} (${topWinner.wins} win${topWinner.wins === 1 ? '' : 's'}).`
+              : 'Weekly recognition for ZAO members who ship.'}
+          </p>
+          <p style={{ margin: '0.5rem 0 0', color: '#e0ddaa', fontSize: '0.9rem' }}>
+            Nominate Mon-Wed, vote Thu-Sun -&gt;
+          </p>
+        </a>
+      </section>
+
+      {/* Section 6 - leaderboard */}
+      <section id="leaderboard" style={{ padding: '0 2rem 2rem', maxWidth: 960, margin: '0 auto' }}>
         <h2
           style={{
             fontSize: '1.5rem',
@@ -120,10 +199,7 @@ export default async function ZabalPage() {
                 </tr>
               )}
               {leaders.map((row) => (
-                <tr
-                  key={row.fid}
-                  style={{ borderTop: '1px solid rgba(224, 221, 170, 0.1)' }}
-                >
+                <tr key={row.fid} style={{ borderTop: '1px solid rgba(224, 221, 170, 0.1)' }}>
                   <td style={td()}>{row.rank}</td>
                   <td style={td()}>{row.username ?? `fid ${row.fid}`}</td>
                   <td style={td({ textAlign: 'right' })}>{row.score}</td>
@@ -138,12 +214,12 @@ export default async function ZabalPage() {
           <a href="https://songjam.space/zabal" style={{ color: '#e0ddaa' }}>
             $ZABAL Empire
           </a>{' '}
-          via Empire Builder.{' '}
-          <a href="/zabal/spotlight" style={{ color: '#e0ddaa' }}>
-            Member Spotlight
-          </a>
+          via Empire Builder.
         </p>
       </section>
+
+      {/* Section 7 - about + socials */}
+      <ZabalAbout />
     </main>
   );
 }

--- a/src/app/zabal/spotlight/_components/ZabalSpotlightClient.tsx
+++ b/src/app/zabal/spotlight/_components/ZabalSpotlightClient.tsx
@@ -37,14 +37,16 @@ export function ZabalSpotlightClient() {
         const ctx = await sdk.context;
         const userFid = ctx?.user?.fid;
         if (cancelled) return;
-        if (userFid) setFid(userFid);
+        // Base App can report fid -1 before context settles (Issue #537).
+        if (userFid && userFid >= 1) setFid(userFid);
 
+        // sdk.actions.ready() is fired globally by <MiniAppReady /> in the
+        // root layout - not called here, so a slow fetch never sticks the splash.
         const res = await fetch('/api/zabal/spotlight/nominees?limit=8');
         if (res.ok) {
           const data = (await res.json()) as { nominees: Nominee[] };
           if (!cancelled) setNominees(data.nominees ?? []);
         }
-        await sdk.actions.ready();
       } catch (err) {
         if (!cancelled) setStatus(`init failed: ${String(err).slice(0, 80)}`);
       }

--- a/src/app/zabal/spotlight/page.tsx
+++ b/src/app/zabal/spotlight/page.tsx
@@ -2,9 +2,30 @@ import { Metadata } from 'next';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { ZabalSpotlightClient } from './_components/ZabalSpotlightClient';
 
+// Per-route Mini App embed - a shared spotlight link launches the
+// spotlight surface, not the root /miniapp. (Research Doc 707 P0.)
+const spotlightEmbed = JSON.stringify({
+  version: '1',
+  imageUrl: 'https://zaoos.com/og/zabal',
+  button: {
+    title: 'Member Spotlight',
+    action: {
+      type: 'launch_miniapp',
+      url: 'https://zaoos.com/zabal/spotlight',
+      name: 'ZABAL',
+      splashImageUrl: 'https://zaoos.com/splash.png',
+      splashBackgroundColor: '#0a0a0a',
+    },
+  },
+});
+
 export const metadata: Metadata = {
   title: 'ZABAL Spotlight - Member of the Week',
   description: 'Nominate and vote for ZAO members who shipped the most this week.',
+  other: {
+    'fc:miniapp': spotlightEmbed,
+    'fc:frame': spotlightEmbed,
+  },
 };
 
 export const revalidate = 60;


### PR DESCRIPTION
## Summary

Turns `/zabal` from a voting app into the canonical ZABAL landing page. Implements research Doc 707 (mini app conformance) + Doc 708 (hub architecture) in one PR.

## 707 - mini app conformance fixes
- **Per-route `fc:miniapp`/`fc:frame` embed** on `/zabal` + `/zabal/spotlight` - shared links now launch the right surface, not root `/miniapp` (the P0 bug)
- New `src/app/og/zabal` OG image route for the embed card
- Removed redundant `sdk.actions.ready()` from both client components - global `<MiniAppReady/>` covers it, so a slow fetch can't stick the splash
- Base App `fid -1` guard (Issue #537)

## 708 - hub sections
New `_components/ZabalHub.tsx` (server components):
- Sticky anchored nav: Vote / Token / Ecosystem / Spotlight / About
- **$ZABAL token panel** - hold-$ZABAL CTA, Empire leaderboard, vote-power explainer
- **Ecosystem portals grid** - 8 cards (The ZAO, ZAO Festivals, WaveWarZ, ZAO OS, BCZ YapZ, ZAO Nexus, Empire Builder, BetterCallZaal)
- Member Spotlight summary card (shows latest winner)
- About ZABAL + all-brand socials footer
- Hero restated; `openGraph` url corrected thezao.com -> zaoos.com

## Test
`npx tsc --noEmit` clean for all `src/app/zabal` + `src/app/og/zabal` files. Ready to test in the Farcaster mini app at zaoos.com/zabal once merged/previewed.

## Related
Research Docs 707 (PR #611), 708 (PR #612), rollup 665.

🤖 Generated with [Claude Code](https://claude.com/claude-code)