### PR TITLE
feat(spaces): host end-room confirm + listener queue position (audio UX patterns)

### DIFF
--- a/research/events/726-session-2026-05-23-tracker-ops-pack/README.md
+++ b/research/events/726-session-2026-05-23-tracker-ops-pack/README.md
@@ -1,0 +1,98 @@
+---
+topic: events
+type: guide
+status: research-complete
+last-validated: 2026-05-23
+related-docs: "712, 713, 714, 715"
+original-query: "all this - recap of the 2026-05-23 session: cowork tracker operational pack, brand filters, bot roster -> Supabase, ping-on-assign, /ping command, /meeting -> Supabase, NL-extractor bug fix, ZOE-as-agent-builder seed"
+tier: QUICK
+---
+
+# 726 - Session recap: cowork tracker operational pack (2026-05-23)
+
+> **Goal:** Record the 2026-05-23 work session - the cowork tracker went from a working-but-shallow tool to a full operational system. Seven PRs landed, the original 2026-05-23 sync bug was closed at the root, and the auto-test-task pattern was locked in as standing behavior.
+
+Direct follow-on to [doc 715](../715-session-2026-05-22-meeting-skill-diarization/) (yesterday's session recap - meeting skill upgrade + Tyler capture).
+
+## Key Outcomes
+
+| # | Outcome | Where | State |
+|---|---------|-------|-------|
+| 1 | Brand tags - multi-brand schema, filter chip, bot hashtags | ZAOcowork PR #4 | merged |
+| 2 | Cross-source visibility - read all tasks, write by UUID | ZAOcowork PR #5 | merged |
+| 3 | Ping-on-assign - DM the new owner on Telegram | ZAOcowork PR #6 | merged |
+| 4 | Bot prefers Supabase team_members for tg_id -> owner | ZAOcowork PR #7 | merged |
+| 5 | Multi-select brand filter pills + filter persistence | ZAOcowork PR #8 | merged |
+| 6 | `/ping <name> [#id] [msg]` - DM teammate via bot | ZAOcowork PR #9 | open |
+| 7 | NL add carries due/priority/notes; strip stray code fences | ZAOcowork PR #10 | open |
+| 8 | `/meeting` -> Supabase tracker (doc 713 step 1) | ZAOOS PR #638 | open |
+
+## What shipped
+
+### Brand-filter operational pack (PRs #4, #5, #8)
+
+The tracker only knew 2 "projects" (`zaodevz`, `wavewarz`) and `category` was internal task-type, not brand. Added a first-class `brands text[]` column with a GIN index, a 20-brand canonical vocab (`brands.ts` in both web + bot, kept in sync), and a multi-select toggle-pill row that shows only brands actually in use. Backfilled from `metadata.brand` so the 9 Tyler-meeting tasks immediately carried `ZAOstock` / `ZABAL Games`. Bot `/add #zaostock book the parklet` parses the hashtag and tags the brand at capture. Filter state persists per-user via localStorage so the board picks up where you left off.
+
+Cross-source visibility (PR #5) closed the gap where meeting-captured and bug-fix tasks lived in Supabase but were hidden by `legacy_source = 'cowork-actions.json'` filters. The fix piped the row UUID through as `ActionItem.dbId` and switched update/delete to target by UUID instead of `legacy_source + legacy_id`. Result: the board grew from ~213 to ~226 visible tasks and every task is editable from the web regardless of source.
+
+### The sync-bug root-cause arc (PRs #6, #7, #9, #10)
+
+Iman reported tasks not syncing. First diagnosis (team.json migration to the new repo) was a real architectural fix but wasn't the actual cause. Second diagnosis traced the real problem: the bot resolved `ctx.from.id -> Owner` via GitHub `data/team.json` only, and when that lookup failed silently the bot wrote `owner_id = NULL`, which then vanished from Iman's mine-only mine-only view, which looked like sync was broken, which made him re-add - which generated the duplicate `$70 food money` task we cleaned up.
+
+The fix was a stack:
+- **PR #7** added `team_members.telegram_id` (schema + Iman + Zaal seeded) and a `tgIdToOwnerSupabase` lookup the bot hits before falling back to GitHub team.json.
+- **PR #6** added `pingOwnerAssigned` to the web's `patchField` / `createItem` / `quickCreate` / `updateItem` so every web-driven assignment DMs the new owner from `@ZAOcoworkingBot` (best-effort, silent skip without `TELEGRAM_BOT_TOKEN`).
+- **PR #9** added `/ping <name> [#id] [msg]` - Iman or Zaal can flag urgent attention from inside the bot. Resolves target via Supabase (PR #7's column) first, GitHub fallback, declines on `Both` / `Open` sentinels.
+- **PR #10** closed the related NL-extractor bug: when the user said "add task with these properties," the LLM mis-routed Due / Priority / Notes onto a random existing task id (#43 Onboard Candy) because the `add` op schema only allowed `title / owner / category`. The fix extended `NewActionInput` + `makeActionItem` + `cmdAdd` to accept full metadata, taught the LLM via memory.ts examples, and added a `stripCodeFences()` pass for ugly ``` blocks leaking into Telegram replies.
+
+### `/meeting` -> Supabase (PR #638, open)
+
+doc 713 step 1. Replaced the `/meeting` skill's `gh api PUT` to the dead `cowork-zaodevz/data/actions.json` with a Supabase REST POST so every future meeting auto-writes onto the live board. Reads `team_members` to resolve owner names to UUIDs, tags `legacy_source = meeting:<slug>-<date>` so every meeting is traceable + revertable. Needs `~/.zao/cowork-tracker.env` on the runner.
+
+### Standing pattern locked: auto-PR-test-task
+
+After PR #4 shipped, Zaal asked for two things on every future PR: a test-plan PR comment + a Supabase tracker task for the right tester. Captured as `feedback_pr_auto_test_task.md` memory. From PR #5 onward every PR I shipped this session posted a structured test comment AND inserted a task in the cowork tracker (`legacy_source = pr-test:<repo>#<N>`). The session generated `test-pr-4` through `test-pr-10` + `test-pr-638` - 8 verification tasks queued for Iman + Zaal.
+
+### Restored data after the NL-editor bug
+
+Re-mapped the Fractal-promo metadata onto its rightful task #220 (P1, due 2026-05-24, full notes) and reset #43 "Onboard Candy" to P2 with no due / no notes after the bot's misroute. No data loss.
+
+## Open Items
+
+- **Bot restart on Iman's VPS** is required for PR #7, #9, #10 to take effect (process memory holds the system prompt + the new commands).
+- **Vercel env var `TELEGRAM_BOT_TOKEN`** on za-ocowork is required for PR #6 pings to actually fire. Without it the writes still work; the DM step skips silently.
+- **`~/.zao/cowork-tracker.env`** (chmod 600) on Zaal's mac is required for PR #638 (`/meeting` -> Supabase). Without it the script hard-fails with a clear message.
+- **PR #638, #9, #10** still open. Merge order does not matter (no overlap).
+- **Named saved views** for the brand filter - deferred from PR #8, tracked as `followup-saved-views` in Supabase, P3.
+- **Roster allowlist + admin + chats migration to Supabase** - the deeper roster move still pending; PR #7 only moved tg_id -> owner. Tracked as a follow-up.
+- **ZOE-as-agent-builder spec** - Zaal raised this mid-session; conflicts with the Hermes-canonical lock (project_hermes_canonical, 2026-05-05). Deferred to its own session via a self-contained seed in `/tmp/clipboard.html` - 8 open questions to grill, hard constraint surfaced. No code touched.
+
+## Also See
+
+- [Doc 712](../../business/712-zao-crm-coworking-app/) - ZAO CRM research (the original "make the tracker more operational" thread)
+- [Doc 713](../../dev-workflows/713-zao-ops-meeting-tracker-crm-bonfire/) - combined meeting/tracker/CRM/Bonfire system (PR #638 was step 1)
+- [Doc 714](../714-tyler-zabal-zaostock-may22/) - Tyler meeting, the trigger for the cross-source visibility fix (his 9 todos were the invisible ones)
+- [Doc 715](../715-session-2026-05-22-meeting-skill-diarization/) - yesterday's session recap
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Set `TELEGRAM_BOT_TOKEN` on Vercel za-ocowork | @Zaal | Manual | Before testing PR #6 |
+| Create `~/.zao/cowork-tracker.env` with Supabase keys | @Zaal | Manual | Before testing PR #638 |
+| Restart bot on VPS | @Iman | Manual | After #7, #9, #10 merge |
+| Walk Iman through the 7 test plans (PR #4-#10 + #638) | @Iman | Test | This week |
+| Complete the deeper roster migration (allowlist + admin + chats to Supabase) | @Zaal | Build | Follow-up |
+| Build named saved views for the brand filter | @Zaal | Build | Polish backlog |
+| ZOE agent-builder spec - new session, no code | @Zaal | Research doc | When ready |
+
+## Sources
+
+- [ZAOcowork PR #4 - brand tags](https://github.com/ZAODEVZ/ZAOcowork/pull/4) [FULL - merged]
+- [ZAOcowork PR #5 - cross-source visibility](https://github.com/ZAODEVZ/ZAOcowork/pull/5) [FULL - merged]
+- [ZAOcowork PR #6 - ping-on-assign](https://github.com/ZAODEVZ/ZAOcowork/pull/6) [FULL - merged]
+- [ZAOcowork PR #7 - bot roster to Supabase](https://github.com/ZAODEVZ/ZAOcowork/pull/7) [FULL - merged]
+- [ZAOcowork PR #8 - multi-select brand pills](https://github.com/ZAODEVZ/ZAOcowork/pull/8) [FULL - merged]
+- [ZAOcowork PR #9 - /ping command](https://github.com/ZAODEVZ/ZAOcowork/pull/9) [FULL - open]
+- [ZAOcowork PR #10 - NL add fix + code-fence strip](https://github.com/ZAODEVZ/ZAOcowork/pull/10) [FULL - open]
+- [ZAOOS PR #638 - /meeting -> Supabase](https://github.com/bettercallzaal/ZAOOS/pull/638) [FULL - open]

--- a/src/app/live/recordings/page.tsx
+++ b/src/app/live/recordings/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { jukeSpaceOgImageUrl } from '@/lib/spaces/juke';
+import { listRecordedJukeSpaces, type JukeSpaceRow } from '@/lib/spaces/jukeSpacesDb';
+import { communityConfig } from '../../../../community.config';
+
+export const metadata: Metadata = {
+  title: `Juke Recordings - ${communityConfig.name}`,
+  description: 'Past Juke audio spaces hosted by The ZAO, with recordings.',
+  robots: { index: false },
+};
+
+/** Render a friendly relative date — "3h ago", "2d ago", "May 22" once we
+ * pass a week, so the recording shelf stays scannable. */
+function formatEndedAt(value: string | null): string {
+  if (!value) return 'recently';
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return 'recently';
+  const diffMs = Date.now() - ts;
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${Math.max(1, minutes)}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/** Safe wrapper around the Supabase query — returns [] on any failure so the
+ * page still renders an empty state instead of a 500. */
+async function safeListRecordings(): Promise<JukeSpaceRow[]> {
+  try {
+    return await listRecordedJukeSpaces(25);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * /live/recordings - shelf of past Juke spaces with recordings.
+ *
+ * Driven by the `recording.ready` webhook from Juke (PR 2026-05-23 item #4):
+ * once Juke stores the recording URL on `juke_spaces.recording_url`, every
+ * ended space with a recording shows up here without further plumbing.
+ *
+ * The OG image comes from juke.audio/space/{id}/opengraph-image so each row
+ * carries Juke's branded thumbnail.
+ */
+export default async function LiveRecordingsPage() {
+  const recordings = await safeListRecordings();
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] text-white">
+      <header className="border-b border-white/[0.08] bg-[#0d1b2a]">
+        <div className="flex items-center gap-3 px-4 py-4 max-w-4xl mx-auto w-full">
+          <Link
+            href="/spaces"
+            aria-label="Back to Spaces"
+            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-800 hover:text-[#f5a623]"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <div className="min-w-0">
+            <h1 className="text-base sm:text-lg font-bold">Juke recordings</h1>
+            <p className="text-xs text-gray-500">Past audio spaces hosted by {communityConfig.name}.</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1 px-4 py-6 max-w-4xl mx-auto w-full">
+        {recordings.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <ul className="grid gap-3 sm:grid-cols-2">
+            {recordings.map((row) => (
+              <RecordingCard key={row.id} row={row} endedLabel={formatEndedAt(row.ended_at)} />
+            ))}
+          </ul>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center">
+      <div className="w-16 h-16 rounded-full bg-[#f5a623]/10 flex items-center justify-center mb-5">
+        <svg className="w-8 h-8 text-[#f5a623]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-14 0m7 7v4m-4 0h8m-7-15a3 3 0 016 0v6a3 3 0 11-6 0V5z" />
+        </svg>
+      </div>
+      <h2 className="text-lg font-semibold mb-1">No recordings yet</h2>
+      <p className="text-gray-500 text-sm max-w-xs">
+        When a ZAO Juke space ends with recording on, it shows up here. Host enables recording from
+        the Juke iOS app.
+      </p>
+      <Link
+        href="/spaces"
+        className="mt-6 inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-sm font-bold transition-colors"
+      >
+        Back to Spaces
+      </Link>
+    </div>
+  );
+}
+
+function RecordingCard({ row, endedLabel }: { row: JukeSpaceRow; endedLabel: string }) {
+  // `row.recording_url` is filtered to NOT NULL in the query, but the type is
+  // still `string | null` — guard locally so TypeScript is happy and the
+  // anchor stays well-formed.
+  const recordingUrl = row.recording_url ?? '';
+  const ogImage = jukeSpaceOgImageUrl(row.id);
+  return (
+    <li className="group bg-[#111d2e] border border-white/[0.08] rounded-xl overflow-hidden transition-all hover:border-gray-600 hover:shadow-lg hover:shadow-black/20">
+      <Link
+        href={`/live/${row.id}`}
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+        aria-label={`Open recording: ${row.title}`}
+      >
+        <div className="aspect-[1200/630] bg-[#0a1628] relative overflow-hidden">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={ogImage}
+            alt=""
+            className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+            loading="lazy"
+          />
+          <div className="absolute top-2 left-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-black/60 backdrop-blur-sm text-[10px] font-bold uppercase tracking-wider text-gray-200">
+            Recording
+          </div>
+        </div>
+        <div className="p-4">
+          <h3 className="text-sm font-bold leading-tight line-clamp-2 group-hover:text-[#f5a623] transition-colors">
+            {row.title || 'Untitled space'}
+          </h3>
+          <p className="text-gray-500 text-xs mt-2">
+            Ended {endedLabel}
+            {typeof row.participant_count === 'number' && row.participant_count > 0 && (
+              <>
+                {' - '}
+                {row.participant_count} {row.participant_count === 1 ? 'listener' : 'listeners'}
+              </>
+            )}
+          </p>
+        </div>
+      </Link>
+      <div className="px-4 pb-4">
+        <a
+          href={recordingUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center justify-center w-full px-4 py-2 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+        >
+          Listen to recording
+        </a>
+      </div>
+    </li>
+  );
+}

--- a/src/app/spaces/[id]/page.tsx
+++ b/src/app/spaces/[id]/page.tsx
@@ -11,6 +11,8 @@ import { communityConfig } from '../../../../community.config';
 import { AudioRoomAdapter } from '@/components/spaces/AudioRoomAdapter';
 import type { Room } from '@/lib/spaces/roomsDb';
 
+import { EndRoomConfirm } from '@/components/spaces/EndRoomConfirm';
+
 // Lazy-load heavy SDKs — Stream.io is ~150KB, only load when entering a room
 const StreamWrapper = dynamic(
   () => import('@/components/spaces/StreamWrapper').then((m) => ({ default: m.StreamWrapper })),
@@ -187,8 +189,12 @@ export default function PublicRoomPage() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [room?.id]);
 
-  const handleLeave = async () => {
-    // End session tracking (keepalive so it survives navigation)
+  /**
+   * Leave the room for this user only. Does NOT close the room for everyone
+   * else - safe to call from the host's "Leave only" path or any non-host's
+   * Leave button.
+   */
+  const leaveSelfOnly = async () => {
     if (room?.id) {
       fetch('/api/spaces/session', {
         method: 'PATCH',
@@ -199,14 +205,33 @@ export default function PublicRoomPage() {
     }
     if (call) await call.leave().catch(console.error);
     if (client) await client.disconnectUser().catch(console.error);
-    if (canEndRoom && room) {
-      await fetch(`/api/stream/rooms/${room.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'end' }),
-      }).catch(console.error);
-    }
     router.push('/spaces');
+  };
+
+  /**
+   * End the room for everyone, then leave for this user. Host + admin only.
+   * Triggered after the EndRoomConfirm dialog accepts.
+   */
+  const endRoomForEveryone = async () => {
+    if (!room) return;
+    await fetch(`/api/stream/rooms/${room.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'end' }),
+    }).catch(console.error);
+    await leaveSelfOnly();
+  };
+
+  // Click handler for the room's Leave/End button. Hosts + admins land in
+  // the confirm dialog before the room ends for everyone; listeners leave
+  // straight away.
+  const [confirmingEnd, setConfirmingEnd] = useState(false);
+  const handleLeave = async () => {
+    if (canEndRoom) {
+      setConfirmingEnd(true);
+      return;
+    }
+    await leaveSelfOnly();
   };
 
   if (loading || authLoading) {
@@ -305,6 +330,24 @@ export default function PublicRoomPage() {
           currentTheme={room.theme || 'default'}
           onClose={() => setShowEdit(false)}
           onSaved={(updated) => setRoom(prev => prev ? { ...prev, ...updated } : prev)}
+        />
+      )}
+      {confirmingEnd && room && (
+        <EndRoomConfirm
+          roomTitle={room.title}
+          onCancel={() => setConfirmingEnd(false)}
+          onConfirm={async () => {
+            setConfirmingEnd(false);
+            await endRoomForEveryone();
+          }}
+          onLeaveOnly={
+            isAdmin && !isHost
+              ? async () => {
+                  setConfirmingEnd(false);
+                  await leaveSelfOnly();
+                }
+              : undefined
+          }
         />
       )}
       <header className="border-b border-white/[0.08] bg-[#0d1b2a] relative">

--- a/src/app/spaces/[id]/page.tsx
+++ b/src/app/spaces/[id]/page.tsx
@@ -390,7 +390,8 @@ export default function PublicRoomPage() {
               )}
               <button
                 onClick={handleLeave}
-                className="px-3 py-1.5 bg-red-500/10 text-red-400 border border-red-500/20 rounded-lg text-xs sm:text-sm font-medium hover:bg-red-500/20 transition-colors"
+                aria-label={canEndRoom ? 'End room for everyone' : 'Leave room'}
+                className="px-3 py-1.5 bg-red-500/10 text-red-400 border border-red-500/20 rounded-lg text-xs sm:text-sm font-medium hover:bg-red-500/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
               >
                 {canEndRoom ? 'End' : 'Leave'}
               </button>

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -100,18 +100,26 @@ export default function PublicSpacesPage() {
         backHref="/home"
         count={stages.length > 0 ? stages.length : undefined}
         rightAction={
-          user ? (
-            <button onClick={() => setShowHostModal(true)} className="flex items-center gap-1.5 px-4 py-2 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-sm font-bold rounded-xl transition-colors shadow-lg shadow-[#f5a623]/20">
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-              </svg>
-              Go Live
-            </button>
-          ) : (
-            <Link href="/" className="px-3 py-1.5 text-xs font-medium text-[#f5a623] border border-[#f5a623]/30 rounded-lg hover:bg-[#f5a623]/10 transition-colors">
-              Sign in to host
+          <div className="flex items-center gap-2">
+            <Link
+              href="/live/recordings"
+              className="hidden sm:inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-300 border border-white/[0.12] rounded-lg hover:bg-white/[0.04] hover:text-white transition-colors"
+            >
+              Recordings
             </Link>
-          )
+            {user ? (
+              <button onClick={() => setShowHostModal(true)} className="flex items-center gap-1.5 px-4 py-2 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-sm font-bold rounded-xl transition-colors shadow-lg shadow-[#f5a623]/20">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                </svg>
+                Go Live
+              </button>
+            ) : (
+              <Link href="/" className="px-3 py-1.5 text-xs font-medium text-[#f5a623] border border-[#f5a623]/30 rounded-lg hover:bg-[#f5a623]/10 transition-colors">
+                Sign in to host
+              </Link>
+            )}
+          </div>
         }
       />
 

--- a/src/components/spaces/CameraButton.tsx
+++ b/src/components/spaces/CameraButton.tsx
@@ -25,7 +25,8 @@ export function CameraButton() {
           }
         }}
         disabled={requesting}
-        className="px-4 py-2.5 bg-[#1a2a3a] text-gray-300 border border-white/[0.08] rounded-xl text-sm transition-colors hover:text-white disabled:opacity-50"
+        aria-label={requesting ? 'Requesting camera permission' : 'Request camera'}
+        className="px-4 py-2.5 bg-[#1a2a3a] text-gray-300 border border-white/[0.08] rounded-xl text-sm transition-colors hover:text-white disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
       >
         {requesting ? 'Requesting...' : 'Camera'}
       </button>
@@ -35,7 +36,9 @@ export function CameraButton() {
   return (
     <button
       onClick={() => camera.toggle()}
-      className={`px-4 py-2.5 rounded-xl font-semibold text-sm transition-colors flex items-center gap-1.5 ${
+      aria-pressed={!isCameraOff}
+      aria-label={isCameraOff ? 'Turn camera on (C)' : 'Turn camera off (C)'}
+      className={`px-4 py-2.5 rounded-xl font-semibold text-sm transition-colors flex items-center gap-1.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628] ${
         isCameraOff
           ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
           : 'bg-blue-600 text-white hover:bg-blue-500'

--- a/src/components/spaces/EndRoomConfirm.tsx
+++ b/src/components/spaces/EndRoomConfirm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface EndRoomConfirmProps {
+  /** Title of the room — surfaces in the dialog so the host can sanity-check. */
+  roomTitle: string;
+  /** Closes the dialog without ending the room. */
+  onCancel: () => void;
+  /** End the room for everyone. The caller leaves Stream + PATCH /api/stream/rooms/{id} action=end. */
+  onConfirm: () => Promise<void> | void;
+  /**
+   * When the actor is also allowed to *just leave* (admin viewing someone
+   * else's room, for instance), surface a third option so they don't have to
+   * cancel and re-click. Defaults to undefined = hidden.
+   */
+  onLeaveOnly?: () => Promise<void> | void;
+}
+
+/**
+ * Confirmation dialog that fires before an `End` action in a Spaces room.
+ * Surfaced for hosts + admins because a fat-thumb End kills the room for
+ * every listener at once. Plain `Leave` actions skip this entirely.
+ *
+ * Esc closes the dialog. Focus is sent to Cancel so a stray Enter does not
+ * end the room.
+ */
+export function EndRoomConfirm({
+  roomTitle,
+  onCancel,
+  onConfirm,
+  onLeaveOnly,
+}: EndRoomConfirmProps) {
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm px-0 sm:px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="end-room-title"
+    >
+      <div className="bg-[#0d1b2a] border border-white/[0.08] rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-md">
+        <div className="mb-2 flex items-center gap-2">
+          <span className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" aria-hidden="true" />
+          <span className="text-red-400 text-[10px] font-bold tracking-wider uppercase">
+            Ends room for everyone
+          </span>
+        </div>
+        <h2 id="end-room-title" className="text-white text-lg font-bold mb-1">
+          End this room?
+        </h2>
+        <p className="text-gray-400 text-sm leading-relaxed mb-5">
+          <span className="text-white font-semibold">{roomTitle || 'This room'}</span> will close
+          for everyone listening. The recording (if on) stops here.
+        </p>
+
+        <div className={`grid gap-2 ${onLeaveOnly ? 'sm:grid-cols-3' : 'sm:grid-cols-2'}`}>
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2.5 rounded-xl border border-white/[0.08] bg-[#1a2a3a] text-gray-300 text-sm font-semibold hover:bg-[#22364a] transition-colors"
+          >
+            Cancel
+          </button>
+          {onLeaveOnly && (
+            <button
+              type="button"
+              onClick={onLeaveOnly}
+              className="px-4 py-2.5 rounded-xl border border-white/[0.08] bg-[#1a2a3a] text-gray-300 text-sm font-semibold hover:bg-[#22364a] transition-colors"
+            >
+              Leave only
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-4 py-2.5 rounded-xl bg-red-500/90 hover:bg-red-500 text-white text-sm font-bold transition-colors"
+          >
+            End room
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/spaces/HandRaiseQueue.tsx
+++ b/src/components/spaces/HandRaiseQueue.tsx
@@ -95,7 +95,7 @@ export function HandRaiseQueue({ roomId, fid, isHost }: HandRaiseQueueProps) {
           disabled={loading}
           aria-pressed={isRaised}
           aria-label={label}
-          className={`relative p-2.5 rounded-xl text-sm transition-colors border ${
+          className={`relative p-2.5 rounded-xl text-sm transition-colors border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628] ${
             isRaised
               ? 'bg-[#f5a623]/15 border-[#f5a623]/40 text-[#f5a623]'
               : 'bg-[#1a2a3a] text-gray-400 hover:text-[#f5a623] border-white/[0.08] hover:border-[#f5a623]/40'

--- a/src/components/spaces/HandRaiseQueue.tsx
+++ b/src/components/spaces/HandRaiseQueue.tsx
@@ -69,27 +69,59 @@ export function HandRaiseQueue({ roomId, fid, isHost }: HandRaiseQueueProps) {
   };
 
   const raisedHands = raises.filter((r) => r.status === 'raised');
+  // Listener-only: 1-indexed position of this FID in the raised-hand queue,
+  // or null when the user has not raised. Surfacing this closes the "did the
+  // host see me?" doubt loop documented in the Clubhouse postmortem.
+  const myQueuePosition = (() => {
+    if (myStatus !== 'raised') return null;
+    const idx = raisedHands.findIndex((r) => r.fid === fid);
+    return idx >= 0 ? idx + 1 : null;
+  })();
 
-  // Listener view: raise/lower hand button
+  // Listener view: raise/lower hand button + queue position when raised.
   if (!isHost) {
+    const isRaised = myStatus === 'raised';
+    const label = isRaised
+      ? myQueuePosition === 1
+        ? 'You are next'
+        : myQueuePosition
+          ? `You are #${myQueuePosition} in line`
+          : 'Hand raised'
+      : 'Raise hand';
     return (
-      <button
-        onClick={() => doAction(myStatus === 'raised' ? 'lower' : 'raise')}
-        disabled={loading}
-        className={`relative p-2.5 rounded-xl text-sm transition-colors border ${
-          myStatus === 'raised'
-            ? 'bg-[#f5a623]/15 border-[#f5a623]/40 text-[#f5a623]'
-            : 'bg-[#1a2a3a] text-gray-400 hover:text-[#f5a623] border-white/[0.08] hover:border-[#f5a623]/40'
-        }`}
-        title={myStatus === 'raised' ? 'Lower hand' : 'Raise hand'}
-      >
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M10.05 4.575a1.575 1.575 0 10-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 013.15 0v1.5m-3.15 0l-.075 5.925m3.075-5.925a1.575 1.575 0 013.15 0v1.5m-3.15-1.5v5.925m3.15-5.925v3.075M16.5 12.75v-3m0 3c0 3.375-2.7 6.75-6 6.75s-6-3.375-6-6.75V7.5m0 0a1.575 1.575 0 013.15 0" />
-        </svg>
-        {myStatus === 'raised' && (
-          <span className="absolute -top-1 -right-1 w-2 h-2 bg-[#f5a623] rounded-full" />
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => doAction(isRaised ? 'lower' : 'raise')}
+          disabled={loading}
+          aria-pressed={isRaised}
+          aria-label={label}
+          className={`relative p-2.5 rounded-xl text-sm transition-colors border ${
+            isRaised
+              ? 'bg-[#f5a623]/15 border-[#f5a623]/40 text-[#f5a623]'
+              : 'bg-[#1a2a3a] text-gray-400 hover:text-[#f5a623] border-white/[0.08] hover:border-[#f5a623]/40'
+          }`}
+          title={isRaised ? 'Lower hand' : 'Raise hand'}
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.05 4.575a1.575 1.575 0 10-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 013.15 0v1.5m-3.15 0l-.075 5.925m3.075-5.925a1.575 1.575 0 013.15 0v1.5m-3.15-1.5v5.925m3.15-5.925v3.075M16.5 12.75v-3m0 3c0 3.375-2.7 6.75-6 6.75s-6-3.375-6-6.75V7.5m0 0a1.575 1.575 0 013.15 0" />
+          </svg>
+          {isRaised && (
+            <span
+              className="absolute -top-1 -right-1 w-2 h-2 bg-[#f5a623] rounded-full"
+              aria-hidden="true"
+            />
+          )}
+        </button>
+        {isRaised && (
+          <span
+            className="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-xs font-semibold"
+            aria-live="polite"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-[#f5a623] animate-pulse" aria-hidden="true" />
+            {label}
+          </span>
         )}
-      </button>
+      </div>
     );
   }
 

--- a/src/components/spaces/MicButton.tsx
+++ b/src/components/spaces/MicButton.tsx
@@ -25,7 +25,8 @@ export function MicButton() {
           }
         }}
         disabled={requesting}
-        className="px-6 py-2.5 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] rounded-xl font-semibold text-sm transition-colors disabled:opacity-50"
+        aria-label={requesting ? 'Requesting permission to speak' : 'Request to speak'}
+        className="px-6 py-2.5 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] rounded-xl font-semibold text-sm transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
       >
         {requesting ? 'Requesting...' : 'Request to Speak'}
       </button>
@@ -35,7 +36,9 @@ export function MicButton() {
   return (
     <button
       onClick={() => microphone.toggle()}
-      className={`px-6 py-2.5 rounded-xl font-semibold text-sm transition-colors ${
+      aria-pressed={!isMute}
+      aria-label={isMute ? 'Unmute microphone (Space)' : 'Mute microphone (Space)'}
+      className={`px-6 py-2.5 rounded-xl font-semibold text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628] ${
         isMute
           ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
           : 'bg-green-600 text-white hover:bg-green-500'

--- a/src/components/spaces/MicLiveToast.tsx
+++ b/src/components/spaces/MicLiveToast.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useCallStateHooks } from '@stream-io/video-react-sdk';
+
+/**
+ * One-time confirmation toast that fires the first time the user unmutes in
+ * a room session. Pattern lifted from Zoom + Google Meet - the "mic is live"
+ * confirmation closes the "did my mic actually work" doubt loop documented
+ * in the Clubhouse + Twitter Spaces audio-room postmortems.
+ *
+ * Renders nothing on initial mount (so an already-unmuted host does not get
+ * a phantom toast on join). Tracks the prior `isMute` value via a ref and
+ * fires only on the off-to-on transition.
+ *
+ * Auto-dismisses after 3 seconds. Shows once per session - we do not
+ * persist across reloads, the gap is "first unmute of this session" not
+ * "first ever."
+ */
+export function MicLiveToast() {
+  const { useMicrophoneState } = useCallStateHooks();
+  const { isMute } = useMicrophoneState();
+  const wasMuteRef = useRef<boolean | null>(null);
+  const hasShownRef = useRef(false);
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    // First mount - record current state and skip.
+    if (wasMuteRef.current === null) {
+      wasMuteRef.current = isMute;
+      return;
+    }
+    const transitionedToLive = wasMuteRef.current === true && isMute === false;
+    wasMuteRef.current = isMute;
+
+    if (!transitionedToLive || hasShownRef.current) return;
+    hasShownRef.current = true;
+    setShow(true);
+    const t = setTimeout(() => setShow(false), 3000);
+    return () => clearTimeout(t);
+  }, [isMute]);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[57] pointer-events-none"
+      aria-live="polite"
+    >
+      <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-green-500/15 border border-green-500/40 text-green-300 text-sm font-semibold backdrop-blur-md shadow-lg shadow-green-500/10">
+        <span className="relative flex h-2 w-2" aria-hidden="true">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+        </span>
+        Your mic is live - say something
+      </div>
+    </div>
+  );
+}

--- a/src/components/spaces/PermissionRequests.tsx
+++ b/src/components/spaces/PermissionRequests.tsx
@@ -1,8 +1,25 @@
 'use client';
 
+import Image from 'next/image';
 import { useState, useEffect, useCallback } from 'react';
 import { useCall, type PermissionRequestEvent } from '@stream-io/video-react-sdk';
 
+/**
+ * Host-only banner that surfaces inbound capability requests from listeners.
+ * Stream fires `call.permission_request` whenever a listener taps "request
+ * mic" / "request camera" / "request screen share" inside the room. The host
+ * grants or denies inline.
+ *
+ * Patterns lifted from the audio-room research:
+ *
+ * - Show the requester's pfp + display name, not just the user id, so the
+ *   host can recognise people at a glance (Discord Stage moderation default).
+ * - Surface the SPECIFIC capability ("camera", "mic", "screen share") rather
+ *   than the generic "wants to speak" — Video Rooms can mix all three.
+ * - aria-live=polite so screen readers announce new requests.
+ * - Allow + Deny are distinguished by both colour AND icon (WCAG, classroom-
+ *   kit research) — not colour alone.
+ */
 export function PermissionRequests() {
   const call = useCall();
   const [requests, setRequests] = useState<PermissionRequestEvent[]>([]);
@@ -15,46 +32,105 @@ export function PermissionRequests() {
     return unsub;
   }, [call]);
 
+  const removeRequest = useCallback((userId: string) => {
+    setRequests((prev) => prev.filter((r) => r.user.id !== userId));
+  }, []);
+
   const handleGrant = useCallback(
     async (request: PermissionRequestEvent) => {
       await call?.grantPermissions(request.user.id, request.permissions);
-      setRequests((prev) => prev.filter((r) => r.user.id !== request.user.id));
+      removeRequest(request.user.id);
     },
-    [call]
+    [call, removeRequest],
   );
 
   const handleDeny = useCallback(
     (request: PermissionRequestEvent) => {
-      setRequests((prev) => prev.filter((r) => r.user.id !== request.user.id));
+      removeRequest(request.user.id);
     },
-    []
+    [removeRequest],
   );
 
   if (requests.length === 0) return null;
 
   return (
-    <div className="px-4 py-2 border-b border-white/[0.08]">
-      {requests.map((request) => (
-        <div key={request.user.id} className="flex items-center justify-between py-1.5">
-          <span className="text-gray-300 text-sm">
-            <strong>{request.user.name || request.user.id}</strong> wants to speak
-          </span>
-          <div className="flex gap-2">
-            <button
-              onClick={() => handleGrant(request)}
-              className="text-xs px-3 py-1 bg-green-600/20 text-green-400 rounded-lg hover:bg-green-600/30"
-            >
-              Allow
-            </button>
-            <button
-              onClick={() => handleDeny(request)}
-              className="text-xs px-3 py-1 bg-red-600/20 text-red-400 rounded-lg hover:bg-red-600/30"
-            >
-              Deny
-            </button>
-          </div>
-        </div>
-      ))}
+    <div
+      className="px-4 py-2 border-b border-white/[0.08] bg-[#0d1b2a]/60"
+      aria-live="polite"
+      aria-label={`${requests.length} pending permission ${requests.length === 1 ? 'request' : 'requests'}`}
+    >
+      <ul className="space-y-1.5">
+        {requests.map((request) => (
+          <li key={request.user.id} className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2 min-w-0">
+              {request.user.image ? (
+                <Image
+                  src={request.user.image}
+                  alt={request.user.name || request.user.id}
+                  width={28}
+                  height={28}
+                  className="w-7 h-7 rounded-full object-cover"
+                  unoptimized
+                />
+              ) : (
+                <div className="w-7 h-7 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center text-white text-xs font-bold">
+                  {(request.user.name || request.user.id || '?')[0]?.toUpperCase()}
+                </div>
+              )}
+              <div className="min-w-0">
+                <p className="text-white text-sm font-semibold truncate">
+                  {request.user.name || request.user.id}
+                </p>
+                <p className="text-gray-500 text-xs truncate">
+                  wants {humanizePermissions(request.permissions)}
+                </p>
+              </div>
+            </div>
+            <div className="flex gap-1.5 flex-shrink-0">
+              <button
+                type="button"
+                onClick={() => handleGrant(request)}
+                aria-label={`Allow ${request.user.name || request.user.id}`}
+                className="inline-flex items-center gap-1 text-xs px-3 py-1.5 bg-green-600/15 border border-green-600/30 text-green-400 rounded-lg hover:bg-green-600/25 transition-colors font-semibold"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                </svg>
+                Allow
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDeny(request)}
+                aria-label={`Deny ${request.user.name || request.user.id}`}
+                className="inline-flex items-center gap-1 text-xs px-3 py-1.5 bg-red-600/15 border border-red-600/30 text-red-400 rounded-lg hover:bg-red-600/25 transition-colors font-semibold"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+                Deny
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
+}
+
+/**
+ * Translate Stream's permission ids into human copy. Stream uses constants
+ * like "send-audio", "send-video", "screenshare". Anything we do not
+ * recognise falls back to "to speak" so the host always sees something.
+ */
+function humanizePermissions(permissions: string[]): string {
+  const parts: string[] = [];
+  const has = (needle: string) =>
+    permissions.some((p) => p.toLowerCase().includes(needle));
+  if (has('audio') || has('mic')) parts.push('mic');
+  if (has('video') || has('cam')) parts.push('camera');
+  if (has('screen')) parts.push('screen share');
+  if (parts.length === 0) return 'to speak';
+  if (parts.length === 1) return parts[0];
+  if (parts.length === 2) return `${parts[0]} + ${parts[1]}`;
+  return parts.slice(0, -1).join(', ') + ', and ' + parts[parts.length - 1];
 }

--- a/src/components/spaces/PromotionConfirm.tsx
+++ b/src/components/spaces/PromotionConfirm.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useCall, useCallStateHooks, OwnCapability } from '@stream-io/video-react-sdk';
+
+/**
+ * Listener-side promotion confirm. Fires when the host grants SEND_AUDIO (or
+ * SEND_VIDEO / SCREEN_SHARE) to the current user — Stream owns the underlying
+ * permission state, this UI gives the listener a 5-second window to either
+ * "Go on stage" (accept + auto-unmute mic) or "Stay as listener" (the host's
+ * grant remains, but the mic stays off).
+ *
+ * Why veto matters: Clubhouse auto-promoted with no listener consent and the
+ * "I wasn't ready to speak" complaint was one of the loudest in the post-
+ * mortem. The 5s countdown auto-accepts, so the silent path still lands a
+ * speaker on stage if they just walk away from the screen.
+ *
+ * Detection: subscribes to `useOwnCapabilities()`. When the set goes from
+ * "missing SEND_AUDIO" to "has SEND_AUDIO" (or video / screen-share), the
+ * dialog opens once and remembers the granted set so it does not re-open
+ * for the same grant on rerenders.
+ */
+export function PromotionConfirm() {
+  const call = useCall();
+  const { useOwnCapabilities } = useCallStateHooks();
+  const ownCapabilities = useOwnCapabilities();
+
+  const [open, setOpen] = useState(false);
+  const [countdown, setCountdown] = useState(5);
+  // Stable set so re-entering an already-acknowledged capability does not
+  // re-pop the dialog after the user dismissed it.
+  const lastSeenSet = useRef<Set<string>>(new Set());
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Detect new grants and open the dialog.
+  useEffect(() => {
+    const current = new Set(ownCapabilities ?? []);
+    const newlyGranted = [...current].some((cap) => !lastSeenSet.current.has(cap));
+    const wantedNew = [
+      OwnCapability.SEND_AUDIO,
+      OwnCapability.SEND_VIDEO,
+      OwnCapability.SCREENSHARE,
+    ].some((cap) => current.has(cap) && !lastSeenSet.current.has(cap));
+
+    if (newlyGranted && wantedNew) {
+      setOpen(true);
+      setCountdown(5);
+    }
+    lastSeenSet.current = current;
+  }, [ownCapabilities]);
+
+  // Countdown to auto-accept.
+  useEffect(() => {
+    if (!open) return;
+    timerRef.current = setInterval(() => {
+      setCountdown((c) => {
+        if (c <= 1) {
+          if (timerRef.current) clearInterval(timerRef.current);
+          handleAccept();
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    cancelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleStay();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  async function handleAccept() {
+    setOpen(false);
+    if (timerRef.current) clearInterval(timerRef.current);
+    // Best-effort. Stream raises if the SDK is mid-disconnect; harmless.
+    await call?.microphone?.enable().catch(() => {});
+  }
+
+  function handleStay() {
+    setOpen(false);
+    if (timerRef.current) clearInterval(timerRef.current);
+    // Intentionally leaves the underlying SDK permission set unchanged. The
+    // listener can flip the mic on later via the controls panel.
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[59] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm px-0 sm:px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="promotion-title"
+    >
+      <div className="bg-[#0d1b2a] border border-[#f5a623]/30 rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-md shadow-xl shadow-[#f5a623]/10">
+        <div className="mb-2 inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-[10px] font-bold tracking-wider uppercase">
+          <span className="w-1.5 h-1.5 rounded-full bg-[#f5a623] animate-pulse" aria-hidden="true" />
+          Host promoted you
+        </div>
+        <h2 id="promotion-title" className="text-white text-lg font-bold mt-2 mb-1">
+          You can speak now
+        </h2>
+        <p className="text-gray-400 text-sm leading-relaxed mb-5">
+          Tap <span className="text-white font-semibold">Go on stage</span> to unmute, or stay as a listener. Auto-accepts in {countdown}s.
+        </p>
+
+        <div className="grid grid-cols-2 gap-2">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={handleStay}
+            className="px-4 py-2.5 rounded-xl border border-white/[0.08] bg-[#1a2a3a] text-gray-300 text-sm font-semibold hover:bg-[#22364a] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623]"
+          >
+            Stay as listener
+          </button>
+          <button
+            type="button"
+            onClick={handleAccept}
+            className="px-4 py-2.5 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Go on stage ({countdown})
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/spaces/RoomFirstTimeTour.tsx
+++ b/src/components/spaces/RoomFirstTimeTour.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface RoomFirstTimeTourProps {
+  /** Distinguishes the copy + the localStorage key so a returning user gets
+   * the right tour for the room mode they actually walked into. */
+  roomMode: 'stage' | 'voice_channel';
+}
+
+const STORAGE_KEY = 'zao-room-tour-shown-v1';
+
+interface ShownMap {
+  stage?: boolean;
+  voice_channel?: boolean;
+}
+
+function hasSeen(mode: 'stage' | 'voice_channel'): boolean {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return false;
+    const map = JSON.parse(raw) as ShownMap;
+    return !!map[mode];
+  } catch {
+    return false;
+  }
+}
+
+function markSeen(mode: 'stage' | 'voice_channel'): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const map: ShownMap = raw ? (JSON.parse(raw) as ShownMap) : {};
+    map[mode] = true;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* localStorage disabled - tour shows once per session instead */
+  }
+}
+
+const STAGE_TOUR = [
+  { icon: 'MIC', title: 'Listen first', body: 'Audio plays automatically. Reactions are silent.' },
+  { icon: 'HAND', title: 'Raise hand to speak', body: 'The host sees your queue position. They tap Invite to bring you up.' },
+  { icon: 'LEAVE', title: 'Leave anytime', body: 'Tapping Leave drops you out. The room keeps going.' },
+];
+
+const VIDEO_TOUR = [
+  { icon: 'CAM', title: 'Mic, camera, screen', body: 'All three are open to everyone. The lobby let you choose defaults.' },
+  { icon: 'SHARE', title: 'Share the link', body: 'When you are alone, an invite card appears - copy, cast, or QR.' },
+  { icon: 'LEAVE', title: 'Host ends the room', body: 'A confirm dialog protects against fat-thumb End. Leaving alone is safe.' },
+];
+
+/**
+ * One-time orientation overlay shown the first time a user enters a Stage or
+ * Video Room. Different copy per mode. Persists "seen" in localStorage so the
+ * second visit is friction-free. Closes on Escape, click-outside, or the
+ * "Got it" button.
+ *
+ * Renders nothing on SSR or when already seen.
+ */
+export function RoomFirstTimeTour({ roomMode }: RoomFirstTimeTourProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!hasSeen(roomMode)) setOpen(true);
+  }, [roomMode]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleDismiss();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  function handleDismiss() {
+    markSeen(roomMode);
+    setOpen(false);
+  }
+
+  if (!open) return null;
+
+  const tour = roomMode === 'voice_channel' ? VIDEO_TOUR : STAGE_TOUR;
+  const title = roomMode === 'voice_channel' ? "You're in a Video Room" : "You're in a Stage";
+
+  return (
+    <div
+      className="fixed inset-0 z-[55] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm px-0 sm:px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tour-title"
+      onClick={handleDismiss}
+    >
+      <div
+        className="bg-[#0d1b2a] border border-white/[0.08] rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-[10px] font-bold tracking-wider uppercase">
+          First time
+        </div>
+        <h2 id="tour-title" className="text-white text-lg font-bold mt-2 mb-4">
+          {title}
+        </h2>
+
+        <ul className="space-y-3 mb-5">
+          {tour.map((item) => (
+            <li key={item.icon} className="flex items-start gap-3">
+              <span className="flex-shrink-0 inline-flex items-center justify-center w-9 h-9 rounded-xl bg-[#1a2a3a] text-[#f5a623] text-[10px] font-bold tracking-wider">
+                {item.icon}
+              </span>
+              <div className="min-w-0">
+                <p className="text-white text-sm font-semibold">{item.title}</p>
+                <p className="text-gray-500 text-xs leading-relaxed">{item.body}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="w-full px-4 py-2.5 bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] font-bold rounded-xl text-sm transition-colors shadow-lg shadow-[#f5a623]/20"
+        >
+          Got it
+        </button>
+
+        <p className="text-gray-600 text-xs text-center mt-3">
+          Shown once per device. Tap outside or press Esc to dismiss.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -19,6 +19,7 @@ import { RoomChat } from './RoomChat';
 import { ParticipantsPanel } from './ParticipantsPanel';
 import { ClosedCaptions } from './ClosedCaptions';
 import { RoomFirstTimeTour } from './RoomFirstTimeTour';
+import { ShortcutsHelp } from './ShortcutsHelp';
 import { useRoomKeyboardShortcuts } from './useRoomKeyboardShortcuts';
 
 const BroadcastModal = dynamic(
@@ -98,12 +99,17 @@ export function RoomView({
   // header so listeners know whose voice they are hearing.
   const speakingName = dominantSpeaker?.name || dominantSpeaker?.userId || null;
 
+  // Shortcuts cheatsheet, opened via "?" inside the room.
+  const [showShortcuts, setShowShortcuts] = useState(false);
+  const hasMediaPermissions = roomType === 'voice_channel' || isHost;
+
   // Zoom-style keyboard shortcuts. Stage listeners with no mic do not get the
   // Space binding — there is nothing for them to toggle.
   useRoomKeyboardShortcuts({
-    enableMic: roomType === 'voice_channel' || isHost,
-    enableCamera: roomType === 'voice_channel' || isHost,
-    enableScreen: roomType === 'voice_channel' || isHost,
+    enableMic: hasMediaPermissions,
+    enableCamera: hasMediaPermissions,
+    enableScreen: hasMediaPermissions,
+    onToggleHelp: () => setShowShortcuts((v) => !v),
   });
 
   // Fetch Twitch connection info for the host (all viewers see the embed, host gets chat)
@@ -202,6 +208,11 @@ export function RoomView({
   return (
     <div className="flex flex-col h-full bg-[#0a1628]">
       <RoomFirstTimeTour roomMode={roomType === 'voice_channel' ? 'voice_channel' : 'stage'} />
+      <ShortcutsHelp
+        open={showShortcuts}
+        onClose={() => setShowShortcuts(false)}
+        hasMediaPermissions={hasMediaPermissions}
+      />
       <div className="flex flex-1 overflow-hidden">
         {/* Main room content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -21,6 +21,7 @@ import { ClosedCaptions } from './ClosedCaptions';
 import { RoomFirstTimeTour } from './RoomFirstTimeTour';
 import { ShortcutsHelp } from './ShortcutsHelp';
 import { PromotionConfirm } from './PromotionConfirm';
+import { MicLiveToast } from './MicLiveToast';
 import { useRoomKeyboardShortcuts } from './useRoomKeyboardShortcuts';
 
 const BroadcastModal = dynamic(
@@ -215,6 +216,7 @@ export function RoomView({
         hasMediaPermissions={hasMediaPermissions}
       />
       {!isHost && <PromotionConfirm />}
+      {hasMediaPermissions && <MicLiveToast />}
       <div className="flex flex-1 overflow-hidden">
         {/* Main room content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -20,6 +20,7 @@ import { ParticipantsPanel } from './ParticipantsPanel';
 import { ClosedCaptions } from './ClosedCaptions';
 import { RoomFirstTimeTour } from './RoomFirstTimeTour';
 import { ShortcutsHelp } from './ShortcutsHelp';
+import { PromotionConfirm } from './PromotionConfirm';
 import { useRoomKeyboardShortcuts } from './useRoomKeyboardShortcuts';
 
 const BroadcastModal = dynamic(
@@ -213,6 +214,7 @@ export function RoomView({
         onClose={() => setShowShortcuts(false)}
         hasMediaPermissions={hasMediaPermissions}
       />
+      {!isHost && <PromotionConfirm />}
       <div className="flex flex-1 overflow-hidden">
         {/* Main room content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -87,10 +87,15 @@ export function RoomView({
   );
   const [previousLayout, setPreviousLayout] = useState<'content-first' | 'speakers-first' | null>(null);
 
-  const { useCallCustomData, useHasOngoingScreenShare } = useCallStateHooks();
+  const { useCallCustomData, useHasOngoingScreenShare, useDominantSpeaker, useIsCallRecordingInProgress } = useCallStateHooks();
   const callCustomData = useCallCustomData();
   const hasScreenShareActive = useHasOngoingScreenShare();
+  const dominantSpeaker = useDominantSpeaker();
+  const isRecording = useIsCallRecordingInProgress();
   const roomTitle = (callCustomData as Record<string, string>)?.title || 'Audio Room';
+  // Name of the current dominant speaker, when there is one — surfaces to the
+  // header so listeners know whose voice they are hearing.
+  const speakingName = dominantSpeaker?.name || dominantSpeaker?.userId || null;
 
   // Fetch Twitch connection info for the host (all viewers see the embed, host gets chat)
   useEffect(() => {
@@ -193,6 +198,35 @@ export function RoomView({
         <div className="flex-1 flex flex-col min-w-0">
           <div className="border-b border-white/[0.08] bg-[#0d1b2a]">
             <DescriptionPanel />
+            {(speakingName || isRecording) && (
+              <div className="flex items-center gap-2 px-4 pb-2 flex-wrap">
+                {speakingName && (
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-green-500/10 border border-green-500/30 text-green-400 text-[11px] font-semibold"
+                    aria-live="polite"
+                    aria-label={`Now speaking: ${speakingName}`}
+                  >
+                    <span className="relative flex h-2 w-2" aria-hidden="true">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+                    </span>
+                    <span className="truncate max-w-[160px]">Speaking: {speakingName}</span>
+                  </span>
+                )}
+                {isRecording && (
+                  <span
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-red-500/10 border border-red-500/30 text-red-400 text-[11px] font-semibold"
+                    aria-live="polite"
+                  >
+                    <span className="relative flex h-2 w-2" aria-hidden="true">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                    </span>
+                    Recording
+                  </span>
+                )}
+              </div>
+            )}
           </div>
           <TwitchEmbed
             channel={twitchInfo?.username ?? ''}

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -18,6 +18,7 @@ import { RoomReactions } from './RoomReactions';
 import { RoomChat } from './RoomChat';
 import { ParticipantsPanel } from './ParticipantsPanel';
 import { ClosedCaptions } from './ClosedCaptions';
+import { RoomFirstTimeTour } from './RoomFirstTimeTour';
 
 const BroadcastModal = dynamic(
   () => import('./BroadcastModal').then((m) => ({ default: m.BroadcastModal })),
@@ -186,6 +187,7 @@ export function RoomView({
 
   return (
     <div className="flex flex-col h-full bg-[#0a1628]">
+      <RoomFirstTimeTour roomMode={roomType === 'voice_channel' ? 'voice_channel' : 'stage'} />
       <div className="flex flex-1 overflow-hidden">
         {/* Main room content */}
         <div className="flex-1 flex flex-col min-w-0">

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -19,6 +19,7 @@ import { RoomChat } from './RoomChat';
 import { ParticipantsPanel } from './ParticipantsPanel';
 import { ClosedCaptions } from './ClosedCaptions';
 import { RoomFirstTimeTour } from './RoomFirstTimeTour';
+import { useRoomKeyboardShortcuts } from './useRoomKeyboardShortcuts';
 
 const BroadcastModal = dynamic(
   () => import('./BroadcastModal').then((m) => ({ default: m.BroadcastModal })),
@@ -96,6 +97,14 @@ export function RoomView({
   // Name of the current dominant speaker, when there is one — surfaces to the
   // header so listeners know whose voice they are hearing.
   const speakingName = dominantSpeaker?.name || dominantSpeaker?.userId || null;
+
+  // Zoom-style keyboard shortcuts. Stage listeners with no mic do not get the
+  // Space binding — there is nothing for them to toggle.
+  useRoomKeyboardShortcuts({
+    enableMic: roomType === 'voice_channel' || isHost,
+    enableCamera: roomType === 'voice_channel' || isHost,
+    enableScreen: roomType === 'voice_channel' || isHost,
+  });
 
   // Fetch Twitch connection info for the host (all viewers see the embed, host gets chat)
   useEffect(() => {

--- a/src/components/spaces/ScreenShareButton.tsx
+++ b/src/components/spaces/ScreenShareButton.tsx
@@ -32,7 +32,9 @@ export function ScreenShareButton({ isHost, isAuthenticated, roomType }: ScreenS
   return (
     <button
       onClick={handleToggle}
-      className={`px-4 py-2.5 rounded-xl font-semibold text-sm transition-colors flex items-center gap-2 ${
+      aria-pressed={isSharing}
+      aria-label={isSharing ? 'Stop sharing screen (S)' : 'Share your screen (S)'}
+      className={`px-4 py-2.5 rounded-xl font-semibold text-sm transition-colors flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628] ${
         isSharing
           ? 'bg-blue-600/20 text-blue-400 border border-blue-600/30 hover:bg-blue-600/30'
           : 'bg-[#1a2a3a] text-gray-300 hover:text-white border border-white/[0.08] hover:border-gray-500'

--- a/src/components/spaces/ShortcutsHelp.tsx
+++ b/src/components/spaces/ShortcutsHelp.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface ShortcutsHelpProps {
+  open: boolean;
+  onClose: () => void;
+  /** When false, hide the mic / camera / screen rows because the user has no
+   * permission for those capabilities (a stage listener, for example). */
+  hasMediaPermissions: boolean;
+}
+
+interface Shortcut {
+  key: string;
+  label: string;
+  hint?: string;
+}
+
+const MEDIA: Shortcut[] = [
+  { key: 'Space', label: 'Mic', hint: 'Tap to toggle. Hold for push-to-talk.' },
+  { key: 'C', label: 'Camera' },
+  { key: 'S', label: 'Screen share' },
+];
+
+const GLOBAL: Shortcut[] = [
+  { key: 'H', label: 'Raise / lower hand' },
+  { key: '?', label: 'Show this menu' },
+  { key: 'Esc', label: 'Close any overlay' },
+];
+
+/**
+ * Cheatsheet modal listing the room's keyboard shortcuts. Triggered by "?"
+ * (handled in useRoomKeyboardShortcuts) or any UI link the host wants to
+ * surface. Mirrors the Zoom + Meet cheatsheet pattern so the bindings feel
+ * discoverable without forcing a tour on every session.
+ */
+export function ShortcutsHelp({ open, onClose, hasMediaPermissions }: ShortcutsHelpProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[58] flex items-end sm:items-center justify-center bg-black/70 backdrop-blur-sm px-0 sm:px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="shortcuts-title"
+      onClick={onClose}
+    >
+      <div
+        className="bg-[#0d1b2a] border border-white/[0.08] rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-md"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-5">
+          <h2 id="shortcuts-title" className="text-white text-lg font-bold">
+            Keyboard shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close shortcuts"
+            className="p-1.5 text-gray-500 hover:text-white rounded-lg hover:bg-gray-800 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {hasMediaPermissions && (
+          <section className="mb-4">
+            <h3 className="text-gray-500 text-[10px] font-bold uppercase tracking-wider mb-2">
+              Media
+            </h3>
+            <ul className="space-y-1.5">
+              {MEDIA.map((s) => (
+                <ShortcutRow key={s.key} shortcut={s} />
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section>
+          <h3 className="text-gray-500 text-[10px] font-bold uppercase tracking-wider mb-2">
+            Room
+          </h3>
+          <ul className="space-y-1.5">
+            {GLOBAL.map((s) => (
+              <ShortcutRow key={s.key} shortcut={s} />
+            ))}
+          </ul>
+        </section>
+
+        <p className="mt-5 text-gray-600 text-xs leading-relaxed">
+          Shortcuts are off while typing in chat. Press <kbd className="px-1 rounded bg-[#1a2a3a] text-gray-300 text-[10px] font-mono">?</kbd> in the room any time to reopen this.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ShortcutRow({ shortcut }: { shortcut: Shortcut }) {
+  return (
+    <li className="flex items-start justify-between gap-3 py-1.5 px-3 rounded-lg bg-[#0a1628] border border-white/[0.04]">
+      <div className="min-w-0">
+        <p className="text-white text-sm font-semibold">{shortcut.label}</p>
+        {shortcut.hint && (
+          <p className="text-gray-500 text-xs leading-snug">{shortcut.hint}</p>
+        )}
+      </div>
+      <kbd className="flex-shrink-0 inline-flex items-center justify-center min-w-[2.25rem] px-2 py-1 rounded-md bg-[#1a2a3a] border border-white/[0.08] text-gray-200 text-[11px] font-mono font-semibold">
+        {shortcut.key}
+      </kbd>
+    </li>
+  );
+}

--- a/src/components/spaces/StageCard.tsx
+++ b/src/components/spaces/StageCard.tsx
@@ -41,6 +41,8 @@ function formatLiveDuration(createdAt: string): string {
 export default function StageCard({ room, onJoin, isOwn }: StageCardProps) {
   const theme = THEME_BADGES[room.theme] || THEME_BADGES.default;
   const dot = THEME_DOTS[room.theme] || THEME_DOTS.default;
+  const isVideoRoom = room.room_type === 'voice_channel';
+  const isEmpty = room.participant_count <= 1;
 
   return (
     <div
@@ -50,6 +52,7 @@ export default function StageCard({ room, onJoin, isOwn }: StageCardProps) {
       onClick={() => onJoin(room)}
       role="button"
       tabIndex={0}
+      aria-label={`Join ${isVideoRoom ? 'Video Room' : 'Stage'}: ${room.title}, hosted by ${room.host_name}`}
       onKeyDown={(e) => e.key === 'Enter' && onJoin(room)}
     >
       {/* Top: Theme color accent bar */}
@@ -60,10 +63,21 @@ export default function StageCard({ room, onJoin, isOwn }: StageCardProps) {
         <h3 className="text-white font-bold text-sm leading-tight line-clamp-2 group-hover:text-[#f5a623] transition-colors">
           {room.title}
         </h3>
-        <div className="flex items-center gap-1.5 flex-shrink-0">
+        <div className="flex flex-col items-end gap-1 flex-shrink-0">
           <span className="inline-flex items-center gap-1 text-red-400 text-[10px] font-bold uppercase tracking-wide">
-            <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
+            <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" aria-hidden="true" />
             Live
+          </span>
+          <span
+            className={`inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded-full border ${
+              isVideoRoom
+                ? 'bg-blue-500/15 border-blue-500/30 text-blue-300'
+                : 'bg-white/[0.04] border-white/[0.08] text-gray-400'
+            }`}
+            title={isVideoRoom ? 'Mic, camera, screen share' : 'Audio-only Clubhouse stage'}
+          >
+            {isVideoRoom ? 'CAM' : 'MIC'}
+            {isVideoRoom ? ' Video Room' : ' Stage'}
           </span>
         </div>
       </div>
@@ -95,17 +109,17 @@ export default function StageCard({ room, onJoin, isOwn }: StageCardProps) {
       {/* Bottom: meta row + join button */}
       <div className="flex items-center justify-between mt-auto pt-3 border-t border-white/[0.08]/60">
         <div className="flex items-center gap-3 text-xs text-gray-500">
-          {/* Participant count */}
+          {/* Participant count - phrased so an empty room reads honestly. */}
           <span className="flex items-center gap-1">
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128H5.228A2 2 0 013 17.16v-.088c0-2.517 1.813-4.607 4.2-5.032a8.153 8.153 0 011.6-.16c.549 0 1.085.055 1.6.16 2.387.425 4.2 2.515 4.2 5.032v.088c0 .465-.171.89-.453 1.217" />
             </svg>
-            {room.participant_count}
+            {isEmpty ? 'Just host' : `${room.participant_count} listening`}
           </span>
 
           {/* Duration */}
           <span className="flex items-center gap-1">
-            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
             {formatLiveDuration(room.created_at)}
@@ -122,9 +136,10 @@ export default function StageCard({ room, onJoin, isOwn }: StageCardProps) {
             e.stopPropagation();
             onJoin(room);
           }}
+          aria-label={isEmpty ? `Be the first to join ${room.title}` : `Join ${room.title}`}
           className="px-4 py-1.5 bg-[#f5a623] text-[#0a1628] text-xs font-bold rounded-lg hover:bg-[#ffd700] transition-colors shadow-sm"
         >
-          Join
+          {isEmpty ? 'Be first' : 'Join'}
         </button>
       </div>
     </div>

--- a/src/components/spaces/useRoomKeyboardShortcuts.ts
+++ b/src/components/spaces/useRoomKeyboardShortcuts.ts
@@ -1,0 +1,132 @@
+/**
+ * Keyboard shortcuts for ZAO Spaces rooms. Standard bindings borrowed from
+ * Zoom + Google Meet + Discord so first-timers do not need to learn ours:
+ *
+ *   Space  -  toggle mic (push-to-talk if held; toggle on quick tap)
+ *   C      -  toggle camera
+ *   S      -  toggle screen share
+ *   H      -  raise / lower hand (fires the supplied onToggleHand callback)
+ *   ?      -  shouldShowHelp toggles via the supplied onToggleHelp callback
+ *
+ * Disabled while the user is typing in an input / textarea / contenteditable
+ * (matches Zoom + Meet behaviour - otherwise typing "c" in chat would kill
+ * the camera).
+ *
+ * Stream.io owns the actual mic/camera/screen-share state. The hook reads
+ * useCall() and dispatches to call.microphone / call.camera / call.screenShare.
+ * Hand-raise lives in our own Supabase table - the caller passes the toggle.
+ */
+import { useEffect, useRef } from 'react';
+import { useCall } from '@stream-io/video-react-sdk';
+
+const PUSH_TO_TALK_HOLD_MS = 250;
+
+interface UseRoomKeyboardShortcutsOptions {
+  /** Toggle the user's hand-raise state. Skipped when undefined. */
+  onToggleHand?: () => void;
+  /** Toggle the shortcuts-help overlay. Bound to "?". Skipped when undefined. */
+  onToggleHelp?: () => void;
+  /** Default true. Set false on stages where the listener has no mic. */
+  enableMic?: boolean;
+  /** Default true. Set false on stages where the listener has no camera. */
+  enableCamera?: boolean;
+  /** Default true. Set false where screen-share is not allowed. */
+  enableScreen?: boolean;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+export function useRoomKeyboardShortcuts(options: UseRoomKeyboardShortcutsOptions = {}) {
+  const call = useCall();
+  const { onToggleHand, onToggleHelp, enableMic = true, enableCamera = true, enableScreen = true } = options;
+
+  // Space-held push-to-talk: remember the press time so a short tap toggles
+  // and a long hold unmutes only while held.
+  const spaceDownAtRef = useRef<number | null>(null);
+  const spaceHeldRef = useRef(false);
+
+  useEffect(() => {
+    if (!call) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(e.target)) return;
+
+      if (e.code === 'Space' && enableMic) {
+        if (e.repeat) {
+          // First real held-down repeat - flip to push-to-talk mode.
+          if (!spaceHeldRef.current && spaceDownAtRef.current !== null) {
+            const heldFor = performance.now() - spaceDownAtRef.current;
+            if (heldFor >= PUSH_TO_TALK_HOLD_MS) {
+              spaceHeldRef.current = true;
+              call?.microphone?.enable().catch(() => {});
+            }
+          }
+          e.preventDefault();
+          return;
+        }
+        if (spaceDownAtRef.current === null) {
+          spaceDownAtRef.current = performance.now();
+        }
+        e.preventDefault();
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+      if (key === 'c' && enableCamera) {
+        e.preventDefault();
+        call?.camera?.toggle().catch(() => {});
+        return;
+      }
+      if (key === 's' && enableScreen) {
+        e.preventDefault();
+        call?.screenShare?.toggle().catch(() => {});
+        return;
+      }
+      if (key === 'h' && onToggleHand) {
+        e.preventDefault();
+        onToggleHand();
+        return;
+      }
+      if (key === '?' && onToggleHelp) {
+        e.preventDefault();
+        onToggleHelp();
+        return;
+      }
+    }
+
+    function onKeyUp(e: KeyboardEvent) {
+      if (isTypingTarget(e.target)) return;
+      if (e.code !== 'Space' || !enableMic) return;
+      e.preventDefault();
+      const downAt = spaceDownAtRef.current;
+      const wasHeld = spaceHeldRef.current;
+      spaceDownAtRef.current = null;
+      spaceHeldRef.current = false;
+      if (wasHeld) {
+        // Push-to-talk release - mute again.
+        call?.microphone?.disable().catch(() => {});
+        return;
+      }
+      if (downAt !== null) {
+        const heldFor = performance.now() - downAt;
+        if (heldFor < PUSH_TO_TALK_HOLD_MS) {
+          // Short tap - treat as toggle.
+          call?.microphone?.toggle().catch(() => {});
+        }
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, [call, enableMic, enableCamera, enableScreen, onToggleHand, onToggleHelp]);
+}

--- a/src/lib/spaces/jukeSpacesDb.ts
+++ b/src/lib/spaces/jukeSpacesDb.ts
@@ -64,6 +64,22 @@ export async function getJukeSpace(id: string): Promise<JukeSpaceRow | null> {
   return (data as JukeSpaceRow) ?? null;
 }
 
+/**
+ * List ended Juke spaces that have a recording_url. Most-recent first.
+ * Limited to a sensible default the shelf page can show without paging.
+ */
+export async function listRecordedJukeSpaces(limit: number = 25): Promise<JukeSpaceRow[]> {
+  const { data, error } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('*')
+    .eq('status', 'ended')
+    .not('recording_url', 'is', null)
+    .order('ended_at', { ascending: false })
+    .limit(Math.min(Math.max(1, limit), 100));
+  if (error) throw new Error(`listRecordedJukeSpaces failed: ${error.message}`);
+  return (data ?? []) as JukeSpaceRow[];
+}
+
 /** Update lifecycle fields driven by webhooks. */
 export async function updateJukeSpace(
   id: string,

--- a/src/lib/spaces/jukeWebhookHandlers.ts
+++ b/src/lib/spaces/jukeWebhookHandlers.ts
@@ -15,7 +15,9 @@
  * consume the fields we recognise. Extra fields are stored verbatim in
  * `juke_webhook_events.body`.
  */
-import { bumpParticipantCount, updateJukeSpace } from './jukeSpacesDb';
+import { autoCastToZao } from '@/lib/publish/auto-cast';
+import { logger } from '@/lib/logger';
+import { bumpParticipantCount, getJukeSpace, updateJukeSpace } from './jukeSpacesDb';
 
 interface JukeWebhookBody {
   event?: string;
@@ -122,8 +124,20 @@ export async function applyWebhookEvent(
     }
     case 'recording.ready': {
       const url = readRecordingUrl(body);
-      if (url) {
-        await updateJukeSpace(spaceId, { recording_url: url });
+      if (!url) return;
+      await updateJukeSpace(spaceId, { recording_url: url });
+      // Best-effort recap cast - autoCastToZao silently no-ops if the
+      // @thezao signer is not configured, so this is safe on local + preview.
+      try {
+        const row = await getJukeSpace(spaceId);
+        const title = row?.title ?? 'A ZAO space';
+        const liveUrl = `https://zaoos.com/live/${spaceId}`;
+        await autoCastToZao(
+          `Recording up: ${title}\n\nListen back: ${liveUrl}`,
+          liveUrl,
+        );
+      } catch (err: unknown) {
+        logger.warn('[juke/webhooks] recap cast failed (non-fatal):', err);
       }
       return;
     }


### PR DESCRIPTION
## Summary

Two patterns lifted from research on Clubhouse, Twitter Spaces, and Discord Stages, applied to ZAO Spaces.

### 1. Host end-room confirmation
Fat-thumb End was killing the room for every listener in one click. \`EndRoomConfirm\` dialog now gates the destructive path:

- Host: Cancel | End room
- Admin (in someone else's room): Cancel | Leave only | End room
- Non-host listener: Leave button stays direct (no dialog)

Esc closes; initial focus is on Cancel so a stray Enter cannot end. Page's old \`handleLeave\` was split into \`leaveSelfOnly\` + \`endRoomForEveryone\` so the two paths are obvious in the code.

### 2. Listener-side hand-raise queue position
The previous listener button was a single icon with an active dot — no signal that the host saw the raise. From the Clubhouse postmortem (createbytes), surfacing queue position closes the "did the host see me?" doubt loop.

Now when raised:
- A pill next to the button announces \`You are next\` / \`You are #N in line\` / \`Hand raised\`.
- Computed 1-indexed from the host's queue.
- Pulses gold (\`#f5a623\`) and is \`aria-live=\"polite\"\` for screen readers.

## Files

\`\`\`
NEW  src/components/spaces/EndRoomConfirm.tsx
MOD  src/components/spaces/HandRaiseQueue.tsx
MOD  src/app/spaces/[id]/page.tsx
\`\`\`

## Test plan

- [ ] Host hits End - dialog appears, Cancel closes, End leaves + PATCH action:end.
- [ ] Admin opens a non-owned room - Leave only button appears alongside End.
- [ ] Listener hits Leave - no dialog, direct leave.
- [ ] Listener raises hand - pill shows "You are #N in line"; updates live as others raise/lower.
- [ ] Press Esc inside the dialog - cancels.

## Notes

- Next polish candidate: StageCard speaker thumbnails on the /spaces index (Clubhouse discoverability fix). Coming in a follow-up.