### PR TITLE
doc 742: Zaal Panthaki founder dossier + WaveWarZ brag source (DISPATCH tier)

### DIFF
--- a/research/community/742-zaal-panthaki-profile-dossier/README.md
+++ b/research/community/742-zaal-panthaki-profile-dossier/README.md
@@ -1,0 +1,293 @@
+---
+topic: community
+type: guide
+status: research-complete
+last-validated: 2026-05-25
+related-docs: "050, 051, 101, 180, 406, 608, 711, 723"
+original-query: "/zao-research zaal and bettercallzaal and all ive talked aobut in [this session, for the WaveWarZ Alliance accelerator hackathon submission brag paragraph]"
+tier: DISPATCH
+---
+
+# 742 — Zaal Panthaki: Founder Dossier + WaveWarZ Brag Source
+
+> **Goal:** Comprehensive founder dossier on Zaal Panthaki (Director of Ecosystem Strategy & Partnerships, WaveWarZ) — mined from local research + public footprint — to source his brag paragraph for the WaveWarZ Alliance accelerator hackathon submission. Mirrors Hurric4n3IKE's brag structure for shape consistency.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | USE **"Director of Ecosystem Strategy & Partnerships"** as on-camera title | Matches Feb 2024 - Present role. WaveWarZ public whitepaper lists "Internal & External Communications" — Alliance application gets the upgraded title that reflects deal-flow ownership (Coinflow ISV, Privy, Juke, Magnetiq, Empire Builder). |
+| 2 | USE **"The Connector / Bridge-Builder"** as Zaal's archetype in the brag | All three public surfaces converge on it: bettercallzaal.com headline ("The Connector"), Farcaster bio ("focused on bringing"), HackMD resume ("Swiss Army Knife engineer"), public testimonials ("creating spaces where to coordinate"). |
+| 3 | USE **BetterCallZaal nickname tie-back** as mythology hook | Direct structural mirror of Ike's "Hurric4n3IKE → WaveZ" tie-back. "Got a problem? BetterCallZaal" is already on the homepage. Lands the same kind of name-foretells-destiny move. |
+| 4 | USE **The ZAO is the purpose, WaveWarZ is the role** framing | Important nuance: Ike's purpose = WaveWarZ. Zaal's purpose = The ZAO (decentralized impact network). WaveWarZ is where his role finally synthesizes every skill he stacked. Honest, and stronger than copy-pasting Ike's "purpose" line. |
+| 5 | USE Solana volume + ZAO scale + Coinflow rail as the proof points | Concrete, specific, verifiable: $50-60K+ trading volume, 735 battles, 472 SOL, 188 ZAO members already trading, Coinflow ISV closed (merchantID "wavestation"). |
+
+## Identity
+
+| Field | Value | Source |
+|---|---|---|
+| Full name | Zaal Panthaki | `zaalp99@gmail.com` (per system context) + Doc 050 |
+| Age range | ~24-26 (RIT BS class of 2022) | Doc 050 |
+| Hometown / current | Ellsworth, Maine (rural Downeast) — relocated 2024 | Doc 050; bettercallzaal.com About timeline |
+| Education | BS Electrical Engineering, Rochester Institute of Technology (2022) | Doc 050; HackMD resume |
+| Previous role | Automation Engineer, PCC Structurals — led $1.5M robotics project, 7x throughput | Doc 050 |
+| Current day job | Building Automation Technician, The Jackson Laboratory → Riverside Group (full-time June 2026) | memory `project_zaal_jackson_to_riverside` |
+| Pre-engineer signals | Eagle Scout + ski patrol (Maine mountains) | bettercallzaal.com About timeline |
+| Farcaster | `@zaal` (FID 19640) — 5,114 followers | warpcast.com/zaal (FULL) |
+| X / Twitter | `@bettercallzaal` — 4,880 followers, 44,500+ tweets, joined Feb 2023 | x.com/bettercallzaal (PARTIAL — auth wall) |
+| YouTube | `@bettercallzaal` — hosts BCZ YapZ (20 episodes) | youtube.com/@bettercallzaal (PARTIAL) |
+| GitHub | `bettercallzaal` — 65+ public repos | github.com/bettercallzaal (per Doc 050) |
+| Personal site | bettercallzaal.com — tagline "Got a problem? BetterCallZaal." | bettercallzaal.com (FULL) |
+| Email | `zaal@thezao.com` (ecosystem) + `zaalp99@gmail.com` (personal) | memory `project_zao_contact_email` |
+| Legal entity | BCZ Strategies LLC (Delaware) | memory `project_bcz_strategies_llc` |
+
+## The ZAO Arc (Founder Story)
+
+| Year | Beat | Source |
+|---|---|---|
+| 2022 | RIT BS EE graduated. Worked PCC Structurals automation. Discovered during 2022 bear market that "software could move value directly" — pivoted into Web3. | Doc 050 |
+| 2022 | Founded ZTalent Agency. | Doc 050 |
+| 2023 | Pivoted ZTalent → The ZAO (ZTalent Artist Organization). Dropped agency model. Bear market timing: "people still building were serious." | Doc 050 |
+| 2023 | Co-founded WaveWarZ with Hurric4n3IKE + Candytoybox (Samantha Denton-Kinney). | WaveWarZ whitepaper; Doc 050 |
+| 2024 | Apr: produced **ZAO-PALOOZA** at NFT NYC (12 artists, 6 weeks lead, broke even). | Doc 050 |
+| 2024 | Dec: produced **ZAO-CHELLA** at Miami Art Basel (10 artists, WaveWarZ LIVE battle, AR art). | Doc 050 |
+| 2024 | Started weekly Respect Game fractal governance. 90+ consecutive weeks as of May 2026. | Doc 050 |
+| 2024 | Relocated to Ellsworth, Maine. "Where there was zero blockchain exposure" — turned that into bridging local arts scene to onchain rails. | Doc 050; bettercallzaal.com |
+| 2026 | Jan 1: launched **$ZABAL token** on Base via Clanker/Empire Builder. Liquid reward token, no governance power. Contract `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07`. | memory `project_nexus_hub_live` |
+| 2026 | May 7: shipped **Nexus Hub** — 14-brand ecosystem directory at bettercallzaal.com/nexus.html. | memory `project_nexus_hub_live` |
+| 2026 | Apr 29: graduated **ZAOstock** to own repo + domain. Code DELETED from ZAOOS per "monorepo as lab" pattern. | memory `project_zaostock_spinout` |
+| 2026 | Oct 3 (upcoming): **ZAOstock 2026** flagship festival, Ellsworth Franklin Street Parklet, $5-25K budget, Fractured Atlas fiscal sponsor via FailOften. | memory `project_zao_stock_confirmed`, `project_nmc_fractured_atlas` |
+
+**Canonical pitch:** "decentralized impact network" — bringing profit margin, data, and IP rights back to independent artists. (Sources: memory `project_zao_canonical_pitch`; warpcast.com/zaal bio.)
+
+## WaveWarZ-Specific Contribution (the brag-source section)
+
+Public whitepaper team listing:
+
+| Role | Name | Whitepaper duty |
+|---|---|---|
+| Founder / Developer / Visionary | Hurric4n3IKE | Architected the platform. Anchor/Rust. |
+| Design / Marketing / CC0 artist | Candytoybox (Samantha Denton-Kinney) | Brand identity, UX, growth marketing. |
+| **Internal & External Communications** | **BetterCallZaal** | Community management, partnerships, stakeholder relations. Manages artist relations + community engagement + external partnerships. |
+
+For the Alliance application Zaal upgrades the title to **"Director of Ecosystem Strategy & Partnerships"** to match what the actual work has become.
+
+**Specific rails Zaal owns (verifiable):**
+
+| Rail | Status | Source |
+|---|---|---|
+| **Coinflow ISV deal** — merchantID "wavestation", fiat on-ramp, Solana tx fees covered, ZAO is ISV umbrella, WaveWarZ is submerchant | Closed | Doc 406 |
+| **Privy onboarding** — built, ready to flip on (the explicit Alliance ask) | Built | Per the script provided by user |
+| **Juke audio partnership** — 9 of 11 ZAO asks shipped May 23 2026 by Nicky (Juke founder): webhooks, audio=off, scheduled countdown, key-only auth, SSO, FID enrichment, agent-join, changelog | Live | memory `project_juke_consumer_2026_05_24`, recent commits |
+| **Magnetiq / Proof of Meet** — Tyler Stambaugh collab, ZABAL Connector at ETH Boulder Feb 2026 | Shipped | Doc 050; memory `project_tyler_stambaugh` |
+| **Empire Builder v3 integration** — 6 PRs across docs 560-566, 582-585 | Live | memory `project_empire_builder_zabal_integration` |
+| **Arthur (Neynar) Base agentic build** — EVM dev brought in as ZABAL Games mentor + WaveWarZ integration | In progress | Doc 711; memory `project_arthur_neynar` |
+| **Lil WaveWarZ takeover @ NFT NYC** — Zaal led the IRL event | Shipped | HackMD team doc |
+
+**Public WaveWarZ testimonial (bettercallzaal.com):**
+
+> "Zaal helped build and scale WaveWarZ to over $60k+ in volume with a completely new music model, over 1.2k followers on X in a few months, and organized and hosted our first in real life WaveWarZ battle. Without Zaal WaveWarZ would not be dominating Web 3 Music the way it is now. This is your GUY."
+
+**WaveWarZ scale to cite in the brag (per public whitepaper + Doc 723d):**
+
+- $50,000-$60,000+ cumulative trading volume
+- 735 live battles run
+- 472.71 SOL cumulative volume (~$37,845 at SOL=$80)
+- Daily X Spaces Mon-Fri 11am EST
+- Sunday 8pm EST battles + special events
+- Real-time scoring + automated payout (no team intervention)
+
+## BetterCallZaal Personal Brand (the "rooms + rails" identity)
+
+**Homepage (bettercallzaal.com) verbatim positioning:**
+
+- Headline: **"Got a problem? BetterCallZaal."**
+- Subtitle: **"Engineer · Builder · Connector · Ecosystem Architect"**
+- CTA: **"Tell me what you're building. I'll bring the right people to the table — including myself — to build, grow, and ship."**
+
+**Portfolio tiers (from bettercallzaal.com):**
+
+- Tier 1: The ZAO, WaveWarZ, BCZ YapZ, ZAOstock
+- Tier 2: Streaming, Maine client work, engineering history, Zlank
+- 25+ projects across music, gaming, community governance
+
+**BCZ Strategies LLC (Delaware):**
+
+- Legal hub for ecosystem work + agency model
+- Coinflow ISV relationship runs through it
+- ZAO Music DBA (BMI + DistroKid + 0xSplits, first release "Cipher") — memory `project_zao_music_entity`
+
+**Voice across surfaces (consistent):**
+
+- "ZM" as community greeting (ZAO/ZABAL signal)
+- Build-in-public via 400+ newsletter editions (Year of the ZAO, Year of the ZABAL, ZTalent series)
+- Educational + founder storytelling, no hype — emphasis on shipped > promised
+- Cross-platform: Farcaster primary, X amplification, YouTube long-form (BCZ YapZ Tuesdays)
+- Self-identifying phrases: "monorepo as lab", "incubator model", "picks and shovels", "tools not empires"
+
+## Skill Chain (the brag's load-bearing list)
+
+Mirrors Ike's chain (football → EE → Infosys → sales → spaces → indie artist → WaveWarZ). Zaal's chain, chronological:
+
+1. **Eagle Scout + ski patrol** in the mountains of Maine — discipline, risk-reading, emergency response
+2. **BS Electrical Engineering at RIT (2022)** — systems thinking foundation, hardware-to-software bridge
+3. **Automation Engineer at PCC Structurals** — $1.5M robotics project, 7x throughput; learning to make systems that move physical value
+4. **2022 bear market Web3 pivot** — discovered software could MOVE VALUE not just compute; smart contracts on Base + Solana, zero exploits
+5. **Founded The ZAO (2023)** in the crypto winter — only-the-serious-people-left timing
+6. **90+ weeks of fractal Respect Game governance** — designed + iterated soulbound mechanics + education-through-participation
+7. **Produced ZAO-PALOOZA (NFT NYC) + ZAO-CHELLA (Art Basel)** — six-person team, six-week lead, broke even on PALOOZA, brought music into web3 events
+8. **400+ daily newsletter editions** building in public — Year of the ZAO, ZABAL, ZTalent
+9. **BCZ YapZ podcast (20 episodes)** + co-hosting LTAW3 — long-form public speaking via voice
+10. **Closed the rails for WaveWarZ** — Coinflow ISV, Privy onboarding, Juke audio, Magnetiq IRL, Empire Builder rewards, Neynar EVM — every partnership a separate room walked into and closed
+
+## Network (Brokered Relationships)
+
+| Person | Context | What Zaal brokered |
+|---|---|---|
+| **Hurric4n3IKE** (Ikechi Nwachukwu) | WaveWarZ founder / lead dev (Anchor/Rust) | Co-founded WaveWarZ 2023; Zaal owns ecosystem/partnerships, Ike owns tech |
+| **Candytoybox** (Samantha Denton-Kinney) | WaveWarZ co-founder, CC0 artist, ZAO cofounder | Co-founded across both orgs |
+| **Arthur (Neynar)** | EVM dev | Brought as ZABAL Games mentor + WaveWarZ-on-Base agentic builder (Doc 711) |
+| **Tyler Stambaugh** | Magnetiq / Proof of Meet founder | ZABAL Connector at ETH Boulder; recurring ZAOstock partner |
+| **Nicky (Juke)** | Farcaster audio client founder | 9 of 11 ZAO asks shipped May 2026; /spaces + /live integration |
+| **Ryan Kagy** | Bonfires founder (knowledge graph) | Agent-architecture partner for ZAO memory stack |
+| **Iman** | songchaindao GH owner, ZAO Devz lead | Built cowork-zaodevz tracker; runs ZAOcoworkingBot on his VPS |
+| **FailOften** | Creative technologist (NEA/Warhol funded) | ZAOstock production + Fractured Atlas fiscal sponsor intro |
+| **Steve Peer** | Ellsworth musician (37-yr music scene) | Anchor artist for ZAOstock Oct 3 in hometown |
+| **Roddy Ehrlenbach** | Ellsworth Parks & Rec director | Venue contact for ZAOstock Franklin Street Parklet |
+| **Cassie** | ZAOstock thesis validator | Validated infrastructure-as-product framing (Doc 547) |
+| **Shriyash Soni** | Apna Coding founder (50k+ devs) | ZABAL Games June presenter |
+| **Vlad** | Singularity.diy founder, Eden Fractal lineage | Shared DAO governance patterns (Doc 738) |
+| **Matteo Tambussi** | Livepeer OG, ETHTurin founder | ZAO Italy bridge candidate (Doc 419) |
+| **Jordan Oram** | Empire Builder founder | Integration partner + ZABAL Games |
+| **kmac.eth** | Farcaster snap builder | ZAO snap-as-ad collab |
+| **Jangouu** | NYC musician | First artist at ZAO-PALOOZA; "JANGOUU FOREVER" foundational |
+
+## Voice & Mythology (the brag's mythology beat)
+
+**Name origin candidates for the tie-back move:**
+
+| Hook | Material | Use? |
+|---|---|---|
+| **"BetterCallZaal" → "Got a problem? BetterCallZaal"** | Already on his homepage. Wordplay on Better Call Saul. The fixer / connector identity baked into the brand name. | **YES — primary mythology hook**. Direct analog to Ike's "Hurric4n3IKE foretold the WaveZ." Nickname-foretells-destiny. |
+| Maine isolation → bridge-building | Relocated 2024 to a region with zero blockchain exposure. "Bridge between two things that were never meant to talk." | Secondary — works for the engineering origin |
+| Eagle Scout + ski patrol → discipline | Same energy as Ike's "grit, toughness, discipline, durability" from football | Use in skill chain not as the closing mythology |
+
+## Concrete Numbers (for the brag's proof points)
+
+- **188** ZAO members on Base
+- **1,000+** ecosystem participants (broader)
+- **90+** consecutive weekly Respect Games
+- **540+** research docs in ZAOOS
+- **301** API routes, **279** components, **19** custom hooks
+- **400+** daily newsletter editions
+- **65+** public GitHub repos
+- **78** paid newsletter supporters pre-product
+- **22** artists in ZAO roster
+- **378,000+** combined Spotify monthly listeners
+- **500+** tracks across artist roster
+- **735** WaveWarZ live battles
+- **472.71** SOL cumulative WaveWarZ volume
+- **$50,000-$60,000+** WaveWarZ trading volume
+- **$10,000+** ecosystem revenue (festivals + WaveWarZ)
+- **150+** consecutive weekly COC Concertz concerts
+- **14-brand** Nexus Hub
+- **20** BCZ YapZ podcast episodes
+- **5,114** Farcaster followers; **4,880** X followers
+- **$1.5M** robotics project (PCC) — **7x** throughput
+- **0** smart contract exploits
+
+## Shipping Evidence (Last 6 Months)
+
+1. **Juke integration** (May 2026, 10 PRs merged) — webhook consumers for 4 endpoints, stale-room hints, end-space button, manifest v1.3 (PRs #670-#673)
+2. **Juke Status dashboard** (May 2026, PR #670)
+3. **Airtable Agentic CRM v3** (May 2026, PR #667; Doc 737)
+4. **ZAOstock spinout** (Apr 29 2026) — own repo + domain, code DELETED from ZAOOS
+5. **Empire Builder v3 integration** (Apr-May 2026, 6 PRs, Docs 560-566 + 582-585)
+6. **Nexus Hub** (May 7 2026) — 14-brand ecosystem at bettercallzaal.com/nexus.html
+7. **$ZABAL token** (Jan 1 2026) — Base via Clanker/Empire Builder
+8. **Respect Leaderboard + on-chain balance queries** on Optimism
+9. **Spaces/Live triple-provider** (Stream.io + 100ms + Juke from one Go-Live button)
+10. **Coinflow ISV merchant** "wavestation" assigned for WaveWarZ (Doc 406)
+
+## Brag Paragraph Drafts (mirroring Ike's structure)
+
+Ike's structure decoded:
+1. Long subordinate-clause skill chain
+2. "I have finally found my purpose"
+3. Purpose named: "WaveWarZ"
+4. Bold thesis sentence
+5. Why this matters globally
+6. Mythology hook (Hurricane Ike + jersey 43)
+7. Tie-back (name foretold the destiny)
+
+### v1 — "The Connector finally finds the rail" (closest mirror of Ike's shape)
+
+> After years of searching and accumulating skills — discipline and risk-reading from Eagle Scout work and ski patrol in the mountains of Maine, systems thinking from a BS in Electrical Engineering at RIT, running a $1.5 million robotics project that delivered seven-times throughput as an automation engineer at PCC Structurals, learning during the 2022 bear market that software could not just compute but actually move value, founding The ZAO music collective in the depths of crypto winter when only the serious people were still building, running ninety consecutive weeks of fractal Respect governance, producing ZAO-PALOOZA at NFT NYC and ZAO-CHELLA at Miami Art Basel from a six-person team on a six-week runway, publishing four hundred daily newsletters building in public, hosting twenty episodes of the BCZ YapZ builder podcast, and walking into room after room to close the rails (Coinflow as the fiat on-ramp, Privy as the onboarding, Juke as the audio, Magnetiq as the IRL, Empire Builder as the rewards) — I have finally found my role. The thing that ties together every system I have ever built and every person I have ever introduced. WaveWarZ. We are building the first global music battle league that has ever existed, and I am the connector who turns a Solana platform into an ecosystem: $60K+ already traded, seven hundred and thirty-five battles already run, The ZAO's 188 members already trading and watching nightly, every rail in place because somebody had to walk into the room and close it. My brand for years has been BetterCallZaal because when artists, builders, and ecosystems hit a problem, they call. Little did I know that nickname would foretell the role I would play in the WaveZ that are about to hit the world…
+
+### v2 — "The bridge-builder finds a sport worth bridging" (sharper thesis)
+
+> After years of building things people could actually touch — robotic systems that moved metal through factories, a $1.5 million automation project at PCC Structurals that pulled seven-times throughput out of a manufacturing line, an Electrical Engineering degree from RIT spent learning that the hardest part of any system is the interface between two things that were never meant to talk — I crossed over into software during the 2022 bear market and found something that broke me open. Software could not just compute. Software could move value. I founded The ZAO music collective that winter when most of crypto was leaving the room, ran ninety consecutive weeks of fractal Respect governance, produced ZAO-PALOOZA at NFT NYC and ZAO-CHELLA at Art Basel with six weeks and a six-person team, shipped four hundred newsletters building in public, started a builder podcast that's run twenty episodes, and relocated to a corner of rural Maine where the blockchain exposure was zero — because building bridges between two things that were never meant to talk is the only thing I have ever actually been good at. WaveWarZ is the synthesis. The first global music battle league that has ever existed runs on Solana because I closed Coinflow as the fiat rail, Privy as the onboarding rail, Juke as the audio rail, Magnetiq as the IRL rail, and brought The ZAO's 188 members in as the first thousand live trades. They call me BetterCallZaal because when artists, builders, and ecosystems need a rail built — somebody calls. The WaveZ hitting the world right now? That's what happens when a Maine engineer who builds bridges between things finally finds a sport worth bridging the world around.
+
+## Script Brag Line Options (~10-15 words, on-camera)
+
+Script context (verbatim from user):
+
+> [ZAAL] "I'm Zaal — I founded The ZAO music collective and I'm [his role on WaveWarz]. [His brag line here.]"
+
+Three options, distinct angles:
+
+| # | Line | Angle |
+|---|---|---|
+| A | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **I close the rails that turn a Solana platform into an ecosystem.**" | Rails / partnerships angle. Most direct map to title. |
+| B | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **If WaveWarZ has a deal, a partner, or a room — I closed it.**" | Closer / dealmaker angle. Punchier, matches Samantha's "I build from the ground up and ship" energy. |
+| C | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **I built a 14-brand ecosystem around music ownership — WaveWarZ is the engine.**" | Ecosystem-thesis angle. Bigger swing, ties brand work to WaveWarZ. |
+
+**Recommended: B.** Matches the cadence + register of Samantha's line ("I build from the ground up and ship"). Punchier than A. More personal than C.
+
+## Also See
+
+- [Doc 050 — The ZAO Complete Guide](../050-the-zao-complete-guide/)
+- [Doc 051 — ZAO Whitepaper 2026](../051-zao-whitepaper-2026/)
+- [Doc 101 — WaveWarZ x ZAO OS Integration Whitepaper](../../wavewarz/101-wavewarz-zao-whitepaper/)
+- [Doc 180 — WaveWarZ Integration Blueprints](../../wavewarz/180-wavewarz-integration-blueprints/)
+- [Doc 406 — Coinflow ISV Deep Dive (WaveWarZ + ZAO)](../../business/406-coinflow-isv-deep-dive-wavewarz-zao/)
+- [Doc 608 — WaveWarZ Africa RAM SongChain](../../events/608-wavewarz-africa-ram-songchain-may4/)
+- [Doc 711 — Arthur WaveWarZ Base Call](../../events/711-arthur-wavewarz-base-call-may19/)
+- [Doc 723 — ZABAL Avax x402 WaveWarZ Agentic](../../business/723-zabal-avax-x402-wavewarz-agentic/)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Pick v1 vs v2 brag paragraph + optional edits | @Zaal | Decision | Before Alliance submission deadline |
+| Pick script brag line A / B / C | @Zaal | Decision | Before video shoot |
+| Confirm "Director of Ecosystem Strategy & Partnerships" is the title Zaal wants public for Alliance + downstream materials | @Zaal | Decision | Before submission |
+| Escalate PARTIAL public-footprint sources (X profile, Nexus Hub JS, YouTube channel) via Playwright if needed for follow-up | @Claude | Follow-up | When next public-bio refresh is requested |
+| Update memory `user_zaal.md` + create `user_zaal_full_bio.md` with the locked title + brag final | @Claude | Memory write | After Zaal locks v1/v2 |
+
+## Sources
+
+**Local research (FULL — all read directly):**
+
+- [Doc 050 — The ZAO Complete Guide](../050-the-zao-complete-guide/) [FULL]
+- [Doc 406 — Coinflow ISV Deep Dive](../../business/406-coinflow-isv-deep-dive-wavewarz-zao/) [FULL]
+- [Doc 101 — WaveWarZ x ZAO OS Whitepaper](../../wavewarz/101-wavewarz-zao-whitepaper/) [FULL]
+- [Doc 711 — Arthur Base Call](../../events/711-arthur-wavewarz-base-call-may19/) [FULL]
+- [Doc 723 — ZABAL Avax x402 WaveWarZ Agentic](../../business/723-zabal-avax-x402-wavewarz-agentic/) [FULL]
+- Memory: `project_zao_canonical_pitch`, `project_bcz_strategies_llc`, `project_nexus_hub_live`, `project_zao_music_entity`, `project_zaal_jackson_to_riverside`, `project_zao_stock_confirmed`, `project_zaostock_spinout`, `project_juke_consumer_2026_05_24`, `project_arthur_neynar`, `project_tyler_stambaugh`, `project_empire_builder_zabal_integration` [all FULL]
+
+**Public footprint:**
+
+- [bettercallzaal.com](https://bettercallzaal.com) [FULL] — homepage, bio, portfolio, About timeline, public testimonial
+- [warpcast.com/zaal](https://warpcast.com/zaal) [FULL] — Farcaster profile, bio, pinned cast, recent activity
+- [wavewarz.com](https://www.wavewarz.com) [FULL] — public WaveWarZ site, team page, scale stats
+- HackMD public resume [FULL] — "Backend Engineer | Web3 Builder | Automation Systems"
+- HackMD WaveWarZ team doc [FULL] — Zaal's role description verbatim
+- [x.com/bettercallzaal](https://x.com/bettercallzaal) [PARTIAL — auth wall on logged-out X; bio + follower counts + several recent tweets captured via Sorsa snapshot, but full timeline requires logged-in fetch. Escalation: Playwright MCP not run for this draft — recommend escalating before any follow-on public-bio doc.]
+- [bettercallzaal.com/nexus.html](https://bettercallzaal.com/nexus.html) [PARTIAL — JS-rendered, 14-brand list not enumerated by WebFetch. Escalation: Playwright MCP not run; the 14 brands are catalogued in memory `project_nexus_hub_live` (FULL there).]
+- [youtube.com/@bettercallzaal](https://youtube.com/@bettercallzaal) [PARTIAL — channel hub loaded, subscriber count + recent video list need JS render. Recent episode titles captured via search snippets + memory. Escalation: not run for this draft.]
+- KFM Talks guest appearance [FULL via exa] — "Zaal; The ZAO Revolution"
+- Token for Your Thoughts guest appearance Apr 2026 [FULL via exa]
+- Third-party testimonials [FULL via exa] — "creating spaces where to coordinate" + bettercallzaal.com IKE testimonial
+
+**Note on PARTIAL sources:** All three PARTIAL items are auxiliary to the brag deliverable (Zaal's bio + voice + recent posts are confirmed FULL via Farcaster + bettercallzaal.com + HackMD resume). The PARTIAL sources are flagged transparently per skill Hard Requirement #11 and queued for Playwright escalation on the next refresh.

--- a/research/community/742-zaal-panthaki-profile-dossier/README.md
+++ b/research/community/742-zaal-panthaki-profile-dossier/README.md
@@ -17,7 +17,7 @@ tier: DISPATCH
 | # | Decision | Rationale |
 |---|----------|-----------|
 | 1 | USE **"Director of Ecosystem Strategy & Partnerships"** as on-camera title | Matches Feb 2024 - Present role. WaveWarZ public whitepaper lists "Internal & External Communications" — Alliance application gets the upgraded title that reflects deal-flow ownership (Coinflow ISV, Privy, Juke, Magnetiq, Empire Builder). |
-| 2 | USE **"The Connector / Bridge-Builder"** as Zaal's archetype in the brag | All three public surfaces converge on it: bettercallzaal.com headline ("The Connector"), Farcaster bio ("focused on bringing"), HackMD resume ("Swiss Army Knife engineer"), public testimonials ("creating spaces where to coordinate"). |
+| 2 | USE **"The Front Door / Gravity Well"** as Zaal's archetype (LOCKED 2026-05-25 by Zaal) | Zaal corrected the framing during draft review: he is not the rails-closer or partnerships negotiator (those are outcomes). He is the person other founders bring their own ecosystems through. The ZAO is the gravity well; WaveWarZ is what those founders discover once they're inside. Proof points: Tyler/Magnetiq, Jordan/Empire Builder, Arthur/Neynar, Ryan/Bonfires, Nicky/Juke, Vlad/Singularity, Shriyash/Apna Coding — all run their own ecosystems and orbit The ZAO. See [[feedback_zaal_wavewarz_positioning]]. |
 | 3 | USE **BetterCallZaal nickname tie-back** as mythology hook | Direct structural mirror of Ike's "Hurric4n3IKE → WaveZ" tie-back. "Got a problem? BetterCallZaal" is already on the homepage. Lands the same kind of name-foretells-destiny move. |
 | 4 | USE **The ZAO is the purpose, WaveWarZ is the role** framing | Important nuance: Ike's purpose = WaveWarZ. Zaal's purpose = The ZAO (decentralized impact network). WaveWarZ is where his role finally synthesizes every skill he stacked. Honest, and stronger than copy-pasting Ike's "purpose" line. |
 | 5 | USE Solana volume + ZAO scale + Coinflow rail as the proof points | Concrete, specific, verifiable: $50-60K+ trading volume, 735 battles, 472 SOL, 188 ZAO members already trading, Coinflow ISV closed (merchantID "wavestation"). |
@@ -220,11 +220,15 @@ Ike's structure decoded:
 6. Mythology hook (Hurricane Ike + jersey 43)
 7. Tie-back (name foretold the destiny)
 
-### v1 — "The Connector finally finds the rail" (closest mirror of Ike's shape)
+### v3 — "The Front Door" (LOCKED ANGLE, 2026-05-25)
+
+> After years of accumulating skills from completely different worlds — Eagle Scout discipline and ski patrol training in the mountains of Maine, a BS in Electrical Engineering from RIT, a $1.5 million robotics project at PCC Structurals that delivered seven-times throughput, the 2022 bear market revelation that software could not just compute but actually move value, founding The ZAO music collective in the depth of crypto winter when only the serious people were still building, running ninety consecutive weeks of fractal Respect governance, producing ZAO-PALOOZA at NFT NYC and ZAO-CHELLA at Miami Art Basel from a six-person team on a six-week runway, publishing four hundred newsletters building in public, hosting twenty episodes of the BCZ YapZ builder podcast, and quietly building a fourteen-brand ecosystem out of a corner of rural Maine where the blockchain exposure was zero — I have finally found my role. I'm not the loudest person in the room and I'm not the one closing the cap table. I'm the person other founders bring their own ecosystems through. Tyler from Magnetiq, Jordan from Empire Builder, Arthur from Neynar, Ryan from Bonfires, Nicky from Juke, Vlad from Singularity, Shriyash from Apna Coding with his fifty thousand developers — they all walked through The ZAO because that's where they meet each other. And once they're in, they discover WaveWarZ. That's not partnership development. That's gravity. WaveWarZ is the first global music battle league that has ever existed and it doesn't need to chase distribution because The ZAO already pulls in the operators who can carry it. They call me BetterCallZaal because when builders and ecosystems need a room to walk into, somebody calls. Little did I know that nickname would foretell the role I would play — not the closer, not the founder, the front door. The WaveZ hitting the world right now? They flow through it.
+
+### v1 — "The Connector finally finds the rail" (SUPERSEDED by v3 — kept for reference)
 
 > After years of searching and accumulating skills — discipline and risk-reading from Eagle Scout work and ski patrol in the mountains of Maine, systems thinking from a BS in Electrical Engineering at RIT, running a $1.5 million robotics project that delivered seven-times throughput as an automation engineer at PCC Structurals, learning during the 2022 bear market that software could not just compute but actually move value, founding The ZAO music collective in the depths of crypto winter when only the serious people were still building, running ninety consecutive weeks of fractal Respect governance, producing ZAO-PALOOZA at NFT NYC and ZAO-CHELLA at Miami Art Basel from a six-person team on a six-week runway, publishing four hundred daily newsletters building in public, hosting twenty episodes of the BCZ YapZ builder podcast, and walking into room after room to close the rails (Coinflow as the fiat on-ramp, Privy as the onboarding, Juke as the audio, Magnetiq as the IRL, Empire Builder as the rewards) — I have finally found my role. The thing that ties together every system I have ever built and every person I have ever introduced. WaveWarZ. We are building the first global music battle league that has ever existed, and I am the connector who turns a Solana platform into an ecosystem: $60K+ already traded, seven hundred and thirty-five battles already run, The ZAO's 188 members already trading and watching nightly, every rail in place because somebody had to walk into the room and close it. My brand for years has been BetterCallZaal because when artists, builders, and ecosystems hit a problem, they call. Little did I know that nickname would foretell the role I would play in the WaveZ that are about to hit the world…
 
-### v2 — "The bridge-builder finds a sport worth bridging" (sharper thesis)
+### v2 — "The bridge-builder finds a sport worth bridging" (SUPERSEDED by v3 — kept for reference)
 
 > After years of building things people could actually touch — robotic systems that moved metal through factories, a $1.5 million automation project at PCC Structurals that pulled seven-times throughput out of a manufacturing line, an Electrical Engineering degree from RIT spent learning that the hardest part of any system is the interface between two things that were never meant to talk — I crossed over into software during the 2022 bear market and found something that broke me open. Software could not just compute. Software could move value. I founded The ZAO music collective that winter when most of crypto was leaving the room, ran ninety consecutive weeks of fractal Respect governance, produced ZAO-PALOOZA at NFT NYC and ZAO-CHELLA at Art Basel with six weeks and a six-person team, shipped four hundred newsletters building in public, started a builder podcast that's run twenty episodes, and relocated to a corner of rural Maine where the blockchain exposure was zero — because building bridges between two things that were never meant to talk is the only thing I have ever actually been good at. WaveWarZ is the synthesis. The first global music battle league that has ever existed runs on Solana because I closed Coinflow as the fiat rail, Privy as the onboarding rail, Juke as the audio rail, Magnetiq as the IRL rail, and brought The ZAO's 188 members in as the first thousand live trades. They call me BetterCallZaal because when artists, builders, and ecosystems need a rail built — somebody calls. The WaveZ hitting the world right now? That's what happens when a Maine engineer who builds bridges between things finally finds a sport worth bridging the world around.
 
@@ -234,15 +238,15 @@ Script context (verbatim from user):
 
 > [ZAAL] "I'm Zaal — I founded The ZAO music collective and I'm [his role on WaveWarz]. [His brag line here.]"
 
-Three options, distinct angles:
+Four options, distinct angles. Zaal locked the **gravity-well / front-door** angle 2026-05-25 — C-family wins; A + B kept for reference.
 
-| # | Line | Angle |
-|---|---|---|
-| A | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **I close the rails that turn a Solana platform into an ecosystem.**" | Rails / partnerships angle. Most direct map to title. |
-| B | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **If WaveWarZ has a deal, a partner, or a room — I closed it.**" | Closer / dealmaker angle. Punchier, matches Samantha's "I build from the ground up and ship" energy. |
-| C | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **I built a 14-brand ecosystem around music ownership — WaveWarZ is the engine.**" | Ecosystem-thesis angle. Bigger swing, ties brand work to WaveWarZ. |
-
-**Recommended: B.** Matches the cadence + register of Samantha's line ("I build from the ground up and ship"). Punchier than A. More personal than C.
+| # | Line | Angle | Status |
+|---|---|---|---|
+| **C1** | "I'm Zaal. I founded The ZAO music collective and I'm Director of Ecosystem Strategy & Partnerships. **I bring ecosystem founders into The ZAO — WaveWarZ is what they take home.**" | Gravity-well / front-door (~12 words). Punchiest, mirrors Samantha's cadence. | **LOCKED — RECOMMENDED** |
+| C2 | "...**I bring founders with their own ecosystems into The ZAO — WaveWarZ is what they find when they get there.**" | Same angle, more setup (~16 words). | Alt |
+| C3 | "...**I'm the front door for founders who already run ecosystems — they come for The ZAO, they leave talking about WaveWarZ.**" | Same angle, fullest (~21 words). | Alt |
+| A | "...**I close the rails that turn a Solana platform into an ecosystem.**" | Rails / partnerships. | SUPERSEDED — wrong frame |
+| B | "...**If WaveWarZ has a deal, a partner, or a room — I closed it.**" | Closer / dealmaker. | SUPERSEDED — wrong frame |
 
 ## Also See
 
@@ -257,13 +261,15 @@ Three options, distinct angles:
 
 ## Next Actions
 
-| Action | Owner | Type | By When |
-|--------|-------|------|---------|
-| Pick v1 vs v2 brag paragraph + optional edits | @Zaal | Decision | Before Alliance submission deadline |
-| Pick script brag line A / B / C | @Zaal | Decision | Before video shoot |
-| Confirm "Director of Ecosystem Strategy & Partnerships" is the title Zaal wants public for Alliance + downstream materials | @Zaal | Decision | Before submission |
-| Escalate PARTIAL public-footprint sources (X profile, Nexus Hub JS, YouTube channel) via Playwright if needed for follow-up | @Claude | Follow-up | When next public-bio refresh is requested |
-| Update memory `user_zaal.md` + create `user_zaal_full_bio.md` with the locked title + brag final | @Claude | Memory write | After Zaal locks v1/v2 |
+| Action | Owner | Type | By When | Status |
+|--------|-------|------|---------|--------|
+| Lock gravity-well positioning (front-door, not closer) | @Zaal | Decision | 2026-05-25 | DONE |
+| Pick brag paragraph version | @Zaal | Decision | DONE — v3 locked | DONE |
+| Pick script brag line | @Zaal | Decision | DONE — C1 locked | DONE |
+| Save positioning to memory | @Claude | Memory write | 2026-05-25 | DONE — `feedback_zaal_wavewarz_positioning.md` |
+| Confirm "Director of Ecosystem Strategy & Partnerships" title for downstream materials beyond Alliance | @Zaal | Decision | When next bio published | Pending |
+| Apply v3 brag + C1 line into the Alliance video script + written submission | @Zaal | Application | Before Alliance deadline | Pending |
+| Escalate 3 PARTIAL public-footprint sources via Playwright on next refresh | @Claude | Follow-up | Next bio request | Queued |
 
 ## Sources
 


### PR DESCRIPTION
## Summary

Doc 742 — comprehensive founder dossier on Zaal Panthaki (Director of Ecosystem Strategy & Partnerships, WaveWarZ) — synthesized from local research + memory + public footprint. Sources the brag paragraph + on-camera script line for the WaveWarZ Alliance accelerator hackathon submission. Mirrors Hurric4n3IKE's brag structure (skill chain → purpose turn → thesis → mythology → tie-back).

## Tier

DISPATCH (2 parallel sub-agents: local mining + public footprint, then synthesis)

## Sources

- Local research: 5 docs FULL (050, 101, 406, 711, 723) + 12 memory files FULL
- Public footprint: 7 surfaces (bettercallzaal.com FULL, warpcast.com/zaal FULL, wavewarz.com FULL, HackMD resume FULL, HackMD WaveWarZ team doc FULL, KFM Talks FULL, exa testimonials FULL)
- 3 PARTIAL sources flagged (x.com auth wall, nexus.html JS, youtube.com JS) — non-critical to brag deliverable, escalation queued for follow-up

## Deliverables in the doc

- 2 brag paragraph drafts (v1 connector mirror / v2 bridge-builder thesis)
- 3 script brag line options (A rails / B closer / C ecosystem) — recommends B
- Network table of 17 brokered relationships
- Skill chain (10 items, chronological)
- Concrete numbers (22 specific stats)
- Last-6-months shipping evidence (10 items)

## Next Actions

See the "Next Actions" section in the doc — top items are Zaal-locked decisions on v1 vs v2 brag + A/B/C script line, before Alliance submission.

## Test plan

- [ ] Zaal reads the doc, picks v1 or v2 brag + edits to taste
- [ ] Zaal picks script line A/B/C
- [ ] Confirm "Director of Ecosystem Strategy & Partnerships" is the title to use publicly downstream
- [ ] After Zaal locks, update memory user_zaal.md + create user_zaal_full_bio.md
- [ ] Optional: Playwright-escalate the 3 PARTIAL public sources on next bio refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)