### PR TITLE
feat(juke): consume Nicky's PR #175 (reads + rate-limit + delete-webhook + authoritative cron)

### DIFF
--- a/src/app/api/cron/juke-stale-rooms/route.ts
+++ b/src/app/api/cron/juke-stale-rooms/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { ENV } from '@/lib/env';
 import { logger } from '@/lib/logger';
+import { getJukeRoomDetail } from '@/lib/spaces/juke-api-reads';
 
 /**
  * GET /api/cron/juke-stale-rooms
@@ -94,16 +96,64 @@ export async function GET(request: NextRequest) {
   const nowIso = new Date().toISOString();
   let endedCount = 0;
   let skipped = 0;
+  let confirmedByJuke = 0;
+  let heuristicOnly = 0;
   const endedIds: string[] = [];
+
+  // Juke shipped GET /v1/developer/spaces/{id} on 2026-05-25 (Nicky PR #175).
+  // When the key is present, treat Juke as the authoritative source - if Juke
+  // says the room is still active, leave our row alone even if our webhook
+  // timeline is quiet. Only flip when Juke confirms ended (or 404s, meaning
+  // the room no longer exists on their side). When the key is absent (local
+  // dev / preview without the env var), fall back to the heuristic.
+  const apiKey = ENV.JUKE_API_KEY;
+  const useAuthoritative = Boolean(apiKey);
 
   for (const c of candidates) {
     const lastEvent = lastEventByRoom.get(c.id);
     if (lastEvent && lastEvent > thresholdIso) {
       // Recent activity on this room - probably a long-form session, not a
-      // ghost. Skip.
+      // ghost. Skip without even hitting Juke.
       skipped += 1;
       continue;
     }
+
+    if (useAuthoritative) {
+      const detail = await getJukeRoomDetail(c.id, apiKey as string);
+      if (detail.ok && detail.data) {
+        const jukeStatus = detail.data.status;
+        if (jukeStatus === 'active') {
+          // Juke says it's still active. Our webhook timeline lied (or just
+          // ran quiet because no one joined/left). Trust Juke.
+          skipped += 1;
+          continue;
+        }
+        // Juke says ended (or scheduled) - flip our row.
+      } else if (detail.status === 404) {
+        // Cross-app or deleted on Juke's side. Flip locally so /spaces stops
+        // listing a row Juke does not even know about.
+      } else if (detail.status === 429) {
+        // Read budget hit (120/min per key per Nicky's PR #175). Fall back
+        // to heuristic for the rest of this run + back off.
+        logger.warn('[cron/juke-stale-rooms] hit Juke read rate limit; falling back', {
+          spaceId: c.id,
+          rate_limit: detail.rateLimit,
+        });
+      } else {
+        // Other failure (5xx, timeout) - don't trust either side, skip.
+        logger.warn('[cron/juke-stale-rooms] Juke read failed; skipping', {
+          spaceId: c.id,
+          status: detail.status,
+          error: detail.error,
+        });
+        skipped += 1;
+        continue;
+      }
+      confirmedByJuke += 1;
+    } else {
+      heuristicOnly += 1;
+    }
+
     try {
       const { error } = await supabaseAdmin
         .from('juke_spaces')
@@ -122,7 +172,7 @@ export async function GET(request: NextRequest) {
   }
 
   logger.info(
-    `[cron/juke-stale-rooms] checked=${candidates.length} ended=${endedCount} skipped=${skipped}`,
+    `[cron/juke-stale-rooms] checked=${candidates.length} ended=${endedCount} skipped=${skipped} authoritative=${confirmedByJuke} heuristic=${heuristicOnly}`,
     { endedIds },
   );
 
@@ -131,6 +181,8 @@ export async function GET(request: NextRequest) {
     checked: candidates.length,
     ended: endedCount,
     skipped,
+    confirmed_by_juke: confirmedByJuke,
+    heuristic_only: heuristicOnly,
     threshold_minutes: STALE_THRESHOLD_MINUTES,
     ended_ids: endedIds,
   });

--- a/src/app/api/juke/admin/delete-webhook/route.ts
+++ b/src/app/api/juke/admin/delete-webhook/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { deleteJukeWebhook, getJukeWebhookDetail } from '@/lib/spaces/juke-api-reads';
+
+/**
+ * POST /api/juke/admin/delete-webhook
+ *
+ * Admin-only cleanup for orphan webhook subscriptions on Juke's side. Created
+ * to clear the leftover 61b1400b-3df2-4d19-a761-a13d39b36e8f subscription
+ * from the secret-rotation incident on 2026-05-24 (we never used that
+ * webhook after re-registering, but it stayed on Juke). Per Nicky 2026-05-25
+ * the DELETE /v1/developer/webhooks/{id} endpoint already exists; this route
+ * wraps it so we don't need a one-off DevTools fetch.
+ *
+ * Body: { webhookId }
+ * Returns 200 { ok: true, deleted } on success, 4xx on Juke rejection.
+ *
+ * Safety: we GET the webhook first so we can log the URL + events that are
+ * about to be deleted - a small breadcrumb in case someone deletes the
+ * wrong one. The actual DELETE is fire-and-go.
+ */
+
+const BodySchema = z.object({
+  webhookId: z
+    .string()
+    .min(8)
+    .max(128)
+    .regex(/^[A-Za-z0-9_-]+$/, 'Invalid webhook id'),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSessionData();
+  if (!session?.isAdmin) {
+    return NextResponse.json({ ok: false, error: 'Admin only' }, { status: 401 });
+  }
+
+  const apiKey = ENV.JUKE_API_KEY;
+  if (!apiKey) {
+    return NextResponse.json(
+      { ok: false, error: 'JUKE_API_KEY not configured' },
+      { status: 503 },
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'Body must be JSON' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid body', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+  const { webhookId } = parsed.data;
+
+  // Best-effort introspection first so the audit log shows what was deleted.
+  const detail = await getJukeWebhookDetail(webhookId, apiKey);
+  if (detail.ok && detail.data) {
+    logger.info('[juke/admin/delete-webhook] deleting subscription', {
+      webhookId,
+      url: detail.data.url,
+      events: detail.data.events,
+      last_status: detail.data.last_status,
+      consecutive_failures: detail.data.consecutive_failures,
+    });
+  } else {
+    logger.info('[juke/admin/delete-webhook] introspection failed (proceeding)', {
+      webhookId,
+      status: detail.status,
+    });
+  }
+
+  const result = await deleteJukeWebhook(webhookId, apiKey);
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.error ?? `Juke returned ${result.status}`,
+        juke_status: result.status,
+        rate_limit: result.rateLimit,
+      },
+      { status: result.status >= 500 || result.status === 0 ? 502 : result.status },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    deleted: webhookId,
+    juke_status: result.status,
+    rate_limit: result.rateLimit,
+  });
+}
+
+export const GET = () =>
+  NextResponse.json(
+    { ok: false, error: 'POST only - send { webhookId } as JSON' },
+    { status: 405 },
+  );

--- a/src/lib/spaces/juke-api-reads.ts
+++ b/src/lib/spaces/juke-api-reads.ts
@@ -1,0 +1,217 @@
+/**
+ * Juke developer-API READ endpoints. SERVER ONLY.
+ *
+ * Shipped by Juke in PR #175 (2026-05-25) - the same payload Nicky sketched
+ * out when we asked for reconcile + observability primitives:
+ *
+ *   GET /v1/developer/spaces/{id}    -> RoomDetailResponse (status, participants,
+ *                                        started_at, ended_at, recording state,
+ *                                        same shape as public GET /v1/rooms/{id})
+ *   GET /v1/developer/webhooks/{id}  -> WebhookDetailResponse (url, events,
+ *                                        last_delivery_at, last_status,
+ *                                        last_error, disabled_at,
+ *                                        consecutive_failures)
+ *   DELETE /v1/developer/webhooks/{id} -> 204 (already existed; surfaces here
+ *                                          for the orphan-cleanup admin script)
+ *
+ * Read budget: 120/min per key (security hardening from PR #175 so a leaked
+ * key cannot be used for unbounded participant polling).
+ *
+ * Rate-limit observability: every key-authed response now carries
+ *   X-Juke-Rate-Limit-Limit / Remaining / Reset
+ * We surface these on every call so callers can back off proactively. Daily
+ * cap still only signals via 429 + Retry-After.
+ */
+import { logger } from '@/lib/logger';
+
+export const JUKE_API_ORIGIN = 'https://api.juke.audio';
+const TIMEOUT_MS = 10_000;
+
+export interface JukeRateLimit {
+  limit: number | null;
+  remaining: number | null;
+  resetAtSeconds: number | null;
+}
+
+export interface JukeReadResult<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  error?: string;
+  rateLimit: JukeRateLimit;
+}
+
+/** Defensive shape - Nicky's sketch (RoomDetailResponse) has these fields, but
+ * we treat the body as best-effort and only consume what we recognise. */
+export interface JukeRoomDetail {
+  id: string;
+  status: 'active' | 'scheduled' | 'ended' | string;
+  title?: string | null;
+  started_at?: string | null;
+  ended_at?: string | null;
+  scheduled_at?: string | null;
+  participants?: Array<{
+    fid: number;
+    display_name?: string | null;
+    role?: string | null;
+    joined_at?: string | null;
+  }>;
+  participant_count?: number;
+  recording_url?: string | null;
+  recording_status?: string | null;
+  raw?: unknown;
+}
+
+export interface JukeWebhookDetail {
+  id: string;
+  url: string;
+  events: string[];
+  last_delivery_at?: string | null;
+  last_status?: number | null;
+  last_error?: string | null;
+  disabled_at?: string | null;
+  consecutive_failures?: number;
+  raw?: unknown;
+}
+
+function readRateLimit(headers: Headers): JukeRateLimit {
+  const limit = Number(headers.get('X-Juke-Rate-Limit-Limit'));
+  const remaining = Number(headers.get('X-Juke-Rate-Limit-Remaining'));
+  const reset = Number(headers.get('X-Juke-Rate-Limit-Reset'));
+  return {
+    limit: Number.isFinite(limit) ? limit : null,
+    remaining: Number.isFinite(remaining) ? remaining : null,
+    resetAtSeconds: Number.isFinite(reset) ? reset : null,
+  };
+}
+
+function logRateLimit(label: string, rl: JukeRateLimit, status: number) {
+  if (rl.remaining !== null && rl.limit !== null) {
+    const ratio = rl.remaining / rl.limit;
+    if (ratio < 0.2) {
+      logger.warn(
+        `[juke-api] ${label} rate-limit low: ${rl.remaining}/${rl.limit} remaining, resets at ${rl.resetAtSeconds}`,
+        { status },
+      );
+    } else {
+      logger.info(`[juke-api] ${label} ${rl.remaining}/${rl.limit} remaining`, { status });
+    }
+  }
+}
+
+async function jukeGet<T>(
+  endpoint: string,
+  apiKey: string,
+  label: string,
+): Promise<JukeReadResult<T>> {
+  let res: Response;
+  try {
+    res = await fetch(`${JUKE_API_ORIGIN}${endpoint}`, {
+      method: 'GET',
+      headers: { 'X-Juke-Api-Key': apiKey, Accept: 'application/json' },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    logger.error(`[juke-api] ${label} fetch failed`, err);
+    return {
+      ok: false,
+      status: 0,
+      error: 'Juke API unreachable',
+      rateLimit: { limit: null, remaining: null, resetAtSeconds: null },
+    };
+  }
+  const rateLimit = readRateLimit(res.headers);
+  logRateLimit(label, rateLimit, res.status);
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    body = text;
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      error: typeof body === 'string' ? body : `Juke returned ${res.status}`,
+      data: body as T | undefined,
+      rateLimit,
+    };
+  }
+  return { ok: true, status: res.status, data: body as T, rateLimit };
+}
+
+/**
+ * Read the authoritative state of a Juke space we own. Use this to reconcile
+ * after a suspected missed webhook (e.g. stale-room cron) or to power a
+ * "live participants right now" badge without waiting for webhook lag.
+ *
+ * 404 = either the space does not exist on Juke, OR it was created by
+ * another developer app (cross-app + iOS-native rooms return 404 with the
+ * same shape; no enumeration oracle). Callers should treat 404 as a hint
+ * that our local row is the authoritative state.
+ */
+export async function getJukeRoomDetail(
+  spaceId: string,
+  apiKey: string,
+): Promise<JukeReadResult<JukeRoomDetail>> {
+  return jukeGet<JukeRoomDetail>(
+    `/v1/developer/spaces/${encodeURIComponent(spaceId)}`,
+    apiKey,
+    `GET space ${spaceId.slice(0, 8)}`,
+  );
+}
+
+/**
+ * Read one webhook subscription's current state - lets us verify the URL,
+ * events, and recent delivery health without paging the full list. Use this
+ * alongside our orphan-cleanup admin script.
+ */
+export async function getJukeWebhookDetail(
+  webhookId: string,
+  apiKey: string,
+): Promise<JukeReadResult<JukeWebhookDetail>> {
+  return jukeGet<JukeWebhookDetail>(
+    `/v1/developer/webhooks/${encodeURIComponent(webhookId)}`,
+    apiKey,
+    `GET webhook ${webhookId.slice(0, 8)}`,
+  );
+}
+
+/**
+ * Delete one webhook subscription. Already existed in the original webhooks
+ * PR per Nicky 2026-05-25. Returns 204 on success, 404 if the id is unknown.
+ */
+export async function deleteJukeWebhook(
+  webhookId: string,
+  apiKey: string,
+): Promise<JukeReadResult<undefined>> {
+  let res: Response;
+  try {
+    res = await fetch(`${JUKE_API_ORIGIN}/v1/developer/webhooks/${encodeURIComponent(webhookId)}`, {
+      method: 'DELETE',
+      headers: { 'X-Juke-Api-Key': apiKey },
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+  } catch (err: unknown) {
+    logger.error('[juke-api] DELETE webhook fetch failed', err);
+    return {
+      ok: false,
+      status: 0,
+      error: 'Juke API unreachable',
+      rateLimit: { limit: null, remaining: null, resetAtSeconds: null },
+    };
+  }
+  const rateLimit = readRateLimit(res.headers);
+  logRateLimit(`DELETE webhook ${webhookId.slice(0, 8)}`, rateLimit, res.status);
+  if (!res.ok) {
+    const text = await res.text();
+    return {
+      ok: false,
+      status: res.status,
+      error: text || `Juke returned ${res.status}`,
+      rateLimit,
+    };
+  }
+  return { ok: true, status: res.status, rateLimit };
+}

--- a/src/lib/spaces/jukeIntegrationManifest.ts
+++ b/src/lib/spaces/jukeIntegrationManifest.ts
@@ -255,6 +255,19 @@ const SHIPPED: ShippedFeature[] = [
     reference: 'Branches on Nicky 2026-05-24 ended_via payload addition.',
   },
   {
+    id: 'developer-reads-and-observability',
+    title: 'Consumer code for Juke developer reads + rate-limit observability',
+    description:
+      "Wraps Juke's PR #175 ship (2026-05-25): GET /v1/developer/spaces/{id} returns RoomDetailResponse (status + participants + recording in one call), GET /v1/developer/webhooks/{id} returns delivery health, DELETE /v1/developer/webhooks/{id} cleans up orphans (already existed). New helper at src/lib/spaces/juke-api-reads.ts surfaces all three behind one client + extracts X-Juke-Rate-Limit-Limit / Remaining / Reset from every response, logging a warn when remaining drops below 20% of the limit. Stale-room cron at /api/cron/juke-stale-rooms now uses GET /spaces/{id} as the authoritative source - only flips a row to ended when Juke confirms ended (or 404s), trusting Juke over our webhook timeline. Fallback to the older heuristic when JUKE_API_KEY is absent (local/preview). Admin route /api/juke/admin/delete-webhook wraps DELETE with an introspection-before-delete audit log.",
+    shippedAt: '2026-05-25',
+    files: [
+      'src/lib/spaces/juke-api-reads.ts',
+      'src/app/api/juke/admin/delete-webhook/route.ts',
+      'src/app/api/cron/juke-stale-rooms/route.ts',
+    ],
+    reference: "Nicky 2026-05-25 ship: GET reads + X-Juke-Rate-Limit-* + X-Juke-Idempotency-Key headers (PR #175).",
+  },
+  {
     id: 'host-end-space-button',
     title: 'Host "End space" button on /live/{id} + admin end-space route',
     description:
@@ -310,6 +323,30 @@ const OPEN_ASKS: OpenAsk[] = [
       "Surfaced 2026-05-24 while debugging the missing room.finished webhook. Iframe Leave is a pure LiveKit room.disconnect() with anon: participant identity — no API call to api.juke.audio, so the room stays alive on Juke's side until LiveKit's empty-room 300s timeout. Additionally Juke's own end_room handler was flipping Room.status to 'ended' before livekit teardown, so the room_finished dispatcher's WHERE status='active' filter excluded the row and the outbound webhook silently never fired (same blind spot for iOS host-end). We need either a developer POST /v1/developer/spaces/{id}/end (we'd wire it to a host 'End space' button on /live/{id}), OR room.finished firing synchronously when end_room flips status (not after a 5min wait). Confirmed by Nicky 2026-05-24: both ship in their PR #174 (POST /v1/developer/spaces/{room_id}/end, X-Juke-Api-Key auth, idempotent, fires room.finished inline with ended_via: 'host'|'api' on the payload).",
     blocks: '/spaces showing dead rooms as Live + recap-cast trigger never firing for host-ended rooms',
     priority: 'p0',
+  },
+  {
+    id: 'webhook-delivery-log',
+    title: 'GET /v1/developer/webhooks/{id}/deliveries - delivery audit log',
+    reason:
+      'Nicky filed as issue #177 on 2026-05-25 (P1). We need per-delivery visibility (timestamp, event_type, status, retry count, last_error, body) so when our /api/juke/webhooks endpoint was down during a retry window we can see exactly what was dropped. Unblocks the webhook-replay endpoint (issue #181) - replay needs a delivery id to target.',
+    blocks: 'Detecting missed webhooks during downtime + queueing replays',
+    priority: 'p1',
+  },
+  {
+    id: 'participant-role-changed',
+    title: 'participant.role_changed webhook event',
+    reason:
+      "Nicky filed as issue #183 on 2026-05-25 (P1). Fires when a host promotes a hand-raiser to speaker. Real social signal - we'd cast 'X just stepped up to speak in {title}' to /zao, driving organic discovery of who is contributing. Payload shape we want: { participant_fid, old_role, new_role, occurred_at }.",
+    blocks: 'Speaker-promotion recap casts + contributor discovery',
+    priority: 'p1',
+  },
+  {
+    id: 'agent-visibility-flag',
+    title: 'Agent silent-observer flag (hide ZOE from iframe avatar bar)',
+    reason:
+      'Nicky filed as issue #190 on 2026-05-25 (P1). When ZOE joins as a partner-scoped agent for note-taking, we want her hidden from the iframe avatar bar / participant count to avoid the "why is there a robot in the room" UX surprise. Pairs with ZAO_AUTO_AGENT_JOIN going live - without this flag, every ZAO room would visibly grow a robot.',
+    blocks: 'Clean UX for ZOE-in-Juke once we flip ZAO_AUTO_AGENT_JOIN',
+    priority: 'p1',
   },
 ];
 
@@ -387,7 +424,7 @@ export const INTEGRATION_ARCHITECTURE_ASCII = String.raw`
 
 export function getJukeIntegrationManifest(): IntegrationManifest {
   return {
-    version: '1.4',
+    version: '1.5',
     generated_at: new Date().toISOString(),
     about: {
       name: 'The ZAO',


### PR DESCRIPTION
## Why

Nicky shipped PR #175 today with everything from our top-priority subset: read endpoints, rate-limit headers, idempotency-key, plus clarified DELETE already exists. This PR wires our consumer code so the moment his deploy lands, our stuff goes live.

## What

- **src/lib/spaces/juke-api-reads.ts** - client for GET /spaces/{id}, GET /webhooks/{id}, DELETE /webhooks/{id}. Surfaces rate-limit headers + warns at <20% remaining.
- **/api/juke/admin/delete-webhook** - admin POST that wraps DELETE, introspects first for audit log. Clears the leftover 61b1400b-... orphan.
- **/api/cron/juke-stale-rooms upgrade** - now uses GET /spaces/{id} as authoritative source. Only flips ended when Juke confirms (or 404s). 429 falls back gracefully. Key absent = older heuristic.
- **Manifest v1.5** - adds developer-reads-and-observability as shipped, adds webhook-delivery-log + participant-role-changed + agent-visibility-flag asks (matching Nicky's issue slugs #177, #183, #190 - auto-flip when those ship).

## What's NOT in (intentional)

X-Juke-Idempotency-Key capture - we already dedup on signature_hash + event_id (same value). Belt-and-suspenders not a real gain. Will revisit if dup-delivery bug ever surfaces.

## Verifies

- 50/50 spaces tests pass
- tsc clean

## Smoke after merge + Nicky deploy

1. Open /juke-status#asks - 4 previously-resolved asks still green + 3 new yellow open asks
2. Trigger /api/cron/juke-stale-rooms manually via the CRON_SECRET bearer - response now includes `confirmed_by_juke` + `heuristic_only` counts
3. Delete orphan: POST /api/juke/admin/delete-webhook with { "webhookId": "61b1400b-3df2-4d19-a761-a13d39b36e8f" } - expect 200 + Juke 204
4. Vercel logs on any Juke API call now show `[juke-api] ... N/M remaining` rate-limit lines

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>