### PR TITLE
chore(serena): wire serena-hooks + relocate UVR memory (doc 728 actions)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,15 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "mcp__serena__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks auto-approve --client=claude-code"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "if": "Bash(git commit*)",
         "hooks": [
@@ -82,6 +91,20 @@
             "type": "command",
             "command": "cd \"$PROJECT_DIR\" && BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [[ \"$BRANCH\" != ws/* ]]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"SessionStart\\\",\\\"additionalContext\\\":\\\"WARNING: You are on branch [$BRANCH], not a ws/ worksession branch. CLAUDE.md requires running /worksession at session start to create an isolated branch. Invoke /worksession NOW before doing any work.\\\"}}\"; fi",
             "statusMessage": "Checking worksession branch..."
+          },
+          {
+            "type": "command",
+            "command": "serena-hooks activate --client=claude-code"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "serena-hooks cleanup --client=claude-code"
           }
         ]
       }

--- a/research/community/_relocated/serena-memory-uvr-playbook.md
+++ b/research/community/_relocated/serena-memory-uvr-playbook.md
@@ -1,5 +1,16 @@
 # UVR (Underground Violet Rave) Playbook - Research Complete
 
+> **Relocated 2026-05-23 (doc 728 Action #3):** This file used to live at `.serena/memories/project_uvr_playbook.md`. That directory is for per-project structural memories (project_structure, commands, agent_stack) consumed by Serena MCP, NOT for research content. The playbook summary belongs in `research/community/`.
+>
+> **Related primary UVR research docs:**
+> - [Doc 427 - UVR / Jadyn Violet brand intro bot](../427-uvr-jadyn-violet-brand-intro-bot/)
+> - [Doc 600 - Jadyn Violet UVR deep dive](../600-jadyn-violet-uvr-deep-dive/)
+> - [Doc 651 - Jadyn Violet UVR producer brief](../../music/651-jadyn-violet-uvr-producer-brief.md)
+>
+> The "Doc 560" path referenced below does not exist on `main` (the path was speculative when this summary was written). Use the docs listed above as the canonical references.
+
+---
+
 **Doc:** research/community/uvr-underground-violet-rave-playbook.md (Doc 560)
 **Completed:** May 14 2026
 **Tier:** STANDARD (7 sources verified)


### PR DESCRIPTION
## Summary
Actions from doc 728's "Today unblocked" list. Two atomic changes:

1. **Wire serena-hooks into .claude/settings.json** (doc 728 "Hook Wiring" section):
   - `PreToolUse` matcher `mcp__serena__*` -> `serena-hooks auto-approve` (kills per-call permission prompt)
   - `SessionStart` adds `serena-hooks activate` alongside existing branch-guard
   - New `Stop` hook -> `serena-hooks cleanup`
   - Existing Bash hooks (lint/branch-guard/typecheck/PostToolUse-eslint-fix) preserved
   - `serena-hooks` binary verified at `/Users/zaalpanthaki/.local/bin/serena-hooks`
   - settings.json validated with `python3 -m json.tool`

2. **Relocate `.serena/memories/project_uvr_playbook.md`** (doc 728 Action #3):
   - Moved to `research/community/_relocated/serena-memory-uvr-playbook.md`
   - Annotated with cross-links to actual UVR research docs (427, 600, 651) plus context on why it was moved
   - `.serena/memories/` is now empty, ready for `mcp__serena__onboarding` to seed properly

## Test plan
- [ ] `which serena-hooks` returns `/Users/zaalpanthaki/.local/bin/serena-hooks`
- [ ] Restart Claude Code; verify `mcp__serena__*` calls no longer trigger permission prompts
- [ ] Verify existing Bash hooks still fire (`git commit` triggers lint, `git push` triggers branch-guard + typecheck)
- [ ] `SessionStart` warning on non-ws branch still fires
- [ ] On session exit, `Stop` hook fires `serena-hooks cleanup` (LSP process released)
- [ ] `.serena/memories/` is empty (next session: run `mcp__serena__onboarding` per doc 728 Action #3)
- [ ] `research/community/_relocated/serena-memory-uvr-playbook.md` cross-links resolve

## Next steps (per doc 728)
- Run `mcp__serena__onboarding` on ZAOOS root to seed 5 project memories: project_structure, commands, agent_stack, graduation_protocol, boundaries
- Run `/doctor` (user-only command) to verify Tool Search + skill truncation count

## Tier
Chore - implementation of already-approved doc 728 actions, no new research.