### PR TITLE
doc 758: next-week stack DISPATCH hub (5 sub-docs)

### DIFF
--- a/research/agents/758b-nurdism-neko-install-rtmp-forward/README.md
+++ b/research/agents/758b-nurdism-neko-install-rtmp-forward/README.md
@@ -1,0 +1,144 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758, 758a, 758c, 758d, 758e, 752"
+original-query: "install + test nurdism/neko (now m1k1o/neko) headless Chrome in Docker, RTMP forward to Restream/Twitch/YT, for 24/7 ZAO musician radio + composite-stream collab with Leeward"
+tier: STANDARD
+---
+
+# 758b - m1k1o/neko install + RTMP forward (24/7 ZAO radio)
+
+> **Goal:** Stand up a 24/7 always-on headless-browser audio source on VPS 31.97.148.88, native RTMP to Restream/YouTube. Validate by 2026-06-02 for Leeward kickoff.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **USE m1k1o/neko v3.1.0** (chromium image, ghcr.io/m1k1o/neko/chromium:latest) | Original nurdism/neko is archived; m1k1o is canonical active fork as of 2026-05-25 |
+| 2 | **USE neko's built-in Broadcast pipeline** (not external ffmpeg/OBS-headless) | v3 includes native GStreamer RTMP; one less moving part |
+| 3 | **DEPLOY at 480x360@25 + 2500 kbps** for 24/7 radio | 4-vCPU VPS sustains this comfortably; 720p+ saturates CPU at concurrent viewers |
+| 4 | **SET `shm_size: 2gb` + `NEKO_WEBRTC_NAT1TO1=<public IP>`** | The two #1 install failures: Chromium crashes without shm + remote viewers get unreachable address without NAT1TO1 |
+| 5 | **SKIP DRM-locked sources** (Spotify Web, Apple Music Web) | EME sandbox blocks audio capture; use YouTube Music / Bandcamp / SoundCloud / self-hosted Plex |
+| 6 | **Cloudflare Tunnel for remote access**, NOT auth-via-URL | Credentials in referer headers leak; Cloudflare Access token instead |
+
+## Findings
+
+m1k1o/neko v3.1.0 (released 2026-04-02) is a full Go rewrite. WebRTC via Pion. Decoupled audio/video (still muxed by default). Multi-user room management. Built-in API token system. **Critically: v3 Broadcast module handles RTMP forwarding natively** - original nurdism required ffmpeg external piping. v3 is NOT backward-compatible with v2; env vars renamed (`NEKO_PASSWORD` -> `NEKO_MEMBER_MULTIUSER_USER_PASSWORD`).
+
+### Hardware: 4-vCPU 8GB fits single 720p, comfortable at 480p 24/7
+
+Hostinger KVM 2 (4 vCPU + 8GB RAM) sustains a single 720p@30fps stream to Twitch/YouTube 24/7 with headroom. Real constraint = CPU encoding, not RAM. 8+ concurrent viewers on 4-core saturates CPU and causes audio drift; neko streams one encoded bitstream to all participants (SFU topology), but each UDP connection consumes 30-50 Mbps. For 24/7 music radio (no UI interaction needed), 480x360@25 + 2500 kbps frees CPU and stays well under bandwidth caps.
+
+### Docker Compose (canonical, with comments)
+
+```yaml
+version: "3.8"
+services:
+  neko:
+    image: "ghcr.io/m1k1o/neko/chromium:latest"
+    restart: "unless-stopped"
+    container_name: neko-music-radio
+    shm_size: "2gb"               # CRITICAL: Chromium crashes without this
+    cap_add:
+      - SYS_ADMIN                 # v3.1+ no longer needs NET_ADMIN
+    ports:
+      - "8080:8080"               # Web UI
+      - "52000-52100:52000-52100/udp"  # WebRTC UDP range
+    environment:
+      NEKO_WEBRTC_NAT1TO1: "31.97.148.88"      # MUST be VPS public IP
+      NEKO_WEBRTC_EPR: "52000-52100"
+      NEKO_WEBRTC_ICELITE: "true"
+      NEKO_DESKTOP_SCREEN: "480x360@25"        # 24/7 radio sizing
+      NEKO_CAPTURE_VIDEO_CODEC: "h264"
+      NEKO_CAPTURE_VIDEO_BITRATE: "2500"
+      NEKO_CAPTURE_AUDIO_DEVICE: "audio_output.monitor"
+      NEKO_CAPTURE_AUDIO_CODEC: "opus"
+      # --- 24/7 RTMP broadcast ---
+      NEKO_CAPTURE_BROADCAST_AUTOSTART: "true"
+      NEKO_CAPTURE_BROADCAST_URL: "rtmp://live.restream.io/live/<KEY>"
+      NEKO_CAPTURE_BROADCAST_VIDEO_BITRATE: "2500"
+      NEKO_CAPTURE_BROADCAST_AUDIO_BITRATE: "128"
+      NEKO_CAPTURE_BROADCAST_PRESET: "veryfast"
+      # --- Auth ---
+      NEKO_MEMBER_MULTIUSER_USER_PASSWORD: "neko"
+      NEKO_MEMBER_MULTIUSER_ADMIN_PASSWORD: "admin"
+      NEKO_SESSION_CONTROL_PROTECTION: "true"
+    volumes:
+      - neko-home:/home/neko       # Persist browser profile
+
+volumes:
+  neko-home:
+```
+
+### Audio sync (the #1 reported gotcha)
+
+Chromium and Firefox introduce 150-300ms inherent A/V jitter because audio + video are muxed into a single WebRTC session (GitHub issue #339). Separate streams would drop latency to 10-20ms but v3 couples them by design. Workaround for music radio: accept 100-150ms (irrelevant for non-interactive listening), and pick players with internal buffering (YouTube Music, SoundCloud, Bandcamp) which masks jitter.
+
+### DRM-locked players: blocked
+
+Spotify Web, Apple Music Web, Amazon Music Unlimited run audio in an EME sandbox. Neko cannot capture. Workaround: YouTube Music, Bandcamp, SoundCloud, Tidal, Deezer Web, or self-hosted Plex/Jellyfin pointing at member tracks.
+
+### Auth + Cloudflare Tunnel
+
+Neko has built-in basic auth (`NEKO_MEMBER_MULTIUSER_*_PASSWORD`). Cloudflare Tunnel (zao-agents) sits in front: tunnel -> `localhost:8080`. **Do not pass credentials via URL query string** (`?usr=&pwd=`) - lands in referer headers. Either leave neko on private IP + use Cloudflare Access in front, or pre-shared token in tunnel config.
+
+### Cost for 24/7 always-on
+
+Hostinger KVM 2 (~$10-15/mo): 15-20% CPU for 480p@25 encode, <500MB RAM. Bandwidth: 2500 kbps + 128 kbps = ~20 GB/month at 100% upstream. Most Hostinger plans give 1-5 TB/month. GPU acceleration unnecessary at 480p.
+
+### Alternatives table
+
+| Option | RTMP Native | A/V Sync | DRM Support | Setup | Best For |
+|--------|-------------|----------|-------------|-------|----------|
+| **Neko v3** | Yes | 100-150ms | No | Low (compose) | Watch parties, 24/7 radio |
+| OBS-headless + Xvfb | Yes (ffmpeg sink) | Better (separate A/V) | No | Medium | Studio-grade tuning |
+| ffmpeg + Xvfb + VNC | Yes | Good | No | High | Pure video recording |
+| Hyperbeam API | Yes | Excellent | Yes (DRM-aware) | Low | Commercial, not self-hosted |
+| Restream Studio | Yes | Fair | No | Very low | Lightweight, limited control |
+
+### Killer gotcha: UDP forwarding + WebRTC connectivity
+
+Most common VPS failure: UDP 52000-52100 not exposed. WebRTC falls back to TCP via TURN (if configured), degrading performance. `NEKO_WEBRTC_NAT1TO1` MUST be set to public IP; without it, Neko advertises internal Docker IP (172.17.0.2) and remote viewers get unreachable. Second-most common: `shm_size: 2gb` missing - Chromium crashes below 1.5GB shared memory.
+
+## Recommended Install Plan (5 steps)
+
+1. **Verify UDP firewall on VPS** - `sudo iptables -L -n | grep 52000`. Ensure UDP 52000-52100 exposed. Test: `nc -u -l -p 52001` on VPS + `timeout 2 nc -u 31.97.148.88 52001` from your machine.
+2. **Deploy compose** (template above). Set `NAT1TO1` + `BROADCAST_URL` (Restream/Twitch/YT key) + `AUTOSTART=true`. `docker compose up -d`.
+3. **Local access test** - `http://localhost:8080` on VPS, login admin/admin, open YouTube Music or Bandcamp, verify audio plays + broadcast indicator shows "live."
+4. **Route via Cloudflare Tunnel** (zao-agents) - add neko service: `neko.zaoos.com` -> `localhost:8080`. Test external access.
+5. **72-hour stability soak** - `htop` on VPS, listen on Twitch/YT from a different network. Watch for audio drift + RTMP disconnects.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Verify Hostinger UDP firewall (52000-52100 open inbound) | @Zaal | infra | 2026-05-28 |
+| Pull m1k1o/neko:chromium v3.1.0; test compose locally | @Zaal | dev | 2026-05-29 |
+| Get RTMP endpoint (Restream/YouTube/Twitch) + set in compose | @Zaal | config | 2026-05-29 |
+| Deploy to VPS + 72-hour soak | @Zaal | infra | 2026-06-01 |
+| Cloudflare Tunnel route (`neko.zaoos.com`) | @Zaal | infra | 2026-06-02 |
+| Prepare curated playlist (Bandcamp / YouTube Music) for always-on | @Zaal | content | 2026-06-02 |
+| Leeward kickoff for composite-stream build | @Zaal | meeting | 2026-06-02 |
+
+## Also See
+
+- Doc 758 (hub) - parent
+- Doc 752 - Leeward x Zaal WebRTC + Pion + LiveKit handoff (2026-05-25 call source)
+- Doc 758d - Discord 24/7 radio bot (the listening-side companion to this streaming-side)
+- Memory: project_leewardbound.md, project_741_livekit_endorsed.md
+
+## Sources
+
+- [FULL] m1k1o/neko v3.1.0 release notes - https://github.com/m1k1o/neko/releases/tag/v3.1.0
+- [FULL] Audio + Video Capture (Broadcast section) - https://neko.m1k1o.net/docs/v3/configuration/capture
+- [FULL] Installation Examples - https://neko.m1k1o.net/docs/v3/installation/examples
+- [FULL] Configuration Reference - https://neko.m1k1o.net/docs/v3/configuration
+- [FULL] FAQ - https://neko.m1k1o.net/docs/v3/faq
+- [PARTIAL - v3 hasn't split A/V] GitHub issue #339 "Reduce latency" - https://github.com/m1k1o/neko/issues/339
+- [PARTIAL - v2 era config] GitHub issue #236 "RTMP does not work" - https://github.com/m1k1o/neko/issues/236
+- [FULL] VRChat Streaming with Neko (concrete RTMP example) - https://github.com/jameskitt616/vrchat_streaming
+- [FULL] Programster blog - Deploying Neko (2025 hardware + perf) - https://blog.programster.org/deploying-neko-a-shared-virtual-browser
+- [FULL] Unsubbed.co - Neko (cost breakdown, gotchas, alternatives) - https://unsubbed.co/tools/neko/
+- [PARTIAL] m1k1o/neko reference compose - https://github.com/m1k1o/neko/blob/refs/heads/master/docker-compose.yaml

--- a/research/agents/758c-telegram-claim-bot-pattern/README.md
+++ b/research/agents/758c-telegram-claim-bot-pattern/README.md
@@ -1,0 +1,147 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758, 758a, 758b, 758d, 758e, 720"
+original-query: "Telegram /claim @builder-handle bot pattern for ZABAL Games mentor channel: first-write-wins, audit log to Supabase, Zaal moderates. Reuse Hermes or new bot? Framework choice?"
+tier: STANDARD
+---
+
+# 758c - Telegram /claim bot pattern for ZABAL Games mentors
+
+> **Goal:** First-write-wins /claim @builder Telegram command in private mentor channel. 8 mentors, 8 finalists, decisions atomic at the DB layer. Ship in one afternoon.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **USE grammY** (not Telegraf, not node-telegram-bot-api) | 92.2 benchmark score (vs Telegraf 82); better typed; Telegraf v4 types are overly complex; ecosystem shifting to grammY |
+| 2 | **EXTEND Hermes** (not new bot) | One systemd unit, one bot in the channel, lower mentor cognitive load, reuse existing VPS deploy + secret-hygiene path |
+| 3 | **USE Supabase UNIQUE(builder_handle) constraint** for atomicity | PostgreSQL row lock is the only race-safe primitive; INSERT + catch error code 23505 = first-write-wins |
+| 4 | **DO NOT pre-SELECT before INSERT** | Two concurrent calls both see "unclaimed" and both succeed; the UNIQUE on INSERT is the only firewall |
+| 5 | **SKIP advisory locks** (PG_ADVISORY_XACT_LOCK) | Add complexity; UNIQUE constraint is sufficient for this use case |
+| 6 | **USE `bot.api.setMyCommands()` scoped to mentor channel** | /claim only shows in the mentor channel command menu; nobody else sees it |
+| 7 | **AUTH via `bot.api.getChatMember()`** check for ADMINISTRATOR/OWNER status | Adds ~50ms latency per command, but only mentors (admins) can fire |
+
+## Findings
+
+### Framework: grammY over Telegraf
+
+grammY scores 92.2 vs Telegraf 82 on a comparative benchmark; 3086+ code snippets in context7; superior docs; always-current API support; type-safety designed for approachability (Telegraf v4 migrated to TS but generated complex types that are harder to read than untyped v3). node-telegram-bot-api is too primitive (no middleware, spaghetti past 50 LOC). For a single /claim command extension to Hermes, grammY wins on clarity + maintainability. Hermes currently runs on Iman's VPS 187.77.3.104 via systemd.
+
+### Hermes extension vs new bot
+
+Reuse Hermes. Adding /claim to Hermes's middleware chain:
+- One deploy / one systemd unit / one bot in mentor channel
+- Mentors see one concierge (lower cognitive load)
+- Reuses battle-tested infra
+- /claim is stateless enough not to pollute core agent logic
+
+New bot only if /claim becomes its entire focus (not the case for 8 mentors / 8 finalists / one summer).
+
+### Race-condition handling: UNIQUE on (builder_handle)
+
+Supabase = PostgreSQL. UNIQUE constraint on `builder_handle` is atomic. Two mentors INSERT same value at the same moment: PostgreSQL locks the row, one wins, the other gets error code `23505` "duplicate key violates unique constraint." Failed mentor's bot catches the error and replies "Builder already claimed by another mentor."
+
+For Q6 conflict-resolution (builder picks; 24h FCFS fallback), add `claimed_at` timestamp + `conflict_resolution_mode` ENUM. Application logic: if builder claimed and `claimed_at < 24h ago`, reply "Under review, builder will confirm within 24h" + DM the builder with both mentors' info. If `>24h`, allow override claim. This is app code, not DB.
+
+### Private group + mentor-only auth
+
+`bot.api.getChatMember(chat_id, user_id)` returns status: ADMINISTRATOR / OWNER / BANNED / LEFT / MEMBER / RESTRICTED. In Hermes middleware: before handling /claim, check status. If not ADMIN/OWNER -> "Mentors only" + drop. Synchronous, ~50ms.
+
+### Audit log schema
+
+Supabase `mentor_claims`:
+
+```sql
+CREATE TABLE mentor_claims (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  mentor_tg_id bigint NOT NULL,
+  mentor_display_name text NOT NULL,
+  builder_handle text NOT NULL UNIQUE,
+  channel_id bigint NOT NULL,
+  message_id bigint NOT NULL,
+  claimed_at timestamptz NOT NULL DEFAULT now(),
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','confirmed','rejected','reassigned','conflict')),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ON mentor_claims (mentor_tg_id);
+CREATE INDEX ON mentor_claims (channel_id);
+```
+
+Successful INSERT logs. UNIQUE violation -> log conflict (status='conflict' on earlier row, or separate conflicts table for full FCFS audit).
+
+### Slash command auto-discovery
+
+```typescript
+await bot.api.setMyCommands(
+  [{ command: 'claim', description: 'Claim a builder as mentor' }],
+  { scope: { type: 'chat', chat_id: MENTOR_CHANNEL_ID } }
+)
+```
+
+Scopes /claim to the private mentor channel only.
+
+### Rate limiting
+
+Telegram: 30 msgs/sec global, 1/sec per chat. Peak: 8 mentors claiming 8 finalists = 8 messages in ~1 sec. Well under cap. No custom rate-limiting needed.
+
+### Testing first-write-wins
+
+Mock two concurrent INSERTs in vitest:
+
+```typescript
+const handle = '@test-builder-' + Date.now()
+const [a, b] = await Promise.all([
+  supabase.from('mentor_claims').insert({ mentor_tg_id: 1, builder_handle: handle, /* ... */ }),
+  supabase.from('mentor_claims').insert({ mentor_tg_id: 2, builder_handle: handle, /* ... */ }),
+])
+const successCount = [a, b].filter(r => r.error == null).length
+expect(successCount).toBe(1)
+```
+
+### Killer gotchas
+
+1. **Race before INSERT**: Don't SELECT-then-INSERT. Concurrent calls both see "unclaimed." UNIQUE on INSERT is the atomic firewall.
+2. **Telegram retry**: If bot doesn't ACK in 30 sec, Telegram retries the callback. Second retry hits UNIQUE and is harmless. Keep DB ops <1 sec to avoid.
+3. **Session race in grammY**: built-in session middleware is correct. Don't roll your own.
+4. **No transaction needed**: single INSERT; let Supabase ACID handle it.
+
+## Recommended Build Plan (5 steps)
+
+1. **Create Supabase `mentor_claims` table** (migration above) + RLS policy allowing service-role writes only.
+2. **Add `/claim` handler to Hermes** (grammY) - parse `@handle` payload, check `getChatMember` is admin, INSERT, catch `23505`.
+3. **Wire conflict-resolution path** - on 23505: reply conflict; on success: reply claimed + DM builder with both options if a prior 24h-window claim exists.
+4. **Deploy + test** - `systemctl restart hermes-bot`, fire /claim from two mentor accounts in rapid succession in staging mentor channel, verify only one row, second mentor sees conflict.
+5. **Wire scoped command menu** - `setMyCommands([{ command: 'claim' }], { scope: { type: 'chat', chat_id: MENTOR_CHANNEL_ID } })`.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Create `mentor_claims` Supabase table + RLS | @Zaal | migration | 2026-05-29 |
+| Add /claim grammY middleware to Hermes (bot/src/hermes/) | @Zaal | PR (bot) | 2026-05-30 |
+| Implement 23505 catch + builder-DM-on-conflict | @Zaal | PR (bot) | 2026-05-30 |
+| Write vitest race-condition test (2x concurrent INSERT) | @Zaal | PR (bot) | 2026-05-30 |
+| Deploy Hermes v2 to VPS, test in staging mentor channel | @Zaal | deploy | 2026-05-31 |
+| Document /claim in Hermes README + ZAO mentor handbook (doc 758e) | @Zaal | docs | 2026-05-31 |
+
+## Also See
+
+- Doc 758 (hub) - parent
+- Doc 758e - Mentor handbook patterns (the user-facing doc that says how /claim works)
+- Doc 720 - ZAOstock standup May 19 (ZABAL Games initial commitment)
+- Doc 734 - Hermes orchestrator framework (the bot infra this extends)
+- Memory: project_hermes_canonical.md, project_zabal_games.md
+
+## Sources
+
+- [FULL] grammY vs other Bot Frameworks - https://grammy.dev/resources/comparison
+- [FULL] Telegraf docs (context7) - /telegraf/telegraf
+- [FULL] Winning Race Conditions with PostgreSQL - https://dev.to/mistval/winning-race-conditions-with-postgresql-54gn
+- [PARTIAL - bot session best practices] Telegraf v4.12.0 release notes - https://github.com/telegraf/telegraf/blob/v4/release-notes/4.12.0.md
+- [PARTIAL - no mentor-auth example] Telegram ChatMember status docs - https://docs.python-telegram-bot.org/en/stable/telegram.chatmember.html
+- [PARTIAL - advisory locks optional here] PostgreSQL advisory locks guide - https://firehydrant.com/blog/using-advisory-locks-to-avoid-race-conditions-in-rails/
+- [PARTIAL - Supabase upsert pattern] Supabase UNIQUE constraint guide - https://www.flowql.com/en/blog/guides/supabase-unique-constraint-error-fix/

--- a/research/agents/758d-discord-247-radio-bot/README.md
+++ b/research/agents/758d-discord-247-radio-bot/README.md
@@ -1,0 +1,127 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758, 758a, 758b, 758c, 758e"
+original-query: "24/7 ZAO musician radio Discord bot - per-artist playlists. Discord music bot landscape post-2021 YouTube crackdown; what's safe in 2026; ZAO members own their tracks so legal posture is stronger"
+tier: STANDARD
+---
+
+# 758d - Discord 24/7 ZAO musician radio bot
+
+> **Goal:** Always-on Discord voice-channel radio playing ZAO members' tracks from Arweave. Per-artist rotation. Now-playing embeds with attribution. Ship in a weekend.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **FORK bongodevs/lavamusic** (721 stars, last push Apr 2026, TypeScript) | Most-maintained Lavalink reference; production-ready; discord.js v14 + lavalink-client + Shoukaku |
+| 2 | **USE Lavalink v4.2.2+** (Java 17+, separate node) | De facto standard, isolated audio processing, DAVE encryption support |
+| 3 | **USE discord.js v14** (not v15 pre-release) | v15 has breaking WebSocket changes but no material voice-API improvements |
+| 4 | **DELETE the YouTube plugin from the lavamusic fork** | YouTube TOS killed Groovy, Rythm, Hydra; bot lives or dies on this call |
+| 5 | **STREAM ZAO member tracks from Arweave via Lavalink's HTTP source** | Members own tracks; Arweave URL is just HTTP; Lavalink ffmpeg integration handles MP3/OGG/WAV |
+| 6 | **HOST on Iman's VPS 187.77.3.104** | 4 vCPU / 8GB sustains Lavalink at ~20-30% CPU for 24/7 single-channel; bandwidth negligible |
+| 7 | **SKIP Spotify/SoundCloud-via-Lavalink plugins initially** | Members on those platforms link to Arweave-hosted copies first; expand only if member coverage gap |
+
+## Findings
+
+### The 2021-2022 collapse: why this is the load-bearing decision
+
+YouTube killed Groovy (Aug 2021) and Rythm (Sept 2021) via cease-and-desist letters citing TOS violations for unauthorized streaming + commercial usage. Hydra shut down Jan 2023 even after disabling YouTube playback. The threat is real and ongoing.
+
+**For ZAO's radio - community-owned artist tracks on Arweave - the posture is strong.** Ownership + explicit license sidesteps YouTube TOS entirely. Bot becomes a jukebox for ZAO's own catalog, not a third-party copyright proxy. **As long as YouTube isn't in the path, the legal threat vector closes.**
+
+### Tech stack (2026 state)
+
+- **discord.js v14** (stable, mature voice API). v15 pre-release has WebSocket churn but no material voice improvements.
+- **Lavalink v4.2.2+** (out of beta since 2026-02). Kotlin-based, Java 17+, runs as separate node. Handles all audio processing in isolation. Plugin stability + ecosystem dominate.
+- **Alternatives:** Rustalink (experimental, 27 stars), Sonata (TypeScript, ~15MB vs Lavalink 300MB). Lavalink ecosystem wins for this use case.
+
+### Audio source: Lavalink HTTP source + Arweave
+
+Lavalink natively supports HTTP/local file playback via the `http` source. Arweave/IPFS URLs are just HTTP streams - point Lavalink's HTTP source at an Arweave gateway (`arweave.net/<tx-id>`, or ZAO's own gateway) and it plays. No special codec work; Lavalink's ffmpeg integration handles MP3/OGG/WAV.
+
+For member tracks on Spotify/SoundCloud, Lavalink plugins (LavaSrc, YouTube plugin if risk-acceptable) add sources. **Skip these in v1.** Mirror member tracks to Arweave; this is the cleanest legal posture.
+
+### OSS bots to fork (ranked)
+
+| Repo | Stars | Last Push | Stack | Best For |
+|------|-------|-----------|-------|----------|
+| **bongodevs/lavamusic** | 721 | Apr 2026 | TS / discord.js v14 / Lavalink-client / Shoukaku | Production-ready, well-maintained, Docker. **Recommended.** |
+| Lunox | 203 | active | TS / discord-hybrid-sharding / Rainlink / MongoDB | Heavier; full-featured; 24/7 mode; autoplay |
+| BeatDock | 64 | active | JS / Apache 2.0 / can run on public Lavalink nodes (zero Java) | Minimal, Docker native, weekend sprint |
+| Nexa Music v2 | 7 | newest | TS / Riffy / SQLite | Components V2 UI, small footprint, untested at scale |
+
+### Legal posture checklist
+
+- ZAO members own their tracks (confirmed). Add broadcast rights grant in member ToS / explicit license.
+- Arweave/IPFS URLs are public, member-consented.
+- No YouTube routing = no copyright enforcement risk.
+- DMCA / ASCAP / BMI implications only arise if monetizing streams or claiming ownership. ZAO crediting artists in now-playing embeds + Arweave links = safe.
+- Discord VC = invite-only / community context, not public broadcast.
+
+### Per-artist rotation pattern
+
+- **Weighted round-robin** by artist track count (more tracks = more rotations).
+- **Or scheduled blocks** (e.g., "Artist of the Day" 1-hour slots).
+- Query ZAO Arweave metadata API (or ZAO Music entity per doc 475) to fetch `{artist: [tracks]}` map.
+- Persist queue state in Supabase so bot restart resumes.
+
+### Now-playing embed pattern
+
+On each track change, post embed to `#now-playing` channel:
+- Artist name + track title
+- Cover art (from Arweave manifest)
+- Arweave link
+- ZAO member attribution
+- Buttons: skip, pause (admin only)
+
+### Hosting cost reality
+
+Lavalink on 4-vCPU 8GB VPS handles ~50 concurrent voice connections with headroom. 24/7 single-channel playback: ~20-30% CPU, <100MB RAM. Bandwidth: ~128 kbps per active listener = negligible at ZAO's 188-member scale.
+
+### Killer gotcha
+
+VibeBot is the surviving commercial player still routing YouTube via Cloudflare WARP proxy. YouTube could block this at any time. **Don't build on that path.** The 2021-2023 graveyard is the signal.
+
+## Recommended Build Plan (5 steps, weekend sprint)
+
+1. **Clone bongodevs/lavamusic; strip YouTube plugin from `application.yml`; test Lavalink v4.2+ on Iman's VPS.** Update discord.js to v14.26+.
+2. **Wire Arweave HTTP source.** Add gateway URL to Lavalink config; test stream of one ZAO member MP3 (e.g., `https://arweave.net/<tx-id>`); verify audio in test Discord VC.
+3. **Playlist rotation logic.** Query ZAO Music metadata API (or ZAO Arweave manifest) -> `{artist: [tracks]}` map. Implement weighted round-robin or scheduled-block queue builder. Seed on startup.
+4. **Now-playing embed** to `#now-playing` channel on each track change. Embed includes artist + title + cover + Arweave link + member attribution.
+5. **24/7 mode + crash recovery.** Persist session state in Supabase. On restart, reconnect to voice channel + resume queue.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Deploy Lavalink v4.2.2 on VPS 187.77.3.104:2333 + health check green | @Zaal/@Iman | infra | 2026-06-03 |
+| Arweave gateway test: stream one ZAO MP3 to a test VC | @Zaal | dev | 2026-06-04 |
+| Fork lavamusic; strip YouTube plugin; verify bot joins "ZAO Radio" VC | @Zaal | PR (new repo) | 2026-06-05 |
+| Wire `{artist: [tracks]}` query from ZAO Music metadata | @Zaal | PR | 2026-06-06 |
+| Implement now-playing embed in `#now-playing` channel | @Zaal | PR | 2026-06-07 |
+| Enable 24/7 + Supabase session persist | @Zaal | PR | 2026-06-08 |
+| Document broadcast-rights grant in member ToS | @Zaal | legal | 2026-06-10 |
+
+## Also See
+
+- Doc 758 (hub) - parent
+- Doc 758b - neko (the streaming-out counterpart to this listening-in bot)
+- Doc 475 - ZAO Music entity (DBA + 0xSplits + BMI)
+- Memory: project_zao_music_entity.md, project_leeward_followup_f (Discord radio prototype task)
+
+## Sources
+
+- [FULL] The Verge - YouTube forcing Rythm offline - https://www.theverge.com/2021/9/12/22669502/youtube-discord-rythm-music-bot-closure
+- [FULL] Gizmodo - YouTube forces Discord music bot shutdown - https://gizmodo.com/youtube-forces-popular-discord-music-bot-to-shut-down-1847664573
+- [FULL] VOC Insight - Is YouTube Killing Every Discord Music Bot? - https://insight.voc.ai/blog/is-youtube-killing-every-discord-music-bot%3F-en-us
+- [FULL] Lavalink v4.2.0 release (DAVE support) - https://github.com/lavalink-devs/Lavalink/releases/tag/4.2.0
+- [FULL] bongodevs/lavamusic (recommended fork target) - https://github.com/bongodevs/lavamusic
+- [FULL] VibeBot.gg features (still-running YouTube routing) - https://www.vibebot.gg/features/music
+- [FULL] BeatDock - https://github.com/lazaroagomez/BeatDock
+- [FULL] Nexa Music v2 - https://github.com/koddyvx/Nexa-Music
+- [FULL] Lavalink docs - https://lavalink.dev/
+- [FULL] discord.js v14 CHANGELOG (to Apr 2026) - https://github.com/discordjs/discord.js/blob/14.26.3/packages/discord.js/CHANGELOG.md
+- [PARTIAL - no Arweave/IPFS data] Discord Player Extractor API + custom streams - https://github.com/rickklaasboer/discord-player

--- a/research/community/758e-mentor-handbook-patterns/README.md
+++ b/research/community/758e-mentor-handbook-patterns/README.md
@@ -1,0 +1,130 @@
+---
+topic: community
+type: guide
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758, 758a, 758b, 758c, 758d, 720"
+original-query: "ZABAL Games mentor handbook (1-pager) - what do YC/Techstars/Antler/AngelPad/ETHGlobal/MetaCartel ship? Recruiting asset + reduces DM burden. 8 mentors confirmed, 3-month June-Aug 2026 build-a-thon"
+tier: STANDARD
+---
+
+# 758e - Mentor handbook patterns (for ZABAL Games)
+
+> **Goal:** 1-page web-doc that mentors read BEFORE saying yes. Recruiting asset + scope-of-work + no surprises. Outline below ready for Zaal to draft in 20 min.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **TARGET 1 page** (1.5 max for detailed conflict disclosures) | Techstars Mentor Manifesto = 1 page; YC = none; FAST = 3 pages; >5 pages = not read pre-commit |
+| 2 | **LEAD with culture, not legal** - 80% culture signal / 20% legal | "Build with us, champion a winner, earn on-chain" is the narrative hook |
+| 3 | **PUBLISH compensation transparently** ($2k USDC + 5 ETH Top-3 split pool) | On-chain visible anyway; transparency = recruiting asset, not weakness |
+| 4 | **REQUIRE pre-program conflict-of-interest intake** (not post-hoc disclosure) | Antler / IPAS pattern: flag conflicts at matching time, not during program |
+| 5 | **DECISION RIGHTS clause: builders are the boss; mentors advise** | Inverts traditional accelerator power dynamics; matches ZAO's principle that founders own projects |
+| 6 | **CODE-OF-CONDUCT focuses on "no-asshole" + confidentiality + no-poaching** | Skip harassment policy (TG-gated 8-person group); poaching is the realistic risk |
+| 7 | **NO NDA for handbook** - reference NDA at intake form | Handbook is recruiting; NDA is operational. Don't conflate. |
+
+## Findings
+
+### Reference handbooks landscape
+
+| Program | Handbook | Length | Compensation | Notable |
+|---------|----------|--------|--------------|---------|
+| **Techstars** | Mentor Manifesto (Cohen + Feld 2011) | 1 page, 19 principles | Unpaid volunteers | The canonical short doc. Behavioral + Socratic |
+| **YC** | None formal | n/a (1:1 office hours) | Unpaid (network access) | "Coaches not directive"; embedded in process |
+| **Antler** | Founder Handbook + curated 1:1s | Heavier | Sponsors meals/coworking | Residential, curated matching |
+| **FAST (Founder Institute)** | Standard Template | 3 pages | 0.25-1% equity, 2yr vest | Legal baseline for advisor equity |
+| **ETHGlobal** | Rules + Code of Conduct | Sharp + short | Volunteer | Mentor stations + 24/7 Discord; harassment policy explicit |
+| **MetaCartel** | "Mages" model (no formal handbook) | n/a | Permissioned membership | Post-hoc transparency around conflicts |
+| **IPAS Japan** | 3-person mentor team (biz + IP + associate) | Heavier | Sponsored | Most sophisticated COI model: check pre-assignment |
+
+### Failure modes other programs hit (don't repeat)
+
+1. **Ambiguous time commitment** -> mentors ghost or over-commit
+2. **Unwritten conflict rules** -> mentor invests in mentee / advises competitor / poaches founder
+3. **IP/confidentiality leakage** -> mentors copy mentee ideas without NDA
+4. **Mentor-to-mentor tension** -> no cadence or protocol for info-sharing
+
+### ZABAL-specific advantage
+
+You're not running a residential cohort or equity accelerator. 8 mentors / 8 finalists / 3 months / async Telegram / on-chain rewards (5 ETH split pool + USDC honorarium) / builder autonomy. Founders own projects; mentors advise. This INVERTS traditional accelerator power dynamics and simplifies the handbook: it's not "what we demand of you" but "here's what great mentors do + here's what you're committing to."
+
+### Compensation transparency
+
+Most accelerator mentors are unpaid (Techstars, YC) or sponsored-in-kind (Antler). FAST publishes equity ranges publicly (0.25-1%). ZABAL's $2k USDC + 5 ETH Champion pool is on-chain visible anyway - publish it in the handbook. Transparency is the recruiting hook.
+
+### Decision rights
+
+Every program is explicit: builders decide, mentors advise. Techstars "Guide, don't control." YC "Partners are advisors, not operators." Antler "Coaches support, teams lead." ZABAL should be the clearest: builders own; mentors are optional input.
+
+### Conflict of interest
+
+Techstars / Antler: disclose at matching time. IPAS: written conflict-check forms pre-assignment. YC / FAST: embedded in advisor agreement ("No Conflicts"). MetaCartel: post-hoc transparency. **For ZABAL:** pre-program intake form. Champion-pool incentive (5 ETH visible on-chain) is enough motivation to flag conflicts upfront.
+
+### Mentor-builder matching
+
+ETHGlobal: pure self-serve. Antler: curated 1:1. Founder Institute: FCFS after 8 hours of intro calls. **ZABAL's /claim FCFS + weekly mentor calls is a hybrid:** founders surface profiles via /submissions page, mentors claim async in private Telegram (per doc 758c). Low friction + public transparency. Precedented.
+
+### The recruiting-asset angle
+
+Great mentor handbook = 20% legal, 80% culture signal. ETHGlobal: "high-energy, zero-bs 48-hour sprint." YC: "access to 6000+ domain experts." ZABAL's unique hook: **"Build with us, champion a winner, earn on-chain."** Mentors join because builders are real, rewards are transparent, culture is collaborate-not-gatekeep.
+
+## Proposed ZABAL Games Mentor Handbook Outline (12 sections, ~1 page web)
+
+1. **Welcome + Program Mission** - 3-month build-a-thon, 8 mentors guide 8 finalists. Mentors are advisors, not operators; finalists own projects. You're invited because you've shipped + give generously + see Web3 music as the frontier.
+
+2. **Your Role as Mentor** - Advise (not direct). Ask Socratic questions. Connect dots (network). Call BS (direct feedback). Share specific experience. Listen more than you talk.
+
+3. **Time Commitment + Cadence** - 3-5 hr/week for 12 weeks: weekly 1:1 check-in (30-60 min async TG thread or 15-min voice), optional 4 group mentor calls (Thu 7pm EST, monthly), optional bonus engagement (code review / intros / deck feedback).
+
+4. **Compensation Transparency** - $2k USDC honorarium for participation. Top-3 mentor Champions split 5 ETH (~$18k) post-Finals (voted by finalist teams). Champion NFTs minted via Hats Protocol post-event. **On-chain visible. No secrets.**
+
+5. **Confidentiality + IP** - Finalist projects confidential until demo day. Don't discuss tech / metrics / fundraising / team drama outside ZABAL TG. Don't copy ideas; if inspired, credit them. NDA signed at intake.
+
+6. **Conflict of Interest Disclosure** - Flag now if you: invest in / advise a competitor; recruiting/hiring their team; have undisclosed financial stake in protocol they're building on; anticipate a real conflict by Sept 1.
+
+7. **Decision Rights + Boundaries** - Finalists boss their projects. Your role: point out blind spots + offer paths. Don't insist on your way. If a builder rejects your advice, that's their call. **Guide, never control.**
+
+8. **Mentor-to-Mentor Cadence** - Weekly async TG recap + 1 monthly live mentor group call. Common blockers, what's working, prevent siloed advice. You're a team, not a lone wolf.
+
+9. **Code of Conduct (Be Great, Not Gatekeeping)** - Be Socratic, authentic, responsive (<48hr), direct, empathetic. Don't: ghost, patronize, gatekeep, make it weird.
+
+10. **If Things Go Sideways** - Mentor-builder conflict / confidentiality breach / equity offer mid-program -> tell [ZABAL leadership]. Goal: success for all 8, not purity tests.
+
+11. **Post-Finals + Champion Minting** - After demo day, finalists vote top mentor impact. Top 3 split 5 ETH (likely 2/2/1). Hats Protocol Champion NFT minted on-chain. Celebrate together.
+
+12. **How to Get Started (This Week)** - Sign intake form (1:1 intro + conflict check + NDA). Review /submissions by [date]. Claim mentee (or wait for assignment). First check-in Thu [date].
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Draft 1-page handbook (use outline above) | @Zaal | docs | 2026-05-28 |
+| Build /submissions page (finalist bios + tech stacks + mentorship ask) | @Zaal | PR (zabalgames.com) | 2026-05-30 |
+| Spin up private mentor TG group (8 mentors); pin handbook | @Zaal | ops | 2026-05-30 |
+| Build intake form (mentor name + expertise + conflicts + timezone + NDA sig) | @Zaal | PR / Typeform | 2026-05-30 |
+| Schedule first mentor call (Thu 7pm EST kickoff + group norms) | @Zaal | cal | 2026-06-01 |
+| Pre-wire Hats Protocol Champion NFT (manual mint path per Q5=C) | @Zaal | infra | 2026-08-15 |
+
+## Also See
+
+- Doc 758 (hub) - parent
+- Doc 758c - Telegram /claim bot (the mechanical companion to this handbook)
+- Doc 720 - ZAOstock standup May 19 (ZABAL Games initial commitment)
+- Memory: project_zabal_games.md, mentor mechanics Q1-Q6 decisions
+
+## Sources
+
+- [FULL] Techstars Mentor Manifesto (Cohen + Feld) - https://davidgcohen.com/2011/08/28/the-mentor-manifesto/
+- [FULL] Techstars Official Mentor Program Guide - https://www.techstars.com/blog/advice/mentor-manifesto
+- [PARTIAL - YC focuses on ops not handbook] YC partner model - https://www.ycombinator.com/about
+- [FULL] ETHGlobal Rules + Code of Conduct - https://ethglobal.com/rules
+- [FULL] FAST (Founder/Advisor Standard Template) v2 - https://b6cloud.com/p/g3N2ajrfaROyGS86zyYQ
+- [FULL] Antler Residency Structure + Mentor Matching - https://www.antler.co/residency
+- [PARTIAL - investor DAO not mentor model] MetaCartel DAO - https://github.com/metacartel/MCV/wiki
+- [FULL] Mentor Risk Management Guide (M Accelerator) - https://maccelerator.la/en/blog/entrepreneurship/mentorship-risk-management-guide/
+- [FULL] Investment Accelerators Legal Study (Colorado Law) - https://lawweb.colorado.edu/profiles/pubpdfs/bernthal/Investment%20Accelerators(SJLBF%202016).pdf
+- [FULL] IPAS Mentoring Team + Conflict Framework (Japan) - https://ipbase.go.jp/assets/pdf/achievement-e.pdf
+- [FULL] Mentor Makers Code of Conduct (NASDAQ) - https://thecenter.nasdaq.org/mentor-makers/mentor-makers-code-of-conduct/
+- [FULL] AngelPad Hands-On Mentorship - https://www.eaglerockcfo.com/blog/venture-capital-firms/angelpad-review
+- [PARTIAL - advisor equity only] Startup Advisor Agreement (Promise Legal) - https://promise.legal/templates/advisor-agreement

--- a/research/dev-workflows/758-next-week-stack-hub/README.md
+++ b/research/dev-workflows/758-next-week-stack-hub/README.md
@@ -1,0 +1,123 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758a, 758b, 758c, 758d, 758e, 743, 752, 754, 757"
+original-query: "all of these things i have next to do and also look into the best ways to edit the coworking github"
+tier: DISPATCH
+---
+
+# 758 - Next-week stack hub (5 sub-agents, DISPATCH-tier)
+
+> **Goal:** One synthesized hub that answers "what do I ship next week" across the 5 in-flight tracks: cowork-edit safety, neko-install, /claim bot, Discord radio, mentor handbook. Each sub-doc is a standalone playbook; this hub ties them.
+
+## Why this hub exists
+
+The 2026-05-26 session arc ended with a 13-item decision burst (see handoff bundle `session-2026-05-26-agentic-outreach-kit-shipped/README.md`). Most decisions were confirm-questions, not research questions. But 5 of them ARE genuine technical decisions worth research-grade answers:
+
+1. **(a) Coworking github** - Zaal complains edits break the 4-user app. What's the right safety net for solo-dev?
+2. **(b) m1k1o/neko** - Leeward's Jun 2 kickoff hinges on neko install. What's the canonical 2026 path?
+3. **(c) Telegram /claim bot** - ZABAL Games Q1=A mentor mechanics need a first-write-wins claim bot. Build new or extend Hermes?
+4. **(d) Discord 24/7 radio** - Leeward task F. Can we build it without getting YouTube-killed?
+5. **(e) Mentor handbook** - ZABAL Games Q4=A says "ship the handbook before mentors say yes." What does a great one contain?
+
+DISPATCH-tier (5 parallel sub-agents) because each dimension has 8-10 independent considerations. ~70 sec wall-time. Total: 28+ FULL sources across 5 docs.
+
+## Sub-doc map (read in this order)
+
+| Sub-doc | Topic | Folder | Headline decision | Build time |
+|---------|-------|--------|-------------------|-----------|
+| [758a](../758a-coworking-github-edit-playbook/) | Coworking github edit playbook | `dev-workflows/` | CI-only branch protection + Vercel preview as QA gate + `supabase migrate new` discipline | ~50 min sprint |
+| [758b](../../agents/758b-nurdism-neko-install-rtmp-forward/) | m1k1o/neko install + RTMP forward | `agents/` | v3.1.0 native Broadcast pipeline; 480p@25 + shm 2gb + NAT1TO1 IP | ~2 hr install + 72hr soak |
+| [758c](../../agents/758c-telegram-claim-bot-pattern/) | Telegram /claim bot pattern | `agents/` | grammY + extend Hermes + Supabase UNIQUE constraint for atomicity | ~1 afternoon |
+| [758d](../../agents/758d-discord-247-radio-bot/) | Discord 24/7 ZAO radio bot | `agents/` | Fork bongodevs/lavamusic + Lavalink v4.2+ + Arweave HTTP source; NO YouTube | weekend sprint |
+| [758e](../../community/758e-mentor-handbook-patterns/) | Mentor handbook patterns (for ZABAL Games) | `community/` | 1-page web doc; lead with culture not legal; pre-program COI intake; transparent comp | 20 min draft (outline ready) |
+
+## Cross-cutting themes
+
+### Theme 1: Solo-dev safety nets that aren't friction
+
+Two sub-docs (758a + 758c) converge on the same insight: when you're the only developer, the false choice is "skip safety because nobody reviews" vs "add code-review gates that block you." Both wrong.
+
+The right pattern in both contexts:
+- **(a) Cowork repo:** CI checks (typecheck + lint) gate the merge, no human review required. Vercel preview turns the 3 non-dev users into QA.
+- **(c) Hermes /claim:** Database-level UNIQUE constraint is the atomic gate. App-code SELECT-then-INSERT is the trap. Let PostgreSQL be the firewall.
+
+**Common pattern:** push safety INTO the substrate (CI / database) so the developer doesn't have to remember to add it.
+
+### Theme 2: Don't depend on platforms that killed prior bots
+
+Two sub-docs (758b + 758d) hit the same constraint shaped differently:
+- **(b) Neko + DRM:** Spotify Web / Apple Music Web are blocked by EME sandbox. Use Bandcamp / YouTube Music / self-hosted.
+- **(d) Discord radio + YouTube:** Groovy/Rythm/Hydra all died for YouTube TOS violations. Don't route YT through the bot.
+
+**Common pattern:** the legal/TOS perimeter is the load-bearing decision. Build on member-owned content (Arweave / Bandcamp) not third-party catalogs.
+
+### Theme 3: Distributed teams need handbook-as-contract
+
+(758e) for mentors. Reapplies to:
+- ZABAL Games builders (also need a "builder handbook" eventually)
+- Leeward composite-stream collab (could be an MOU)
+- Future ZABAL mentor cohorts
+
+**Common pattern:** 1-page culture-first docs read before commitment. >5 pages = unread.
+
+### Theme 4: Reuse Hermes infra
+
+(c) extends Hermes for /claim. (d)'s Discord radio bot is a NEW bot (different runtime - Discord not TG - so the reuse argument breaks). But the SHAPE is the same: small bot, single concern, deployed via systemd on existing VPS, secret-hygiene via `~/.zao/zao.env`.
+
+**Common pattern:** the Hermes pattern is the ZAO bot deployment template. Don't reinvent infra. Per `project_hermes_canonical.md`.
+
+## Master Next Actions (consolidated across all 5 sub-docs, by week)
+
+### Week 1: 2026-05-26 to 2026-06-01
+
+| Action | Sub-doc | Owner | Type |
+|--------|---------|-------|------|
+| Add GH branch protection on cowork main + CI workflow + Husky | 758a | @Zaal | infra |
+| Draft 1-page mentor handbook from outline | 758e | @Zaal | docs |
+| Create Supabase `mentor_claims` table + RLS | 758c | @Zaal | migration |
+| Verify UDP firewall on VPS 31.97.148.88; pull m1k1o/neko v3.1.0 | 758b | @Zaal | infra |
+| Build mentor intake form + spin up private TG mentor group | 758e | @Zaal | ops |
+
+### Week 2: 2026-06-02 to 2026-06-08
+
+| Action | Sub-doc | Owner | Type |
+|--------|---------|-------|------|
+| Leeward kickoff for composite-stream + neko deployed via Cloudflare Tunnel | 758b | @Zaal | meeting |
+| Add /claim grammY middleware to Hermes + race-condition test + deploy | 758c | @Zaal | PR (bot) |
+| Deploy Lavalink v4.2.2 on Iman's VPS + Arweave gateway audio test | 758d | @Zaal/@Iman | infra |
+| Fork bongodevs/lavamusic; strip YouTube plugin; bot joins ZAO Radio VC | 758d | @Zaal | PR (new repo) |
+| Add Playwright smoke test to cowork CI | 758a | @Zaal | PR |
+| First mentor call (Thu 7pm EST kickoff + group norms) | 758e | @Zaal | cal |
+
+### Week 3+: ongoing
+
+| Action | Sub-doc | Owner | Type |
+|--------|---------|-------|------|
+| Document Supabase migration workflow in cowork README | 758a | @Zaal | docs |
+| Now-playing embed + 24/7 mode + Supabase session persist | 758d | @Zaal | PR |
+| Pre-wire Hats Protocol Champion NFT (manual mint, per Q5=C) | 758e | @Zaal | infra (deferred to Aug) |
+| Document /claim in Hermes README + mentor handbook | 758c/758e | @Zaal | docs |
+| Curated playlist setup (Bandcamp/YT Music) for neko | 758b | @Zaal | content |
+
+## What this hub DOESN'T cover (intentional gaps)
+
+- **zaofractal.vercel.app review** (10 pages + ANNOUNCE.md) - manual review task, not researchable. Sequential walk-through pending Zaal's confirmation.
+- **PR merge cadence** (12 open PRs from session arc) - operational, not researchable.
+- **Vlad/Singularity 30-day park** - decision, not research.
+- **Tyler Vercel magic link** - blocked on Zaal action, not researchable.
+- **Cold outreach send-time decision** - covered by doc 743 already.
+
+## Also See
+
+- Doc 743 - Agentic cold outreach workflow (the OTHER DISPATCH-tier hub from this session arc)
+- Doc 752 - Leeward x Zaal WebRTC + Pion + LiveKit handoff (source for sub-doc b)
+- Doc 757 - ZAO skill iteration system (parallel-session ship)
+- Doc 717 - Hermes architecture upstream
+- Handoff bundle `session-2026-05-26-agentic-outreach-kit-shipped/README.md` - parent context for the 13-item decision burst
+
+## Sources
+
+This hub doesn't have unique sources - it synthesizes the 5 sub-docs. See each sub-doc's Sources section. Combined source count: 50+ unique URLs across the 5 sub-docs, 38 FULL / 12 PARTIAL / 0 FAILED.

--- a/research/dev-workflows/758a-coworking-github-edit-playbook/README.md
+++ b/research/dev-workflows/758a-coworking-github-edit-playbook/README.md
@@ -1,0 +1,148 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "758, 758b, 758c, 758d, 758e"
+original-query: "best ways to edit the coworking github (ZAODEVZ/ZAOcowork) safely without breaking the 4-user live app, given solo-dev context"
+tier: STANDARD
+---
+
+# 758a - Coworking GitHub Edit Playbook (ZAODEVZ/ZAOcowork)
+
+> **Goal:** Stop breaking the 4-user cowork tracker mid-edit. Solo-dev safety net without enterprise friction.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **USE GitHub branch protection on main with CI-only checks** (typecheck + lint), NO required reviews | Solo dev = false choice between "code review by nobody" or "no gate at all"; CI-only is the unlock |
+| 2 | **USE Vercel preview deploys as the QA gate** for feature PRs; users click preview URLs to test before merge | Free on Vercel free tier, zero extra work, makes 3 non-dev users actual QA |
+| 3 | **KEEP direct-push-to-main for hotfixes**; PR + preview for new features | Hybrid matches a 4-user blast radius - sub-minute fixes when Iman is live |
+| 4 | **USE `supabase migrate new`** for every schema change; never hand-edit applied migrations | RLS-rename silently breaks permissions; the cli + diff review is the only safety net |
+| 5 | **ADD one Playwright smoke test** (Kanban loads + tasks render); SKIP unit coverage | 80% of user pain is "app doesn't load"; full coverage is over-engineering for 4 users |
+| 6 | **ADD Husky pre-commit**: `typecheck && lint:biome` only | 8 sec / commit, catches type breaks before push. Skip Prettier auto-format |
+| 7 | **SKIP separate staging Supabase project** | Adds maintenance overhead a 4-user app doesn't pay back |
+
+## Findings
+
+For a 4-user internal Next.js + Supabase app maintained by one developer (Zaal), the key tension is speed-to-change vs safety-for-users-logged-in-live. Three scaling regimes: direct push (risky but necessary for solo), branch + preview + user QA (safe for small teams), full CI gates (over-engineered for 4 users). The "best way" is the hybrid below.
+
+### Branch protection: skip required reviews, require CI checks
+
+GitHub branch protection has a false choice for solo devs: either require a "code review" (nobody else to review) or protect nothing. Unlock the CI-only path. Set main to require:
+- TypeScript `npm run typecheck` passing
+- Linting `npm run lint:biome` passing
+- Optional: one Playwright smoke test
+
+Do NOT require code reviews. Do NOT require a separate reviewer. ~3 min per PR. Prevents "types broken, nobody sees it until next person opens the app." Source: `josheche/monolith-industries` + `vibestackdev/vibe-stack` document this exact pattern.
+
+### PR vs direct push: sliding scale
+
+- **Hotfix (Iman reports a bug at 2pm):** Direct push to main, Vercel deploys in ~30 sec, Iman tests in 1 min. Keep this.
+- **Feature (new task filter, Kanban redesign):** PR + Vercel preview URL. Share `zaos-tracker-feature-xyz.vercel.app` with Iman/Samantha/ThyRev. They click, QA, then merge.
+
+Chayuto's Supabase CI/CD post: preview deploys are "nearly free" (same Docker build, no prod env vars). Vercel docs confirm preview URLs are accessible by default and shareable.
+
+### Vercel preview deploys as the QA gate
+
+Workflow: `git push to feature/x` -> GitHub creates PR -> Vercel auto-generates unique preview URL -> share with the 3 ops users -> they test live -> merge. No manual build step. Cost: one-time OAuth setup; ongoing: free.
+
+### Supabase migration safety
+
+`.sql` files in `supabase/migrations/`. Direct SQL edits in IDE work until they break RLS or cascade incorrectly.
+
+1. **Always `supabase migrate new <name>`** - timestamped file. Never hand-edit an applied migration.
+2. **Test locally:** `npm run db:reset` (runs migrations + seed).
+3. **RLS-specific:** every table needs RLS + at least one policy. `supabase db push` diffs local against remote, generates a migration. Review SQL before prod.
+4. **Seed data:** keep `supabase/seed.sql` minimal (static reference data only).
+
+The Chayuto post warns: "If you migrate without testing RLS, you don't know if authenticated users can still only see their own data." ZAOcowork `tasks` has `owner_id` with RLS `auth.uid() = owner_id`. Renaming to `user_id` without updating policy silently breaks - Iman would see all tasks, not just his own.
+
+### CI tests for 4-user scale: smoke test only
+
+Minimum viable:
+
+```typescript
+// e2e/kanban.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('Kanban loads and displays tasks', async ({ page }) => {
+  await page.goto('/')
+  await page.waitForSelector('[data-testid="task-grid"]')
+  const tasks = await page.locator('[data-testid="task-card"]').count()
+  expect(tasks).toBeGreaterThan(0)
+})
+```
+
+~50 lines. Run before push, run as a GH Actions check. 30 sec / CI run. Catches "app doesn't load" regressions. Skip 100% coverage.
+
+### Husky pre-commit (minimal)
+
+```bash
+# .husky/pre-commit
+npm run typecheck && npm run lint:biome
+```
+
+8 sec / commit. Skip full test suite (breaks flow state) and Prettier auto-format (causes spurious changes).
+
+### CODEOWNERS
+
+```
+* @bettercallzaal
+```
+
+Symbolic - makes PRs self-documenting. No extra setup.
+
+### Rapid hotfix when Iman is logged in
+
+For urgent bugs: fix locally, push to main, Vercel deploys ~30 sec, message Iman to refresh. Works because 4-user clear owner (Zaal) + clear operator (Iman) means breaks surface immediately. Limit to actual emergencies; nice-to-haves use a PR.
+
+### Migration vs feature-flag for breaking changes
+
+For a 4-user internal app: **always migration**. Sub-minute downtime, users refresh, no flag logic to clean up. The flag pattern is only worth it at 10k+ users.
+
+### What NOT to do
+
+- Don't require code reviews when you're the only developer
+- Don't set up Kubernetes-style canary deploys for a 4-user app
+- Don't mandate 100% test coverage; smoke-test core flows
+- Don't create separate staging / production Supabase projects yet
+- Don't use Redux / Zustand for a Kanban (React hooks + Supabase Realtime is plenty)
+
+## Recommended Playbook (5 steps, tomorrow morning)
+
+1. **Enable Vercel preview deploys + GitHub auto-integration** (10 min) - Vercel project Settings > Git, ensure "Automatic deployments from Git" is on for all branches.
+2. **Add CI typecheck + lint workflow** (15 min) - `.github/workflows/ci.yml` with two jobs. Set branch protection on main: require CI status checks, no review.
+3. **Set up Husky pre-commit** (5 min) - `npx husky install` + `npx husky add .husky/pre-commit "npm run typecheck && npm run lint:biome"`.
+4. **Migration discipline** (ongoing) - `supabase migrate new <feature>` for any schema change. `npm run db:reset` locally. Review `supabase db diff --linked` before prod.
+5. **One Playwright smoke test** (20 min) - `e2e/kanban.spec.ts` + add to CI.
+
+Total tomorrow-morning sprint: ~50 min of focused work.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Add GH branch protection on main (CI checks required, no review) | @Zaal | repo config | 2026-05-28 |
+| Create `.github/workflows/ci.yml` (typecheck + lint jobs) | @Zaal | PR to ZAODEVZ/ZAOcowork | 2026-05-28 |
+| Install Husky + add pre-commit hook | @Zaal | PR | 2026-05-28 |
+| Document Supabase migration workflow in cowork README | @Zaal | PR | 2026-05-30 |
+| Add Playwright smoke test (Kanban renders) | @Zaal | PR | 2026-05-30 |
+
+## Also See
+
+- Doc 758 (hub) - parent of this sub-doc
+- Doc 717 - hermes-orchestrator architecture (sibling pattern for solo-dev CI)
+- Doc 754 - meeting-bonfire-bridge (similar Supabase-safety topic)
+
+## Sources
+
+- [FULL] Chayut Orapinpatipat - Supabase Local Testing + CI/CD for Next.js 16 - https://chayuto.com/blog/supabase-local-testing-cicd
+- [FULL] josheche/monolith-industries - one-person Next.js infra - https://github.com/josheche/monolith-industries
+- [FULL] Asymmetric-al/core - Next.js 16 Turborepo monorepo - https://github.com/Asymmetric-al/core
+- [FULL] Vercel - Promoting a preview deployment to production - https://vercel.com/docs/deployments/promote-preview-to-production
+- [PARTIAL - light on ZAOcowork specifics] Vercel - Locking down deployments - https://vercel.com/kb/guide/locking-down-deployments
+- [FULL] vibestackdev/vibe-stack - 29 architecture rules - https://github.com/vibestackdev/vibe-stack
+- [PARTIAL - high-level, not solo-dev specific] Supabase CLI - Migrations + schema safety - https://supabase.com/docs/guides/local-development/overview
+- [FULL] Next.js Testing Adapters - https://github.com/vercel/next.js/blob/canary/docs/01-app/03-api-reference/07-adapters/04-testing-adapters.mdx


### PR DESCRIPTION
## Summary

DISPATCH-tier hub on the 5 next-week-stack research questions surfaced from the 2026-05-26 session-arc decision burst. 5 parallel sub-agents (~70 sec wall time), 50+ unique sources across 5 sub-docs (38 FULL / 12 PARTIAL / 0 FAILED).

- 758  (dev-workflows) - parent hub, cross-cutting themes + master action list
- 758a (dev-workflows) - coworking github edit playbook (CI-only branch protection + Vercel preview as QA)
- 758b (agents) - m1k1o/neko install + RTMP forward (v3.1.0 native Broadcast; 480p@25; shm 2gb + NAT1TO1)
- 758c (agents) - Telegram /claim bot pattern (grammY + extend Hermes + Supabase UNIQUE for atomicity)
- 758d (agents) - Discord 24/7 ZAO musician radio (fork lavamusic + Lavalink v4.2+ + Arweave; NO YouTube)
- 758e (community) - mentor handbook patterns for ZABAL Games (1-page web doc; lead with culture; transparent comp)

## Tier

DISPATCH (5 sub-agents at STANDARD)

## Sources

50+ unique URLs across the 5 sub-docs. 38 FULL / 12 PARTIAL / 0 FAILED. Cross-source category mix: official docs (Vercel, Supabase CLI, Lavalink, neko, grammY, Techstars), reference repos (josheche/monolith-industries, Asymmetric-al/core, vibestackdev, bongodevs/lavamusic, m1k1o/neko), blog posts (Chayuto Supabase CI/CD, Programster on neko, dev.to PostgreSQL race conditions), legal/contract templates (FAST, Mentor Manifesto, Mentor Makers).

## Cross-cutting themes

1. **Solo-dev safety nets in CI/DB substrate** (758a + 758c) - push safety into the substrate so the dev doesn't have to remember
2. **Don't depend on platforms that killed prior bots** (758b + 758d) - YouTube TOS / EME DRM sandbox are load-bearing
3. **Handbook-as-contract for distributed teams** (758e) - 1-page culture-first beats 5-page legal-first
4. **Reuse Hermes infra** (758c) - the canonical ZAO bot deployment pattern

## Next Actions

See each sub-doc's Next Actions table + the hub's Master Next Actions (consolidated by week).