### PR TITLE
fix(juke): register-webhook omits client secret, captures Juke-generated one

### DIFF
--- a/src/app/api/juke/admin/register-webhook/route.ts
+++ b/src/app/api/juke/admin/register-webhook/route.ts
@@ -7,22 +7,27 @@ import { logger } from '@/lib/logger';
 /**
  * POST /api/juke/admin/register-webhook
  *
- * Server-side wrapper around `POST https://api.juke.audio/v1/developer/webhooks`
- * so the registration runs in an environment where JUKE_API_KEY + JUKE_WEBHOOK_SECRET
- * already live (Vercel encrypted env). Avoids the Vercel-CLI-pull-redacts-sensitive
- * dance for the local register-juke-webhook.ts script.
+ * Server-side wrapper around `POST https://api.juke.audio/v1/developer/webhooks`.
  *
- * Admin-only. Idempotent in practice: Juke caps webhook subs at max 5 per app +
- * uniques by (app_id, url), so re-running with the same URL returns the existing
- * subscription rather than duplicating.
+ * Juke generates the HMAC secret server-side (it rejects with `extra_forbidden`
+ * if we try to send our own) and returns it ONCE in the response body. The
+ * admin who calls this route must immediately copy `juke.secret` from the
+ * response into the JUKE_WEBHOOK_SECRET env var on Vercel (Production +
+ * Preview + Development), then redeploy. The verifier in /api/juke/webhooks
+ * reads JUKE_WEBHOOK_SECRET to validate every inbound signature; without the
+ * copy the receiver 401s every delivery.
+ *
+ * Admin-only. Idempotent in practice: Juke caps webhook subs at max 5 per app
+ * + uniques by (app_id, url), so re-running with the same URL returns the
+ * existing subscription rather than duplicating.
  *
  * Body (optional):
  *   { url?: string }   defaults to https://zaoos.com/api/juke/webhooks
  *
  * Response:
- *   201 + { ok: true, juke: <whatever Juke returned> }
+ *   201 + { ok: true, juke: <Juke response incl. generated secret>, action_required: "..." }
  *   401 if not admin
- *   503 if JUKE_API_KEY or JUKE_WEBHOOK_SECRET is unset
+ *   503 if JUKE_API_KEY is unset
  *   502 if Juke rejects
  */
 
@@ -46,13 +51,9 @@ export async function POST(request: NextRequest) {
   }
 
   const apiKey = ENV.JUKE_API_KEY;
-  const secret = ENV.JUKE_WEBHOOK_SECRET;
-  if (!apiKey || !secret) {
-    const missing = [!apiKey ? 'JUKE_API_KEY' : null, !secret ? 'JUKE_WEBHOOK_SECRET' : null]
-      .filter(Boolean)
-      .join(' and ');
+  if (!apiKey) {
     return NextResponse.json(
-      { ok: false, error: `Missing ${missing} on the server.` },
+      { ok: false, error: 'Missing JUKE_API_KEY on the server.' },
       { status: 503 },
     );
   }
@@ -73,13 +74,14 @@ export async function POST(request: NextRequest) {
   const url = parsed.data.url ?? DEFAULT_URL;
 
   try {
+    // No `secret` in the body - Juke generates and returns it.
     const res = await fetch('https://api.juke.audio/v1/developer/webhooks', {
       method: 'POST',
       headers: {
         'X-Juke-Api-Key': apiKey,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ url, secret, events: EVENTS }),
+      body: JSON.stringify({ url, events: EVENTS }),
     });
     const text = await res.text();
     let jukeBody: unknown;
@@ -95,8 +97,26 @@ export async function POST(request: NextRequest) {
         { status: 502 },
       );
     }
+    // Server log records the registration (without the secret) so the action
+    // trail exists. The secret value lives only in the response body the
+    // admin sees in their browser.
+    const safeForLog = (() => {
+      if (typeof jukeBody !== 'object' || jukeBody === null) return jukeBody;
+      const clone = { ...(jukeBody as Record<string, unknown>) };
+      if ('secret' in clone) clone.secret = '<redacted>';
+      return clone;
+    })();
+    logger.info('[juke/admin/register-webhook] registered', { url, juke: safeForLog });
+
     return NextResponse.json(
-      { ok: true, url, events: EVENTS, juke: jukeBody },
+      {
+        ok: true,
+        url,
+        events: EVENTS,
+        juke: jukeBody,
+        action_required:
+          'COPY the value of juke.secret into JUKE_WEBHOOK_SECRET on Vercel (Production + Preview + Development), then redeploy. The webhook receiver verifies every inbound delivery against this secret; without it every delivery 401s. Then close this tab - do not leave the secret on screen.',
+      },
       { status: 201 },
     );
   } catch (err: unknown) {


### PR DESCRIPTION
## Root cause

Juke rejected \`POST /v1/developer/webhooks\` with \`422 extra_forbidden\` on the \`body.secret\` field. Juke generates the HMAC secret server-side and returns it ONCE in the response. Our admin route was sending its own \`JUKE_WEBHOOK_SECRET\` value as the body's \`secret\` field, which both failed the request and echoed the secret back in Juke's error response (visible in the browser tab / any captured log).

## Fix

- Drop \`secret\` from the POST body.
- Drop the JUKE_WEBHOOK_SECRET requirement on the admin route (no longer needed pre-registration).
- Return Juke's full response under \`.juke\` - it now includes the generated secret.
- New \`action_required\` field in the response tells the calling admin to copy \`juke.secret\` into the JUKE_WEBHOOK_SECRET env var on Vercel and redeploy.
- Server log redacts the secret before recording the registration action.

## Operational

The value of JUKE_WEBHOOK_SECRET on Vercel BEFORE this PR was a self-generated placeholder; it never matched what Juke would sign with. The placeholder was rotated locally after the 422-echo leak. After merging this PR + redeploying + hitting the admin route, Zaal must copy the real value Juke returns into Vercel + redeploy a final time.

## Files

\`\`\`
MOD src/app/api/juke/admin/register-webhook/route.ts
\`\`\`