### PR TITLE
feat: /bonfire skill - post to the ZABAL Bonfire KG via the VPS

### DIFF
--- a/.claude/skills/bonfire/SKILL.md
+++ b/.claude/skills/bonfire/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: bonfire
+description: Post episodes to the ZABAL Bonfire knowledge graph, or look up how Bonfire works. Bonfire is ZAO's knowledge-graph memory at zabal.bonfires.ai - meetings, decisions, captures flow in as natural-language episodes. The API key lives only on the VPS, so this skill posts via SSH and the key never touches the local machine. Use when the user types /bonfire, asks to push something to the knowledge graph, asks "what is in our Bonfire", or asks how Bonfire posting works.
+allowed-tools: Read Write Edit Bash
+---
+
+# /bonfire - ZABAL Bonfire knowledge graph
+
+Post natural-language episodes into the ZABAL Bonfire so the knowledge graph
+always has full context. Bonfire's auto-extraction turns each episode body into
+graph nodes + edges.
+
+Design doc: `research/agents/717-meeting-bonfire-posting-via-vps`. Bonfire
+deep-dive: `research/agents/665-bonfires-deep-dive-zao-integration`. Bridge
+design: `research/agents/680-meeting-skill-bonfire-bridge`.
+
+## The key constraint - why this skill SSHes the VPS
+
+The Bonfire API key (`BONFIRE_API_KEY`) lives ONLY on the VPS, in
+`/root/cowork-zaodevz/agent/.env`. It is deliberately not on Zaal's mac. So
+this skill never holds the key: it secret-scans the episodes locally, ships
+them to the VPS over SSH, and runs the POST there where the env already has
+the key. This mirrors how `transcribe.sh` falls back to the VPS.
+
+| Fact | Value |
+|------|-------|
+| VPS | `root@187.77.3.104` (override with `BONFIRE_VPS`) |
+| Key env file (on VPS) | `/root/cowork-zaodevz/agent/.env` - has `BONFIRE_API_KEY`, `BONFIRE_ID`, `BONFIRE_API_URL` |
+| API base | `https://tnt-v2.api.bonfires.ai` |
+| Write endpoint | `POST /knowledge_graph/episode/create` - works with the non-admin key |
+| Read endpoint | `POST /vector_store/search` - works but returns `[]` until an admin runs labeling (doc 680) |
+| ZAO's bonfire | `zabal.bonfires.ai` |
+
+## When to fire
+
+- The user types `/bonfire`
+- "push this to the knowledge graph", "post this to Bonfire", "add this to our Bonfire"
+- "what is in our Bonfire", "how does Bonfire posting work"
+- After a `/meeting` run, to post the meeting episodes (the `/meeting` skill
+  also does this itself via `bonfire-episode.sh`)
+
+## Posting episodes
+
+### Step 1 - build an episodes JSON
+
+Write `/tmp/bonfire-episodes.json` in this shape:
+
+```json
+{
+  "episodes": [
+    {"name": "<stable unique id>", "body": "<self-contained natural-language prose>", "source_tag": "<short source label>"}
+  ]
+}
+```
+
+Rules for episode bodies:
+- **Self-contained prose.** Each body must make sense alone - name the people,
+  the date, the project. Bonfire auto-extraction reads prose, and a graph node
+  must stand on its own. Good: "On 2026-05-19, Zaal and Arthur decided X."
+  Bad: "decided X" (no context).
+- **One idea per episode.** One decision, one action, one fact. Atomic episodes
+  make a cleaner graph than one giant blob.
+- **`name` is stable + unique.** A re-post with the same `name` updates rather
+  than duplicates. Use a pattern like `meeting:2026-05-19:decision-1`.
+
+### Step 2 - post via the VPS
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/scripts/bonfire-post.sh /tmp/bonfire-episodes.json
+```
+
+`bonfire-post.sh`:
+1. Validates the JSON and **secret-scans every body locally** - aborts if any
+   body contains a key-shaped string. Nothing leaves the machine until it is clean.
+2. SSHes to the VPS, ships the episodes + the remote poster to `/tmp/` there.
+3. Runs the POST on the VPS, where `/root/cowork-zaodevz/agent/.env` supplies
+   the key. Cleans up the remote temp files.
+4. Prints `Bonfire: N posted, M failed (of T)`.
+
+Best-effort: a Bonfire failure prints `FAIL` per episode but never aborts a
+larger workflow.
+
+## Reading / querying Bonfire
+
+The read path (`POST /vector_store/search`) works but currently returns `[]` -
+the ZABAL bonfire's episodes are not searchable until an admin runs labeling
+(`/labeling/hybrid` is 403 for the non-admin key). This is a known gate (doc
+680). Until then, Bonfire is write-mostly: episodes ingest and grow the graph,
+but programmatic recall is not yet live. ZOE's `bot/src/zoe/recall.ts`
+`recall()` already handles this gracefully (falls back to a manual relay).
+
+When the read path opens up, querying is `POST /vector_store/search` with
+`{bonfire_ref: BONFIRE_ID, search_string: "<query>", limit: N}` - run it on the
+VPS the same way (the key constraint is identical).
+
+## Scripts
+
+- `scripts/bonfire-post.sh` - local: validate + secret-scan + ship to VPS + run + report
+- `scripts/bonfire-remote-post.sh` - runs ON the VPS: sources the env, curl-POSTs each episode
+
+## Guardrails
+
+- **Never read or print `BONFIRE_API_KEY`.** The skill only ever needs the file
+  path, never the value. The key stays on the VPS.
+- **Secret-scan every episode body before it leaves the machine.** A meeting
+  transcript or a pasted note could carry a key.
+- Do not commit episodes JSON with secrets. `/tmp/` only.

--- a/.claude/skills/bonfire/scripts/bonfire-post.sh
+++ b/.claude/skills/bonfire/scripts/bonfire-post.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# bonfire-post.sh - post episodes to the ZABAL Bonfire knowledge graph.
+#
+# The Bonfire API key lives ONLY on the VPS (/root/cowork-zaodevz/agent/.env),
+# never on this machine. This script secret-scans the episodes locally, ships
+# them to the VPS, and runs the POST there. The key never touches the mac.
+#
+# Usage:   bonfire-post.sh <episodes-json>
+# Input:   {"episodes":[{"name":"...","body":"...","source_tag":"..."}]}
+# Outputs: prints "Bonfire: N posted, M failed (of T)".
+set -euo pipefail
+
+INPUT="${1:?missing episodes-json path}"
+VPS="${BONFIRE_VPS:-root@187.77.3.104}"
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "ERROR: episodes file not found: $INPUT" >&2
+  exit 2
+fi
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 3; }
+if ! jq empty "$INPUT" 2>/dev/null; then
+  echo "ERROR: not valid JSON: $INPUT" >&2
+  exit 3
+fi
+
+N=$(jq '.episodes | length' "$INPUT" 2>/dev/null || echo 0)
+if [[ "$N" -eq 0 ]]; then
+  echo "Bonfire: 0 episodes - nothing to post"
+  exit 0
+fi
+
+# Local secret scan - never ship a key-shaped episode body anywhere.
+SECRET_RE='sk-ant-[A-Za-z0-9_-]{20,}|sk-(proj-|cp-)?[A-Za-z0-9_-]{30,}|ghp_[A-Za-z0-9]{36}|github_pat_[A-Za-z0-9_]{60,}|-----BEGIN ([A-Z]+ )?PRIVATE KEY-----|0x[0-9a-fA-F]{64}|AKIA[0-9A-Z]{16}|xox[bpaors]-[A-Za-z0-9-]{10,}'
+if jq -r '.episodes[].body' "$INPUT" 2>/dev/null | grep -qE "$SECRET_RE"; then
+  echo "ERROR: an episode body contains a secret-shaped string - aborting, nothing sent" >&2
+  exit 4
+fi
+
+REMOTE_SCRIPT="$SKILL_DIR/bonfire-remote-post.sh"
+if [[ ! -f "$REMOTE_SCRIPT" ]]; then
+  echo "ERROR: bonfire-remote-post.sh missing next to this script" >&2
+  exit 3
+fi
+
+# Preflight SSH
+if ! ssh -o ConnectTimeout=10 -o BatchMode=yes "$VPS" 'echo ok' >/dev/null 2>&1; then
+  echo "ERROR: cannot SSH to $VPS - check the key + host" >&2
+  exit 5
+fi
+
+STAMP=$(date +%Y%m%d-%H%M%S)
+REMOTE_JSON="/tmp/bonfire-episodes-$STAMP.json"
+REMOTE_SH="/tmp/bonfire-remote-post-$STAMP.sh"
+
+echo "[bonfire] shipping $N episodes to $VPS" >&2
+scp -q "$INPUT" "$VPS:$REMOTE_JSON"
+scp -q "$REMOTE_SCRIPT" "$VPS:$REMOTE_SH"
+
+# Run the POST on the VPS (key comes from its env), then clean up remote temps.
+ssh "$VPS" "bash $REMOTE_SH $REMOTE_JSON; rm -f $REMOTE_JSON $REMOTE_SH"

--- a/.claude/skills/bonfire/scripts/bonfire-remote-post.sh
+++ b/.claude/skills/bonfire/scripts/bonfire-remote-post.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# bonfire-remote-post.sh - runs ON the VPS. Sources the bot env (which holds
+# BONFIRE_API_KEY) and POSTs each episode in the given JSON to the Bonfire KG.
+#
+# Shipped to the VPS by bonfire-post.sh - not run directly on the mac.
+# Usage: bonfire-remote-post.sh <episodes-json>
+set -uo pipefail
+
+INPUT="${1:?missing episodes json}"
+ENV_FILE="${BONFIRE_ENV_FILE:-/root/cowork-zaodevz/agent/.env}"
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "Bonfire: episodes file not found on VPS: $INPUT"
+  exit 0
+fi
+
+# Source the env that holds the key. set -a so the vars export into this shell.
+if [[ -f "$ENV_FILE" ]]; then
+  set -a; . "$ENV_FILE"; set +a
+fi
+
+API_URL="${BONFIRE_API_URL:-https://tnt-v2.api.bonfires.ai}"
+API_KEY="${BONFIRE_API_KEY:-}"
+BID="${BONFIRE_ID:-}"
+
+if [[ -z "$API_KEY" || -z "$BID" ]]; then
+  echo "Bonfire: BONFIRE_API_KEY / BONFIRE_ID not found in $ENV_FILE - skipped"
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Bonfire: jq not on VPS - skipped"
+  exit 0
+fi
+
+N=$(jq '.episodes | length' "$INPUT" 2>/dev/null || echo 0)
+if [[ "$N" -eq 0 ]]; then
+  echo "Bonfire: 0 episodes"
+  exit 0
+fi
+
+posted=0
+failed=0
+
+for i in $(seq 0 $((N - 1))); do
+  name=$(jq -r ".episodes[$i].name" "$INPUT")
+  body=$(jq -r ".episodes[$i].body" "$INPUT")
+  tag=$(jq -r ".episodes[$i].source_tag // \"bonfire-skill\"" "$INPUT")
+
+  if [[ -z "$body" || "$body" == "null" ]]; then
+    echo "SKIP $name - empty body"
+    continue
+  fi
+
+  payload=$(jq -n \
+    --arg bid "$BID" --arg name "$name" --arg body "$body" \
+    --arg tag "$tag" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" \
+    '{bonfire_id: $bid, name: $name, episode_body: $body, source: "text", source_description: $tag, reference_time: $ts}')
+
+  code=$(curl -s -o /tmp/bonfire-resp.txt -w '%{http_code}' \
+    --max-time 15 -X POST "$API_URL/knowledge_graph/episode/create" \
+    -H "Authorization: Bearer $API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$payload" 2>/dev/null || echo "000")
+
+  if [[ "$code" =~ ^2 ]]; then
+    echo "OK   $name"
+    posted=$((posted + 1))
+  else
+    echo "FAIL $name - HTTP $code $(head -c 120 /tmp/bonfire-resp.txt 2>/dev/null)"
+    failed=$((failed + 1))
+  fi
+done
+
+rm -f /tmp/bonfire-resp.txt
+echo "Bonfire: $posted posted, $failed failed (of $N)"
+exit 0


### PR DESCRIPTION
## Summary

New `/bonfire` skill. Posts natural-language episodes to the ZABAL Bonfire knowledge graph. The Bonfire API key lives only on the VPS (`/root/cowork-zaodevz/agent/.env`), so the skill secret-scans episodes locally, ships them to the VPS over SSH, and runs the POST there - the key never touches the mac. Implements doc 717.

## Contents

- `.claude/skills/bonfire/SKILL.md` - what Bonfire is, the post flow, the read-path labeling caveat
- `scripts/bonfire-post.sh` - local: validate + secret-scan + scp + ssh-run + report
- `scripts/bonfire-remote-post.sh` - runs on the VPS, sources the env, curl-POSTs episodes

## Verified live

Posted the 11 episodes from the 2026-05-19 Arthur meeting to the ZABAL Bonfire - 11 ok, 0 failed. This also completes the doc-711 Bonfire backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)