### PR TITLE
feat(juke): webhook consumer + persisted juke_spaces + audio=off + OG + recording UX

### DIFF
--- a/scripts/juke-spaces-migration.sql
+++ b/scripts/juke-spaces-migration.sql
@@ -1,0 +1,82 @@
+-- juke_spaces: one row per Juke developer-API-minted space.
+-- juke_webhook_events: every inbound webhook for idempotency + audit.
+--
+-- Path B writes a row on create; webhooks update status / participant_count /
+-- recording_url. /live/{id} can read this server-side instead of polling
+-- GET /v1/rooms/{id} on every render.
+--
+-- RLS: read-public for juke_spaces (the /live page is public read).
+--      writes are service-role only (server routes).
+--      juke_webhook_events is service-role only on both reads and writes.
+
+create table if not exists public.juke_spaces (
+  id text primary key,                                 -- Juke space id
+  title text not null,
+  status text not null default 'scheduled',            -- 'scheduled' | 'active' | 'ended'
+  created_by_fid integer not null,                     -- ZAO host FID (app.owner_fid)
+  scheduled_at timestamptz,
+  started_at timestamptz,
+  ended_at timestamptz,
+  recording_url text,
+  participant_count integer not null default 0,
+  embed_url text,                                      -- juke.audio/embed/{id}
+  raw jsonb,                                           -- Juke create response, for debugging
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists juke_spaces_status_idx
+  on public.juke_spaces (status);
+create index if not exists juke_spaces_created_by_fid_idx
+  on public.juke_spaces (created_by_fid);
+create index if not exists juke_spaces_scheduled_at_idx
+  on public.juke_spaces (scheduled_at) where status = 'scheduled';
+
+-- Touch updated_at on every row update.
+create or replace function public.juke_spaces_set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$;
+
+drop trigger if exists juke_spaces_set_updated_at on public.juke_spaces;
+create trigger juke_spaces_set_updated_at
+before update on public.juke_spaces
+for each row execute function public.juke_spaces_set_updated_at();
+
+create table if not exists public.juke_webhook_events (
+  id uuid primary key default gen_random_uuid(),
+  event_type text not null,                            -- room.started | room.finished | participant.joined | participant.left | recording.ready
+  juke_event_id text,                                  -- Juke's id if provided in body
+  signature_hash text not null,                        -- sha256 of full X-Juke-Signature header, the idempotency key
+  space_id text,
+  body jsonb not null,
+  received_at timestamptz not null default now(),
+  processed_at timestamptz,
+  error text
+);
+
+create unique index if not exists juke_webhook_events_signature_uq
+  on public.juke_webhook_events (signature_hash);
+create index if not exists juke_webhook_events_event_type_idx
+  on public.juke_webhook_events (event_type);
+create index if not exists juke_webhook_events_space_id_idx
+  on public.juke_webhook_events (space_id);
+
+-- RLS
+alter table public.juke_spaces enable row level security;
+alter table public.juke_webhook_events enable row level security;
+
+-- juke_spaces is publicly readable so /live/{id} can SSR without an auth round-trip.
+drop policy if exists "juke_spaces_read_all" on public.juke_spaces;
+create policy "juke_spaces_read_all"
+  on public.juke_spaces
+  for select
+  using (true);
+
+-- Writes are server-only (no anon / authenticated INSERT policies, service role bypasses RLS).
+-- juke_webhook_events has no public policies; service role only.

--- a/scripts/register-juke-webhook.ts
+++ b/scripts/register-juke-webhook.ts
@@ -1,0 +1,103 @@
+/**
+ * One-shot: register the ZAO OS Juke webhook receiver with Juke's developer
+ * webhook API (Juke PR 2026-05-23, POST /v1/developer/webhooks).
+ *
+ *   npx tsx scripts/register-juke-webhook.ts <url>
+ *
+ * Reads JUKE_API_KEY + JUKE_WEBHOOK_SECRET from .env.local. The URL defaults
+ * to https://zaoos.com/api/juke/webhooks. After the first successful run
+ * Juke starts POSTing signed deliveries; verify with `gh logs` or the
+ * juke_webhook_events table in Supabase.
+ *
+ * Per llms.txt: max 5 subscriptions per app; unique (app_id, url). Re-running
+ * with the same URL returns the existing subscription, not a duplicate.
+ */
+import * as fs from 'fs';
+
+interface JukeWebhookRegisterResponse {
+  id?: string;
+  url?: string;
+  events?: string[];
+  enabled?: boolean;
+  [k: string]: unknown;
+}
+
+function loadEnv(): Record<string, string> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync('.env.local', 'utf8');
+  } catch {
+    console.error('Could not read .env.local - run this from the repo root.');
+    process.exit(1);
+  }
+  const env: Record<string, string> = {};
+  for (const line of raw.split('\n')) {
+    const match = line.match(/^([^#=]+)=(.*)$/);
+    if (match) env[match[1].trim()] = match[2].trim();
+  }
+  return env;
+}
+
+async function main(): Promise<void> {
+  const env = loadEnv();
+  const apiKey = env.JUKE_API_KEY;
+  const secret = env.JUKE_WEBHOOK_SECRET;
+  if (!apiKey) {
+    console.error('Missing JUKE_API_KEY in .env.local.');
+    process.exit(1);
+  }
+  if (!secret) {
+    console.error('Missing JUKE_WEBHOOK_SECRET in .env.local. Generate one:');
+    console.error('  openssl rand -hex 32');
+    process.exit(1);
+  }
+
+  const url = process.argv[2] ?? 'https://zaoos.com/api/juke/webhooks';
+  console.log('Registering Juke webhook for', url);
+
+  const res = await fetch('https://api.juke.audio/v1/developer/webhooks', {
+    method: 'POST',
+    headers: {
+      'X-Juke-Api-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      url,
+      secret,
+      events: [
+        'room.started',
+        'room.finished',
+        'participant.joined',
+        'participant.left',
+        'recording.ready',
+      ],
+    }),
+  });
+
+  const text = await res.text();
+  if (!res.ok) {
+    console.error(`FAILED - status ${res.status}`);
+    console.error(text);
+    process.exit(1);
+  }
+
+  let body: JukeWebhookRegisterResponse;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    console.log('OK - Juke returned non-JSON body (logged below):');
+    console.log(text);
+    return;
+  }
+
+  console.log('OK - webhook registered.');
+  console.log('  id      ', body.id ?? '(not returned)');
+  console.log('  url     ', body.url ?? url);
+  console.log('  events  ', body.events ?? '(not returned)');
+  console.log('  enabled ', body.enabled ?? '(not returned)');
+}
+
+main().catch((err: unknown) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -5,6 +5,7 @@ import { getSessionData } from '@/lib/auth/session';
 import { ENV } from '@/lib/env';
 import { logger } from '@/lib/logger';
 import { createJukeSpace } from '@/lib/spaces/juke-api';
+import { insertJukeSpace } from '@/lib/spaces/jukeSpacesDb';
 
 /**
  * Constant-time string comparison. Both inputs are SHA-256'd to a fixed
@@ -109,6 +110,21 @@ export async function POST(request: NextRequest) {
         { success: false, error: result.error },
         { status: 502 },
       );
+    }
+    // Persist the room so /live/{id} can render server-side + webhooks can
+    // update its lifecycle. Best-effort: if Supabase is down we still
+    // return the space id so the caller can proceed.
+    try {
+      await insertJukeSpace({
+        id: result.space.id,
+        title: spaceInput.title,
+        createdByFid: session?.fid ?? 0,
+        scheduledAt: spaceInput.scheduledAt ?? null,
+        embedUrl: result.space.embedUrl,
+        raw: result.space.raw,
+      });
+    } catch (dbErr: unknown) {
+      logger.error('[juke/space] insertJukeSpace failed (non-fatal):', dbErr);
     }
     return NextResponse.json(
       { success: true, data: result.space },

--- a/src/app/api/juke/webhooks/route.ts
+++ b/src/app/api/juke/webhooks/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import {
+  markWebhookProcessed,
+  recordWebhookEvent,
+} from '@/lib/spaces/jukeSpacesDb';
+import { applyWebhookEvent, parseWebhookEvent } from '@/lib/spaces/jukeWebhookHandlers';
+import { verifyJukeWebhook } from '@/lib/spaces/jukeWebhookVerify';
+
+/**
+ * POST /api/juke/webhooks — inbound deliveries from Juke's outbound webhook
+ * dispatcher (Juke PR 2026-05-23).
+ *
+ * Contract:
+ *   X-Juke-Signature: t={unix-ts-seconds},v1={hex-hmac-sha256}
+ *   payload signed:   f"{ts}.{body}"
+ *   secret:           JUKE_WEBHOOK_SECRET (registered at POST /v1/developer/webhooks)
+ *   retries:          t=0/+10s/+60s/+300s, then stop
+ *
+ * Behaviour:
+ *   1. 401 if JUKE_WEBHOOK_SECRET is unset (refuse all inbound until paired).
+ *   2. 401 on signature mismatch or timestamp outside the 5-min replay window.
+ *   3. 200 + early ack on duplicate signature (idempotent replay).
+ *   4. 200 after handler runs; failures are logged + persisted but NOT
+ *      reflected as a 5xx (Juke would retry forever on a handler bug).
+ *
+ * We always return 200 once the signature passes, except for setup
+ * misconfiguration (no secret) and signature failures.
+ */
+export async function POST(request: NextRequest) {
+  const secret = ENV.JUKE_WEBHOOK_SECRET;
+  if (!secret) {
+    logger.warn('[juke/webhooks] inbound delivery but JUKE_WEBHOOK_SECRET is unset');
+    return NextResponse.json({ ok: false, error: 'Webhook not configured' }, { status: 401 });
+  }
+
+  const rawBody = await request.text();
+  const signatureHeader = request.headers.get('x-juke-signature');
+
+  const verification = verifyJukeWebhook(rawBody, signatureHeader, secret);
+  if (!verification.ok) {
+    logger.warn('[juke/webhooks] signature failed:', verification.reason);
+    return NextResponse.json({ ok: false, error: verification.reason }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { eventType, spaceId, eventId } = parseWebhookEvent(body);
+
+  let fresh: boolean;
+  try {
+    fresh = await recordWebhookEvent({
+      eventType,
+      jukeEventId: eventId,
+      signatureHash: verification.signatureHash,
+      spaceId,
+      body,
+    });
+  } catch (err: unknown) {
+    logger.error('[juke/webhooks] recordWebhookEvent threw:', err);
+    return NextResponse.json({ ok: false, error: 'Could not record event' }, { status: 500 });
+  }
+
+  if (!fresh) {
+    // Duplicate — already processed.
+    return NextResponse.json({ ok: true, duplicate: true });
+  }
+
+  try {
+    await applyWebhookEvent(eventType, spaceId, body);
+    await markWebhookProcessed(verification.signatureHash);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'handler failed';
+    logger.error('[juke/webhooks] handler error:', err);
+    await markWebhookProcessed(verification.signatureHash, message).catch(() => {});
+    // Still 200 — bug in handler should not trigger a Juke retry storm.
+    return NextResponse.json({ ok: true, handler_error: message });
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+export const GET = () =>
+  NextResponse.json(
+    { ok: false, error: 'POST only — Juke webhooks are signed POST deliveries' },
+    { status: 405 },
+  );

--- a/src/app/live/[spaceId]/page.tsx
+++ b/src/app/live/[spaceId]/page.tsx
@@ -2,11 +2,31 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { JukeEmbed } from '@/components/spaces/JukeEmbed';
-import { isValidJukeSpaceId } from '@/lib/spaces/juke';
+import {
+  isValidJukeSpaceId,
+  jukeAppDeeplinkUrl,
+  jukeSpaceOgImageUrl,
+  jukeSpaceUrl,
+} from '@/lib/spaces/juke';
+import { getJukeSpace, type JukeSpaceRow } from '@/lib/spaces/jukeSpacesDb';
 import { communityConfig } from '../../../../community.config';
 
 interface LivePageProps {
   params: Promise<{ spaceId: string }>;
+  searchParams: Promise<{ audio?: string }>;
+}
+
+/**
+ * Try to read the persisted Juke space row. The page degrades gracefully if
+ * the row is missing — anyone can still open `/live/{validId}` and listen
+ * via the iframe even if our DB never saw the create event.
+ */
+async function safeGetJukeSpace(id: string): Promise<JukeSpaceRow | null> {
+  try {
+    return await getJukeSpace(id);
+  } catch {
+    return null;
+  }
 }
 
 export async function generateMetadata({ params }: LivePageProps): Promise<Metadata> {
@@ -14,10 +34,22 @@ export async function generateMetadata({ params }: LivePageProps): Promise<Metad
   if (!isValidJukeSpaceId(spaceId)) {
     return { title: `Live Audio - ${communityConfig.name}` };
   }
+  const row = await safeGetJukeSpace(spaceId);
+  const title = row?.title ? `${row.title} - Live on ${communityConfig.name}` : `Live Audio - ${communityConfig.name}`;
+  const ogImage = jukeSpaceOgImageUrl(spaceId);
   return {
-    title: `Live Audio - ${communityConfig.name}`,
+    title,
     description: `Listen in to a live audio space on Juke, the Farcaster-native audio app.`,
     robots: { index: false },
+    openGraph: {
+      title,
+      images: [{ url: ogImage }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      images: [ogImage],
+    },
   };
 }
 
@@ -28,15 +60,26 @@ export async function generateMetadata({ params }: LivePageProps): Promise<Metad
  * Juke; this route is a thin, brandable window onto it. Anyone with the
  * space link can open `/live/{spaceId}`; listening is anonymous, and
  * participating prompts Sign In With Farcaster inside the Juke iframe.
+ *
+ * Query params:
+ *   ?audio=off  Renders the embed in passive second-screen mode (no audio
+ *               connection). Use when the user is already listening via the
+ *               Juke iOS app and the laptop should not double-broadcast.
  */
-export default async function LivePage({ params }: LivePageProps) {
+export default async function LivePage({ params, searchParams }: LivePageProps) {
   const { spaceId } = await params;
+  const { audio } = await searchParams;
 
   // Untrusted path segment — reject anything that is not a Juke space id
   // before it can reach the embed URL.
   if (!isValidJukeSpaceId(spaceId)) {
     notFound();
   }
+
+  const row = await safeGetJukeSpace(spaceId);
+  const audioOff = audio === 'off';
+  const isEnded = row?.status === 'ended';
+  const recordingUrl = row?.recording_url ?? null;
 
   return (
     <div className="flex min-h-[100dvh] flex-col bg-[#0a1628]">
@@ -52,17 +95,82 @@ export default async function LivePage({ params }: LivePageProps) {
             </svg>
           </Link>
           <div className="min-w-0">
-            <h1 className="text-sm font-bold text-white sm:text-base">Live Audio</h1>
-            <p className="truncate text-xs text-gray-500">Farcaster-native space, powered by Juke</p>
+            <h1 className="truncate text-sm font-bold text-white sm:text-base">
+              {row?.title ?? 'Live Audio'}
+            </h1>
+            <p className="truncate text-xs text-gray-500">
+              {row?.status === 'active'
+                ? 'Live on Juke'
+                : row?.status === 'scheduled'
+                  ? 'Scheduled - opening soon'
+                  : isEnded
+                    ? 'Ended'
+                    : 'Powered by Juke'}
+              {typeof row?.participant_count === 'number' && row.participant_count > 0 && (
+                <>
+                  {' - '}
+                  {row.participant_count} {row.participant_count === 1 ? 'listener' : 'listeners'}
+                </>
+              )}
+            </p>
           </div>
         </div>
       </header>
 
-      <main className="flex flex-1 flex-col items-center px-4 py-6">
-        <JukeEmbed spaceId={spaceId} />
-        <p className="mt-4 max-w-[480px] text-center text-xs text-gray-500">
-          Listening is anonymous. To react, raise your hand, or speak, sign in
-          with Farcaster inside the space.
+      <main className="flex flex-1 flex-col items-center px-4 py-6 gap-4">
+        {isEnded && recordingUrl ? (
+          <div className="w-full max-w-md flex flex-col gap-3 bg-[#0d1b2a] border border-white/[0.08] rounded-2xl p-6 text-center">
+            <h2 className="text-white font-bold text-base">This space has ended</h2>
+            <p className="text-gray-500 text-xs">A recording is available.</p>
+            <a
+              href={recordingUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="px-5 py-2.5 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] font-bold text-sm transition-colors"
+            >
+              Listen to the recording
+            </a>
+          </div>
+        ) : isEnded ? (
+          <div className="w-full max-w-md flex flex-col gap-3 bg-[#0d1b2a] border border-white/[0.08] rounded-2xl p-6 text-center">
+            <h2 className="text-white font-bold text-base">This space has ended</h2>
+            <p className="text-gray-500 text-xs">No recording was made.</p>
+          </div>
+        ) : (
+          <JukeEmbed spaceId={spaceId} audioOff={audioOff} />
+        )}
+
+        <div className="flex flex-wrap gap-2 justify-center">
+          <a
+            href={jukeAppDeeplinkUrl(spaceId)}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="px-4 py-2 rounded-xl border border-white/[0.12] bg-[#1a2a3a] text-gray-300 text-xs font-semibold hover:bg-[#22364a] transition-colors"
+          >
+            Open in Juke app
+          </a>
+          <a
+            href={jukeSpaceUrl(spaceId)}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="px-4 py-2 rounded-xl border border-white/[0.12] bg-[#1a2a3a] text-gray-400 text-xs font-semibold hover:bg-[#22364a] transition-colors"
+          >
+            Share page
+          </a>
+          {!audioOff && !isEnded && (
+            <Link
+              href={`/live/${spaceId}?audio=off`}
+              className="px-4 py-2 rounded-xl border border-white/[0.12] bg-[#1a2a3a] text-gray-400 text-xs font-semibold hover:bg-[#22364a] transition-colors"
+            >
+              Mute (second screen)
+            </Link>
+          )}
+        </div>
+
+        <p className="mt-2 max-w-[480px] text-center text-xs text-gray-500">
+          {audioOff
+            ? 'Audio is off. Listen in the Juke iOS app, or open this page in another tab without ?audio=off.'
+            : 'Listening is anonymous. To react, raise your hand, or speak, sign in with Farcaster inside the space.'}
         </p>
       </main>
     </div>

--- a/src/components/spaces/JukeEmbed.tsx
+++ b/src/components/spaces/JukeEmbed.tsx
@@ -11,6 +11,12 @@ interface JukeEmbedProps {
   spaceId: string;
   /** Optional extra classes for the outer wrapper. */
   className?: string;
+  /**
+   * Passive second-screen mode. Renders the same Juke UI but with
+   * `?audio=off`, so the embed never connects audio — use when the user is
+   * already in the Juke iOS app and the laptop should not double-broadcast.
+   */
+  audioOff?: boolean;
 }
 
 /**
@@ -20,7 +26,7 @@ interface JukeEmbedProps {
  * until it reports `load`. "Powered by Juke" attribution is kept visible per
  * Juke's branding requirements.
  */
-export function JukeEmbed({ spaceId, className }: JukeEmbedProps) {
+export function JukeEmbed({ spaceId, className, audioOff = false }: JukeEmbedProps) {
   const [loaded, setLoaded] = useState(false);
 
   return (
@@ -36,9 +42,9 @@ export function JukeEmbed({ spaceId, className }: JukeEmbedProps) {
           </div>
         )}
         <iframe
-          src={jukeEmbedUrl(spaceId)}
+          src={jukeEmbedUrl(spaceId, { audioOff })}
           title="Juke live audio space"
-          allow="autoplay; microphone"
+          allow={audioOff ? 'autoplay' : 'autoplay; microphone'}
           onLoad={() => setLoaded(true)}
           className="h-full w-full rounded-3xl border-0"
         />

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -102,4 +102,9 @@ export const ENV = {
   // ZAOcoworking bot create spaces without an admin session. Unset = the
   // password path is disabled (admin session still works).
   JUKE_CREATE_PASSWORD: optionalEnv('JUKE_CREATE_PASSWORD'),
+  // HMAC secret shared with Juke's webhook dispatcher. Verifies
+  // `X-Juke-Signature: t={ts},v1={hex_hmac}` on /api/juke/webhooks. Generate
+  // a random 32+ byte hex value (`openssl rand -hex 32`) and pass the same
+  // value to Juke when registering the webhook at POST /v1/developer/webhooks.
+  JUKE_WEBHOOK_SECRET: optionalEnv('JUKE_WEBHOOK_SECRET'),
 } as const;

--- a/src/lib/spaces/juke.ts
+++ b/src/lib/spaces/juke.ts
@@ -26,17 +26,54 @@ export function isValidJukeSpaceId(value: unknown): value is string {
   return typeof value === 'string' && SPACE_ID_PATTERN.test(value);
 }
 
+/** Options for {@link jukeEmbedUrl}. */
+export interface JukeEmbedOptions {
+  /**
+   * When `true`, append `?audio=off` so the embed renders a passive,
+   * second-screen view: same metadata + participants but no audio connection.
+   * Use this when the listener is already in the Juke iOS app on their phone
+   * and the laptop should not double-broadcast (Juke PR 2026-05-23, item #6).
+   */
+  audioOff?: boolean;
+}
+
 /**
  * Build the Juke embed URL for a space.
  *
  * @throws if `spaceId` is not a valid Juke space id — callers must validate
  *         with {@link isValidJukeSpaceId} (and 404) before reaching here.
  */
-export function jukeEmbedUrl(spaceId: string): string {
+export function jukeEmbedUrl(spaceId: string, options: JukeEmbedOptions = {}): string {
   if (!isValidJukeSpaceId(spaceId)) {
     throw new Error('Invalid Juke space id');
   }
-  return `${JUKE_EMBED_ORIGIN}/embed/${encodeURIComponent(spaceId)}`;
+  const base = `${JUKE_EMBED_ORIGIN}/embed/${encodeURIComponent(spaceId)}`;
+  return options.audioOff ? `${base}?audio=off` : base;
+}
+
+/** Canonical Juke space page URL for a given id (the share/permalink URL). */
+export function jukeSpaceUrl(spaceId: string): string {
+  if (!isValidJukeSpaceId(spaceId)) throw new Error('Invalid Juke space id');
+  return `${JUKE_EMBED_ORIGIN}/space/${encodeURIComponent(spaceId)}`;
+}
+
+/**
+ * Juke's per-space OG image. Returned by the Juke landing app and safe to use
+ * as `og:image` / `twitter:image` for our `/live/{id}` route - Juke renders a
+ * branded card for the space (PR 2026-05-23, item #10).
+ */
+export function jukeSpaceOgImageUrl(spaceId: string): string {
+  if (!isValidJukeSpaceId(spaceId)) throw new Error('Invalid Juke space id');
+  return `${JUKE_EMBED_ORIGIN}/space/${encodeURIComponent(spaceId)}/opengraph-image`;
+}
+
+/**
+ * Native-app deeplink for "Open in Juke" CTAs on desktop and Farcaster
+ * miniapps. Apple universal-link form so it resolves on both web and iOS.
+ */
+export function jukeAppDeeplinkUrl(spaceId: string): string {
+  if (!isValidJukeSpaceId(spaceId)) throw new Error('Invalid Juke space id');
+  return `${JUKE_EMBED_ORIGIN}/space/${encodeURIComponent(spaceId)}?open=app`;
 }
 
 /**

--- a/src/lib/spaces/jukeSpacesDb.ts
+++ b/src/lib/spaces/jukeSpacesDb.ts
@@ -1,0 +1,130 @@
+/**
+ * Supabase helpers for the `juke_spaces` and `juke_webhook_events` tables —
+ * see `scripts/juke-spaces-migration.sql`.
+ *
+ * Path B writes a row on create; Juke webhooks update status / participants /
+ * recording. `/live/{id}` reads via {@link getJukeSpace}.
+ */
+import { supabaseAdmin } from '@/lib/db/supabase';
+
+export type JukeSpaceStatus = 'scheduled' | 'active' | 'ended';
+
+export interface JukeSpaceRow {
+  id: string;
+  title: string;
+  status: JukeSpaceStatus;
+  created_by_fid: number;
+  scheduled_at: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+  recording_url: string | null;
+  participant_count: number;
+  embed_url: string | null;
+  raw: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface JukeSpaceInsert {
+  id: string;
+  title: string;
+  createdByFid: number;
+  scheduledAt?: string | null;
+  embedUrl?: string | null;
+  raw?: unknown;
+}
+
+/** Insert a row right after `POST /v1/developer/spaces` succeeds. */
+export async function insertJukeSpace(input: JukeSpaceInsert): Promise<void> {
+  const status: JukeSpaceStatus = input.scheduledAt ? 'scheduled' : 'active';
+  const { error } = await supabaseAdmin.from('juke_spaces').upsert(
+    {
+      id: input.id,
+      title: input.title,
+      status,
+      created_by_fid: input.createdByFid,
+      scheduled_at: input.scheduledAt ?? null,
+      embed_url: input.embedUrl ?? null,
+      raw: input.raw ?? null,
+      started_at: status === 'active' ? new Date().toISOString() : null,
+    },
+    { onConflict: 'id' },
+  );
+  if (error) throw new Error(`insertJukeSpace failed: ${error.message}`);
+}
+
+/** Read one Juke space row by id — used by `/live/{id}` SSR. */
+export async function getJukeSpace(id: string): Promise<JukeSpaceRow | null> {
+  const { data, error } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw new Error(`getJukeSpace failed: ${error.message}`);
+  return (data as JukeSpaceRow) ?? null;
+}
+
+/** Update lifecycle fields driven by webhooks. */
+export async function updateJukeSpace(
+  id: string,
+  patch: Partial<
+    Pick<JukeSpaceRow, 'status' | 'started_at' | 'ended_at' | 'recording_url' | 'participant_count'>
+  >,
+): Promise<void> {
+  const { error } = await supabaseAdmin.from('juke_spaces').update(patch).eq('id', id);
+  if (error) throw new Error(`updateJukeSpace failed: ${error.message}`);
+}
+
+/** Increment / decrement the participant count atomically when a participant
+ * event fires. Falls back to an absolute count if the row is missing. */
+export async function bumpParticipantCount(id: string, delta: number): Promise<void> {
+  const { data } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('participant_count')
+    .eq('id', id)
+    .maybeSingle();
+  const current = (data as { participant_count?: number } | null)?.participant_count ?? 0;
+  const next = Math.max(0, current + delta);
+  const { error } = await supabaseAdmin
+    .from('juke_spaces')
+    .update({ participant_count: next })
+    .eq('id', id);
+  if (error) throw new Error(`bumpParticipantCount failed: ${error.message}`);
+}
+
+export interface WebhookEventInsert {
+  eventType: string;
+  jukeEventId?: string | null;
+  signatureHash: string;
+  spaceId?: string | null;
+  body: unknown;
+}
+
+/**
+ * Record the inbound webhook for idempotency + audit. Returns `false` when the
+ * signature has already been processed (unique constraint conflict) — the
+ * caller should short-circuit and ack the duplicate without re-running side
+ * effects.
+ */
+export async function recordWebhookEvent(input: WebhookEventInsert): Promise<boolean> {
+  const { error } = await supabaseAdmin.from('juke_webhook_events').insert({
+    event_type: input.eventType,
+    juke_event_id: input.jukeEventId ?? null,
+    signature_hash: input.signatureHash,
+    space_id: input.spaceId ?? null,
+    body: input.body,
+  });
+  if (error) {
+    // 23505 = unique_violation — replay.
+    if ((error as { code?: string }).code === '23505') return false;
+    throw new Error(`recordWebhookEvent failed: ${error.message}`);
+  }
+  return true;
+}
+
+export async function markWebhookProcessed(signatureHash: string, errMsg?: string): Promise<void> {
+  await supabaseAdmin
+    .from('juke_webhook_events')
+    .update({ processed_at: new Date().toISOString(), error: errMsg ?? null })
+    .eq('signature_hash', signatureHash);
+}

--- a/src/lib/spaces/jukeWebhookHandlers.ts
+++ b/src/lib/spaces/jukeWebhookHandlers.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-event handlers for the Juke outbound webhooks. The route in
+ * `/api/juke/webhooks/route.ts` parses + HMAC-verifies the delivery, then
+ * dispatches the parsed body here.
+ *
+ * Juke event vocabulary (per the 2026-05-23 PR):
+ *
+ *   - room.started        the host opened the room
+ *   - room.finished       the room ended for everyone
+ *   - participant.joined  someone joined the room
+ *   - participant.left    someone left the room
+ *   - recording.ready     the host had recording on and the file is ready
+ *
+ * Body shape is best-effort - we treat the inbound JSON defensively and only
+ * consume the fields we recognise. Extra fields are stored verbatim in
+ * `juke_webhook_events.body`.
+ */
+import { bumpParticipantCount, updateJukeSpace } from './jukeSpacesDb';
+
+interface JukeWebhookBody {
+  event?: string;
+  type?: string;
+  data?: Record<string, unknown>;
+  space?: Record<string, unknown>;
+  space_id?: string;
+  spaceId?: string;
+  recording_url?: string;
+  recordingUrl?: string;
+  occurred_at?: string;
+  occurredAt?: string;
+}
+
+export interface ParsedWebhookEvent {
+  /** Normalised event name, e.g. `room.finished`. */
+  eventType: string;
+  /** Juke space id this event is for, when extractable from the body. */
+  spaceId: string | null;
+  /** Optional Juke-side event id, when present in the body. */
+  eventId: string | null;
+}
+
+/**
+ * Extract `eventType` + `spaceId` + `eventId` from the Juke body without
+ * assuming a single shape. Juke's PR description names the events but the
+ * payload schema is not yet in llms.txt — be defensive.
+ */
+export function parseWebhookEvent(body: unknown): ParsedWebhookEvent {
+  const b = (body ?? {}) as JukeWebhookBody;
+  const eventType = (b.event ?? b.type ?? '').toString();
+  const spaceId =
+    b.space_id ??
+    b.spaceId ??
+    (typeof b.data === 'object' && b.data !== null
+      ? ((b.data as { space_id?: string; spaceId?: string; id?: string }).space_id ??
+        (b.data as { space_id?: string; spaceId?: string; id?: string }).spaceId ??
+        (b.data as { space_id?: string; spaceId?: string; id?: string }).id ??
+        null)
+      : null) ??
+    (typeof b.space === 'object' && b.space !== null
+      ? ((b.space as { id?: string }).id ?? null)
+      : null) ??
+    null;
+  const eventId =
+    typeof b.data === 'object' && b.data !== null
+      ? ((b.data as { id?: string }).id ?? null)
+      : null;
+  return { eventType, spaceId, eventId };
+}
+
+/** Pull the recording url from any reasonable place in the body. */
+function readRecordingUrl(body: unknown): string | null {
+  const b = (body ?? {}) as JukeWebhookBody;
+  if (typeof b.recording_url === 'string') return b.recording_url;
+  if (typeof b.recordingUrl === 'string') return b.recordingUrl;
+  if (b.data && typeof b.data === 'object') {
+    const d = b.data as { recording_url?: string; recordingUrl?: string; url?: string };
+    if (typeof d.recording_url === 'string') return d.recording_url;
+    if (typeof d.recordingUrl === 'string') return d.recordingUrl;
+    if (typeof d.url === 'string') return d.url;
+  }
+  return null;
+}
+
+function readOccurredAt(body: unknown): string {
+  const b = (body ?? {}) as JukeWebhookBody;
+  return b.occurred_at ?? b.occurredAt ?? new Date().toISOString();
+}
+
+/**
+ * Apply the side effects for one verified, deduplicated webhook event.
+ *
+ * Errors are surfaced to the caller — the route persists the error message
+ * on the corresponding `juke_webhook_events` row but always returns 200 so
+ * Juke does not retry a handler bug forever.
+ */
+export async function applyWebhookEvent(
+  eventType: string,
+  spaceId: string | null,
+  body: unknown,
+): Promise<void> {
+  if (!spaceId) {
+    // Without a space id there is nothing to update. Acknowledge silently.
+    return;
+  }
+  switch (eventType) {
+    case 'room.started': {
+      await updateJukeSpace(spaceId, { status: 'active', started_at: readOccurredAt(body) });
+      return;
+    }
+    case 'room.finished':
+    case 'room.ended': {
+      await updateJukeSpace(spaceId, { status: 'ended', ended_at: readOccurredAt(body) });
+      return;
+    }
+    case 'participant.joined': {
+      await bumpParticipantCount(spaceId, +1);
+      return;
+    }
+    case 'participant.left': {
+      await bumpParticipantCount(spaceId, -1);
+      return;
+    }
+    case 'recording.ready': {
+      const url = readRecordingUrl(body);
+      if (url) {
+        await updateJukeSpace(spaceId, { recording_url: url });
+      }
+      return;
+    }
+    default: {
+      // Unknown event - record only (the route already inserted the audit row).
+      return;
+    }
+  }
+}

--- a/src/lib/spaces/jukeWebhookVerify.test.ts
+++ b/src/lib/spaces/jukeWebhookVerify.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { parseJukeSignature, verifyJukeWebhook } from './jukeWebhookVerify';
+
+const SECRET = 'jk_whsec_test_only';
+
+function signed(body: string, ts: number = Math.floor(Date.now() / 1000)): string {
+  const sig = createHmac('sha256', SECRET).update(`${ts}.${body}`).digest('hex');
+  return `t=${ts},v1=${sig}`;
+}
+
+describe('parseJukeSignature', () => {
+  it('parses a well-formed header', () => {
+    expect(parseJukeSignature('t=123,v1=abc')).toEqual({ ts: 123, v1: 'abc' });
+  });
+
+  it('tolerates whitespace and reordered fields', () => {
+    expect(parseJukeSignature(' v1=abc , t=123 ')).toEqual({ ts: 123, v1: 'abc' });
+  });
+
+  it('ignores unknown fields', () => {
+    expect(parseJukeSignature('t=123,v1=abc,v2=xyz,foo=bar')).toEqual({ ts: 123, v1: 'abc' });
+  });
+
+  it('rejects when ts or v1 is missing', () => {
+    expect(parseJukeSignature('v1=abc')).toBeNull();
+    expect(parseJukeSignature('t=123')).toBeNull();
+    expect(parseJukeSignature('')).toBeNull();
+    expect(parseJukeSignature(null)).toBeNull();
+    expect(parseJukeSignature(undefined)).toBeNull();
+  });
+});
+
+describe('verifyJukeWebhook', () => {
+  it('accepts a valid signature within the replay window', () => {
+    const body = JSON.stringify({ event: 'room.finished', space_id: 'abc' });
+    const ts = Math.floor(Date.now() / 1000);
+    const header = signed(body, ts);
+    const result = verifyJukeWebhook(body, header, SECRET, ts);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.ts).toBe(ts);
+      expect(result.signatureHash).toMatch(/^[a-f0-9]{64}$/);
+    }
+  });
+
+  it('rejects a body that has been tampered with', () => {
+    const body = JSON.stringify({ event: 'room.finished', space_id: 'abc' });
+    const header = signed(body);
+    const result = verifyJukeWebhook(`${body} `, header, SECRET);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects when the timestamp is outside the replay window', () => {
+    const body = JSON.stringify({ event: 'room.finished' });
+    const ts = Math.floor(Date.now() / 1000) - 60 * 60;
+    const header = signed(body, ts);
+    const result = verifyJukeWebhook(body, header, SECRET);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/replay window/i);
+  });
+
+  it('rejects when the wrong secret signed the body', () => {
+    const body = JSON.stringify({ event: 'room.finished' });
+    const ts = Math.floor(Date.now() / 1000);
+    const wrong = createHmac('sha256', 'other').update(`${ts}.${body}`).digest('hex');
+    const header = `t=${ts},v1=${wrong}`;
+    const result = verifyJukeWebhook(body, header, SECRET, ts);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects when the secret is not configured', () => {
+    const body = '{}';
+    const result = verifyJukeWebhook(body, signed(body), '');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toMatch(/JUKE_WEBHOOK_SECRET/);
+  });
+
+  it('rejects a missing or malformed header', () => {
+    const body = '{}';
+    expect(verifyJukeWebhook(body, null, SECRET).ok).toBe(false);
+    expect(verifyJukeWebhook(body, 'garbage', SECRET).ok).toBe(false);
+  });
+
+  it('produces a deterministic signatureHash for idempotency', () => {
+    const body = JSON.stringify({ event: 'room.started', space_id: 'abc' });
+    const ts = Math.floor(Date.now() / 1000);
+    const header = signed(body, ts);
+    const a = verifyJukeWebhook(body, header, SECRET, ts);
+    const b = verifyJukeWebhook(body, header, SECRET, ts);
+    expect(a.ok && b.ok).toBe(true);
+    if (a.ok && b.ok) expect(a.signatureHash).toBe(b.signatureHash);
+  });
+});

--- a/src/lib/spaces/jukeWebhookVerify.ts
+++ b/src/lib/spaces/jukeWebhookVerify.ts
@@ -1,0 +1,89 @@
+/**
+ * HMAC verifier for Juke's outbound webhook deliveries (see Juke 2026-05-23
+ * PR: outbound developer webhooks).
+ *
+ * Juke signs each delivery with:
+ *
+ *     X-Juke-Signature: t={unix-ts-seconds},v1={hex-hmac-sha256}
+ *
+ * The signed payload is `f"{ts}.{body}"`, where `body` is the raw request body
+ * exactly as sent (do not re-serialize - whitespace differences will break the
+ * verification). The HMAC key is the secret shared at registration time via
+ * `POST /v1/developer/webhooks` and stored locally as `JUKE_WEBHOOK_SECRET`.
+ *
+ * Replay defense: we reject deliveries whose `t` is more than 5 minutes off
+ * from now. Juke retries at +10s/+60s/+300s so a 5-minute window covers the
+ * full retry ladder without admitting hour-old replays.
+ */
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+
+const REPLAY_WINDOW_SECONDS = 5 * 60;
+
+export interface ParsedSignature {
+  ts: number;
+  v1: string;
+}
+
+export type VerifyResult =
+  | { ok: true; ts: number; signatureHash: string }
+  | { ok: false; reason: string };
+
+/** Parse `t={ts},v1={hex}` (order-insensitive, ignores unknown keys). */
+export function parseJukeSignature(header: string | null | undefined): ParsedSignature | null {
+  if (!header) return null;
+  const parts = header.split(',').map((p) => p.trim());
+  let ts: number | null = null;
+  let v1: string | null = null;
+  for (const part of parts) {
+    const eq = part.indexOf('=');
+    if (eq <= 0) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key === 't') {
+      const n = Number(value);
+      if (Number.isFinite(n)) ts = n;
+    } else if (key === 'v1') {
+      v1 = value;
+    }
+  }
+  if (ts === null || !v1) return null;
+  return { ts, v1 };
+}
+
+/**
+ * Verify a webhook delivery. Caller passes the RAW body string (not parsed
+ * JSON) so the HMAC matches the bytes Juke signed.
+ *
+ * Returns either `{ ok: true, signatureHash }` (sha256 of the v1 hex - the
+ * idempotency key persisted in `juke_webhook_events`) or `{ ok: false, reason }`.
+ */
+export function verifyJukeWebhook(
+  rawBody: string,
+  signatureHeader: string | null | undefined,
+  secret: string,
+  now: number = Math.floor(Date.now() / 1000),
+): VerifyResult {
+  if (!secret) return { ok: false, reason: 'JUKE_WEBHOOK_SECRET not configured' };
+
+  const parsed = parseJukeSignature(signatureHeader);
+  if (!parsed) return { ok: false, reason: 'Missing or malformed X-Juke-Signature header' };
+
+  if (Math.abs(now - parsed.ts) > REPLAY_WINDOW_SECONDS) {
+    return { ok: false, reason: 'Signature timestamp outside replay window' };
+  }
+
+  const expected = createHmac('sha256', secret).update(`${parsed.ts}.${rawBody}`).digest('hex');
+
+  // timingSafeEqual requires equal-length buffers and throws otherwise.
+  if (expected.length !== parsed.v1.length) {
+    return { ok: false, reason: 'Signature length mismatch' };
+  }
+  const a = Buffer.from(expected, 'utf8');
+  const b = Buffer.from(parsed.v1, 'utf8');
+  if (!timingSafeEqual(a, b)) {
+    return { ok: false, reason: 'Signature mismatch' };
+  }
+
+  const signatureHash = createHash('sha256').update(parsed.v1).digest('hex');
+  return { ok: true, ts: parsed.ts, signatureHash };
+}


### PR DESCRIPTION
## Summary

Consume Juke's 2026-05-23 PR drop (9 of 11 ZAO asks closed in one ship). Closes loops on items #2/#4/#5/#6/#8/#10. Items #3/#7/#9/#11 are doc-only / await next iteration.

## What landed

### Inbound webhooks (item #2)
- New `POST /api/juke/webhooks` — verifies `X-Juke-Signature: t={ts},v1={hex_hmac}` over \`\${ts}.\${body}\`, 5-min replay window.
- Idempotent via unique \`signature_hash\` in \`juke_webhook_events\`. Duplicate deliveries return 200 with \`{duplicate:true}\`.
- Handlers: \`room.started\` → status=active + started_at; \`room.finished\` → status=ended + ended_at; \`participant.joined/left\` → bumpParticipantCount; \`recording.ready\` → recording_url.

### Persisted juke_spaces (foundational)
- \`/api/juke/space\` inserts a row on every successful create. Best-effort; if Supabase is down the API still returns the space id.
- \`/live/{id}\` now SSR's against the row: real title, OG image, status badge ("Live" / "Scheduled" / "Ended"), participant count.

### Recording (item #4)
- When \`recording.ready\` fires for a space, the room's \`recording_url\` is persisted. \`/live/{id}\` shows "Listen to the recording" CTA in the ended state.

### audio=off second-screen (item #6)
- \`jukeEmbedUrl(spaceId, { audioOff: true })\` appends \`?audio=off\`.
- \`/live/{id}?audio=off\` renders the passive view + a copy switch.
- "Mute (second screen)" button on the live page links to \`?audio=off\`.

### OG image (item #10)
- \`generateMetadata\` pulls \`juke.audio/space/{id}/opengraph-image\` for Open Graph + Twitter card. ZAO casts/X posts of \`/live/{id}\` now render the Juke-rendered branded card.

### iOS deeplink (item #8)
- "Open in Juke app" button uses \`juke.audio/space/{id}?open=app\` (universal link).

## Files

\`\`\`
NEW  scripts/juke-spaces-migration.sql
NEW  scripts/register-juke-webhook.ts
NEW  src/app/api/juke/webhooks/route.ts
NEW  src/lib/spaces/jukeSpacesDb.ts
NEW  src/lib/spaces/jukeWebhookVerify.ts
NEW  src/lib/spaces/jukeWebhookVerify.test.ts (11/11 pass)
NEW  src/lib/spaces/jukeWebhookHandlers.ts
MOD  src/app/api/juke/space/route.ts
MOD  src/app/live/[spaceId]/page.tsx
MOD  src/components/spaces/JukeEmbed.tsx
MOD  src/lib/env.ts
MOD  src/lib/spaces/juke.ts
\`\`\`

## Deploy steps (Zaal)

1. Apply \`scripts/juke-spaces-migration.sql\` against the ZAO OS Supabase (the MCP was pointed at ZAOcoworking when this was authored — apply manually via Studio).
2. Add \`JUKE_WEBHOOK_SECRET\` in Vercel env (Production + Preview):
   \`\`\`
   openssl rand -hex 32
   \`\`\`
3. Merge + deploy.
4. Once live, run:
   \`\`\`
   npx tsx scripts/register-juke-webhook.ts https://zaoos.com/api/juke/webhooks
   \`\`\`
   to subscribe (PR #4 of Nicky's drop: \`POST /v1/developer/webhooks\`).

## Test plan

- [x] \`npx vitest run src/lib/spaces/jukeWebhookVerify.test.ts\` — 11/11 pass.
- [x] \`npx tsc --noEmit\` — no juke-touching errors.
- [ ] After registration, hit a Juke space and end it; confirm \`juke_webhook_events\` row + \`juke_spaces.status='ended'\`.
- [ ] Open \`/live/{id}?audio=off\` while the iOS app is playing the same space — confirm no audio doubling.
- [ ] Cast \`/live/{id}\` from Farcaster — confirm Juke's OG image renders in the cast preview.

## Open Nicky asks (not done by his PR)

Still need from Nicky:
- Item #3 agent surface timeline.
- Item #7 participant FID list endpoint (we count, but don't know WHO).
- Item #9 desktop browser mic publish confirmation.
- Item #11 OSS SPEC.md timeline (he declined; llms.txt is the spec).

Will iterate as he ships more.