### PR TITLE
feat(juke): host End-space button + admin routes + manifest v1.3

### DIFF
--- a/src/app/api/juke/admin/end-space/route.ts
+++ b/src/app/api/juke/admin/end-space/route.ts
@@ -1,0 +1,173 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { isValidJukeSpaceId } from '@/lib/spaces/juke';
+import { getJukeSpace, updateJukeSpace } from '@/lib/spaces/jukeSpacesDb';
+
+/**
+ * POST /api/juke/admin/end-space
+ *
+ * Calls Juke's developer end-space endpoint to terminate a room the host or
+ * an admin owns. Confirmed shape by Nicky 2026-05-24:
+ *
+ *   POST https://api.juke.audio/v1/developer/spaces/{room_id}/end
+ *   X-Juke-Api-Key: <JUKE_API_KEY>
+ *   -> 200 {"status": "ended"}
+ *
+ * Ownership: must be a room we (ZAO) created via POST /v1/developer/spaces.
+ * Cross-app + iOS-native rooms 404 with the same shape (no enumeration
+ * oracle). Idempotent on already-ended rooms. Fires `room.finished` to our
+ * webhook handler immediately with `ended_via: "api"` - no 5min LiveKit
+ * empty-timeout wait. We do NOT proactively flip our DB status here; the
+ * inbound webhook handler is the source of truth for the lifecycle update,
+ * which keeps the dispatch path identical to natural ends.
+ *
+ * Auth: signed-in user must be the original host (created_by_fid === fid) OR
+ * an admin. If you want a manual override that updates our DB without
+ * touching Juke (e.g. ghost rooms where Juke is unreachable), use
+ * /api/juke/admin/mark-ended instead.
+ *
+ * Body: { spaceId }
+ * Returns:
+ *   200 { ok: true, spaceId, juke: { status: 'ended' } }
+ *   202 { ok: true, spaceId, fallback: 'mark-ended' } when Juke 404s the
+ *       endpoint (i.e. they have not shipped PR #174 yet) - in that case the
+ *       caller should follow up with mark-ended for an interim manual flip.
+ *   503 { ok: false, error: 'JUKE_API_KEY not configured' }
+ */
+
+const BodySchema = z.object({
+  spaceId: z.string().refine(isValidJukeSpaceId, { message: 'Invalid Juke space id' }),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSessionData();
+  if (!session?.fid) {
+    return NextResponse.json({ ok: false, error: 'Sign in required' }, { status: 401 });
+  }
+
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, error: 'JUKE_API_KEY not configured on the server' },
+      { status: 503 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Body must be JSON' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid body', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { spaceId } = parsed.data;
+
+  const row = await getJukeSpace(spaceId);
+  if (!row) {
+    return NextResponse.json({ ok: false, error: 'Space not found' }, { status: 404 });
+  }
+
+  const isAdmin = Boolean(session.isAdmin);
+  const isHost = row.created_by_fid === session.fid;
+  if (!isAdmin && !isHost) {
+    return NextResponse.json(
+      { ok: false, error: 'Only the host or an admin can end this space' },
+      { status: 403 },
+    );
+  }
+
+  if (row.status === 'ended') {
+    return NextResponse.json({ ok: true, spaceId, alreadyEnded: true });
+  }
+
+  const endpoint = `https://api.juke.audio/v1/developer/spaces/${encodeURIComponent(spaceId)}/end`;
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'X-Juke-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err: unknown) {
+    logger.error('[juke/admin/end-space] fetch failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'Juke end-space API unreachable' },
+      { status: 502 },
+    );
+  }
+
+  const text = await res.text();
+  let jukeBody: unknown;
+  try {
+    jukeBody = JSON.parse(text);
+  } catch {
+    jukeBody = text;
+  }
+
+  // 404 = Juke has not shipped PR #174 yet, OR cross-app / iOS-native room.
+  // Same shape from Juke's side - no enumeration oracle. We flip our DB to
+  // ended as a graceful fallback so /spaces stops showing the row as Live;
+  // when room.finished eventually arrives from a later natural end, the
+  // handler is idempotent + a no-op.
+  if (res.status === 404) {
+    logger.warn(
+      '[juke/admin/end-space] Juke 404 - end-space endpoint not yet shipped or cross-app room',
+      { spaceId },
+    );
+    try {
+      await updateJukeSpace(spaceId, {
+        status: 'ended',
+        ended_at: new Date().toISOString(),
+      });
+    } catch (err: unknown) {
+      logger.error('[juke/admin/end-space] fallback mark-ended DB update failed', err);
+      return NextResponse.json(
+        { ok: false, error: 'Juke end-space 404 + local fallback failed' },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json(
+      {
+        ok: true,
+        spaceId,
+        fallback: 'mark-ended',
+        note: 'Juke end-space endpoint not yet available; flipped local status to ended. A real room.finished may still arrive later.',
+      },
+      { status: 202 },
+    );
+  }
+
+  if (!res.ok) {
+    logger.warn('[juke/admin/end-space] Juke rejected', res.status, jukeBody);
+    return NextResponse.json(
+      { ok: false, error: `Juke returned ${res.status}`, juke: jukeBody },
+      { status: res.status >= 500 ? 502 : res.status },
+    );
+  }
+
+  // Success path: Juke accepted. We do NOT flip our DB here - the inbound
+  // room.finished webhook will arrive almost immediately (Nicky confirmed
+  // synchronous dispatch in same PR #174) and the handler will update the row
+  // with the canonical ended_at + ended_via payload. Keeping all lifecycle
+  // updates in the webhook handler means natural ends and API ends share the
+  // same code path, fewer divergence bugs.
+  return NextResponse.json({ ok: true, spaceId, juke: jukeBody });
+}
+
+export const GET = () =>
+  NextResponse.json(
+    { ok: false, error: 'POST only - send { spaceId } as JSON' },
+    { status: 405 },
+  );

--- a/src/app/api/juke/admin/mark-ended/route.ts
+++ b/src/app/api/juke/admin/mark-ended/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { logger } from '@/lib/logger';
+import { getJukeSpace, updateJukeSpace } from '@/lib/spaces/jukeSpacesDb';
+import { isValidJukeSpaceId } from '@/lib/spaces/juke';
+
+/**
+ * POST /api/juke/admin/mark-ended
+ *
+ * Manual override that flips a Juke space row to `status: 'ended'` in our DB,
+ * decoupled from the Juke `room.finished` webhook. Required today because the
+ * Juke iframe Leave button is a pure LiveKit `room.disconnect()` and does not
+ * trigger an end on Juke's side; rooms we create via the developer API only
+ * really end when (a) Juke's developer end-space endpoint is called (no spec
+ * for that yet, blocked on Nicky) or (b) Juke times the room out internally.
+ *
+ * Without this route, /spaces shows "test4" as Live for hours after the host
+ * walked away. This bridges the gap.
+ *
+ * Admin OR original host (created_by_fid === session.fid) can mark a space
+ * ended. The row is updated in-place; if a real `room.finished` webhook
+ * arrives later, the handler is idempotent so it's a no-op.
+ *
+ * Body: { spaceId }
+ * Returns: { ok: true, spaceId, status: 'ended' }
+ */
+
+const BodySchema = z.object({
+  spaceId: z.string().refine(isValidJukeSpaceId, { message: 'Invalid Juke space id' }),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSessionData();
+  if (!session?.fid) {
+    return NextResponse.json({ ok: false, error: 'Sign in required' }, { status: 401 });
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Body must be JSON' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid body', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { spaceId } = parsed.data;
+
+  const row = await getJukeSpace(spaceId);
+  if (!row) {
+    return NextResponse.json({ ok: false, error: 'Space not found' }, { status: 404 });
+  }
+
+  const isAdmin = Boolean(session.isAdmin);
+  const isHost = row.created_by_fid === session.fid;
+  if (!isAdmin && !isHost) {
+    return NextResponse.json(
+      { ok: false, error: 'Only the host or an admin can end this space' },
+      { status: 403 },
+    );
+  }
+
+  if (row.status === 'ended') {
+    return NextResponse.json({ ok: true, spaceId, status: 'ended', alreadyEnded: true });
+  }
+
+  try {
+    await updateJukeSpace(spaceId, {
+      status: 'ended',
+      ended_at: new Date().toISOString(),
+    });
+  } catch (err: unknown) {
+    logger.error('[juke/admin/mark-ended] DB update failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to mark space as ended' },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, spaceId, status: 'ended' });
+}
+
+export const GET = () =>
+  NextResponse.json(
+    { ok: false, error: 'POST only - send { spaceId } as JSON' },
+    { status: 405 },
+  );

--- a/src/app/live/[spaceId]/page.tsx
+++ b/src/app/live/[spaceId]/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { getSessionData } from '@/lib/auth/session';
+import { EndJukeSpaceButton } from '@/components/spaces/EndJukeSpaceButton';
 import { JukeEmbed } from '@/components/spaces/JukeEmbed';
 import {
   isValidJukeSpaceId,
@@ -76,10 +78,20 @@ export default async function LivePage({ params, searchParams }: LivePageProps) 
     notFound();
   }
 
-  const row = await safeGetJukeSpace(spaceId);
+  const [row, session] = await Promise.all([safeGetJukeSpace(spaceId), getSessionData()]);
   const audioOff = audio === 'off';
   const isEnded = row?.status === 'ended';
   const recordingUrl = row?.recording_url ?? null;
+  // Host-or-admin gate for the End space button. Iframe Leave is participant-
+  // only (LiveKit disconnect, no API hit), so without this the room stays
+  // ACTIVE in our DB forever; the button calls our admin endpoint that proxies
+  // to Juke's new POST /v1/developer/spaces/{id}/end (Nicky PR #174).
+  const canEnd = Boolean(
+    !isEnded &&
+      row?.created_by_fid &&
+      session?.fid &&
+      (session.isAdmin || row.created_by_fid === session.fid),
+  );
 
   return (
     <div className="flex min-h-[100dvh] flex-col bg-[#0a1628]">
@@ -166,6 +178,15 @@ export default async function LivePage({ params, searchParams }: LivePageProps) 
             </Link>
           )}
         </div>
+
+        {canEnd && (
+          <div className="flex flex-col items-center gap-1.5 pt-2">
+            <EndJukeSpaceButton spaceId={spaceId} />
+            <p className="text-[10px] text-gray-600">
+              Iframe Leave only disconnects you. Use this to end the room for everyone.
+            </p>
+          </div>
+        )}
 
         <p className="mt-2 max-w-[480px] text-center text-xs text-gray-500">
           {audioOff

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -277,7 +277,35 @@ function LiveTab({ loading, stages, jukeRooms, myRooms, otherRooms, user, onHost
  * shape is distinct. A subtle "FC" badge per-card makes the source obvious so
  * a listener knows what they are walking into.
  */
+/**
+ * Rooms marked `active` in our DB but whose host walked away without
+ * triggering room.finished show up as Live forever. Until Juke's webhook
+ * lifecycle is bulletproof, anything `active` older than 30 minutes is
+ * suspect — surface a soft "may have ended" hint so listeners are not
+ * fooled into clicking dead rooms first.
+ *
+ * Calling this `stale` rather than `ended` is deliberate: we don't have
+ * authoritative evidence the room is over, so we keep the row clickable
+ * (a curious listener can still try it) but visually dim it so live rooms
+ * dominate.
+ */
+const STALE_JUKE_THRESHOLD_MS = 30 * 60 * 1000;
+function isJukeRoomStale(r: JukeRoomCard): boolean {
+  if (!r.started_at) return false;
+  const ageMs = Date.now() - new Date(r.started_at).getTime();
+  return ageMs > STALE_JUKE_THRESHOLD_MS;
+}
+
 function JukeLiveSection({ rooms }: { rooms: JukeRoomCard[] }) {
+  // Sort fresh first so a freshly-launched room beats a 4-hour-old ghost.
+  const sorted = [...rooms].sort((a, b) => {
+    const aStale = isJukeRoomStale(a) ? 1 : 0;
+    const bStale = isJukeRoomStale(b) ? 1 : 0;
+    if (aStale !== bStale) return aStale - bStale;
+    const at = a.started_at ? new Date(a.started_at).getTime() : 0;
+    const bt = b.started_at ? new Date(b.started_at).getTime() : 0;
+    return bt - at;
+  });
   return (
     <section>
       <h3 className="text-xs font-semibold uppercase tracking-wider mb-3 flex items-center gap-2 text-[#855dcd]">
@@ -285,40 +313,71 @@ function JukeLiveSection({ rooms }: { rooms: JukeRoomCard[] }) {
         Live on Juke
       </h3>
       <div className="grid gap-4 md:grid-cols-2">
-        {rooms.map((r) => (
-          <Link
-            key={r.id}
-            href={`/live/${r.id}`}
-            aria-label={`Join Juke space: ${r.title}`}
-            className="group block bg-[#111d2e] border border-white/[0.08] rounded-xl p-4 transition-all hover:border-gray-600 hover:shadow-lg hover:shadow-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#855dcd] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
-          >
-            <div className="w-8 h-1 rounded-full bg-[#855dcd] mb-3 opacity-60" aria-hidden="true" />
-            <div className="flex items-start justify-between gap-2 mb-3">
-              <h4 className="text-white font-bold text-sm leading-tight line-clamp-2 group-hover:text-[#a78bfa] transition-colors">
-                {r.title || 'Untitled space'}
-              </h4>
-              <div className="flex flex-col items-end gap-1 flex-shrink-0">
-                <span className="inline-flex items-center gap-1 text-red-400 text-[10px] font-bold uppercase tracking-wide">
-                  <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" aria-hidden="true" />
-                  Live
+        {sorted.map((r) => {
+          const stale = isJukeRoomStale(r);
+          return (
+            <Link
+              key={r.id}
+              href={`/live/${r.id}`}
+              aria-label={`Join Juke space: ${r.title}${stale ? ' (may have ended)' : ''}`}
+              className={`group block border rounded-xl p-4 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#855dcd] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628] ${
+                stale
+                  ? 'bg-[#0d1620] border-white/[0.04] opacity-60 hover:opacity-100 hover:border-amber-500/30'
+                  : 'bg-[#111d2e] border-white/[0.08] hover:border-gray-600 hover:shadow-lg hover:shadow-black/20'
+              }`}
+            >
+              <div
+                className={`w-8 h-1 rounded-full mb-3 ${stale ? 'bg-amber-500 opacity-50' : 'bg-[#855dcd] opacity-60'}`}
+                aria-hidden="true"
+              />
+              <div className="flex items-start justify-between gap-2 mb-3">
+                <h4
+                  className={`font-bold text-sm leading-tight line-clamp-2 transition-colors ${
+                    stale
+                      ? 'text-gray-400 group-hover:text-gray-200'
+                      : 'text-white group-hover:text-[#a78bfa]'
+                  }`}
+                >
+                  {r.title || 'Untitled space'}
+                </h4>
+                <div className="flex flex-col items-end gap-1 flex-shrink-0">
+                  {stale ? (
+                    <span className="inline-flex items-center gap-1 text-amber-400 text-[10px] font-bold uppercase tracking-wide">
+                      <span className="w-1.5 h-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+                      Stale
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 text-red-400 text-[10px] font-bold uppercase tracking-wide">
+                      <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" aria-hidden="true" />
+                      Live
+                    </span>
+                  )}
+                  <span className="inline-flex items-center text-[10px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border border-[#855dcd]/40 bg-[#855dcd]/10 text-[#a78bfa]">
+                    FC Juke
+                  </span>
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-xs text-gray-500">
+                <span>
+                  {stale
+                    ? 'May have ended - tap to check'
+                    : r.participant_count <= 1
+                      ? 'Just host'
+                      : `${r.participant_count} listening`}
                 </span>
-                <span className="inline-flex items-center text-[10px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border border-[#855dcd]/40 bg-[#855dcd]/10 text-[#a78bfa]">
-                  FC Juke
+                <span
+                  className={`inline-flex items-center px-3 py-1 rounded-lg text-white text-xs font-bold transition-colors ${
+                    stale
+                      ? 'bg-gray-600 group-hover:bg-amber-600'
+                      : 'bg-[#855dcd] group-hover:bg-[#a78bfa]'
+                  }`}
+                >
+                  {stale ? 'Check' : 'Listen'}
                 </span>
               </div>
-            </div>
-            <div className="flex items-center justify-between text-xs text-gray-500">
-              <span>
-                {r.participant_count <= 1
-                  ? 'Just host'
-                  : `${r.participant_count} listening`}
-              </span>
-              <span className="inline-flex items-center px-3 py-1 rounded-lg bg-[#855dcd] text-white text-xs font-bold group-hover:bg-[#a78bfa] transition-colors">
-                Listen
-              </span>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/spaces/EndJukeSpaceButton.tsx
+++ b/src/components/spaces/EndJukeSpaceButton.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface EndJukeSpaceButtonProps {
+  spaceId: string;
+}
+
+type EndState =
+  | { status: 'idle' }
+  | { status: 'confirming' }
+  | { status: 'ending' }
+  | { status: 'ended'; via: 'juke' | 'fallback' }
+  | { status: 'error'; message: string };
+
+/**
+ * Host/admin-only "End space" button. Calls `/api/juke/admin/end-space` which
+ * proxies to Juke's developer end endpoint (PR #174 on their side). If Juke
+ * 404s the endpoint (not shipped yet), our server falls back to a local
+ * mark-ended write so /spaces stops showing the row as Live.
+ *
+ * Rendering is gated by the server (we only render this for session.fid
+ * matching `created_by_fid`, or admin). We do not re-check that here - the
+ * server endpoint enforces it again with a 403.
+ *
+ * Two-step confirm pattern (single button morphs into "Confirm? / Cancel")
+ * prevents fat-finger ends mid-broadcast.
+ */
+export function EndJukeSpaceButton({ spaceId }: EndJukeSpaceButtonProps) {
+  const router = useRouter();
+  const [state, setState] = useState<EndState>({ status: 'idle' });
+
+  async function doEnd() {
+    setState({ status: 'ending' });
+    try {
+      const res = await fetch('/api/juke/admin/end-space', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ spaceId }),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+        fallback?: string;
+      };
+      if (!res.ok && !body.ok) {
+        setState({
+          status: 'error',
+          message: body.error ?? `End-space failed (${res.status})`,
+        });
+        return;
+      }
+      const via = body.fallback === 'mark-ended' ? 'fallback' : 'juke';
+      setState({ status: 'ended', via });
+      // Refresh the SSR page so the iframe collapses into the "ended" view.
+      // 800ms grace lets the toast read first.
+      setTimeout(() => router.refresh(), 800);
+    } catch (err: unknown) {
+      setState({
+        status: 'error',
+        message: err instanceof Error ? err.message : 'Network error',
+      });
+    }
+  }
+
+  if (state.status === 'ended') {
+    return (
+      <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-4 py-2.5 text-xs font-semibold text-emerald-300">
+        Space ended{state.via === 'fallback' ? ' (local-only - Juke endpoint not shipped yet)' : ''}
+      </div>
+    );
+  }
+
+  if (state.status === 'error') {
+    return (
+      <div className="flex flex-col items-center gap-2">
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs text-red-300">
+          {state.message}
+        </div>
+        <button
+          type="button"
+          onClick={() => setState({ status: 'idle' })}
+          className="text-[11px] text-gray-400 underline hover:text-gray-200"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (state.status === 'confirming') {
+    return (
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-300">End the space for everyone?</span>
+        <button
+          type="button"
+          onClick={doEnd}
+          className="rounded-xl border border-red-500/40 bg-red-500/15 px-3 py-1.5 text-xs font-bold text-red-300 transition-colors hover:bg-red-500/25"
+        >
+          Confirm
+        </button>
+        <button
+          type="button"
+          onClick={() => setState({ status: 'idle' })}
+          className="rounded-xl border border-white/[0.12] bg-[#1a2a3a] px-3 py-1.5 text-xs font-semibold text-gray-400 transition-colors hover:bg-[#22364a]"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  if (state.status === 'ending') {
+    return (
+      <div className="rounded-xl border border-white/[0.08] bg-[#1a2a3a] px-4 py-2.5 text-xs font-semibold text-gray-400">
+        Ending space...
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setState({ status: 'confirming' })}
+      className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-2 text-xs font-bold text-red-300 transition-colors hover:bg-red-500/20"
+    >
+      End space (host)
+    </button>
+  );
+}

--- a/src/lib/spaces/jukeChangelog.ts
+++ b/src/lib/spaces/jukeChangelog.ts
@@ -60,11 +60,22 @@ export function buildResolutionIndex(
   const out = new Map<string, JukeChangelogEntry>();
   if (!changelog) return out;
   for (const entry of changelog.entries) {
+    // 1) Explicit join: entry.resolves[] -> OpenAsk.id (canonical path).
     for (const askId of entry.resolves ?? []) {
       const prior = out.get(askId);
       if (!prior || entry.shipped_at > prior.shipped_at) {
         out.set(askId, entry);
       }
+    }
+    // 2) Implicit join: an OpenAsk.id matches the entry.id directly. Lets a
+    // newly-shipped Juke entry resolve our ask without needing Nicky to
+    // backfill the resolves[] array. Pre-condition is identical ids on both
+    // sides - which is exactly how we author asks for new Juke features
+    // (e.g. our 'developer-end-space' ask matches Juke's 'developer-end-space'
+    // changelog entry). resolves[] still wins for explicit cross-id mappings.
+    const idMatch = out.get(entry.id);
+    if (!idMatch || entry.shipped_at > idMatch.shipped_at) {
+      out.set(entry.id, entry);
     }
   }
   return out;

--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -236,6 +236,29 @@ const SHIPPED: ShippedFeature[] = [
     pr: 'https://github.com/bettercallzaal/ZAOOS/pull/669',
     files: ['src/app/api/juke/admin/register-webhook/route.ts'],
   },
+  {
+    id: 'webhook-payload-parser',
+    title: 'Webhook payload parser: event_type / data.room_id / event_id',
+    description:
+      'parseWebhookEvent now reads Juke 2026-05-23 shape (event_type + event_id at top level, data.room_id for the space id) instead of the legacy event / type / data.id fields. Defensive aliases keep the older shape working. readParticipant accepts fid / participant_fid / user_fid / host_fid + display_name / displayName / username for human-or-agent identification. Result: webhooks no longer log "no space_id" and lifecycle updates apply.',
+    shippedAt: '2026-05-24',
+    pr: 'https://github.com/bettercallzaal/ZAOOS/pull/677',
+    files: ['src/lib/spaces/jukeWebhookHandlers.ts'],
+  },
+  {
+    id: 'host-end-space-button',
+    title: 'Host "End space" button on /live/{id} + admin end-space route',
+    description:
+      "Iframe Leave is a pure LiveKit room.disconnect() with anon: participant identity - no API call, so rooms we create via developer API stay alive until LiveKit's 300s empty-room timeout. EndJukeSpaceButton on /live/{id} (gated to host or admin via SSR session) calls POST /api/juke/admin/end-space which proxies to Juke's POST /v1/developer/spaces/{id}/end (Nicky's PR #174). On a 404 from Juke (endpoint not shipped yet, or cross-app room), the route falls back to flipping our local juke_spaces row to ended so /spaces stops showing dead rooms as Live. The webhook handler remains the source of truth for the canonical room.finished event - we do not pre-flip our DB on the success path. Two-step confirm pattern on the button prevents fat-finger ends.",
+    shippedAt: '2026-05-24',
+    files: [
+      'src/app/api/juke/admin/end-space/route.ts',
+      'src/app/api/juke/admin/mark-ended/route.ts',
+      'src/components/spaces/EndJukeSpaceButton.tsx',
+      'src/app/live/[spaceId]/page.tsx',
+    ],
+    reference: "Nicky 2026-05-24 confirmation: POST /v1/developer/spaces/{room_id}/end, X-Juke-Api-Key auth, idempotent, fires room.finished synchronously with ended_via: 'host'|'api' payload.",
+  },
 ];
 
 const OPEN_ASKS: OpenAsk[] = [
@@ -272,12 +295,12 @@ const OPEN_ASKS: OpenAsk[] = [
     priority: 'p1',
   },
   {
-    id: 'partner-sso-bridge',
-    title: 'Parent-frame SSO so authed users on partner sites do not re-sign',
+    id: 'developer-end-space',
+    title: 'Developer API to end a space (host-end + immediate webhook dispatch)',
     reason:
-      "ZAO uses Sign In With Neynar (SIWN) - managed signer registered by ZAO's app FID. Juke uses SIWF (fresh EIP-4361 SIWE in the moment by user's custody). Different primitives, so a direct hand-off does not exist - a ZAO user already signed in at zaoos.com still has to do a second SIWF dance inside the Juke iframe to participate. Anonymous listen is fine (one-tap autoplay bypass). Three options in ascending lift: (1) Parent-frame Quick Auth via postMessage - ZAO posts {fid, signed-proof} into the iframe, Juke mints its JWT without showing the QR. Likely closest to your miniapp Quick Auth code path. (2) Trusted-partner pre-mint endpoint - ZAO server POSTs {fid, signed-proof} to Juke, gets back a short-lived JWT, passes as ?token=... on iframe src. Cleanest SSO. (3) Quick Auth via miniapp shell already works when ZAO is loaded INSIDE the FC client. Any of these closes the double-sign-in.",
-    blocks: 'Friction-free participate (react / raise hand / speak) inside ZAO OS embeds',
-    priority: 'p1',
+      "Surfaced 2026-05-24 while debugging the missing room.finished webhook. Iframe Leave is a pure LiveKit room.disconnect() with anon: participant identity — no API call to api.juke.audio, so the room stays alive on Juke's side until LiveKit's empty-room 300s timeout. Additionally Juke's own end_room handler was flipping Room.status to 'ended' before livekit teardown, so the room_finished dispatcher's WHERE status='active' filter excluded the row and the outbound webhook silently never fired (same blind spot for iOS host-end). We need either a developer POST /v1/developer/spaces/{id}/end (we'd wire it to a host 'End space' button on /live/{id}), OR room.finished firing synchronously when end_room flips status (not after a 5min wait). Confirmed by Nicky 2026-05-24: both ship in their PR #174 (POST /v1/developer/spaces/{room_id}/end, X-Juke-Api-Key auth, idempotent, fires room.finished inline with ended_via: 'host'|'api' on the payload).",
+    blocks: '/spaces showing dead rooms as Live + recap-cast trigger never firing for host-ended rooms',
+    priority: 'p0',
   },
 ];
 
@@ -355,7 +378,7 @@ export const INTEGRATION_ARCHITECTURE_ASCII = String.raw`
 
 export function getJukeIntegrationManifest(): IntegrationManifest {
   return {
-    version: '1.2',
+    version: '1.3',
     generated_at: new Date().toISOString(),
     about: {
       name: 'The ZAO',

--- a/src/lib/spaces/jukeWebhookHandlers.ts
+++ b/src/lib/spaces/jukeWebhookHandlers.ts
@@ -109,6 +109,20 @@ function readOccurredAt(body: unknown): string {
   return b.occurred_at ?? b.occurredAt ?? new Date().toISOString();
 }
 
+/**
+ * Extract `ended_via` from a room.finished body. Lives on `data.ended_via`
+ * per Nicky 2026-05-24 ship, with `endedVia` as a defensive camelCase alias.
+ * `host` = iOS host-end, `api` = developer-API end (e.g. our End-space
+ * button), undefined = LiveKit empty-room timeout.
+ */
+function readEndedVia(body: unknown): 'host' | 'api' | null {
+  const b = (body ?? {}) as { data?: Record<string, unknown> };
+  const d = (b.data ?? {}) as { ended_via?: unknown; endedVia?: unknown };
+  const raw = d.ended_via ?? d.endedVia;
+  if (raw === 'host' || raw === 'api') return raw;
+  return null;
+}
+
 /** Pull a JukeParticipantEntry from a participant.joined/left body. Returns
  * null if no usable fid is present (Juke filters anon listeners + virtual
  * participants out, so an event without an fid is unexpected but possible). */
@@ -164,6 +178,17 @@ export async function applyWebhookEvent(
     }
     case 'room.finished':
     case 'room.ended': {
+      // Juke 2026-05-24 ship (Nicky PR #174): room.finished carries
+      // `ended_via: "host" | "api"` on the payload. Omitted means LiveKit's
+      // empty-room timeout fired (no human action). We don't store it as a
+      // typed column yet - the raw body persists in `juke_webhook_events`
+      // for any later analysis - but we log it so future recap-cast routing
+      // (e.g. only auto-cast on host/api ends, skip silent timeouts) has a
+      // clear signal to wire onto.
+      const endedVia = readEndedVia(body);
+      if (endedVia) {
+        logger.info('[juke/webhooks] room.finished ended_via=' + endedVia, { spaceId });
+      }
       await updateJukeSpace(spaceId, { status: 'ended', ended_at: readOccurredAt(body) });
       return;
     }


### PR DESCRIPTION
## Why

Closes the room.finished blind spot surfaced during today's debug session. Iframe Leave = pure LiveKit room.disconnect() with anon: participant identity (NO API call to api.juke.audio). Rooms stay alive until LiveKit's 300s empty-timeout. Nicky confirmed same gap on Juke's side (end_room flipped status before livekit teardown, so room_finished WHERE filter dropped the row). His PR #174 fixes both with POST /v1/developer/spaces/{id}/end + synchronous webhook dispatch + ended_via payload.

This push gets ZAO ready to consume the moment Nicky deploys + gives us a graceful fallback for ghost rooms today.

## What

- **POST /api/juke/admin/end-space** - proxies to Juke's new endpoint. On 404, falls back to local mark-ended.
- **POST /api/juke/admin/mark-ended** - manual override for ghost rooms (host or admin).
- **EndJukeSpaceButton** client component - two-step confirm, host/admin only via SSR session.
- **/live/[spaceId]** wires the button in below the existing CTA row, gated by isAdmin || created_by_fid === session.fid.
- **Manifest v1.3** - adds developer-end-space ask (auto-flips green on Juke changelog ship), adds host-end-space-button + webhook-payload-parser shipped entries, dedupes partner-sso-bridge.

## Source-of-truth pattern

On end-space success, we do NOT pre-flip our DB. The inbound room.finished webhook (synchronous per Nicky) updates the row. Same code path for natural ends, API ends, and iOS host-ends. The 404-fallback IS a local-only flip because in that case Juke won't fire the webhook anyway.

## Auth

end-space + mark-ended: 401 unsigned, 403 non-host non-admin. Button is server-gated too so it never renders for randos.

## Verifies

- tsc clean on changed files
- POST-only routes, GET returns 405

## Smoke after merge

1. Sign in as admin
2. Create test5 Juke space via /spaces - Go Live - Juke
3. /live/{newId} - "End space (host)" button visible below CTA row
4. Click it - "Confirm?" appears - click Confirm
5. Two paths:
   - Juke #174 deployed: 200, room.finished webhook lands, DB flips ended, iframe collapses to ended state
   - Juke #174 not deployed yet: 202 fallback, DB flips ended locally, button shows "local-only" hint

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>