### PR TITLE
doc 712: ZAO CRM research (STANDARD tier)

### DIFF
--- a/research/business/712-zao-crm-coworking-app/README.md
+++ b/research/business/712-zao-crm-coworking-app/README.md
@@ -1,0 +1,110 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-05-22
+superseded-by:
+related-docs: 692, 650, 668, 679
+original-query: "the next thing we should build is a ZAO CRM /zao-research this idea to include into the coworking app"
+tier: STANDARD
+---
+
+# 712 — ZAO CRM: a relationship layer for the cowork tracker
+
+> **Goal:** Decide what a "ZAO CRM" should be and how it bolts into the cowork tracker (ZAODEVZ/ZAOcowork) - scoped, buildable, not a Salesforce clone.
+
+## Key Decisions
+
+| Decision | Recommendation | Why |
+|----------|---------------|-----|
+| CRM style | **Folk-style** - relationship-first, lightweight. NOT Attio (build-your-own-schema) or HubSpot (sales pipeline). | ZAO tracks relationships, not deals. 4-person team. Speed and zero-config beat customization. |
+| Build vs buy | **Build it into the cowork tracker.** Do not buy Folk ($20/user/mo). | The data layer is already ~60% scaffolded (see Findings), and ZAO can solve the one problem every CRM vendor fails at. |
+| Data model | **One `contacts` table with a `type` discriminator** + a `contact_id` FK on `tasks`. | Mirrors doc 692's unified-table pattern. The schema already has `sponsors`/`artists`/`volunteers`. |
+| v1 scope | `contacts` + `contact_log` + task↔contact link + a "Contacts" tab. Nothing else. | Attio's own onboarding advice: start with 3-4 objects, run one real process for two weeks before expanding. |
+| The differentiator | The **bot + `/meeting` skill auto-log touches** into `contact_log`. | Every CRM's fatal flaw is that humans do not log. ZAO has capture surfaces Folk/Attio do not. |
+
+## Findings
+
+**1. The data layer already exists - this is mostly a "surface what is there" job.**
+doc 692's unified Supabase schema (`db/schema.sql` in thezao-tracker) created 13 tables. Five are CRM-shaped and **all sit empty, 0 rows, never surfaced by the app** - only `tasks` is wired up:
+
+- `sponsors` (name, tier, amount, status, contact, circle_id, notes)
+- `artists` (name, status, set_length, contact, circle_id, notes)
+- `volunteers` (name, role, status, contact, notes)
+- `contact_log` (contact, channel, summary, logged_by, logged_at)
+- `meeting_notes` (title, body, meeting_date, created_by)
+
+A ZAO CRM is ~60% wiring up tables that exist, not a from-scratch build.
+
+**2. The market splits three ways - take Folk's philosophy, not its product.**
+
+| Tool | Model | Price | Fit for ZAO |
+|------|-------|-------|-------------|
+| **Folk** | Relationship-first, lightweight, spreadsheet-style, "works for any relationship not just sales" | $20/user/mo (free <200 contacts) | Right philosophy - wrong to pay for it |
+| **Attio** | Object-based, you model your own schema, custom objects + relations | Free / $29/user/mo | Too much DIY config for a 4-person team |
+| **HubSpot** | Full sales + marketing platform, pipelines, sequences | Free / $90/user/mo for sequences | Enterprise-sales bloat ZAO does not need |
+
+Folk's pitch: "strips away the bloat of Salesforce/HubSpot to focus on what matters - people, conversations, follow-ups." That is exactly the ZAO CRM. It just costs $20/user/mo for something the cowork tracker is two tables away from.
+
+**3. Do NOT build sales-CRM bloat.** Every source agrees: skip pipelines/deal stages, forecasting, lead scoring, email sequences, territory/quota management. That weight is for sales orgs running complex deal motions. ZAO's relationships are sponsors, artists, volunteers, partners, venues, press, leads - tracked, not "closed."
+
+**4. The killer CRM-task pattern is "next action linked to contact."** Every task tied to a person/company so you see context instantly. The cowork tracker **is already a task system** - so adding a `contacts` object and a task↔contact link *is* the CRM. ZAO's existing tasks already prove the need: "Get the Empire Builder API key from Jordan", "Send testimonial outreach DMs", "Confirm the Eden Fractal schedule with Dan/Tadas" are all relationship tasks with no contact to hang on.
+
+**5. The universal CRM failure mode - and ZAO's unfair advantage.** Every comparison flagged the same flaw: CRMs depend on humans to log conversations, so the data "slowly drifts from reality." Vendors (Lightfield, Coffee) now sell auto-capture as the fix. **ZAO already has the capture surfaces** - the Telegram bot (natural-language: "logged a call with the venue") and the `/meeting` skill (transcript -> extracted decisions/contacts). The `contact_log` can populate itself. That is the reason to build this in rather than buy Folk.
+
+## Recommended data model
+
+Fold the three empty ZAOstock-scoped tables into one general table (0 rows - trivial migration):
+
+```
+contacts
+  id            uuid pk
+  type          text   -- sponsor | artist | volunteer | partner | venue | lead | press | member
+  name          text not null
+  project       text   -- zaostock | zaodevz | bcz | ...
+  status        text   -- e.g. prospect | active | confirmed | cold
+  handle        text   -- email / X / Telegram / phone
+  circle_id     uuid references circles(id)
+  owner_id      uuid references team_members(id)   -- who owns the relationship
+  last_touch_at timestamptz
+  notes         text
+  metadata      jsonb default '{}'
+  created_at    timestamptz default now()
+
+tasks.contact_id   uuid references contacts(id)   -- a task can be "about" a contact
+```
+
+Keep `contact_log` (the touch history) and `meeting_notes` as-is.
+
+## v1 scope (ship this, nothing more)
+
+- Migration: `contacts` table, `tasks.contact_id`, backfill nothing (start clean).
+- Web: a **Contacts tab** next to Board / Assistant - a list (filter by type/owner) + a contact detail view = info, linked open tasks ("next actions"), and the `contact_log` timeline.
+- Add-contact + log-a-touch: a web form, and bot commands `/contact` and `/log`.
+- Auto-log: the bot's NL path and the `/meeting` skill write `contact_log` rows.
+- **Skip:** pipelines, deal stages, enrichment, email sequences, reporting dashboards.
+
+## Also See
+
+- [Doc 692](../../) — the unified Supabase schema this builds on (`tasks` + the 13-table greenfield).
+- [Doc 650](../../) — cowork-zaodevz, the team action tracker.
+- [Doc 668](../../) / [Doc 679](../../) — ZAOcoworkingBot, the Telegram surface that would carry `/contact` + `/log`.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Migration: `contacts` table + `tasks.contact_id` FK | @Zaal | PR to ZAODEVZ/ZAOcowork | Next build session |
+| Build the Contacts tab (list + detail) | @Zaal | PR | After migration |
+| Bot `/contact` + `/log` commands | @Zaal | PR | After the tab |
+| Wire the `/meeting` skill to write `contact_log` | @Zaal | Skill update | After bot commands |
+| Decide: fold `sponsors`/`artists`/`volunteers` into `contacts`, or keep separate | @Zaal | Decision | Before the migration |
+
+## Sources
+
+- [Attio vs folk - CRM comparison (5050 Growth)](https://5050growth.com/attio-vs/folk/) — [FULL] feature/price split, when each fits.
+- [folk CRM Review 2026 (MakerStack)](https://makerstack.co/reviews/folk-crm-review/) — [FULL] folk's relationship-first positioning, pricing, AI follow-ups.
+- [Attio vs Folk for Growing Teams (Lightfield)](https://lightfield.app/blog/attio-vs-folk) — [FULL] the shared data-drift flaw - "the CRM slowly drifts from reality."
+- [Attio Review 2026 (CRM.org)](https://crm.org/news/attio-review) — [FULL] object-model tradeoffs, "start with 3-4 objects" onboarding advice.
+- WebSearch: CRM + task management patterns (OnePageCRM, Capsule, HubSpot) — [PARTIAL - summary only] the "next action linked to contact" pattern.
+- Codebase: `db/schema.sql` (thezao-tracker) — [FULL] confirmed the 5 empty CRM tables via Supabase `list_tables` (all 0 rows).

--- a/research/dev-workflows/713-zao-ops-meeting-tracker-crm-bonfire/README.md
+++ b/research/dev-workflows/713-zao-ops-meeting-tracker-crm-bonfire/README.md
@@ -1,0 +1,114 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-05-22
+superseded-by:
+related-docs: 712, 692, 650, 668, 673, 676, 680
+original-query: "here is how I'm doing the meetings - I want it to combine kinda and also include the bonfires as part of it. /zao-research this implementation idea, think through it, brainstorm, make suggestions, grill if needed."
+tier: STANDARD
+---
+
+# 713 — ZAO Ops: meeting capture unified into the tracker + CRM + Bonfire
+
+> **Goal:** Combine the four disconnected operational pieces - the `/meeting` skill, the cowork tracker, the CRM (doc 712), and Bonfire - into one system: one capture, one queue, one memory.
+
+## Key Decisions
+
+| Decision | Recommendation | Why |
+|----------|---------------|-----|
+| The combine | `/meeting` becomes the **front door** of the cowork system. A meeting writes tasks + contacts + a meeting record + Bonfire episodes to **one Supabase**. | A meeting *is* an ingestion event of the same shape as everything else. All four pieces already share one DB. |
+| Capture model | **Automatic, zero-confirm.** Meeting output lands without an approval step. | Zaal (grill answer): meeting action items currently "die in the recap doc" - the whole point is they auto-appear, waiting. |
+| Landing zone | Meeting actions land in an **Inbox** - a triage holding state, not the main board. | Grill answer (b): a clean "here is what came in since last time" list beats silently bloating the board. |
+| New task status | Add **`WAITING`** - waiting on someone out-of-org. Distinct from `BLOCKED` (stuck) and `TODO` (assigned in-org). With a dedicated "Waiting On" list view. | Grill answer: external-owned meeting actions are real follow-through but are not your todos until stale. |
+| `/meeting` -> tracker | **Re-point `/meeting`'s task write from `actions.json` to the Supabase `tasks` table.** This is the literal combine point. | `/meeting` still writes the dead GitHub-JSON store; the tracker migrated to Supabase (doc 692). They are disconnected today. |
+
+## Findings
+
+**1. The four pieces are disconnected today - and one is writing to a dead store.**
+
+- `/meeting` skill — transcribes, runs 5-pass extraction (decisions/actions/quotes/people), routes to: a `research/events/` recap doc, `actions.json`, Bonfire, memory, Telegram.
+- Cowork tracker — `tasks` on Supabase (doc 692), bot + web board.
+- CRM (doc 712) — `contacts`/`contact_log`/`meeting_notes` tables exist, empty, unsurfaced.
+- Bonfire — the knowledge graph.
+
+The break: **`/meeting` writes task output to `actions.json` (the old GitHub-JSON backend). The tracker migrated to Supabase.** `/meeting` writes where the tracker no longer reads - which is why the parallel session "HELD the tracker write" on the Arthur call. Re-pointing `/meeting` to the Supabase `tasks` table is step one.
+
+**2. The four pieces are the same shape - a meeting produces all of them.**
+The Arthur intro call (doc 711) is the worked proof:
+
+| Meeting output | Lands as |
+|----------------|----------|
+| 6 action items | `tasks` in the **Inbox**, owner pre-filled |
+| Actions owned by Arthur (external) | `tasks` status `WAITING`, `contact_id` = Arthur |
+| Arthur (a new person) | a `contact` (type: partner) + a `contact_log` touch |
+| The call itself | a `meeting_notes` row |
+| Decisions + quotes + the recap | Bonfire episodes (the recall layer) |
+
+**3. The Inbox and `WAITING` are two different axes - keep them orthogonal.**
+- **Inbox** = a *triage* state: "freshly captured, not yet sorted." Best as a boolean flag (`inbox: true`) on the task, NOT a status. A fresh meeting task = `inbox: true`, status `TODO`. Triaging clears the flag.
+- **`WAITING`** = a *status*, alongside TODO / WIP / BLOCKED / DONE. For triaged tasks where the ball is in an out-of-org person's court.
+
+Keeping them separate keeps the status enum clean (5 values) and the Inbox a simple sweep queue.
+
+**4. Bonfire is the memory layer, not a second source of truth.**
+Supabase holds the structured records (tasks, contacts, meetings). Bonfire mirrors decisions/quotes/episodes as a *graph for recall* ("what did Arthur say about agent security?"). The cowork app's Assistant tab queries Bonfire. Supabase is always the source of truth; Bonfire is the searchable memory.
+
+## The combined system
+
+```
+CAPTURE        /meeting (recordings)   +   bot (Telegram NL)   +   web add-task
+                              |  |  |
+                              v  v  v
+STORE          one Supabase:  tasks  ·  contacts  ·  contact_log  ·  meeting_notes
+                 tasks.status: TODO / WIP / BLOCKED / WAITING / DONE
+                 tasks.inbox:  true = freshly captured, awaiting triage
+                 tasks.contact_id -> contacts
+                              |
+                              v
+MEMORY         Bonfire  <- decisions, quotes, meeting episodes (recall layer)
+                              |
+                              v
+SURFACE        cowork app:  Board  ·  Inbox lane  ·  Waiting On list  ·  Contacts tab  ·  Assistant (queries Bonfire)
+```
+
+**The daily loop it produces:** Zaal finishes a meeting -> `/meeting` runs -> actions, contacts, the meeting record, and Bonfire episodes all land automatically. Later, Zaal opens the board to "knock out todos" -> the **Inbox** shows "N captured since last time" -> a quick triage sweep -> work the board. The **Waiting On** list shows what is in other people's courts. Nothing dies in a recap doc.
+
+## Build order
+
+1. **Re-point `/meeting` -> Supabase `tasks`.** Smallest, highest-leverage step - instantly connects meeting capture to the live tracker. Tag each task `inbox: true`, `metadata.source = meeting:<doc>`.
+2. **Add the `WAITING` status + `inbox` flag** to `tasks` - schema + the bot status enum + the web board columns.
+3. **Build the CRM** (doc 712): `contacts` table + `tasks.contact_id`.
+4. **Wire `/meeting` full output**: actions -> Inbox tasks; external-owner actions -> `WAITING` + `contact_id`; people -> `contacts` + `contact_log`; the call -> `meeting_notes`; decisions/quotes -> Bonfire episodes.
+5. **Web surfaces**: an Inbox lane, a Waiting On list, the Contacts tab.
+6. Drop `/meeting`'s Phase 3 confirm for the auto-land path (Zaal chose zero-confirm); keep a one-line "N items captured" notice.
+
+## Open questions (not yet grilled - resolve before step 4)
+
+- **Contact auto-creation noise:** every named person in a meeting -> a contact, or only the meeting's main external party? Lean: only people the meeting clearly treats as a real contact; one-off mentions stay in the recap text.
+- **Whose meetings flow in:** only Zaal's `/meeting` runs, or should the team drop recordings to the bot? If the team, meeting capture has to move into the bot, not stay a terminal skill.
+
+## Also See
+
+- [Doc 712](../../business/712-zao-crm-coworking-app/) — the ZAO CRM (the `contacts` layer this system writes to).
+- [Doc 692](../../) — the unified Supabase schema (`tasks` + the 13-table greenfield).
+- [Doc 650](../../) / [Doc 668](../../) — the cowork tracker + ZAOcoworkingBot.
+- [Doc 673](../../) / [Doc 676](../../) / [Doc 680](../../) — the `/meeting` skill + Bonfire integration.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Re-point `/meeting` task write to Supabase `tasks` | @Zaal | PR (skill + ZAOcowork) | First build session |
+| Migration: `tasks.status` += `WAITING`, `tasks.inbox` boolean | @Zaal | PR to ZAODEVZ/ZAOcowork | With step 1 |
+| Build the CRM (`contacts` + `tasks.contact_id`) per doc 712 | @Zaal | PR | After the schema change |
+| Wire `/meeting` to write Inbox tasks + contacts + meeting_notes | @Zaal | Skill update | After the CRM |
+| Web: Inbox lane + Waiting On list + Contacts tab | @Zaal | PR | After the wiring |
+
+## Sources
+
+- [Doc 711](../../events/711-arthur-wavewarz-base-call-may19/) — the Arthur intro call: worked example of meeting -> tasks/contacts/decisions. [FULL]
+- [Doc 712](../../business/712-zao-crm-coworking-app/) — the ZAO CRM research this builds on. [FULL]
+- The `/meeting` skill (`.claude/skills/meeting/SKILL.md`) — current pipeline + the `actions.json` write. [FULL - read in session]
+- `db/schema.sql` (thezao-tracker) + Supabase `list_tables` — confirmed `tasks` + the 5 empty CRM tables. [FULL]
+- Grill answers from Zaal, 2026-05-22 (this session) — capture model, Inbox lane, `WAITING` status. [FULL]

--- a/research/events/711-arthur-wavewarz-base-call-may19/README.md
+++ b/research/events/711-arthur-wavewarz-base-call-may19/README.md
@@ -1,0 +1,110 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-22
+related-docs: "701"
+tier: STANDARD
+---
+
+# 711 - Arthur intro call: WaveWarZ Base agentic version
+
+> **Goal:** Lock in action items + decisions from the 2026-05-19 video call between Zaal, Sam (Samantha / candytoybox), and Arthur (Neynar) covering the ZAO incubator model, the agentic WaveWarZ build on Base, and Arthur joining as a smart-contract collaborator + ZABAL Games mentor.
+
+## Key Decisions
+
+| # | Decision | Owner | Status |
+|---|----------|-------|--------|
+| 1 | **Zaal sends Arthur the Base WaveWarZ repo** to kick off the collaboration and "start locking that in" | Zaal | TODO |
+| 2 | **Zaal creates a Farcaster group chat** - Zaal + Sam + Arthur, then adds Hurric4n3ike so he is pulled onto Farcaster | Zaal | TODO |
+| 3 | **Arthur reviews the Base WaveWarZ smart contracts** and gives pointers + security suggestions | Arthur | TODO |
+| 4 | **Arthur sends agent-security reference resources** - good repositories with security references for pointing AI agents at | Arthur | TODO |
+
+## Thread 1 - The ZAO incubator + WaveWarZ context
+
+### The Idea
+
+Zaal gave Arthur the background: The ZAO ("the z talent artist organization") is a progressively-decentralized incubator for on-chain music projects, governed by soulbound, illiquid Respect tokens earned weekly through fractal meetings (groups of six reach consensus on contribution, distributed on a Fibonacci curve). The first project incubated out of The ZAO is WaveWarZ - live-traded music battles, founded by Hurric4n3ike with Zaal and Sam. It runs on Solana: 1% of trade volume routes immediately to the artist, the losing side's pool partly feeds the winning side, settled on-chain via smart contract (no custody). To date WaveWarZ has run roughly 456 SOL of volume, producing about $650 / 7.74 SOL in fees (number garbled in transcript - see VERIFY). WaveWarZ runs 11 shows a week: five morning + five night Mon-Fri, plus Sunday-night battles.
+
+### Why It Matters
+
+This is Arthur's onboarding context - he is new to the ZAO/WaveWarZ orbit. It also frames why the Base build matters: WaveWarZ is The ZAO's revenue driver and the proof case for the incubator model.
+
+## Thread 2 - Agentic WaveWarZ on Base (the core ask)
+
+### The Idea
+
+Sam has started a Base version of WaveWarZ, prompted by the rise of agent payments (x402). The concept: an agentic WaveWarZ where AI agents generate their own music, battle it, and trade on it - settled in a neutral asset (SOL / ETH / USDC) rather than a project token, so it becomes "employment for agents". Zaal's extension: each human trader also runs a paired agent in the agentic version, learning trading strategies (early-buy on the bonding curve, top-selling, end-of-battle sniping) and surfacing them. Sam has two smart contracts on testnet already. The economic hook: a battle costs a roughly fixed program fee, the margin is high, and a pre-funded agent could run an "infinite loop" of battles - any artist (or an agent acting for a musician) entering a song earns the 1% artist cut during the 10-minute battle.
+
+### Decisions Pending
+
+- Whether each trader gets a paired learning agent (Zaal's idea) vs purely autonomous agents (Sam's framing) - not resolved on the call.
+- The smart contracts are on testnet but "need to be flushed out by someone who knows what they're doing" - which is the explicit reason for bringing Arthur in.
+
+### Next Step
+
+Zaal sends Arthur the repo; Arthur reviews the contracts and points the team at security references. Arthur flagged the key need plainly: "knowing what resources to point the agents at" plus "great repositories that have security references".
+
+## Thread 3 - Maine event, ZABAL Games, Arthur as mentor
+
+### The Idea
+
+Zaal walked through ZAO Festivals (ZAO-PALOOZA at NFT NYC 2024, ZAO-CHELLA at Art Basel) and the 2026 plan: an October 3 music event in down east Maine near Acadia, tied to a local art event, with two non-negotiables - come in under budget, and have a live stream. Arthur signed up to mentor for ZABAL Games. Arthur cannot attend the Maine event (it is the day after his daughter's first birthday) but offered to participate virtually and help where he can - noting he is "better with EVM than Solana", which fits the Base build.
+
+### Why It Matters
+
+Arthur is a multi-surface collaborator now: WaveWarZ Base smart contracts + ZABAL Games mentorship + virtual event participation.
+
+## Action Items
+
+| # | Action | Owner | Category | Due |
+|---|--------|-------|----------|-----|
+| 1 | Send Arthur the Base WaveWarZ repo | Zaal | WaveWarZ | TBD |
+| 2 | Create a Farcaster group chat (Zaal, Sam, Arthur, then add Hurric4n3ike) | Zaal | WaveWarZ | TBD |
+| 3 | Review the Base WaveWarZ smart contracts, give pointers + security suggestions | Arthur | WaveWarZ | TBD |
+| 4 | Send agent-security reference resources / repos for pointing AI agents at | Arthur | WaveWarZ | TBD |
+| 5 | Check out "like.fun" on Farcaster for UX influence (similar play loop) | Zaal | WaveWarZ | TBD |
+| 6 | Join a WaveWarZ event - Good Boy Music AI-artist tournament, first battle Sun 2026-05-31 7pm ET (open invite, not firm) | Arthur | WaveWarZ | 2026-05-31 |
+
+## Key Quotes
+
+> "You show up and you do work and then you get a voting stake - I think that works better almost every time versus buying a share and being able to vote." - Arthur, on soulbound governance
+
+> "The ones that are not making good music and are not winning these battles should kind of die off, and then the ones that are doing well will be able to pay for their own inference." - Arthur, on agent musicians
+
+> "I have two non-negotiables for the event - come in under budget, and have a live stream." - Zaal, on the October Maine event
+
+> "We always had this thesis with Giveth that the biggest impact you can make is to local communities that you're embedded in." - Arthur
+
+> "Going super hard on Farcaster - it's the right place in web3 that I've landed to find what I need to build out here." - Zaal
+
+## Research Seeds
+
+- **like.fun on Farcaster** - prediction/betting markets on likes for short-form content; Arthur flagged its gamified play loop as a UX reference for WaveWarZ.
+- **Agentic WaveWarZ on Base + x402** - AI agents generating, battling, and trading music; agent-payment rails as the economic primitive.
+- **AI-agent-musician economy** - agents that pay for their own inference by winning battles; "stable" of agent musicians where weak ones die off.
+
+## Memory Updates
+
+Files written to `~/.claude/projects/.../memory/`:
+
+- `project_arthur_neynar.md` - new: Arthur (Neynar), smart-contract dev + ZABAL Games mentor, helping the WaveWarZ Base agentic build.
+
+## Also See
+
+- [Doc 701 - ZABAL Games canonical state](../701-zabal-games-canonical-state/) - the build-a-thon Arthur signed up to mentor for
+- [[project_candytoybox_samantha]] - Sam = Samantha = candytoybox, WaveWarZ cofounder
+- [[project_hurric4n3ike]] - Hurric4n3ike, WaveWarZ founder + lead dev
+- [[project_zabal_games]] - ZABAL Games build-a-thon
+
+## Distribution Log
+
+- actions.json: HELD - 6 items prepared; tracker brand-label schema being redesigned (see PR / chat note)
+- Bonfire episodes: built (11 episodes - summary + 4 decisions + 6 actions) but skipped at run time - `BONFIRE_API_KEY` / `BONFIRE_ID` not set in env. Re-run `scripts/bonfire-episode.sh /tmp/meeting-bonfire-episodes.json` once the key is present.
+- Telegram: block printed in session
+- Calendar: skipped (not selected)
+- Memory writes: 1 entry (project_arthur_neynar)
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md)

--- a/research/events/711-arthur-wavewarz-base-call-may19/README.md
+++ b/research/events/711-arthur-wavewarz-base-call-may19/README.md
@@ -24,7 +24,7 @@ tier: STANDARD
 
 ### The Idea
 
-Zaal gave Arthur the background: The ZAO ("the z talent artist organization") is a progressively-decentralized incubator for on-chain music projects, governed by soulbound, illiquid Respect tokens earned weekly through fractal meetings (groups of six reach consensus on contribution, distributed on a Fibonacci curve). The first project incubated out of The ZAO is WaveWarZ - live-traded music battles, founded by Hurric4n3ike with Zaal and Sam. It runs on Solana: 1% of trade volume routes immediately to the artist, the losing side's pool partly feeds the winning side, settled on-chain via smart contract (no custody). To date WaveWarZ has run roughly 456 SOL of volume, producing about $650 / 7.74 SOL in fees (number garbled in transcript - see VERIFY). WaveWarZ runs 11 shows a week: five morning + five night Mon-Fri, plus Sunday-night battles.
+Zaal gave Arthur the background: The ZAO ("the z talent artist organization") is a progressively-decentralized incubator for on-chain music projects, governed by soulbound, illiquid Respect tokens earned weekly through fractal meetings (groups of six reach consensus on contribution, distributed on a Fibonacci curve). The first project incubated out of The ZAO is WaveWarZ - live-traded music battles, founded by Hurric4n3ike with Zaal and Sam. It runs on Solana: 1% of trade volume routes immediately to the artist, the losing side's pool partly feeds the winning side, settled on-chain via smart contract (no custody). To date WaveWarZ has run roughly 456 SOL of volume, producing about $650 / 7.74 SOL in fees (figures garbled in transcript - see Verify / Low-confidence below). WaveWarZ runs 11 shows a week: five morning + five night Mon-Fri, plus Sunday-night battles.
 
 ### Why It Matters
 
@@ -78,11 +78,20 @@ Arthur is a multi-surface collaborator now: WaveWarZ Base smart contracts + ZABA
 
 > "Going super hard on Farcaster - it's the right place in web3 that I've landed to find what I need to build out here." - Zaal
 
+## Verify / Low-confidence
+
+Items that need a human check before being treated as fact:
+
+- **WaveWarZ stats numbers** - the transcript span "456 SOL volume / $650 / 7.74 SOL in fees" is garbled; Whisper likely mis-segmented the figures. Confirm the real volume + fee totals against the WaveWarZ stats app before quoting.
+- **Action 6 (Arthur joins a WaveWarZ event)** - an open invitation, not a firm commitment. Arthur said he would try to drop in; do not treat as owed.
+- **Arthur's name/handle** - on-screen name tag read "Art L"; the transcript has a garbled aside ("topo / tophat / Kevin") where Zaal stumbled on a name. "Arthur" is taken from the recording filename. Confirm his preferred handle.
+
 ## Research Seeds
 
 - **like.fun on Farcaster** - prediction/betting markets on likes for short-form content; Arthur flagged its gamified play loop as a UX reference for WaveWarZ.
 - **Agentic WaveWarZ on Base + x402** - AI agents generating, battling, and trading music; agent-payment rails as the economic primitive.
 - **AI-agent-musician economy** - agents that pay for their own inference by winning battles; "stable" of agent musicians where weak ones die off.
+- **WaveWarZ Africa** - an Africa-based team approached WaveWarZ about using the tech to run an on-chain battle league per country. Mentioned in passing; worth its own scoping doc.
 
 ## Memory Updates
 

--- a/research/events/711-arthur-wavewarz-base-call-may19/transcript.md
+++ b/research/events/711-arthur-wavewarz-base-call-may19/transcript.md
@@ -1,0 +1,313 @@
+# Transcript - Arthur intro call: WaveWarZ Base agentic version (2026-05-19)
+
+Attendees: Zaal, Sam (Samantha / candytoybox), Arthur (Neynar).
+Transcribed locally via mlx-whisper large-v3-turbo. Verbatim, lightly run-on - raw record.
+
+---
+
+remember awesome so I got a lot of things I also hear that you have some
+ideas I don't know how much background you have on me but very focused on on
+chain music last three years have been like my crypto years three years before
+that starting to learn about startups because of a musician I met in RIT my
+lecture engineering degree perfect timing for Sam I got my lecture
+engineering degree from RIT I graduated I moved from this is Sam by the way what
+up Sam if you want to say hi before we get into it but hi how are you I see him
+Sam's been with me there since the start so it's been I can also share about that
+but I'll try and do a quick overview because I definitely have some ideas and
+agenda items I want to get through so essentially grew up Massachusetts 18 years
+of my life big mass hole like sports energy love love the Boston sports moved
+to New York for five years for RIT and then I moved out to Oregon for two years
+that's where I fell down the crypto rabbit hole I was very lucky I found a lot of
+regen heavy folks over there the PDX DAO crew joined DAOs got deep into it like the
+ideas was part of a few defunct DAOs then Sam and I were the last two people of a DAO
+that I joined where I met her she was like you're doing the music thing like
+let's actually just do this she came up with the name for the DAO which was
+amazing because we were z talent at that point so now we're the z talent artist
+organization the ZOW we started progressively decentralized using a
+our respect tokens our governance tokens soulbound and illiquid so you can't
+buy and sell it you can't send it to anyone so it's our like social capital you
+can earn it every week by participating in our weekly meetings our fractals we
+split off into groups of six share what we're doing to forward the ecosystem and
+then reach consensus on who's done the most the second most third most fourth
+most and then everyone gets distributed based on a Fibonacci curve of what people
+contributed for that week so there's a max amount of the tokens that are sent out
+every week essentially it's a lot harder to game 50% attack we're very
+focused on social capital as opposed to financial capital time to governance that
+has been an incubator that's the ultimate goal so we've incubated a few
+projects one of them being wave wars which is where Sam I and hurricane came
+to me he's a founder he's a musician came with this idea for live trade of
+music battles it started out as just music battles and now we've added the live
+traded part it's on salon and one of the things that I was telling top hat I'm
+topo I'm forgetting his name off the top of my head but um Kevin but topo top hat is
+fine yeah so one of the things I was telling him is one of the things I have
+literally been like just honestly too busy to dive into and like I've been
+wanting to do for since you guys you guys being farcaster release the Solana
+integration has been actually making a proper mini app for our app it's on
+Solana as people trade 1% of the volume goes immediately to the artists that you
+trade on their ephemeral tokens so they end at the end of the battle and you
+essentially withdraw into soul the losing side a portion of it goes to the winning
+side not all of it so it's a prediction market but for more subjective things
+essentially and we've used it to leverage people getting a new vertical for
+musicians to like have some some song that was like sitting on Spotify from
+three years ago they can play it and like actually produce revenue off of it
+right then and there and it paid immediately right because it's all
+blockchain so we don't have the custody everything it's a smart contract as well
+so hurricane genius behind it started that literally because he wanted to get
+this idea into life I spent three weeks out with him in Costa Rica in 2024 then
+this year from 25 we've been really focused on wave wars he spent three
+months out here in Maine with me helping blitz scale the product Sam helped with a
+lot of the marketing design runs a lot of different things on on the like promo
+marketing and everything else that that I or him don't do I've stepped away from the
+day to day to kind of build ecosystem things for wave wars but wave wars is
+essentially our main project our first project our revenue driver and one of
+the things we're pushing the most especially me being an on-chain music the
+last three years that's given me the bandwidth to start focusing on the Dow the
+region side and like a lot more of the last year and a half that I've been on
+Farcaster really finding my social graph and figuring that out started to build a
+client over the last few weeks to months because I see a value in like a
+community hub and I have been trying to onboard people to Farcaster but have
+different challenges with it so I think the the client will actually be a big
+part of being able to actually do that in the way I want to do it so that's kind
+of where I'm at I have that Zabal games idea as well as a couple other ones
+kind of floating in the tank that are coming up that I'm excited about but I would
+love to hear a little bit more about you and then any of the ideas you're
+thinking overall like I think there's a lot of fun things that we can do with
+music and Farcaster that hasn't gotten like the upper music as a whole in
+crypto hasn't gotten its opportunity to shine kind of like visual art and I
+think that's such a big lane there's our goal has just been like getting as much
+of the market share of on-chain music which has dwindled since I joined which
+is kind of been good for us but overall bad so wave wars has been that energy
+like we are bringing that as the now people that I talked about music we have
+11 shows a week five in the morning on Monday through Friday five at night on
+Monday through Friday and then our big battles on on Sunday nights but am I
+missing anything Sam from wave wars that's important I don't think so only that
+yeah I'm and from Africa team kind of approached us about using our the tech in
+Africa so they have got a team together and they're making an on-chain battle
+league in each country so we got that going too but um but yeah and we have a
+stats app which I built it does a bunch more fun things but essentially we've had
+about 456 so soul run through our platform in total and that's led to a
+total of 650 dollars or 7.74 soul because a bunch of that was when soul was a
+little higher um but that's what that is now a day outside artists so that's where
+we're at with it I've like been a little bit waiting for like my right
+opportunity to bring it to Farcaster in the way I wanted to I know there's so
+many good ways I can integrate it I'm just kind of like um at a somewhat of a
+pause because I'm not the developer for this like hurricane has been so like
+there's specific things that me and Sam have created as like different vibe
+coded things that we can't create that's easy to do with like anything that's
+public on blockchain but being able to play around with where we're there's a
+couple different challenges but anyways I'll stop there and excited to hear
+hear more from you sure um I'll give like a very high level intro uh I've been
+doing like ethereum related smart contract development since 2017 um I make and have
+made music since like 2015 um although I do it a lot less now because I've got oh
+yeah um I'm gonna be a banker and Farcaster too so you know they're kind of my
+children to some extent um but like deep into the dow culture early dow culture
+um the first project that I contributed to was giveth so I'm super familiar with
+like the region crew yeah that's all like kind of downstream of a lot of the stuff
+that we were doing then um I think that the soulbound token approach is super cool
+um like I'm a big fan of that um where it's like you show up and you do work and
+then you get a voting stake I think that works better almost every time versus like
+buying a share and being able to vote for it um also I think that like decay sometimes is useful
+I don't know what I'm doing for decay is every year I'm doubling the amount right now that people get
+yeah so same thing basically same end result I love that um so it sounds like that's a cool setup I'd
+love to participate in any way I can um I signed up to do like mentorship I saw that I'm very excited
+because basically my idea for this ball games is like our big essentially one of the things that I
+left out was we the second project we created was uh Zao festivals we started doing IRL events tied to
+crypto conferences 20 in 2024 started with NFT NYC called it Zao Palooza did it with six people who we
+all met on the day of the event for the first time I saw the venue on the day of the event we did it in
+six weeks it was a very web three thing it was absolutely nuts still that it happened and then
+we spent the next six months planning for Art Basel, Zaocella trying to get as much of the on-chain
+music community together that was our brand building opportunity now 2025 was Wave Wars now 2026 I've
+moved to Maine uh we bought a house last year here and um I'm starting to make local connections so I'm
+starting to plan for an event here again in uh October October 3rd music event but now tied to an art event
+um that's out here because like rural Maine no like tech a hub at all so it's like I would like
+to create a conference dash like eventually create this hub out here in down east Maine it's right by
+Acadia National Park so there's a lot of opportunity for like tourist a to come through but then be like
+this area and region could use like a little bit of web3 money and it would go a lot longer farther as
+well so that's why I'm doing my event out here it's like walkable from my house there's a lot of like
+both of the other events we did I was halfway across the world halfway across the U.S. in Portland so
+it was like completely different so I'm just excited to make more connections out here using this event
+as well as creating it as a place to like show off all my musicians when they all come from all over and
+like really showcase what we're about so that's what the big plan right now and the thing that I'm working
+on over the next six months is but then that ties into Zabal Games will get attention towards it
+all these other things I'm doing over on Parcaster I really want to make it an interactive event to
+where like I have two kind of non-negotiables for the event come in under budget and actually have it be
+come in under budget and have a live stream which is like the live stream part is a big focus over the
+last year and a half of like seeing different communities in digital creation leveraging that I see
+very much in this AI content world live streaming to be like an absolutely super authentic way to like
+create content and a media form so been tapping into that but like really creating a lot of other
+distribution things around it because a lot of streamers like that is their one and only thing
+so I'm curious to see like how we can leverage multi-streaming like just like using streaming as a
+distribution tool just like a token could be um to really get out there so like I'm trying to build
+all the online presence we have another uh project which is CoC Concerts which is a collaboration with
+the Zao and the CoC community we've been a part of for quite some time and the last two years and
+essentially they're just metaverse concerts um just live stream to the metaverse and all of our streaming
+platforms as a zero cost way to enable some of these things that we want to do with our IRL events and
+showcase some of our musicians but at a zero overhead kind of mentality um so we have a lot of different
+ways to bring attention towards live streaming and I think bringing like all the crypto stuff and like
+attention awareness token um opportunities um is great for live stream but because we're out here in
+rural Maine making like the event itself just like a successful music event so that I can do it again next
+year so yeah those are kind of like the other things I'm working on cool yeah all sounds
+interesting um the your event is the day after my daughter's first birthday so I probably not be at
+this one but it sounds cool like literally that day I'd probably try and make it out and it still might
+be possible honestly um to see when we're doing our birthday party but um I think that that's a great
+philosophy we always had this thesis with Giveth that like the the biggest impact you can make is to
+local communities that you're embedded in exactly the Cosmo localism really got to me when I went
+out to ETH Boulder this year which was a really good opportunity to a see a bunch of my region friends
+from PDX that I hadn't talked to in two years which was really cool and then also just like that
+conference was every single conference I've went to I feel like um we basically I went to Miami because of
+a music NFT artist having a side event uh to Basel 2023 then I went to NFT NYC um we did our event then
+Basel we did our event and then Farcon in 2024 last 25 last year in New York which what really progressed
+my life understanding of where we could go with Farcaster or where I could go with Farcaster um and then
+uh ETH Boston and Seoul Boston which were just like local here uh to me so uh each of and then then this
+event that which was like more of an actual Ethereum event of like ETH Boulder it was a great opportunity
+to see the region folks and like see the the that community thriving because I hadn't seen that in a
+while so um yeah each event and that I've gone to has been progressively better and better and seeing all
+the way the different organizers are creating different things I think there's some really cool things that
+we can incorporate so um I would love to even if you can't make it out there physically to be there
+virtually right so definitely yeah and if I can help in any way um I'm definitely better with EVM than I
+am with Seoul yeah no that's okay so Sam can you explain our your idea of with the base ecosystem because
+I have this I honestly have this write-up because I sent something over to Dish a little bit ago um that
+is here let me actually just pull it up I'm also like fine I'm I'm the clanker person now too so exactly so
+well it was actually a post like him saying he's leaving and I was like okay bro I got a couple
+ideas that we we could use so some thoughts in so uh but he of course he's taking some time and I was
+like bro just call me when you have some time we'll we'll sit for dinner and we can talk about whatever
+I'm at then he's close too you guys are super close to you yeah no I met him at youth boston which
+was really cool it's a good chance to really chat um there but you was probably at that right
+what'd you say sorry boston base too I don't think I met I've met grin ever is the thing I probably have
+at farcon but I didn't wreck I I didn't know him uh then or anyone really by faces um so uh I probably
+have seen him before there but other like I've never spoken with him uh on the interwebs yeah sorry
+sam uh do you want to share about the idea um yeah so basically uh yeah we're on solana but well when
+the agent started with the x402 um I started making a base version of the same you know wave wars because um
+um technically like well we were thinking you know about doing an agentic version of wave wars so the
+agents could make their own music um and be battling it and then the trader trading agents or you know the
+agents can trade on it um basically it kind of becomes like a uh place of employment almost for agents because
+since it's it's in you know the regular token soul or you know eath or usdc it's not like our token
+it kind of becomes like uh good employment for the agents in a way um but yeah so is that what you were
+talking about like uh zol is doing the the base version of wave wars yeah the agents for sure because we were
+thinking basically one of the things I was thinking instead actually that I think would be really cool so essentially
+I was going to show you an example but I don't know what's happening my computer always has some trouble
+um I'll pull it up on my phone here in a minute but um or sam if you want to pull it up
+um essentially what we've done with wave wars we created the first version of it it all works and then we
+created quick battles which essentially anyone that has a song on audius can sync their audius songs to our wave wars catalog
+and anyone can upload those songs in a quick battle against any other song and those are automatically
+played out of the website versus our traditional battles we just like whatever media source you're on
+you're on and it's just that timer and uh the um the two songs um but the quick battles give us this
+opportunity to tap into different platforms like audius and essentially I we all of us have been learning as
+like traders to how like wave wars works in many different ways and like improving on that I think
+it could be really powerful if each trader also had an agent in the agentic version of wave wars where
+we were running these and like the only reason we don't run them more often is because we don't have
+enough volume like and all all we need to start a battle is pay a specific program fee which is not a
+variable cost so in the end of the day like there is a lot of opportunity here in the profit margin of
+it being very high but also because we so essentially we take half a percent the artist takes one percent
+and 98.5 goes into the um goes into the chart so uh it's basically one and a half percent fee if you're
+looking at trading but we're kind of creating like a new form of entertainment I don't know how to explain
+it Sam I don't know I feel like you and her came in super deep in this what what's the pitch
+what's the pitch that you give if uh for for that side of it where it's not um I don't even know how
+to explain the culture but my point is it'd be really cool to have each person each trader that's
+a musician to have an agent that they could play in the gentic one that they're all trading against
+each other and it's giving you suggestions on like your play style is some people um try and buy as early
+as possible because of course that'll be better on a bonding curve um but then there's also people
+selling at the top and then people buying at uh as it comes down and then people buying or selling at
+the very end to snipe one side or the other so like there's all these different strategies and
+especially if they're a gentic there could be a lot of different because they're all like happening on
+the like one second left essentially if you're gonna do like sniping different things so like
+there's a lot of different mechanics to it and then also all of it's on chain so if our agents could
+also be learning and self-aware of like like I'm watching many of these wallets and like this singular
+person is doing all these things and like I can find strategies I think it could be really fun like
+on the gaming it side of it of like the lore of like what you can possibly do with wave wars a lot
+more in depth of like how the game of wave wars works have you seen like.fun on far faster
+i've heard of it i don't really know i would check that out just for ux influence um because they have
+like a very similar like user play loop um only they're doing like uh kind of like prediction
+betting markets around likes on short form content um the way in which they've gamified it is like
+very sticky and very compelling um and their underlying loop is very similar so it might be
+interesting for for some influence and like i literally just used to like watch beat battles back
+in the day like kenny beats constantly i still watch bsu battles pretty regularly so like i get the
+entertainment factor and i think it makes total sense you've also got this like sort of like
+stable to to train and get decent artists like agent musicians too because like over time the ones that
+are not making good music and are not winning these battles should like kind of die off right and then
+the ones that are doing well will be able to pay for their own inference um yeah i don't see any
+autonomy so much opportunity with the the fact that agents need money and this is a place where like
+there is a like you're basically it costs let's say it costs a dollar to start a battle you know we need
+two hundred dollars in volume for um us to make money if we start the battle but if any artist puts their
+song and and this could be a agent acting for a musician and bringing their song in and that that artist
+gets a hundred dollars and gets that one dollar one percent in volume on their chart during that 10
+minute battle then that agent could continue continuously play that battle especially if we
+fund like a x amount up front which could be very uh potent i think for starting the infinite loop of
+like we only do 8 30 at night basically eastern you should if if you're ever available you're welcome to
+pop in that's our like time for our quick battles uh this usually starts closer to 9 p.m eastern and uh
+essentially we just do quick battle night at night three to like six usually and uh and it's just like
+getting used to this getting more people in having a lot of different opportunities to to have musicians
+try out their songs to battle each other and uh and yeah i think there could be a lot there with the
+potential of agents but we haven't each of us have played with it but like sam and i are more heavy
+on the vibe coding side because like we've gotten a lot better at being able to manifest our ideas
+leveraging tooling like ai but when neither of us were smart contract developers before hurricane kind
+of learned smart contract developing with the systems of ai very much like uh ai engineering it um and uh
+and is now like an insane in a lot better at solana than he could have ever been uh but i think there's
+a lot of value on this side it's just we don't we're like i think sam's made also the um the two
+smart contracts on testnet as well to like start it off so we have like some of that idea we just need to
+like kind of flush it out honestly with someone who knows what they're doing so that could be helpful
+yeah um if there's a repo i can look it over give some pointers give some suggestions um honestly one
+of the biggest things is just knowing what resources to point the agents at exactly really great
+repositories that have like you know security references and yeah if you have any additional
+resources on that front please send anything over i will send it to our community because that's like
+very heavy on where we're at where like that's why i'm building all these primitives on my side because
+i want eventually to have any of my either future agents or future people um come back into it and
+look at it and like build on top of it so um yeah i i'm like pointing it to the right stuff and compiling
+that is one of our ultimate goals so yeah i would love any and all support on that that'd be huge can do
+um and yeah you said that the biggest ones you have are usually on sundays that might work actually
+pretty well for me sunday 7 p.m eastern um also we have monday through friday 11 a.m eastern as well
+that's our conversation one okay what's conversation versus uh wave battle uh just having a conversation
+on like either the night before music as a whole um i don't know sam you're in them every day yeah um
+actually we have the we're kicking we just kicked off our um ai artist good boy music tournament um
+and we have some really talented musicians that get extra extra talented when they play with ai um and
+that that uh first battle is this on the 31st the sunday is that this no next sunday
+okay we're two sundays i don't know next sunday the 31st it's 7 p.m eastern is the first battle um
+so that is going to be great if you want to come join check that out yeah what we do is the first three
+people to come up as speakers um are that want to judge and are not biased um die their artist uh we we
+ask the judge so like if you're either i mean you can come in and watch and watch where we we'd love that
+as well but i feel like it could be really fun as well to be a part of it so seven is when i put my
+sundown um so i'd probably be a little late but yeah it doesn't always start we usually start like
+7 30 8. yeah it's usually the conversation getting people in kind of start and same thing with the the
+quick battles at night at 8 30 um and usually it's slow at the beginning at 11 as well but it
+sometimes they stay for like two three hours but like 11 um is always a great opportunity to just
+like share a little bit about yourself as a musician and like learn a little bit about the community and
+the culture of the community there um those everything's on x with wave wars essentially
+and then a lot of content is on youtube wave wars w-a-v-e w-a-r-z with z is a big part of our brand
+so uh that's kind of you should be able to find it there but yeah so those are all spaces and that's
+why i've been very excited about the farcaster native spaces so i'm stoked to get more into that
+with whomever the farcaster intern is and and all of you guys but um but yeah i think there's a lot of
+fun things we can do with it is it uh adult whim
+is that right uh because that's what i'm seeing when i search for wave wars
+is that how you're spelling it so uh about a year ago w-a-v-o uh w oh no i don't have any got it got
+it i thought it was like w-a-v like wave files yeah well that's that is the point but it's not
+spelt like that okay got it got it i hadn't thought about that angle well that's a good one
+so hurricane's whole thing is he had wavy wednesday when i met him he was doing for like seven years
+pushing and content on wednesdays his whole like every city go to if you go to hurricane ike which is
+also spelt super whack um but here hurricane ike um you'll see it in in in the wave or in his profile
+as well but essentially if you go to his profile every thing on spotify i think every single song
+ends with waves so it's like something wave like he's a very that's his brand so he he's the perfect
+person to like first of all i in me working in this space it's amazing to have someone else to like
+work on a team with as opposed to like building everything like being the leader and people
+having looking to you so like that's been huge for wave wars is like he's been leading it as like
+the first project out of the incubator the zao essentially and uh it's been an honestly a blast
+because it's just been cool to i we argue a lot on like the actual methodology but like he has the
+like uh ultimate like decision making and it's great because there's so many times i've been proved
+wrong there's so many times he's been like no you're right and like it's just a me him and sam
+have a very good because we had the chemistry before actually starting the startup we have a
+very good way of working with um ourselves and the way we work together so um essentially the goal
+of the zao is to have this incubator where like you can have these already knowing each other
+community members to really manifest an idea for any kind of piece of media
+um yeah so we're almost at time but like is what's the the number one way i can help like what
+are what i'll send you over the repo for the base thing and then we'll start locking that in um and
+i'll make a group chat with uh with the three of us and then probably pop hurricane in there as well on
+on farcaster so that'll force him to to pop in over there if you want to do one on farcaster that
+works if you want to do an on x that works too um i'm trying to be more active on x oh well there you go
+that is a perfect way to do it yeah i'm probably one of the few people who has more activity and
+more follows on the farcaster side than the x side well yeah i i like that like i'm very like anti-axe
+again like i said the only reason i'm still on it is because of the waveforms brand and i still see
+so much value a tremendous value there but for where i'm at as a builder right now like going super
+hard on farcaster as like it's the right place in web 3 that i've landed to find what i need to
+build out out here so it's really cool to like i think we're on the precipice of putting ourselves
+in a really good spot to capture a lot of like the growth that i think farcaster is about to see so
+i appreciate you appreciate everything you're doing thank you for your time and uh i'll catch you soon
+yeah let's talk soon thanks peace out yes thank you so much

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-05-19 | Arthur intro call - WaveWarZ Base agentic version | WaveWarZ | Zaal, Sam, Arthur | [711](711-arthur-wavewarz-base-call-may19/) | 6 |
 | 2026-05-19 | ZAOstock advisor call | ZAOstock | Zaal, failoften | [678](678-zaostock-advisor-call-may19/) | 12 |
 | 2026-05-18 | Iman call - ZAO Craig + PizzaDAO Zambia | ZAO Devz | Zaal, Iman | [670](670-iman-call-may18-craig-pizzadao/) | ~4 |
 | 2026-05-18 | Tanja Fractal Book call | ZAO OS / Fractal | Zaal, Tanja | [675](675-tanja-fractal-book-call-may18/) | 7 |


### PR DESCRIPTION
## Summary
Researches the "ZAO CRM" idea - a relationship layer for the cowork tracker. Recommendation: build it in (the unified Supabase schema already has 5 empty CRM-shaped tables), Folk-style (relationship-first, lightweight), one `contacts` table + a `tasks.contact_id` link. The differentiator: the bot + `/meeting` skill auto-log touches into `contact_log`, solving the data-drift flaw every CRM vendor has.

## Tier
STANDARD - codebase grounding (db/schema.sql + Supabase list_tables) + 4 CRM-comparison sources + 1 web search.

## Sources
4 CRM comparisons (Attio/Folk/HubSpot - all FULL), 1 web search (CRM+task patterns - PARTIAL), 1 codebase (schema - FULL).

## Next Actions
See the doc's Next Actions table - migration (`contacts` table + `tasks.contact_id`), Contacts tab, bot `/contact` + `/log`, `/meeting` auto-log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)