### PR TITLE
fix(juke): /v1/developer/spaces is key-only per llms.txt

### DIFF
--- a/scripts/test-juke-space.ts
+++ b/scripts/test-juke-space.ts
@@ -1,18 +1,20 @@
 /**
  * Smoke-test the Juke developer API (research doc 695, Path B).
  *
- * Run this ONCE after JUKE_API_KEY + JUKE_USER_TOKEN land in `.env.local`.
- * It creates a throwaway Juke space and prints the result — confirming the
- * credentials work end-to-end and revealing the (undocumented) create-space
- * response shape before the live `/api/juke/space` route is relied on.
+ * Run this ONCE after JUKE_API_KEY lands in `.env.local`. Juke's
+ * `/v1/developer/spaces` is key-only per llms.txt (room owner = the app's
+ * owner_fid). It creates a throwaway Juke space and prints the result —
+ * confirming the credential works end-to-end and revealing the (undocumented)
+ * create-space response shape before the live `/api/juke/space` route is
+ * relied on.
  *
  * If the response shape differs from what `extractSpaceId` expects, this is
  * where it shows up first.
  *
  *   npx tsx scripts/test-juke-space.ts
  *
- * Reads secrets from `.env.local` (gitignored) and prints them only as
- * "set" / "MISSING" — never the values.
+ * Reads JUKE_API_KEY from `.env.local` (gitignored) and prints it only as
+ * "set" / "MISSING" — never the value.
  */
 import * as fs from 'fs';
 import { createJukeSpace } from '../src/lib/spaces/juke-api';
@@ -37,13 +39,10 @@ function loadEnv(): Record<string, string> {
 async function main(): Promise<void> {
   const env = loadEnv();
   const apiKey = env.JUKE_API_KEY;
-  const userToken = env.JUKE_USER_TOKEN;
 
-  if (!apiKey || !userToken) {
-    console.error('Missing Juke credentials in .env.local:');
-    console.error('  JUKE_API_KEY    ', apiKey ? 'set' : 'MISSING');
-    console.error('  JUKE_USER_TOKEN ', userToken ? 'set' : 'MISSING');
-    console.error('Apply at juke.audio/developers, then add both to .env.local.');
+  if (!apiKey) {
+    console.error('Missing JUKE_API_KEY in .env.local.');
+    console.error('Apply at juke.audio/developers, then add it to .env.local.');
     process.exit(1);
   }
 
@@ -52,7 +51,7 @@ async function main(): Promise<void> {
 
   const result = await createJukeSpace(
     { title, allowAgents: true },
-    { apiKey, userToken },
+    { apiKey },
   );
 
   if (!result.ok) {

--- a/src/app/api/juke/space/__tests__/route.test.ts
+++ b/src/app/api/juke/space/__tests__/route.test.ts
@@ -9,7 +9,6 @@ import {
 
 const mockEnv = vi.hoisted(() => ({
   JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
-  JUKE_USER_TOKEN: 'jwt_test' as string | undefined,
   JUKE_CREATE_PASSWORD: 'ZAO' as string | undefined,
 }));
 
@@ -48,7 +47,6 @@ describe('POST /api/juke/space', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
-    mockEnv.JUKE_USER_TOKEN = 'jwt_test';
     mockEnv.JUKE_CREATE_PASSWORD = 'ZAO';
     mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
   });
@@ -105,7 +103,7 @@ describe('POST /api/juke/space', () => {
       // The password must not be forwarded to the Juke client.
       expect(mockCreateJukeSpace).toHaveBeenCalledWith(
         { title: 'Fractal Call' },
-        { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
+        { apiKey: 'jk_sec_live_test' },
       );
     });
 
@@ -122,13 +120,13 @@ describe('POST /api/juke/space', () => {
       expect(body.data.id).toBe('zao-live-1');
       expect(mockCreateJukeSpace).toHaveBeenCalledWith(
         { title: 'ZAOstock Standup', announceCast: true },
-        { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' },
+        { apiKey: 'jk_sec_live_test' },
       );
     });
   });
 
   describe('configuration', () => {
-    it('returns 503 naming JUKE_API_KEY when only the key is missing', async () => {
+    it('returns 503 naming JUKE_API_KEY when the key is missing', async () => {
       mockGetSessionData.mockResolvedValue(mockAdminSession());
       mockEnv.JUKE_API_KEY = undefined;
 
@@ -137,31 +135,6 @@ describe('POST /api/juke/space', () => {
 
       expect(res.status).toBe(503);
       expect(body.error).toContain('JUKE_API_KEY');
-      expect(body.error).not.toContain('JUKE_USER_TOKEN');
-    });
-
-    it('returns 503 naming JUKE_USER_TOKEN when only the token is missing', async () => {
-      mockGetSessionData.mockResolvedValue(mockAdminSession());
-      mockEnv.JUKE_USER_TOKEN = undefined;
-
-      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-      const body = await res.json();
-
-      expect(res.status).toBe(503);
-      expect(body.error).toContain('JUKE_USER_TOKEN');
-    });
-
-    it('returns 503 naming both when neither credential is set', async () => {
-      mockGetSessionData.mockResolvedValue(mockAdminSession());
-      mockEnv.JUKE_API_KEY = undefined;
-      mockEnv.JUKE_USER_TOKEN = undefined;
-
-      const res = await POST(makePostRequest('/api/juke/space', { title: 'ZAO Live' }));
-      const body = await res.json();
-
-      expect(res.status).toBe(503);
-      expect(body.error).toContain('JUKE_API_KEY');
-      expect(body.error).toContain('JUKE_USER_TOKEN');
     });
   });
 

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -84,27 +84,22 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Juke's create-space endpoint needs both the app key and a host JWT.
+  // Juke's create-space endpoint is key-only per llms.txt; room owner is the
+  // developer app's owner_fid.
   const apiKey = ENV.JUKE_API_KEY;
-  const userToken = ENV.JUKE_USER_TOKEN;
-  if (!apiKey || !userToken) {
-    const missing = [
-      !apiKey ? 'JUKE_API_KEY' : null,
-      !userToken ? 'JUKE_USER_TOKEN' : null,
-    ]
-      .filter(Boolean)
-      .join(' and ');
+  if (!apiKey) {
     return NextResponse.json(
       {
         success: false,
-        error: `Juke developer API is not configured (missing ${missing}). Apply at juke.audio/developers.`,
+        error:
+          'Juke developer API is not configured (missing JUKE_API_KEY). Apply at juke.audio/developers.',
       },
       { status: 503 },
     );
   }
 
   try {
-    const result = await createJukeSpace(spaceInput, { apiKey, userToken });
+    const result = await createJukeSpace(spaceInput, { apiKey });
     if (!result.ok) {
       // Upstream Juke failure. Log the real status server-side; report a
       // single 502 to the client — a Juke 401/400 is an integration problem,

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -89,11 +89,14 @@ export const ENV = {
   ZX_API_KEY: optionalEnv('ZX_API_KEY'),
 
   // Juke developer API -- server-side Juke space creation (doc 695, Path B).
-  // Needs BOTH: JUKE_API_KEY (app secret, shown once at key creation) and
-  // JUKE_USER_TOKEN (Juke JWT for the host account, from Sign In With
-  // Farcaster). Apply at juke.audio/developers. Either absent =
-  // /api/juke/space returns 503; the keyless /live embed still works.
+  // Key-only per juke.audio/llms.txt: `/v1/developer/spaces` takes
+  // `X-Juke-Api-Key` and derives the room owner from the app's owner_fid.
+  // No bearer JWT is sent. Apply at juke.audio/developers. Absent = 503;
+  // the keyless /live embed still works.
   JUKE_API_KEY: optionalEnv('JUKE_API_KEY'),
+  // DEPRECATED 2026-05-22: llms.txt confirmed key-only auth on
+  // /v1/developer/spaces. Kept here to avoid breaking existing .env.local
+  // files; no longer read by the Juke client.
   JUKE_USER_TOKEN: optionalEnv('JUKE_USER_TOKEN'),
   // Shared password for /api/juke/space — lets the /live/create page and the
   // ZAOcoworking bot create spaces without an admin session. Unset = the

--- a/src/lib/spaces/juke-api.test.ts
+++ b/src/lib/spaces/juke-api.test.ts
@@ -6,8 +6,8 @@ import {
   type JukeCredentials,
 } from './juke-api';
 
-/** A complete credentials pair for tests that do not assert on the values. */
-const CREDS: JukeCredentials = { apiKey: 'jk_sec_live_test', userToken: 'jwt_test' };
+/** Credentials for tests that do not assert on the values. */
+const CREDS: JukeCredentials = { apiKey: 'jk_sec_live_test' };
 
 describe('extractSpaceId', () => {
   it('reads a top-level id', () => {
@@ -72,12 +72,12 @@ describe('createJukeSpace', () => {
     } as Response);
   }
 
-  it('posts to the developer endpoint with both auth headers', async () => {
+  it('posts to the developer endpoint with the api key header only', async () => {
     mockFetchOnce({ ok: true, status: 201, json: () => ({ id: 'abc123' }) });
 
     await createJukeSpace(
       { title: 'ZAO Standup' },
-      { apiKey: 'jk_sec_live_test', userToken: 'jwt_abc' },
+      { apiKey: 'jk_sec_live_test' },
     );
 
     expect(fetch).toHaveBeenCalledTimes(1);
@@ -85,7 +85,7 @@ describe('createJukeSpace', () => {
     expect(url).toBe(`${JUKE_API_ORIGIN}/v1/developer/spaces`);
     expect(options.method).toBe('POST');
     expect(options.headers['X-Juke-Api-Key']).toBe('jk_sec_live_test');
-    expect(options.headers.Authorization).toBe('Bearer jwt_abc');
+    expect(options.headers.Authorization).toBeUndefined();
     expect(options.headers['Content-Type']).toBe('application/json');
   });
 
@@ -155,7 +155,7 @@ describe('createJukeSpace', () => {
 
     const result = await createJukeSpace(
       { title: 'ZAO Live' },
-      { apiKey: 'bad-key', userToken: 'bad-jwt' },
+      { apiKey: 'bad-key' },
     );
 
     expect(result.ok).toBe(false);

--- a/src/lib/spaces/juke-api.ts
+++ b/src/lib/spaces/juke-api.ts
@@ -3,19 +3,24 @@
  *
  * Creates branded Juke spaces for recurring ZAO events via the Juke developer
  * API (`api.juke.audio`). Path A (the iframe embed in `juke.ts`) needs no
- * keys; Path B does — `POST /v1/developer/spaces` takes TWO credentials:
- * `X-Juke-Api-Key` authorises the app, and `Authorization: Bearer <jwt>`
- * identifies the Juke account that will host the new space.
+ * keys; Path B sends `X-Juke-Api-Key` ONLY (per juke.audio/llms.txt, verified
+ * 2026-05-22): "`/v1/developer/spaces` — key only. Send `X-Juke-Api-Key`; do
+ * not send a bearer JWT. The room owner is derived from the key's owning
+ * developer app's `owner_fid`."
  *
- * IMPORTANT: never import this module from a client component. Both secrets
- * are passed in by the caller (the API route reads them from the
- * environment), so this file holds no secret literal — but the Juke developer
- * API surface is server-only regardless.
+ * The juke.audio/developers landing page still shows a stale example with a
+ * Bearer `JUKE_USER_TOKEN` — llms.txt (the canonical agent-facing spec) is
+ * authoritative. See research docs 695 + 710 + the supersession note in the
+ * 2026-05-22 patch.
+ *
+ * IMPORTANT: never import this module from a client component. The api key is
+ * passed in by the caller (the API route reads it from the environment), so
+ * this file holds no secret literal — but the Juke developer API surface is
+ * server-only regardless.
  *
  * The Juke developer API is in beta; its create-space *response* shape is not
  * publicly documented. `createJukeSpace` parses the response defensively and
- * only trusts a space id that passes `isValidJukeSpaceId`. See research doc
- * 695 and juke.audio/llms.txt for the verified request contract.
+ * only trusts a space id that passes `isValidJukeSpaceId`.
  */
 import { isValidJukeSpaceId, jukeEmbedUrl } from './juke';
 
@@ -59,19 +64,13 @@ export type CreateJukeSpaceResult =
   | { ok: false; status: number; error: string };
 
 /**
- * Credentials for a Juke developer API call. BOTH are required: Juke's
- * `POST /v1/developer/spaces` authorises the *app* with `X-Juke-Api-Key` and
- * identifies the *host* of the new space with a user JWT.
+ * Credentials for a Juke developer API call. `POST /v1/developer/spaces` is
+ * key-only per llms.txt: `X-Juke-Api-Key` authorises the app and the room
+ * owner is derived from `app.owner_fid` — no bearer JWT is sent.
  */
 export interface JukeCredentials {
   /** `JUKE_API_KEY` — the app's static developer secret (juke.audio/developers). */
   apiKey: string;
-  /**
-   * `JUKE_USER_TOKEN` — a Juke JWT for the account that will host the space,
-   * obtained via Sign In With Farcaster. Juke JWTs expire; refreshing this
-   * server-side is an open question for nickysap — see research doc 695.
-   */
-  userToken: string;
 }
 
 /** Id fields the Juke response is most likely to use, in priority order. */
@@ -136,8 +135,7 @@ export async function createJukeSpace(
     response = await fetch(`${JUKE_API_ORIGIN}${CREATE_SPACE_PATH}`, {
       method: 'POST',
       headers: {
-        // App credential + host-identifying user JWT — Juke requires both.
-        Authorization: `Bearer ${credentials.userToken}`,
+        // Key-only per llms.txt; the room owner is app.owner_fid.
         'X-Juke-Api-Key': credentials.apiKey,
         'Content-Type': 'application/json',
       },


### PR DESCRIPTION
## Summary

`juke.audio/llms.txt` (canonical agent spec, verified 2026-05-22, verbatim):

> `/v1/developer/spaces` - key only. Send `X-Juke-Api-Key`; do not send a bearer JWT. The room owner is derived from the key's owning developer app's `owner_fid`.

The `juke.audio/developers` page still shows a stale example using `Authorization: Bearer ${JUKE_USER_TOKEN}` - llms.txt is authoritative. Docs 695 + 710 + the original Path B build all assumed two credentials (api key + Juke JWT minted via SIWF on the host account). This patch realigns the implementation with the spec so a fresh `JUKE_API_KEY` alone ships Path B.

## Why now

Zaal got the `JUKE_API_KEY` from nickysap. Before the smoke test could run, the code required `JUKE_USER_TOKEN` (a flow that does not exist as a developer-facing endpoint - SIWF JWTs are SDK-internal). Without this patch, adding only `JUKE_API_KEY` to Vercel returns 503.

## Changes

- `src/lib/spaces/juke-api.ts` - drop `Authorization: Bearer` header; `JukeCredentials = { apiKey }`.
- `src/app/api/juke/space/route.ts` - drop `JUKE_USER_TOKEN` guard; 503 names only `JUKE_API_KEY`.
- `scripts/test-juke-space.ts` - smoke test only checks `JUKE_API_KEY`.
- `src/lib/env.ts` - `JUKE_USER_TOKEN` marked deprecated, kept for `.env.local` back-compat (no longer read).
- Unit tests updated; assert no `Authorization` header is sent.

Supersedes the token-TTL + refresh-strategy section of doc 710 - that machinery solves a problem that no longer exists. Followup research doc to capture the contradiction publicly.

## Test plan

- [x] `npx vitest run src/lib/spaces/juke-api.test.ts src/app/api/juke/space/__tests__/route.test.ts` - 29/29 pass.
- [x] `npx tsc --noEmit` - no juke-related TS errors.
- [ ] Add `JUKE_API_KEY` in Vercel preview env.
- [ ] `npx tsx scripts/test-juke-space.ts` against preview, OR hit `/live/create` with `JUKE_CREATE_PASSWORD` + title; confirm `/live/{id}` renders.
- [ ] Verify the developer app's `owner_fid` is the intended ZAO host account (room owner is derived from it).

## Notes

- `npm run lint:biome` at HEAD is broken by nested worktree `biome.json` configs (pre-existing, unrelated). Per-file lint also blocked by Biome `files.includes` quirk. The diff is removes; tests are green.