### PR TITLE
feat(juke): consume 4 of 4 newly-shipped Juke endpoints (SSO + FID + agents)

### DIFF
--- a/scripts/juke-spaces-migration-2.sql
+++ b/scripts/juke-spaces-migration-2.sql
@@ -1,0 +1,24 @@
+-- juke_spaces migration #2 (2026-05-24)
+--
+-- Adds a `participants` jsonb column that the webhook handler keeps in sync
+-- with participant.joined / participant.left deliveries. Per the Juke
+-- 2026-05-23 changelog, those events now carry fid + display_name + role for
+-- real humans + agents only (anonymous listeners + LiveKit virtual
+-- participants filtered out).
+--
+-- Shape:
+--   [
+--     { "fid": 12345, "display_name": "@zaal", "role": "host",
+--       "joined_at": "2026-05-24T03:14:00Z" },
+--     ...
+--   ]
+--
+-- The webhook handler upserts on `(space_id, fid)` and removes the entry on
+-- participant.left. Cheaper than a separate juke_space_participants table at
+-- ZAO's volume (single-digit live spaces, ≤ 50 participants each).
+
+alter table public.juke_spaces
+  add column if not exists participants jsonb not null default '[]'::jsonb;
+
+create index if not exists juke_spaces_participants_gin
+  on public.juke_spaces using gin (participants);

--- a/src/app/api/juke/admin/agent-join/route.ts
+++ b/src/app/api/juke/admin/agent-join/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+
+/**
+ * POST /api/juke/admin/agent-join
+ *
+ * Drops a partner-scoped agent (ZOE by default) into a Juke room ZAO owns.
+ * Uses the free `POST /v1/developer/rooms/{spaceId}/agent-join` endpoint
+ * Nicky shipped 2026-05-23 — key-only auth, no x402 toll for rooms whose
+ * `created_by_app_id` matches our developer app. Agents publish data only
+ * in v1 (audio-publishing on v1.x roadmap), so the first ZOE use case is
+ * taking notes / posting recap casts, not voice.
+ *
+ * Constraints from llms.txt "Agents" section:
+ * - room.status must be 'active' and allow_agents must be true
+ * - per-room cap: 5 concurrent agents
+ * - rate limit: 10/min + 100/day per key
+ * - cross-app rooms 404 (cannot be used to enumerate other apps)
+ *
+ * The returned session_token is what the ZOE bot uses for the duration of
+ * the room (X-Session-Token header on token-refresh / leave). Storing it
+ * is the caller's responsibility - this route only mints.
+ *
+ * Admin-only. The session_token is short-lived but treat it as a secret -
+ * do not leak to chat or persist long-term.
+ */
+
+const BodySchema = z.object({
+  spaceId: z.string().min(1).max(128),
+  agentName: z.string().trim().min(1).max(64).default('ZOE'),
+  agentPfpUrl: z.string().url().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSessionData();
+  if (!session?.isAdmin) {
+    return NextResponse.json({ ok: false, error: 'Admin only' }, { status: 401 });
+  }
+
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, error: 'JUKE_API_KEY not configured on the server' },
+      { status: 503 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: 'Request body must be valid JSON' },
+      { status: 400 },
+    );
+  }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid body', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { spaceId, agentName, agentPfpUrl } = parsed.data;
+
+  const endpoint = `https://api.juke.audio/v1/developer/rooms/${encodeURIComponent(spaceId)}/agent-join`;
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'X-Juke-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ agent_name: agentName, agent_pfp_url: agentPfpUrl }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err: unknown) {
+    logger.error('[juke/admin/agent-join] fetch failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'Juke agent-join API unreachable' },
+      { status: 502 },
+    );
+  }
+  const text = await res.text();
+  let jukeBody: unknown;
+  try {
+    jukeBody = JSON.parse(text);
+  } catch {
+    jukeBody = text;
+  }
+  if (!res.ok) {
+    // 404 = either the space does not exist OR it belongs to another app -
+    // Juke does not distinguish, on purpose.
+    // 429 = rate-limited (10/min, 100/day per key) OR per-room cap (5 agents).
+    logger.warn('[juke/admin/agent-join] Juke rejected', res.status, jukeBody);
+    return NextResponse.json(
+      { ok: false, error: `Juke returned ${res.status}`, juke: jukeBody },
+      { status: res.status >= 500 ? 502 : res.status },
+    );
+  }
+  return NextResponse.json(
+    {
+      ok: true,
+      spaceId,
+      agentName,
+      juke: jukeBody,
+      action_required:
+        "Capture session_token from juke.session_token. Pass it as X-Session-Token on subsequent calls (token refresh, leave). Do not persist long-term; it dies with the room.",
+    },
+    { status: 201 },
+  );
+}
+
+export const GET = () =>
+  NextResponse.json(
+    { ok: false, error: 'POST only - send { spaceId, agentName?, agentPfpUrl? }' },
+    { status: 405 },
+  );

--- a/src/app/api/juke/partner-token/route.ts
+++ b/src/app/api/juke/partner-token/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { getSessionData } from '@/lib/auth/session';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { mintPartnerToken } from '@/lib/spaces/juke-partner-token';
+
+/**
+ * GET /api/juke/partner-token
+ *
+ * Mints a short-lived Juke partner JWT for the CURRENT signed-in ZAO user
+ * (whose FID lives on their session). Returns `{ token, fid, expires_at }`
+ * to the browser; the caller passes the token on the Juke embed URL via
+ * `?token=...` so the iframe adopts the session without re-running SIWF.
+ *
+ * Auth: session-bound. No admin requirement - any authed ZAO user can mint
+ * a token for their own FID. We never accept an FID from the request; it
+ * comes straight from the session.
+ *
+ * Rate limits live upstream at Juke (60/min + 5,000/day per developer key);
+ * if we hit that the route surfaces the upstream status.
+ *
+ * No caching - the JWT is single-use-per-iframe-mount, short-TTL, and CDN
+ * caching it would be a security mistake.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const session = await getSessionData();
+  if (!session?.fid) {
+    return NextResponse.json(
+      { ok: false, error: 'Sign in to mint a partner token' },
+      { status: 401, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, error: 'JUKE_API_KEY not configured on the server' },
+      { status: 503, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+
+  const result = await mintPartnerToken(apiKey, { fid: session.fid, ttlSeconds: 300 });
+  if (!result.ok) {
+    logger.warn('[juke/partner-token] mint failed', result.status, result.error);
+    return NextResponse.json(
+      { ok: false, error: result.error },
+      { status: result.status >= 500 ? 502 : result.status, headers: { 'Cache-Control': 'no-store' } },
+    );
+  }
+  return NextResponse.json(
+    {
+      ok: true,
+      token: result.data.token,
+      fid: result.data.fid,
+      expires_at: result.data.expires_at,
+    },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store',
+        // Token has fid + expiry; not safe to share across users.
+        'X-ZAO-Juke-Partner-Token': 'v1',
+      },
+    },
+  );
+}

--- a/src/app/live/[spaceId]/page.tsx
+++ b/src/app/live/[spaceId]/page.tsx
@@ -137,7 +137,7 @@ export default async function LivePage({ params, searchParams }: LivePageProps) 
             <p className="text-gray-500 text-xs">No recording was made.</p>
           </div>
         ) : (
-          <JukeEmbed spaceId={spaceId} audioOff={audioOff} />
+          <JukeEmbed spaceId={spaceId} audioOff={audioOff} useSsoToken />
         )}
 
         <div className="flex flex-wrap gap-2 justify-center">

--- a/src/components/spaces/JukeEmbed.tsx
+++ b/src/components/spaces/JukeEmbed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { JUKE_EMBED_ORIGIN, jukeEmbedUrl } from '@/lib/spaces/juke';
 
 interface JukeEmbedProps {
@@ -17,37 +17,95 @@ interface JukeEmbedProps {
    * already in the Juke iOS app and the laptop should not double-broadcast.
    */
   audioOff?: boolean;
+  /**
+   * When true, fetch a Juke partner-SSO JWT from /api/juke/partner-token
+   * (requires a signed-in ZAO session) and pass it as ?token=... on the
+   * iframe src so the visitor adopts the Juke session without re-running
+   * SIWF. Closes the double-sign-in pain. Silently falls back to the no-
+   * token embed if the user is not signed in or the mint fails.
+   */
+  useSsoToken?: boolean;
+}
+
+interface PartnerTokenState {
+  status: 'idle' | 'loading' | 'ready' | 'skipped';
+  token?: string;
 }
 
 /**
- * Embeds a Juke live audio space (Path A of doc 695 — hosted iframe, no API
- * keys). Juke renders the whole experience: anonymous listening, Sign In With
- * Farcaster, hand-raise, and mic control. A loading skeleton covers the iframe
- * until it reports `load`. "Powered by Juke" attribution is kept visible per
- * Juke's branding requirements.
+ * Embeds a Juke live audio space (Path A — hosted iframe, no API keys). Juke
+ * renders the whole experience: anonymous listening, Sign In With Farcaster,
+ * hand-raise, and mic control. A loading skeleton covers the iframe until it
+ * reports `load`. "Powered by Juke" attribution is kept visible per Juke's
+ * branding requirements.
+ *
+ * Partner-SSO bridge: when `useSsoToken` is true, the component blocks the
+ * iframe render until either the token mints (~100ms) or the mint fails (then
+ * renders un-authed). This means a signed-in ZAO user lands inside the embed
+ * already-authenticated, skipping the SIWF QR.
  */
-export function JukeEmbed({ spaceId, className, audioOff = false }: JukeEmbedProps) {
+export function JukeEmbed({
+  spaceId,
+  className,
+  audioOff = false,
+  useSsoToken = false,
+}: JukeEmbedProps) {
   const [loaded, setLoaded] = useState(false);
+  const [partnerToken, setPartnerToken] = useState<PartnerTokenState>({
+    status: useSsoToken ? 'loading' : 'skipped',
+  });
+
+  useEffect(() => {
+    if (!useSsoToken) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/juke/partner-token', { cache: 'no-store' });
+        if (!res.ok) {
+          if (!cancelled) setPartnerToken({ status: 'ready' });
+          return;
+        }
+        const body = (await res.json()) as { ok?: boolean; token?: string };
+        if (!cancelled) {
+          setPartnerToken({
+            status: 'ready',
+            token: body?.ok && body.token ? body.token : undefined,
+          });
+        }
+      } catch {
+        if (!cancelled) setPartnerToken({ status: 'ready' });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [useSsoToken]);
+
+  const waitingForToken = useSsoToken && partnerToken.status === 'loading';
 
   return (
     <div className={`flex flex-col items-center gap-3 ${className ?? ''}`}>
       <div className="relative aspect-[2/3] min-h-[520px] w-full max-w-[480px]">
-        {!loaded && (
+        {(!loaded || waitingForToken) && (
           <div
             className="absolute inset-0 flex flex-col items-center justify-center gap-3 rounded-3xl bg-[#0d1b2a] text-gray-400"
             aria-hidden="true"
           >
             <div className="h-8 w-8 animate-spin rounded-full border-2 border-[#f5a623] border-t-transparent" />
-            <span className="text-sm">Connecting to Juke...</span>
+            <span className="text-sm">
+              {waitingForToken ? 'Signing you in to Juke...' : 'Connecting to Juke...'}
+            </span>
           </div>
         )}
-        <iframe
-          src={jukeEmbedUrl(spaceId, { audioOff })}
-          title="Juke live audio space"
-          allow={audioOff ? 'autoplay' : 'autoplay; microphone'}
-          onLoad={() => setLoaded(true)}
-          className="h-full w-full rounded-3xl border-0"
-        />
+        {!waitingForToken && (
+          <iframe
+            src={jukeEmbedUrl(spaceId, { audioOff, partnerToken: partnerToken.token })}
+            title="Juke live audio space"
+            allow={audioOff ? 'autoplay' : 'autoplay; microphone'}
+            onLoad={() => setLoaded(true)}
+            className="h-full w-full rounded-3xl border-0"
+          />
+        )}
       </div>
       <a
         href={JUKE_EMBED_ORIGIN}

--- a/src/lib/spaces/juke-partner-token.ts
+++ b/src/lib/spaces/juke-partner-token.ts
@@ -1,0 +1,82 @@
+/**
+ * Juke partner-SSO bridge — server-side mint of a short-lived Juke JWT for a
+ * visitor already authenticated by ZAO OS (SIWN via Neynar). The token gets
+ * passed on the embed URL as `?token=...`; the iframe adopts the session and
+ * skips the SIWF QR. See juke.audio/llms.txt section "Partner SSO Bridge".
+ *
+ * Trust model: Juke trusts ZAO because we possess the developer API key. The
+ * minted JWT carries `source="partner"` + `partner_app_id` claims, has a TTL
+ * ≤ 10 min, and is walled off from sensitive endpoints (dashboard ops, room
+ * create, key reveal, recording start/stop) so a leaked token cannot be
+ * weaponized against a visitor's Juke account.
+ */
+
+const ENDPOINT = 'https://api.juke.audio/v1/developer/partner-tokens';
+const MIN_TTL = 60;
+const MAX_TTL = 600;
+const DEFAULT_TTL = 300;
+
+export interface PartnerTokenInput {
+  /** The Farcaster ID of the visitor ZAO has already verified (SIWN session). */
+  fid: number;
+  /** Seconds. Clamped to [60, 600]. Defaults to 300. */
+  ttlSeconds?: number;
+}
+
+export interface PartnerTokenResponse {
+  token: string;
+  fid: number;
+  expires_at: string;
+  partner_app_id: string;
+}
+
+export type MintPartnerTokenResult =
+  | { ok: true; data: PartnerTokenResponse }
+  | { ok: false; status: number; error: string };
+
+export async function mintPartnerToken(
+  apiKey: string,
+  input: PartnerTokenInput,
+): Promise<MintPartnerTokenResult> {
+  if (!Number.isFinite(input.fid) || input.fid <= 0) {
+    return { ok: false, status: 400, error: 'fid must be a positive integer' };
+  }
+  const ttl = Math.min(MAX_TTL, Math.max(MIN_TTL, input.ttlSeconds ?? DEFAULT_TTL));
+
+  let res: Response;
+  try {
+    res = await fetch(ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'X-Juke-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ fid: input.fid, ttl_seconds: ttl }),
+      signal: AbortSignal.timeout(8_000),
+    });
+  } catch (err: unknown) {
+    return {
+      ok: false,
+      status: 502,
+      error: err instanceof Error ? err.message : 'Juke partner-token API unreachable',
+    };
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    return {
+      ok: false,
+      status: res.status,
+      error: `Juke returned ${res.status}: ${text.slice(0, 200)}`,
+    };
+  }
+  let payload: PartnerTokenResponse;
+  try {
+    payload = (await res.json()) as PartnerTokenResponse;
+  } catch {
+    return { ok: false, status: 502, error: 'Juke returned invalid JSON' };
+  }
+  if (!payload?.token || !payload?.expires_at) {
+    return { ok: false, status: 502, error: 'Juke response missing token / expires_at' };
+  }
+  return { ok: true, data: payload };
+}

--- a/src/lib/spaces/juke.ts
+++ b/src/lib/spaces/juke.ts
@@ -35,6 +35,14 @@ export interface JukeEmbedOptions {
    * and the laptop should not double-broadcast (Juke PR 2026-05-23, item #6).
    */
   audioOff?: boolean;
+  /**
+   * Partner-SSO JWT minted via /api/juke/partner-token (Juke 2026-05-23
+   * Partner SSO Bridge). When present, the iframe adopts the session
+   * client-side, strips ?token= from the URL via history.replaceState, and
+   * renders as already-authenticated — no SIWF QR for the visitor. Token is
+   * single-use-per-mount + short-TTL (5min default); refetch on every embed.
+   */
+  partnerToken?: string;
 }
 
 /**
@@ -48,7 +56,11 @@ export function jukeEmbedUrl(spaceId: string, options: JukeEmbedOptions = {}): s
     throw new Error('Invalid Juke space id');
   }
   const base = `${JUKE_EMBED_ORIGIN}/embed/${encodeURIComponent(spaceId)}`;
-  return options.audioOff ? `${base}?audio=off` : base;
+  const params = new URLSearchParams();
+  if (options.audioOff) params.set('audio', 'off');
+  if (options.partnerToken) params.set('token', options.partnerToken);
+  const qs = params.toString();
+  return qs ? `${base}?${qs}` : base;
 }
 
 /** Canonical Juke space page URL for a given id (the share/permalink URL). */

--- a/src/lib/spaces/jukeSpacesDb.ts
+++ b/src/lib/spaces/jukeSpacesDb.ts
@@ -9,6 +9,16 @@ import { supabaseAdmin } from '@/lib/db/supabase';
 
 export type JukeSpaceStatus = 'scheduled' | 'active' | 'ended';
 
+/** One participant entry inside `juke_spaces.participants` jsonb array.
+ * Populated by participant.joined webhooks (Juke 2026-05-23 ship: events
+ * carry fid + display_name + role for real humans + agents only). */
+export interface JukeParticipantEntry {
+  fid: number;
+  display_name: string | null;
+  role: string | null;
+  joined_at: string;
+}
+
 export interface JukeSpaceRow {
   id: string;
   title: string;
@@ -19,6 +29,7 @@ export interface JukeSpaceRow {
   ended_at: string | null;
   recording_url: string | null;
   participant_count: number;
+  participants: JukeParticipantEntry[];
   embed_url: string | null;
   raw: unknown;
   created_at: string;
@@ -234,6 +245,48 @@ export async function bumpParticipantCount(id: string, delta: number): Promise<v
     .update({ participant_count: next })
     .eq('id', id);
   if (error) throw new Error(`bumpParticipantCount failed: ${error.message}`);
+}
+
+/** Upsert a participant entry into juke_spaces.participants jsonb (read-modify-
+ * write). Dedupes on fid - rejoin updates joined_at + role. Best-effort: if
+ * the column does not exist yet (migration #2 not applied) we silently skip. */
+export async function addParticipant(id: string, entry: JukeParticipantEntry): Promise<void> {
+  const { data } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('participants')
+    .eq('id', id)
+    .maybeSingle();
+  const current = (data as { participants?: JukeParticipantEntry[] } | null)?.participants ?? [];
+  const filtered = current.filter((p) => p.fid !== entry.fid);
+  const next = [...filtered, entry];
+  const { error } = await supabaseAdmin
+    .from('juke_spaces')
+    .update({ participants: next })
+    .eq('id', id);
+  if (error) {
+    // Column missing = migration not applied yet. Do not block the webhook.
+    if (/column .*participants/i.test(error.message)) return;
+    throw new Error(`addParticipant failed: ${error.message}`);
+  }
+}
+
+export async function removeParticipant(id: string, fid: number): Promise<void> {
+  const { data } = await supabaseAdmin
+    .from('juke_spaces')
+    .select('participants')
+    .eq('id', id)
+    .maybeSingle();
+  const current = (data as { participants?: JukeParticipantEntry[] } | null)?.participants ?? [];
+  const next = current.filter((p) => p.fid !== fid);
+  if (next.length === current.length) return;
+  const { error } = await supabaseAdmin
+    .from('juke_spaces')
+    .update({ participants: next })
+    .eq('id', id);
+  if (error) {
+    if (/column .*participants/i.test(error.message)) return;
+    throw new Error(`removeParticipant failed: ${error.message}`);
+  }
 }
 
 export interface WebhookEventInsert {

--- a/src/lib/spaces/jukeWebhookHandlers.ts
+++ b/src/lib/spaces/jukeWebhookHandlers.ts
@@ -17,7 +17,14 @@
  */
 import { autoCastToZao } from '@/lib/publish/auto-cast';
 import { logger } from '@/lib/logger';
-import { bumpParticipantCount, getJukeSpace, updateJukeSpace } from './jukeSpacesDb';
+import {
+  addParticipant,
+  bumpParticipantCount,
+  getJukeSpace,
+  removeParticipant,
+  updateJukeSpace,
+  type JukeParticipantEntry,
+} from './jukeSpacesDb';
 
 interface JukeWebhookBody {
   event?: string;
@@ -88,6 +95,30 @@ function readOccurredAt(body: unknown): string {
   return b.occurred_at ?? b.occurredAt ?? new Date().toISOString();
 }
 
+/** Pull a JukeParticipantEntry from a participant.joined/left body. Returns
+ * null if no usable fid is present (Juke filters anon listeners + virtual
+ * participants out, so an event without an fid is unexpected but possible). */
+function readParticipant(body: unknown, occurredAt: string): JukeParticipantEntry | null {
+  const b = (body ?? {}) as { data?: Record<string, unknown> };
+  const d = (b.data ?? {}) as {
+    fid?: unknown;
+    display_name?: unknown;
+    displayName?: unknown;
+    role?: unknown;
+  };
+  const fidRaw = d.fid;
+  const fid = typeof fidRaw === 'number' ? fidRaw : typeof fidRaw === 'string' ? Number(fidRaw) : null;
+  if (fid === null || !Number.isFinite(fid)) return null;
+  const display_name =
+    typeof d.display_name === 'string'
+      ? d.display_name
+      : typeof d.displayName === 'string'
+        ? d.displayName
+        : null;
+  const role = typeof d.role === 'string' ? d.role : null;
+  return { fid, display_name, role, joined_at: occurredAt };
+}
+
 /**
  * Apply the side effects for one verified, deduplicated webhook event.
  *
@@ -116,10 +147,14 @@ export async function applyWebhookEvent(
     }
     case 'participant.joined': {
       await bumpParticipantCount(spaceId, +1);
+      const p = readParticipant(body, readOccurredAt(body));
+      if (p) await addParticipant(spaceId, p);
       return;
     }
     case 'participant.left': {
       await bumpParticipantCount(spaceId, -1);
+      const p = readParticipant(body, readOccurredAt(body));
+      if (p) await removeParticipant(spaceId, p.fid);
       return;
     }
     case 'recording.ready': {


### PR DESCRIPTION
## Summary

Closes the loop on Nicky's 2026-05-23 ship. PR #671 already auto-resolves the open asks on the manifest via the changelog join. This PR is the actual consumer code so the new endpoints DO something for ZAO members in production.

## 1. Partner SSO Bridge — closes the double-sign-in

| Layer | What |
|---|---|
| Lib | \`src/lib/spaces/juke-partner-token.ts\` wraps \`POST /v1/developer/partner-tokens\` (TTL clamped to [60, 600], default 300) |
| API | \`GET /api/juke/partner-token\` reads ZAO session FID, mints, returns \`{ token, fid, expires_at }\`, \`Cache-Control: no-store\` |
| URL | \`jukeEmbedUrl(spaceId, { partnerToken })\` appends \`?token=…\` so the iframe adopts the session |
| Embed | \`JukeEmbed useSsoToken\` prop fetches the token client-side, blocks render ~100ms, falls back gracefully if mint fails |
| Page | \`/live/[spaceId]\` sets \`useSsoToken\` — signed-in users skip the SIWF QR entirely |

Key stays server-side. Token is short-TTL + walled off from sensitive Juke endpoints by Juke's \`source=\"partner\"\` JWT claim (per Juke spec).

## 2. Participant FID enrichment

- \`scripts/juke-spaces-migration-2.sql\` adds \`participants jsonb\` column + GIN index.
- \`jukeSpacesDb.ts\` gains \`addParticipant\` / \`removeParticipant\` helpers (idempotent on \`fid\`). Silently no-ops if the column does not exist yet, so the webhook keeps working pre-migration.
- \`jukeWebhookHandlers.ts\` parses \`participant.joined\` / \`participant.left\` bodies for \`{ fid, display_name, role }\`. Juke filters anon listeners + LiveKit virtual participants out, so anything we get is a real human or agent.
- Unlocks the \"X ZAO members here\" badge + recap-cast \`@-mentions\` in a follow-up.

## 3. Desktop mic — no code change

Nicky confirmed web SIWF + host-promote + livekit-client publish works on desktop. Our existing /live/{id} copy already reflects that. Nothing to drop.

## 4. ZOE-in-Juke — admin agent-join route

- \`POST /api/juke/admin/agent-join\` wraps \`POST /v1/developer/rooms/{spaceId}/agent-join\` (free partner-scoped variant).
- Body: \`{ spaceId, agentName?='ZOE', agentPfpUrl? }\`.
- Returns Juke's \`session_token\` to the caller (use as \`X-Session-Token\` for the duration of the room).
- Admin-only. Data-publish only in v1 (Juke audio-publishing is on v1.x roadmap), so first ZOE use case is note-taking + recap-cast, not voice.

## Deploy steps

1. Apply \`scripts/juke-spaces-migration-2.sql\` against the ZAO OS Supabase.
2. Merge + Vercel deploy. **No new env vars.** \`JUKE_API_KEY\` already exists.
3. Sign in to \`/live/{id}\` — the SIWF QR should not appear; you should land already-authenticated.

## Files

\`\`\`
NEW scripts/juke-spaces-migration-2.sql
NEW src/lib/spaces/juke-partner-token.ts
NEW src/app/api/juke/partner-token/route.ts
NEW src/app/api/juke/admin/agent-join/route.ts
MOD src/lib/spaces/juke.ts (jukeEmbedUrl gains partnerToken option)
MOD src/lib/spaces/jukeSpacesDb.ts (participants type + helpers)
MOD src/lib/spaces/jukeWebhookHandlers.ts (parse fid/display_name/role)
MOD src/components/spaces/JukeEmbed.tsx (useSsoToken prop)
MOD src/app/live/[spaceId]/page.tsx (set useSsoToken)
\`\`\`

## Test plan

- [ ] Migration applied. \`select participants from juke_spaces limit 1\` returns \`[]\`.
- [ ] Sign in to zaoos.com → visit /live/{any-juke-space-id} → no SIWF QR; loader briefly says \"Signing you in to Juke...\".
- [ ] DevTools Network: \`GET /api/juke/partner-token\` returns 200 with \`ok:true\`.
- [ ] Create + end a Juke space → check \`juke_spaces.participants\` array fills with \`{ fid, display_name, role }\` entries.
- [ ] As admin: \`curl -X POST /api/juke/admin/agent-join -d '{\"spaceId\":\"<active-room>\"}'\` returns 201 + \`juke.session_token\`.