### PR TITLE
docs(juke): add partner-SSO bridge to open asks

### DIFF
--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -172,6 +172,14 @@ const OPEN_ASKS: OpenAsk[] = [
     priority: 'p1',
   },
   {
+    id: 'partner-sso-bridge',
+    title: 'Parent-frame SSO so authed users on partner sites do not re-sign',
+    reason:
+      "ZAO uses Sign In With Neynar (SIWN) - a managed signer registered by ZAO's app FID. Juke uses SIWF (fresh EIP-4361 SIWE in the moment by user's custody). Different primitives, so a direct hand-off does not exist - a ZAO user already signed in at zaoos.com still has to do a second SIWF dance inside the Juke iframe to react/raise hand/speak. Anonymous listen is fine (one-tap autoplay bypass). Three options for an SSO bridge, in ascending lift on your side: (1) Parent-frame Quick Auth via postMessage - ZAO posts {fid, signed-proof} into the iframe, Juke mints its JWT without showing the QR. You already have the miniapp Quick Auth code path; this is essentially 'trust the parent frame like a miniapp host'. (2) Trusted-partner pre-mint endpoint - ZAO server POSTs {fid, signed-proof} to a Juke endpoint, gets back a short-lived Juke JWT, passes it as ?token=... on the iframe src. Juke trusts ZAO because we hold a developer key + a registered allowed_origin. Cleanest SSO. (3) Quick Auth via the Farcaster miniapp shell already exists but only works when ZAO is loaded INSIDE the FC client, not on zaoos.com directly. Any of these closes the double-sign-in.",
+    blocks: 'Friction-free participate (react / raise hand / speak) inside ZAO OS embeds',
+    priority: 'p1',
+  },
+  {
     id: 'oss-spec',
     title: 'Open-source SPEC.md / codebase drop',
     reason:


### PR DESCRIPTION
## Summary

Zaal observed the double-sign-in pain: he already signed into ZAO OS with Farcaster (SIWN via Neynar), but participating inside the Juke iframe asks for a fresh SIWF signature.

Adds a new p1 open-ask to the manifest so Nicky + his agent see it on /juke-status. Three concrete options enumerated, in ascending lift on Juke's side:

1. **Parent-frame Quick Auth via postMessage** - ZAO posts {fid, signed-proof} into the iframe; Juke mints its JWT without showing the QR. Likely closest to the existing miniapp Quick Auth code path.
2. **Trusted-partner pre-mint endpoint** - ZAO server POSTs {fid, signed-proof} to Juke, gets back a short-lived Juke JWT, passes it as ?token=... on the iframe src. Cleanest SSO; relies on ZAO holding a developer key + a registered allowed_origin.
3. **Quick Auth via the Farcaster miniapp shell** already works when ZAO is loaded inside the FC client. Only mentioned for completeness.

Anonymous listen is fine (one-tap autoplay bypass). The double-sign only bites on participate (react / raise hand / speak).

## Files

\`\`\`
MOD src/lib/spaces/jukeIntegrationManifest.ts (one OpenAsk entry added)
\`\`\`

## Effect

The single source of truth is jukeIntegrationManifest.ts, so the moment this merges the new ask surfaces automatically on:

- https://zaoos.com/juke-status (HTML for humans + Nicky)
- https://zaoos.com/api/juke/status (JSON for agents)
- https://zaoos.com/juke-integration.md (markdown for LLMs)

No clipboard giant-paste to send him - just the URL.