### PR TITLE
feat(juke-status): tab nav (Overview / Shipped / Asks / Architecture / About)

### DIFF
--- a/src/app/juke-status/JukeStatusTabs.tsx
+++ b/src/app/juke-status/JukeStatusTabs.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+
+/**
+ * Client-side tab shell for /juke-status. The server page hands in each
+ * top-level section as a slot (overview / shipped / asks / architecture /
+ * about) and this component renders only the active one, while keeping a
+ * sticky tab strip at the top so visitors can jump between facets without
+ * scrolling a 600-line page.
+ *
+ * URL hash (#shipped, #asks, ...) is the source of truth so deep-links are
+ * shareable. Default tab is `overview`. Unknown hashes fall back to overview.
+ *
+ * Counts in tab labels (e.g. "Shipped (15)") are passed by the server since
+ * it already has the numbers.
+ */
+
+export type JukeStatusTabId = 'overview' | 'shipped' | 'asks' | 'architecture' | 'about';
+
+export interface JukeStatusTabsProps {
+  overview: ReactNode;
+  shipped: ReactNode;
+  asks: ReactNode;
+  architecture: ReactNode;
+  about: ReactNode;
+  counts: {
+    shipped: number;
+    asks: number;
+    resolvedAsks: number;
+    webhooks: number;
+    spaces: number;
+  };
+}
+
+interface TabDef {
+  id: JukeStatusTabId;
+  label: string;
+  hint?: string;
+}
+
+function buildTabs(counts: JukeStatusTabsProps['counts']): TabDef[] {
+  return [
+    {
+      id: 'overview',
+      label: 'Overview',
+      hint: `${counts.webhooks} webhooks - ${counts.spaces} spaces`,
+    },
+    { id: 'shipped', label: `Shipped (${counts.shipped})` },
+    {
+      id: 'asks',
+      label: `Asks (${counts.asks})`,
+      hint: counts.resolvedAsks > 0 ? `${counts.resolvedAsks} resolved by Juke` : undefined,
+    },
+    { id: 'architecture', label: 'Architecture' },
+    { id: 'about', label: 'About' },
+  ];
+}
+
+function isTabId(value: string): value is JukeStatusTabId {
+  return (
+    value === 'overview' ||
+    value === 'shipped' ||
+    value === 'asks' ||
+    value === 'architecture' ||
+    value === 'about'
+  );
+}
+
+export function JukeStatusTabs({
+  overview,
+  shipped,
+  asks,
+  architecture,
+  about,
+  counts,
+}: JukeStatusTabsProps) {
+  const [active, setActive] = useState<JukeStatusTabId>('overview');
+
+  // Hash sync: read on mount + listen for hashchange so back/forward + deep
+  // links land on the right tab. Hash drives state, never the other way - the
+  // setter both updates state and rewrites the hash so they cannot diverge.
+  useEffect(() => {
+    const fromHash = () => {
+      const raw = window.location.hash.replace(/^#/, '').toLowerCase();
+      if (raw && isTabId(raw)) setActive(raw);
+    };
+    fromHash();
+    window.addEventListener('hashchange', fromHash);
+    return () => window.removeEventListener('hashchange', fromHash);
+  }, []);
+
+  function selectTab(id: JukeStatusTabId) {
+    setActive(id);
+    if (typeof window !== 'undefined') {
+      // history.replaceState avoids piling up nav entries when bouncing tabs.
+      window.history.replaceState(null, '', `#${id}`);
+    }
+  }
+
+  const tabs = buildTabs(counts);
+  const panels: Record<JukeStatusTabId, ReactNode> = {
+    overview,
+    shipped,
+    asks,
+    architecture,
+    about,
+  };
+
+  return (
+    <>
+      <div className="sticky top-0 z-20 -mx-4 sm:-mx-6 px-4 sm:px-6 bg-[#0a1628]/95 backdrop-blur border-b border-white/[0.08]">
+        <div
+          className="flex gap-1 overflow-x-auto py-2 -mb-px scrollbar-hide"
+          role="tablist"
+          aria-label="ZAO + Juke status sections"
+        >
+          {tabs.map((tab) => {
+            const isActive = active === tab.id;
+            return (
+              <button
+                key={tab.id}
+                role="tab"
+                type="button"
+                aria-selected={isActive}
+                onClick={() => selectTab(tab.id)}
+                className={`group relative flex-shrink-0 px-3 sm:px-4 py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors ${
+                  isActive
+                    ? 'bg-[#f5a623]/15 text-[#f5a623] border border-[#f5a623]/30'
+                    : 'text-gray-400 hover:text-gray-200 border border-transparent hover:border-white/[0.08]'
+                }`}
+              >
+                <span>{tab.label}</span>
+                {tab.hint && (
+                  <span
+                    className={`hidden md:inline ml-2 text-[10px] font-normal ${
+                      isActive ? 'text-[#f5a623]/80' : 'text-gray-500'
+                    }`}
+                  >
+                    {tab.hint}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div role="tabpanel" aria-labelledby={`tab-${active}`} className="pt-6">
+        {panels[active]}
+      </div>
+    </>
+  );
+}

--- a/src/app/juke-status/page.tsx
+++ b/src/app/juke-status/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { JukeStatusTabs } from './JukeStatusTabs';
 import {
   getJukeIntegrationManifest,
   INTEGRATION_ARCHITECTURE_ASCII,
@@ -139,16 +140,45 @@ export default async function JukeStatusPage() {
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-10">
-        <StatsRow stats={stats} lastEvent={lastEvent} />
-        <WebhookTimelineSection events={recentEvents} />
-        <RecentSpacesSection rows={recentSpaces} />
-        <ArchitectureSection />
-        <ShippedSection manifest={manifest} />
-        <AsksSection manifest={manifest} resolutionIndex={resolutionIndex} />
-        <CodeExamplesSection />
-        <ConventionsSection manifest={manifest} />
-        <ContactSection manifest={manifest} />
+      <main className="max-w-5xl mx-auto px-4 sm:px-6 py-6 pb-12">
+        <JukeStatusTabs
+          counts={{
+            shipped: manifest.shipped.length,
+            asks: manifest.open_asks.length,
+            resolvedAsks: manifest.open_asks.filter((a) => resolutionIndex.has(a.id)).length,
+            webhooks: stats.total_webhook_events,
+            spaces: stats.total_spaces,
+          }}
+          overview={
+            <div className="space-y-8">
+              <StatsRow stats={stats} lastEvent={lastEvent} />
+              <WebhookTimelineSection events={recentEvents.slice(0, 8)} />
+              <RecentSpacesSection rows={recentSpaces.slice(0, 6)} />
+            </div>
+          }
+          shipped={
+            <div className="space-y-6">
+              <ShippedSection manifest={manifest} />
+            </div>
+          }
+          asks={
+            <div className="space-y-6">
+              <AsksSection manifest={manifest} resolutionIndex={resolutionIndex} />
+            </div>
+          }
+          architecture={
+            <div className="space-y-8">
+              <ArchitectureSection />
+              <CodeExamplesSection />
+            </div>
+          }
+          about={
+            <div className="space-y-8">
+              <ConventionsSection manifest={manifest} />
+              <ContactSection manifest={manifest} />
+            </div>
+          }
+        />
       </main>
     </div>
   );


### PR DESCRIPTION
## Why

/juke-status was a 633-line scroll-everything dashboard. Pushback after PR #680: "this UI for juke status isn't great, it's just one long page, index this better."

## What

Five tabs:
- **Overview** - live stats + 8 most recent webhooks + 6 most recent spaces
- **Shipped (N)** - full feature history
- **Asks (N)** - open + resolved (changelog join), with green hint when any resolved
- **Architecture** - ASCII diagram + ZAO code examples
- **About** - conventions + contact

URL hash drives state (#shipped, #asks...). Deep links work, back/forward works, replaceState avoids history pile-up.

Sticky tab bar with backdrop-blur so it stays readable scrolling inside tall tabs (Shipped / Asks).

Mobile: tabs horizontal-scroll if they overflow.

## Server boundary

RSC unchanged - manifest + stats + changelog still fetch in parallel server-side. Each tab's content is server-rendered, handed to JukeStatusTabs as slot props. The client only owns the tab strip + active-slot selection.

## Verifies

- tsc clean
- No data shape changes
- /api/juke/status and /juke-integration.md untouched - machine-readable mirrors still flat

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>