### PR TITLE
feat(zoe/posts): dedicated Sunday-3pm-ET Fractal-promo slot (closes cowork #220)

### DIFF
--- a/bot/src/zoe/posts/fractal-promo.ts
+++ b/bot/src/zoe/posts/fractal-promo.ts
@@ -1,0 +1,51 @@
+// fractal-promo.ts - dedicated weekly post slot for the ZAO Fractal.
+//
+// The Fractal runs Mondays 6pm EST (project_fractal_process: 90+ weeks,
+// Discord bot, OG vs ZOR Respect, frapps). This module fires every Sunday
+// at 3pm ET via a cron in scheduler.ts - a guaranteed weekly drumbeat that
+// bypasses the random-slot pool.
+//
+// doc 722 3-month synthesis, task #220 2026-05-23: day-1 activation for new
+// ZAO members = Fractal participation. With ~3-5 new humans joining every
+// 73 days, the Sunday lead-time post is a cheap, recurring activation hook.
+//
+// Goes through the same POST/REGEN/SKIP review flow as every other ZOE post
+// so Zaal still gates the actual publish - never auto-fires to socials.
+//
+// The join link is read from FRACTAL_JOIN_URL env (set on Zaal's mac /
+// wherever the bot runs). Falls back to the public ZAO Discord invite if
+// unset, so the slot never breaks silently.
+
+import type { Bot } from 'grammy';
+import { sendDraftWithKeyboard } from './buttons';
+
+const DEFAULT_JOIN_URL = 'https://discord.gg/thezao';
+
+function buildFractalDraft(): string {
+  const url = process.env.FRACTAL_JOIN_URL || DEFAULT_JOIN_URL;
+  // Spartan, lowercase-ish, no emojis, no em-dashes (matches the ZOE voice
+  // contract from bot/src/zoe/human.md).
+  return [
+    'fractal tomorrow 6pm EST.',
+    '',
+    'where ZAO members do the actual work + earn Respect tokens. week 90+ and counting - the longest-running ritual in the ecosystem.',
+    '',
+    `join: ${url}`,
+  ].join('\n');
+}
+
+/**
+ * Send the Sunday Fractal-promo draft to Zaal via the standard
+ * sendDraftWithKeyboard flow (POST/REGEN/SKIP). Called by the Sunday-3pm-ET
+ * cron in scheduler.ts. Best-effort: errors are logged by the underlying
+ * sendDraftWithKeyboard via appendLog.
+ */
+export async function sendFractalPromo(bot: Bot, zaalTgId: number): Promise<void> {
+  await sendDraftWithKeyboard({
+    bot: bot.api,
+    zaalTgId,
+    category: 'event',
+    text: buildFractalDraft(),
+    isResend: false,
+  });
+}

--- a/bot/src/zoe/posts/scheduler.ts
+++ b/bot/src/zoe/posts/scheduler.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 import { ZOE_PATHS } from '../memory';
 import { sendDraftWithKeyboard } from './buttons';
 import { draftPost } from './drafters';
+import { sendFractalPromo } from './fractal-promo';
 import { clearPending, isExpired, loadPending, shouldResend } from './pending';
 import {
   gatherBuildSignals,
@@ -267,12 +268,33 @@ export function startPostsScheduler(opts: PostsSchedulerOptions): { stop: () => 
     { timezone: 'America/New_York' },
   );
 
-  console.log(`[zoe/posts] scheduler started (target ${pings} pings/day, window ${WINDOW_START_HOUR_ET}am-${WINDOW_END_HOUR_ET - 12}pm ET)`);
+  // Sunday Fractal-promo - dedicated weekly slot (doc 722, task #220).
+  // Fires every Sunday at 3pm ET. The 6pm Monday Fractal needs lead-time
+  // outreach to convert new ZAO members; this is the standing reminder.
+  // Goes through the standard POST/REGEN/SKIP review like every other
+  // draft - Zaal still gates whether it actually publishes.
+  const fractalTask = cron.schedule(
+    '0 15 * * 0', // 15:00 (3pm) every Sunday
+    async () => {
+      try {
+        await sendFractalPromo(opts.bot, opts.zaalTgId);
+        await appendLog({ event: 'fractal-promo-sent' });
+        console.log('[zoe/posts] fractal-promo: sent Sunday draft');
+      } catch (err) {
+        await appendLog({ event: 'fractal-promo-error', error: (err as Error).message });
+        console.error('[zoe/posts] fractal-promo failed:', (err as Error).message);
+      }
+    },
+    { timezone: 'America/New_York' },
+  );
+
+  console.log(`[zoe/posts] scheduler started (target ${pings} pings/day, window ${WINDOW_START_HOUR_ET}am-${WINDOW_END_HOUR_ET - 12}pm ET) + sunday-3pm fractal slot`);
 
   return {
     stop: () => {
       midnightTask.stop();
       tickTask.stop();
+      fractalTask.stop();
     },
   };
 }


### PR DESCRIPTION
## Summary
Closes cowork tracker task `#220` - the Sunday-afternoon Fractal-promo slot. Surfaced in doc 722 (3-month synthesis): day-1 activation for new ZAO members = Fractal participation, and at ~3-5 new humans per 73 days, the standing Sunday lead-time reminder is the cheapest recurring activation hook.

## What ships
- New file `bot/src/zoe/posts/fractal-promo.ts` - templated draft body + send function.
- `scheduler.ts` registers a dedicated cron at **Sunday 15:00 America/New_York** that fires the Fractal draft via the standard `sendDraftWithKeyboard` flow.

## How it works
1. Sunday 3pm ET, cron fires.
2. ZOE sends Zaal the draft DM with POST/REGEN/SKIP buttons (same review flow as every other ZOE post - never auto-publishes).
3. Zaal taps POST -> the message goes to the configured socials destinations.
4. Monday 6pm EST the Fractal kicks off with one more head of lead time.

## Body
```
fractal tomorrow 6pm EST.

where ZAO members do the actual work + earn Respect tokens. week 90+ and counting - the longest-running ritual in the ecosystem.

join: <FRACTAL_JOIN_URL>
```

Style matches the ZOE voice contract (lowercase-ish, no emojis, no em-dashes, spartan).

## Required env
- `FRACTAL_JOIN_URL` - the canonical Discord invite (or other join URL). Falls back to `https://discord.gg/thezao` if unset so the slot never breaks silently. Set on Zaal's mac / wherever zoe-bot runs.

## Verification
First live fire: **Sunday 2026-05-25 at 3pm ET** (less than 24h before the 2026-05-26 6pm EST Fractal).

## Tier
N/A - feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)