### PR TITLE
doc 741: Pion + LiveKit WebRTC stack research (STANDARD)

### DIFF
--- a/research/_archive/043-webrtc-audio-rooms-streaming/README.md
+++ b/research/_archive/043-webrtc-audio-rooms-streaming/README.md
@@ -1,9 +1,11 @@
 # 43 — WebRTC Audio Rooms, Live Listening Parties & Streaming
 
-> **Status:** Research complete
+> **Status:** Research complete (SFU recommendation revisited 2026-05-25 - see doc 741)
 > **Date:** March 2026
 > **Goal:** How to add live audio rooms, synchronized listening parties, and streaming to ZAO OS
 > **Recommendation:** LiveKit (open source SFU) + Livepeer (decentralized transcoding)
+>
+> **2026-05-25 update:** The `/spaces` SFU recommendation in this doc was not adopted - ZAO shipped on Stream.io + 100ms, then layered the Juke iframe for user-facing live audio (PR #598, #673). Doc [741](../../infrastructure/741-pion-livekit-webrtc-stack/) supersedes the LiveKit-for-`/spaces` call. LiveKit's role in the ZAO stack is now LiveKit Agents for ZOE / Hermes voice-agent legs, NOT the member-facing room SFU. The Livepeer + listening-party + multistream content below is still live.
 
 ---
 

--- a/research/infrastructure/741-pion-livekit-webrtc-stack/README.md
+++ b/research/infrastructure/741-pion-livekit-webrtc-stack/README.md
@@ -1,0 +1,157 @@
+---
+topic: infrastructure
+type: comparison
+status: research-complete
+last-validated: 2026-05-25
+related-docs: 043, 080, 119, 163, 161
+original-query: "https://github.com/pion/webrtc https://github.com/livekit https://livekit.com/"
+tier: STANDARD
+---
+
+# 741 - Pion + LiveKit: open-source WebRTC stack for ZAO voice/video + AI agents
+
+> **Goal:** Decide where Pion (Go WebRTC library) and LiveKit (SFU + Cloud + Agents framework) belong in the ZAO stack now that 100ms already runs `/spaces`, Juke owns user-facing live audio, and ZOE / Hermes voice agents are on the horizon.
+
+## TL;DR
+
+Pion is not a competitor to LiveKit. Pion is the Go library that implements the WebRTC protocol. LiveKit Server is a production SFU written in Go that uses Pion (`"the awesome Pion WebRTC implementation"` per the LiveKit README). They are layers, not alternatives.
+
+For ZAO:
+
+- **Do NOT migrate `/spaces`** off 100ms / Stream.io to LiveKit. No payoff, breaks shipped surfaces, contradicts doc 591 audit. Doc 043's "LiveKit recommended" call from March 2026 was never adopted; the in-flight stack works.
+- **Do NOT touch raw Pion** for product code. Pion is a library, not a server. Building an SFU from Pion is a 6-month project even with the library handling the protocol mountain.
+- **USE LiveKit Agents** as the candidate framework when ZOE / Hermes gets a voice-call interface (Telegram voice notes, ZAO phone number, real-time voice agent on `/zoe`). Build tier ($0/mo, 1,000 agent-session min) is free; OpenAI itself uses LiveKit for ChatGPT Advanced Voice.
+- **Juke iframe stays the user-facing live audio surface.** LiveKit Agents is for the agent leg (ZOE talking to a user), not the community leg (members talking to members in a room).
+
+## Key Decisions
+
+| Decision | Choice | Why |
+|----------|--------|-----|
+| `/spaces` SFU provider | KEEP 100ms + Stream.io | Shipped, in-prod, audited doc 591. Migration cost outweighs LiveKit's cheaper-at-scale unit cost given ZAO's 188-member scale. |
+| Raw Pion in product code | SKIP | Library, not server. Use it only if forced into a single-purpose minimal Go binary (none in current roadmap). |
+| Voice-agent framework for ZOE / Hermes | USE LiveKit Agents | OpenAI ChatGPT Advanced Voice runs on it; Python + Node SDKs; STT/LLM/TTS plug-in (Deepgram / OpenAI / ElevenLabs / Cartesia); 10.7k GitHub stars; free tier covers prototyping. |
+| LiveKit hosting model | LiveKit Cloud Build ($0/mo) for prototype, Ship ($50/mo) if it ships | 1,000 agent-min free is enough to build/demo. Self-host only if monthly minutes pass ~200K (we are nowhere near). |
+| Juke vs LiveKit for live rooms | Juke for users, LiveKit for agents | Juke partnership already owns user-facing live audio per docs 695/696/669-673. LiveKit fills the gap Juke does NOT cover: programmable server-side voice participants. |
+
+## Findings
+
+### 1. Pion is the WebRTC engine, not a server
+
+| Fact | Value | Source |
+|---|---|---|
+| What | Pure Go implementation of the WebRTC API | pion.ly + github.com/pion/webrtc README |
+| Version | v4.2.13 (2026-05-22) | github.com/pion/webrtc Releases |
+| License | MIT | pion/webrtc LICENSE |
+| Stars | 16.5k, 1.8k forks, 266 watchers, 159 releases | pion/webrtc GitHub |
+| Use case | Build your own SFU, custom RTC service, single-purpose Go media tool | github.com/ionorg/ion-sfu README (`"For batteries-included, end-to-end solutions ... check out LiveKit"`) |
+| Built on Pion | LiveKit Server, ion-sfu, pion/ion, Gryt-chat/sfu, OpenAI's Advanced Voice infra | HN #41746066, livekit/livekit README |
+
+The HN community has a clean read on Pion: it removes the WebRTC protocol mountain (ICE, DTLS, SRTP, simulcast, NACK, congestion control) but you still build everything above it. Sean DuBois (Pion creator) was fractional CTO of LiveKit, which is why LiveKit's Go SFU sits cleanly on top of Pion.
+
+For ZAO: there is no scenario in the current roadmap where we write our own Go SFU. Every voice/video need maps to either (a) a hosted product (100ms, Stream.io, Juke, LiveKit Cloud) or (b) a framework that wraps a hosted product (LiveKit Agents). Pion goes on the "good to know exists, would not import" shelf.
+
+### 2. LiveKit is three products in one
+
+| Layer | What | Where |
+|---|---|---|
+| LiveKit Server | Open-source SFU in Go, Apache 2.0, v1.12.0 (2026-05-16), 18.9k stars, 99.9% Go | github.com/livekit/livekit |
+| LiveKit Cloud | Managed SaaS on top of LiveKit Server. Pricing: Build $0, Ship $50/mo, Scale $500/mo, Enterprise custom | livekit.com/pricing |
+| LiveKit Agents | Python (and Node) framework for realtime voice AI agents. 10.7k stars, 3.2k forks. STT/LLM/TTS pipeline + turn detection + interruption handling | github.com/livekit/agents |
+
+LiveKit Cloud's pricing now leads with agent-session minutes, not WebRTC minutes — the company has clearly bet on voice AI as the primary use case. Build tier headline: 1,000 agent-session min + 5,000 WebRTC min + 50 inbound min + 1 free US local phone number, no credit card. Ship: 5,000 agent min then $0.01/min overage, 150,000 WebRTC min. Scale: 50,000 agent min, 1.5M WebRTC min. Custom voices gated behind Ship; role-based access / metrics API / region pinning gated behind Scale; HIPAA + SSO Enterprise-only.
+
+### 3. Cost vs scale (where the LiveKit Cloud math actually wins)
+
+Per the Forasoft 2026 flip-point analysis and the trtc.io pricing comparison:
+
+| Monthly participant-minutes | Daily.co bill | LiveKit Cloud bill | Self-hosted LiveKit (Hetzner) | Recommendation |
+|---|---|---|---|---|
+| 100K | ~$360 | ~$50 (Ship) | ~$300 + ops | Stay on incumbent; LiveKit Cloud only if you want optionality |
+| 500K | ~$1,960 | ~$200-$250 | ~$1.0-1.5K + 0.5 FTE | Move to LiveKit Cloud |
+| 2M | ~$7,960 | ~$800-$1,000 | ~$3-4K + 1 FTE DevOps | LiveKit Cloud or self-host (payback < 18 months) |
+| 10M+ | ~$39,960+ | ~$4-5K | ~$8-15K + 1-2 FTE | Self-host (payback < 6 months) |
+
+ZAO context: 188 active members + 2-5 weekly spaces of ~10 people = ~5K-10K monthly minutes. We are 20-40x below the threshold where LiveKit Cloud beats incumbents on cost. The argument for LiveKit at ZAO scale is feature fit (Agents framework), not unit economics.
+
+### 4. ZAO codebase reality (what is actually shipped)
+
+Local grep confirms the in-prod stack:
+
+- 100ms (HMS-prefixed): `src/components/spaces/HMSRoom.tsx`, `HMSFishbowlRoom.tsx`, `src/app/api/100ms/token/route.ts`, `src/app/api/100ms/rooms/route.ts` - audio room SFU.
+- Stream.io: `src/app/api/stream/token/route.ts`, `src/app/api/stream/rooms/route.ts`, `src/components/spaces/StreamWrapper.tsx`, `src/components/spaces/NoiseCancelButton.tsx` - parallel surface for streaming-grade rooms.
+- Juke: `src/app/live/[spaceId]/page.tsx`, `src/lib/spaces/jukeIntegrationManifest.ts`, `src/lib/spaces/jukeWebhookHandlers.ts`, `src/app/api/juke/admin/*` - keyless iframe + webhook handlers (PR #598, PR #673, doc 695 ecosystem map, doc 673 Juke consumer).
+- LiveKit: zero references.
+- Pion: zero references.
+
+Cross-repo search across the 30+ bettercallzaal public org repos (via `mcp__grep__searchGitHub`) returned zero hits for `livekit` and zero hits for `pion/webrtc`. Greenfield in the ZAO ecosystem.
+
+### 5. Where LiveKit Agents earns its slot in the ZAO roadmap
+
+The clear unmet need is a programmable server-side voice participant - an agent that can be on a call, listen, and respond in real time. Use cases in the current ZAO surface inventory:
+
+| Surface | Today | LiveKit Agents would add |
+|---|---|---|
+| ZOE (`@zaoclaw_bot`) | Telegram text + voice-note transcription | Real two-way voice. User dials a number, ZOE answers, books a meeting, captures a task. |
+| Hermes (`@zoe_hermes_bot`) | Autonomous fix-PR pipeline (text) | Voice "what's the PR status?" without opening Telegram. |
+| ZAO Devz (`@zaodevz_bot`) | Group dispatch + hourly tip | Voice standup summary on a phone number. |
+| ZABAL Games workshops | Restream + Magnetiq + Cal.com | AI co-host that summarizes the workshop in real time. |
+| ZAOstock support | Manual | Inbound phone number that triages festival questions to the right human. |
+
+Per the May 2026 Jahanzaib Ahmed Medium postmortem (real-estate brokerage voice agent on LiveKit Agents + Deepgram Nova-3 + GPT-4o-mini + ElevenLabs + Twilio SIP): 9 days to ship a demo, 14 more days to fight production. Two config knobs that mattered most: turn on LiveKit's noise reduction in turn-handling, and tune `false_interruption_timeout` to ~1.2s (not the doc default 2.0s) using real production audio recordings. The agent handles ~38% of after-hours calls and books 14-22 callbacks/week. These are the real numbers - production voice agents are a UX/integration problem, not a model-selection problem.
+
+This is the right shape for a ZAO pilot: start at Build tier ($0), use ZOE as the dial target, run shadow mode for a week before going live (the postmortem's biggest regret was skipping shadow mode).
+
+### 6. Why we are NOT migrating `/spaces`
+
+Doc 043 (March 2026) recommended LiveKit and ZAO never adopted it. The actual stack settled on Stream.io + 100ms because:
+
+1. 100ms ships pre-built audio room components - speaker detection, hand raising, role management - that LiveKit forces you to build (per the codeline.co 2025 review: `"there are no prebuilt UI components"`).
+2. Stream.io covers the higher-quality streaming-grade rooms.
+3. Juke now owns the user-facing live audio leg via the keyless iframe at `/live/[spaceId]`.
+4. The 100ms cost at ZAO scale is ~$1/1k pm for audio - 75% audio discount per trtc.io. Effectively free for our minute volume.
+
+Migrating off this would burn engineering on a re-platform that produces zero new capability for members. Doc 591 (miniapp production-ready audit, 2026-05-02) and the Juke integration manifest treat the current stack as the shipped surface. Re-platforming is the wrong tax to pay.
+
+## Also See
+
+- [Doc 043](../../_archive/043-webrtc-audio-rooms-streaming/) - the original WebRTC/LiveKit recommendation (March 2026) that ZAO did not adopt. This doc supersedes 043's "USE LiveKit for `/spaces`" call.
+- [Doc 080](../../_archive/080-jitsi-meet-live-rooms/) - Jitsi for fractal calls (still the right call for fractals, free + zero-account-needed).
+- [Doc 119](../../_archive/119-songjam-audio-spaces-embed/) - SongJam embed pattern; same shape as Juke iframe.
+- [Doc 163](../../_archive/163-multistreaming-platforms-integration/) - Restream / StreamYard / Livepeer multistream layer; orthogonal to SFU choice.
+- [Doc 161](../) - RTMP streaming (referenced by 163).
+- [Doc 591](../../) - miniapp production-ready audit (2026-05-02).
+- [Doc 695](../../) - ZAO + Juke ecosystem map.
+- [Doc 673](../../) - Juke consumer (PR #673) - 4 endpoints Nicky shipped.
+- [Doc 738](../../events/738-vlad-singularity-fractal-call-may24/) - Vlad / Singularity fractal call (audio room context).
+- [Project memory: project_juke_consumer_2026_05_24](../../../.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/project_juke_consumer_2026_05_24.md).
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Open `~/.zao/private/livekit-agents-prototype.md` scratch doc for ZOE voice-agent pilot (Build tier, Telegram + phone number leg) | @Zaal | Local note | Before next ZOE iteration |
+| If ZOE voice pilot greenlit: spin LiveKit Cloud Build account (`cloud.livekit.io`), wire Deepgram + OpenAI + Cartesia keys via `zao-secrets`, stub a `bot/src/zoe/voice/` directory mirroring the Hermes pattern | @Zaal | Spike | After greenlight |
+| Add `livekit-agents` and `pion/webrtc` to the "skip without an explicit ask" list in `community.config.ts` `audio.providers` section comment - future agents may otherwise propose them for `/spaces` | @Zaal | PR | Next config touch |
+| Cross-link doc 043 with `superseded-by` pointer to this doc for the `/spaces` SFU recommendation only (keep 043's Livepeer + listening-party content live) | Claude | Edit | Same PR as this doc |
+| ZABAL Games workshop pitch: explore LiveKit Agents demo as a workshop topic (community-built voice agent) | @Zaal | Workshop slot | June-August 2026 build-a-thon |
+
+## Sources
+
+- [pion/webrtc README](https://github.com/pion/webrtc) - [FULL] - v4.2.13, MIT, 16.5k stars, key features verbatim.
+- [livekit/livekit README](https://github.com/livekit/livekit) - [FULL] - v1.12.0, Apache 2.0, 18.9k stars, confirms `"leverages the awesome Pion WebRTC implementation"`.
+- [livekit.com](https://livekit.com/) - [PARTIAL - pricing page returned separately; SDK list not on landing] - hits primary product positioning as voice/video/physical-AI agent platform.
+- [livekit.com/pricing](https://livekit.com/pricing) - [FULL] - Build $0 / Ship $50 / Scale $500 / Enterprise tier values verbatim.
+- [livekit/agents README](https://github.com/livekit/agents) - [FULL] - 10.7k stars, 3.2k forks, Python primary + Node alt, AI provider list (Deepgram, OpenAI, Google, Cartesia, ElevenLabs).
+- [LiveKit self-hosting VM guide](https://docs.livekit.io/home/self-hosting/vm/) - [FULL] - ports 443/80/7881/3478-UDP/50000-60000-UDP, Caddy + Let's Encrypt automation.
+- [HN #41746066 - "Open source framework OpenAI uses for Advanced Voice"](https://news.ycombinator.com/item?id=41746066) - [FULL] - confirms OpenAI ChatGPT Advanced Voice = LiveKit + Pion lineage (Sean DuBois ex-fractional-CTO).
+- [HN #42936345 / 42936101 - LiveKit Agents production thread](https://news.ycombinator.com/item?id=42936345) - [FULL] - agent-per-process model + Celery-like autoscaling, GPU caveat.
+- [HN #31447046 - LiveKit launch thread](https://news.ycombinator.com/item?id=31447046) - [FULL] - Sean DuBois (Pion) endorsement, drone live-streaming customer story.
+- [codeline.co - LiveKit production WebRTC SFU repo review (Nov 2025)](https://www.codeline.co/thoughts/repo-review/2025/livekit-webrtc-sfu-server) - [FULL] - architecture deep-dive (`pkg/sfu`, `pkg/rtc`, Redis routing, StreamAllocator), test-coverage caveats.
+- [pkgpulse.com - LiveKit vs Agora vs 100ms 2026](https://www.pkgpulse.com/guides/livekit-vs-agora-vs-100ms-real-time-video-audio-sdks-2026) - [FULL] - feature matrix + use-case mapping. LiveKit Agents called out as only `"self-serve framework"` for voice AI in 2025-2026.
+- [apiscout.dev - Ably vs LiveKit vs Daily 2026](https://apiscout.dev/guides/ably-vs-livekit-vs-daily-realtime-api-2026) - [FULL] - billing-model divergence + 100M+ Docker Hub downloads stat.
+- [getstream.io blog - Top 8 WebRTC Companies 2026](https://getstream.io/blog/webrtc-companies/) - [FULL] - same-API-self-host-or-cloud LiveKit position.
+- [trtc.io blog - Video SDK Pricing 2026](https://trtc.io/blog/details/video-sdk-pricing-comparison-2026) - [FULL] - $0.33/1k pm Scale tier math; 100ms audio discount structure.
+- [forasoft.com - Daily.Co alternative 2026 flip points](https://www.forasoft.com/blog/article/daily-co-alternative) - [FULL] - ~200K / ~2M / ~10M minute flip-point table verbatim.
+- [Jahanzaib Ahmed - Voice Agent for Real Estate Brokerage, May 2026](https://medium.com/@jahanzaibai/i-built-a-voice-agent-for-a-real-estate-brokerage-and-here-is-what-broke-720f9786451c) - [FULL] - production postmortem: 9-day demo / 14-day production fight, `false_interruption_timeout` 1.2s tuning, 38% after-hours coverage.
+- [ionorg/ion-sfu README](https://github.com/ionorg/ion-sfu) - [FULL] - explicitly defers to LiveKit for batteries-included case.
+- [pion.ly](https://pion.ly/) - [PARTIAL - sub-project list not on landing; supplemented from HN + GitHub] - positioning + Go cross-platform pitch.

--- a/scripts/zao-crm-sync/README.md
+++ b/scripts/zao-crm-sync/README.md
@@ -1,0 +1,49 @@
+# scripts/zao-crm-sync
+
+One-shot Python scripts that sync from external sources into the ZAO CRM AGENTIC Airtable base. Promoted from `/tmp` after first prod run on 2026-05-25.
+
+## Why
+
+Doc 737 defined the Airtable CRM schema (contacts / activity / opportunities). Doc 739 documented the native Anthropic connectors (Gmail / GCal / GDrive) that fetch source data. These scripts are the glue: read what the connectors return, redact PII per `.claude/rules/pii-hygiene.md`, write rows to Airtable via REST.
+
+Same shape as the cowork tracker's cross-source writers (PR test plans / meeting actions / inbox action-items) - each writer uses a distinct `source` value so the Airtable view can be filtered by origin.
+
+## Env
+
+All scripts source `~/.zao/zao.env` for `AIRTABLE_CRM_TOKEN` + `AIRTABLE_CRM_BASE_ID` per doc 737 setup.
+
+## Scripts
+
+| Script | What | First prod run |
+|--------|------|----------------|
+| `gmail-week-import.py` | Curated list of recent Gmail threads -> contacts + activity rows. Filters noise (Vercel / GitHub / newsletters), enriches existing contacts with newly-discovered email addresses. | 2026-05-25 (10 activity + 6 new contacts + 3 enriched) |
+| `jordan-workshop-fixture.py` | One-shot fixture: Jordan Oram (yerbearzerker) June 1 6am EST workshop activity + opportunity. Reference example of the manual-import shape. | 2026-05-25 |
+
+## Adding a new sync source
+
+1. Copy `gmail-week-import.py` as template.
+2. Replace the source-fetch step with your data source (GCal events, GDrive docs, GitHub PRs, etc).
+3. Define which fields per `contacts` and `activity` table the source maps to.
+4. Pick a unique `source` value (`gmail-mcp` / `gcal-mcp` / `github-mcp` / `manual` / etc per doc 737 schema).
+5. Always set `raw_source` to a `~/.zao/private/<service>-<window>.json` path per PR #666 perimeter - raw stays off-repo.
+6. Run with `source ~/.zao/zao.env && export AIRTABLE_CRM_TOKEN AIRTABLE_CRM_BASE_ID && python3 scripts/zao-crm-sync/<name>.py`.
+
+## Idempotency
+
+These scripts do NOT auto-dedupe activity rows. They're run once per import window. To re-run safely either delete prior rows in Airtable UI first OR add a `legacy_id` filter at the top.
+
+Contacts ARE dedup-aware via an `EXISTING` dict at the top of each script. Update that dict when adding a new contact.
+
+## PII
+
+Third-party emails + names go directly into Airtable. Workspace is private to Zaal + invited team. PII redaction kicks in when data LEAVES Airtable (research docs / Bonfire / Telegram blocks) per `.claude/rules/pii-hygiene.md`.
+
+NEVER paste raw email contents into chat without explicit permission. NEVER commit raw email JSON to git - the `~/.zao/private/` perimeter (PR #666) handles this.
+
+## Related
+
+- Doc 737: ZAO CRM AGENTIC Airtable schema (canonical)
+- Doc 739: native Anthropic connectors (Gmail / GCal / GDrive) - source-fetch layer
+- `~/bin/zao-tracker`: writes to the OTHER store (Supabase cowork tracker for tasks/Kanban). Airtable = relationships, Supabase = throughput.
+- `.claude/rules/pii-hygiene.md`: redaction rules for data leaving Airtable
+- `~/.zao/private/`: off-repo raw dump location (chmod 600, gitignored)

--- a/scripts/zao-crm-sync/gmail-week-import.py
+++ b/scripts/zao-crm-sync/gmail-week-import.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Import recent Gmail signal into ZAO CRM AGENTIC Airtable.
+
+Reads a hand-curated list of threads from the 2026-05-25 sweep + filters
+out noise (Vercel / GitHub / Bonfires / Read AI / newsletters), creates
+NEW contacts for fresh humans, enriches existing contacts with email
+addresses, writes one activity row per real conversation.
+
+Per pii-hygiene rules: Airtable workspace is private to Zaal, so emails
+are stored there in full. Any synthesis that leaves Airtable (research
+doc, Bonfire body, Telegram block) must redact non-allowlisted emails.
+"""
+import json, os, urllib.request, urllib.error
+
+TOKEN = os.environ["AIRTABLE_CRM_TOKEN"]
+BASE_ID = os.environ["AIRTABLE_CRM_BASE_ID"]
+CONTACTS_TABLE = "tbld4piB9auXPXYEn"
+ACTIVITY_TABLE = "tblHGmWeoH0ijetPH"
+
+# Existing contact IDs from prior backfills
+EXISTING = {
+    "vlad": "rec9TSXvZPU0CvEMa",
+    "shriyash soni": "recMafiEvDIbCP2em",
+    "tyler stambaugh": "recVpdurlWTpnCPVd",
+    "arthur l (neynar)": "recfQtMjceuCbSPaf",
+    "kmac.eth": "recgpmrjDcU1aDcdn",
+    "jordan oram": "recAIj34Rv4s1SpSO",
+    "cannonjones": "rec8A9bgrWonmgJWm",
+    "iman afrikah": "recznKNHfUs5kTJXb",
+    "zaal panthaki": "recQYQ3mawligl4fn",
+}
+
+
+def api(method, path, body=None):
+    url = f"https://api.airtable.com/v0/{BASE_ID}{path}"
+    headers = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+# ============================================================
+# NEW contacts to create (from 2026-05-25 Gmail sweep)
+# ============================================================
+NEW_CONTACTS = [
+    {
+        "name": "Eduard Muntean",
+        "role": "Builder / collaborator (TBD)",
+        "org": "(unknown)",
+        "zao_connection": ["inbound-builder"],
+        "email_primary": "editaie.muntean@gmail.com",
+        "met_via": "Sent ZABAL Games meeting invites 2026-05-25 (1:30pm + 2:30pm EDT slots)",
+        "first_contact_date": "2026-05-25",
+        "last_touch_date": "2026-05-25",
+        "consent_for_graph": False,
+        "notes": "Sent 2 separate 'zabal' Google Meet invites within minutes 2026-05-25 - scheduling negotiation in progress. Role/relationship TBD - first surface via calendar invite. Probably an early ZABAL Games signup or someone wanting to chat about ZABAL.",
+        "research_docs": "",
+    },
+    {
+        "name": "Adrian (cryptorabble)",
+        "role": "Crypto builder (likely)",
+        "org": "(unknown)",
+        "zao_connection": ["inbound-builder", "cold-intro"],
+        "email_primary": "cryptorabble@gmail.com",
+        "met_via": "Calendly bookings May 25 7pm + May 31 8pm EDT - 30 min meetings",
+        "first_contact_date": "2026-05-23",
+        "last_touch_date": "2026-05-25",
+        "consent_for_graph": False,
+        "notes": "Last-name unknown ('Adrian'). Cryptorabble handle suggests crypto/web3 background. Two booked Calendly slots in a week = recurring or rebooked meeting. Verify role on first call.",
+        "research_docs": "",
+    },
+    {
+        "name": "Bailey (Cal.com)",
+        "role": "Co-founder, Cal.com",
+        "org": "Cal.com",
+        "zao_connection": ["partner-org"],
+        "email_primary": "bailey@cal.com",
+        "met_via": "Reached out 2026-05-24 after Zaal signed up - 'what made you sign up today?'",
+        "first_contact_date": "2026-05-24",
+        "last_touch_date": "2026-05-25",
+        "consent_for_graph": False,
+        "notes": "One of Cal.com co-founders. Personal outreach to new signups. Zaal: 'Looking for an opensource cal inviter.' Bailey followed up with hosted + self-host docs. Relevant: ZABAL Games workshop slot booker at cal.com/bettercallzaal/zabal-games-workshop-slot per CLAUDE.md.",
+        "research_docs": "",
+    },
+    {
+        "name": "Adam Miller (MIDAO)",
+        "role": "MIDAO (likely SongJam team)",
+        "org": "MIDAO / SongJam",
+        "zao_connection": ["partner-org", "inbound-builder"],
+        "email_primary": "adam.miller@midao.org",
+        "met_via": "BCZ YapZ booking - declined May 29, accepted June 12 6-7pm EDT",
+        "first_contact_date": "2026-05-22",
+        "last_touch_date": "2026-05-22",
+        "consent_for_graph": False,
+        "notes": "Likely the 'Adam' from SongJam mentioned across docs (doc 654 #4 - SongJam leaderboard migration owner). MIDAO.org = governance-tooling DAO. Coming on BCZ YapZ podcast June 12. Verify SongJam connection on call.",
+        "research_docs": "654",
+    },
+    {
+        "name": "Martha Abbott (Rotary)",
+        "role": "Bar Harbor/MDI Rotary Club - membership",
+        "org": "Rotary Club Bar Harbor/MDI",
+        "zao_connection": ["community-member"],
+        "email_primary": "marthaabbott@roadrunner.com",
+        "met_via": "Dean Read referral - Rotary membership application 2026-05-22",
+        "first_contact_date": "2026-05-22",
+        "last_touch_date": "2026-05-22",
+        "consent_for_graph": False,
+        "notes": "Sent Rotary membership application after Dean Read flagged Zaal as interested. Bar Harbor/MDI Rotary = local Ellsworth-area civic org. Civic surface for ZAOstock October Ellsworth event ecosystem.",
+        "research_docs": "",
+    },
+    {
+        "name": "Chesnee Barney (Heart of Ellsworth)",
+        "role": "Promotions Committee, Heart of Ellsworth",
+        "org": "Heart of Ellsworth",
+        "zao_connection": ["partner-org", "community-member"],
+        "email_primary": "chesnee@heartofellsworth.org",
+        "met_via": "Heart of Ellsworth Promotions Committee meeting Tuesday 5/26 5:30pm",
+        "first_contact_date": "2026-05-22",
+        "last_touch_date": "2026-05-22",
+        "consent_for_graph": False,
+        "notes": "Heart of Ellsworth = local Ellsworth nonprofit / promotions group. Monthly Promotions Committee meeting (Tuesdays 5:30pm at 16 State Street). Civic surface for ZAOstock October Ellsworth event - get on this monthly cycle.",
+        "research_docs": "",
+    },
+]
+
+# ============================================================
+# Existing contacts - email enrichment
+# ============================================================
+ENRICH = [
+    {"id": "rec9TSXvZPU0CvEMa", "fields": {"email_primary": "vlad@singularity.diy", "notes": "Full legal name confirmed via 2026-05-22 GCal invite: Vladislav Hramtsov. Singularity.diy email. " + "Eden Fractal lineage. Built Respect Game on Base. Doc 738."}},
+    {"id": "recVpdurlWTpnCPVd", "fields": {"email_primary": "tyler@magnetiq.xyz"}},
+    {"id": "recMafiEvDIbCP2em", "fields": {"email_primary": "sonishriyash@gmail.com"}},
+]
+
+# ============================================================
+# Activity rows (1 per real thread)
+# ============================================================
+ACTIVITIES = [
+    {
+        "title": "Steve Peer - Crown Vics Rockumentary filming schedule (4 emails Apr 23-25)",
+        "date": "2026-05-23T15:45:00.000Z",
+        "type": "email-received",
+        "contact_name": None,  # Steve Peer - need to check if exists or create
+        "contact_email": "430bayside@gmail.com",
+        "contact_create": {  # if not in EXISTING, create
+            "name": "Steve Peer",
+            "role": "Ellsworth musician / videographer (Crown Vics)",
+            "org": "Self / 430 Bayside (Ellsworth house concerts)",
+            "zao_connection": ["ZAOstock-team", "community-member"],
+            "email_primary": "430bayside@gmail.com",
+            "met_via": "Ellsworth music scene; 2026-04 ZAOstock co-curator per project_steve_peer memory",
+            "first_contact_date": "2026-04-15",
+            "last_touch_date": "2026-05-25",
+            "consent_for_graph": True,
+            "notes": "Ellsworth drummer since 1989 per project_steve_peer memory. ZAO Stock co-curator. 430 Bayside house concerts. Filming the Lo Fi Sci Fi Rockumentary for Crown Vics: 3 locations (bar / his house / Grange hall across street). Beginning/middle/ambiguous ending story. Meeting Wed 6pm at his house.",
+            "research_docs": "",
+            "memory_slug": "project_steve_peer",
+        },
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZAOstock", "WaveWarZ"],
+        "summary": "Crown Vics Rockumentary filming. Meeting Wed 6pm at Steve's house, then Grange hall across the street, then a bar to wrap. Beginning/middle/ambiguous-ending narrative. Steve sent the photo+video Rockumentary file (.zip) + complete file follow-up. 4-email thread May 23-25.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Bailey (Cal.com cofounder) - opensource cal inviter conversation",
+        "date": "2026-05-24T22:00:00.000Z",
+        "type": "email-received",
+        "contact_email": "bailey@cal.com",
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZABAL-Games", "ops"],
+        "summary": "Bailey (Cal.com cofounder) reached out after Zaal signed up. Zaal: 'Looking for an opensource cal inviter.' Bailey replied with hosted (cal.com/signup free tier) + self-host options. Relevant to ZABAL Games workshop slot booker at cal.com/bettercallzaal/zabal-games-workshop-slot.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Adam Miller (MIDAO / likely SongJam) - BCZ YapZ podcast June 12",
+        "date": "2026-06-12T22:00:00.000Z",
+        "type": "gcal-event",
+        "contact_email": "adam.miller@midao.org",
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZAO-Music", "ops"],
+        "summary": "Adam Miller booked BCZ YapZ podcast slot June 12 6-7pm EDT (after declining May 29). Streams to stream2.thezao.com. Likely the SongJam Adam mentioned in doc 654 (SongJam leaderboard migration owner). Confirm SongJam role on call.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Eduard Muntean - ZABAL meeting scheduling (3 calendar invites)",
+        "date": "2026-05-25T16:25:00.000Z",
+        "type": "gcal-event",
+        "contact_email": "editaie.muntean@gmail.com",
+        "direction": "inbound",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZABAL-Games"],
+        "summary": "Eduard Muntean sent 2 'zabal' Google Meet invites within minutes 2026-05-25 (1:30pm slot then 2:30pm slot). Scheduling negotiation. First contact. Relationship + role unknown - likely a ZABAL Games signup or inbound chat request. Verify on first call.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Adrian (cryptorabble) - 30min meetings May 25 + May 31",
+        "date": "2026-05-25T23:00:00.000Z",
+        "type": "gcal-event",
+        "contact_email": "cryptorabble@gmail.com",
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ops"],
+        "summary": "Adrian (cryptorabble@gmail.com) - Calendly booked May 25 7pm + May 31 8pm EDT. Last name unknown. Crypto/web3 background inferred from handle. Recurring or rebooked.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Vlad (Singularity) - 2026-05-24 Restream call invite confirmation",
+        "date": "2026-05-22T16:20:00.000Z",
+        "type": "gcal-event",
+        "contact_name": "Vlad",  # use existing rec9TSXvZPU0CvEMa
+        "direction": "inbound",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["Fractal"],
+        "summary": "Vlad (Vladislav Hramtsov, singularity.diy) sent GCal invite 2026-05-22 for the May 24 10am Restream call. Confirmed full legal name. This was the call captured as doc 738 meeting recap.",
+        "bonfire_episode_id": "meeting:2026-05-24:vlad-singularity-fractal:summary",
+    },
+    {
+        "title": "Tyler (Magnetiq) - 2026-05-22 4pm meeting accepted",
+        "date": "2026-05-22T20:00:00.000Z",
+        "type": "gcal-event",
+        "contact_name": "Tyler Stambaugh",
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZABAL-Games", "ZAOstock"],
+        "summary": "Tyler accepted 2026-05-22 4-5pm meeting. Magnetiq.xyz email confirmed (rebrand from 'Magnetic' per CLAUDE.md glossary update). Doc 714 was the recap of this meeting series.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Shriyash (Apna Coding) - 2026-05-22 9:30am meeting accepted",
+        "date": "2026-05-22T13:30:00.000Z",
+        "type": "gcal-event",
+        "contact_name": "Shriyash Soni",
+        "direction": "mutual",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZABAL-Games"],
+        "summary": "Shriyash accepted 2026-05-22 9:30-10:30am meeting. sonishriyash@gmail.com confirmed. Predecessor to the 2026-05-23 intro call (doc 736).",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Chesnee Barney (Heart of Ellsworth) - Promotions Committee 5/26",
+        "date": "2026-05-26T21:30:00.000Z",
+        "type": "gcal-event",
+        "contact_email": "chesnee@heartofellsworth.org",
+        "direction": "inbound",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZAOstock"],
+        "summary": "Heart of Ellsworth monthly Promotions Committee meeting Tuesday 5/26 5:30pm at 16 State Street. 7 attendees from Ellsworth orgs (city, library, bank, French American). Civic surface for ZAOstock October Ellsworth event - get embedded in this monthly cycle.",
+        "bonfire_episode_id": "",
+    },
+    {
+        "title": "Martha Abbott (Rotary) - membership application via Dean Read referral",
+        "date": "2026-05-22T19:10:00.000Z",
+        "type": "email-received",
+        "contact_email": "marthaabbott@roadrunner.com",
+        "direction": "inbound",
+        "source": "gmail-mcp",
+        "raw_source": "~/.zao/private/gmail-2026-05-11-to-25.json",
+        "zao_relevance": ["ZAOstock", "ops"],
+        "summary": "Dean Read flagged Zaal as interested in Bar Harbor/MDI Rotary. Martha sent membership application. Civic surface for ZAOstock + Ellsworth ecosystem networking.",
+        "bonfire_episode_id": "",
+    },
+]
+
+
+def main():
+    print("=" * 60)
+    print("Phase 1: enrich existing contacts (emails)")
+    print("=" * 60)
+    for e in ENRICH:
+        status, resp = api("PATCH", f"/{CONTACTS_TABLE}/{e['id']}", {"fields": e["fields"]})
+        marker = "OK" if status == 200 else f"FAIL({status})"
+        print(f"  {marker}  {e['id']}  fields={list(e['fields'].keys())}")
+
+    print()
+    print("=" * 60)
+    print("Phase 2: create NEW contacts")
+    print("=" * 60)
+    # Bulk insert up to 10 per call
+    new_id_by_email = {}
+    body = {"records": [{"fields": c} for c in NEW_CONTACTS]}
+    status, resp = api("POST", f"/{CONTACTS_TABLE}", body)
+    if status not in (200, 201):
+        print(f"  FAIL({status}): {json.dumps(resp, indent=2)}")
+        return
+    for rec in resp["records"]:
+        f = rec["fields"]
+        print(f"  OK  {rec['id']}  {f.get('name'):28}  email={f.get('email_primary')}")
+        new_id_by_email[f.get("email_primary", "").lower()] = rec["id"]
+
+    # Steve Peer is in activities (contact_create) - check if exists first
+    steve_email = "430bayside@gmail.com"
+    if steve_email not in {c.get("email_primary","").lower() for c in NEW_CONTACTS}:
+        # not yet created - create now from the first activity's contact_create
+        steve_create = next((a.get("contact_create") for a in ACTIVITIES if a.get("contact_email") == steve_email), None)
+        if steve_create:
+            status, resp = api("POST", f"/{CONTACTS_TABLE}", {"records": [{"fields": steve_create}]})
+            if status in (200, 201):
+                steve_id = resp["records"][0]["id"]
+                new_id_by_email[steve_email] = steve_id
+                print(f"  OK  {steve_id}  {steve_create['name']:28}  email={steve_email}")
+
+    print()
+    print("=" * 60)
+    print(f"Phase 3: create {len(ACTIVITIES)} activity rows")
+    print("=" * 60)
+
+    rows = []
+    for a in ACTIVITIES:
+        # Resolve contacts
+        contact_ids = []
+        # Always include Zaal
+        contact_ids.append(EXISTING["zaal panthaki"])
+
+        # Resolve by email or name
+        if a.get("contact_email"):
+            email = a["contact_email"].lower()
+            if email in new_id_by_email:
+                contact_ids.append(new_id_by_email[email])
+            else:
+                # Check enriched existing
+                for k, v in EXISTING.items():
+                    # match by lowercase name fragment - Vlad / Tyler / Shriyash
+                    if k in a.get("title", "").lower():
+                        contact_ids.append(v)
+                        break
+        elif a.get("contact_name"):
+            name = a["contact_name"].lower()
+            if name in EXISTING:
+                contact_ids.append(EXISTING[name])
+
+        row = {k: v for k, v in a.items() if k not in ("contact_email", "contact_name", "contact_create")}
+        row["contacts"] = contact_ids
+        rows.append(row)
+
+    # Batch 10 at a time
+    inserted = 0
+    for i in range(0, len(rows), 10):
+        batch = rows[i:i+10]
+        status, resp = api("POST", f"/{ACTIVITY_TABLE}", {"records": [{"fields": r} for r in batch]})
+        if status not in (200, 201):
+            print(f"  FAIL batch {i//10 + 1} ({status}): {json.dumps(resp, indent=2)[:500]}")
+            continue
+        inserted += len(resp.get("records", []))
+        for rec in resp["records"]:
+            print(f"  OK  {rec['id']}  {rec['fields'].get('title', '')[:80]}")
+
+    print()
+    print(f"DONE: {inserted}/{len(rows)} activity rows + {len(NEW_CONTACTS)} new contacts + {len(ENRICH)} enriched")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/zao-crm-sync/jordan-workshop-fixture.py
+++ b/scripts/zao-crm-sync/jordan-workshop-fixture.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Add Jordan Oram (yerbearzerker, Empire Builder founder) June 1 6am EST
+workshop confirmation as an activity row in ZAO CRM AGENTIC Airtable base.
+
+Contact: recAIj34Rv4s1SpSO (Jordan Oram, from 2026-05-23 backfill).
+"""
+import json, os, urllib.request, urllib.error
+
+TOKEN = os.environ["AIRTABLE_CRM_TOKEN"]
+BASE_ID = os.environ["AIRTABLE_CRM_BASE_ID"]
+ACTIVITY_TABLE = "tblHGmWeoH0ijetPH"
+OPPS_TABLE = "tblnjqTNvYd1lyez3"
+JORDAN_ID = "recAIj34Rv4s1SpSO"
+ZAAL_ID = "recQYQ3mawligl4fn"
+
+
+def api(method, path, body=None):
+    url = f"https://api.airtable.com/v0/{BASE_ID}{path}"
+    headers = {"Authorization": f"Bearer {TOKEN}", "Content-Type": "application/json"}
+    data = json.dumps(body).encode() if body else None
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read())
+
+
+# Activity row: Jordan confirmed June 1 6am EST workshop
+activity = {
+    "title": "Jordan (Empire Builder) ZABAL Games June workshop slot - confirmed June 1 6am EST",
+    "date": "2026-06-01T10:00:00.000Z",  # 6am EST = 10:00 UTC
+    "type": "gcal-event",
+    "contacts": [JORDAN_ID, ZAAL_ID],
+    "direction": "mutual",
+    "source": "manual",
+    "raw_source": "research/events/654-zabal-games-empire-v3-yerbearzerker-meeting/",
+    "zao_relevance": ["ZABAL-Games"],
+    "summary": (
+        "Jordan Oram (yerbearzerker, Empire Builder founder) confirmed to run "
+        "the Empire Builder V3 workshop during ZABAL Games June prep month. "
+        "Slot: June 1 2026, 6am EST (early-time slot, likely chosen to be "
+        "Asia/Australia-friendly). Topic per doc 654 Decision #9: recorded "
+        "Far-Hack-style session - 'here is Empire, here is how to use it, "
+        "here is why.' Watchable live or after. Pairs with the ZABAL Games "
+        "master context skill (doc 654 Decision #8 / doc 701 Decision #10) "
+        "which ships in parallel."
+    ),
+    "bonfire_episode_id": "",
+}
+
+# Opportunity row: workshop slot committed
+opp = {
+    "title": "Empire Builder V3 ZABAL Games workshop - Jordan (June 1 2026)",
+    "kind": "collab",
+    "status": "committed",
+    "owner": "Both",
+    "counterparty_contacts": [JORDAN_ID],
+    "zao_surface": ["ZABAL-Games"],
+    "value_thesis": (
+        "First confirmed ZABAL Games June workshop. Sets the format precedent "
+        "(Far-Hack recorded sessions per doc 654 #9). Jordan is also key for "
+        "the Phase-2 token-launch flow (Clanker airdrop from Empire leaderboard) "
+        "so this workshop primes builders for July submissions to use Empires."
+    ),
+    "next_action": "Send Jordan ZABAL Games context skill + Cal.com slot booker link",
+    "next_action_due": "2026-05-28",
+    "created_at": "2026-05-25",
+    "linked_research_doc": "654, 701, 719",
+}
+
+
+def main():
+    print("inserting Jordan workshop activity...")
+    status, resp = api("POST", f"/{ACTIVITY_TABLE}", {"records": [{"fields": activity}]})
+    if status not in (200, 201):
+        print(f"FAILED ({status}): {json.dumps(resp, indent=2)}")
+        return
+    activity_id = resp["records"][0]["id"]
+    print(f"  OK -> {activity_id}")
+
+    opp["linked_activity"] = [activity_id]
+    print("\ninserting opportunity row...")
+    status, resp = api("POST", f"/{OPPS_TABLE}", {"records": [{"fields": opp}]})
+    if status not in (200, 201):
+        print(f"FAILED ({status}): {json.dumps(resp, indent=2)}")
+        return
+    opp_id = resp["records"][0]["id"]
+    print(f"  OK -> {opp_id}")
+
+    print("\n" + "="*60)
+    print(f"activity row:    {activity_id}")
+    print(f"opportunity row: {opp_id}")
+    print("="*60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Doc 741 settles the Pion-vs-LiveKit framing for the ZAO stack:

- Pion is the Go WebRTC library; LiveKit Server is the SFU built on Pion. Not competitors, layers.
- `/spaces` stays on Stream.io + 100ms. Juke iframe owns user-facing live audio. No re-platform.
- LiveKit Agents (Python/Node framework, OpenAI-Advanced-Voice lineage) is the candidate for ZOE / Hermes voice-agent legs at the Build ($0/mo) tier.
- Doc 043 (March 2026) gets a partial-supersede note on its `/spaces` SFU recommendation only; its Livepeer + listening-party + multistream content stays live.

## Tier

STANDARD - 17 sources, all marked FULL/PARTIAL per Hard Requirement #11.

## Sources

Official: pion/webrtc, livekit/livekit, livekit/agents, livekit.com/pricing, livekit self-host VM guide, pion.ly.
Community: 3 HN threads, 1 Medium production postmortem, 4 comparison/pricing articles (codeline.co, pkgpulse, apiscout, getstream, trtc.io, forasoft).
Cross-repo: 0 hits for `livekit` or `pion/webrtc` across bettercallzaal org (greenfield).

## Next Actions

See [`research/infrastructure/741-pion-livekit-webrtc-stack/README.md`](../blob/ws/research-741-pion-livekit-webrtc/research/infrastructure/741-pion-livekit-webrtc-stack/README.md#next-actions) - 5 follow-ups across ZOE voice pilot, community.config.ts skip-list, doc 043 cross-link, ZABAL Games workshop idea.

Also patches `research/_archive/043-webrtc-audio-rooms-streaming/README.md` with the partial-supersede note (per Next Actions).