### PR TITLE
fix(vercel): juke-stale-rooms cron daily (unblocks all deploys)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,6 @@
     },
     { "path": "/api/cron/agents/banker", "schedule": "0 14 * * *" },
     { "path": "/api/cron/agents/dealer", "schedule": "0 22 * * *" },
-    { "path": "/api/cron/juke-stale-rooms", "schedule": "*/30 * * * *" }
+    { "path": "/api/cron/juke-stale-rooms", "schedule": "0 4 * * *" }
   ]
 }


### PR DESCRIPTION
## Why

Hobby tier limits Vercel cron to 1/day. My PR #689 added \`*/30 * * * *\` for /api/cron/juke-stale-rooms = 48/day. That's been silently failing every build since:

- vercel inspect shows prod deploy built from commit \`58828e5\` (= PR #684 merge)
- 15 PRs merged on main since, none deployed
- Vercel CLI errors out: \`Hobby accounts are limited to daily cron jobs\`

Symptom Zaal hit: zaoos.com/listen + /juke return 404, even though files are on main since yesterday.

## What

Change schedule from \`*/30 * * * *\` to \`0 4 * * *\` (daily, 04:00 UTC = midnight ET). Ghost rooms sitting up to a day is fine - the authoritative GET /spaces/{id} check inside the cron means we verify against Juke before flipping anyway.

## Verifies

- Single-char schedule change
- No code changes

## After merge

\`vercel --prod\` will succeed. /listen + /juke + everything else from the last 15 merged PRs will go live.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>