### PR TITLE
feat(juke): listener batch - badge + stale cron + recordings + ZOE auto-join

### DIFF
--- a/src/app/api/cron/juke-stale-rooms/route.ts
+++ b/src/app/api/cron/juke-stale-rooms/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/db/supabase';
+import { logger } from '@/lib/logger';
+
+/**
+ * GET /api/cron/juke-stale-rooms
+ *
+ * Sweeps any juke_spaces row still marked `active` that has not seen a
+ * webhook event in the last 2 hours and flips it to `ended`. Auto-cleanup
+ * for ghost rooms - cases where the host walked away without the iframe or
+ * iOS app triggering an end, and Juke's empty-room timeout webhook either
+ * didn't fire or got dropped during a downtime window.
+ *
+ * Conservative thresholds:
+ *  - room.started must be > 2h ago (long enough that a real long-form space
+ *    like a 3-hour fractal call isn't terminated mid-session)
+ *  - last associated webhook on this room must also be > 2h old (means
+ *    participant events stopped flowing, room is dead)
+ *
+ * Idempotent: a real room.finished webhook arriving later for the same
+ * spaceId is a no-op since the row is already ended.
+ *
+ * Auth: Bearer CRON_SECRET (Vercel cron header). Manual GETs from the
+ * outside without the bearer get 401.
+ *
+ * Runs every 30 minutes via vercel.json cron config.
+ */
+
+const STALE_THRESHOLD_MINUTES = 120;
+
+export async function GET(request: NextRequest) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json(
+      { ok: false, error: 'CRON_SECRET not configured' },
+      { status: 500 },
+    );
+  }
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const thresholdIso = new Date(
+    Date.now() - STALE_THRESHOLD_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  let candidates: Array<{ id: string; title: string | null; started_at: string | null }>;
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('juke_spaces')
+      .select('id, title, started_at')
+      .eq('status', 'active')
+      .lt('started_at', thresholdIso)
+      .order('started_at', { ascending: true })
+      .limit(50);
+    if (error) throw error;
+    candidates = data ?? [];
+  } catch (err: unknown) {
+    logger.error('[cron/juke-stale-rooms] candidate query failed', err);
+    return NextResponse.json(
+      { ok: false, error: 'Candidate query failed' },
+      { status: 500 },
+    );
+  }
+
+  if (candidates.length === 0) {
+    return NextResponse.json({ ok: true, checked: 0, ended: 0, skipped: 0 });
+  }
+
+  // Cross-check: only end rows whose latest associated webhook is ALSO older
+  // than the threshold. A row started 3h ago with a participant.joined event
+  // 10min ago is still genuinely active (long-form space). One query per
+  // candidate is cheap given the limit of 50 and the index on space_id.
+  const ids = candidates.map((c) => c.id);
+  let lastEventByRoom = new Map<string, string>();
+  try {
+    const { data, error } = await supabaseAdmin
+      .from('juke_webhook_events')
+      .select('space_id, received_at')
+      .in('space_id', ids)
+      .order('received_at', { ascending: false });
+    if (error) throw error;
+    for (const row of data ?? []) {
+      if (row.space_id && !lastEventByRoom.has(row.space_id)) {
+        lastEventByRoom.set(row.space_id, row.received_at);
+      }
+    }
+  } catch (err: unknown) {
+    logger.error('[cron/juke-stale-rooms] webhook event lookup failed', err);
+    // Continue with empty map - we'll just use started_at as the only signal.
+  }
+
+  const nowIso = new Date().toISOString();
+  let endedCount = 0;
+  let skipped = 0;
+  const endedIds: string[] = [];
+
+  for (const c of candidates) {
+    const lastEvent = lastEventByRoom.get(c.id);
+    if (lastEvent && lastEvent > thresholdIso) {
+      // Recent activity on this room - probably a long-form session, not a
+      // ghost. Skip.
+      skipped += 1;
+      continue;
+    }
+    try {
+      const { error } = await supabaseAdmin
+        .from('juke_spaces')
+        .update({ status: 'ended', ended_at: nowIso })
+        .eq('id', c.id)
+        .eq('status', 'active'); // optimistic: skip if another path already ended it
+      if (error) {
+        logger.warn('[cron/juke-stale-rooms] update failed for ' + c.id, error);
+        continue;
+      }
+      endedCount += 1;
+      endedIds.push(c.id);
+    } catch (err: unknown) {
+      logger.warn('[cron/juke-stale-rooms] update threw for ' + c.id, err);
+    }
+  }
+
+  logger.info(
+    `[cron/juke-stale-rooms] checked=${candidates.length} ended=${endedCount} skipped=${skipped}`,
+    { endedIds },
+  );
+
+  return NextResponse.json({
+    ok: true,
+    checked: candidates.length,
+    ended: endedCount,
+    skipped,
+    threshold_minutes: STALE_THRESHOLD_MINUTES,
+    ended_ids: endedIds,
+  });
+}

--- a/src/app/live/[spaceId]/page.tsx
+++ b/src/app/live/[spaceId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import { getSessionData } from '@/lib/auth/session';
 import { EndJukeSpaceButton } from '@/components/spaces/EndJukeSpaceButton';
 import { JukeEmbed } from '@/components/spaces/JukeEmbed';
+import { JukeListenerBadge } from '@/components/spaces/JukeListenerBadge';
 import {
   isValidJukeSpaceId,
   jukeAppDeeplinkUrl,
@@ -130,6 +131,12 @@ export default async function LivePage({ params, searchParams }: LivePageProps) 
       </header>
 
       <main className="flex flex-1 flex-col items-center px-4 py-6 gap-4">
+        {!isEnded && (
+          <JukeListenerBadge
+            participants={row?.participants}
+            participantCount={row?.participant_count ?? 0}
+          />
+        )}
         {isEnded && recordingUrl ? (
           <div className="w-full max-w-md flex flex-col gap-3 bg-[#0d1b2a] border border-white/[0.08] rounded-2xl p-6 text-center">
             <h2 className="text-white font-bold text-base">This space has ended</h2>

--- a/src/app/live/recordings/page.tsx
+++ b/src/app/live/recordings/page.tsx
@@ -62,10 +62,16 @@ export default async function LiveRecordingsPage() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
             </svg>
           </Link>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <h1 className="text-base sm:text-lg font-bold">Juke recordings</h1>
             <p className="text-xs text-gray-500">Past audio spaces hosted by {communityConfig.name}.</p>
           </div>
+          <span
+            className="flex-shrink-0 inline-flex items-center px-2 py-0.5 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-[11px] font-bold"
+            aria-label={`${recordings.length} ${recordings.length === 1 ? 'recording' : 'recordings'}`}
+          >
+            {recordings.length}
+          </span>
         </div>
       </header>
 
@@ -147,14 +153,24 @@ function RecordingCard({ row, endedLabel }: { row: JukeSpaceRow; endedLabel: str
           </p>
         </div>
       </Link>
-      <div className="px-4 pb-4">
+      <div className="px-4 pb-4 space-y-2">
+        {/* Native HTML5 player so desktop visitors can preview without opening
+            a new tab. Mobile + Safari still get a usable control set. */}
+        <audio
+          controls
+          preload="none"
+          src={recordingUrl}
+          className="w-full h-9 [&::-webkit-media-controls-panel]:bg-[#0a1628]"
+        >
+          Your browser does not support inline audio playback.
+        </audio>
         <a
           href={recordingUrl}
           target="_blank"
           rel="noreferrer noopener"
-          className="inline-flex items-center justify-center w-full px-4 py-2 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-xs font-bold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
+          className="inline-flex items-center justify-center w-full px-4 py-2 rounded-xl border border-white/[0.12] bg-[#1a2a3a] text-gray-300 text-[11px] font-semibold hover:bg-[#22364a] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f5a623] focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a1628]"
         >
-          Listen to recording
+          Open recording in new tab
         </a>
       </div>
     </li>

--- a/src/components/spaces/JukeListenerBadge.tsx
+++ b/src/components/spaces/JukeListenerBadge.tsx
@@ -1,0 +1,81 @@
+import type { JukeParticipantEntry } from '@/lib/spaces/jukeSpacesDb';
+
+/**
+ * "N ZAO members here" badge above the Juke iframe on /live/{id}. Reads from
+ * the `participants` jsonb on the space row (populated by participant.joined /
+ * participant.left webhooks). Server-rendered — refreshes only on a page
+ * reload, which is fine for v1: this is a passive ambient signal, not a
+ * realtime presence list.
+ *
+ * Limits the visible name list to the first 6 distinct display names; any
+ * extras collapse into a +N pill so the badge stays single-line on mobile.
+ *
+ * Hidden entirely when there are zero known participants — the iframe already
+ * shows a generic listener count, so an empty wrapper here would be noise.
+ */
+export function JukeListenerBadge({
+  participants,
+  participantCount,
+}: {
+  participants: JukeParticipantEntry[] | null | undefined;
+  participantCount: number;
+}) {
+  const arr = Array.isArray(participants) ? participants : [];
+  if (arr.length === 0 && participantCount <= 0) return null;
+
+  // Distinct by FID so a join/leave/join sequence does not double-list.
+  const distinct = new Map<number, JukeParticipantEntry>();
+  for (const p of arr) {
+    if (!distinct.has(p.fid)) distinct.set(p.fid, p);
+  }
+  const list = Array.from(distinct.values());
+  const visible = list.slice(0, 6);
+  const overflow = Math.max(0, list.length - visible.length);
+  const headlineCount = Math.max(list.length, participantCount);
+
+  return (
+    <div className="w-full max-w-md rounded-2xl border border-[#855dcd]/30 bg-[#855dcd]/[0.06] px-4 py-3">
+      <div className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider text-[#a78bfa]">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#a78bfa]" aria-hidden="true" />
+        {headlineCount} ZAO {headlineCount === 1 ? 'member' : 'members'} here
+      </div>
+      {visible.length > 0 && (
+        <ul className="mt-2 flex flex-wrap items-center gap-1.5">
+          {visible.map((p) => {
+            const label =
+              p.display_name && p.display_name.trim().length > 0
+                ? p.display_name
+                : `fid ${p.fid}`;
+            return (
+              <li key={p.fid}>
+                <a
+                  href={`https://farcaster.xyz/~/profiles/${p.fid}`}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center gap-1 rounded-full border border-white/[0.08] bg-[#0d1b2a] px-2 py-0.5 text-[11px] text-gray-300 hover:border-[#a78bfa]/40 hover:text-white transition-colors"
+                  title={`FID ${p.fid}`}
+                >
+                  {p.role === 'host' && (
+                    <span
+                      className="text-[#f5a623]"
+                      aria-label="host"
+                      title="host"
+                    >
+                      *
+                    </span>
+                  )}
+                  {label}
+                </a>
+              </li>
+            );
+          })}
+          {overflow > 0 && (
+            <li className="rounded-full border border-white/[0.08] bg-[#0d1b2a] px-2 py-0.5 text-[11px] text-gray-500">
+              +{overflow} more
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/spaces/jukeAgentJoin.ts
+++ b/src/lib/spaces/jukeAgentJoin.ts
@@ -1,0 +1,88 @@
+/**
+ * Thin helper to call Juke's free partner-scoped agent-join endpoint. Shared
+ * by the admin route (`POST /api/juke/admin/agent-join`) and the optional
+ * auto-join hook that fires on `room.started` webhooks (off by default, gated
+ * by `ZAO_AUTO_AGENT_JOIN=true`).
+ *
+ * Returns the session_token on success. Caller decides whether to persist it
+ * (the token is short-lived + tied to the room, so storing long-term has no
+ * value). Logs everything so we have an audit trail when ZOE joins a room.
+ *
+ * Constraints (per Juke 2026-05-23 ship + llms.txt agents section):
+ * - Room must be `active` with `allow_agents: true`
+ * - Per-room cap: 5 concurrent agents
+ * - Rate: 10/min + 100/day per developer key
+ * - Cross-app rooms 404 (no enumeration oracle)
+ * - Agents publish DATA only in v1 (audio-publish on v1.x roadmap)
+ */
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+
+export interface AgentJoinResult {
+  ok: boolean;
+  sessionToken?: string;
+  status?: number;
+  juke?: unknown;
+  error?: string;
+}
+
+export interface AgentJoinInput {
+  spaceId: string;
+  agentName?: string;
+  agentPfpUrl?: string;
+}
+
+const ENDPOINT_BASE = 'https://api.juke.audio/v1/developer/rooms';
+
+export async function joinAgentInJukeRoom(
+  input: AgentJoinInput,
+): Promise<AgentJoinResult> {
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return { ok: false, error: 'JUKE_API_KEY not configured' };
+  }
+  const { spaceId, agentName = 'ZOE', agentPfpUrl } = input;
+  const endpoint = `${ENDPOINT_BASE}/${encodeURIComponent(spaceId)}/agent-join`;
+
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'X-Juke-Api-Key': apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ agent_name: agentName, agent_pfp_url: agentPfpUrl }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err: unknown) {
+    logger.error('[juke/agent-join] fetch failed', err);
+    return { ok: false, error: 'Juke agent-join API unreachable' };
+  }
+  const text = await res.text();
+  let jukeBody: unknown;
+  try {
+    jukeBody = JSON.parse(text);
+  } catch {
+    jukeBody = text;
+  }
+  if (!res.ok) {
+    logger.warn('[juke/agent-join] Juke rejected', res.status, jukeBody);
+    return { ok: false, status: res.status, juke: jukeBody };
+  }
+  const sessionToken =
+    typeof jukeBody === 'object' && jukeBody !== null
+      ? ((jukeBody as { session_token?: string }).session_token ?? undefined)
+      : undefined;
+  return { ok: true, status: res.status, juke: jukeBody, sessionToken };
+}
+
+/**
+ * Should we auto-join an agent into a freshly-started ZAO room? Off by
+ * default. Flip the env var when ZOE is ready to consume agent sessions on
+ * the VPS side (currently we'd join + immediately drop the token, which has
+ * no real value beyond making sure the wiring works).
+ */
+export function isAutoAgentJoinEnabled(): boolean {
+  return process.env.ZAO_AUTO_AGENT_JOIN === 'true';
+}

--- a/src/lib/spaces/jukeWebhookHandlers.ts
+++ b/src/lib/spaces/jukeWebhookHandlers.ts
@@ -17,6 +17,7 @@
  */
 import { autoCastToZao } from '@/lib/publish/auto-cast';
 import { logger } from '@/lib/logger';
+import { isAutoAgentJoinEnabled, joinAgentInJukeRoom } from './jukeAgentJoin';
 import {
   addParticipant,
   bumpParticipantCount,
@@ -174,6 +175,30 @@ export async function applyWebhookEvent(
   switch (eventType) {
     case 'room.started': {
       await updateJukeSpace(spaceId, { status: 'active', started_at: readOccurredAt(body) });
+      // Optional: drop ZOE into the room as a partner-scoped agent. Gated
+      // by ZAO_AUTO_AGENT_JOIN=true env var since agents are data-publish
+      // only in Juke v1 (no audio yet) and we don't have a VPS consumer
+      // for the session token yet. Flag exists so the wiring is in place
+      // the moment ZOE-on-the-VPS is ready to consume sessions.
+      if (isAutoAgentJoinEnabled()) {
+        try {
+          const join = await joinAgentInJukeRoom({ spaceId, agentName: 'ZOE' });
+          if (join.ok && join.sessionToken) {
+            logger.info('[juke/webhooks] auto agent-join ok', {
+              spaceId,
+              token_len: join.sessionToken.length,
+            });
+          } else if (!join.ok) {
+            logger.warn('[juke/webhooks] auto agent-join failed', {
+              spaceId,
+              status: join.status,
+              error: join.error,
+            });
+          }
+        } catch (err: unknown) {
+          logger.warn('[juke/webhooks] auto agent-join threw (non-fatal):', err);
+        }
+      }
       return;
     }
     case 'room.finished':

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,7 @@
       "schedule": "0 6 * * *"
     },
     { "path": "/api/cron/agents/banker", "schedule": "0 14 * * *" },
-    { "path": "/api/cron/agents/dealer", "schedule": "0 22 * * *" }
+    { "path": "/api/cron/agents/dealer", "schedule": "0 22 * * *" },
+    { "path": "/api/cron/juke-stale-rooms", "schedule": "*/30 * * * *" }
   ]
 }


### PR DESCRIPTION
## Why

Four small wins bundled while we wait on Nicky's next round of asks.

## What

1. **JukeListenerBadge** on /live/{id} - "N ZAO members here" pill above the iframe, names linked to Farcaster profiles, host starred, +N overflow collapse
2. **Stale-room cron** at /api/cron/juke-stale-rooms - sweeps active spaces with no webhooks in 2h, flips to ended. Cross-checks started_at AND most-recent webhook so 3hr fractal calls aren't terminated mid-session. Idempotent.
3. **/live/recordings polish** - count badge in header + native HTML5 audio player on each card for inline preview
4. **ZAO_AUTO_AGENT_JOIN wiring** - shared helper src/lib/spaces/jukeAgentJoin.ts + opt-in env-gated auto-join on room.started. Off by default. Flipping the env var = ZOE joins every ZAO room the moment audio-publish ships or VPS consumer is ready.

## Source-of-truth pattern preserved

- Listener badge reads juke_spaces.participants - written ONLY by webhook handler
- Stale cron updates juke_spaces.status - idempotent vs real room.finished
- Auto agent-join fires alongside the room.started DB update, doesn't block it (try/catch + warn on fail)

## Verifies

- 50/50 spaces tests pass
- tsc clean
- Vercel cron registered: \`*/30 * * * *\` for juke-stale-rooms

## Smoke after merge

1. Join an active Juke space as a 2nd user (FID != host) → refresh /live/{id} → expect "2 ZAO members here" pill with both names
2. Create + abandon a Juke space (close tab without End-space click) → wait 2h → cron sweeps it → /spaces no longer shows as Live
3. Visit /live/recordings → count badge shows; each card has an inline play button + secondary external link
4. (Skip until ZOE ready) Set ZAO_AUTO_AGENT_JOIN=true in Vercel → next room.started fires agent-join silently → Vercel logs "auto agent-join ok"

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>