### PR TITLE
feat(spaces): expose Video Room mode - audio + camera + screen share, FC-gated

### DIFF
--- a/src/app/spaces/[id]/page.tsx
+++ b/src/app/spaces/[id]/page.tsx
@@ -116,7 +116,10 @@ export default function PublicRoomPage() {
         const initialToken = await tokenProvider();
         const { StreamVideoClient: SVC } = await import('@stream-io/video-react-sdk');
         newClient = new SVC({ apiKey, user: streamUser, token: initialToken, tokenProvider });
-        newCall = newClient.call('audio_room', roomData.stream_call_id);
+        // Stage = Clubhouse-style audio room (mics-only, hand-raise to speak).
+        // Voice channel = full A/V conference: everyone can mic, camera, screen-share.
+        const streamCallType = roomData.room_type === 'voice_channel' ? 'default' : 'audio_room';
+        newCall = newClient.call(streamCallType, roomData.stream_call_id);
 
         const userIsHost = user.fid === roomData.host_fid;
         if (userIsHost) {

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { getSupabaseBrowser } from '@/lib/db/supabase';
 import { PageHeader } from '@/components/navigation/PageHeader';
 import StageCard from '@/components/spaces/StageCard';
-import { HostRoomModal, type RoomTheme } from '@/components/spaces/HostRoomModal';
+import { HostRoomModal, type RoomTheme, type RoomMode } from '@/components/spaces/HostRoomModal';
 import type { GateConfig } from '@/components/spaces/TokenGateSection';
 import { generateCallId, generateSlug } from '@/lib/spaces/streamHelpers';
 import SpacesTabs from '@/components/spaces/SpacesTabs';
@@ -27,10 +27,11 @@ export default function PublicSpacesPage() {
 
   const fetchStages = useCallback(async () => {
     const supabase = getSupabaseBrowser();
+    // Include both stage (audio-only) and voice_channel (full A+V) live rooms.
     const { data } = await supabase
       .from('rooms')
       .select('*')
-      .eq('room_type', 'stage')
+      .in('room_type', ['stage', 'voice_channel'])
       .eq('state', 'live')
       .order('created_at', { ascending: false });
 
@@ -55,7 +56,8 @@ export default function PublicSpacesPage() {
     description: string,
     theme: RoomTheme,
     gateConfig?: GateConfig | null,
-    provider: AudioProvider = 'stream'
+    provider: AudioProvider = 'stream',
+    roomMode: RoomMode = 'stage',
   ) => {
     if (!user) throw new Error('Not authenticated');
     const streamCallId = generateCallId();
@@ -65,7 +67,7 @@ export default function PublicSpacesPage() {
     const res = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, description, streamCallId, theme, room_type: 'stage', gate_config: gateConfig || null, provider, slug }),
+      body: JSON.stringify({ title, description, streamCallId, theme, room_type: roomMode, gate_config: gateConfig || null, provider, slug }),
     });
     if (!res.ok) throw new Error('Failed to create room');
     const { room } = await res.json();

--- a/src/components/spaces/HostRoomModal.tsx
+++ b/src/components/spaces/HostRoomModal.tsx
@@ -6,6 +6,22 @@ import { communityConfig } from '../../../community.config';
 import type { AudioProvider } from '@/lib/spaces/roomsDb';
 
 export type RoomTheme = 'default' | 'music' | 'podcast' | 'ama' | 'chill';
+export type RoomMode = 'stage' | 'voice_channel';
+
+const ROOM_MODES: { id: RoomMode; label: string; description: string; badge: string }[] = [
+  {
+    id: 'stage',
+    label: 'Stage',
+    description: 'Audio only. Host speaks; listeners raise hand to join.',
+    badge: 'MIC',
+  },
+  {
+    id: 'voice_channel',
+    label: 'Video Room',
+    description: 'Everyone can mic, camera, and screen share.',
+    badge: 'CAM',
+  },
+];
 
 const PROVIDERS: { id: AudioProvider; label: string; description: string; badge: string }[] = [
   {
@@ -76,7 +92,8 @@ interface HostRoomModalProps {
     description: string,
     theme: RoomTheme,
     gateConfig?: GateConfig | null,
-    provider?: AudioProvider
+    provider?: AudioProvider,
+    roomMode?: RoomMode,
   ) => Promise<void>;
 }
 
@@ -85,6 +102,7 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
   const [description, setDescription] = useState('');
   const [theme, setTheme] = useState<RoomTheme>('default');
   const [provider, setProvider] = useState<AudioProvider>(communityConfig.audioProvider ?? 'stream');
+  const [roomMode, setRoomMode] = useState<RoomMode>('stage');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [titleTouched, setTitleTouched] = useState(false);
@@ -102,10 +120,11 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
     setLoading(true);
     setError(null);
     try {
-      await onCreateRoom(title.trim(), description.trim(), theme, gateConfig, provider);
+      await onCreateRoom(title.trim(), description.trim(), theme, gateConfig, provider, roomMode);
       setTitle('');
       setDescription('');
       setTheme('default');
+      setRoomMode('stage');
       setTitleTouched(false);
       setGateConfig(null);
       onClose();
@@ -121,7 +140,9 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
       <div className="bg-[#0d1b2a] border border-white/[0.08] rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-md max-h-[90dvh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between mb-5">
-          <h2 className="text-white text-lg font-bold">Create a Stage</h2>
+          <h2 className="text-white text-lg font-bold">
+            {roomMode === 'voice_channel' ? 'Create a Video Room' : 'Create a Stage'}
+          </h2>
           <button
             onClick={onClose}
             className="p-1.5 text-gray-500 hover:text-white rounded-lg hover:bg-gray-800 transition-colors"
@@ -143,6 +164,32 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
         )}
 
         <form onSubmit={handleSubmit}>
+          {/* Room mode selector */}
+          <div className="mb-5">
+            <label className="text-gray-400 text-xs font-medium uppercase tracking-wider mb-2.5 block">
+              Mode
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {ROOM_MODES.map((m) => (
+                <button
+                  key={m.id}
+                  type="button"
+                  onClick={() => setRoomMode(m.id)}
+                  disabled={loading}
+                  className={`flex flex-col gap-1 px-3 py-3 rounded-xl border text-left text-sm transition-all ${
+                    roomMode === m.id
+                      ? 'border-[#f5a623] bg-[#f5a623]/10 text-white'
+                      : 'border-white/[0.08] bg-[#0a1628] text-gray-400 hover:border-gray-600'
+                  }`}
+                >
+                  <span className="text-[10px] font-bold tracking-wider text-[#f5a623]">{m.badge}</span>
+                  <span className="font-semibold text-white">{m.label}</span>
+                  <span className="text-xs text-gray-500 leading-tight">{m.description}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
           {/* Theme selector */}
           <div className="mb-5">
             <label className="text-gray-400 text-xs font-medium uppercase tracking-wider mb-2.5 block">
@@ -280,6 +327,8 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
                   </svg>
                   Creating...
                 </span>
+              ) : roomMode === 'voice_channel' ? (
+                'Start Video Room'
               ) : (
                 'Go Live'
               )}


### PR DESCRIPTION
## Summary

Make /spaces a full Farcaster-gated audio + video webapp ready for live use TODAY. ZAO already has 40+ Spaces components (Stream.io + 100ms adapters, hand-raise, captions, RTMP multistream, token gating) - the system was 95% built. The actual gap:

- HostRoomModal only let users create \`room_type='stage'\`. No way to opt into full A+V.
- /spaces/[id]/page.tsx hardcoded Stream call type \`'audio_room'\` (mics-only). Camera + screen-share components existed but the underlying call type denied SEND_VIDEO.

This PR closes both gaps.

## Changes

| File | What |
|---|---|
| HostRoomModal | New Mode selector (Stage / Video Room) at top of form. |
| /spaces/page.tsx | Thread room_mode -> POST body; live list includes both \`stage\` and \`voice_channel\` rooms. |
| /spaces/[id]/page.tsx | Stream call type = \`'default'\` for voice_channel, \`'audio_room'\` for stage. |

ScreenShareButton (line 17) and ControlsPanel already authorized \`voice_channel\` for all auth users. CameraButton requests SEND_VIDEO via Stream's permission API. With the call type now correct, those caps are granted on join in Video Rooms.

DB already supports both room types (\`roomsDb.ts:19\`). No migration.

## Modes

- **Stage** (default, unchanged): audio-only Clubhouse. Host speaks; listeners raise hand to join.
- **Video Room** (new): full A/V conference. Everyone can mic, camera, screen share. Map to Stream \`default\` call type.

## Test plan

Vercel preview:
- [ ] Visit /spaces, click Go Live, pick Video Room, set title, submit.
- [ ] Land on /spaces/{id}; mic + camera + screen-share buttons all present in ControlsPanel.
- [ ] Camera toggle works (browser permission prompt; video tile renders).
- [ ] Screen-share toggle works (system picker; ContentView shows shared screen).
- [ ] Second FC user joins same room; can speak + camera + screen share.
- [ ] Repeat with Stage mode - confirm it still behaves as audio Clubhouse (hand-raise to speak).

## Notes

- Stream's \`default\` call type is a built-in - no dashboard setup needed (per Stream docs).
- If Stream rejects \`role: 'speaker'\` on the default call type for non-hosts, we'll drop the role and let Stream assign default - flag if seen in preview.
- LiveButton (call.goLive) is gated host-only; in default type it's a no-op visually but should not error.