### PR TITLE
feat(spaces): pre-join lobby for Video Rooms (stacked on #634)

### DIFF
--- a/src/app/spaces/[id]/page.tsx
+++ b/src/app/spaces/[id]/page.tsx
@@ -9,6 +9,7 @@ import { useAccount } from 'wagmi';
 import { createStreamUser } from '@/lib/spaces/streamHelpers';
 import { communityConfig } from '../../../../community.config';
 import { AudioRoomAdapter } from '@/components/spaces/AudioRoomAdapter';
+import { PreJoinLobby, type LobbyJoinConfig } from '@/components/spaces/PreJoinLobby';
 import type { Room } from '@/lib/spaces/roomsDb';
 
 // Lazy-load heavy SDKs — Stream.io is ~150KB, only load when entering a room
@@ -65,33 +66,40 @@ export default function PublicRoomPage() {
   const [loading, setLoading] = useState(true);
   const [showEdit, setShowEdit] = useState(false);
   const [gateBlocked, setGateBlocked] = useState(false);
+  // For voice_channel rooms we run a pre-join lobby (camera/mic preview,
+  // device pick, enter-with-video-off toggle) before calling Stream.io.
+  // null = lobby not yet confirmed; non-null = user clicked Join with these
+  // preferences and the Stream init effect can run.
+  const [lobbyConfig, setLobbyConfig] = useState<LobbyJoinConfig | null>(null);
 
   const isHost = user?.fid === room?.host_fid;
   const isAdmin = user ? (communityConfig.adminFids as readonly number[]).includes(user.fid) : false;
   const canEndRoom = isHost || isAdmin;
 
+  // Phase 1: fetch room metadata + run the token gate. Does not touch
+  // Stream.io. For voice_channel rooms we stop here and render the lobby —
+  // Phase 2 runs once the user confirms.
   useEffect(() => {
     if (authLoading) return;
     if (!user) {
-      // Require authentication to join — guests can't get a Stream token
       setError('Sign in to join this space');
       setLoading(false);
       return;
     }
 
     let mounted = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let newClient: any = null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let newCall: any = null;
 
-    const init = async () => {
+    const fetchMeta = async () => {
       try {
         const roomData = await fetchRoom(roomId);
-        if (roomData.state === 'ended') throw new Error('This room has ended');
-        if (mounted) setRoom(roomData);
+        if (!mounted) return;
+        if (roomData.state === 'ended') {
+          setError('This room has ended');
+          setLoading(false);
+          return;
+        }
+        setRoom(roomData);
 
-        // Check token gate before joining
         if (roomData.gate_config && walletAddress) {
           const gateRes = await fetch('/api/spaces/gate-check', {
             method: 'POST',
@@ -108,45 +116,99 @@ export default function PublicRoomPage() {
           return;
         }
 
+        if (mounted) setLoading(false);
+      } catch (err) {
+        if (mounted) {
+          setError(err instanceof Error ? err.message : 'Failed to load room');
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchMeta();
+
+    return () => {
+      mounted = false;
+    };
+  }, [roomId, user, authLoading, walletAddress]);
+
+  // Phase 2: open the Stream.io call. For stage rooms this runs immediately
+  // after Phase 1 (lobbyConfig stays null). For voice_channel rooms this
+  // waits for the user to confirm the lobby — then `lobbyConfig` carries the
+  // mic/camera/device choices.
+  useEffect(() => {
+    if (!user || !room || gateBlocked || error) return;
+    if (room.room_type === 'voice_channel' && !lobbyConfig) return;
+
+    let mounted = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let newClient: any = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let newCall: any = null;
+
+    const join = async () => {
+      try {
         const streamUser = createStreamUser(user);
-        const tokenProvider = async () => {
-          return fetchStreamToken(streamUser.id);
-        };
-        // Fetch initial token for immediate use
+        const tokenProvider = async () => fetchStreamToken(streamUser.id);
         const initialToken = await tokenProvider();
         const { StreamVideoClient: SVC } = await import('@stream-io/video-react-sdk');
         newClient = new SVC({ apiKey, user: streamUser, token: initialToken, tokenProvider });
         // Stage = Clubhouse-style audio room (mics-only, hand-raise to speak).
         // Voice channel = full A/V conference: everyone can mic, camera, screen-share.
-        const streamCallType = roomData.room_type === 'voice_channel' ? 'default' : 'audio_room';
-        newCall = newClient.call(streamCallType, roomData.stream_call_id);
+        const streamCallType = room.room_type === 'voice_channel' ? 'default' : 'audio_room';
+        newCall = newClient.call(streamCallType, room.stream_call_id);
 
-        const userIsHost = user.fid === roomData.host_fid;
+        const userIsHost = user.fid === room.host_fid;
         if (userIsHost) {
           await newCall.join({
             create: true,
             data: {
               members: [{ user_id: streamUser.id, role: 'host' }],
-              custom: { title: roomData.title, description: roomData.description || '' },
+              custom: { title: room.title, description: room.description || '' },
             },
           });
-          // Enable mic for host — audio_room type starts muted by default
-          await newCall.microphone.enable().catch(() => {});
+          // Stage host: audio_room starts muted by default - turn the mic on.
+          // Voice room host: honor the lobby's "mic on" preference.
+          const hostShouldMic = room.room_type === 'voice_channel'
+            ? (lobbyConfig?.audioEnabled ?? true)
+            : true;
+          if (hostShouldMic) {
+            await newCall.microphone.enable().catch(() => {});
+          } else {
+            await newCall.microphone.disable().catch(() => {});
+          }
         } else {
           await newCall.join({
             create: false,
             data: { members: [{ user_id: streamUser.id, role: 'speaker' }] },
           });
+          if (room.room_type === 'voice_channel') {
+            if (lobbyConfig?.audioEnabled) {
+              await newCall.microphone.enable().catch(() => {});
+            }
+          }
         }
 
-        // Fire-and-forget session tracking on join
+        // Voice room: apply lobby device + camera preferences.
+        if (room.room_type === 'voice_channel' && lobbyConfig) {
+          if (lobbyConfig.audioDeviceId) {
+            await newCall.microphone.select(lobbyConfig.audioDeviceId).catch(() => {});
+          }
+          if (lobbyConfig.videoDeviceId) {
+            await newCall.camera.select(lobbyConfig.videoDeviceId).catch(() => {});
+          }
+          if (lobbyConfig.videoEnabled) {
+            await newCall.camera.enable().catch(() => {});
+          }
+        }
+
         fetch('/api/spaces/session', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            roomId: roomData.id,
-            roomName: roomData.title,
-            roomType: roomData.room_type ?? 'stage',
+            roomId: room.id,
+            roomName: room.title,
+            roomType: room.room_type ?? 'stage',
           }),
         }).catch(() => {});
 
@@ -156,20 +218,17 @@ export default function PublicRoomPage() {
         }
       } catch (err) {
         if (mounted) setError(err instanceof Error ? err.message : 'Failed to join room');
-      } finally {
-        if (mounted) setLoading(false);
       }
     };
 
-    init();
+    join();
 
     return () => {
       mounted = false;
-      // Clean up Stream resources on unmount to prevent stale connections
       if (newCall) newCall.leave().catch(() => {});
       if (newClient) newClient.disconnectUser().catch(() => {});
     };
-  }, [roomId, user, authLoading, walletAddress]);
+  }, [user, room, gateBlocked, error, lobbyConfig]);
 
   // End session on browser close / tab close
   useEffect(() => {
@@ -281,6 +340,22 @@ export default function PublicRoomPage() {
           onLeave={handleLeave}
         />
       </div>
+    );
+  }
+
+  // Voice rooms: gate on the pre-join lobby. Stage rooms skip this (they
+  // join immediately on Phase 2 with mic-on).
+  if (room && room.room_type === 'voice_channel' && !lobbyConfig) {
+    return (
+      <PreJoinLobby
+        roomTitle={room.title}
+        hostName={room.host_name ?? room.host_username ?? undefined}
+        participantCount={room.participant_count}
+        username={user?.username}
+        pfpUrl={user?.pfpUrl}
+        onJoin={(config) => setLobbyConfig(config)}
+        onCancel={() => router.push('/spaces')}
+      />
     );
   }
 

--- a/src/components/spaces/InviteCard.tsx
+++ b/src/components/spaces/InviteCard.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
+
+interface InviteCardProps {
+  /** Room title shown in the headline and pre-filled into the cast text. */
+  roomTitle: string;
+  /** Fully-qualified room URL (https://zaoos.com/spaces/…). */
+  roomUrl: string;
+  /** When true, the card is small enough to sit as a panel inside the room. */
+  compact?: boolean;
+}
+
+/**
+ * Shown to the host (and any solo participant) when a Video Room has no
+ * other people yet. Three primary actions: copy the link, cast it to /zao,
+ * scan a QR with a phone. The card hides itself once others join.
+ *
+ * Renders nothing if SSR — the room URL is built client-side from
+ * `window.location` to avoid leaking dev hostnames into the deployed bundle.
+ */
+export function InviteCard({ roomTitle, roomUrl, compact = false }: InviteCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1800);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(roomUrl);
+      setCopied(true);
+    } catch {
+      /* clipboard may be blocked - the user can still copy from the input below */
+    }
+  };
+
+  const castText = encodeURIComponent(`Live in a ZAO Video Room: ${roomTitle}\n\nCome through, mic + cam + screen share are open.`);
+  const castUrl = `https://warpcast.com/~/compose?text=${castText}&embeds[]=${encodeURIComponent(roomUrl)}&channelKey=zao`;
+
+  const xText = encodeURIComponent(`Live in a ZAO Video Room: ${roomTitle}\n\nJoin: ${roomUrl}`);
+  const xUrl = `https://twitter.com/intent/tweet?text=${xText}`;
+
+  return (
+    <div
+      className={`bg-[#0d1b2a] border border-white/[0.08] rounded-2xl ${
+        compact ? 'p-4' : 'p-6 sm:p-8'
+      } w-full max-w-md mx-auto`}
+    >
+      <div className="text-center mb-5">
+        <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-xs font-semibold tracking-wider uppercase mb-3">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#f5a623] animate-pulse" />
+          Live - waiting for people
+        </div>
+        <h2 className={`text-white font-bold ${compact ? 'text-base' : 'text-lg sm:text-xl'} mb-1`}>
+          Invite people in
+        </h2>
+        <p className="text-gray-500 text-xs sm:text-sm leading-relaxed">
+          The room is open. Share the link or scan the code to bring others.
+        </p>
+      </div>
+
+      {/* Copy link */}
+      <div className="flex items-center gap-2 bg-[#0a1628] border border-white/[0.08] rounded-xl px-3 py-2 mb-3">
+        <input
+          type="text"
+          readOnly
+          value={roomUrl}
+          onFocus={(e) => e.currentTarget.select()}
+          className="flex-1 bg-transparent text-gray-300 text-xs sm:text-sm font-mono truncate focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={handleCopy}
+          className={`px-3 py-1.5 rounded-lg text-xs font-bold transition-colors flex-shrink-0 ${
+            copied
+              ? 'bg-green-500/20 text-green-400 border border-green-500/30'
+              : 'bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628]'
+          }`}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      </div>
+
+      {/* Share buttons */}
+      <div className="grid grid-cols-2 gap-2 mb-5">
+        <a
+          href={castUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl border border-[#855dcd]/40 bg-[#855dcd]/10 text-[#a78bfa] text-xs sm:text-sm font-semibold hover:bg-[#855dcd]/20 transition-colors"
+        >
+          Cast to /zao
+        </a>
+        <a
+          href={xUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl border border-white/[0.12] bg-[#1a2a3a] text-gray-300 text-xs sm:text-sm font-semibold hover:bg-[#22364a] transition-colors"
+        >
+          Post on X
+        </a>
+      </div>
+
+      {/* QR */}
+      {!compact && (
+        <div className="flex flex-col items-center gap-2 pt-4 border-t border-white/[0.06]">
+          <div className="p-3 rounded-xl bg-white">
+            <QRCodeSVG
+              value={roomUrl}
+              size={132}
+              level="M"
+              marginSize={0}
+              fgColor="#0a1628"
+              bgColor="#ffffff"
+            />
+          </div>
+          <span className="text-gray-500 text-xs">Scan with your phone to join</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/spaces/PreJoinLobby.tsx
+++ b/src/components/spaces/PreJoinLobby.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Configuration the user picks in the lobby before joining a voice_channel
+ * (full A/V) room. Passed up to /spaces/[id]/page.tsx which forwards camera +
+ * mic + device choices into the Stream call.
+ */
+export interface LobbyJoinConfig {
+  audioEnabled: boolean;
+  videoEnabled: boolean;
+  audioDeviceId: string | null;
+  videoDeviceId: string | null;
+}
+
+interface PreJoinLobbyProps {
+  roomTitle: string;
+  hostName?: string;
+  participantCount?: number;
+  username?: string;
+  pfpUrl?: string;
+  onJoin: (config: LobbyJoinConfig) => void;
+  onCancel: () => void;
+}
+
+interface MediaDeviceOption {
+  deviceId: string;
+  label: string;
+}
+
+const STORAGE_KEY = 'zao-lobby-prefs-v1';
+
+interface LobbyPrefs {
+  audioEnabled: boolean;
+  videoEnabled: boolean;
+  audioDeviceId: string | null;
+  videoDeviceId: string | null;
+}
+
+function loadPrefs(): LobbyPrefs {
+  if (typeof window === 'undefined') {
+    return { audioEnabled: true, videoEnabled: true, audioDeviceId: null, videoDeviceId: null };
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { audioEnabled: true, videoEnabled: true, audioDeviceId: null, videoDeviceId: null };
+    const parsed = JSON.parse(raw) as Partial<LobbyPrefs>;
+    return {
+      audioEnabled: parsed.audioEnabled ?? true,
+      videoEnabled: parsed.videoEnabled ?? true,
+      audioDeviceId: parsed.audioDeviceId ?? null,
+      videoDeviceId: parsed.videoDeviceId ?? null,
+    };
+  } catch {
+    return { audioEnabled: true, videoEnabled: true, audioDeviceId: null, videoDeviceId: null };
+  }
+}
+
+function savePrefs(prefs: LobbyPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    /* localStorage disabled — preferences just won't persist */
+  }
+}
+
+/**
+ * Pre-join lobby for Video Rooms. Renders a local camera preview, audio level
+ * meter, device pickers, and toggles for whether to enter with mic/camera on.
+ * Stream.io is intentionally NOT involved here — the preview runs off a plain
+ * getUserMedia stream and is torn down before the room's Stream call joins,
+ * so there is no "double mic" or token-mint race to worry about.
+ */
+export function PreJoinLobby({
+  roomTitle,
+  hostName,
+  participantCount,
+  username,
+  pfpUrl,
+  onJoin,
+  onCancel,
+}: PreJoinLobbyProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const rafRef = useRef<number | null>(null);
+
+  const initialPrefs = loadPrefs();
+  const [audioEnabled, setAudioEnabled] = useState(initialPrefs.audioEnabled);
+  const [videoEnabled, setVideoEnabled] = useState(initialPrefs.videoEnabled);
+  const [audioDeviceId, setAudioDeviceId] = useState<string | null>(initialPrefs.audioDeviceId);
+  const [videoDeviceId, setVideoDeviceId] = useState<string | null>(initialPrefs.videoDeviceId);
+
+  const [audioDevices, setAudioDevices] = useState<MediaDeviceOption[]>([]);
+  const [videoDevices, setVideoDevices] = useState<MediaDeviceOption[]>([]);
+  const [permissionState, setPermissionState] = useState<'prompt' | 'granted' | 'denied' | 'unsupported'>('prompt');
+  const [error, setError] = useState<string | null>(null);
+  const [micLevel, setMicLevel] = useState(0);
+
+  const stopTracks = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close().catch(() => {});
+      audioCtxRef.current = null;
+      analyserRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+  }, []);
+
+  const acquire = useCallback(async () => {
+    stopTracks();
+
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      setPermissionState('unsupported');
+      setError('Your browser does not support camera or microphone access.');
+      return;
+    }
+
+    const constraints: MediaStreamConstraints = {
+      audio: audioEnabled
+        ? audioDeviceId
+          ? { deviceId: { exact: audioDeviceId } }
+          : true
+        : false,
+      video: videoEnabled
+        ? videoDeviceId
+          ? { deviceId: { exact: videoDeviceId } }
+          : true
+        : false,
+    };
+
+    if (!audioEnabled && !videoEnabled) {
+      setPermissionState('granted');
+      setError(null);
+      return;
+    }
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      streamRef.current = stream;
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        videoRef.current.play().catch(() => {});
+      }
+      setPermissionState('granted');
+      setError(null);
+
+      if (audioEnabled && stream.getAudioTracks().length > 0) {
+        try {
+          const Ctx = window.AudioContext || (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+          if (Ctx) {
+            const ctx = new Ctx();
+            const source = ctx.createMediaStreamSource(stream);
+            const analyser = ctx.createAnalyser();
+            analyser.fftSize = 512;
+            source.connect(analyser);
+            audioCtxRef.current = ctx;
+            analyserRef.current = analyser;
+
+            const buf = new Uint8Array(analyser.frequencyBinCount);
+            const tick = () => {
+              if (!analyserRef.current) return;
+              analyserRef.current.getByteFrequencyData(buf);
+              let sum = 0;
+              for (const v of buf) sum += v;
+              const avg = sum / buf.length / 255;
+              setMicLevel(avg);
+              rafRef.current = requestAnimationFrame(tick);
+            };
+            tick();
+          }
+        } catch {
+          /* mic meter is best-effort */
+        }
+      }
+
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        setAudioDevices(
+          devices
+            .filter((d) => d.kind === 'audioinput')
+            .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Microphone ${i + 1}` })),
+        );
+        setVideoDevices(
+          devices
+            .filter((d) => d.kind === 'videoinput')
+            .map((d, i) => ({ deviceId: d.deviceId, label: d.label || `Camera ${i + 1}` })),
+        );
+      } catch {
+        /* device enumeration is best-effort */
+      }
+    } catch (err: unknown) {
+      const name = err instanceof Error ? err.name : 'Error';
+      const isPermission = name === 'NotAllowedError' || name === 'SecurityError';
+      const isNotFound = name === 'NotFoundError' || name === 'OverconstrainedError';
+      setPermissionState(isPermission ? 'denied' : 'granted');
+      setError(
+        isPermission
+          ? 'Camera or microphone permission was blocked. Allow access in your browser and try again.'
+          : isNotFound
+            ? 'Could not find the selected camera or microphone. Pick a different device.'
+            : 'Could not access camera or microphone.',
+      );
+    }
+  }, [audioEnabled, videoEnabled, audioDeviceId, videoDeviceId, stopTracks]);
+
+  useEffect(() => {
+    acquire();
+    return () => {
+      stopTracks();
+    };
+  }, [acquire, stopTracks]);
+
+  const handleJoin = () => {
+    savePrefs({ audioEnabled, videoEnabled, audioDeviceId, videoDeviceId });
+    stopTracks();
+    onJoin({ audioEnabled, videoEnabled, audioDeviceId, videoDeviceId });
+  };
+
+  const handleCancel = () => {
+    stopTracks();
+    onCancel();
+  };
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] flex flex-col">
+      <header className="border-b border-white/[0.08] bg-[#0d1b2a] px-4 py-3">
+        <div className="max-w-4xl mx-auto flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-white font-bold text-sm sm:text-base truncate">{roomTitle}</h1>
+            <p className="text-gray-500 text-xs truncate mt-0.5">
+              {hostName ? `Hosted by ${hostName}` : 'Video room'}
+              {typeof participantCount === 'number' && participantCount > 0 && (
+                <>
+                  {' '}- {participantCount} {participantCount === 1 ? 'person' : 'people'} here
+                </>
+              )}
+            </p>
+          </div>
+          <button
+            onClick={handleCancel}
+            className="px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-white border border-white/[0.08] rounded-lg hover:bg-white/[0.04] transition-colors"
+          >
+            Back
+          </button>
+        </div>
+      </header>
+
+      <main className="flex-1 px-4 py-6 max-w-4xl mx-auto w-full grid gap-6 lg:grid-cols-[1fr_320px]">
+        <section className="space-y-3">
+          <div className="relative aspect-video w-full max-w-3xl mx-auto rounded-2xl overflow-hidden border border-white/[0.08] bg-black">
+            {videoEnabled && permissionState === 'granted' ? (
+              <video
+                ref={videoRef}
+                autoPlay
+                muted
+                playsInline
+                className="w-full h-full object-cover scale-x-[-1]"
+              />
+            ) : (
+              <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 text-gray-500">
+                {pfpUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={pfpUrl}
+                    alt={username ?? 'You'}
+                    className="w-20 h-20 rounded-full object-cover border-2 border-white/[0.08]"
+                  />
+                ) : (
+                  <div className="w-20 h-20 rounded-full bg-gradient-to-br from-[#f5a623] to-[#ffd700] flex items-center justify-center text-[#0a1628] text-3xl font-bold">
+                    {(username ?? '?')[0].toUpperCase()}
+                  </div>
+                )}
+                <span className="text-sm">
+                  {permissionState === 'denied'
+                    ? 'Camera blocked'
+                    : videoEnabled
+                      ? 'Starting camera...'
+                      : 'Camera off'}
+                </span>
+              </div>
+            )}
+
+            {/* Mic level meter */}
+            {audioEnabled && permissionState === 'granted' && (
+              <div className="absolute bottom-3 left-3 right-3 flex items-center gap-2">
+                <div className="w-6 h-6 rounded-full bg-black/60 flex items-center justify-center">
+                  <svg className="w-3.5 h-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
+                  </svg>
+                </div>
+                <div className="flex-1 h-1 rounded-full bg-black/60 overflow-hidden">
+                  <div
+                    className="h-full bg-[#f5a623] transition-all duration-75"
+                    style={{ width: `${Math.min(100, micLevel * 200)}%` }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Toggle buttons */}
+          <div className="flex items-center justify-center gap-3">
+            <button
+              type="button"
+              onClick={() => setAudioEnabled((v) => !v)}
+              className={`px-5 py-2.5 rounded-xl font-semibold text-sm flex items-center gap-2 border transition-colors ${
+                audioEnabled
+                  ? 'bg-[#1a2a3a] text-white border-white/[0.08] hover:border-gray-500'
+                  : 'bg-red-500/15 text-red-400 border-red-500/30 hover:bg-red-500/20'
+              }`}
+            >
+              {audioEnabled ? 'Mic on' : 'Mic off'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setVideoEnabled((v) => !v)}
+              className={`px-5 py-2.5 rounded-xl font-semibold text-sm flex items-center gap-2 border transition-colors ${
+                videoEnabled
+                  ? 'bg-[#1a2a3a] text-white border-white/[0.08] hover:border-gray-500'
+                  : 'bg-red-500/15 text-red-400 border-red-500/30 hover:bg-red-500/20'
+              }`}
+            >
+              {videoEnabled ? 'Camera on' : 'Camera off'}
+            </button>
+          </div>
+
+          {error && (
+            <div className="mx-auto max-w-md flex items-start gap-2 bg-red-500/10 border border-red-500/20 text-red-400 text-sm px-3 py-2.5 rounded-lg">
+              <span>{error}</span>
+            </div>
+          )}
+        </section>
+
+        <aside className="space-y-4">
+          <div>
+            <label className="block text-gray-400 text-xs font-medium uppercase tracking-wider mb-1.5">
+              Microphone
+            </label>
+            <select
+              value={audioDeviceId ?? ''}
+              onChange={(e) => setAudioDeviceId(e.target.value || null)}
+              disabled={!audioEnabled || audioDevices.length === 0}
+              className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-xl px-3 py-2.5 text-white text-sm focus:border-[#f5a623] focus:outline-none disabled:opacity-50"
+            >
+              <option value="">Default microphone</option>
+              {audioDevices.map((d) => (
+                <option key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-gray-400 text-xs font-medium uppercase tracking-wider mb-1.5">
+              Camera
+            </label>
+            <select
+              value={videoDeviceId ?? ''}
+              onChange={(e) => setVideoDeviceId(e.target.value || null)}
+              disabled={!videoEnabled || videoDevices.length === 0}
+              className="w-full bg-[#0d1b2a] border border-white/[0.08] rounded-xl px-3 py-2.5 text-white text-sm focus:border-[#f5a623] focus:outline-none disabled:opacity-50"
+            >
+              <option value="">Default camera</option>
+              {videoDevices.map((d) => (
+                <option key={d.deviceId} value={d.deviceId}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleJoin}
+            disabled={permissionState === 'denied' && (audioEnabled || videoEnabled)}
+            className="w-full px-4 py-3 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] font-bold rounded-xl text-sm transition-colors shadow-lg shadow-[#f5a623]/20 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Join room
+          </button>
+
+          <p className="text-gray-600 text-xs leading-relaxed">
+            You can change mic, camera, and screen share inside the room.
+          </p>
+        </aside>
+      </main>
+    </div>
+  );
+}

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -18,6 +18,7 @@ import { RoomReactions } from './RoomReactions';
 import { RoomChat } from './RoomChat';
 import { ParticipantsPanel } from './ParticipantsPanel';
 import { ClosedCaptions } from './ClosedCaptions';
+import { InviteCard } from './InviteCard';
 
 const BroadcastModal = dynamic(
   () => import('./BroadcastModal').then((m) => ({ default: m.BroadcastModal })),
@@ -86,10 +87,21 @@ export function RoomView({
   );
   const [previousLayout, setPreviousLayout] = useState<'content-first' | 'speakers-first' | null>(null);
 
-  const { useCallCustomData, useHasOngoingScreenShare } = useCallStateHooks();
+  const { useCallCustomData, useHasOngoingScreenShare, useParticipants } = useCallStateHooks();
   const callCustomData = useCallCustomData();
   const hasScreenShareActive = useHasOngoingScreenShare();
+  const participants = useParticipants();
   const roomTitle = (callCustomData as Record<string, string>)?.title || 'Audio Room';
+
+  // For Video Rooms only: show an invite card while the host is alone.
+  // Hidden as soon as a second participant joins.
+  const isAlone = participants.length <= 1;
+  const showInviteCard = roomType === 'voice_channel' && isAlone;
+  const [roomUrl, setRoomUrl] = useState('');
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setRoomUrl(window.location.href);
+  }, []);
 
   // Fetch Twitch connection info for the host (all viewers see the embed, host gets chat)
   useEffect(() => {
@@ -204,6 +216,15 @@ export function RoomView({
               <ContentView isHost={isHost} />
             ) : (
               <SpeakersGrid hostFid={hostFid} />
+            )}
+
+            {/* Invite card overlay - Video Rooms only, while alone */}
+            {showInviteCard && roomUrl && (
+              <div className="absolute inset-0 flex items-center justify-center p-4 pointer-events-none">
+                <div className="pointer-events-auto">
+                  <InviteCard roomTitle={roomTitle} roomUrl={roomUrl} />
+                </div>
+              </div>
             )}
 
             {/* Closed captions overlay */}


### PR DESCRIPTION
## Summary

Adds a pre-join lobby for Video Rooms so users see themselves + check their mic before dropping into the live call. Stacked on top of #634 (Video Room mode). Stage rooms are unchanged - they keep direct-join.

## Why

Dropping a first-time user straight into a 4-cam video call is jarring. Lobby gives them:
- Local camera preview (mirrored, like every other tool they have used)
- Audio level meter (proves the mic works before they speak)
- Mic / camera toggles (join with one or both off)
- Device pickers (multiple cameras, USB mic, etc.)
- localStorage'd preferences so returning users skip the rediscovery

## Architecture

Split the page's init effect in two:
- **Phase 1**: fetch room + run the token gate. Always runs. Does NOT touch Stream.io.
- **Phase 2**: open the Stream.io call. For stage rooms runs immediately (current UX). For voice_channel rooms waits on \`lobbyConfig\`. The lobby's choices feed \`call.microphone.select\`, \`call.camera.select\`, and \`call.camera.enable\`.

Preview runs off plain \`getUserMedia\` (no Stream coupling) and is torn down before Phase 2's own MediaStream, so no "double mic" or pre-join token mint.

## Files

- new \`src/components/spaces/PreJoinLobby.tsx\` (~360 lines)
- \`src/app/spaces/[id]/page.tsx\` - effect split + lobby render gate

## Test plan (Vercel preview)

- [ ] Voice Room as host - lobby shows, camera preview works, mic meter responds, devices enumerate, "Join room" enters with chosen state.
- [ ] Voice Room as second user - same. Sees self in lobby with chosen device.
- [ ] Toggle camera OFF then Join - enters room muted-camera; can flip on inside.
- [ ] Toggle mic OFF then Join - enters muted; can unmute inside.
- [ ] Stage room (PR #634 path) - direct-join unchanged, no lobby.
- [ ] Token-gated room - gate still blocks before lobby renders.

## Notes

- localStorage key: \`zao-lobby-prefs-v1\`.
- Camera preview is \`scale-x-[-1]\` (mirrored) to match every meeting tool's convention.
- Permission-denied path shows an inline message instead of breaking.