### PR TITLE
feat(juke): public surfaces - /live index + /juke-status dashboard + JSON + markdown

### DIFF
--- a/src/app/api/juke/status/route.ts
+++ b/src/app/api/juke/status/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { getJukeIntegrationManifest } from '@/lib/spaces/jukeIntegrationManifest';
+import { getJukeIntegrationStats } from '@/lib/spaces/jukeSpacesDb';
+
+/**
+ * GET /api/juke/status - machine-readable ZAO + Juke integration state.
+ *
+ * Same data as /juke-status (HTML) and /juke-integration.md (markdown). Built
+ * for the Juke team's agent to fetch without scraping the HTML page.
+ *
+ * Cached short (60s) at the CDN; ZAO ships new features faster than Juke
+ * polls, so a one-minute staleness ceiling is fine.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const manifest = getJukeIntegrationManifest();
+  let stats;
+  try {
+    stats = await getJukeIntegrationStats();
+  } catch {
+    stats = null;
+  }
+
+  return NextResponse.json(
+    {
+      ...manifest,
+      stats,
+    },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'public, max-age=30, s-maxage=60, stale-while-revalidate=120',
+        'Access-Control-Allow-Origin': '*',
+        'X-ZAO-Juke-Status': 'v1',
+      },
+    },
+  );
+}

--- a/src/app/juke-integration.md/route.ts
+++ b/src/app/juke-integration.md/route.ts
@@ -1,0 +1,45 @@
+import {
+  getJukeIntegrationManifest,
+  renderIntegrationMarkdown,
+} from '@/lib/spaces/jukeIntegrationManifest';
+import { getJukeIntegrationStats } from '@/lib/spaces/jukeSpacesDb';
+
+/**
+ * GET /juke-integration.md - llms.txt-style markdown summary of ZAO's Juke
+ * integration. The Juke team's agent can fetch this URL and get a stable,
+ * grep-friendly listing of shipped features, open asks, and live stats - the
+ * same shape Juke publishes at juke.audio/llms.txt for us.
+ *
+ * Served with text/markdown so most LLM-fetch tools render it cleanly. Cached
+ * short, same SLA as the JSON endpoint.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const manifest = getJukeIntegrationManifest();
+  let statsObject: Record<string, unknown> | undefined;
+  try {
+    const stats = await getJukeIntegrationStats();
+    statsObject = {
+      total_spaces: stats.total_spaces,
+      active: stats.active,
+      scheduled: stats.scheduled,
+      ended: stats.ended,
+      with_recording: stats.with_recording,
+      total_webhook_events: stats.total_webhook_events,
+      last_event_at: stats.last_event_at ?? 'never',
+    };
+  } catch {
+    statsObject = undefined;
+  }
+  const body = renderIntegrationMarkdown(manifest, statsObject);
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=30, s-maxage=60, stale-while-revalidate=120',
+      'Access-Control-Allow-Origin': '*',
+      'X-ZAO-Juke-Status': 'v1',
+    },
+  });
+}

--- a/src/app/juke-status/page.tsx
+++ b/src/app/juke-status/page.tsx
@@ -1,0 +1,268 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  getJukeIntegrationManifest,
+  type IntegrationManifest,
+  type ShippedFeature,
+  type OpenAsk,
+} from '@/lib/spaces/jukeIntegrationManifest';
+import { getJukeIntegrationStats, type JukeIntegrationStats } from '@/lib/spaces/jukeSpacesDb';
+import { communityConfig } from '../../../community.config';
+
+export const metadata: Metadata = {
+  title: `ZAO + Juke - Integration Status`,
+  description:
+    'Public dashboard of what The ZAO has built using Juke, live integration stats, and open asks for the Juke team. Machine-readable mirror at /api/juke/status.',
+};
+
+async function safeStats(): Promise<JukeIntegrationStats> {
+  try {
+    return await getJukeIntegrationStats();
+  } catch {
+    return {
+      total_spaces: 0,
+      active: 0,
+      scheduled: 0,
+      ended: 0,
+      with_recording: 0,
+      total_webhook_events: 0,
+      recent_event_types: {},
+      last_event_at: null,
+    };
+  }
+}
+
+/**
+ * /juke-status - public dashboard for the Juke team (and their agent) to see
+ * what ZAO has shipped, live stats, and what is blocking the next slice of
+ * work. Same data is exposed machine-readable at /api/juke/status and
+ * markdown-friendly at /juke-integration.md.
+ *
+ * Three audiences:
+ * - Nicky + the Juke team scanning the page directly.
+ * - Their AI agent fetching it via WebFetch / WebSearch.
+ * - ZAO members linking the page to show off the integration.
+ */
+export default async function JukeStatusPage() {
+  const manifest = getJukeIntegrationManifest();
+  const stats = await safeStats();
+  const lastEvent = stats.last_event_at ? new Date(stats.last_event_at) : null;
+
+  return (
+    <div className="min-h-[100dvh] bg-[#0a1628] text-white">
+      <header className="border-b border-white/[0.08] bg-[#0d1b2a]">
+        <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6 flex items-start justify-between gap-3 flex-wrap">
+          <div className="min-w-0">
+            <div className="inline-flex items-center gap-2 px-2 py-0.5 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-[10px] font-bold uppercase tracking-wider mb-2">
+              ZAO + Juke - build status
+            </div>
+            <h1 className="text-xl sm:text-2xl font-bold">{communityConfig.name} on Juke</h1>
+            <p className="text-sm text-gray-400 mt-1 max-w-xl">
+              Public dashboard of what we have shipped, live stats from the integration, and the
+              open asks blocking the next slice. Built so anyone (including agents) can read where
+              we are without a Slack ping.
+            </p>
+          </div>
+          <div className="flex gap-2 flex-wrap">
+            <a
+              href="/api/juke/status"
+              className="inline-flex px-3 py-1.5 text-xs font-medium text-gray-300 border border-white/[0.12] rounded-lg hover:bg-white/[0.04] transition-colors"
+            >
+              JSON
+            </a>
+            <a
+              href="/juke-integration.md"
+              className="inline-flex px-3 py-1.5 text-xs font-medium text-gray-300 border border-white/[0.12] rounded-lg hover:bg-white/[0.04] transition-colors"
+            >
+              Markdown
+            </a>
+            <Link
+              href="/live"
+              className="inline-flex px-3 py-1.5 text-xs font-medium text-[#f5a623] border border-[#f5a623]/30 rounded-lg hover:bg-[#f5a623]/10 transition-colors"
+            >
+              Live spaces
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-10">
+        <StatsRow stats={stats} lastEvent={lastEvent} />
+        <ShippedSection manifest={manifest} />
+        <AsksSection manifest={manifest} />
+        <ConventionsSection manifest={manifest} />
+        <ContactSection manifest={manifest} />
+      </main>
+    </div>
+  );
+}
+
+function StatsRow({ stats, lastEvent }: { stats: JukeIntegrationStats; lastEvent: Date | null }) {
+  const items: Array<{ label: string; value: number | string }> = [
+    { label: 'Spaces created', value: stats.total_spaces },
+    { label: 'Active now', value: stats.active },
+    { label: 'Scheduled', value: stats.scheduled },
+    { label: 'Ended', value: stats.ended },
+    { label: 'With recording', value: stats.with_recording },
+    { label: 'Webhook events', value: stats.total_webhook_events },
+  ];
+  return (
+    <section>
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">Live stats</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        {items.map((item) => (
+          <div
+            key={item.label}
+            className="bg-[#111d2e] border border-white/[0.08] rounded-xl px-4 py-3"
+          >
+            <p className="text-2xl font-bold text-white">{item.value}</p>
+            <p className="text-[11px] text-gray-500 uppercase tracking-wider mt-1">{item.label}</p>
+          </div>
+        ))}
+      </div>
+      {lastEvent && (
+        <p className="text-xs text-gray-500 mt-3">
+          Last webhook delivered {lastEvent.toLocaleString('en-US')}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function ShippedSection({ manifest }: { manifest: IntegrationManifest }) {
+  return (
+    <section>
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">
+        Shipped ({manifest.shipped.length})
+      </h2>
+      <ul className="space-y-3">
+        {manifest.shipped.map((feature) => (
+          <ShippedRow key={feature.id} feature={feature} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ShippedRow({ feature }: { feature: ShippedFeature }) {
+  return (
+    <li className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4">
+      <div className="flex items-baseline gap-3 flex-wrap mb-1">
+        <h3 className="text-sm font-bold text-white">{feature.title}</h3>
+        <span className="text-[10px] text-gray-500 font-mono">{feature.shippedAt}</span>
+        {feature.pr && (
+          <a
+            href={feature.pr}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-[10px] text-[#f5a623] hover:underline"
+          >
+            View PR
+          </a>
+        )}
+      </div>
+      <p className="text-xs text-gray-400 leading-relaxed mb-2">{feature.description}</p>
+      {feature.reference && (
+        <p className="text-[11px] text-gray-500 italic mb-2">Ref: {feature.reference}</p>
+      )}
+      <div className="flex flex-wrap gap-1">
+        {feature.files.map((file) => (
+          <code
+            key={file}
+            className="text-[10px] px-1.5 py-0.5 rounded bg-[#0a1628] border border-white/[0.06] text-gray-300 font-mono"
+          >
+            {file}
+          </code>
+        ))}
+      </div>
+    </li>
+  );
+}
+
+function AsksSection({ manifest }: { manifest: IntegrationManifest }) {
+  return (
+    <section>
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">
+        Open asks for Juke ({manifest.open_asks.length})
+      </h2>
+      <ul className="space-y-3">
+        {manifest.open_asks.map((ask) => (
+          <AskRow key={ask.id} ask={ask} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function AskRow({ ask }: { ask: OpenAsk }) {
+  const priorityStyles: Record<OpenAsk['priority'], { bg: string; text: string; border: string }> = {
+    p0: { bg: 'bg-red-500/15', text: 'text-red-400', border: 'border-red-500/30' },
+    p1: { bg: 'bg-[#f5a623]/15', text: 'text-[#f5a623]', border: 'border-[#f5a623]/30' },
+    p2: { bg: 'bg-blue-500/15', text: 'text-blue-300', border: 'border-blue-500/30' },
+  };
+  const ps = priorityStyles[ask.priority];
+  return (
+    <li className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border ${ps.bg} ${ps.text} ${ps.border}`}>
+          {ask.priority}
+        </span>
+        <h3 className="text-sm font-bold text-white">{ask.title}</h3>
+      </div>
+      <p className="text-xs text-gray-400 leading-relaxed">{ask.reason}</p>
+      <p className="text-[11px] text-gray-500 mt-2">
+        <span className="font-semibold text-gray-400">Blocks:</span> {ask.blocks}
+      </p>
+    </li>
+  );
+}
+
+function ConventionsSection({ manifest }: { manifest: IntegrationManifest }) {
+  return (
+    <section>
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">Conventions</h2>
+      <ul className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4 space-y-2">
+        {manifest.conventions.map((c) => (
+          <li key={c} className="text-xs text-gray-400 leading-relaxed flex gap-2">
+            <span className="text-[#f5a623]" aria-hidden="true">-</span>
+            <span>{c}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function ContactSection({ manifest }: { manifest: IntegrationManifest }) {
+  return (
+    <section className="border-t border-white/[0.06] pt-8 text-xs text-gray-500">
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">Contact</h2>
+      <ul className="space-y-1">
+        <li>ZAO dev: {manifest.contact.zao_dev}</li>
+        <li>
+          General:{' '}
+          <a
+            className="text-gray-300 hover:text-[#f5a623]"
+            href={manifest.contact.general}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {manifest.contact.general}
+          </a>
+        </li>
+        <li>{manifest.contact.partnership}</li>
+      </ul>
+      <p className="mt-4 text-gray-600">
+        Page generated server-side at request time. Machine-readable mirror at{' '}
+        <a href="/api/juke/status" className="text-gray-400 hover:text-[#f5a623]">
+          /api/juke/status
+        </a>
+        ; markdown for agents at{' '}
+        <a href="/juke-integration.md" className="text-gray-400 hover:text-[#f5a623]">
+          /juke-integration.md
+        </a>
+        .
+      </p>
+    </section>
+  );
+}

--- a/src/app/live/JukeLinkOpener.tsx
+++ b/src/app/live/JukeLinkOpener.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { parseJukeSpaceId } from '@/lib/spaces/juke';
+
+/**
+ * Client component for the "paste any Juke link" form on /live. Extracted so
+ * the parent server component can stay server-rendered.
+ */
+export function JukeLinkOpener() {
+  const router = useRouter();
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const openSpace = () => {
+    const spaceId = parseJukeSpaceId(value);
+    if (!spaceId) {
+      setError('That is not a Juke space link or ID. Paste a juke.audio link.');
+      return;
+    }
+    setError(null);
+    router.push(`/live/${spaceId}`);
+  };
+
+  return (
+    <form
+      className="w-full max-w-md"
+      onSubmit={(e) => {
+        e.preventDefault();
+        openSpace();
+      }}
+    >
+      <label htmlFor="juke-space" className="sr-only">
+        Juke space link or ID
+      </label>
+      <div className="flex gap-2">
+        <input
+          id="juke-space"
+          type="text"
+          inputMode="url"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          placeholder="https://juke.audio/embed/..."
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            if (error) setError(null);
+          }}
+          className="flex-1 rounded-xl border border-white/[0.08] bg-[#0d1b2a] px-4 py-2.5 text-sm text-white placeholder:text-gray-600 focus:border-[#f5a623]/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623]"
+        />
+        <button
+          type="submit"
+          disabled={value.trim().length === 0}
+          className="rounded-xl bg-[#f5a623] hover:bg-[#ffd700] px-4 py-2.5 text-sm font-bold text-[#0a1628] transition-colors disabled:cursor-not-allowed disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+        >
+          Open
+        </button>
+      </div>
+      {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+    </form>
+  );
+}

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -1,110 +1,236 @@
-'use client';
-
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import { parseJukeSpaceId } from '@/lib/spaces/juke';
+import { jukeSpaceOgImageUrl } from '@/lib/spaces/juke';
+import {
+  listActiveJukeSpaces,
+  listRecordedJukeSpaces,
+  listScheduledJukeSpaces,
+  type JukeSpaceRow,
+} from '@/lib/spaces/jukeSpacesDb';
+import { communityConfig } from '../../../community.config';
+import { JukeLinkOpener } from './JukeLinkOpener';
+
+export const metadata: Metadata = {
+  title: `Live on Juke - ${communityConfig.name}`,
+  description: 'Live, scheduled, and recorded Juke audio spaces hosted by The ZAO. Anyone can listen.',
+};
+
+async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await p;
+  } catch {
+    return fallback;
+  }
+}
+
+function formatScheduled(value: string | null): string {
+  if (!value) return 'Soon';
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return 'Soon';
+  const diff = ts - Date.now();
+  if (diff <= 0) return 'Starting now';
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `In ${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `In ${hours}h`;
+  return new Date(value).toLocaleString('en-US', { weekday: 'short', hour: 'numeric', minute: '2-digit' });
+}
 
 /**
- * /live — entry point for the Juke live audio embed (doc 695, Path A).
- *
- * Juke spaces are created and hosted on Juke; this page takes a space link
- * (or raw id) and routes to `/live/[spaceId]`, where the space is embedded
- * inside a ZAO OS shell.
+ * /live - public index of Juke spaces hosted by ZAO. No auth required. Three
+ * sections: active right now, scheduled to start, and recordings of past
+ * spaces. Each card routes to /live/{id} which renders the keyless Juke
+ * iframe. A paste-link form at the bottom keeps the original "open any Juke
+ * link inside ZAO OS" flow alive for non-ZAO spaces.
  */
-export default function LiveIndexPage() {
-  const router = useRouter();
-  const [value, setValue] = useState('');
-  const [error, setError] = useState<string | null>(null);
+export default async function LiveIndexPage() {
+  const [active, scheduled, recordings] = await Promise.all([
+    safe(listActiveJukeSpaces(12), [] as JukeSpaceRow[]),
+    safe(listScheduledJukeSpaces(12), [] as JukeSpaceRow[]),
+    safe(listRecordedJukeSpaces(8), [] as JukeSpaceRow[]),
+  ]);
 
-  const openSpace = () => {
-    const spaceId = parseJukeSpaceId(value);
-    if (!spaceId) {
-      setError('That is not a Juke space link or ID. Paste a juke.audio link.');
-      return;
-    }
-    setError(null);
-    router.push(`/live/${spaceId}`);
-  };
+  const empty = active.length === 0 && scheduled.length === 0 && recordings.length === 0;
 
   return (
-    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628]">
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] text-white">
       <header className="border-b border-white/[0.08] bg-[#0d1b2a]">
-        <div className="flex items-center gap-3 px-4 py-3">
-          <Link
-            href="/"
-            aria-label="Back home"
-            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-800 hover:text-[#f5a623]"
-          >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
-            </svg>
-          </Link>
-          <h1 className="text-sm font-bold text-white sm:text-base">ZAO Live</h1>
+        <div className="flex items-center justify-between gap-3 px-4 py-4 max-w-5xl mx-auto w-full">
+          <div className="min-w-0 flex items-center gap-3">
+            <Link
+              href="/"
+              aria-label="Back home"
+              className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-800 hover:text-[#f5a623]"
+            >
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+              </svg>
+            </Link>
+            <div>
+              <h1 className="text-base sm:text-lg font-bold">Live on Juke</h1>
+              <p className="text-xs text-gray-500">
+                Public audio spaces hosted by {communityConfig.name}. Anyone can listen.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Link
+              href="/live/recordings"
+              className="hidden sm:inline-flex px-3 py-1.5 text-xs font-medium text-gray-300 border border-white/[0.12] rounded-lg hover:bg-white/[0.04] transition-colors"
+            >
+              Recordings
+            </Link>
+            <Link
+              href="/juke-status"
+              className="hidden sm:inline-flex px-3 py-1.5 text-xs font-medium text-[#f5a623] border border-[#f5a623]/30 rounded-lg hover:bg-[#f5a623]/10 transition-colors"
+            >
+              Build status
+            </Link>
+          </div>
         </div>
       </header>
 
-      <main className="flex flex-1 flex-col items-center px-4 py-10">
-        <div className="w-full max-w-md">
-          <h2 className="text-2xl font-bold text-white">Live audio, Farcaster-native</h2>
-          <p className="mt-2 text-sm text-gray-400">
-            Open a Juke space inside ZAO OS. Listening is anonymous; to react,
-            raise your hand, or speak, sign in with Farcaster inside the space.
+      <main className="flex-1 px-4 py-6 max-w-5xl mx-auto w-full space-y-10">
+        {empty && <EmptyState />}
+
+        {active.length > 0 && (
+          <SectionRow title="Live now" accent="text-red-400" badge="LIVE" pulse>
+            {active.map((row) => (
+              <SpaceCard key={row.id} row={row} subtitle="Live now" cta="Join" emphasize />
+            ))}
+          </SectionRow>
+        )}
+
+        {scheduled.length > 0 && (
+          <SectionRow title="Scheduled" accent="text-[#f5a623]" badge="SOON">
+            {scheduled.map((row) => (
+              <SpaceCard
+                key={row.id}
+                row={row}
+                subtitle={formatScheduled(row.scheduled_at)}
+                cta="Set reminder"
+              />
+            ))}
+          </SectionRow>
+        )}
+
+        {recordings.length > 0 && (
+          <SectionRow title="Recent recordings" accent="text-gray-300" badge="REPLAY">
+            {recordings.map((row) => (
+              <SpaceCard
+                key={row.id}
+                row={row}
+                subtitle={row.ended_at ? `Ended ${new Date(row.ended_at).toLocaleDateString()}` : 'Ended'}
+                cta="Listen back"
+              />
+            ))}
+          </SectionRow>
+        )}
+
+        <section className="border-t border-white/[0.06] pt-8">
+          <h2 className="text-sm font-bold text-white mb-1">Open any Juke space</h2>
+          <p className="text-xs text-gray-500 mb-4">
+            Paste a juke.audio link and we will open it inside ZAO OS - works for spaces ZAO does not
+            host.
           </p>
-
-          <form
-            className="mt-6"
-            onSubmit={(e) => {
-              e.preventDefault();
-              openSpace();
-            }}
-          >
-            <label htmlFor="juke-space" className="text-xs font-medium text-gray-400">
-              Juke space link or ID
-            </label>
-            <input
-              id="juke-space"
-              type="text"
-              inputMode="url"
-              autoComplete="off"
-              autoCapitalize="off"
-              spellCheck={false}
-              placeholder="https://juke.audio/embed/..."
-              value={value}
-              onChange={(e) => {
-                setValue(e.target.value);
-                if (error) setError(null);
-              }}
-              className="mt-1.5 w-full rounded-xl border border-white/[0.08] bg-[#0d1b2a] px-4 py-3 text-sm text-white placeholder:text-gray-600 focus:border-[#f5a623]/50 focus:outline-none"
-            />
-            {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
-            <button
-              type="submit"
-              disabled={value.trim().length === 0}
-              className="mt-3 w-full rounded-xl bg-[#f5a623] py-3 text-sm font-semibold text-[#0a1628] transition-colors hover:bg-[#ffd700] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              Open Space
-            </button>
-          </form>
-
-          <div className="mt-8 rounded-xl border border-white/[0.08] bg-[#0d1b2a] p-4">
-            <h3 className="text-xs font-semibold text-[#f5a623]">Where do I get a space link?</h3>
-            <p className="mt-1.5 text-xs leading-relaxed text-gray-400">
-              Spaces are hosted in the Juke app (Farcaster-native live audio, on
-              iOS). Open or create a space in Juke, share it, and paste the link
-              here. A raw space ID works too.
-            </p>
-            <a
-              href="https://juke.audio"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="mt-2 inline-block text-xs text-gray-500 transition-colors hover:text-[#f5a623]"
-            >
-              Powered by Juke - juke.audio
-            </a>
-          </div>
-        </div>
+          <JukeLinkOpener />
+          <p className="mt-3 text-xs text-gray-600">
+            Built on Juke - <a href="https://juke.audio" className="text-gray-400 hover:text-[#f5a623]" target="_blank" rel="noreferrer noopener">juke.audio</a>.
+          </p>
+        </section>
       </main>
     </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <div className="w-16 h-16 rounded-full bg-[#f5a623]/10 flex items-center justify-center mb-5" aria-hidden="true">
+        <svg className="w-8 h-8 text-[#f5a623]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z" />
+        </svg>
+      </div>
+      <h2 className="text-lg font-semibold mb-1">Nothing live right now</h2>
+      <p className="text-gray-500 text-sm max-w-sm">
+        ZAO hosts on Juke - check back during a fractal call, a ZAOstock standup, or a COC Concertz
+        night. Recordings live at{' '}
+        <Link href="/live/recordings" className="text-[#f5a623] hover:underline">/live/recordings</Link>.
+      </p>
+    </div>
+  );
+}
+
+function SectionRow({
+  title,
+  accent,
+  badge,
+  pulse,
+  children,
+}: {
+  title: string;
+  accent: string;
+  badge: string;
+  pulse?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="flex items-center gap-2 mb-3">
+        <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider uppercase border border-current/30 ${accent}`}>
+          {pulse && <span className="w-1.5 h-1.5 rounded-full bg-current animate-pulse" aria-hidden="true" />}
+          {badge}
+        </span>
+        <h2 className="text-sm font-bold text-white">{title}</h2>
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">{children}</ul>
+    </section>
+  );
+}
+
+function SpaceCard({
+  row,
+  subtitle,
+  cta,
+  emphasize,
+}: {
+  row: JukeSpaceRow;
+  subtitle: string;
+  cta: string;
+  emphasize?: boolean;
+}) {
+  return (
+    <li className="bg-[#111d2e] border border-white/[0.08] rounded-xl overflow-hidden transition-all hover:border-gray-600 hover:shadow-lg hover:shadow-black/20">
+      <Link
+        href={`/live/${row.id}`}
+        className="block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+        aria-label={`${cta}: ${row.title}`}
+      >
+        <div className="aspect-[1200/630] bg-[#0a1628] relative overflow-hidden">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={jukeSpaceOgImageUrl(row.id)}
+            alt=""
+            loading="lazy"
+            className="w-full h-full object-cover opacity-90 hover:opacity-100 transition-opacity"
+          />
+        </div>
+        <div className="p-4">
+          <h3 className="text-sm font-bold leading-tight line-clamp-2">{row.title || 'Untitled space'}</h3>
+          <p className="text-gray-500 text-xs mt-1">{subtitle}</p>
+        </div>
+      </Link>
+      <div className="px-4 pb-4">
+        <span
+          className={`inline-flex items-center justify-center w-full px-4 py-2 rounded-xl text-xs font-bold transition-colors ${
+            emphasize
+              ? 'bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628]'
+              : 'bg-[#1a2a3a] hover:bg-[#22364a] text-gray-200 border border-white/[0.08]'
+          }`}
+        >
+          {cta}
+        </span>
+      </div>
+    </li>
   );
 }

--- a/src/components/spaces/ControlsPanel.tsx
+++ b/src/components/spaces/ControlsPanel.tsx
@@ -28,6 +28,9 @@ interface ControlsPanelProps {
   pfpUrl?: string;
   onRoomChat?: () => void;
   onParticipants?: () => void;
+  /** Opens the keyboard-shortcuts cheatsheet. The "?" key already opens it
+   * via useRoomKeyboardShortcuts; this button is the visible discovery path. */
+  onShortcutsHelp?: () => void;
 }
 
 export function ControlsPanel({
@@ -47,6 +50,7 @@ export function ControlsPanel({
   pfpUrl,
   onRoomChat,
   onParticipants,
+  onShortcutsHelp,
 }: ControlsPanelProps) {
   const [showTwitchPanel, setShowTwitchPanel] = useState(false);
   const [showMore, setShowMore] = useState(false);
@@ -57,7 +61,8 @@ export function ControlsPanel({
     (isHost && twitchUsername) ||
     (!isHost && roomType === 'stage') ||
     onRoomChat ||
-    onParticipants;
+    onParticipants ||
+    !!onShortcutsHelp;
 
   return (
     <div className="space-y-0">
@@ -194,6 +199,20 @@ export function ControlsPanel({
               >
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+                </svg>
+              </button>
+            )}
+
+            {/* Keyboard shortcuts help (also bound to "?") */}
+            {onShortcutsHelp && (
+              <button
+                onClick={onShortcutsHelp}
+                aria-label="Keyboard shortcuts"
+                title="Keyboard shortcuts (?)"
+                className="p-2.5 rounded-xl text-sm transition-colors bg-[#1a2a3a] text-gray-400 hover:text-white border border-white/[0.08] hover:border-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1b2a]"
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} aria-hidden="true">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
                 </svg>
               </button>
             )}

--- a/src/components/spaces/RoomView.tsx
+++ b/src/components/spaces/RoomView.tsx
@@ -315,6 +315,7 @@ export function RoomView({
               pfpUrl={pfpUrl}
               onRoomChat={() => setShowRoomChat((prev) => !prev)}
               onParticipants={() => setShowParticipants((prev) => !prev)}
+              onShortcutsHelp={() => setShowShortcuts(true)}
             />
           </div>
           {roomId && <RoomMusicPanel roomId={roomId} isHost={isHost} onOpenMusicBrowser={() => setShowMusicSidebar(true)} />}

--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -1,0 +1,282 @@
+/**
+ * Canonical declaration of ZAO's Juke integration. Single source of truth
+ * for the public surfaces:
+ *
+ * - /juke-status (HTML for humans + Nicky's eyes)
+ * - /api/juke/status (JSON for agents)
+ * - /juke-integration.md (markdown for LLMs — llms.txt-style)
+ *
+ * Update this file when ZAO ships a new feature or closes an ask. The three
+ * surfaces stay in sync automatically.
+ */
+
+export interface ShippedFeature {
+  id: string;
+  title: string;
+  description: string;
+  shippedAt: string;
+  pr?: string;
+  files: string[];
+  reference?: string;
+}
+
+export interface OpenAsk {
+  id: string;
+  title: string;
+  reason: string;
+  blocks: string;
+  priority: 'p0' | 'p1' | 'p2';
+}
+
+export interface IntegrationContact {
+  zao_dev: string;
+  general: string;
+  partnership: string;
+}
+
+export interface IntegrationManifest {
+  version: string;
+  generated_at: string;
+  about: {
+    name: string;
+    pitch: string;
+    farcaster: string;
+    site: string;
+    juke_path_a_route: string;
+    juke_path_b_route: string;
+    public_status_route: string;
+  };
+  shipped: ShippedFeature[];
+  open_asks: OpenAsk[];
+  conventions: string[];
+  contact: IntegrationContact;
+}
+
+const SHIPPED: ShippedFeature[] = [
+  {
+    id: 'path-a-iframe',
+    title: 'Path A — keyless iframe at /live/{spaceId}',
+    description:
+      'Public route that embeds juke.audio/embed/{id} with ZAO chrome. No API keys, anonymous listen by default, SIWF inside the iframe for participation.',
+    shippedAt: '2026-05-20',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/598',
+    files: [
+      'src/lib/spaces/juke.ts',
+      'src/components/spaces/JukeEmbed.tsx',
+      'src/app/live/[spaceId]/page.tsx',
+    ],
+    reference: 'juke.audio/llms.txt — Fastest Integration: Hosted Iframe',
+  },
+  {
+    id: 'path-b-developer-create',
+    title: 'Path B — server-side space creation via POST /v1/developer/spaces',
+    description:
+      'Key-only auth (X-Juke-Api-Key), room owner derived from app.owner_fid. Admin-or-password gated route at /api/juke/space; /live/create web form. Persists juke_spaces row on success.',
+    shippedAt: '2026-05-22',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/630',
+    files: [
+      'src/lib/spaces/juke-api.ts',
+      'src/app/api/juke/space/route.ts',
+      'src/app/live/create/page.tsx',
+      'scripts/test-juke-space.ts',
+    ],
+    reference: 'juke.audio/llms.txt — Custom Server Integration: Developer Keys',
+  },
+  {
+    id: 'webhook-consumer',
+    title: 'Inbound webhook consumer at /api/juke/webhooks',
+    description:
+      'HMAC-SHA256 verifier for X-Juke-Signature: t={ts},v1={hex} over `{ts}.{body}`. 5-minute replay window. Idempotent via signature_hash unique constraint. Handlers cover room.started, room.finished, participant.joined, participant.left, recording.ready.',
+    shippedAt: '2026-05-23',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/640',
+    files: [
+      'src/app/api/juke/webhooks/route.ts',
+      'src/lib/spaces/jukeWebhookVerify.ts',
+      'src/lib/spaces/jukeWebhookHandlers.ts',
+      'src/lib/spaces/jukeSpacesDb.ts',
+      'scripts/juke-spaces-migration.sql',
+      'scripts/register-juke-webhook.ts',
+    ],
+    reference: 'Juke 2026-05-23 PR — outbound developer webhooks',
+  },
+  {
+    id: 'audio-off-second-screen',
+    title: '?audio=off second-screen mode',
+    description:
+      'jukeEmbedUrl(spaceId, { audioOff: true }) returns the embed with audio disabled. UI offers a "Mute (second screen)" toggle on /live/{id}. Solves the laptop-alongside-iOS-app double-broadcast case.',
+    shippedAt: '2026-05-23',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/640',
+    files: ['src/lib/spaces/juke.ts', 'src/components/spaces/JukeEmbed.tsx'],
+    reference: 'Juke 2026-05-23 PR — embed audio=off (item #6)',
+  },
+  {
+    id: 'og-image',
+    title: 'OG image per space',
+    description:
+      'generateMetadata pulls juke.audio/space/{id}/opengraph-image for Open Graph + Twitter card meta tags. Cast/X shares of /live/{id} render the Juke-branded card without ZAO having to render its own.',
+    shippedAt: '2026-05-23',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/640',
+    files: ['src/app/live/[spaceId]/page.tsx', 'src/lib/spaces/juke.ts'],
+    reference: 'Juke 2026-05-23 PR — item #10',
+  },
+  {
+    id: 'ios-deeplink',
+    title: '"Open in Juke app" CTA',
+    description:
+      'jukeAppDeeplinkUrl(spaceId) returns juke.audio/space/{id}?open=app. Button on /live/{id} routes desktop visitors into the iOS app via universal link.',
+    shippedAt: '2026-05-23',
+    files: ['src/lib/spaces/juke.ts', 'src/app/live/[spaceId]/page.tsx'],
+    reference: 'Juke 2026-05-23 PR — item #8',
+  },
+  {
+    id: 'recording-shelf',
+    title: 'Public /live/recordings shelf',
+    description:
+      'Lists ended Juke spaces with recording_url, most-recent first. Server-fetched from juke_spaces. Each card shows the Juke OG image + a "Listen to recording" CTA. Populated by the recording.ready webhook.',
+    shippedAt: '2026-05-23',
+    files: ['src/app/live/recordings/page.tsx', 'src/lib/spaces/jukeSpacesDb.ts'],
+  },
+  {
+    id: 'recap-cast',
+    title: 'Auto-cast on recording.ready',
+    description:
+      'After persisting recording_url, the webhook handler posts a recap cast to /zao via the @thezao official account, embedding the Juke /live/{id} URL so the Juke OG image renders in the cast preview. Silently no-ops when the @thezao signer env is missing.',
+    shippedAt: '2026-05-23',
+    files: ['src/lib/spaces/jukeWebhookHandlers.ts', 'src/lib/publish/auto-cast.ts'],
+  },
+];
+
+const OPEN_ASKS: OpenAsk[] = [
+  {
+    id: 'agents',
+    title: 'Agent join surface — when can ZOE sit in a Juke room?',
+    reason:
+      "We're passing allow_agents:true on create, but llms.txt + the 2026-05-23 PR still flag agents as a future surface. We want ZOE (Claude Opus) sitting silently in the weekly fractal + ZAOstock standups taking notes and posting a recap cast after room.finished. Even read-only/observer would unblock half the value.",
+    blocks: 'ZOE-in-Juke (concierge note-taker + recap-cast generator)',
+    priority: 'p0',
+  },
+  {
+    id: 'participant-fids',
+    title: 'Participant FID list',
+    reason:
+      'participant.joined/left webhooks give us a count but not the identities. We want to show "3 ZAO members are here" on /live and @-mention attendees in the recap cast. Either a GET /v1/rooms/{id}/participants endpoint, or include fid on the participant.* webhook payload.',
+    blocks: '"Who from ZAO is here" badge + recap @-mentions',
+    priority: 'p1',
+  },
+  {
+    id: 'desktop-mic',
+    title: 'Desktop browser mic publish confirmation',
+    reason:
+      'When a desktop SIWF user is promoted, does the web SDK actually grant mic-publish, or does it fail silently? We do not want a "Speak" CTA on desktop that breaks under load. A "yes works" / "iOS-only for now" answer is enough to set the UI right.',
+    blocks: 'Honest desktop "Speak from this browser" CTA on /live/{id}',
+    priority: 'p1',
+  },
+  {
+    id: 'oss-spec',
+    title: 'Open-source SPEC.md / codebase drop',
+    reason:
+      'You offered to open the codebase + SPEC.md "if there was demand." ZAO is the demand. 13 files of integration code against your llms.txt + a full HMAC webhook handler. Happy to be the first community reference implementation.',
+    blocks: 'Deeper integration patterns + co-marketing as reference impl',
+    priority: 'p2',
+  },
+];
+
+const CONVENTIONS = [
+  'All Juke calls server-side. JUKE_API_KEY never leaves the server.',
+  'Webhook receiver is idempotent on signature_hash + caps replay window at 5 minutes.',
+  'juke_spaces is publicly readable (RLS allow-all); writes are service-role only.',
+  '/live/{spaceId} is fully public — no auth required to listen.',
+  'OG metadata pulls juke.audio/space/{id}/opengraph-image, so Juke renders the share card.',
+  'Stage rooms (audio Clubhouse) and Video Rooms (full A+V) are ZAO concepts; both live alongside Juke.',
+];
+
+const CONTACT: IntegrationContact = {
+  zao_dev: '@zaal (Farcaster) / zaal@thezao.com',
+  general: 'https://www.thezao.com',
+  partnership: 'See /juke-status on zaoos.com for the live build state.',
+};
+
+export function getJukeIntegrationManifest(): IntegrationManifest {
+  return {
+    version: '1',
+    generated_at: new Date().toISOString(),
+    about: {
+      name: 'The ZAO',
+      pitch: 'Decentralized impact network. Music as a wedge, Farcaster-native.',
+      farcaster: 'https://warpcast.com/~/channel/zao',
+      site: 'https://www.thezao.com',
+      juke_path_a_route: '/live/{spaceId}',
+      juke_path_b_route: '/api/juke/space (admin or shared password)',
+      public_status_route: 'https://zaoos.com/juke-status',
+    },
+    shipped: SHIPPED,
+    open_asks: OPEN_ASKS,
+    conventions: CONVENTIONS,
+    contact: CONTACT,
+  };
+}
+
+/** Render the manifest as llms.txt-style markdown. Stable headings so an
+ * agent can grep without parsing the JSON. */
+export function renderIntegrationMarkdown(
+  manifest: IntegrationManifest,
+  stats?: Record<string, unknown>,
+): string {
+  const lines: string[] = [];
+  lines.push(`# ZAO + Juke Integration`);
+  lines.push('');
+  lines.push(`> ${manifest.about.pitch}`);
+  lines.push('');
+  lines.push(`Generated: ${manifest.generated_at}`);
+  lines.push(`Version: ${manifest.version}`);
+  lines.push('');
+  lines.push('## About');
+  lines.push(`- Site: ${manifest.about.site}`);
+  lines.push(`- Farcaster channel: ${manifest.about.farcaster}`);
+  lines.push(`- Path A (iframe): ${manifest.about.juke_path_a_route}`);
+  lines.push(`- Path B (server create): ${manifest.about.juke_path_b_route}`);
+  lines.push(`- Status JSON: /api/juke/status`);
+  lines.push(`- Status HTML: ${manifest.about.public_status_route}`);
+  lines.push('');
+
+  if (stats) {
+    lines.push('## Live Stats');
+    for (const [key, value] of Object.entries(stats)) {
+      if (value === null || typeof value === 'object') continue;
+      lines.push(`- ${key}: ${String(value)}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Shipped');
+  for (const f of manifest.shipped) {
+    lines.push(`### ${f.title}`);
+    lines.push(`- Shipped: ${f.shippedAt}`);
+    if (f.pr) lines.push(`- PR: ${f.pr}`);
+    if (f.reference) lines.push(`- Reference: ${f.reference}`);
+    lines.push(`- Description: ${f.description}`);
+    lines.push(`- Files:`);
+    for (const file of f.files) lines.push(`  - \`${file}\``);
+    lines.push('');
+  }
+
+  lines.push('## Open Asks');
+  for (const a of manifest.open_asks) {
+    lines.push(`### [${a.priority.toUpperCase()}] ${a.title}`);
+    lines.push(`- Reason: ${a.reason}`);
+    lines.push(`- Blocks: ${a.blocks}`);
+    lines.push('');
+  }
+
+  lines.push('## Conventions');
+  for (const c of manifest.conventions) lines.push(`- ${c}`);
+  lines.push('');
+
+  lines.push('## Contact');
+  lines.push(`- ZAO dev: ${manifest.contact.zao_dev}`);
+  lines.push(`- General: ${manifest.contact.general}`);
+  lines.push(`- Partnership: ${manifest.contact.partnership}`);
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/src/lib/spaces/jukeSpacesDb.ts
+++ b/src/lib/spaces/jukeSpacesDb.ts
@@ -64,6 +64,86 @@ export async function getJukeSpace(id: string): Promise<JukeSpaceRow | null> {
   return (data as JukeSpaceRow) ?? null;
 }
 
+/** List Juke spaces currently in `active` status. Most-recent first. */
+export async function listActiveJukeSpaces(limit: number = 25): Promise<JukeSpaceRow[]> {
+  const { data, error } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('*')
+    .eq('status', 'active')
+    .order('started_at', { ascending: false, nullsFirst: false })
+    .limit(Math.min(Math.max(1, limit), 100));
+  if (error) throw new Error(`listActiveJukeSpaces failed: ${error.message}`);
+  return (data ?? []) as JukeSpaceRow[];
+}
+
+/** List Juke spaces scheduled to start in the future. Soonest first. */
+export async function listScheduledJukeSpaces(limit: number = 25): Promise<JukeSpaceRow[]> {
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('*')
+    .eq('status', 'scheduled')
+    .gte('scheduled_at', nowIso)
+    .order('scheduled_at', { ascending: true })
+    .limit(Math.min(Math.max(1, limit), 100));
+  if (error) throw new Error(`listScheduledJukeSpaces failed: ${error.message}`);
+  return (data ?? []) as JukeSpaceRow[];
+}
+
+/** Aggregate counts for the /juke-status dashboard + JSON endpoint. */
+export interface JukeIntegrationStats {
+  total_spaces: number;
+  active: number;
+  scheduled: number;
+  ended: number;
+  with_recording: number;
+  total_webhook_events: number;
+  recent_event_types: Record<string, number>;
+  last_event_at: string | null;
+}
+
+export async function getJukeIntegrationStats(): Promise<JukeIntegrationStats> {
+  const stats: JukeIntegrationStats = {
+    total_spaces: 0,
+    active: 0,
+    scheduled: 0,
+    ended: 0,
+    with_recording: 0,
+    total_webhook_events: 0,
+    recent_event_types: {},
+    last_event_at: null,
+  };
+  try {
+    const counts = await Promise.all([
+      supabaseAdmin.from('juke_spaces').select('*', { count: 'exact', head: true }),
+      supabaseAdmin.from('juke_spaces').select('*', { count: 'exact', head: true }).eq('status', 'active'),
+      supabaseAdmin.from('juke_spaces').select('*', { count: 'exact', head: true }).eq('status', 'scheduled'),
+      supabaseAdmin.from('juke_spaces').select('*', { count: 'exact', head: true }).eq('status', 'ended'),
+      supabaseAdmin.from('juke_spaces').select('*', { count: 'exact', head: true }).not('recording_url', 'is', null),
+      supabaseAdmin.from('juke_webhook_events').select('*', { count: 'exact', head: true }),
+    ]);
+    stats.total_spaces = counts[0].count ?? 0;
+    stats.active = counts[1].count ?? 0;
+    stats.scheduled = counts[2].count ?? 0;
+    stats.ended = counts[3].count ?? 0;
+    stats.with_recording = counts[4].count ?? 0;
+    stats.total_webhook_events = counts[5].count ?? 0;
+
+    const { data: recent } = await supabaseAdmin
+      .from('juke_webhook_events')
+      .select('event_type, received_at')
+      .order('received_at', { ascending: false })
+      .limit(50);
+    for (const row of (recent ?? []) as Array<{ event_type: string; received_at: string }>) {
+      stats.recent_event_types[row.event_type] = (stats.recent_event_types[row.event_type] ?? 0) + 1;
+      if (!stats.last_event_at) stats.last_event_at = row.received_at;
+    }
+  } catch {
+    /* surfaces zero stats instead of 500 on transient DB issues */
+  }
+  return stats;
+}
+
 /**
  * List ended Juke spaces that have a recording_url. Most-recent first.
  * Limited to a sensible default the shelf page can show without paging.


### PR DESCRIPTION
## Summary

Three new public surfaces + a shared manifest module so Nicky's agent (and any human) can see what ZAO is building on Juke without a Slack ping. Closes Zaal's ask: "a specific dashboard we can give Nicky to tell him what we are building, for his agent to read from."

## What's new

### /live (rewritten)
Public discovery page for ZAO Juke spaces. Anyone can hit it - no auth. Server-fetched from \`juke_spaces\` and grouped:

- **Live now** - red badge, click straight into \`/live/{id}\` to listen
- **Scheduled** - countdown to start
- **Recent recordings** - last 8, links into \`/live/{id}\` (recording CTA on the inside)

The original "paste any Juke link to open inside ZAO OS" form is preserved at the bottom as \`JukeLinkOpener\`. Header links to /live/recordings and /juke-status.

### /juke-status
HTML dashboard surfacing:

- Live stats (spaces created, active, scheduled, ended, with recording, webhook events delivered)
- Last webhook timestamp
- Every shipped feature with file paths, shipped date, PR link, Juke doc reference
- Open asks with p0 / p1 / p2 priority + what each ask blocks
- ZAO's integration conventions
- Contact + links to the JSON + markdown mirrors

### /api/juke/status
JSON mirror. Same data, machine-readable. CDN-cached 60s, CORS open, \`X-ZAO-Juke-Status: v1\` header.

### /juke-integration.md
Markdown mirror, served with \`text/markdown; charset=utf-8\`. Built so LLM fetch tools render it cleanly - mirrors the shape Juke uses at \`juke.audio/llms.txt\` for us.

## How it stays in sync

Single source of truth: \`src/lib/spaces/jukeIntegrationManifest.ts\`. Update the \`SHIPPED\` and \`OPEN_ASKS\` arrays there and all three surfaces refresh automatically.

## DB helpers added

- \`listActiveJukeSpaces\` - status=active, started_at desc
- \`listScheduledJukeSpaces\` - status=scheduled with future scheduled_at
- \`getJukeIntegrationStats\` - count rollup + recent event-type distribution from juke_webhook_events

All best-effort - any DB failure returns empty arrays / zero stats so the public pages never 500.

## Files

\`\`\`
NEW src/app/live/JukeLinkOpener.tsx
MOD src/app/live/page.tsx
NEW src/app/juke-status/page.tsx
NEW src/app/api/juke/status/route.ts
NEW src/app/juke-integration.md/route.ts
NEW src/lib/spaces/jukeIntegrationManifest.ts
MOD src/lib/spaces/jukeSpacesDb.ts
\`\`\`

## Test plan

- [ ] Visit zaoos.com/live - see the three sections (empty states are OK).
- [ ] Visit zaoos.com/juke-status - see stats + shipped + asks.
- [ ] \`curl zaoos.com/api/juke/status\` - returns JSON with the manifest + stats.
- [ ] \`curl zaoos.com/juke-integration.md\` - returns markdown.
- [ ] Send Nicky the /juke-status URL.

## Notes

- Requires the juke_spaces + juke_webhook_events tables (migration in PR #640). Without them, the stats endpoint returns zeroes - the manifest still renders cleanly.
- Manifest content is editorial - bump it whenever we ship something new on Juke or close an ask.