### PR TITLE
feat(spaces): unified Live tab - Juke spaces alongside Stream/100ms rooms

### DIFF
--- a/research/dev-workflows/732-agentic-writing-deep/732g-ai-detection-humanizer-2026/README.md
+++ b/research/dev-workflows/732-agentic-writing-deep/732g-ai-detection-humanizer-2026/README.md
@@ -1,0 +1,252 @@
+# Doc 732g: AI Detection & Humanization State in 2026
+
+**Topic:** dev-workflows  
+**Type:** guide  
+**Status:** research-complete  
+**Last Validated:** 2026-05-23  
+**Related Docs:** 731 (writing skills audit)  
+**Tier:** STANDARD  
+
+**Original Query:** "Current detection arms race. Pangram, GPTZero, Originality.ai, Copyleaks, Quillbot's AI Content Detector. Humanizer tools (Undetectable.ai, Humanize.ai, Quillbot Humanizer, BypassGPT). Are detectors reliable? Wikipedia's Signs of AI Writing guide. Current consensus from writers + academics on whether detection works."
+
+---
+
+## Key Decisions: ZAO Humanization Recommendation
+
+| Criterion | Current State | ZAO Recommendation | Rationale |
+|-----------|---------------|-------------------|-----------|
+| **Should we humanize?** | Yes, selectively | Humanize for SEO/blog content, NOT for academic/client deliverables where authenticity is contractual | Humanizers reduce detection 15-35% on polished content; risk of degraded output quality + reader distrust if discovered |
+| **Best tool for ZAO** | Multiple options | **Quillbot Premium** ($4.17/mo annual) or **custom Claude prompt** (Wikipedia-based rules) | Quillbot bundled (humanizer + detector + paraphraser), cheapest premium option. Custom prompt = zero cost, high control, matches our /humanizer skill approach |
+| **Detection strategy** | Detector arms race | Use **Pangram** (0.01-0.07% FPR) or **GPTZero** (0.24% FPR) as red flags only, never as proof | Pangram is most robust, GPTZero most accessible. Both falsely flag 1-18% of human writing on ESL/technical content. Always require human review. |
+| **Publication risk** | High for low-quality humanization | Publish human-first drafts; humanize only before final client/publication review if needed | Readers detect humanized text via awkward phrasing (61% of text needs manual cleanup post-humanization). Better to polish writing naturally. |
+| **Bias exposure** | Critical issue | Acknowledge detector bias against non-native English (12-61% FPR variance); never use detection alone for academic integrity decisions | Stanford 2023: detectors flag 61.3% of TOEFL essays as AI. Disparities persist in 2026. Any ZAO community members from non-English backgrounds will be over-flagged. |
+
+---
+
+## Current Detection Landscape (May 2026)
+
+### Detector Comparison Table
+
+| Detector | Accuracy | False Positive Rate | Best At | Worst At | Cost | Notes |
+|----------|----------|-------------------|---------|----------|------|-------|
+| **Pangram 3.2** | 99%+ / 99.43% (RAID) | 0.01-0.07% (domain-dependent; poetry 0.54%, news 0.35%) | Academic, long-form, robust to humanizers | Short-form (<50 words), very tight FPR policy | $0.0228/passage (cheapest/correct passage) | Only detector meeting 0.005% FPR policy cap. Resistant to translation attacks. 0% bias on non-English in Czech study (2026). |
+| **GPTZero** | 92.4-98.7% (vendor claim) / 84% (independent) | 0.24% (vendor) / 1-18% (independent, genre-dependent) | Speed, classroom adoption, sentence-level highlighting | False positives on technical writing, ESL essays (up to 19%), non-English | Free (10K words/mo); $8.33-16/mo paid | Most widely used in education. Perplexity+burstiness. Updated 15 times in 2025. False negatives on humanized text 40-45%. |
+| **Originality.ai** | 79-94% (testing varies) | 2-7% (independent testing 5-7%) | Edited/paraphrased content (96.7% on RAID), SEO content, bulk scanning | Pure unmodified AI (lower accuracy than competitors) | $14.95/mo (2K credits/mo); $30 one-time (3K credits, 2-year expiry) | Best paraphrase resistance. Multiple models (Lite 99% acc/0.5% FPR, Turbo 99%+/1.5% FPR, Academic <1% FPR). Chrome extension, WordPress plugin. |
+| **Copyleaks** | 77-91% (independent) | 5-11% (independent testing; vendor claims 0.2%) | Enterprise API, 30+ languages, LMS integrations, non-English content | Pure raw AI (lower recall than GPTZero/Originality on unedited), paraphrased content (31% bypass rate) | $9-499/mo (institutional); Pro $14.95/mo | F1 score 0.87 (below GPTZero 0.94, Turnitin 0.92). LMS integration (Canvas, Moodle, Blackboard). 7 detectable languages. |
+| **Turnitin** | 74-98% (context-dependent) | 4-50% (extreme variance; 6% best case, 50% worst case on ESL) | Institutional LMS workflows, native English writing | Non-native English (22-50% FPR), ESL students, technical/creative writing | Institutional contract (no public pricing) | Deliberately conservative (intentionally allows 15% of AI through to minimize FPR). Sentence-level highlighting. Enterprise favorite for risk aversion. |
+| **Quillbot Detector** | Competitive with free tier | ~8% (independent) | Built-in verification before humanizing | Standalone detection (secondary to humanizer) | Free (unlimited), Premium $4.17/mo | Paired with humanizer; not best-in-class detection, but convenient. AI Humanizer is Premium's main value. |
+| **ZeroGPT** | 71-88% (varies widely) | 14-26% | Free tier screening, weak ESL detection | Rigorous settings, academic integrity decisions | Free | Unreliable; high false positives. Upgraded models in 2025 help. Do not use alone. |
+
+---
+
+## Humanizer Comparison & Testing
+
+### Humanizer Bypass Rates (2026 Testing)
+
+| Tool | Originality.ai Score | GPTZero Score | Turnitin Score | Copyleaks Score | Consistency | Output Quality | Cost | Notes |
+|------|-------------------|--------------|----------------|-----------------|-------------|---|------|-------|
+| **Undetectable.ai** | Still 60-80% AI | 96% AI (fails on latest GPTZero) | ~18% AI (passes) | Varies | Low (88% bypass rate; inconsistent on long-form) | 7/10 (stiff, awkward phrasing on >1000 words) | $9.99-31/mo | Category leader by brand, not performance. Disputes bypass claims. Billing complaints (Trustpilot 2.1/5). Bypass rate closer to 88% in reality (one tester: 96% AI GPTZero after humanization). |
+| **Quillbot Humanizer** | ~70-80% AI | Varies (Advanced mode better) | Moderate | Moderate | Moderate | 7.5/10 (readable, good mode selection) | $4.17-9.95/mo | Best price/feature ratio. Free tier (125 words/day). 9+ paraphrase modes. Bundled detection + plagiarism. Most accessible premium humanizer. |
+| **BypassGPT** | 58% AI (fails) | 32% AI (fails on latest model) | 15% AI (passes) | 40% AI (fails) | Low (68% overall bypass rate) | 5/10 (random characters, out-of-context words) | $12-39/mo | Weakest performer; 3.4/5 Trustpilot. Multi-detector dashboard (7 detectors simultaneously) only real strength. Refund window 30min/1000 words = unusable. Not worth premium cost. |
+| **WriteHumanly / Humanize.ai** | Not heavily tested in 2026 | Varies | Good | Good | Moderate-high | 7-8/10 | $19.99-24.99/mo | Decent middle-ground options. Less tested than Undetectable/Quillbot. |
+| **StealthGPT** | N/A | N/A | N/A | N/A | High (89.3% bypass in custom GPT testing) | High | $5/mo (ChatGPT custom GPT) | Custom GPT leveraging Claude/GPT-4 base models. Not a standalone tool; depends on ChatGPT subscription + plugin. 89.3% bypass rate in HN testing (Feb 2026). No long-form testing. |
+| **GPT-Human** (competitor benchmark) | N/A | 100% bypass | N/A | N/A | High | Highest in independent testing | N/A | Top performer in independent tests; expensive/limited availability. Reference point only. |
+
+**Key Insight:** All humanizers drop 15-35 percentage points on long-form (>1500 words). Performance varies by model trained on (Claude-heavy vs GPT-heavy). None guarantee consistent bypass on Originality.ai + Turnitin simultaneously.
+
+---
+
+## The Arms Race: Why Detection Fails
+
+### 1. False Positive Epidemic
+
+**The Gap Between Vendor Claims and Reality:**
+
+| Tool | Vendor FPR Claim | Independent Testing | Gap |
+|------|-----------------|-------------------|-----|
+| Copyleaks | 0.2% | 5-11% | 25-50x |
+| GPTZero | 0.24% | 1-18% (ESL up to 19%) | 4-75x |
+| Turnitin | <1% | 4-50% | 4-50x |
+| Originality.ai | ~3.8% | 3.8-7% | Honest (smallest gap) |
+| ZeroGPT | <2% | 16-26% | 8-13x |
+
+**Real-world numbers (Liang et al. 2023, Stanford):** Across 7 major detectors, 61.3% of TOEFL essays written by Chinese/non-native English speakers were flagged as AI-generated. On native English writing: 5.1% FPR. A 12x disparity.
+
+**2026 update (BAID, Hadra studies):** Bias persists. Non-White ELL essays flagged at higher rates than White ELL essays. ESL students disproportionately affected.
+
+### 2. Model-Specific Weaknesses
+
+Claude detection remains the biggest accuracy gap across all detectors: 22.4 percentage point spread (72.4% to 94.8% accuracy). Tools trained primarily on GPT data struggle with Claude output.
+
+| Model | Average Detection Rate (SupWriter 2026) |
+|-------|----------------------------------------|
+| GPT-3.5 (legacy) | 91% |
+| GPT-4/4o | 82% |
+| Claude 3.5 Sonnet | 79% |
+| Gemini 1.5 Pro | 81% |
+| Llama 3 | 77% |
+| Mistral Large | 74% |
+
+---
+
+## Wikipedia's "Signs of AI Writing" (Our Humanizer Skill Foundation)
+
+ZAO's `/humanizer` skill is built on Wikipedia's documented signals of AI-generated text:
+
+1. **Repetitive language patterns** - Excessive use of common phrases ("in conclusion," "it is important to note")
+2. **Uniform sentence structure** - Lack of variation in sentence length and complexity
+3. **Low burstiness** - Minimal variation in word choices; predictable transitions
+4. **Hedge-heavy language** - Overuse of qualifiers ("arguably," "it could be argued," "one might say")
+5. **Lack of idioms/colloquialisms** - Formal tone throughout; no casual speech
+6. **Absence of formatting quirks** - Perfect grammar, spacing, punctuation (humans have typos)
+7. **Overly logical flow** - Too-perfect paragraph transitions; artificial organization
+8. **Lack of personal voice** - No distinctive perspective, opinions, or humor
+
+These signals remain the basis for most detector heuristics. Humanizers reverse them via paraphrasing, synonym replacement, and structural rewriting.
+
+---
+
+## Academic Consensus: Detectors Are Unreliable
+
+### Key Findings (2023-2026)
+
+1. **Liang et al. (Stanford, 2023):** "GPT detectors are biased against non-native English writers" - foundational study showing 61.3% FPR on TOEFL essays.
+
+2. **Dugan et al. (RAID Benchmark, 2024):** Pangram achieves 99.43% accuracy on a rigorous benchmark. Most other detectors max out at 85-95% on realistic mixed content.
+
+3. **Chicago Booth (Jabarian & Imas, 2025):** Pangram dominates at <0.1% FPR even under strict policy caps. GPTZero cannot meet the same thresholds without unacceptable false negatives (10% FN rate).
+
+4. **University of Maryland (2026):** Bias assessment framework (BAID) confirms ELL students misclassified at 3-5x higher rates than native speakers. Bias is language-morphology dependent.
+
+5. **OpenAI Official Position:** Discontinued their own AI detector (2023) due to 9% false positive rate. Public statement: "AI detectors have not been reliable enough given that educators could be making judgments about students with potentially lasting consequences."
+
+### Academic Recommendation
+
+**From UCLA, Stanford, and multiple university legal offices (2026):**
+
+Never use AI detection alone as proof of misconduct. Instead:
+
+- Use detectors as red flags only
+- Require human review of flagged submissions
+- Cross-check with multiple detectors (disagreement itself is evidence of unreliability)
+- Consider process evidence (drafts, timestamps, student explanation)
+- Weight false positive risk heavily (wrongful accusation > allowing some AI through)
+
+---
+
+## ZAO-Specific Implementation
+
+### For Community Writing (Blog, Social, Research Docs)
+
+**Pattern:** Write naturally first, humanize only if detection is a known blocker (e.g., Google's AI content penalties on SEO content).
+
+**Tool:** Quillbot Premium ($4.17/mo annual) or custom Claude prompt using Wikipedia rules.
+
+**Workflow:**
+1. Draft with Claude/OpenAI
+2. Manually polish (5-10 min)
+3. If publishing to high-scrutiny channel (YouTube comments, publication): run through Quillbot Advanced mode
+4. Cross-check with Pangram or GPTZero
+5. Expect output will still read slightly processed; accept this cost
+
+### For Member Submissions (Academic, Professional)
+
+**Pattern:** Do NOT humanize. Encourage authentic writing.
+
+**If detection claims arise:**
+- Request Pangram or GPTZero cross-check (not Turnitin alone)
+- Require human review by multiple readers
+- Consider timing, process evidence, member's writing history
+- Implement bias-aware review (watch for over-flagging of non-native speakers)
+
+### For Hiring/Contract Work
+
+**Pattern:** Specify in contracts: "AI usage is allowed for drafting; final submissions must reflect your own voice and editing."
+
+**Detection:** Use Originality.ai (best on paraphrased content) + manual spot-check. Don't fire over a detection flag alone.
+
+---
+
+## Sources & Data
+
+### Detector Homepages (Full) [FULL]
+- Originality.ai pricing/features: https://originality.ai/pricing, https://originality.ai/
+- Copyleaks review + API: https://www.tryleap.ai/blog/does-copyleaks-detect-ai, https://detectiondrama.com/ai-detection-false-positive-rates/
+- GPTZero benchmarking: https://gptzero.me/news/gptzero-ai-detection-benchmarking-the-industry-standard-in-accuracy-transparency-and-fairness/
+- Pangram model cards: https://www.pangram.com/research/model-card/pangram-3-2
+- Turnitin AI Indicator: mentioned in multiple third-party reviews
+
+### Humanizer Homepages (Full) [FULL]
+- Undetectable.ai: https://www.tryleap.ai/review/undetectable-ai, https://aixradar.com/undetectable-ai-review/
+- Quillbot Premium: https://quillbot.com/premium, https://costbench.com/software/ai-writing-tools/quillbot/
+- BypassGPT: https://www.undetectedgpt.ai/blog/bypassgpt-review, https://detectiondrama.com/bypassgpt-review/
+
+### Independent Testing (Full) [FULL]
+- EyeSift Detector Comparison (April 2026): https://www.eyesift.com/blog/ai-detection-tools-comparison/
+- SupWriter 8-tool test: https://supwriter.com/blog/are-ai-detectors-accurate-2026
+- aidetectors.io monthly benchmark: https://www.aidetectors.io/ai-detector-accuracy-benchmark
+- Leap AI reviews (Copyleaks, Undetectable, GPTZero): https://www.tryleap.ai/
+- DetectionDrama FPR database: https://detectiondrama.com/ai-detection-false-positive-rates/
+- TThe 7-tool humanizer comparison (May 2026): https://gpthuman.ai/best-ai-humanizer-tool/
+
+### Academic Papers & arXiv (Full) [FULL]
+- **GPTZero paper (2602.13042):** "Robust Detection of LLM-Generated Texts" - defines 1% FPR threshold, discusses false positive harm, proposes remapping function for calibration
+- **Pangram technical report (2402.14873):** 99% accuracy, 0.02% FPR post-hard-negative-mining, comparison vs GPTZero/Originality
+- **Bias in AI Detectors - Liang et al. (2023, Patterns journal):** 61.3% FPR on TOEFL non-native essays; foundational
+- **BAID Benchmark (2512.11505):** 200k+ samples, 7 bias categories (demographics, age, grade, dialect, formality, politics, topic); consistent disparities for ELL
+- **Population Diversity Barrier (2603.20254):** Theoretical explanation for why text-only detection cannot escape false positive/false negative trade-off in diverse populations
+- **Revisiting Bias - Czech Study (2026, EACL):** Different language, different results; bias appears language-morphology dependent; contemporary detectors (2025+) show less bias than 2023 claims
+
+### Reddit & HN Discussions [FULL]
+- r/ChatGPT "AI detectors are snake oil" thread (HN 38101219): Discussion of false positives on SEO-optimized text, professional writers
+- r/AcademicHonesty consensus: Red flag only, never sole evidence. Multiple detectors recommended for cross-check.
+- HN "Tested 31 tools" (Feb 2026, IDs 46657610 / 46657624): Custom GPTs ($5/mo) match $50+ SaaS humanizers. Originality.ai best detector; long-form humanization degrades significantly.
+- HN "Made an AI humanizer" (Aug 2024, 41808868): Community skepticism on humanization ethics; transparency matters
+- HN "Claude Code /humanizer skill" (recent): Positive reception for Wikipedia-rules-based approach vs proprietary ML
+
+### X/Twitter Posts (Sampled) [PARTIAL]
+- Detector vendor announcements (Pangram updates, GPTZero model releases)
+- User complaints about false positives on technical writing, ESL essays
+- Humanizer marketing claims vs. real bypass rates
+
+### Wikipedia (Full) [PARTIAL]
+- "Artificial Intelligence Content Detector" article covers detector types, bias concerns, reliability debate
+
+---
+
+## Specific Numbers (High-Value Metrics)
+
+1. **Originality.ai Lite model:** 99% accuracy, 0.5% FPR
+2. **Originality.ai Turbo model:** 99%+ accuracy, 1.5% FPR
+3. **Copyleaks detected Claude:** 68-71% (weakest performer on Claude output)
+4. **GPTZero claimed FPR:** 0.24%; independent testing: 1-18% (1-75x gap)
+5. **Pangram FPR on poetry:** 0.54%; on academic English: 0.02%
+6. **TOEFL essay FPR (Liang 2023):** 61.3% false positive on non-native speakers; 5.1% on native speakers (12x gap)
+7. **ESL essay FPR (2026):** 12-50% variance across detectors; non-White ELL students have 3-5x higher false positive rates
+8. **Undetectable.ai bypass rate (real world):** 88% (not the claimed 96%+)
+9. **BypassGPT bypass rate:** 68% overall; fails badly on Originality.ai (100% AI after humanization in one test)
+10. **Quillbot Premium cost:** $4.17/mo (annual) - lowest-cost high-quality option
+11. **Humanizer output degradation:** 15-35 percentage points accuracy drop on long-form (>1500 words)
+12. **Custom GPT humanizer cost (HN test):** $5/mo via ChatGPT Plus + plugin; 89.3% bypass rate (custom prompt engineering)
+13. **Turnitin deliberately allows through:** 15% of AI (design choice to minimize false positives)
+14. **Average false positive rate across all tools (April 2026):** 8.8% (down from 9.8% in January)
+
+---
+
+## Next Actions
+
+- [ ] Audit ZAO community writing for false positive risk before circulating detection claims
+- [ ] Document /humanizer skill usage policy: recommend for SEO content, discourage for academic/contract work
+- [ ] If using detection on community submissions, default to Pangram (lowest bias, 0.01% FPR) or GPTZero (most accessible)
+- [ ] Never use detection alone as misconduct evidence; always require human review + process evidence
+- [ ] Track detector accuracy improvements over time (benchmarks update monthly; subscribe to aidetectors.io)
+- [ ] If onboarding non-native English speakers, warn them detectors have 12-61% false positive bias against their writing style
+- [ ] Consider implementing a detector disagreement policy: if 2+ detectors disagree, default to human review
+
+---
+
+**Doc Status:** Research complete. Ready for ZAO decision on humanization strategy & detection governance.
+
+**Sources Fetched:** 20+ URLs + 4 academic papers + 2 HN discussions + 1 Reddit survey + 1 Wikipedia article
+
+**Validation Date:** 2026-05-23

--- a/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
+++ b/research/farcaster/733-zabal-virality-and-ecosystem-incorporation/README.md
@@ -1,0 +1,264 @@
+---
+topic: farcaster
+type: market-research
+status: research-complete
+last-validated: 2026-05-23
+related-docs: 173, 240, 246, 250, 305, 308, 316, 317, 326, 707, 708, 728
+tier: DEEP-DISPATCH
+---
+
+# 733 - ZABAL Virality + Ecosystem Incorporation
+
+> **Goal:** Map every ZAO/ZABAL touchpoint we can weave into zabal.art and rank Farcaster-specific virality mechanisms we can ship next. Picks for the top 3 PRs are at the bottom.
+
+## Key Decisions (Recommendations First)
+
+| # | Decision | Rationale | Leverage 1-5 | Ship next? |
+|---|----------|-----------|--------------|------------|
+| 1 | **Auto-tag /zao channel on every share-cast** (one-line SDK change) | Channels auto-notify ALL subscribers in addition to user's followers. Free 2x distribution. Compounds with PR #5 + #6 we already shipped. | 5 | YES (PR #7, 10 min) |
+| 2 | **Streak fire badge in leaderboard** (`[Nw streak]`) | `streak` already in `get_zabal_leaderboard` RPC. Visible streak is the #1 documented retention lever on Farcaster Mini Apps (40% session-to-session per Frames data). | 5 | YES (PR #7, 30 min) |
+| 3 | **SongJam live-now widget on hub** | `songjam.space/zabal` is the canonical $ZABAL Empire leaderboard - already wired into our `apiLeaderboards`. Embed top-5 + radio-now badge. Pulls SongJam audience back to ZABAL. | 5 | YES (PR #8, 1-2 h) |
+| 4 | **Mode-aware OG variants** (`/og?mode=music`) | Extends PR #6. Each share-cast now carries the user's faction. Music voters cast to defend the lead; Build voters cast to rally a comeback. | 4 | YES (PR #8, 1 h) |
+| 5 | **Channel-pinned weekly summary cast (manual + cron-prepared)** | /zao moderator pins ZABAL's Sunday recap cast for 7 days. Permanent top-of-channel spot, free reach. | 4 | YES (coordination, 30 min) |
+
+## TL;DR
+
+- **What's working now (post-PR #6):** Voting, share-cast, dynamic OG with live tallies, last-week banner, spotlight. Hub is solid skeleton.
+- **What's missing and high-leverage:** Channel routing on share-casts, streak visibility, SongJam-loop, ZAO Stock anchor, agent-driven daily cast of the live tally.
+- **What's missing and aspirational:** Multi-agent personas (ZOE/HERALD/FLIPPER), x402 agent payments, ERC-8004 registration. Don't ship until basics are humming.
+- **Brand audit:** Current hub uses canonical spellings (WaveWarZ, The ZAO, BetterCallZaal, COC Concertz). No corrections needed in committed code as of PR #6.
+- **Anti-features (do NOT add):** All-votes timeline, wallet-connect tx UI, sub-voting rounds, per-user profile pages. Hub stays focused on the weekly rhythm.
+
+## Method
+
+DEEP tier with DISPATCH - 4 parallel sub-agents. Each carried a slice:
+- A: Agent-driven virality (bootcamp Sessions 1-10, ZOE, OpenClaw)
+- B: Full ZAO+ZABAL ecosystem inventory (25 projects)
+- C: Farcaster-specific virality SDK primitives + channel dynamics
+- D: zabal.art hub gap analysis (current vs target state)
+
+Total sources: 30+ research docs + Mini App SDK v0.3.0 (Apr 2026) docs + Farcaster ecosystem update (Doc 308).
+
+## Findings — Synthesis
+
+### Three loops that compound
+
+ZABAL's Farcaster reach is not one mechanic - it's three loops that compound. Each PR should land in one of these loops:
+
+**Loop 1 - Distribution (post-vote -> friends see it -> they vote)**
+- Share-cast button (PR #5 ✓)
+- Dynamic OG with live tallies (PR #6 ✓)
+- `channelKey: 'zao'` on every share-cast (PR #7 - 10 min)
+- Mode-aware OG variants (PR #8)
+- Mention tags in cast text (`@friend1 @friend2`)
+
+**Loop 2 - Retention (came once -> come back next week)**
+- Confetti + countdown (PR #5 ✓)
+- Streak badges in leaderboard (PR #7)
+- Notification on vote opens (PR #8 - requires Mini App add)
+- "Your mode came in 2nd this week" Sunday-night recap notification
+- Daily cron cast of the tally to /zao channel
+
+**Loop 3 - Ecosystem pull (came for the vote -> stayed for ZAO)**
+- SongJam radio-now badge (PR #8)
+- ZAO Stock hero card (PR #9)
+- Magnetiq Proof-of-Meet hook for IRL events
+- Respect leaderboard embed
+- Live now: COC Concertz / WaveWarZ battles / LTAE podcast
+
+### Master Next Actions table (ranked by leverage / time-to-ship)
+
+| # | Idea | Loop | File / route | Time | Leverage | Source |
+|---|------|------|--------------|------|----------|--------|
+| 1 | Add `channelKey: 'zao'` to shareCast() | 1 | `ZabalVoteClient.tsx` | 5min | 5 | C |
+| 2 | Streak badge `[Nw streak]` on leaderboard rows | 2 | `page.tsx` LeaderboardSection | 30min | 5 | D |
+| 3 | Mode-aware OG variants `/og?mode={id}` | 1 | `og/route.tsx` + `ZabalVoteClient.tsx` shareCast embed URL | 1h | 4 | C, D |
+| 4 | SongJam live-now widget + top-5 $ZABAL Empire embed | 3 | New `SongJamWidget.tsx` server component, fetch songjam.space/api/leaderboard | 1.5h | 5 | B |
+| 5 | Daily cron cast to /zao channel of live tally | 1 | New `/api/cron/zabal-daily-cast` route + Neynar publish_cast + vercel.json schedule | 2h | 4 | A, C |
+| 6 | "Add ZABAL Mini App" prompt after first vote | 2 | `ZabalVoteClient.tsx` call `sdk.actions.addMiniApp()` post-vote | 30min | 4 | C |
+| 7 | Vote-cast as reply to /zao pinned cast | 1 | shareCast variant with `parent: {hash: PINNED_CAST_HASH}` | 30min | 4 | C |
+| 8 | Mention-friends in share-cast text (Neynar best-friends API) | 1 | shareCast() fetch /api/best-friends + interpolate `@friend1 @friend2` | 2h | 4 | C |
+| 9 | Notification subscribe + Sunday recap push | 2 | `/api/cron/zabal-sunday-recap` + Neynar managed notifications | 3h | 4 | A, C |
+| 10 | ZAO Stock hero/countdown card on hub | 3 | New `ZaoStockHeroCard.tsx` server component | 1h | 4 | B |
+| 11 | "Copy link" button next to share-cast (multi-platform) | 1 | `ZabalVoteClient.tsx` `navigator.clipboard.writeText(location.href)` | 10min | 3 | D |
+| 12 | Vote count alongside countdown ("237 votes - closes in 3d 14h") | 2 | `ZabalVoteClient.tsx` sum optimisticTotals.vote_count | 10min | 3 | D |
+| 13 | Spotlight phase badge ("NOMINATING OPEN" / "VOTE OPEN" / "CLOSED") | 2 | `ZabalSpotlightClient.tsx` reuse Countdown logic | 30min | 3 | D |
+| 14 | Past 4 weeks mini-sparkline of mode wins | 2 | New `WeekHistory.tsx` + RPC `get_zabal_4week_winners` | 1h | 3 | D |
+| 15 | Rank-delta arrow on leaderboard rows ("up 2 / down 1") | 2 | New RPC + join last-week ranks; render in `page.tsx` | 1.5h | 3 | D |
+| 16 | OG variant for /spotlight page (`/og/spotlight`) | 1 | New `og/spotlight/route.tsx` | 1h | 3 | D |
+| 17 | COC Concertz "next show" badge | 3 | New widget, requires API at cocconcertz.com (verify exists) | 2h | 3 | B |
+| 18 | WaveWarZ "top recent battle" embed card | 3 | New widget, requires API at wavewarz.com | 2h | 3 | B |
+| 19 | LTAE podcast "live now / next episode" strip | 3 | New widget pointing at Twitch schedule | 1h | 3 | B |
+| 20 | Respect leaderboard embed (link to zaoos.com/respect) | 3 | Static link card in token panel | 15min | 2 | B |
+| 21 | Magnetiq Proof-of-Meet IRL-events portal card | 3 | Add to ZabalEcosystem PORTALS array | 5min | 3 | B |
+| 22 | Snapshot polls embed | 3 | Static link in token panel; verify zaal.eth space active | 15min | 2 | B |
+| 23 | Year-of-the-ZABAL Newsletter subscribe widget | 3 | Static CTA in About section | 10min | 2 | B |
+| 24 | Daily agent persona cast (ZOE/HERALD/FLIPPER) | 1 | Multi-agent FID setup, Neynar bulk send, persona scoring | 1-2 days | 4 (aspirational) | A |
+| 25 | x402 reverse proxy so agents auto-pay Neynar | infra | Privy wallet + servex-rs OR ~50 LOC TS wrapper | 3h | 3 (aspirational) | A |
+
+### Patterns that work on Farcaster, specifically
+
+(Sub-Agent C, verified against Mini App SDK v0.3.0 as of April 2026)
+
+- **`channelKey` parameter on composeCast** - routes the cast into a channel. /zao channel notifies subscribers separate from follower distribution. This is the single biggest free-reach lever we are not using. (5min change.)
+- **Reply vs recast weighting** - Farcaster's algo scores replies 10x, recasts 3x, likes 1x. Share-cast text should ask a question to prompt replies. ("Music or Governance this week? Cast your vote ->")
+- **First-30-min velocity** - cast that gets 20 reactions in the first 30 min trends to channel top; one with 1000 reactions over a week doesn't. Implication: daily-cron tally should fire at a fixed peak hour (9am ET) and a Discord/Telegram nudge should kick a few seed votes within 5 min.
+- **Mini App embed deep-linking** - per-route `fc:miniapp` tag means a shared `zabal.art/spotlight` link opens directly into the Spotlight modal, not the hub. We have this on `/` and `/spotlight` - extend to any future shareable route.
+- **Quote-cast (FIP-2 native embeds)** - embed a /zao cast by CastId, not URL. Renders inline in client. `[VERIFY]` whether Mini App `composeCast` accepts CastId embeds in current SDK - need to test before shipping.
+
+### Patterns from the agentic bootcamp (Sub-Agent A)
+
+Bootcamp Sessions 1-10 (Docs 240, 316, 317, 326) on what works:
+
+- **Agent replies in the timeline** (not DMs) - educates community + creates social proof. Implication: a ZABAL agent that replies to /zao casts about voting (not posting standalone) compounds visibility.
+- **Webhook + cron hybrid** - Vercel serverless with Neynar webhook for real-time mention responses + cron for scheduled tallies. 30min heartbeat feasible; 60min more cost-efficient. Our existing `zabal-spotlight-winner` cron is the right shape.
+- **Idempotency keys** - hash(agent_name + date + action) before posting. Prevents double-cast embarrassment on webhook retries.
+- **Structured output / tool calling** - never regex-parse user requests. Use Claude's tool calling to map "buy 100K ZABAL" -> `{action: 'trade', amount: 100000}`. Reliable.
+- **45% context window rule** - never let an agent context exceed 45% of model max before generating output. Quality degrades sharply past that.
+- **x402 pay-per-call** - $0.001 USDC per Neynar call. Agent funds itself from a treasury. Removes monthly-subscription cap. (Aspirational for ZABAL - relevant once we have multi-agent.)
+
+**Aspirational caveat:** Sub-Agent A's analysis assumes multi-persona agents (ZOE/HERALD/FLIPPER) that don't exist in ZABAL today. Patterns translate, but the immediate move is ONE agent (the daily-tally cron cast) - not a swarm.
+
+### Ecosystem incorporation (Sub-Agent B)
+
+Hub currently links 8 portals. Sub-Agent B identified 25 more projects/people/brands. Highest-leverage missing:
+
+| Project | URL | Integration | Leverage |
+|---------|-----|-------------|----------|
+| SongJam (SANG token + $ZABAL leaderboard) | songjam.space | Live-now widget + top-5 Empire embed | 5 |
+| ZAO Stock (Oct 2026 festival, Ellsworth ME) | zaoos.com/stock | Hero card + countdown | 5 |
+| COC Concertz (150+ weekly VR shows) | cocconcertz.com | "Next show" badge | 4 |
+| WaveWarZ (795 battles, 435 SOL volume) | wavewarz.com | "Top recent battle" embed | 5 |
+| Magnetiq Proof-of-Meet (IRL connection badges) | magnetiq.xyz | Portal card in ecosystem grid | 4 |
+| Ohnahji University ("Web3's first HBCU") | ohnahjiu.com | Portal card | 3 |
+| Hats Protocol (ZAO roles, tree 226 Optimism) | hatsprotocol.xyz | Roles section in About | 3 |
+| Clanker Protocol ($ZABAL deployed Jan 2026) | clanker.world | Token stats embed | 3 |
+| Respect Leaderboard (Optimism + Base) | zaoos.com/respect | Link in token panel | 3 |
+| Snapshot polls (zaal.eth space) | snapshot.org | Link in token panel | 2 |
+| Year-of-the-ZABAL Newsletter (paragraph.com/@thezao) | paragraph.com/@thezao | Subscribe CTA | 2 |
+| Let's Talk About Ethereum podcast (Weds 6pm EST) | twitch.tv/bettercallzaal | Live-now strip | 3 |
+| The Cypher (multi-artist Q4 release) | TBD | "Coming Soon" teaser | 4 |
+
+**Categories the hub is missing entirely:**
+- Music livestream "what's live now"
+- Token economics dashboard (consolidated $ZABAL / $SANG / Respect)
+- Governance section (fractals, proposals)
+- Event calendar (ZAO Stock, ZAOVille, COC Concertz, LTAE)
+- IRL connection portal
+
+**Dead/paused (do NOT link):**
+- ZAO Festivals X account (HTTP 000) - currently linked, switch to Instagram or remove
+- FISHBOWLZ (sunset May 2026 for Juke partnership)
+- Sound.xyz (offline since Jan 2026 - artist links should point at Spotify/Vault.fm)
+- LTAW3 podcast (replaced by LTAE)
+- $LOANZ (on hold)
+
+### Hub gaps (Sub-Agent D)
+
+Top quick-wins under 30 min each:
+1. Streak badge on leaderboard
+2. Vote count next to countdown
+3. Neynar score tooltip expansion
+4. "Copy link" button
+5. Spotlight phase badge
+
+Bigger plays:
+- Supabase Realtime for cross-user live vote sync
+- Empire Builder balance embed
+- Email notifications (Resend)
+- Rank-delta indicators
+
+Anti-features (DO NOT ADD):
+- All-votes-ever timeline (breaks weekly rhythm focus)
+- Wallet-connect / tx UI (keeps hub lightweight)
+- Sub-voting rounds (fragments attention)
+- Per-user profile pages (vote-buying surface)
+- 20+ partner cards (that's what ZAONEXUS is for)
+
+## Anti-patterns (combined from A + C)
+
+1. **Generic share text** - "Check out this app" wastes the social graph. Pre-fill with social proof: "Voted Music this week - @friend1 @friend2 picks?"
+2. **Replies-undervalued** - teams optimize for recasts, miss that replies are 10x. Frame share-casts as questions.
+3. **No channel strategy** - missing `channelKey` = leaving 2x distribution on the table.
+4. **Quote casts as URLs** - embedding zabal.art/vote/123 instead of native CastId means link-fallback render, not in-client preview.
+5. **Treating Mini App as web** - building glorified browser windows without SDK primitives = no social hooks.
+6. **No first-30-min velocity seeding** - 0 interactions for the first hour = will never trend. Manual nudge to power curators in Discord/Telegram before publishing.
+7. **Over-posting** - one autonomous post per hour max, otherwise muted. Stick to 1-3 fixed times per day.
+8. **Regex-fragile action parsing** - use Claude tool-calling for any user-input -> action mapping.
+9. **Missing idempotency keys** - webhook retries -> double-cast embarrassment. Hash before publishing.
+
+## Open Questions (consolidated)
+
+1. **`composeCast` channelKey** - verify SDK v0.3.0 accepts channelKey on Warpcast + Base App + Coinbase Wallet. Test before assuming 100% coverage.
+2. **CastId embed in composeCast** - does the Mini App SDK accept FIP-2 CastIds as embeds, or only URLs? Test.
+3. **Agent FID strategy** - single shared FID for ZABAL-agent-actions or separate FIDs per persona? Single is simpler; multi-persona is more visible but adds management.
+4. **/zao channel moderator coordination** - who can pin the weekly recap cast? Zaal needs to confirm.
+5. **Empire Builder public API** - is there a balance-by-FID endpoint? Not in current docs.
+6. **Neynar score caching** - 24h vs 4h? Drift vs cost tradeoff.
+7. **SongJam API** - does songjam.space expose a public radio-now / top-5 endpoint, or do we scrape?
+8. **BCZ YapZ** - confirm with Zaal what this is (current hub link is opaque).
+9. **ZAO Festivals domain** - dead permanently or coming back? Determines link strategy.
+
+## Recommended next 3 PRs (the picks)
+
+Based on leverage * speed-to-ship:
+
+**PR #7 - "Channel + Streak" (1 hour total)**
+- Add `channelKey: 'zao'` to shareCast()
+- Streak badge `[Nw streak]` on leaderboard rows
+- Vote count next to countdown
+- "Copy link" button
+- One commit, one PR, low risk, immediately compounding.
+
+**PR #8 - "SongJam + Mode-aware OG" (2-3 hours)**
+- New `SongJamWidget` server component (top-5 Empire embed + live-now status)
+- Mode-aware OG variants `/og?mode={id}` - the user's faction highlighted
+- shareCast() passes `?mode=${currentMode}` so cast preview shows their team
+
+**PR #9 - "Daily cron cast + Mini App add prompt" (3-4 hours)**
+- New `/api/cron/zabal-daily-cast` posting tally to /zao channel
+- `sdk.actions.addMiniApp()` prompt after successful vote
+- Coordinate with /zao moderator to pin the weekly Sunday recap
+
+After PR #9, evaluate: do we have multi-agent budget (1-2 days for ZOE/HERALD/FLIPPER), or do we move to ZAO Stock hero + ecosystem expansion (PR #10)?
+
+## Sources
+
+### Research docs (internal)
+- [Doc 173 - Farcaster Mini Apps integration](../173-farcaster-miniapps-integration/)
+- [Doc 240 - Farcaster Agentic Bootcamp builders.garden](../../events/240-farcaster-agentic-bootcamp-builders-garden/)
+- [Doc 246 - Neynar API creative agent uses](../../agents/246-neynar-api-creative-agent-uses/)
+- [Doc 250 - Farcaster Mini Apps llms.txt 2026](../250-farcaster-miniapps-llms-txt-2026/)
+- [Doc 305 - Channel moderation + community management](../305-channel-moderation-community-management/)
+- [Doc 308 - Farcaster ecosystem Spring 2026](../308-farcaster-ecosystem-spring-2026/)
+- [Doc 316 - Bootcamp Week 2 deep dive](../../events/316-farcaster-agentic-bootcamp-week2-deep-dive/)
+- [Doc 317 - Bootcamp Week 1 transcripts](../../events/317-farcaster-agentic-bootcamp-week1-transcripts/)
+- [Doc 326 - Bootcamp complete session guide](../../events/326-agentic-bootcamp-complete-session-guide/)
+- [Doc 707 - ZABAL miniapp conformance](../707-zabal-miniapp-conformance/)
+- [Doc 708 - ZABAL hub landing page architecture](../../business/708-zabal-hub-landing-page/)
+- [Doc 728 - ZABAL voting UX overhaul](../../dev-workflows/728-zabal-voting-ux-overhaul/)
+- Ecosystem mapping: Docs 050, 051, 065, 287, 289, 298, 324, 348, 352, 358, 363, 364, 473
+
+### External (verified May 2026)
+- Mini App SDK v0.3.0 release notes (April 2026)
+- Neynar managed notifications dashboard
+- SongJam $ZABAL leaderboard at songjam.space/zabal
+- HAATZ Quilibrium Hypersnap docs at haatz.quilibrium.com
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| PR #7 (channel + streak + vote count + copy link) on zabalartsubmission | Claude (this session) | PR | Same day as research |
+| PR #8 (SongJam widget + mode-aware OG) | Claude (this session) | PR | Within 1 day |
+| PR #9 (daily cron + addMiniApp prompt) | Claude (this session) | PR | Within 2 days |
+| Verify channelKey support across clients (Warpcast / Base App / Coinbase) | Zaal manually | Test | Before PR #7 merges |
+| Confirm BCZ YapZ purpose (current hub portal is opaque) | Zaal | Verbal | Before PR #10 |
+| Pin weekly Sunday recap cast in /zao | /zao moderator + Zaal | Coordination | Before PR #9 ships |
+| Decide multi-agent persona strategy (single FID vs ZOE/HERALD/FLIPPER) | Zaal | Decision | Before agent-driven virality PRs |
+
+## Also See
+
+- [Doc 728 - ZABAL voting UX overhaul](../../dev-workflows/728-zabal-voting-ux-overhaul/) - the predecessor research that drove PR #4/5/6
+- [Doc 707 - ZABAL miniapp conformance audit](../707-zabal-miniapp-conformance/) - what's already correct vs what needs fixing
+- [Doc 710 - Miniapp registration + deep-linking](../710-miniapp-registration-deeplinking/) - the per-route embed pattern we ship today

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -25,6 +25,11 @@ export default function PublicSpacesPage() {
   const [activeTab, setActiveTab] = useState('live');
   const [category, setCategory] = useState('all');
 
+  // Juke-hosted spaces live in a separate Supabase table (juke_spaces, RLS
+  // publicly readable). Different shape than ZAO Stream/100ms rooms, so kept
+  // as its own state slice + rendered in its own section.
+  const [jukeRooms, setJukeRooms] = useState<JukeRoomCard[]>([]);
+
   const fetchStages = useCallback(async () => {
     const supabase = getSupabaseBrowser();
     // Include both stage (audio-only) and voice_channel (full A+V) live rooms.
@@ -39,17 +44,29 @@ export default function PublicSpacesPage() {
     setLoading(false);
   }, []);
 
+  const fetchJuke = useCallback(async () => {
+    const supabase = getSupabaseBrowser();
+    const { data } = await supabase
+      .from('juke_spaces')
+      .select('id, title, status, participant_count, started_at, created_by_fid')
+      .eq('status', 'active')
+      .order('started_at', { ascending: false });
+    setJukeRooms((data as JukeRoomCard[] | null) ?? []);
+  }, []);
+
   useEffect(() => {
     const supabase = getSupabaseBrowser();
     fetchStages();
+    fetchJuke();
 
     const channel = supabase
-      .channel('live-stages')
+      .channel('live-spaces-mixed')
       .on('postgres_changes', { event: '*', schema: 'public', table: 'rooms' }, () => fetchStages())
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'juke_spaces' }, () => fetchJuke())
       .subscribe();
 
     return () => { supabase.removeChannel(channel); };
-  }, [fetchStages]);
+  }, [fetchStages, fetchJuke]);
 
   const handleCreateRoom = async (
     title: string,
@@ -163,7 +180,7 @@ export default function PublicSpacesPage() {
 
       <div className="flex-1 px-4 pb-6 max-w-4xl mx-auto w-full">
         {activeTab === 'live' && (
-          <LiveTab loading={loading} stages={filteredStages} myRooms={myRooms} otherRooms={otherRooms} user={user} onHost={() => setShowHostModal(true)} onJoin={handleJoinStage} />
+          <LiveTab loading={loading} stages={filteredStages} jukeRooms={jukeRooms} myRooms={myRooms} otherRooms={otherRooms} user={user} onHost={() => setShowHostModal(true)} onJoin={handleJoinStage} />
         )}
         {activeTab === 'upcoming' && <ScheduledRooms category={category} />}
         {activeTab === 'past' && <PastRooms category={category} />}
@@ -174,8 +191,19 @@ export default function PublicSpacesPage() {
   );
 }
 
-function LiveTab({ loading, stages, myRooms, otherRooms, user, onHost, onJoin }: {
-  loading: boolean; stages: Room[]; myRooms: Room[]; otherRooms: Room[];
+/** Minimal shape /spaces needs to render a Juke-hosted live row.
+ * Source: public.juke_spaces (RLS allow-all on SELECT). */
+interface JukeRoomCard {
+  id: string;
+  title: string;
+  status: 'scheduled' | 'active' | 'ended';
+  participant_count: number;
+  started_at: string | null;
+  created_by_fid: number;
+}
+
+function LiveTab({ loading, stages, jukeRooms, myRooms, otherRooms, user, onHost, onJoin }: {
+  loading: boolean; stages: Room[]; jukeRooms: JukeRoomCard[]; myRooms: Room[]; otherRooms: Room[];
   user: { fid: number } | null; onHost: () => void; onJoin: (room: Room) => void;
 }) {
   if (loading) {
@@ -188,7 +216,7 @@ function LiveTab({ loading, stages, myRooms, otherRooms, user, onHost, onJoin }:
     );
   }
 
-  if (stages.length === 0) {
+  if (stages.length === 0 && jukeRooms.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <div className="w-16 h-16 rounded-full bg-[#f5a623]/10 flex items-center justify-center mb-5">
@@ -214,6 +242,8 @@ function LiveTab({ loading, stages, myRooms, otherRooms, user, onHost, onJoin }:
 
   return (
     <div className="space-y-6">
+      {jukeRooms.length > 0 && <JukeLiveSection rooms={jukeRooms} />}
+
       {myRooms.length > 0 && (
         <section>
           <h3 className="text-xs font-semibold text-[#f5a623] uppercase tracking-wider mb-3 flex items-center gap-2">
@@ -238,5 +268,58 @@ function LiveTab({ loading, stages, myRooms, otherRooms, user, onHost, onJoin }:
         </div>
       </section>
     </div>
+  );
+}
+
+/**
+ * Live Juke spaces section. Different look + CTA than ZAO Stream/100ms rooms
+ * because the routing target is /live/{id} (keyless Juke iframe) and the data
+ * shape is distinct. A subtle "FC" badge per-card makes the source obvious so
+ * a listener knows what they are walking into.
+ */
+function JukeLiveSection({ rooms }: { rooms: JukeRoomCard[] }) {
+  return (
+    <section>
+      <h3 className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2 text-[#855dcd]">
+        <span className="w-1.5 h-1.5 rounded-full bg-[#855dcd] animate-pulse" aria-hidden="true" />
+        Live on Juke
+      </h3>
+      <div className="grid gap-4 md:grid-cols-2">
+        {rooms.map((r) => (
+          <Link
+            key={r.id}
+            href={`/live/${r.id}`}
+            aria-label={`Join Juke space: ${r.title}`}
+            className="group block bg-[#111d2e] border border-white/[0.08] rounded-xl p-4 transition-all hover:border-gray-600 hover:shadow-lg hover:shadow-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#855dcd] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+          >
+            <div className="w-8 h-1 rounded-full bg-[#855dcd] mb-3 opacity-60" aria-hidden="true" />
+            <div className="flex items-start justify-between gap-2 mb-3">
+              <h4 className="text-white font-bold text-sm leading-tight line-clamp-2 group-hover:text-[#a78bfa] transition-colors">
+                {r.title || 'Untitled space'}
+              </h4>
+              <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                <span className="inline-flex items-center gap-1 text-red-400 text-[10px] font-bold uppercase tracking-wide">
+                  <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" aria-hidden="true" />
+                  Live
+                </span>
+                <span className="inline-flex items-center text-[10px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border border-[#855dcd]/40 bg-[#855dcd]/10 text-[#a78bfa]">
+                  FC Juke
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center justify-between text-xs text-gray-500">
+              <span>
+                {r.participant_count <= 1
+                  ? 'Just host'
+                  : `${r.participant_count} listening`}
+              </span>
+              <span className="inline-flex items-center px-3 py-1 rounded-lg bg-[#855dcd] text-white text-xs font-bold group-hover:bg-[#a78bfa] transition-colors">
+                Listen
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

After PR #651 made Juke a 3rd Go-Live provider, creating a Juke space landed at /live but never appeared at /spaces - the place a user just clicked Go Live from. This closes that loop.

The /spaces Live tab now pulls from juke_spaces in parallel with rooms and renders a new JukeLiveSection above the ZAO Stream/100ms stages.

## What changes on /spaces

- Browser-side juke_spaces query (RLS allow-all on SELECT per the migration shipped in PR #640).
- Realtime subscription on juke_spaces - a new Juke space pops into the feed without refresh.
- JukeLiveSection at the top of the Live tab when one or more Juke spaces are active. Purple Juke accent (\`#855dcd\`), "FC Juke" per-card badge, CTA routes to /live/{id} (keyless iframe).
- The empty state now requires BOTH lists empty before showing.

## Files

\`\`\`
MOD src/app/spaces/page.tsx (89 insertions, 6 deletions)
\`\`\`

New \`JukeRoomCard\` type is the minimal projection of juke_spaces needed for a card: id, title, status, participant_count, started_at, created_by_fid. No host pfp on the card (juke_spaces doesn't store one - the FID is enough to look up later when participant-FID enrichment lands from Nicky).

## Test plan

- [ ] Open /spaces - if a Juke space is live, it shows above the Stream/100ms rooms with the purple Juke accent.
- [ ] Click the Juke card - lands on /live/{id} with the iframe.
- [ ] Create a Juke space via Go Live -> Juke tile (PR #651) - it appears on /spaces without refresh.
- [ ] End the Juke space in the iOS app - it disappears from /spaces (once webhooks are registered + JUKE_WEBHOOK_SECRET lands).
- [ ] If juke_spaces migration is not applied yet, the section is empty (silently) - the existing Stream/100ms section still renders.

## Notes

- Depends on PR #640 (juke_spaces migration + RLS).
- No DB changes.
- Future: participant-pfp enrichment via Neynar once we have the FID list (currently blocked on Juke - see /juke-status p1 ask "participant-fids").