### PR TITLE
event 753: ADVANCED acronym Reel capture (@pjdlifts) - content-capture not meeting

### DIFF
--- a/research/events/753-pjdlifts-advanced-acronym-reel-capture/README.md
+++ b/research/events/753-pjdlifts-advanced-acronym-reel-capture/README.md
@@ -1,0 +1,73 @@
+---
+topic: events
+type: content-capture
+status: research-complete
+last-validated: 2026-05-25
+related-docs: ""
+original-query: "screen-recorded Instagram Reel by @pjdlifts captured 2025-12-15 05:38, processed via /meeting on 2026-05-25 and re-routed to content-capture per skill rule (not a meeting, no attendees)"
+tier: QUICK
+captured-from: "Instagram Reel - @pjdlifts - 'Stop Letting Work RUN Your Life' / 'Engineer More Personal Time W/Out Quitting Your 9-5'"
+reel-url-fragment: "instagram.com/reel/DRhkeItDaNb/"
+recording-context: "Zaal screen recording, browser tabs: THE ZAO Todos, Year of the ZAO Google Doc, Zaal Productivity Planner, the Reel itself, Gemini"
+---
+
+# 753 - ADVANCED acronym - engineer personal time around a 9-5 (@pjdlifts Reel capture)
+
+> **Goal:** Capture the ADVANCED productivity framework from a @pjdlifts Instagram Reel that Zaal screen-recorded on 2025-12-15 while in productivity-planning mode. Source for the Zaal Productivity Planner. Not a meeting.
+
+## The framework
+
+**ADVANCED** = an acronym aimed at people stuck in a 9-5 + commute who want their evenings back.
+
+| Letter | Practice | Verbatim claim |
+|---|---|---|
+| **A** | **Anchor hours** | "High performers start their day with 2 hours that never move. One fitness hour that everything works around, and one hour for deep block that everything works around. No matter how chaotic your day gets, these never move." Kills decision fatigue. |
+| **D** | **Deep work sprints** | "Having a 3-hour deep work block can be great... but getting a 3-hour deep work block in a 9-5 is impossible. So how we are going to implement ours is by having 25-45 minute sprints in our day for deep work." Go on do-not-disturb, lock yourself away, no windows in the room, headphones with white noise. |
+| **V** | **(Avoid) distractions** ("V" = a-V-oid in the acronym) | "Digital guardrails... if you have a side hustle, a business, or personal project, you're not allowed to go on your phone until 1 hour is complete of that project. Phone goes in another room on do-not-disturb in a drawer while we are working. Keep dopamine as low as possible until this is complete. That goes for the entire day." |
+| **A** | **Admin batching** | "Batch all of our admin work for our life into one block. Bills, groceries, emails, cleaning, all in one chunk. For me, I like to do it Sunday morning from 8 to 12. This makes Monday through Saturday really easy to work through." |
+| **N** | **Neutralize the dip** | "The post 9-to-5 dip is where most people lose their life. From 5 to 7 you're tired, drained, brain fried. No motivation is going to help you here, you need to have a set plan. Pre-log dinner before it even happens. Eat the same meal every night. Have a 30-minute decompression time - not on your phone. Then hit gym or project." |
+| **C** | **Commute school** | "Most people lose 5 to 10 hours a week just through their commute. True high performers turn their commute into school. Audiobooks, podcasts, planning tomorrow, voice notes. Free and easy progress every single day." |
+| **E** | **Evening prep** | "Tomorrow's success starts tonight. Gym clothes laid out. Gym bag pre-prepped. Meals prepped. Coffee and water ready. Your goal is to remove every little friction against you and your anchor hours tomorrow." |
+
+## Why Zaal captured it
+
+Visible in the recording's browser chrome:
+
+- `List | General Todos | THE ZAO` (active ZAO todos list)
+- `Year of the ZAO - Google Doc`
+- `Zaal Productivity Planner - Google Doc`
+- `Lfg good tips for getting out...` (tab title - likely Zaal's working tab for this very kind of advice)
+- Instagram (active tab playing the Reel)
+- Gemini
+
+Reading: Zaal was in active productivity-planning mode, sourcing tactics for the Zaal Productivity Planner / Year of the ZAO. The recording is a self-source, not a passive scroll.
+
+## What overlaps Zaal already does (memory cross-check)
+
+Per `user_zaal_schedule.md`: "Zaal's M-F schedule: 4:30am wake, gym, work DND, lunch stream, prime building 4-7pm."
+
+| ADVANCED letter | Already in Zaal's stack | Gap |
+|---|---|---|
+| Anchor hours (A) | YES - 4:30am wake + gym is an anchor; "work DND" is a deep-work anchor | Refine: name the two anchors explicitly in the Productivity Planner |
+| Deep work sprints (D) | PARTIAL - "prime building 4-7pm" is a block, not sprints | Test 25-45 min sprint format inside the 4-7pm block |
+| Avoid distractions (V) | YES - "work DND" already covered | Codify: phone in drawer during ZAO building sprints, not just DND |
+| Admin batching (A) | UNKNOWN - not in schedule memory | New: pick a weekly admin block (Sunday 8-12 candidate) |
+| Neutralize the dip (N) | PARTIAL - "lunch stream" is mid-day; no explicit 5-7pm dip plan | New: build a 5-7pm protocol |
+| Commute school (C) | N/A - Zaal works from home (Ellsworth + Mexico travel) | Skip - the commute lever does not apply |
+| Evening prep (E) | UNKNOWN | New: candidate ritual |
+
+## Source
+
+- [Instagram Reel - @pjdlifts](https://www.instagram.com/reel/DRhkeItDaNb/) [PARTIAL - URL fragment captured from screen recording, did not re-fetch the live Reel; 24,150 likes visible at capture time on 2025-12-15, posted "2w ago" so circa late November 2025; comments visible from @ryansimms05 ("eating the same meal every night is a recipe for fatigue") and @kaylsraymond ("wake up at 5 AM, hour and a half drive, can't afford breakfast") - the contrarian comment on "same meal every night" is itself useful context]
+- Local transcript at `/tmp/meeting-20260525-192113.txt` [FULL - 80 lines via mlx-whisper-large-v3-turbo, audio-only transcription of the screen recording's audio track; no diarization needed (single voice). May be cleared if disk pressure recurs.]
+- Frames directory at `/tmp/meeting-frames-20260525-192106/` [FULL - 12 interval frames extracted via ffmpeg; static screen recording so all frames near-identical, mainly used to read browser tab titles + whiteboard visible in Reel ("A: Anchor hours / D: Deep work sprints / V: Void distractions" etc). May be cleared.]
+- Recording: `/Users/zaalpanthaki/Movies/2025-12-15 05-38-13.mov` (55MB, ~3 min, captured 5:38am)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Decide whether to fold ADVANCED into the Zaal Productivity Planner Google Doc (Admin batching + Neutralize the dip + Evening prep are the new levers vs current schedule). | @Zaal | Personal | This week |
+| If folding in: write the 5-7pm protocol (the genuine gap in current schedule memory). | @Zaal | Personal | After fold-in |
+| OPTIONAL: drop transient files - `rm /tmp/meeting-20260525-192113.txt /tmp/meeting-20260525-192113.json /tmp/meeting-frames-20260525-192106/` once you've confirmed the doc captured everything you wanted. | @Zaal | Cleanup | Anytime |
+| OPTIONAL: if this becomes a recurring pattern (screen-recording productivity content for the Planner), spec a `/capture` skill that's distinct from `/meeting` so this routing happens automatically. | @Zaal | Skill spec | If pattern recurs |


### PR DESCRIPTION
## Summary

Re-routed /meeting on an Instagram Reel screen-recording (2025-12-15) into a content-capture note rather than forcing the full meeting flow (no attendees, no decisions, just productivity content @pjdlifts posted).

Doc captures the ADVANCED acronym verbatim + maps each letter against your current schedule memory (\`user_zaal_schedule.md\`). New gaps surfaced: weekly admin batch, explicit 5-7pm dip protocol, evening prep ritual.

## Tier

QUICK - source = 1 Reel transcript (mlx-whisper-large-v3-turbo, local) + 12 ffmpeg frames + 1 memory cross-check.

## Skips (per skill rule \"never invent owners/decisions/attendees\")

- No Bonfire episode (no real attendees)
- No Airtable contact/activity (no real attendees)
- No tracker actions (only self-imposed personal todos in the doc's action table)
- No row in \`research/events/_meetings-index.md\` (this isn't a meeting)

## Next Actions (in doc)

- Decide whether to fold ADVANCED into the Zaal Productivity Planner Google Doc
- Write the 5-7pm protocol if folding in
- Optional: clean transient /tmp files
- Optional: spec a \`/capture\` skill if this becomes a recurring pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)