### PR TITLE
feat(juke-status): consume juke.audio/changelog.json - auto-resolve open asks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The pattern: **Monorepo as Lab.**
 | ZAOstock 2026 dashboard + Telegram bot | **Graduating to its own repo + zaostock.com (Wed 2026-04-29)** |
 | Agent stack (ZOE, Hermes, others) | In R&D until one is solid + worth its own brand |
 | Music player components (Sonata-pattern, etc) | In R&D |
+| Live audio: ZAO Spaces (Stream.io + 100ms) + Juke integration ([/spaces](https://zaoos.com/spaces), [/live](https://zaoos.com/live), [/juke-status](https://zaoos.com/juke-status)) | In production - 3 providers from one Go-Live button, public Juke dashboard for partner |
 | Research library (540+ docs across 13 topic areas) | Always stays here |
 
 ### What&rsquo;s already graduated

--- a/src/app/api/juke/status/route.ts
+++ b/src/app/api/juke/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getJukeIntegrationManifest } from '@/lib/spaces/jukeIntegrationManifest';
+import { buildResolutionIndex, fetchJukeChangelog } from '@/lib/spaces/jukeChangelog';
 import {
   getJukeIntegrationStats,
   listRecentJukeSpaces,
@@ -19,25 +20,35 @@ export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const manifest = getJukeIntegrationManifest();
-  const [stats, recentSpaces, recentEvents] = await Promise.all([
+  const [stats, recentSpaces, recentEvents, changelog] = await Promise.all([
     getJukeIntegrationStats().catch(() => null),
     listRecentJukeSpaces(10).catch(() => []),
     listRecentWebhookEvents(15).catch(() => []),
+    fetchJukeChangelog(),
   ]);
+  const resolutionIndex = buildResolutionIndex(changelog);
+  // Decorate open_asks with juke_resolved so consumers see closed asks
+  // without re-joining against juke.audio/changelog.json themselves.
+  const open_asks = manifest.open_asks.map((ask) => {
+    const resolved = resolutionIndex.get(ask.id);
+    return resolved ? { ...ask, juke_resolved: resolved } : ask;
+  });
 
   return NextResponse.json(
     {
       ...manifest,
+      open_asks,
       stats,
       recent_spaces: recentSpaces,
       recent_events: recentEvents,
+      release_feed: 'https://juke.audio/changelog.json',
     },
     {
       status: 200,
       headers: {
         'Cache-Control': 'public, max-age=30, s-maxage=60, stale-while-revalidate=120',
         'Access-Control-Allow-Origin': '*',
-        'X-ZAO-Juke-Status': 'v2',
+        'X-ZAO-Juke-Status': 'v3',
       },
     },
   );

--- a/src/app/juke-integration.md/route.ts
+++ b/src/app/juke-integration.md/route.ts
@@ -2,6 +2,7 @@ import {
   getJukeIntegrationManifest,
   renderIntegrationMarkdown,
 } from '@/lib/spaces/jukeIntegrationManifest';
+import { buildResolutionIndex, fetchJukeChangelog } from '@/lib/spaces/jukeChangelog';
 import {
   getJukeIntegrationStats,
   listRecentJukeSpaces,
@@ -22,11 +23,13 @@ export const dynamic = 'force-dynamic';
 
 export async function GET() {
   const manifest = getJukeIntegrationManifest();
-  const [stats, recentSpaces, recentEvents] = await Promise.all([
+  const [stats, recentSpaces, recentEvents, changelog] = await Promise.all([
     getJukeIntegrationStats().catch(() => null),
     listRecentJukeSpaces(10).catch(() => []),
     listRecentWebhookEvents(15).catch(() => []),
+    fetchJukeChangelog(),
   ]);
+  const resolutionIndex = buildResolutionIndex(changelog);
   const statsObject: Record<string, unknown> | undefined = stats
     ? {
         total_spaces: stats.total_spaces,
@@ -40,6 +43,30 @@ export async function GET() {
     : undefined;
 
   const lines: string[] = [renderIntegrationMarkdown(manifest, statsObject)];
+
+  if (resolutionIndex.size > 0) {
+    lines.push('## Asks resolved by Juke');
+    lines.push(
+      `Joined from https://juke.audio/changelog.json — \`entries[].resolves[]\` maps to \`open_asks[].id\` on this page.`,
+    );
+    lines.push('');
+    for (const ask of manifest.open_asks) {
+      const r = resolutionIndex.get(ask.id);
+      if (!r) continue;
+      lines.push(`### ${ask.id} → ${r.id}`);
+      lines.push(`- Ask: ${ask.title}`);
+      lines.push(`- Juke shipped: ${r.shipped_at} — ${r.title}`);
+      lines.push(`- Summary: ${r.summary}`);
+      if (r.endpoints && r.endpoints.length > 0) {
+        lines.push(`- Endpoints: ${r.endpoints.map((e) => `\`${e}\``).join(', ')}`);
+      }
+      if (r.docs) {
+        lines.push(`- Docs: ${r.docs}${r.docs_section ? ` (section: ${r.docs_section})` : ''}`);
+      }
+      lines.push('');
+    }
+  }
+
 
   if (recentEvents.length > 0) {
     lines.push('## Recent webhooks');

--- a/src/app/juke-status/page.tsx
+++ b/src/app/juke-status/page.tsx
@@ -8,6 +8,11 @@ import {
   type OpenAsk,
 } from '@/lib/spaces/jukeIntegrationManifest';
 import {
+  buildResolutionIndex,
+  fetchJukeChangelog,
+  type JukeChangelogEntry,
+} from '@/lib/spaces/jukeChangelog';
+import {
   getJukeIntegrationStats,
   listRecentJukeSpaces,
   listRecentWebhookEvents,
@@ -87,11 +92,13 @@ function ago(value: string | null | undefined): string {
  */
 export default async function JukeStatusPage() {
   const manifest = getJukeIntegrationManifest();
-  const [stats, recentSpaces, recentEvents] = await Promise.all([
+  const [stats, recentSpaces, recentEvents, changelog] = await Promise.all([
     safeStats(),
     safeRecentSpaces(),
     safeRecentEvents(),
+    fetchJukeChangelog(),
   ]);
+  const resolutionIndex = buildResolutionIndex(changelog);
   const lastEvent = stats.last_event_at ? new Date(stats.last_event_at) : null;
 
   return (
@@ -138,7 +145,7 @@ export default async function JukeStatusPage() {
         <RecentSpacesSection rows={recentSpaces} />
         <ArchitectureSection />
         <ShippedSection manifest={manifest} />
-        <AsksSection manifest={manifest} />
+        <AsksSection manifest={manifest} resolutionIndex={resolutionIndex} />
         <CodeExamplesSection />
         <ConventionsSection manifest={manifest} />
         <ContactSection manifest={manifest} />
@@ -463,22 +470,47 @@ function ShippedRow({ feature }: { feature: ShippedFeature }) {
   );
 }
 
-function AsksSection({ manifest }: { manifest: IntegrationManifest }) {
+function AsksSection({
+  manifest,
+  resolutionIndex,
+}: {
+  manifest: IntegrationManifest;
+  resolutionIndex: Map<string, JukeChangelogEntry>;
+}) {
+  const resolvedCount = manifest.open_asks.filter((a) => resolutionIndex.has(a.id)).length;
   return (
     <section>
       <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">
         Open asks for Juke ({manifest.open_asks.length})
+        {resolvedCount > 0 && (
+          <span className="ml-2 text-green-400 normal-case font-normal">
+            - {resolvedCount} resolved by Juke
+          </span>
+        )}
       </h2>
+      <p className="text-[11px] text-gray-500 mb-3 leading-relaxed">
+        Auto-resolved from{' '}
+        <a
+          href="https://juke.audio/changelog.json"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="text-gray-300 hover:text-[#f5a623] underline"
+        >
+          juke.audio/changelog.json
+        </a>
+        . Each entry's <code className="text-gray-300">resolves[]</code> array maps to{' '}
+        <code className="text-gray-300">open_asks[].id</code> on this page.
+      </p>
       <ul className="space-y-3">
         {manifest.open_asks.map((ask) => (
-          <AskRow key={ask.id} ask={ask} />
+          <AskRow key={ask.id} ask={ask} resolved={resolutionIndex.get(ask.id) ?? null} />
         ))}
       </ul>
     </section>
   );
 }
 
-function AskRow({ ask }: { ask: OpenAsk }) {
+function AskRow({ ask, resolved }: { ask: OpenAsk; resolved: JukeChangelogEntry | null }) {
   const priorityStyles: Record<OpenAsk['priority'], { bg: string; text: string; border: string }> = {
     p0: { bg: 'bg-red-500/15', text: 'text-red-400', border: 'border-red-500/30' },
     p1: { bg: 'bg-[#f5a623]/15', text: 'text-[#f5a623]', border: 'border-[#f5a623]/30' },
@@ -486,17 +518,66 @@ function AskRow({ ask }: { ask: OpenAsk }) {
   };
   const ps = priorityStyles[ask.priority];
   return (
-    <li className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4">
+    <li
+      className={`border rounded-xl p-4 ${
+        resolved
+          ? 'bg-green-500/[0.04] border-green-500/30'
+          : 'bg-[#111d2e] border-white/[0.08]'
+      }`}
+    >
       <div className="flex items-center gap-2 mb-2 flex-wrap">
         <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border ${ps.bg} ${ps.text} ${ps.border}`}>
           {ask.priority}
         </span>
-        <h3 className="text-sm font-bold text-white">{ask.title}</h3>
+        {resolved && (
+          <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border bg-green-500/15 text-green-400 border-green-500/30">
+            Resolved by Juke
+          </span>
+        )}
+        <h3 className={`text-sm font-bold ${resolved ? 'text-green-300' : 'text-white'}`}>
+          {ask.title}
+        </h3>
       </div>
       <p className="text-xs text-gray-400 leading-relaxed">{ask.reason}</p>
       <p className="text-[11px] text-gray-500 mt-2">
         <span className="font-semibold text-gray-400">Blocks:</span> {ask.blocks}
       </p>
+      {resolved && (
+        <div className="mt-3 pt-3 border-t border-green-500/15">
+          <p className="text-[11px] text-green-300 font-semibold mb-1">
+            Shipped {resolved.shipped_at}: {resolved.title}
+          </p>
+          <p className="text-[11px] text-gray-400 leading-relaxed mb-2">{resolved.summary}</p>
+          {resolved.endpoints && resolved.endpoints.length > 0 && (
+            <div className="flex flex-wrap gap-1 mb-2">
+              {resolved.endpoints.map((ep) => (
+                <code
+                  key={ep}
+                  className="text-[10px] px-1.5 py-0.5 rounded bg-[#0a1628] border border-white/[0.06] text-gray-300 font-mono"
+                >
+                  {ep}
+                </code>
+              ))}
+            </div>
+          )}
+          {resolved.docs && (
+            <p className="text-[10px] text-gray-500">
+              Docs:{' '}
+              <a
+                href={resolved.docs}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-gray-400 hover:text-[#f5a623] underline"
+              >
+                {resolved.docs}
+              </a>
+              {resolved.docs_section && (
+                <span className="text-gray-600"> &middot; section: {resolved.docs_section}</span>
+              )}
+            </p>
+          )}
+        </div>
+      )}
     </li>
   );
 }

--- a/src/lib/spaces/jukeChangelog.ts
+++ b/src/lib/spaces/jukeChangelog.ts
@@ -1,0 +1,71 @@
+/**
+ * Juke release-feed consumer.
+ *
+ * Nicky publishes a structured changelog at https://juke.audio/changelog.json.
+ * Each entry has a `resolves: string[]` of opaque slugs that map directly to
+ * our `OpenAsk.id` values. Polling this feed and joining on `resolves[]` lets
+ * /juke-status auto-flip asks from "open" to "resolved" the moment Juke
+ * ships, with zero manual edits to our manifest.
+ *
+ * Server-side fetch only (the page that uses this is SSR). Cached short via
+ * Next's fetch cache so we do not hammer Juke on every page view.
+ */
+
+const CHANGELOG_URL = 'https://juke.audio/changelog.json';
+const CACHE_TTL_SECONDS = 300; // 5 min - changelog updates rarely
+
+export interface JukeChangelogEntry {
+  id: string;
+  shipped_at: string;
+  category: string;
+  title: string;
+  summary: string;
+  endpoints?: string[];
+  docs?: string;
+  docs_section?: string;
+  resolves?: string[];
+}
+
+export interface JukeChangelog {
+  version: number;
+  generated_at: string;
+  canonical_spec: string;
+  skill_md: string;
+  entries: JukeChangelogEntry[];
+}
+
+/** Fetch the Juke changelog. Returns null on any failure - callers should
+ * treat a null as "do not annotate, render asks as-is." */
+export async function fetchJukeChangelog(): Promise<JukeChangelog | null> {
+  try {
+    const res = await fetch(CHANGELOG_URL, {
+      next: { revalidate: CACHE_TTL_SECONDS },
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as JukeChangelog;
+    if (!json || !Array.isArray(json.entries)) return null;
+    return json;
+  } catch {
+    return null;
+  }
+}
+
+/** Build a lookup from OpenAsk.id -> the changelog entry that resolves it,
+ * if any. An ask can be resolved by multiple entries - we keep the most
+ * recent one (highest shipped_at). */
+export function buildResolutionIndex(
+  changelog: JukeChangelog | null,
+): Map<string, JukeChangelogEntry> {
+  const out = new Map<string, JukeChangelogEntry>();
+  if (!changelog) return out;
+  for (const entry of changelog.entries) {
+    for (const askId of entry.resolves ?? []) {
+      const prior = out.get(askId);
+      if (!prior || entry.shipped_at > prior.shipped_at) {
+        out.set(askId, entry);
+      }
+    }
+  }
+  return out;
+}

--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -50,6 +50,8 @@ export interface IntegrationManifest {
   open_asks: OpenAsk[];
   conventions: string[];
   contact: IntegrationContact;
+  /** Upstream release feed - polled by /juke-status to auto-resolve open asks. */
+  juke_release_feed: string;
 }
 
 const SHIPPED: ShippedFeature[] = [
@@ -277,15 +279,12 @@ const OPEN_ASKS: OpenAsk[] = [
     blocks: 'Friction-free participate (react / raise hand / speak) inside ZAO OS embeds',
     priority: 'p1',
   },
-  {
-    id: 'oss-spec',
-    title: 'Open-source SPEC.md / codebase drop',
-    reason:
-      'You offered to open the codebase + SPEC.md "if there was demand." ZAO is the demand. 13 files of integration code against your llms.txt + a full HMAC webhook handler. Happy to be the first community reference implementation.',
-    blocks: 'Deeper integration patterns + co-marketing as reference impl',
-    priority: 'p2',
-  },
 ];
+
+// oss-spec was declined-as-framed by Nicky on 2026-05-24: juke.audio/llms.txt
+// + juke.audio/SKILL.md are the public spec and stay atomic with every ship.
+// Partnership conversation stays open on its own terms; the ask is removed
+// from the queue so the dashboard does not nag.
 
 const CONVENTIONS = [
   'All Juke calls server-side. JUKE_API_KEY never leaves the server.',
@@ -356,7 +355,7 @@ export const INTEGRATION_ARCHITECTURE_ASCII = String.raw`
 
 export function getJukeIntegrationManifest(): IntegrationManifest {
   return {
-    version: '1.1',
+    version: '1.2',
     generated_at: new Date().toISOString(),
     about: {
       name: 'The ZAO',
@@ -371,6 +370,7 @@ export function getJukeIntegrationManifest(): IntegrationManifest {
     open_asks: OPEN_ASKS,
     conventions: CONVENTIONS,
     contact: CONTACT,
+    juke_release_feed: 'https://juke.audio/changelog.json',
   };
 }
 

--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -198,9 +198,41 @@ const SHIPPED: ShippedFeature[] = [
     id: 'recurring-schedule-script',
     title: 'Recurring weekly Juke schedule script',
     description:
-      'scripts/schedule-zao-recurring.ts pre-creates Juke spaces for ZAO\'s weekly events (fractal call, ZAOstock standups). Idempotent (dedupes against juke_spaces.scheduled_at +/- 30min). Safe to wire into a weekly cron.',
+      "scripts/schedule-zao-recurring.ts pre-creates Juke spaces for ZAO's weekly events (fractal call, ZAOstock standups). Idempotent (dedupes against juke_spaces.scheduled_at +/- 30min). Safe to wire into a weekly cron.",
     shippedAt: '2026-05-23',
     files: ['scripts/schedule-zao-recurring.ts', 'scripts/zao-recurring-events.json'],
+  },
+  {
+    id: 'admin-register-webhook',
+    title: 'Admin route to register the Juke webhook server-side',
+    description:
+      'POST /api/juke/admin/register-webhook calls Juke /v1/developer/webhooks from a Vercel context that already has JUKE_API_KEY loaded. Juke generates the HMAC secret server-side and returns it in the response; the admin caller copies it into the JUKE_WEBHOOK_SECRET env var (Production + Preview + Development) and redeploys. Admin-only.',
+    shippedAt: '2026-05-24',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/666',
+    files: ['src/app/api/juke/admin/register-webhook/route.ts'],
+  },
+  {
+    id: 'juke-status-richer',
+    title: 'Richer /juke-status: recent webhooks + recent spaces + code examples',
+    description:
+      "Three new sections on the public dashboard. (1) Recent webhooks - last 15 events with type / space_id / age / processed-vs-failed pill. (2) Recent spaces - last 10 juke_spaces rows with status pill + time marker + participant count + recording link. (3) Code examples - 4 reference snippets matching production (create-space, embed, webhook verify, subscribe). Plus OG + Twitter card meta on the page itself, and recent_spaces + recent_events arrays added to /api/juke/status and /juke-integration.md.",
+    shippedAt: '2026-05-24',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/668',
+    files: [
+      'src/lib/spaces/jukeSpacesDb.ts',
+      'src/app/juke-status/page.tsx',
+      'src/app/api/juke/status/route.ts',
+      'src/app/juke-integration.md/route.ts',
+    ],
+  },
+  {
+    id: 'register-webhook-fix',
+    title: 'Register-webhook fix: Juke generates the HMAC secret, not us',
+    description:
+      "Initial admin route POSTed { url, events, secret } and Juke returned 422 extra_forbidden on the secret field - Juke generates the secret server-side and returns it in the response. Route now POSTs { url, events } only, captures juke.secret from the response, returns it with an action_required instructing the admin to copy it into Vercel's JUKE_WEBHOOK_SECRET env. Server logs the registration with the secret redacted.",
+    shippedAt: '2026-05-24',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/669',
+    files: ['src/app/api/juke/admin/register-webhook/route.ts'],
   },
 ];
 
@@ -324,7 +356,7 @@ export const INTEGRATION_ARCHITECTURE_ASCII = String.raw`
 
 export function getJukeIntegrationManifest(): IntegrationManifest {
   return {
-    version: '1',
+    version: '1.1',
     generated_at: new Date().toISOString(),
     about: {
       name: 'The ZAO',


### PR DESCRIPTION
## Summary

Nicky shipped 4 things 2026-05-23 + a structured release feed at https://juke.audio/changelog.json. Each feed entry has a \`resolves[]\` array that maps to our \`open_asks[].id\` values, so polling the feed and joining auto-flips asks from open to resolved on /juke-status with zero manual edits.

## Behaviour

- New \`lib/spaces/jukeChangelog.ts\` fetches the feed (5-min Next cache, null on failure).
- \`buildResolutionIndex(changelog)\` returns \`Map<askId, JukeChangelogEntry>\`.
- /juke-status AsksSection renders a green \"Resolved by Juke\" badge + the shipped date + summary + endpoints + docs link inline on each resolved ask.
- /api/juke/status decorates each \`open_asks[]\` item with \`juke_resolved\` when present + adds \`release_feed\` at the root.
- /juke-integration.md grows an \"Asks resolved by Juke\" section.
- Manifest version 1.1 → 1.2. New \`juke_release_feed\` field on the root.
- \`oss-spec\` ask removed from OPEN_ASKS (Nicky declined-as-framed; llms.txt + SKILL.md ARE the spec).
- \`X-ZAO-Juke-Status\` header bumped to v3.

## What flips today

As of the changelog at fetch time:

| Our ask | Juke's resolution | Endpoints |
|---|---|---|
| agents (p0) | partner-agent-join | \`POST /v1/developer/rooms/{id}/agent-join\` |
| partner-sso-bridge (p1) | partner-sso-bridge | \`POST /v1/developer/partner-tokens\` |
| participant-fids (p1) | outbound-webhooks | participant.* events carry fid + display_name + role |
| desktop-mic (p1) | desktop-mic-confirmed | yes, web SIWF promotes to mic-publish via livekit-client |

Asks stay in OPEN_ASKS for narrative continuity; the green annotation is what flips. **Consumer work to actually USE the new endpoints lands in follow-up PRs.**

## Files

\`\`\`
NEW src/lib/spaces/jukeChangelog.ts
MOD src/lib/spaces/jukeIntegrationManifest.ts (1.2 + juke_release_feed)
MOD src/app/juke-status/page.tsx (AsksSection + AskRow show Resolved-by-Juke)
MOD src/app/api/juke/status/route.ts (decorate open_asks; release_feed)
MOD src/app/juke-integration.md/route.ts (new section)
\`\`\`