### PR TITLE
feat(meeting-skill): sherpa-onnx speaker diarization + drift-proof skill sync

### DIFF
--- a/.claude/skills/meeting/SKILL.md
+++ b/.claude/skills/meeting/SKILL.md
@@ -97,9 +97,49 @@ The script is local-first:
 2. If local tooling is absent (non-Mac machine), it falls back to Whisper on
    Iman's VPS - SCP up, transcribe, SCP the `.txt` back.
 
+It prints the `.txt` transcript path and writes a `.json` sidecar at the same
+stem (`/tmp/meeting-X.txt` + `/tmp/meeting-X.json`) - the sidecar carries
+segment timestamps that Step 3 needs. The local mlx path produces the sidecar;
+the VPS fallback does not (so Step 3 is skipped on the VPS path).
+
 One-time local setup: `uv tool install mlx-whisper`. For a hard-to-hear or
 many-name meeting, pass a bigger model:
-`transcribe.sh "$MEDIA_PATH" --model mlx-community/whisper-large-v3`.
+`transcribe.sh "$MEDIA_PATH" --model mlx-community/whisper-large-v3`. Avoid
+plain `whisper-large-v3` on long calls - it can loop catastrophically (doc
+709); `whisper-large-v3-turbo` is the safe default.
+
+**Step 3 - diarize (speaker labels).** Whisper emits one unlabeled block - no
+speaker turns. Add them so the extraction passes know who said what:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/diarize.sh "$MEDIA_PATH" "${TRANSCRIPT%.txt}.json"
+```
+
+(`$TRANSCRIPT` is the `.txt` path Step 2 printed.) The script runs `sherpa-onnx`
+diarization fully locally - no Hugging Face token, no GPU. First run downloads
+two small ONNX models (~35MB total) to `~/.zao/diarization-models/`. It prints
+the path to a speaker-labeled transcript (`[Speaker 1] ... [Speaker 2] ...`)
+and the detected speaker count on stderr.
+
+**Pass the speaker count when you know it.** Auto-detect over-clusters - it
+found 8 speakers on a 2-person test call. When the count is known (the filename
+`Tyler x zaal` = 2, a calendar invite, or a quick skim of the plain transcript),
+force it - this is the single biggest quality lever:
+
+```bash
+ZAO_DIARIZATION_NUM_SPEAKERS=2 bash ${CLAUDE_SKILL_DIR}/scripts/diarize.sh "$MEDIA_PATH" "${TRANSCRIPT%.txt}.json"
+```
+
+Leave it unset only when the count is genuinely unknown.
+
+Diarization is best-effort. If `diarize.sh` fails (uv or models unavailable, the
+VPS fallback path produced no json sidecar, or the box is out of memory),
+proceed with the plain unlabeled transcript and attribute speakers from content
+- do not abort the run. Highest value on 3+ person calls; on a 1-2 person call
+the labeled transcript is a nice-to-have, not load-bearing.
+
+When a labeled transcript is produced, use it as the Phase 2 input and as the
+body of `transcript.md`.
 
 ### Mode: craig_url
 Download Craig recording, transcribe.
@@ -125,6 +165,14 @@ shown on a slide but not said aloud (Pass B/C), and confirm name spellings
 against the brand glossary. A frame is corroboration, never a substitute for the
 transcript - if a frame and the transcript conflict, the transcript wins and the
 item is flagged `confidence: low`.
+
+**Speaker-labeled transcript - map the labels.** If Step 3 produced a
+`[Speaker N]`-labeled transcript, those labels are anonymous diarization output.
+In Pass A, map each `Speaker N` to a real attendee using content,
+self-introductions ("this is Sam"), and frame name-tags. Carry the mapping
+through every later pass and into `transcript.md`. If diarization was skipped or
+failed, attribute speakers from content alone - the recap still works, owner
+attribution is just less certain (flag affected actions `confidence: medium`).
 
 1. **Pass A - meeting metadata.** date, duration, title, attendees, platform. Date never invented - from transcript, file mtime, or ask.
 2. **Pass B - decisions.** Things explicitly decided/agreed in the call. Verbatim-anchored.
@@ -402,8 +450,10 @@ When creating the recap doc, parallel Claude sessions may race for the same numb
 
 ## Scripts
 
-- `scripts/transcribe.sh` - local-first transcription: mlx-whisper on Apple Silicon, VPS Whisper fallback
+- `scripts/transcribe.sh` - local-first transcription: mlx-whisper on Apple Silicon, VPS Whisper fallback. Emits a `.txt` transcript + `.json` segment-timestamp sidecar.
 - `scripts/extract-frames.sh` - pull scene-change + interval still frames from a meeting video
+- `scripts/diarize.sh` - speaker diarization via sherpa-onnx: who-spoke-when, merged with the whisper json into a `[Speaker N]`-labeled transcript. Local, offline, no HF token.
+- `scripts/diarize.py` - the diarization + transcript-merge engine called by `diarize.sh` (runs under `uv run --with sherpa-onnx`).
 - `scripts/fetch-craig.sh` - curl Craig recording URL, extract audio
 - `scripts/append-actions.sh` - `gh api` PUT for `data/actions.json` bulk append (ZAO Devz project only)
 - `scripts/bonfire-episode.sh` - POST meeting episodes to the ZABAL Bonfire KG (always-on, best-effort, doc 680)

--- a/.claude/skills/meeting/references/meeting-recap-template.md
+++ b/.claude/skills/meeting/references/meeting-recap-template.md
@@ -58,6 +58,14 @@ tier: STANDARD
 
 > "{quote text}" - {speaker}
 
+## Verify / Low-confidence
+
+Every `confidence: low` (and notable `medium`) decision, action, quote, or garbled
+transcript span goes here so the recap never silently presents an uncertain item
+as fact. Drop this section only if the extraction was genuinely 100% high-confidence.
+
+- **{item}** - {what is uncertain and what a human should check}
+
 ## Research Seeds
 
 {Topics worth a doc later. Each as a bullet.}

--- a/.claude/skills/meeting/scripts/bonfire-episode.sh
+++ b/.claude/skills/meeting/scripts/bonfire-episode.sh
@@ -15,10 +15,23 @@
 #   BONFIRE_API_KEY  required - absent => skip all, exit 0
 #   BONFIRE_ID       required - the ZABAL bonfire id
 #   BONFIRE_API_URL  default https://tnt-v2.api.bonfires.ai
+#
+# Key source: if the vars are not already exported, this script sources a
+# local env file - default ~/.zao/bonfire.env (override with BONFIRE_ENV).
+# Put the key there once (chmod 600); it is never committed and never echoed.
+#   BONFIRE_API_KEY=...
+#   BONFIRE_ID=...
 
 set -uo pipefail
 
 INPUT="${1:?missing episodes-json path}"
+
+# Load the key from a local env file when it is not already in the environment.
+BONFIRE_ENV="${BONFIRE_ENV:-$HOME/.zao/bonfire.env}"
+if [[ -z "${BONFIRE_API_KEY:-}" && -f "$BONFIRE_ENV" ]]; then
+  set -a; . "$BONFIRE_ENV"; set +a
+fi
+
 API_URL="${BONFIRE_API_URL:-https://tnt-v2.api.bonfires.ai}"
 API_KEY="${BONFIRE_API_KEY:-}"
 BONFIRE_ID="${BONFIRE_ID:-}"

--- a/.claude/skills/meeting/scripts/diarize.py
+++ b/.claude/skills/meeting/scripts/diarize.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""diarize.py - speaker diarization for meeting recordings, via sherpa-onnx.
+
+Two modes:
+  diarize - run offline speaker diarization on a 16kHz mono wav, write a
+            TSV of [start, end, speaker] segments.
+  merge   - merge a diarization TSV with an mlx-whisper JSON transcript into
+            a speaker-labeled transcript (consecutive same-speaker turns
+            collapsed into one block).
+
+Invoked by diarize.sh, not meant to be run directly. The diarize mode runs
+inside an ephemeral `uv run --with sherpa-onnx` env so sherpa_onnx imports;
+the merge mode is pure stdlib and runs under plain python3.
+"""
+import argparse
+import json
+import os
+import sys
+
+
+def log(msg):
+    print(f"[diarize.py] {msg}", file=sys.stderr)
+
+
+def read_wav(path):
+    """Read a 16-bit PCM mono wav into a float32 numpy array in [-1, 1).
+
+    sherpa-onnx 1.13.2 does not expose a top-level read_wave helper, so we read
+    the wav ourselves. diarize.sh always feeds us 16kHz mono pcm_s16le.
+    """
+    import wave
+
+    import numpy as np
+
+    with wave.open(path, "rb") as w:
+        if w.getsampwidth() != 2:
+            raise ValueError(f"expected 16-bit PCM wav, got {w.getsampwidth() * 8}-bit")
+        if w.getnchannels() != 1:
+            raise ValueError(f"expected mono wav, got {w.getnchannels()} channels")
+        sample_rate = w.getframerate()
+        raw = w.readframes(w.getnframes())
+    samples = np.frombuffer(raw, dtype=np.int16).astype(np.float32) / 32768.0
+    return samples, sample_rate
+
+
+def run_diarize(wav_path, seg_model, emb_model, out_tsv, num_speakers, threshold):
+    import sherpa_onnx
+
+    for path, label in ((seg_model, "segmentation"), (emb_model, "embedding")):
+        if not os.path.isfile(path):
+            log(f"ERROR: {label} model not found: {path}")
+            sys.exit(6)
+
+    config = sherpa_onnx.OfflineSpeakerDiarizationConfig(
+        segmentation=sherpa_onnx.OfflineSpeakerSegmentationModelConfig(
+            pyannote=sherpa_onnx.OfflineSpeakerSegmentationPyannoteModelConfig(
+                model=seg_model
+            ),
+        ),
+        embedding=sherpa_onnx.SpeakerEmbeddingExtractorConfig(model=emb_model),
+        clustering=sherpa_onnx.FastClusteringConfig(
+            # num_clusters > 0 forces an exact speaker count; -1 = auto-detect
+            # by similarity threshold (the usual case - we rarely know upfront).
+            num_clusters=num_speakers if num_speakers > 0 else -1,
+            threshold=threshold,
+        ),
+        min_duration_on=0.3,
+        min_duration_off=0.5,
+    )
+
+    try:
+        sd = sherpa_onnx.OfflineSpeakerDiarization(config)
+    except Exception as exc:  # noqa: BLE001 - surface any model/config failure
+        log(f"ERROR: could not init diarizer: {exc}")
+        sys.exit(6)
+
+    samples, sample_rate = read_wav(wav_path)
+    if sample_rate != sd.sample_rate:
+        log(f"ERROR: wav is {sample_rate}Hz, model needs {sd.sample_rate}Hz")
+        sys.exit(7)
+
+    result = sd.process(samples).sort_by_start_time()
+    with open(out_tsv, "w") as f:
+        for seg in result:
+            f.write(f"{seg.start:.3f}\t{seg.end:.3f}\t{seg.speaker}\n")
+
+    speakers = sorted({seg.speaker for seg in result})
+    log(f"diarization done - {len(result)} segments, {len(speakers)} speaker(s)")
+    print(len(speakers))  # stdout: speaker count, for the calling shell
+
+
+def load_segments(tsv_path):
+    segs = []
+    with open(tsv_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            start, end, spk = line.split("\t")
+            segs.append((float(start), float(end), int(spk)))
+    return segs
+
+
+def speaker_for(seg_start, seg_end, diar):
+    """Pick the diarization speaker with the most timestamp overlap."""
+    best_spk, best_overlap = None, 0.0
+    for d_start, d_end, spk in diar:
+        overlap = min(seg_end, d_end) - max(seg_start, d_start)
+        if overlap > best_overlap:
+            best_overlap, best_spk = overlap, spk
+    return best_spk
+
+
+def label(spk):
+    # speaker ids are 0-indexed ints; humans read 1-indexed.
+    return f"Speaker {spk + 1}" if spk is not None else "Speaker ?"
+
+
+def run_merge(whisper_json, segments_tsv, out_txt):
+    diar = load_segments(segments_tsv)
+    if not diar:
+        log("WARNING: empty diarization - transcript will be unlabeled")
+
+    with open(whisper_json) as f:
+        data = json.load(f)
+    segments = data.get("segments", [])
+    if not segments:
+        log("ERROR: whisper JSON has no segments - cannot label")
+        sys.exit(8)
+
+    # Collapse consecutive same-speaker whisper segments into one turn block.
+    lines, cur_spk, buf = [], None, []
+    for s in segments:
+        text = (s.get("text") or "").strip()
+        if not text:
+            continue
+        spk = speaker_for(float(s["start"]), float(s["end"]), diar)
+        if buf and spk != cur_spk:
+            lines.append(f"[{label(cur_spk)}] " + " ".join(buf))
+            buf = []
+        cur_spk = spk
+        buf.append(text)
+    if buf:
+        lines.append(f"[{label(cur_spk)}] " + " ".join(buf))
+
+    with open(out_txt, "w") as f:
+        f.write("\n\n".join(lines) + "\n")
+    log(f"merge done - {len(lines)} speaker turns -> {out_txt}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="meeting speaker diarization")
+    sub = ap.add_subparsers(dest="mode", required=True)
+
+    d = sub.add_parser("diarize", help="diarize a 16kHz mono wav")
+    d.add_argument("--wav", required=True)
+    d.add_argument("--seg", required=True, help="segmentation model .onnx")
+    d.add_argument("--emb", required=True, help="speaker-embedding model .onnx")
+    d.add_argument("--out", required=True, help="output segments .tsv")
+    d.add_argument("--num-speakers", type=int, default=0,
+                   help="exact speaker count; 0 = auto-detect")
+    d.add_argument("--threshold", type=float, default=0.5,
+                   help="clustering similarity threshold (auto-detect mode)")
+
+    m = sub.add_parser("merge", help="merge diarization TSV with whisper JSON")
+    m.add_argument("--whisper-json", required=True)
+    m.add_argument("--segments", required=True, help="diarization .tsv")
+    m.add_argument("--out", required=True, help="output labeled transcript .txt")
+
+    args = ap.parse_args()
+    if args.mode == "diarize":
+        run_diarize(args.wav, args.seg, args.emb, args.out,
+                    args.num_speakers, args.threshold)
+    else:
+        run_merge(args.whisper_json, args.segments, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/meeting/scripts/diarize.sh
+++ b/.claude/skills/meeting/scripts/diarize.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# diarize.sh - speaker diarization for a meeting recording, via sherpa-onnx.
+#
+# Whisper (mlx or VPS) emits one unlabeled block - no speaker turns. This adds
+# them: who spoke when. High value on 3+ person calls where owner attribution
+# from content alone is unreliable; low value but harmless on a 1-2 person call.
+#
+# Fully local + offline. sherpa-onnx is pulled on demand via `uv run` (cached
+# after first use); the two ONNX models download once to
+# ~/.zao/diarization-models/ - no Hugging Face token needed (doc 709).
+#
+# Usage:   diarize.sh <media-path> [whisper-json]
+#   no whisper-json  -> prints a TSV of [start, end, speaker] segments
+#   with whisper-json -> prints a speaker-labeled transcript (.txt)
+# Outputs: result path on stdout; speaker count + progress on stderr.
+set -uo pipefail
+
+SRC="${1:?missing media path}"
+WHISPER_JSON="${2:-}"
+if [[ ! -f "$SRC" ]]; then
+  echo "ERROR: media file not found: $SRC" >&2
+  exit 2
+fi
+
+command -v ffmpeg >/dev/null 2>&1 || { echo "ERROR: ffmpeg not installed (brew install ffmpeg)" >&2; exit 3; }
+
+UV_BIN="$(command -v uv || true)"
+if [[ -z "$UV_BIN" && -x "$HOME/.local/bin/uv" ]]; then
+  UV_BIN="$HOME/.local/bin/uv"
+fi
+if [[ -z "$UV_BIN" ]]; then
+  echo "ERROR: uv not installed - diarization needs it." >&2
+  echo "       install: curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+  exit 3
+fi
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIARIZE_PY="$SKILL_DIR/scripts/diarize.py"
+if [[ ! -f "$DIARIZE_PY" ]]; then
+  echo "ERROR: diarize.py missing next to this script" >&2
+  exit 3
+fi
+
+# ---------- models: download once, then cached ----------
+MODEL_DIR="${ZAO_DIARIZATION_MODELS:-$HOME/.zao/diarization-models}"
+mkdir -p "$MODEL_DIR"
+SEG_MODEL="$MODEL_DIR/sherpa-onnx-pyannote-segmentation-3-0/model.onnx"
+EMB_MODEL="$MODEL_DIR/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"
+
+SEG_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-segmentation-models/sherpa-onnx-pyannote-segmentation-3-0.tar.bz2"
+EMB_URL="https://github.com/k2-fsa/sherpa-onnx/releases/download/speaker-recongition-models/3dspeaker_speech_campplus_sv_zh_en_16k-common_advanced.onnx"
+
+if [[ ! -f "$SEG_MODEL" ]]; then
+  echo "[diarize] downloading segmentation model (~7MB, one-time)" >&2
+  curl -fsSL "$SEG_URL" -o "$MODEL_DIR/seg.tar.bz2" \
+    || { echo "ERROR: segmentation model download failed" >&2; exit 4; }
+  tar -xjf "$MODEL_DIR/seg.tar.bz2" -C "$MODEL_DIR" && rm -f "$MODEL_DIR/seg.tar.bz2"
+fi
+if [[ ! -f "$EMB_MODEL" ]]; then
+  echo "[diarize] downloading speaker-embedding model (~28MB, one-time)" >&2
+  curl -fsSL "$EMB_URL" -o "$EMB_MODEL" \
+    || { echo "ERROR: embedding model download failed" >&2; exit 4; }
+fi
+if [[ ! -f "$SEG_MODEL" || ! -f "$EMB_MODEL" ]]; then
+  echo "ERROR: diarization models missing after download attempt" >&2
+  exit 4
+fi
+
+# ---------- extract 16kHz mono wav (sherpa needs exactly this) ----------
+STAMP=$(date +%Y%m%d-%H%M%S)
+WAV="/tmp/meeting-diar-$STAMP.wav"
+echo "[diarize] extracting 16kHz mono wav from $(basename "$SRC")" >&2
+ffmpeg -nostdin -v error -y -i "$SRC" -ac 1 -ar 16000 -c:a pcm_s16le "$WAV" </dev/null
+if [[ ! -f "$WAV" ]]; then
+  echo "ERROR: ffmpeg produced no wav" >&2
+  exit 5
+fi
+
+# ---------- run diarization ----------
+SEGS_TSV="/tmp/meeting-diar-$STAMP.tsv"
+echo "[diarize] running sherpa-onnx diarization (a few minutes for a long call)" >&2
+NUM_SPK=$("$UV_BIN" run --quiet --with sherpa-onnx --with numpy --python 3.12 python "$DIARIZE_PY" diarize \
+  --wav "$WAV" --seg "$SEG_MODEL" --emb "$EMB_MODEL" --out "$SEGS_TSV" \
+  --num-speakers "${ZAO_DIARIZATION_NUM_SPEAKERS:-0}")
+DIAR_RC=$?
+rm -f "$WAV"
+if [[ $DIAR_RC -ne 0 || ! -s "$SEGS_TSV" ]]; then
+  echo "ERROR: diarization failed (rc=$DIAR_RC)" >&2
+  exit 6
+fi
+echo "[diarize] detected ${NUM_SPK:-?} speaker(s)" >&2
+
+# ---------- merge with whisper transcript, if one was given ----------
+if [[ -n "$WHISPER_JSON" && -f "$WHISPER_JSON" ]]; then
+  LABELED="/tmp/meeting-labeled-$STAMP.txt"
+  python3 "$DIARIZE_PY" merge \
+    --whisper-json "$WHISPER_JSON" --segments "$SEGS_TSV" --out "$LABELED" >&2
+  if [[ -s "$LABELED" ]]; then
+    echo "$LABELED"
+    exit 0
+  fi
+  echo "[diarize] merge produced nothing - returning raw segments instead" >&2
+fi
+
+echo "$SEGS_TSV"

--- a/.claude/skills/meeting/scripts/transcribe.sh
+++ b/.claude/skills/meeting/scripts/transcribe.sh
@@ -6,7 +6,9 @@
 # is absent (e.g. running from a non-Mac machine).
 #
 # Usage:   transcribe.sh <media-path> [--model <model>]
-# Outputs: prints the local path to the .txt transcript on success.
+# Outputs: prints the local path to the .txt transcript on success. Also writes
+#          a .json sidecar (same path stem) carrying segment timestamps - the
+#          diarization step (diarize.sh) needs it to label speakers.
 set -euo pipefail
 
 SRC="${1:?missing media path}"
@@ -38,10 +40,12 @@ if [[ -n "$MLX_BIN" ]]; then
   echo "[transcribe] first run for a model downloads it (~1.5GB); later runs are cached" >&2
 
   # mlx_whisper handles mp4/mov directly - ffmpeg strips the audio track.
+  # --output-format all also emits transcript.json (segment timestamps),
+  # which diarize.sh consumes to produce a speaker-labeled transcript.
   "$MLX_BIN" "$SRC" \
     --model "$MODEL" \
     --language en \
-    --output-format txt \
+    --output-format all \
     --output-name transcript \
     --output-dir "$OUTDIR" >&2
 
@@ -50,6 +54,10 @@ if [[ -n "$MLX_BIN" ]]; then
     exit 5
   fi
   cp "$OUTDIR/transcript.txt" "$LOCAL_OUT"
+  # JSON sidecar (same stem) - segment timestamps for the diarization step.
+  if [[ -f "$OUTDIR/transcript.json" ]]; then
+    cp "$OUTDIR/transcript.json" "${LOCAL_OUT%.txt}.json"
+  fi
   echo "[transcribe] done -> $LOCAL_OUT" >&2
   echo "$LOCAL_OUT"
   exit 0

--- a/scripts/sync-meeting-skill.sh
+++ b/scripts/sync-meeting-skill.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# sync-meeting-skill.sh - keep the two copies of the /meeting skill in sync.
+#
+# The skill lives in two places that drift when one is edited and the other is
+# not (this cost real time on 2026-05-22 - autoresearch edits landed in one
+# copy, diarization work in the other):
+#   REPO  .claude/skills/meeting/   - version-controlled, the source of truth
+#   USER  ~/.claude/skills/meeting/ - the copy Claude Code actually runs
+#
+# Rule: edit the REPO copy, then run this. Default direction is REPO -> USER.
+#
+# Usage:
+#   sync-meeting-skill.sh             REPO -> USER (default, after editing repo)
+#   sync-meeting-skill.sh --check     report drift, exit 1 if any (no writes)
+#   sync-meeting-skill.sh --from-user USER -> REPO (escape hatch, rare)
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.claude/skills/meeting"
+USER_DIR="$HOME/.claude/skills/meeting"
+
+[[ -d "$REPO_DIR" ]] || { echo "ERROR: repo skill dir not found: $REPO_DIR" >&2; exit 2; }
+
+DIFF_X=(-x __pycache__ -x '*.pyc' -x .DS_Store)
+RSYNC_X=(--exclude=__pycache__ --exclude='*.pyc' --exclude=.DS_Store)
+
+MODE="${1:-deploy}"
+case "$MODE" in
+  --check)
+    if diff -rq "${DIFF_X[@]}" "$REPO_DIR" "$USER_DIR" >/dev/null 2>&1; then
+      echo "[sync] in sync - REPO and USER copies match"
+      exit 0
+    fi
+    echo "[sync] DRIFT between the two /meeting skill copies:" >&2
+    diff -rq "${DIFF_X[@]}" "$REPO_DIR" "$USER_DIR" >&2 || true
+    echo "[sync] run 'sync-meeting-skill.sh' to deploy REPO -> USER" >&2
+    exit 1
+    ;;
+  --from-user)
+    SRC="$USER_DIR/"; DST="$REPO_DIR/"; LABEL="USER -> REPO"
+    ;;
+  deploy)
+    SRC="$REPO_DIR/"; DST="$USER_DIR/"; LABEL="REPO -> USER"
+    ;;
+  *)
+    echo "usage: sync-meeting-skill.sh [--check | --from-user]" >&2
+    exit 2
+    ;;
+esac
+
+[[ -d "$DST" ]] || mkdir -p "$DST"
+rsync -a --delete "${RSYNC_X[@]}" "$SRC" "$DST"
+echo "[sync] $LABEL done - copies are now byte-identical"


### PR DESCRIPTION
## Summary
Adds **Step 3 speaker diarization** to the `/meeting` skill - `sherpa-onnx` offline diarization, fully local, no Hugging Face token, no GPU. Produces a `[Speaker N]`-labeled transcript so the extraction passes know who said what.

Also fixes the two-copies skill drift with `sync-meeting-skill.sh` (the sync script named in commit 60f95828 was never actually committed) and restores autoresearch-iteration content lost in earlier branch churn.

## What is new
- `scripts/diarize.sh` + `scripts/diarize.py` - sherpa-onnx diarization + transcript merge. Models (~35MB) download once to `~/.zao/diarization-models/`.
- `transcribe.sh` emits a `.json` sidecar (segment timestamps) the diarizer needs.
- `scripts/sync-meeting-skill.sh` - REPO <-> USER skill sync with a `--check` drift detector.

## Build notes / honesty
- Mechanically verified: diarization runs end-to-end on a real recording (read wav -> sherpa -> segments -> merge).
- 3 bugs found + fixed: sherpa 1.13.2 has no `read_wave` (stdlib `wave` instead); py3.13 mis-resolves numpy to a wheelless build (diarize env pinned to py3.12); OOM on a disk-full machine.
- Auto-detect over-clusters (8 speakers on a 2-person call). `SKILL.md` documents passing the known speaker count via `ZAO_DIARIZATION_NUM_SPEAKERS` as the quality lever. Full-call quality validation is pending - blocked by a disk-full dev machine OOM-killing long runs.

## Tier
N/A - skill build

## Next Actions
- Validate full-call diarization once dev-machine disk space is freed.
- Tune default clustering for the count-unknown case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)