### PR TITLE
fix(juke): try multiple secret canonicalizations + log debug

### DIFF
--- a/src/app/api/juke/webhooks/route.ts
+++ b/src/app/api/juke/webhooks/route.ts
@@ -40,8 +40,18 @@ export async function POST(request: NextRequest) {
 
   const verification = verifyJukeWebhook(rawBody, signatureHeader, secret);
   if (!verification.ok) {
-    logger.warn('[juke/webhooks] signature failed:', verification.reason);
+    logger.warn(
+      '[juke/webhooks] signature failed:',
+      verification.reason,
+      verification.debug ? JSON.stringify(verification.debug) : '',
+    );
     return NextResponse.json({ ok: false, error: verification.reason }, { status: 401 });
+  }
+  if (verification.matchedVariant && verification.matchedVariant !== 'raw') {
+    logger.warn(
+      '[juke/webhooks] signature verified via non-raw variant:',
+      verification.matchedVariant,
+    );
   }
 
   let body: unknown;

--- a/src/lib/spaces/jukeWebhookVerify.ts
+++ b/src/lib/spaces/jukeWebhookVerify.ts
@@ -25,8 +25,18 @@ export interface ParsedSignature {
 }
 
 export type VerifyResult =
-  | { ok: true; ts: number; signatureHash: string }
-  | { ok: false; reason: string };
+  | { ok: true; ts: number; signatureHash: string; matchedVariant?: string }
+  | { ok: false; reason: string; debug?: VerifyDebug };
+
+export interface VerifyDebug {
+  secretLen: number;
+  secretFp: string;
+  bodyLen: number;
+  headerRaw: string;
+  expectedRawPrefix: string;
+  receivedV1Prefix: string;
+  variantsTried: string[];
+}
 
 /** Parse `t={ts},v1={hex}` (order-insensitive, ignores unknown keys). */
 export function parseJukeSignature(header: string | null | undefined): ParsedSignature | null {
@@ -72,18 +82,78 @@ export function verifyJukeWebhook(
     return { ok: false, reason: 'Signature timestamp outside replay window' };
   }
 
-  const expected = createHmac('sha256', secret).update(`${parsed.ts}.${rawBody}`).digest('hex');
-
-  // timingSafeEqual requires equal-length buffers and throws otherwise.
-  if (expected.length !== parsed.v1.length) {
-    return { ok: false, reason: 'Signature length mismatch' };
+  // Juke's secret arrives as `whsec_<app-prefix>_<key>`. Different webhook
+  // libraries differ on what bytes get used as the HMAC key — some sign with
+  // the literal string, some strip the `whsec_` prefix, some base64-decode the
+  // key tail. Try every plausible canonicalization so we don't fail loudly
+  // because of a 5-character prefix convention.
+  const variants = buildSecretVariants(secret);
+  const message = `${parsed.ts}.${rawBody}`;
+  let firstExpected = '';
+  for (const variant of variants) {
+    const expected = createHmac('sha256', variant.key).update(message).digest('hex');
+    if (!firstExpected) firstExpected = expected;
+    if (expected.length !== parsed.v1.length) continue;
+    const a = Buffer.from(expected, 'utf8');
+    const b = Buffer.from(parsed.v1, 'utf8');
+    if (timingSafeEqual(a, b)) {
+      const signatureHash = createHash('sha256').update(parsed.v1).digest('hex');
+      return { ok: true, ts: parsed.ts, signatureHash, matchedVariant: variant.name };
+    }
   }
-  const a = Buffer.from(expected, 'utf8');
-  const b = Buffer.from(parsed.v1, 'utf8');
-  if (!timingSafeEqual(a, b)) {
-    return { ok: false, reason: 'Signature mismatch' };
+
+  const debug: VerifyDebug = {
+    secretLen: secret.length,
+    secretFp: createHash('sha256').update(secret).digest('hex').slice(0, 12),
+    bodyLen: rawBody.length,
+    headerRaw: signatureHeader ?? '',
+    expectedRawPrefix: firstExpected.slice(0, 16),
+    receivedV1Prefix: parsed.v1.slice(0, 16),
+    variantsTried: variants.map((v) => `${v.name}:${v.key.length}b`),
+  };
+  return { ok: false, reason: 'Signature mismatch', debug };
+}
+
+interface SecretVariant {
+  name: string;
+  key: Buffer | string;
+}
+
+function buildSecretVariants(secret: string): SecretVariant[] {
+  const variants: SecretVariant[] = [];
+  variants.push({ name: 'raw', key: secret });
+
+  // Strip `whsec_` (Stripe/Svix convention).
+  if (secret.startsWith('whsec_')) {
+    const stripped = secret.slice('whsec_'.length);
+    variants.push({ name: 'no-whsec', key: stripped });
+
+    // Strip `whsec_<app>_` (Juke convention: whsec_awt4_<key>).
+    const nextUnderscore = stripped.indexOf('_');
+    if (nextUnderscore > 0 && nextUnderscore < stripped.length - 1) {
+      const innerKey = stripped.slice(nextUnderscore + 1);
+      variants.push({ name: 'no-whsec-noapp', key: innerKey });
+      // Try base64-decoded key tail (common in webhook libs).
+      try {
+        const decoded = Buffer.from(innerKey, 'base64');
+        if (decoded.length > 0) {
+          variants.push({ name: 'no-whsec-noapp-b64', key: decoded });
+        }
+      } catch {
+        // ignore, base64 decode failed
+      }
+    }
+
+    // Base64 decode of the whole post-whsec tail.
+    try {
+      const decoded = Buffer.from(stripped, 'base64');
+      if (decoded.length > 0) {
+        variants.push({ name: 'no-whsec-b64', key: decoded });
+      }
+    } catch {
+      // ignore
+    }
   }
 
-  const signatureHash = createHash('sha256').update(parsed.v1).digest('hex');
-  return { ok: true, ts: parsed.ts, signatureHash };
+  return variants;
 }


### PR DESCRIPTION
## Why

Juke is delivering webhooks (3 inbound POSTs in last 30 min). Every one 401s with \`Signature mismatch\`. Parse passes, replay window passes, just the HMAC bytes do not match.

Most likely cause: Juke's secret format \`whsec_<app>_<key>\` (Stripe/Svix-style prefixed secret), and some webhook libraries sign with the stripped key, not the literal prefixed string.

## What

- Try multiple secret canonicalizations: raw, \`no-whsec\`, \`no-whsec-noapp\`, \`no-whsec-noapp-b64\`, \`no-whsec-b64\`. Return ok on first that matches + log which variant won.
- On final mismatch: emit VerifyDebug to logs with secret fingerprint (sha256 prefix, never the value), body length, raw header, expected vs received v1 prefixes.

## Verifies

- 11/11 existing tests still pass.
- TS clean.

## Smoke

After deploy: create a Juke space, end it, check Vercel logs for /api/juke/webhooks.
- If a variant matches: warn log says which, /juke-status flips.
- If still mismatch: debug payload tells us whether secret fp is wrong (paste error) or canonicalization differs (need Nicky).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>