### PR TITLE
feat(juke): public /listen + /juke pages

### DIFF
--- a/src/app/juke/page.tsx
+++ b/src/app/juke/page.tsx
@@ -1,0 +1,340 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  getJukeIntegrationManifest,
+  type ShippedFeature,
+} from '@/lib/spaces/jukeIntegrationManifest';
+import {
+  getJukeIntegrationStats,
+  type JukeIntegrationStats,
+} from '@/lib/spaces/jukeSpacesDb';
+import { communityConfig } from '../../../community.config';
+
+export const metadata: Metadata = {
+  title: `${communityConfig.name} x Juke - how we built it`,
+  description:
+    'Case study of the ZAO + Juke live audio integration - what we shipped, why, and how you can build with Juke yourself. Build-in-public on juke.audio.',
+  openGraph: {
+    title: `${communityConfig.name} x Juke`,
+    description: 'We built live audio on Juke. Here is how, and how you can too.',
+    siteName: communityConfig.name,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${communityConfig.name} x Juke`,
+    description: 'We built live audio on Juke. Here is how.',
+  },
+};
+
+async function safeStats(): Promise<JukeIntegrationStats> {
+  try {
+    return await getJukeIntegrationStats();
+  } catch {
+    return {
+      total_spaces: 0,
+      active: 0,
+      scheduled: 0,
+      ended: 0,
+      with_recording: 0,
+      total_webhook_events: 0,
+      recent_event_types: {},
+      last_event_at: null,
+    };
+  }
+}
+
+/**
+ * /juke - partnership case study + build-in-public landing for the ZAO+Juke
+ * integration. Aimed at builders + Farcaster ecosystem folks who want to know
+ * "how did ZAO ship this?" before they pitch their own integration to Nicky,
+ * or who want to embed Juke on their own surface.
+ *
+ * Pairs with /listen (member-facing pull) and /juke-status (live ops
+ * dashboard). This page is the storytelling layer: voice + journey +
+ * receipts. Voice per Zaal 2026-05-25 ("build-in-public framing").
+ *
+ * Data comes from the same jukeIntegrationManifest + juke_spaces stats the
+ * dashboard reads, so the "How many shipped" / "How many spaces" numbers stay
+ * truthful as we ship more.
+ */
+export default async function JukeCaseStudyPage() {
+  const manifest = getJukeIntegrationManifest();
+  const stats = await safeStats();
+  const shippedFeatures = manifest.shipped;
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] text-white">
+      <header className="border-b border-white/[0.08] bg-gradient-to-b from-[#0d1b2a] to-[#0a1628]">
+        <div className="mx-auto w-full max-w-4xl px-4 py-12 sm:py-16">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#f5a623]/10 border border-[#f5a623]/30 text-[#f5a623] text-[10px] font-bold uppercase tracking-wider mb-4">
+            {communityConfig.name} x Juke - build in public
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold leading-tight max-w-2xl">
+            We built live audio on Juke.
+            <span className="block text-[#a78bfa]">Come listen.</span>
+          </h1>
+          <p className="mt-4 max-w-xl text-sm sm:text-base text-gray-400 leading-relaxed">
+            {communityConfig.name} ships live audio on{' '}
+            <a
+              href="https://juke.audio"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-200 underline decoration-[#855dcd]/40 hover:decoration-[#a78bfa]"
+            >
+              juke.audio
+            </a>{' '}
+            - the Farcaster-native audio app from{' '}
+            <a
+              href="https://farcaster.xyz/~/profiles/nickysap"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-200 underline decoration-[#855dcd]/40 hover:decoration-[#a78bfa]"
+            >
+              nickysap
+            </a>
+            . Below: what we shipped, the build journey, and the wires for
+            anyone who wants to build with Juke themselves.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Link
+              href="/listen"
+              className="inline-flex items-center px-5 py-2.5 rounded-xl bg-[#f5a623] hover:bg-[#ffd700] text-[#0a1628] text-sm font-bold transition-colors"
+            >
+              Listen now
+            </Link>
+            <Link
+              href="/juke-status"
+              className="inline-flex items-center px-5 py-2.5 rounded-xl border border-white/[0.12] bg-[#1a2a3a] hover:bg-[#22364a] text-gray-200 text-sm font-bold transition-colors"
+            >
+              See the wires
+            </Link>
+            <a
+              href="https://juke.audio"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="inline-flex items-center px-5 py-2.5 rounded-xl border border-[#855dcd]/30 bg-[#855dcd]/10 hover:bg-[#855dcd]/20 text-[#a78bfa] text-sm font-bold transition-colors"
+            >
+              Build with Juke →
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-10 space-y-12">
+        <StatsStrip stats={stats} shippedCount={shippedFeatures.length} />
+
+        <Section title="Why we built this">
+          <p className="text-sm text-gray-300 leading-relaxed">
+            {communityConfig.name} runs weekly fractal calls, ZAOstock standups,
+            and ad-hoc rooms - all live audio with Farcaster identity as the
+            ticket. The legacy stack (Stream.io + 100ms) gave us the rooms but
+            not the social graph. Juke gave us both: real-time audio + FID-aware
+            identity in the same handshake.
+          </p>
+          <p className="mt-3 text-sm text-gray-400 leading-relaxed">
+            Five days from first read to full integration. Path A iframe + Path
+            B developer API + outbound webhooks + recap-cast wired into the
+            same /zao channel that runs the community. Build-in-public from
+            line one.
+          </p>
+        </Section>
+
+        <Section title="The build">
+          <p className="text-xs text-gray-500 mb-4">
+            Every shipped feature, newest first. Each row links to the PR or the
+            files that landed it.
+          </p>
+          <ol className="space-y-3">
+            {shippedFeatures
+              .slice()
+              .sort((a, b) => (b.shippedAt > a.shippedAt ? 1 : -1))
+              .map((f) => (
+                <BuildRow key={f.id} feature={f} />
+              ))}
+          </ol>
+        </Section>
+
+        <Section title="Screenshots">
+          <p className="text-xs text-gray-500 mb-4">
+            Live tour - drop screenshots in as we go. Today this section is a
+            placeholder; Zaal grabs shots on the next run-through.
+          </p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {[
+              'Host page on /live/{id} with End-space + listener badge',
+              'Public /juke-status dashboard with tabs',
+              'Recap cast in /zao on Farcaster',
+              'Juke iframe with SSO bridge (no QR)',
+            ].map((label) => (
+              <div
+                key={label}
+                className="aspect-[1200/630] rounded-xl border border-dashed border-white/[0.12] bg-[#0d1b2a]/40 flex items-center justify-center p-4 text-center"
+              >
+                <p className="text-[11px] text-gray-500 leading-relaxed">{label}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section title="Build with Juke">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <ResourceCard
+              label="llms.txt"
+              href="https://juke.audio/llms.txt"
+              hint="Canonical machine-readable spec - feed this to your AI."
+            />
+            <ResourceCard
+              label="changelog.json"
+              href="https://juke.audio/changelog.json"
+              hint="Auto-polled by /juke-status to flip resolved asks green."
+            />
+            <ResourceCard
+              label="Our wires"
+              href="/juke-status"
+              hint="HTML dashboard + JSON + markdown mirrors of this integration."
+              internal
+            />
+          </div>
+        </Section>
+      </main>
+
+      <footer className="border-t border-white/[0.06] bg-[#0d1b2a]">
+        <div className="mx-auto w-full max-w-4xl px-4 py-6 flex flex-wrap items-center justify-between gap-3 text-xs text-gray-500">
+          <span>
+            {communityConfig.name} on{' '}
+            <a
+              href="https://juke.audio"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-300 hover:text-[#f5a623]"
+            >
+              Juke
+            </a>{' '}
+            - thanks{' '}
+            <a
+              href="https://farcaster.xyz/~/profiles/nickysap"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-300 hover:text-[#f5a623]"
+            >
+              @nickysap
+            </a>
+            .
+          </span>
+          <div className="flex gap-3 text-[11px]">
+            <Link href="/listen" className="text-gray-400 hover:text-[#f5a623]">
+              Listen now
+            </Link>
+            <Link href="/juke-status" className="text-gray-400 hover:text-[#f5a623]">
+              Build status
+            </Link>
+            <Link href="/juke-integration.md" className="text-gray-400 hover:text-[#f5a623]">
+              llms.txt mirror
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function StatsStrip({
+  stats,
+  shippedCount,
+}: {
+  stats: JukeIntegrationStats;
+  shippedCount: number;
+}) {
+  const items = [
+    { value: shippedCount, label: 'Features shipped' },
+    { value: stats.total_spaces, label: 'Spaces created' },
+    { value: stats.with_recording, label: 'With recording' },
+    { value: stats.total_webhook_events, label: 'Webhook events' },
+  ];
+  return (
+    <section className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {items.map((it) => (
+        <div
+          key={it.label}
+          className="rounded-xl border border-white/[0.08] bg-[#111d2e] px-4 py-3"
+        >
+          <p className="text-2xl font-bold text-white">{it.value}</p>
+          <p className="text-[11px] text-gray-500 uppercase tracking-wider mt-1">{it.label}</p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400 mb-3">{title}</h2>
+      {children}
+    </section>
+  );
+}
+
+function BuildRow({ feature }: { feature: ShippedFeature }) {
+  return (
+    <li className="rounded-xl border border-white/[0.08] bg-[#111d2e] p-4">
+      <div className="flex items-baseline gap-3 flex-wrap mb-1">
+        <h3 className="text-sm font-bold text-white">{feature.title}</h3>
+        <span className="text-[10px] text-gray-500 font-mono">{feature.shippedAt}</span>
+        {feature.pr && (
+          <a
+            href={feature.pr}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="text-[10px] text-[#f5a623] hover:underline"
+          >
+            View PR
+          </a>
+        )}
+      </div>
+      <p className="text-xs text-gray-400 leading-relaxed">{feature.description}</p>
+    </li>
+  );
+}
+
+function ResourceCard({
+  label,
+  href,
+  hint,
+  internal,
+}: {
+  label: string;
+  href: string;
+  hint: string;
+  internal?: boolean;
+}) {
+  if (internal) {
+    return (
+      <Link
+        href={href}
+        className="block rounded-xl border border-white/[0.08] bg-[#111d2e] p-4 hover:border-[#f5a623]/30 transition-colors"
+      >
+        <p className="text-sm font-bold text-white">{label}</p>
+        <p className="text-[11px] text-gray-500 mt-1 leading-relaxed">{hint}</p>
+      </Link>
+    );
+  }
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="block rounded-xl border border-white/[0.08] bg-[#111d2e] p-4 hover:border-[#855dcd]/30 transition-colors"
+    >
+      <p className="text-sm font-bold text-white">{label}</p>
+      <p className="text-[11px] text-gray-500 mt-1 leading-relaxed">{hint}</p>
+    </a>
+  );
+}

--- a/src/app/listen/page.tsx
+++ b/src/app/listen/page.tsx
@@ -1,0 +1,308 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { jukeSpaceOgImageUrl } from '@/lib/spaces/juke';
+import {
+  listActiveJukeSpaces,
+  listScheduledJukeSpaces,
+  listRecordedJukeSpaces,
+  type JukeSpaceRow,
+} from '@/lib/spaces/jukeSpacesDb';
+import { communityConfig } from '../../../community.config';
+
+export const metadata: Metadata = {
+  title: `Listen - live audio on ${communityConfig.name}`,
+  description:
+    'We built live audio on Juke. Come listen. Live ZAO spaces, what is scheduled next, and the recording shelf.',
+  openGraph: {
+    title: `Listen - live audio on ${communityConfig.name}`,
+    description: 'We built live audio on Juke. Come listen.',
+    siteName: communityConfig.name,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `Listen - live audio on ${communityConfig.name}`,
+    description: 'We built live audio on Juke. Come listen.',
+  },
+};
+
+async function safe<T>(p: Promise<T>, fallback: T): Promise<T> {
+  try {
+    return await p;
+  } catch {
+    return fallback;
+  }
+}
+
+function formatScheduled(value: string | null): string {
+  if (!value) return 'Soon';
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return 'Soon';
+  const diff = ts - Date.now();
+  if (diff <= 0) return 'Starting now';
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `In ${Math.max(1, minutes)}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `In ${hours}h`;
+  return new Date(value).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatEnded(value: string | null): string {
+  if (!value) return 'recently';
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return 'recently';
+  const diff = Date.now() - ts;
+  const m = Math.floor(diff / 60_000);
+  if (m < 60) return `${Math.max(1, m)}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return new Date(value).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+/**
+ * /listen - member-facing public page for ZAO's live audio on Juke. Hero +
+ * three sections (live now / coming up / recently recorded). Build-in-public
+ * voice in the hero per Zaal 2026-05-25. Reuses the same juke_spaces helpers
+ * /live uses, but with a more pull-y hierarchy: hero first, live cards
+ * dominant, scheduled + recorded compact, footer credits Juke.
+ *
+ * /live remains the operator-facing dashboard with finer controls. /listen is
+ * the "tap me on a phone, I want to hear something now" surface.
+ */
+export default async function ListenPage() {
+  const [live, scheduled, recorded] = await Promise.all([
+    safe(listActiveJukeSpaces(8), []),
+    safe(listScheduledJukeSpaces(4), []),
+    safe(listRecordedJukeSpaces(6), []),
+  ]);
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] text-white">
+      <header className="border-b border-white/[0.08] bg-gradient-to-b from-[#0d1b2a] to-[#0a1628]">
+        <div className="mx-auto w-full max-w-4xl px-4 py-12 sm:py-16">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#855dcd]/10 border border-[#855dcd]/30 text-[#a78bfa] text-[10px] font-bold uppercase tracking-wider mb-4">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[#a78bfa]" aria-hidden="true" />
+            Live audio - powered by Juke
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold leading-tight max-w-xl">
+            We built live audio on Juke.
+            <span className="block text-[#f5a623]">Come listen.</span>
+          </h1>
+          <p className="mt-4 max-w-lg text-sm sm:text-base text-gray-400 leading-relaxed">
+            Drop into a {communityConfig.name} room when one is on, or scroll back through
+            the recordings shelf. Built in public on{' '}
+            <a
+              href="https://juke.audio"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-200 underline decoration-[#855dcd]/40 hover:decoration-[#a78bfa]"
+            >
+              juke.audio
+            </a>
+            .
+          </p>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-8 space-y-12">
+        <Section title="Live now" count={live.length}>
+          {live.length === 0 ? (
+            <EmptyHint label="No rooms live right now. Check the schedule below." />
+          ) : (
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {live.map((r) => (
+                <LiveCard key={r.id} row={r} />
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        <Section title="Coming up" count={scheduled.length}>
+          {scheduled.length === 0 ? (
+            <EmptyHint label="No scheduled rooms yet." />
+          ) : (
+            <ul className="grid gap-3 sm:grid-cols-2">
+              {scheduled.map((r) => (
+                <ScheduledCard key={r.id} row={r} />
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        <Section
+          title="Recently recorded"
+          count={recorded.length}
+          link={recorded.length > 6 ? { href: '/live/recordings', label: 'See all' } : undefined}
+        >
+          {recorded.length === 0 ? (
+            <EmptyHint label="The first ZAO Juke recording will land here." />
+          ) : (
+            <ul className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {recorded.map((r) => (
+                <RecordingChip key={r.id} row={r} />
+              ))}
+            </ul>
+          )}
+        </Section>
+      </main>
+
+      <footer className="border-t border-white/[0.06] bg-[#0d1b2a]">
+        <div className="mx-auto w-full max-w-4xl px-4 py-6 flex flex-wrap items-center justify-between gap-3 text-xs text-gray-500">
+          <span>
+            Live audio for {communityConfig.name}, on{' '}
+            <a
+              href="https://juke.audio"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-gray-300 hover:text-[#f5a623]"
+            >
+              Juke
+            </a>
+            .
+          </span>
+          <div className="flex gap-3 text-[11px]">
+            <Link href="/juke" className="text-gray-400 hover:text-[#f5a623]">
+              How we built it
+            </Link>
+            <Link href="/juke-status" className="text-gray-400 hover:text-[#f5a623]">
+              Build status
+            </Link>
+            <Link href="/spaces" className="text-gray-400 hover:text-[#f5a623]">
+              All audio surfaces
+            </Link>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  count,
+  link,
+  children,
+}: {
+  title: string;
+  count: number;
+  link?: { href: string; label: string };
+  children: React.ReactNode;
+}) {
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-4">
+        <h2 className="text-sm font-bold uppercase tracking-wider text-gray-400">
+          {title}
+          {count > 0 && (
+            <span className="ml-2 text-[#f5a623] font-normal normal-case tracking-normal text-xs">
+              ({count})
+            </span>
+          )}
+        </h2>
+        {link && (
+          <Link
+            href={link.href}
+            className="text-xs text-gray-500 hover:text-[#f5a623] transition-colors"
+          >
+            {link.label} →
+          </Link>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function EmptyHint({ label }: { label: string }) {
+  return (
+    <div className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4 text-xs text-gray-500">
+      {label}
+    </div>
+  );
+}
+
+function LiveCard({ row }: { row: JukeSpaceRow }) {
+  return (
+    <Link
+      href={`/live/${row.id}`}
+      className="group block rounded-xl border border-[#855dcd]/30 bg-gradient-to-br from-[#1a1428] to-[#111d2e] p-4 transition-all hover:border-[#a78bfa]/50 hover:shadow-lg hover:shadow-[#855dcd]/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#855dcd]"
+      aria-label={`Join: ${row.title}`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-3">
+        <h3 className="font-bold text-sm leading-tight line-clamp-2 text-white group-hover:text-[#a78bfa] transition-colors">
+          {row.title || 'Untitled space'}
+        </h3>
+        <span className="flex-shrink-0 inline-flex items-center gap-1 text-red-400 text-[10px] font-bold uppercase tracking-wider">
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-red-500" aria-hidden="true" />
+          Live
+        </span>
+      </div>
+      <div className="flex items-center justify-between text-xs text-gray-500">
+        <span>
+          {row.participant_count <= 1
+            ? 'Just host'
+            : `${row.participant_count} listening`}
+        </span>
+        <span className="inline-flex items-center px-3 py-1 rounded-lg bg-[#855dcd] text-white text-xs font-bold group-hover:bg-[#a78bfa] transition-colors">
+          Listen
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+function ScheduledCard({ row }: { row: JukeSpaceRow }) {
+  return (
+    <Link
+      href={`/live/${row.id}`}
+      className="group block rounded-xl border border-white/[0.08] bg-[#111d2e] p-4 transition-all hover:border-[#f5a623]/30"
+      aria-label={`Scheduled: ${row.title}`}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h3 className="font-bold text-sm leading-tight line-clamp-2 text-white group-hover:text-[#f5a623] transition-colors">
+          {row.title || 'Untitled space'}
+        </h3>
+        <span className="flex-shrink-0 text-[10px] font-bold uppercase tracking-wider text-[#f5a623]">
+          Soon
+        </span>
+      </div>
+      <p className="text-xs text-gray-500">{formatScheduled(row.scheduled_at)}</p>
+    </Link>
+  );
+}
+
+function RecordingChip({ row }: { row: JukeSpaceRow }) {
+  const recordingUrl = row.recording_url;
+  if (!recordingUrl) return null;
+  const ogImage = jukeSpaceOgImageUrl(row.id);
+  return (
+    <Link
+      href={`/live/${row.id}`}
+      className="group block overflow-hidden rounded-xl border border-white/[0.08] bg-[#111d2e] transition-all hover:border-gray-600"
+      aria-label={`Recording: ${row.title}`}
+    >
+      <div className="aspect-[1200/630] bg-[#0a1628] overflow-hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={ogImage}
+          alt=""
+          className="h-full w-full object-cover opacity-80 group-hover:opacity-100 transition-opacity"
+          loading="lazy"
+        />
+      </div>
+      <div className="p-3">
+        <h3 className="font-bold text-xs leading-tight line-clamp-1 text-white group-hover:text-[#f5a623] transition-colors">
+          {row.title || 'Untitled space'}
+        </h3>
+        <p className="text-[11px] text-gray-500 mt-1">Ended {formatEnded(row.ended_at)}</p>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Why

Nicky asked for screenshots + a public page after seeing the end-to-end flow work. Zaal picked **both pages** + **build-in-public framing**.

## Pages

### /listen (member-pull)

Hero - **"We built live audio on Juke. Come listen."**

- Live now (active Juke spaces, purple Juke-themed cards)
- Coming up (scheduled, relative time)
- Recently recorded (6 most recent recordings as OG-image chips)
- Footer credits Juke

### /juke (partnership case study)

Hero - same headline, builder-focused subhead.

- Stats strip (shipped count + spaces + recordings + webhook events)
- "Why we built this" prose
- "The build" - every shipped feature from manifest, newest first
- "Screenshots" - 4 dashed-border placeholders for Zaal's next pass
- "Build with Juke" - resource cards (llms.txt / changelog.json / /juke-status)

CTAs: Listen now / See the wires / Build with Juke.

## Visual

Juke purple #855dcd as the audio accent, ZAO gold #f5a623 as brand primary, dark navy base. Same header-gradient + footer pattern across both so they read as one ZAO surface.

## RSC

Both pages server-render with no client JS. Reuses listActiveJukeSpaces / listScheduledJukeSpaces / listRecordedJukeSpaces / getJukeIntegrationManifest / getJukeIntegrationStats - no new data layer.

## Verifies

tsc clean. No new dependencies.

## Smoke after merge

1. https://zaoos.com/listen - hero loads, sections populate (or empty hints), CTAs route
2. https://zaoos.com/juke - hero loads, stats strip shows live numbers, build timeline lists every shipped feature with PR links
3. /listen → /juke → /juke-status → /listen all navigate via the footer/CTAs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>