### PR TITLE
doc 710: mini app registration + deep-linking on zaoos.com (STANDARD)

### DIFF
--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meeting
-description: Capture meeting transcripts (voice memo, Craig recording, Fathom URL, paste-in-chat) and distribute extracted decisions, action items, and key quotes to the right ZAO surfaces - cowork-zaodevz actions.json, a research/events/NNN-* recap doc, Bonfire ingest queue, Telegram copy-paste block, memory, and calendar. Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or types "/meeting <path-or-url>". Always fires on meeting context - undertriggering wastes the capture.
+description: Capture meeting transcripts (voice memo, Craig recording, Fathom URL, paste-in-chat) and distribute extracted decisions, action items, and key quotes to the right ZAO surfaces - cowork-zaodevz actions.json, a research/events/NNN-* recap doc, the ZABAL Bonfire knowledge graph, a meetings index, Telegram copy-paste block, memory, and calendar. Use when the user just finished a meeting, shares a recording or transcript, says "process this call", "extract todos from this", "recap that meeting", or types "/meeting <path-or-url>". Always fires on meeting context - undertriggering wastes the capture.
 allowed-tools: Read Write Edit Bash WebFetch Skill AskUserQuestion
 ---
 
@@ -12,7 +12,8 @@ Turn any meeting recording or transcript into:
 - A row in `research/events/_meetings-index.md` - the one canonical list of every past meeting
 - A copy-paste Telegram bubble for sharing
 - A next-actions clipboard page the moment the meeting ends (Phase 6)
-- Optional Bonfire ingest, memory write, calendar update
+- Episodes posted to the ZABAL Bonfire knowledge graph - always-on, so the graph always has full meeting context (doc 680)
+- Optional memory write, calendar update
 
 One command, multiple inputs, project-routed output targets. User-gated per run.
 
@@ -39,7 +40,7 @@ Look at what the user supplied (the slash-command argument, a pasted block, or j
 
 - **craig_url** - the input is a URL starting `https://craig.horse/`
 - **fathom_url** - the input is a URL starting `https://fathom.video/`
-- **local_audio** - the input is a path ending `.m4a` / `.mp3` / `.wav` / `.mp4` / `.opus` and the file exists
+- **local_audio** - the input is a path ending `.m4a` / `.mp3` / `.wav` / `.mp4` / `.mov` / `.opus` and the file exists. A video file (mp4/mov) additionally triggers frame extraction - see Phase 1.
 - **paste** - the input (or the last user message) is a block of transcript / meeting-notes text, roughly 200+ chars. Also covers the user narrating the meeting in chat ("Iman said X, then Zaal said Y...") - use the conversation context as the transcript.
 - **unclear** - none of the above. Ask the user one question: paste the transcript, give a file path, or give a Craig/Fathom URL.
 
@@ -65,18 +66,40 @@ What DOES route per project is the **action tracker** and the **Telegram destina
 ### Mode: paste
 Use the pasted text directly. Skip Phase 1.
 
-### Mode: local_audio
-Audio file is on Zaal's mac. Transcribe via Iman's VPS (per doc 673 decision).
+### Mode: local_audio (audio OR video file)
+
+The file is on Zaal's mac. Transcription runs locally - no upload, no VPS round-trip.
+
+**Step 1 - extract video frames (video files only).** If the file has a video
+stream (mp4, mov), pull representative still frames first. Frames give the
+Phase 2 extraction passes visual context the audio cannot: shared slides,
+screenshares, whiteboards, and the call UI's participant name tags.
 
 ```bash
-bash ${CLAUDE_SKILL_DIR}/scripts/transcribe.sh "$AUDIO_PATH"
+bash ${CLAUDE_SKILL_DIR}/scripts/extract-frames.sh "$MEDIA_PATH"
 ```
 
-The script:
-1. Checks Whisper is installed on VPS. If not, prints install command and exits.
-2. SCPs the audio file to `root@187.77.3.104:/tmp/meeting-input.<ext>`
-3. Runs `whisper --model base --language en /tmp/meeting-input.<ext> --output_dir /tmp/meeting-output/`
-4. SCPs the `.txt` back, prints transcript path.
+The script prints a frames directory path, or the literal `NO_VIDEO` for an
+audio-only file (then skip straight to Step 2). Scene-change detection catches
+slide flips and screenshare switches; a fixed-interval fallback covers static
+talking-head calls. Capped at 24 frames. Keep the frames dir path for Phase 2.
+
+**Step 2 - transcribe.**
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/transcribe.sh "$MEDIA_PATH"
+```
+
+The script is local-first:
+1. If `mlx-whisper` is installed (Apple Silicon), it transcribes locally with
+   `whisper-large-v3-turbo` - fast, offline, accurate on names. Handles mp4/mov
+   directly (ffmpeg strips the audio track). First run for a model downloads it.
+2. If local tooling is absent (non-Mac machine), it falls back to Whisper on
+   Iman's VPS - SCP up, transcribe, SCP the `.txt` back.
+
+One-time local setup: `uv tool install mlx-whisper`. For a hard-to-hear or
+many-name meeting, pass a bigger model:
+`transcribe.sh "$MEDIA_PATH" --model mlx-community/whisper-large-v3`.
 
 ### Mode: craig_url
 Download Craig recording, transcribe.
@@ -93,6 +116,15 @@ Use WebFetch on the share URL to extract transcript JSON from the page. Fathom s
 ## Phase 2 - Extract structure
 
 Multi-pass extraction, NOT one monolithic prompt (doc 676 - monolithic extraction hallucinates). Run these passes in order, each over the same transcript:
+
+**Video input - read the frames first.** If Phase 1 produced a frames directory,
+`Read` every JPG in it before Pass A. Use what the frames show - slide text,
+shared screens, whiteboards, participant name tags - as corroborating context
+across all five passes: they disambiguate attendees (Pass A), surface decisions
+shown on a slide but not said aloud (Pass B/C), and confirm name spellings
+against the brand glossary. A frame is corroboration, never a substitute for the
+transcript - if a frame and the transcript conflict, the transcript wins and the
+item is flagged `confidence: low`.
 
 1. **Pass A - meeting metadata.** date, duration, title, attendees, platform. Date never invented - from transcript, file mtime, or ask.
 2. **Pass B - decisions.** Things explicitly decided/agreed in the call. Verbatim-anchored.
@@ -188,7 +220,7 @@ Then ask Zaal:
 > Targets (action target depends on project - see Phase 0):
 > - [x] Action tracker for `<project>` (default ON)
 > - [x] research/events/NNN-<slug>/README.md (default ON, every meeting, always ZAOOS)
-> - [ ] Bonfire ingest queue (opt-in)
+> - [x] Bonfire knowledge-graph episodes (default ON - the graph should always have meeting context, doc 680)
 > - [ ] Telegram copy-paste block (opt-in, default OFF - print only on request)
 > - [ ] Memory writes (opt-in, confirm each)
 > - [ ] Calendar event update (opt-in if title matches a Google Cal event)
@@ -241,10 +273,33 @@ Then insert the new meeting as the first data row:
 
 This is not optional and not project-routed - every meeting, every project, one index. Commit it alongside the recap doc.
 
-### Bonfire ingest queue
-- Write transcript + recap to `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
-- Run `python3 scripts/bonfire-ingest/secret_scan.py <file>` to filter secrets.
-- Do NOT run `bonfire_client.py` ingest automatically - Zaal triggers when ready (PR #568 just shipped, integration still warm).
+### Bonfire knowledge-graph episodes (always-on - doc 680)
+
+Post the meeting into the ZABAL Bonfire so the knowledge graph always has full context. This is default-ON, not opt-in.
+
+Build an episodes JSON file at `/tmp/meeting-bonfire-episodes.json`:
+
+```json
+{
+  "episodes": [
+    {"name": "meeting:<date>:summary", "body": "<one paragraph: title, date, attendees, project, what it covered>", "source_tag": "meeting:<slug>"},
+    {"name": "meeting:<date>:decision-1", "body": "In the <title> meeting on <date> (<attendees>), the team decided: <decision text>. Owner: <owner>.", "source_tag": "meeting:<slug>"},
+    {"name": "meeting:<date>:action-1", "body": "From the <title> meeting on <date>, <owner> is to <action title>. Due: <due or 'no date set'>.", "source_tag": "meeting:<slug>"}
+  ]
+}
+```
+
+- One summary episode + one per decision + one per action. Quotes are skipped (low KG value as standalone nodes).
+- Episode bodies are natural-language prose, self-contained (name the meeting + date + people) - Bonfires auto-extraction reads prose, and a node must make sense alone.
+- Then run:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/bonfire-episode.sh /tmp/meeting-bonfire-episodes.json
+```
+
+The script POSTs each episode to `POST /knowledge_graph/episode/create` (Bearer `$BONFIRE_API_KEY`, `$BONFIRE_ID`). It is best-effort: secret-scans every body, 15s timeout per POST, always exits 0 - a Bonfire failure never aborts the run. If `$BONFIRE_API_KEY` is unset it prints "skipped (no key)" and continues.
+
+Do NOT use the old `content/bonfire-ingest/` file path - that is the bulk-backfill pipeline (research library, READMEs), wrong tool for per-meeting real-time. See doc 680.
 
 ### Telegram copy-paste block
 Print a single fenced block ready for long-press-copy. No header/footer (per `feedback_copyable_content_own_bubble`). Format:
@@ -331,7 +386,7 @@ Rules:
 - Do NOT propose a new Telegram bot for meeting capture (= ZAO Craig, separate doc 670 work).
 - Do NOT replace `bot/src/capture.ts` `/gemba /idea /note` (ZAOstock bot, different DB, different scope).
 - Do NOT use Deepgram (ZAOstock-only per doc 12; this skill stays free for personal use).
-- Do NOT install Whisper locally on Zaal's mac - all transcription runs on Iman's VPS (per doc 673 decision).
+- Transcription is local-first: mlx-whisper on Zaal's Apple Silicon mac (fast, offline). The VPS is the fallback for non-Mac machines only. This supersedes the doc 673 VPS-only decision - the VPS has no GPU, so local Apple Silicon is faster and has no upload step.
 - Do NOT use emojis in any output (per global `feedback_no_emojis`).
 - Do NOT use em dashes (per global `feedback_no_em_dashes`).
 
@@ -347,9 +402,11 @@ When creating the recap doc, parallel Claude sessions may race for the same numb
 
 ## Scripts
 
-- `scripts/transcribe.sh` - SCP to VPS, run Whisper, SCP back
+- `scripts/transcribe.sh` - local-first transcription: mlx-whisper on Apple Silicon, VPS Whisper fallback
+- `scripts/extract-frames.sh` - pull scene-change + interval still frames from a meeting video
 - `scripts/fetch-craig.sh` - curl Craig recording URL, extract audio
 - `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append (ZAO Devz project only)
+- `scripts/bonfire-episode.sh` - POST meeting episodes to the ZABAL Bonfire KG (always-on, best-effort, doc 680)
 
 ## Evals
 

--- a/.claude/skills/meeting/references/distribution-targets.md
+++ b/.claude/skills/meeting/references/distribution-targets.md
@@ -112,36 +112,50 @@ tier: STANDARD
 ---
 ```
 
-## 3. Bonfire ingest queue
+## 3. Bonfire knowledge-graph episodes (always-on - doc 680)
 
-**Target:** `content/bonfire-ingest/meeting-YYYY-MM-DD-<slug>.md`.
-**Method:** Write file, run secret-scan, do NOT trigger ingest client (Zaal triggers when ready).
+**Target:** the ZABAL Bonfire, `POST https://tnt-v2.api.bonfires.ai/knowledge_graph/episode/create`.
+**Method:** `scripts/bonfire-episode.sh` - curl POST per episode. Best-effort, never aborts the run.
+**Auth:** `$BONFIRE_API_KEY` + `$BONFIRE_ID` (reused from the ZOE bridge, `bot/src/zoe/recall.ts`). Unset => skip + continue.
 
-### File structure
+This is default-ON, every meeting. Goal: the knowledge graph always has full meeting context. Do NOT use the old `content/bonfire-ingest/` file path - that is the bulk-backfill pipeline (research library, GitHub READMEs), wrong tool for per-meeting real-time.
 
-```markdown
-# Meeting: <title>
+### Episodes JSON
 
-**Date:** YYYY-MM-DD
-**Attendees:** <comma-separated>
-**Platform:** <platform>
+Build `/tmp/meeting-bonfire-episodes.json`:
 
-## Transcript
-
-<full transcript here>
-
-## Recap
-
-(insert recap doc body here from template)
+```json
+{
+  "episodes": [
+    {"name": "meeting:<date>:summary",     "body": "<paragraph: title, date, attendees, project, coverage>", "source_tag": "meeting:<slug>"},
+    {"name": "meeting:<date>:decision-<n>", "body": "In the <title> meeting on <date> (<attendees>), the team decided: <text>. Owner: <owner>.", "source_tag": "meeting:<slug>"},
+    {"name": "meeting:<date>:action-<n>",   "body": "From the <title> meeting on <date>, <owner> is to <action>. Due: <due or 'no date set'>.", "source_tag": "meeting:<slug>"}
+  ]
+}
 ```
 
-### Secret-scan gate
+One summary + one per decision + one per action. Quotes skipped. Bodies are self-contained prose (Bonfires auto-extracts entities from prose; a node must stand alone).
+
+### Run
 
 ```bash
-python3 scripts/bonfire-ingest/secret_scan.py content/bonfire-ingest/meeting-<date>-<slug>.md
+bash ${CLAUDE_SKILL_DIR}/scripts/bonfire-episode.sh /tmp/meeting-bonfire-episodes.json
 ```
 
-If exit code != 0, abort write + surface to Zaal. Reference `.claude/rules/secret-hygiene.md`.
+The script secret-scans every body (9 HIGH patterns mirroring `recall.ts` `containsSecret()`), 15s timeout per POST, always exits 0. Episode `name` is deterministic so a re-run updates rather than duplicates.
+
+### Episode payload (what the script sends)
+
+```json
+{
+  "bonfire_id": "$BONFIRE_ID",
+  "name": "meeting:2026-05-19:decision-1",
+  "episode_body": "...",
+  "source": "text",
+  "source_description": "meeting:<slug>",
+  "reference_time": "<ISO now>"
+}
+```
 
 ## 4. Telegram copy-paste block
 

--- a/.claude/skills/meeting/scripts/bonfire-episode.sh
+++ b/.claude/skills/meeting/scripts/bonfire-episode.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# bonfire-episode.sh - POST meeting episodes to the ZABAL Bonfire knowledge graph.
+# Usage: bonfire-episode.sh <episodes-json-path>
+#
+# Input JSON: {"episodes": [{"name": "...", "body": "...", "source_tag": "..."}]}
+#
+# Each episode is POSTed to /knowledge_graph/episode/create. Bonfires
+# auto-extraction turns the natural-language body into KG nodes.
+#
+# Best-effort by design (mirrors bot/src/zoe/recall.ts): a Bonfire failure
+# must NEVER abort the /meeting skill. Always exits 0. Prints per-episode
+# ok/fail/skip to stderr; prints a one-line summary to stdout.
+#
+# Env (reused from the ZOE bridge - no new secrets):
+#   BONFIRE_API_KEY  required - absent => skip all, exit 0
+#   BONFIRE_ID       required - the ZABAL bonfire id
+#   BONFIRE_API_URL  default https://tnt-v2.api.bonfires.ai
+
+set -uo pipefail
+
+INPUT="${1:?missing episodes-json path}"
+API_URL="${BONFIRE_API_URL:-https://tnt-v2.api.bonfires.ai}"
+API_KEY="${BONFIRE_API_KEY:-}"
+BONFIRE_ID="${BONFIRE_ID:-}"
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "[bonfire] ERROR: episodes file not found: $INPUT" >&2
+  echo "Bonfire: skipped (no input file)"
+  exit 0
+fi
+
+if [[ -z "$API_KEY" || -z "$BONFIRE_ID" ]]; then
+  echo "[bonfire] BONFIRE_API_KEY / BONFIRE_ID not set - skipping graph write" >&2
+  echo "Bonfire: skipped (no key)"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null; then
+  echo "[bonfire] ERROR: jq required" >&2
+  echo "Bonfire: skipped (no jq)"
+  exit 0
+fi
+
+# Secret guard - 9 HIGH-severity patterns, mirrors recall.ts containsSecret().
+SECRET_RE='sk-ant-[A-Za-z0-9_-]{20,}|sk-(proj-|cp-)?[A-Za-z0-9_-]{30,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{60,}|-----BEGIN ([A-Z]+ )?PRIVATE KEY-----|0x[0-9a-fA-F]{64}|[0-9]{9,12}:[A-Za-z0-9_-]{30,}|xox[bpaors]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}'
+
+N=$(jq '.episodes | length' "$INPUT" 2>/dev/null || echo 0)
+if [[ "$N" -eq 0 ]]; then
+  echo "[bonfire] no episodes to post" >&2
+  echo "Bonfire: 0 episodes"
+  exit 0
+fi
+
+posted=0
+failed=0
+skipped=0
+
+for i in $(seq 0 $((N - 1))); do
+  name=$(jq -r ".episodes[$i].name" "$INPUT")
+  body=$(jq -r ".episodes[$i].body" "$INPUT")
+  tag=$(jq -r ".episodes[$i].source_tag // \"meeting\"" "$INPUT")
+
+  if [[ -z "$body" || "$body" == "null" ]]; then
+    skipped=$((skipped + 1)); continue
+  fi
+
+  if echo "$body" | grep -qE "$SECRET_RE"; then
+    echo "[bonfire] SKIP $name - body matched a secret pattern" >&2
+    skipped=$((skipped + 1)); continue
+  fi
+
+  payload=$(jq -n \
+    --arg bid "$BONFIRE_ID" --arg name "$name" --arg body "$body" \
+    --arg tag "$tag" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    '{bonfire_id: $bid, name: $name, episode_body: $body, source: "text", source_description: $tag, reference_time: $ts}')
+
+  code=$(curl -s -o /tmp/bonfire-resp.txt -w '%{http_code}' \
+    --max-time 15 -X POST "$API_URL/knowledge_graph/episode/create" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>/dev/null || echo "000")
+
+  if [[ "$code" =~ ^2 ]]; then
+    echo "[bonfire] OK $name" >&2
+    posted=$((posted + 1))
+  else
+    echo "[bonfire] FAIL $name - HTTP $code $(head -c 120 /tmp/bonfire-resp.txt 2>/dev/null)" >&2
+    failed=$((failed + 1))
+  fi
+done
+
+rm -f /tmp/bonfire-resp.txt
+echo "Bonfire: $posted posted, $failed failed, $skipped skipped (of $N)"
+exit 0

--- a/.claude/skills/meeting/scripts/extract-frames.sh
+++ b/.claude/skills/meeting/scripts/extract-frames.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# extract-frames.sh - pull representative still frames from a meeting video.
+#
+# Scene-change detection catches slide flips and screenshare switches; a
+# fixed-interval fallback covers static talking-head calls. Frames give the
+# extraction passes visual context the audio cannot: shared slides, screenshares,
+# whiteboards, and the call UI's participant name tags.
+#
+# Usage:  extract-frames.sh <video-path>
+# Prints: the output directory path on success,
+#         or the literal "NO_VIDEO" for audio-only input (caller skips frames).
+set -euo pipefail
+
+SRC="${1:?missing video path}"
+if [[ ! -f "$SRC" ]]; then
+  echo "ERROR: file not found: $SRC" >&2
+  exit 2
+fi
+
+command -v ffmpeg  >/dev/null 2>&1 || { echo "ERROR: ffmpeg not installed (brew install ffmpeg)" >&2; exit 3; }
+command -v ffprobe >/dev/null 2>&1 || { echo "ERROR: ffprobe not installed (brew install ffmpeg)" >&2; exit 3; }
+
+# Audio-only input (m4a/mp3/wav/opus) has no video stream - nothing to extract.
+HAS_VIDEO=$(ffprobe -v error -select_streams v -show_entries stream=codec_type \
+  -of csv=p=0 "$SRC" 2>/dev/null | head -1)
+if [[ "$HAS_VIDEO" != "video" ]]; then
+  echo "NO_VIDEO"
+  exit 0
+fi
+
+MAX_FRAMES="${MEETING_MAX_FRAMES:-24}"
+SCENE_THRESHOLD="${MEETING_SCENE_THRESHOLD:-0.30}"
+STAMP=$(date +%Y%m%d-%H%M%S)
+OUT="/tmp/meeting-frames-$STAMP"
+mkdir -p "$OUT"
+
+echo "[extract-frames] scanning $SRC for scene changes (threshold $SCENE_THRESHOLD)" >&2
+
+# Pass 1 - scene-change detection. Catches slide flips + screenshare switches.
+# Frames scaled to 960px wide - cheap enough for a vision pass, legible enough
+# to read slide text. -fps_mode vfr stops ffmpeg padding with duplicate frames.
+ffmpeg -nostdin -loglevel error -i "$SRC" \
+  -vf "select='gt(scene,${SCENE_THRESHOLD})',scale=960:-2" -fps_mode vfr -q:v 4 \
+  "$OUT/scene-%04d.jpg" 2>/dev/null || true
+
+COUNT=$(find "$OUT" -maxdepth 1 -name 'scene-*.jpg' | wc -l | tr -d ' ')
+
+# Pass 2 - few/no scene cuts (static talking-heads call): sample on a timer so
+# the extraction still sees the call UI - name tags, who joined or left.
+if [[ "$COUNT" -lt 4 ]]; then
+  DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$SRC" 2>/dev/null | cut -d. -f1)
+  DUR=${DUR:-600}
+  STEP=$(( DUR / 12 )); [[ "$STEP" -lt 5 ]] && STEP=30
+  echo "[extract-frames] only $COUNT scene cuts - adding interval frames every ${STEP}s" >&2
+  ffmpeg -nostdin -loglevel error -i "$SRC" \
+    -vf "fps=1/${STEP},scale=960:-2" -q:v 4 \
+    "$OUT/interval-%04d.jpg" 2>/dev/null || true
+fi
+
+# Cap total frames - keep an evenly-spaced subset if over budget. A vision pass
+# over 100 near-identical frames is wasteful; MAX_FRAMES is the budget.
+TOTAL=$(find "$OUT" -maxdepth 1 -name '*.jpg' | wc -l | tr -d ' ')
+if [[ "$TOTAL" -gt "$MAX_FRAMES" ]]; then
+  KEEP_EVERY=$(( (TOTAL + MAX_FRAMES - 1) / MAX_FRAMES ))
+  echo "[extract-frames] $TOTAL frames over budget $MAX_FRAMES - keeping 1 in $KEEP_EVERY" >&2
+  i=0
+  find "$OUT" -maxdepth 1 -name '*.jpg' | sort | while IFS= read -r f; do
+    if (( i % KEEP_EVERY != 0 )); then rm -f "$f"; fi
+    i=$((i+1))
+  done
+fi
+
+FINAL=$(find "$OUT" -maxdepth 1 -name '*.jpg' | wc -l | tr -d ' ')
+if [[ "$FINAL" -eq 0 ]]; then
+  echo "ERROR: no frames extracted" >&2
+  exit 4
+fi
+echo "[extract-frames] $FINAL frames -> $OUT" >&2
+echo "$OUT"

--- a/.claude/skills/meeting/scripts/transcribe.sh
+++ b/.claude/skills/meeting/scripts/transcribe.sh
@@ -1,25 +1,68 @@
 #!/usr/bin/env bash
-# transcribe.sh - SCP audio file to Iman VPS, run Whisper, SCP transcript back.
-# Usage: transcribe.sh <local-audio-path> [--model base|small|medium]
-# Outputs: prints local path to .txt transcript on success.
-
+# transcribe.sh - transcribe a meeting recording (audio or video) to text.
+#
+# Local-first: mlx-whisper runs natively on Apple Silicon - fast, offline, no
+# GPU server needed. Falls back to Whisper on Iman's VPS only when local tooling
+# is absent (e.g. running from a non-Mac machine).
+#
+# Usage:   transcribe.sh <media-path> [--model <model>]
+# Outputs: prints the local path to the .txt transcript on success.
 set -euo pipefail
 
-VPS_HOST="${ZAOCOWORKING_VPS:-root@187.77.3.104}"
-MODEL="${WHISPER_MODEL:-base}"
-SRC="${1:?missing audio path}"
-
+SRC="${1:?missing media path}"
 if [[ ! -f "$SRC" ]]; then
-  echo "ERROR: audio file not found: $SRC" >&2
+  echo "ERROR: media file not found: $SRC" >&2
   exit 2
 fi
 
-# Parse optional model flag
+# Optional model override: --model <mlx-repo-or-whisper-model>
+MODEL_OVERRIDE=""
 if [[ "${2:-}" == "--model" && -n "${3:-}" ]]; then
-  MODEL="$3"
+  MODEL_OVERRIDE="$3"
 fi
 
-# Preflight - verify whisper installed on VPS
+STAMP=$(date +%Y%m%d-%H%M%S)
+LOCAL_OUT="/tmp/meeting-$STAMP.txt"
+
+# ---------- Path A: local mlx-whisper (Apple Silicon, preferred) ----------
+MLX_BIN="$(command -v mlx_whisper || true)"
+if [[ -z "$MLX_BIN" && -x "$HOME/.local/bin/mlx_whisper" ]]; then
+  MLX_BIN="$HOME/.local/bin/mlx_whisper"
+fi
+
+if [[ -n "$MLX_BIN" ]]; then
+  MODEL="${MODEL_OVERRIDE:-${MLX_WHISPER_MODEL:-mlx-community/whisper-large-v3-turbo}}"
+  OUTDIR="/tmp/meeting-$STAMP"
+  mkdir -p "$OUTDIR"
+  echo "[transcribe] local mlx-whisper - model $MODEL, input $(du -h "$SRC" | cut -f1)" >&2
+  echo "[transcribe] first run for a model downloads it (~1.5GB); later runs are cached" >&2
+
+  # mlx_whisper handles mp4/mov directly - ffmpeg strips the audio track.
+  "$MLX_BIN" "$SRC" \
+    --model "$MODEL" \
+    --language en \
+    --output-format txt \
+    --output-name transcript \
+    --output-dir "$OUTDIR" >&2
+
+  if [[ ! -f "$OUTDIR/transcript.txt" ]]; then
+    echo "ERROR: mlx-whisper produced no transcript at $OUTDIR/transcript.txt" >&2
+    exit 5
+  fi
+  cp "$OUTDIR/transcript.txt" "$LOCAL_OUT"
+  echo "[transcribe] done -> $LOCAL_OUT" >&2
+  echo "$LOCAL_OUT"
+  exit 0
+fi
+
+# ---------- Path B: VPS Whisper fallback ----------
+echo "[transcribe] mlx-whisper not found locally - falling back to VPS Whisper" >&2
+echo "[transcribe] (for the fast local path on Apple Silicon: uv tool install mlx-whisper)" >&2
+
+VPS_HOST="${ZAOCOWORKING_VPS:-root@187.77.3.104}"
+MODEL="${MODEL_OVERRIDE:-${WHISPER_MODEL:-base}}"
+
+# Preflight - verify whisper + ffmpeg installed on VPS
 PREFLIGHT=$(ssh -o ConnectTimeout=8 -o BatchMode=yes "$VPS_HOST" \
   'command -v whisper >/dev/null 2>&1 && command -v ffmpeg >/dev/null 2>&1 && echo OK || echo MISSING' 2>/dev/null || echo "SSH_FAIL")
 
@@ -43,10 +86,8 @@ fi
 
 BASENAME=$(basename "$SRC")
 EXT="${BASENAME##*.}"
-STAMP=$(date +%Y%m%d-%H%M%S)
 REMOTE_DIR="/tmp/meeting-$STAMP"
 REMOTE_AUDIO="$REMOTE_DIR/input.$EXT"
-LOCAL_OUT="/tmp/meeting-$STAMP.txt"
 
 echo "[transcribe] uploading $SRC ($(du -h "$SRC" | cut -f1)) to $VPS_HOST:$REMOTE_AUDIO" >&2
 

--- a/research/dev-workflows/709-meeting-transcription-pipeline-audit/README.md
+++ b/research/dev-workflows/709-meeting-transcription-pipeline-audit/README.md
@@ -1,0 +1,140 @@
+---
+topic: dev-workflows
+type: audit
+status: research-complete
+last-validated: 2026-05-22
+superseded-by:
+related-docs: "673, 674, 670, 676, 680, 313, 327"
+original-query: "Audit and research better/more ways to do meeting transcription and capture for the /meeting skill (diarization, video understanding, transcription engines, capture surfaces). Also check in on the ZAOscribe bot - what it is, its status, how it relates to the /meeting skill and the ZAO Craig bot."
+tier: STANDARD
+---
+
+# 709 - Meeting Transcription Pipeline Audit + ZAOscribe Status Check
+
+> **Goal:** Audit the `/meeting` skill's transcription and capture pipeline against the 2026 landscape, record what shipped this session, and pin the exact status of ZAOscribe.
+
+## Key Decisions
+
+Recommendations first. Items marked SHIPPED were implemented in this session (2026-05-22) and are live in `.claude/skills/meeting/`.
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **`/meeting` transcription = mlx-whisper `large-v3-turbo`, local-first. SHIPPED.** Supersedes doc 673's "Whisper.cpp local OR paste". | mlx-whisper runs native on Apple Silicon (12-36x real-time), free, offline, no HF token. Validated this session: a 29-min 252MB mp4 transcribed to a 5648-word transcript locally. VPS Whisper kept as a non-Mac fallback. |
+| 2 | **Video meetings get ffmpeg scene-change frame extraction. SHIPPED.** | The doc-673/680 design was audio-only. A meeting mp4 carries slides, screenshares, and call-UI name tags that audio drops. `extract-frames.sh` pulls up to 24 frames; the vision passes read them. Validated: 23 frames from the test mp4. |
+| 3 | **Diarization for `/meeting`: add `sherpa-onnx` (no HF token, local) for 3+ speaker meetings; skip for 1-2 person calls.** whisperx + pyannote stays opt-in only. | pyannote 3.1 needs a HuggingFace gated-model token; sherpa-onnx uses pre-converted ONNX models with no token. For 1-2 person calls the LLM attributes speakers from content - diarization adds nothing. NOT YET BUILT - see Next Actions. |
+| 4 | **ZAOscribe: keep Whisper.cpp on VPS 1, keep Discord per-user-stream diarization.** Evaluate `ggml-large-v3-turbo` in place of `ggml-medium`. | Discord's `@discordjs/voice` exposes a separate Opus stream per speaker - free, exact diarization with zero pyannote. That is the right call; do not change it. `large-v3-turbo` is faster and more accurate than `medium` on the same CPU - worth a benchmark before ZAOscribe build. |
+| 5 | **Default upstream capture surface for non-Discord meetings = Fathom.** | Free, unlimited recordings + storage, and a bot-free capture mode since April 2026. The skill already detects `fathom.video` URLs. No spend, no new tooling. |
+| 6 | **Quality-bump fallback = ElevenLabs Scribe v2 ($0.22/hr batch), used only when a local transcript is bad.** | 2.2% WER batch and built-in diarization for up to 48 speakers. Reserve for hard audio; do not make it the default - local mlx-whisper is free and good enough for clean calls. See doc 313. |
+
+## ZAOscribe - Status Check
+
+**ZAOscribe is not the `/meeting` skill.** It is a separate, not-yet-built Discord bot.
+
+| Field | Value |
+|-------|-------|
+| What | Discord audio-capture-to-todo bot (`@ZAOscribeBot`) |
+| Spec doc | Doc 674 (`research/agents/674-zaoscribe-discord-best-plan`), locked 2026-05-18 |
+| Status | **Planned, spec locked, build not started.** 7-phase plan in doc 674's Next Actions. |
+| Repo | `bettercallzaal/zaoscribe` (planned) |
+| Runtime | systemd user unit on VPS 1, autonomous |
+| Transcription | Whisper.cpp `ggml-medium.bin`, local on VPS |
+| Diarization | Free - Discord exposes a per-user audio stream natively |
+| Extraction | Cascade LLM: Haiku 4.5 -> Opus 4.7 on low confidence (~$1/mo at 10 captures/day) |
+| Former name | "ZAO Craig" (doc 670). Renamed per Zaal 2026-05-18 to avoid confusion with the upstream Craig OSS recording bot. ZAO Craig = ZAOscribe; same product. |
+
+**How the three pieces relate** (resolved, per the 2026-05-21 briefing - no conflict, three layers of one pipeline):
+
+- **ZAOscribe** - live audio-in layer. Discord voice channel -> per-speaker Opus -> Whisper -> todos. Autonomous bot. NOT BUILT.
+- **`/meeting` skill** - post-hoc dispatch layer. A finished recording/transcript -> recap doc + actions + Bonfire. Runs inside Claude Code. LIVE, and upgraded this session.
+- **Bonfire** - persistence/recall layer. Both of the above flow into the ZABAL knowledge graph (doc 680 bridge).
+
+## Findings
+
+### Current `/meeting` pipeline (post-2026-05-22 upgrade)
+
+`.claude/skills/meeting/scripts/transcribe.sh` is now local-first: it uses `mlx_whisper` if present, falls back to VPS Whisper otherwise. `extract-frames.sh` is new - ffmpeg scene-change detection with a fixed-interval fallback, capped at 24 frames, returns `NO_VIDEO` for audio-only input. `SKILL.md` Phase 1 runs both; Phase 2 reads the frames as vision context. This replaces the doc-673 "transcribe on Iman's VPS" decision - the VPS is CPU-only (no GPU), so local Apple Silicon is both faster and removes the upload step.
+
+### Transcription engines (2026)
+
+| Engine | Accuracy (WER) | Speed | Cost | Local/Cloud | Diarization |
+|--------|----------------|-------|------|-------------|-------------|
+| mlx-whisper (Apple Silicon) | 2-3% clean | 12-36x RT | Free | Local | No |
+| whisper.cpp (Metal) | 2-3% | 2-4x RT | Free | Local | No |
+| faster-whisper | 2-3% | 4-17x RT | Free | Local | No |
+| NVIDIA Parakeet-TDT v3 | 5.4-6.3% | 155-210x RT | Free | Local (Apple) | No |
+| OpenAI Whisper API | 6-8% | - | $0.006/min | Cloud | No |
+| ElevenLabs Scribe v2 | 2.2% batch | 32x RT | $0.22/hr batch | Cloud | Yes (48 spk) |
+| AssemblyAI Universal-3 | 3.3-5.9% | 98x RT | $0.15/hr streaming | Cloud | Yes (best) |
+| Deepgram Nova-3 | 5.26% | 200-400ms | $0.0043/min batch | Cloud | Yes |
+
+Takeaway: local Apple Silicon Whisper is accuracy-competitive with cloud and free. Parakeet is far faster but English/EU-only and a single deployment path - Whisper's four mature runtimes win on deployability. Cloud only earns its cost when you need built-in diarization or you have hard audio.
+
+### Speaker diarization (2026)
+
+| Approach | HF token? | Local/Cloud | Accuracy | Setup |
+|----------|-----------|-------------|----------|-------|
+| whisperx + pyannote 3.1 | YES (gated) | Local | 90-95% (2-3 spk) | High |
+| sherpa-onnx diarization | NO | Local | 85-92% clean | Medium |
+| NVIDIA NeMo | NO | Local | 88-92% | High |
+| AssemblyAI | NO | Cloud | 94% turn acc | Low |
+| Deepgram Nova-3 | NO | Cloud | ~91% | Low |
+| ElevenLabs Scribe v2 | NO | Cloud | ~90%+ | Low |
+
+The pyannote gated-token requirement (accept 2 HF model licenses, generate a token) is the friction point. `sherpa-onnx` is the no-token local answer for ZAO's privacy-first stance. ZAOscribe sidesteps diarization entirely by recording each Discord speaker on a separate stream - genuinely the cleanest approach where the platform allows it.
+
+### Video-meeting understanding
+
+No production-grade open-source "meeting video understanding" tool exists in 2026 - the field is research prototypes (AURA streaming VideoLLM, PreMind slide segmentation) or proprietary omni-models (NVIDIA Nemotron 3 Nano Omni, 24GB+ VRAM). The pragmatic path for a solo builder is what shipped this session: ffmpeg frame extraction + a general vision LLM (Claude) reading the frames. Cheap, local for the extraction, no special model.
+
+### Capture surfaces
+
+| Tool | Platform | Free tier | Clean transcript |
+|------|----------|-----------|------------------|
+| Fathom | Zoom/Meet/Teams | Unlimited recordings + storage | Yes (SRT/VTT/JSON) |
+| Granola | System audio, Mac | Limited history | Yes, bot-free |
+| Otter.ai | Zoom/Meet/Teams | 300 min/mo | Yes |
+| tl;dv | Zoom/Meet/Teams | 10 lifetime AI notes | Yes + clips |
+| Craig | Discord | Free + paid | Yes (JSON/SRT) |
+
+Fathom is the strongest free option and the skill already supports its URLs. Craig is the Discord-native capture (the upstream tool ZAOscribe is patterned on).
+
+### Staleness flags
+
+- Docs 673 and 680 still state transcription = "Whisper.cpp local OR paste". As of 2026-05-22 the `/meeting` skill SKILL.md uses mlx-whisper local-first. Those docs are stale on this one point - see Next Actions.
+- Doc 673's "what we are NOT building" lists "real-time speaker diarization in v1". Still accurate - diarization remains deferred for `/meeting`; Decision 3 above is the post-v1 plan.
+- Pricing is current as of May 2026; cloud STT vendors reprice quarterly - re-validate before any volume commitment.
+
+## Also See
+
+- [Doc 673 - Meeting Capture Skill Design](../673-meeting-capture-skill/) - the `/meeting` skill spec this audit updates
+- [Doc 674 - ZAOscribe Discord Best Plan](../../agents/674-zaoscribe-discord-best-plan/) - the ZAOscribe spec
+- [Doc 670 - Iman Call: Craig + PizzaDAO](../../events/670-iman-call-may18-craig-pizzadao/) - origin of "ZAO Craig"
+- [Doc 680 - Meeting Skill Bonfire Bridge](../../agents/680-meeting-skill-bonfire-bridge/) - the persistence layer
+- [Doc 313 - ElevenLabs Scribe v2](../../music/313-elevenlabs-scribe-v2-speech-to-text/) - the cloud quality-bump fallback
+- [Doc 327 - Open Source Speech-to-Text: Whisper & Alternatives](../../music/327-open-source-speech-to-text-whisper-alternatives/) - prior engine deep-dive
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Build `sherpa-onnx` diarization step into `transcribe.sh` (3+ speaker meetings only) | @Zaal | PR | Next `/meeting` skill iteration |
+| Update docs 673 + 680 transcription line: Whisper.cpp -> mlx-whisper local-first | @Zaal | PR | With this doc's PR |
+| Benchmark `ggml-large-v3-turbo` vs `ggml-medium` on VPS 1 CPU before ZAOscribe build | @Zaal | Todo | Before doc-674 Phase 1 |
+| Set Fathom as the default non-Discord capture surface; confirm `fathom.video` URL parsing in the skill | @Zaal | Todo | Next meeting capture |
+| Decide whether `/meeting` mp4 runs should also post frames to Bonfire as image episodes | @Zaal | Decision | After doc 680 read-side unblocks |
+
+## Sources
+
+- [Mac speech-to-text: Whisper / MLX / whisper.cpp](https://macgpu.com/en/blog/2026-0410-mac-speech-to-text-whisper-mlx-whispercpp-remote-split.html) - [FULL]
+- [Whisper vs Parakeet ASR decision](https://www.arunbaby.com/speech-tech/0073-whisper-vs-parakeet-asr-decision/) - [FULL]
+- [ElevenLabs Speech-to-Text API](https://elevenlabs.io/speech-to-text-api) - [FULL]
+- [Deepgram vs AssemblyAI vs Whisper 2026](https://supermia.ai/blog/deepgram-vs-assemblyai-vs-whisper/) - [FULL]
+- [WhisperX + pyannote guide](https://localaimaster.com/blog/whisperx-guide) - [FULL]
+- [sherpa-onnx speaker diarization models](https://k2-fsa.github.io/sherpa/onnx/speaker-diarization/models.html) - [FULL]
+- [pyannote speaker-diarization-3.1 (HuggingFace)](https://github.com/pyannote/hf-speaker-diarization-3.1) - [FULL]
+- [whisper.cpp performance scaling issue (GitHub, community source)](https://github.com/ggml-org/whisper.cpp/issues/3682) - [FULL]
+- [Granola vs Otter vs Fathom comparison](https://mundobytes.com/en/Granola-vs-Otter-vs-Fathom%3A-Which-to-choose-as-an-AI-meeting-assistant/) - [FULL]
+- [NVIDIA Nemotron 3 Nano Omni](https://huggingface.co/blog/nvidia/nemotron-3-nano-omni-multimodal-intelligence) - [FULL]
+- r/LocalLLaMA - whisper.cpp + faster-whisper benchmark threads (community source) - [PARTIAL - subagent synthesized thread consensus; individual thread URLs not pinned]
+
+Research conducted via parallel subagents (internal-doc digest + STANDARD-tier web scan), 2026-05-22.

--- a/research/farcaster/710-miniapp-registration-deeplinking/README.md
+++ b/research/farcaster/710-miniapp-registration-deeplinking/README.md
@@ -1,0 +1,158 @@
+---
+topic: farcaster
+type: guide
+status: research-complete
+last-validated: 2026-05-22
+related-docs: 591c, 707, 250, 173, 708
+tier: STANDARD
+---
+
+# 710 — Mini App registration, deep-linking, and running many surfaces on zaoos.com
+
+> **Goal:** Answer Zaal's question directly - "if I share `zaoos.com/zabal/spotlight`, does it open right there or dump the user at the main miniapp page?" - and give the registration/architecture rules for running several mini app ideas on the one `zaoos.com` domain.
+
+## TL;DR — the direct answer
+
+**YES, a shared `zaoos.com/zabal/spotlight` link opens directly at the spotlight surface** - it does NOT route to `/miniapp`. This works because the page carries its own `fc:miniapp` embed whose `action.url` is `zaoos.com/zabal/spotlight` (shipped in PR #614, per Doc 707). The embed's `action.url` is what launches; `homeUrl` is only the default for app-directory launches.
+
+**One caveat that was a real bug:** if a route has NO per-route embed, it inherits the root `layout.tsx` embed - which explicitly sets `action.url = /miniapp`. So it would have dumped users at the gated chat. Doc 707 fixed `/zabal` + `/zabal/spotlight`. Any NEW surface needs the same per-route embed or it inherits `/miniapp`.
+
+## Key Decisions / Recommendations
+
+| # | Decision | Recommendation |
+|---|----------|----------------|
+| 1 | **Deep-link to a sub-route?** | YES. Set a per-route `fc:miniapp` embed with `action.url` = that route. Tapping the embed in a feed launches that exact URL. Confirmed against the official Mini Apps sharing spec. |
+| 2 | **`zaoos.com` = how many registered apps?** | ONE. One domain = one `/.well-known/farcaster.json` = one app in the Farcaster directory ("ZAO OS"). Every route (`/zabal`, `/zabal/spotlight`, `/miniapp`, future ideas) is part of that single registered app. |
+| 3 | **Want a NEW idea to be its OWN app** (own name, icon, directory tile, discovery)? | Give it a **subdomain** - e.g. `zabal.zaoos.com`. Each subdomain hosts its own manifest + its own `accountAssociation` signature = a separate registered app. |
+| 4 | **Want a NEW idea to just be another surface of ZAO OS?** | Keep it a route on `zaoos.com` + add a per-route embed. Shareable + deep-links. Costs nothing. Only downside: one directory tile for the whole domain. |
+| 5 | **ZABAL specifically** | DECISION POINT for Zaal - see Part 4. `/zabal` as a route of ZAO OS (current) vs `zabal.zaoos.com` as its own registered app. Current = route. Recommend route for now; promote to subdomain only when ZABAL needs its own directory presence. |
+| 6 | **Every shareable route needs its own embed** | Make per-route `fc:miniapp` metadata a standard. A route with no embed inherits `/miniapp`. This is a footgun - bake it into the page template. |
+
+## Part 1 — How registration actually works
+
+A Mini App is "registered" by publishing a **manifest** at `https://DOMAIN/.well-known/farcaster.json`. There is no central submission form - hosting the manifest IS the registration. Farcaster clients crawl/cache it.
+
+```json
+{
+  "accountAssociation": {
+    "header": "...", "payload": "...", "signature": "..."
+  },
+  "miniapp": {
+    "version": "1",
+    "name": "ZAO OS",
+    "iconUrl": "https://zaoos.com/icon-1024.png",
+    "homeUrl": "https://zaoos.com/miniapp",
+    "splashImageUrl": "...", "splashBackgroundColor": "#0a1628",
+    "webhookUrl": "https://zaoos.com/api/miniapp/webhook",
+    "primaryCategory": "social",
+    "tags": ["community", "music", "web3", "chat"]
+  }
+}
+```
+
+Three rules that matter here:
+
+1. **One manifest per domain.** `zaoos.com` has exactly one. The `accountAssociation` is a signature binding that manifest to a Farcaster FID (Zaal's, FID 19640) and to the **exact domain string** in the payload.
+2. **`homeUrl`** = the default launch URL. It is used when a user opens the app from the **app directory / catalog** (no cast context). For ZAO OS it is `/miniapp`.
+3. **Domain binding is exact.** The signed `payload` domain must match the host exactly - apex vs `www` mismatch silently breaks it (Doc 591c). `zaoos.com`'s manifest is signed for `zaoos.com`.
+
+## Part 2 — Deep-linking: the three URL layers
+
+When a link is cast, what launches depends on three layers:
+
+| Layer | What it is | Role |
+|-------|-----------|------|
+| **Page URL** | The URL actually shared in the cast (e.g. `zaoos.com/zabal/spotlight`) | The page whose `<head>` is read for embed meta |
+| **`action.url`** | Inside that page's `fc:miniapp` embed | **The URL the app launches at.** If omitted, defaults to the page URL. |
+| **`homeUrl`** | In the domain manifest | Default launch for app-directory opens; fallback for splash config only |
+
+**The launch rule:** tap an embed in a feed -> the app opens at `action.url`. Not `homeUrl`. `homeUrl` is only the "open from the app drawer" destination.
+
+So:
+- Share `zaoos.com/zabal` -> embed `action.url = zaoos.com/zabal` -> opens the ZABAL hub. CORRECT (shipped).
+- Share `zaoos.com/zabal/spotlight` -> embed `action.url = zaoos.com/zabal/spotlight` -> opens spotlight. CORRECT (shipped).
+- Open "ZAO OS" from the Farcaster app directory -> `homeUrl` -> `/miniapp` (gated chat).
+
+**The footgun:** ZAO OS's root `layout.tsx` sets a default `fc:miniapp` embed with `action.url` EXPLICITLY = `/miniapp`. Because it is set explicitly (not omitted), the "defaults to page URL" rule never kicks in. Any route without its own embed override inherits `-> /miniapp`. That is exactly the bug Doc 707 caught and fixed for the ZABAL routes.
+
+## Part 3 — Running multiple mini app ideas on zaoos.com
+
+Two architectures. Pick per idea:
+
+### Option A — Route of ZAO OS (same domain)
+- New idea = `zaoos.com/newthing`, add a per-route `fc:miniapp` embed.
+- Shareable, deep-links, zero registration work.
+- **One** directory tile for all of `zaoos.com` ("ZAO OS"). The new idea is not separately discoverable in the Farcaster app catalog.
+- Shares ZAO OS's manifest, webhook, account association.
+
+### Option B — Its own app (subdomain)
+- New idea = `newthing.zaoos.com`, its own `/.well-known/farcaster.json`, its own `accountAssociation` signature, its own `name`/`icon`/`primaryCategory`.
+- Separate tile in the Farcaster app directory - independently discoverable, searchable, its own splash + identity.
+- More setup per app: sign a new account association, host a second manifest, separate webhook.
+
+| Dimension | A: Route on zaoos.com | B: Subdomain app |
+|-----------|----------------------|------------------|
+| Setup cost | Add an embed - minutes | New manifest + signed association - ~30 min |
+| Directory tile | Shared (ZAO OS only) | Own tile, own discovery |
+| Deep-linking | Yes (per-route embed) | Yes (it is the homeUrl) |
+| Own name / icon / category | No | Yes |
+| Best for | A surface of ZAO OS | A product with its own identity + audience |
+
+## Part 4 — Recommendation for Zaal's surfaces
+
+| Surface | Today | Recommendation |
+|---------|-------|----------------|
+| ZAO OS chat | `zaoos.com/miniapp` (homeUrl) | Keep as the registered app's home |
+| ZABAL hub | `zaoos.com/zabal` (route + embed) | Keep as a route NOW. It deep-links fine. Promote to `zabal.zaoos.com` (own app) only when ZABAL should have its own Farcaster directory tile + discovery - that is a marketing decision, not a tech one |
+| ZABAL Spotlight | `zaoos.com/zabal/spotlight` (route + embed) | Keep as a route - it is a surface of ZABAL, not its own app |
+| Future ideas | - | Default to Option A (route + embed). Use Option B (subdomain) only when the idea needs to be found in the app catalog on its own |
+
+**Rule of thumb:** routes for surfaces, subdomains for products. A thing people discover by browsing the Farcaster app catalog = its own subdomain app. A thing people reach by a shared link or from inside ZAO OS = a route.
+
+## Specific Numbers
+
+| Metric | Value |
+|--------|-------|
+| Manifests per domain | 1 |
+| Manifest path | `/.well-known/farcaster.json` |
+| ZAO OS registered FID (account association) | 19640 |
+| ZAO OS homeUrl | `https://zaoos.com/miniapp` |
+| ZABAL routes with per-route embeds shipped | 2 (`/zabal`, `/zabal/spotlight`) - PR #614 |
+| URL layers governing launch | 3 (page URL, action.url, homeUrl) |
+| icon spec | 1024x1024 PNG, no alpha |
+| What a subdomain costs | 1 new manifest + 1 new signed account association |
+
+## Comparison — where to register a new idea
+
+| Option | Verdict | Why |
+|--------|---------|-----|
+| Route on `zaoos.com` + per-route embed | DEFAULT | Free, deep-links, ships in minutes |
+| Subdomain `idea.zaoos.com` + own manifest | WHEN it needs own discovery | Own directory tile, own identity |
+| Brand-new domain | RARELY | Only if the idea is leaving the ZAO umbrella entirely |
+
+## Sources
+
+- [Farcaster Mini Apps - Sharing your app](https://miniapps.farcaster.xyz/docs/guides/sharing) - confirmed `action.url` launches; defaults to page URL if omitted (verified 2026-05-22)
+- [Farcaster Mini Apps - Manifest spec](https://miniapps.farcaster.xyz/docs/specification) - one manifest per domain, homeUrl, account association
+- [Doc 591c - Manifest + Cross-Client audit](../591c-manifest-cross-client/) - domain binding, subdomain = separate app
+- [Doc 707 - ZABAL mini app conformance](../707-zabal-miniapp-conformance/) - the per-route embed fix
+- [Doc 250 - Farcaster Mini Apps llms.txt 2026](../250-farcaster-miniapps-llms-txt-2026/)
+- Code: `public/.well-known/farcaster.json`, `src/app/layout.tsx` (root embed), `src/app/zabal/page.tsx` (per-route embed shipped)
+
+URLs verified 2026-05-22.
+
+## Also See
+
+- [Doc 707 - ZABAL mini app conformance](../707-zabal-miniapp-conformance/) - implements per-route embeds
+- [Doc 708 - ZABAL hub landing page](../../business/708-zabal-hub-landing-page/) - the hub these embeds point at
+- [Doc 591c - Manifest + Cross-Client](../591c-manifest-cross-client/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Make per-route `fc:miniapp` embed a standard for every new shareable route (template/checklist) | @Zaal / Claude | Convention | Ongoing |
+| Decide if ZABAL should become its own subdomain app (`zabal.zaoos.com`) for Farcaster directory discovery | @Zaal | Decision | When ZABAL marketing needs its own tile |
+| For each "new idea" on zaoos.com: pick Option A (route) or B (subdomain) using Part 4 rule | @Zaal | Decision | Per idea |
+| If any subdomain app is created: sign a new account association for that exact subdomain | @Zaal | Setup | At creation |
+| Re-validate Mini App sharing spec | @Zaal | Doc update | 2026-06-22 |


### PR DESCRIPTION
## Summary

Answers Zaal's question on mini app registration + whether a shared sub-route link deep-links there or dumps the user at the main miniapp page.

## Tier
STANDARD

## The answer

**A shared `zaoos.com/zabal/spotlight` link opens DIRECTLY at spotlight** - not `/miniapp`. The per-route `fc:miniapp` embed's `action.url` is what launches; `homeUrl` is only the app-directory default. The per-route embeds shipped in PR #614 (Doc 707) make this work.

## Also covers

- Manifest registration: one `/.well-known/farcaster.json` per domain, one app in the directory
- The 3 URL layers governing launch (page URL / action.url / homeUrl)
- The footgun: any route with no embed inherits the root `/miniapp` embed
- **Multiple ideas on zaoos.com**: Option A (route + embed, free, shared directory tile) vs Option B (subdomain = its own registered app + own directory tile)
- Rule of thumb: routes for surfaces, subdomains for products
- Per-surface recommendation: ZABAL stays a route for now; promote to `zabal.zaoos.com` only when it needs its own Farcaster directory presence

## Sources
Official Farcaster Mini Apps docs (sharing + manifest spec), Doc 591c (manifest audit), Doc 707, 250 + live code.

## Next Actions
See doc table - mainly: make per-route embeds a standard; decide ZABAL subdomain question when marketing calls for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)