### PR TITLE
docs(inbox): wire action-items label -> cowork tracker auto-task (v2)

### DIFF
--- a/.claude/skills/inbox/SKILL.md
+++ b/.claude/skills/inbox/SKILL.md
@@ -131,6 +131,18 @@ Fetch all messages then filter client-side for messages that have the folder lab
      -d '{"add_labels": ["<folder>", "processed"], "remove_labels": ["unread"]}'
    ```
 
+7. **If `action-items` label was applied -> fire a cowork tracker task (NEW v2 - 2026-05-24).** This auto-creates a `todo` row in the Supabase cowork tracker (project `etwvzrmlxeobinrlytza`, table `tasks`) so the action lands in Iman/Zaal's Kanban without manual re-entry.
+
+   ```bash
+   # Short slug from message-id (last 12 chars, alphanumeric only) for legacy_id stability:
+   MSG_SLUG=$(echo "$MSG_ID" | tr -cd 'a-zA-Z0-9' | tail -c 12)
+   ~/bin/zao-tracker inbox "$MSG_SLUG" "<subject or first 60 chars>"
+   ```
+
+   This creates `legacy_source=inbox:<slug>` + `legacy_id=inbox-<slug>`. Owner defaults to Zaal (his inbox = his actions; pass third arg to override). Best-effort: if Supabase env unset, skill prints the error and continues - the AgentMail PATCH already happened, the tracker task is a nice-to-have.
+
+   Only fire when `action-items` label was applied. Items going to `research` / `x-posts` / `events` / `ideas` do NOT fire a tracker task (those don't need do-something actions).
+
 ### Cluster Mode (`/inbox cluster`)
 
 For draining a large backlog. Forwarded items pile up faster than `/inbox next` clears them, and processing each as its own doc produces many thin docs that miss the cross-cutting pattern. Cluster mode fixes both.
@@ -141,8 +153,8 @@ For draining a large backlog. Forwarded items pile up faster than `/inbox next` 
 
 2. **Triage.** Sort every item into one of three buckets:
    - **Research** - has a topic worth a doc.
-   - **Action-item** - needs Zaal to do something (account setup, a reply, a follow-up). Label `action-items` + `processed`, no doc.
-   - **Noise** - bounce-backs, delivery failures, dead ends. Label `processed` only, no doc.
+   - **Action-item** - needs Zaal to do something (account setup, a reply, a follow-up). Label `action-items` + `processed`, **AND fire `~/bin/zao-tracker inbox <slug> "<subject>"`** to create the matching Kanban row (v2 - 2026-05-24).
+   - **Noise** - bounce-backs, delivery failures, dead ends. Label `processed` only, no doc, no tracker.
 
 3. **Cluster the research bucket by theme.** Group items that share a subject (e.g. "Claude Code workflows", "agent memory", "vibecoding economics"). A cluster = 3+ related items. Leftover singletons go in a "standalone roundup" cluster.
 


### PR DESCRIPTION
## Summary
When /inbox classifies an item as \`action-items\`, also fire \`~/bin/zao-tracker inbox <slug> "<subject>"\` to create the matching Kanban row in the Supabase cowork tracker.

Closes the circle: forwarded email -> AgentMail inbox -> /inbox processing -> action-items label + Supabase task row -> Iman/Zaal sees in their Kanban board at thezao.xyz.

## Edits
- Step 6 of Processing an Item: added Step 7 for the tracker fire (conditional on \`action-items\` label, owner default Zaal)
- Cluster Mode Step 2: action-item triage entry also fires the tracker write

Items going to \`research\` / \`x-posts\` / \`events\` / \`ideas\` do NOT fire tracker tasks (those are reading/synthesis material, not do-something actions).

## Companion changes (not in this PR, but related)
- New unified helper \`~/bin/zao-tracker\` (replaces kind-specific zao-pr-task; old name is now a backcompat shim). Subcommands: \`pr\` / \`research\` / \`inbox\` / \`meeting\` / \`search\` / \`list\`.
- Global \`~/.claude/skills/zao-research/SKILL.md\` updated to v2.4 with Step 2.6 (pre-write tracker query) + Step 9.5 (post-PR research-doc tracker task). This skill is global, not in any repo - lives on Zaal's machine.
- README rewrite for ZAODEVZ/ZAOcowork shipping at https://github.com/ZAODEVZ/ZAOcowork/pull/14 - documents the cross-source-writer contract.

## Cross-source writers contract (post this PR)
| Writer | legacy_source prefix | Owner default |
|---|---|---|
| Telegram bot | (none, normal cols) | (per-message) |
| /meeting recap actions | \`meeting:<slug>-<date>\` | (per-action) |
| PR test-plan tasks | \`pr-auto:<num>\` | Iman |
| /zao-research doc-shipped tasks | \`research-doc:<num>\` | Zaal |
| /inbox action-items | \`inbox:<slug>\` | Zaal |

## Test plan
- [ ] Trigger /inbox on a forwarded email with action-y content; verify it gets \`action-items\` + \`processed\` labels in AgentMail
- [ ] Verify the corresponding row appears in the cowork tracker at thezao.xyz with status=todo, owner=Zaal, due in 3 days
- [ ] Verify the row's \`legacy_source\` is \`inbox:<slug>\` and \`legacy_id\` is \`inbox-<slug>\`
- [ ] Trigger /inbox on a research-y item; verify NO tracker row is created (research goes to /zao-research not tracker directly)
- [ ] Confirm tracker write doesn't abort /inbox if Supabase env unset (best-effort)
- [ ] No emojis, no em dashes

## Next steps after merge
This is part 3 of a 4-piece "cowork github operational + integrate everything" sprint:
1. [shipped] Verify thezao.xyz deploy
2. [shipped at ZAODEVZ/ZAOcowork#14] README rewrite
3. [THIS] /inbox -> tracker (and zao-research v2.4 globally)
4. [pending] Merge ZAODEVZ/ZAOcowork ws/add-tyler-user + set TYLER_PASSWORD on Vercel (separately owned by Zaal)