### PR TITLE
feat(juke): Juke as default + Recording/Agents/Announce toggles

### DIFF
--- a/src/app/api/juke/space/route.ts
+++ b/src/app/api/juke/space/route.ts
@@ -46,6 +46,14 @@ const createSpaceSchema = z.object({
   announceCast: z.boolean().optional(),
   /** When true, AI agents may join the room. */
   allowAgents: z.boolean().optional(),
+  /**
+   * When true, Juke records the room. recording.ready webhook lands when the
+   * file is ready and drives the /live/recordings shelf + "Recording up" cast.
+   * ZAO default is true so every space contributes to the archive.
+   */
+  record: z.boolean().optional(),
+  /** Space description shown inside the Juke embed. */
+  description: z.string().trim().max(500).optional(),
   /** Shared create-password — an alternative to an admin session. */
   password: z.string().optional(),
 });

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -75,17 +75,26 @@ export default function PublicSpacesPage() {
     gateConfig?: GateConfig | null,
     provider: AudioProvider = 'stream',
     roomMode: RoomMode = 'stage',
+    jukeOpts?: { record: boolean; allowAgents: boolean; announceCast?: boolean },
   ) => {
     if (!user) throw new Error('Not authenticated');
 
     // Juke is owned + hosted on juke.audio — Path B via /api/juke/space mints
     // the room on Juke's side and we land on /live/{spaceId} (keyless iframe).
-    // ZAO concepts (theme, room_mode, gate_config, slug) do not apply to Juke.
+    // ZAO concepts (theme, room_mode, gate_config, slug) do not apply to Juke;
+    // jukeOpts carries the record / allowAgents / announceCast flags from
+    // HostRoomModal so they reach Juke's create payload.
     if (provider === 'juke') {
       const res = await fetch('/api/juke/space', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title }),
+        body: JSON.stringify({
+          title,
+          description: description || undefined,
+          record: jukeOpts?.record ?? true,
+          allowAgents: jukeOpts?.allowAgents ?? true,
+          announceCast: jukeOpts?.announceCast ?? false,
+        }),
       });
       if (res.status === 401) {
         throw new Error(

--- a/src/components/spaces/HostRoomModal.tsx
+++ b/src/components/spaces/HostRoomModal.tsx
@@ -100,14 +100,37 @@ interface HostRoomModalProps {
     gateConfig?: GateConfig | null,
     provider?: AudioProvider,
     roomMode?: RoomMode,
+    jukeOpts?: JukeCreateOptions,
   ) => Promise<void>;
+}
+
+/**
+ * Juke-specific create-time options. Plumbed through HostRoomModal when the
+ * Juke tile is selected; ignored by Stream.io + 100ms paths.
+ */
+export interface JukeCreateOptions {
+  /** Record the room - drives /live/recordings shelf + recording.ready cast. */
+  record: boolean;
+  /** Let agents (e.g. ZOE) join the room via partner-scoped agent-join. */
+  allowAgents: boolean;
+  /** Have Juke post an announcement cast on Farcaster when the space opens. */
+  announceCast?: boolean;
 }
 
 export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalProps) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [theme, setTheme] = useState<RoomTheme>('default');
-  const [provider, setProvider] = useState<AudioProvider>(communityConfig.audioProvider ?? 'stream');
+  // Juke is the default provider - "Live audio on Farcaster" is the headline
+  // surface today. communityConfig.audioProvider can override if a forked
+  // community wants Stream.io / 100ms as the default.
+  const [provider, setProvider] = useState<AudioProvider>(communityConfig.audioProvider ?? 'juke');
+  // Juke-specific defaults: record=true (every space becomes a recording
+  // artifact unless host opts out), allowAgents=true (gates ZOE auto-join when
+  // we flip ZAO_AUTO_AGENT_JOIN once Nicky's #190 visibility flag ships).
+  const [jukeRecord, setJukeRecord] = useState<boolean>(true);
+  const [jukeAllowAgents, setJukeAllowAgents] = useState<boolean>(true);
+  const [jukeAnnounceCast, setJukeAnnounceCast] = useState<boolean>(false);
   const [roomMode, setRoomMode] = useState<RoomMode>('stage');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -126,7 +149,21 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
     setLoading(true);
     setError(null);
     try {
-      await onCreateRoom(title.trim(), description.trim(), theme, gateConfig, provider, roomMode);
+      await onCreateRoom(
+        title.trim(),
+        description.trim(),
+        theme,
+        gateConfig,
+        provider,
+        roomMode,
+        provider === 'juke'
+          ? {
+              record: jukeRecord,
+              allowAgents: jukeAllowAgents,
+              announceCast: jukeAnnounceCast,
+            }
+          : undefined,
+      );
       setTitle('');
       setDescription('');
       setTheme('default');
@@ -328,18 +365,51 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
               </p>
             </div>
           ) : (
-            <div className="mb-6">
-              <label className="text-gray-400 text-xs font-medium uppercase tracking-wider mb-2.5 block">
-                Juke notes
-              </label>
-              <p className="text-gray-500 text-xs leading-relaxed">
-                The room lives on Juke. After creating you land on{' '}
-                <span className="text-[#f5a623]">/live/&#123;id&#125;</span> with the keyless
-                iframe. Listening is anonymous; speaking prompts Sign In With Farcaster inside the
-                embed. To create from a non-admin account use{' '}
-                <span className="text-[#f5a623]">/live/create</span> with the team password.
-              </p>
-            </div>
+            <>
+              <div className="mb-5">
+                <label className="text-gray-400 text-xs font-medium uppercase tracking-wider mb-2.5 block">
+                  Juke options
+                </label>
+                <div className="space-y-2">
+                  <JukeToggle
+                    id="juke-record"
+                    label="Record the space"
+                    hint="Drops a Juke recording into /live/recordings + auto-casts the listen-back."
+                    checked={jukeRecord}
+                    disabled={loading}
+                    onChange={setJukeRecord}
+                  />
+                  <JukeToggle
+                    id="juke-allow-agents"
+                    label="Allow agents (ZOE)"
+                    hint="Lets ZOE join silently for note-taking. Activated when ZAO_AUTO_AGENT_JOIN flips on."
+                    checked={jukeAllowAgents}
+                    disabled={loading}
+                    onChange={setJukeAllowAgents}
+                  />
+                  <JukeToggle
+                    id="juke-announce-cast"
+                    label="Announce on Farcaster"
+                    hint="Asks Juke to post a kickoff cast when the space opens."
+                    checked={jukeAnnounceCast}
+                    disabled={loading}
+                    onChange={setJukeAnnounceCast}
+                  />
+                </div>
+              </div>
+              <div className="mb-6">
+                <label className="text-gray-400 text-xs font-medium uppercase tracking-wider mb-2.5 block">
+                  Juke notes
+                </label>
+                <p className="text-gray-500 text-xs leading-relaxed">
+                  The room lives on Juke. After creating you land on{' '}
+                  <span className="text-[#f5a623]">/live/&#123;id&#125;</span> with the keyless
+                  iframe. Listening is anonymous; speaking prompts Sign In With Farcaster inside the
+                  embed. To create from a non-admin account use{' '}
+                  <span className="text-[#f5a623]">/live/create</span> with the team password.
+                </p>
+              </div>
+            </>
           )}
 
           {/* Actions */}
@@ -377,5 +447,49 @@ export function HostRoomModal({ isOpen, onClose, onCreateRoom }: HostRoomModalPr
         </form>
       </div>
     </div>
+  );
+}
+
+/**
+ * Compact toggle row for the Juke options block. Visual style matches the
+ * surrounding modal (border + bg + gold accent on checked).
+ */
+function JukeToggle({
+  id,
+  label,
+  hint,
+  checked,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  hint: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <label
+      htmlFor={id}
+      className={`flex items-start gap-3 px-3 py-2.5 rounded-xl border cursor-pointer transition-colors ${
+        checked
+          ? 'border-[#f5a623]/40 bg-[#f5a623]/[0.06]'
+          : 'border-white/[0.08] bg-[#0a1628] hover:border-white/[0.12]'
+      } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+    >
+      <input
+        id={id}
+        type="checkbox"
+        checked={checked}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="mt-0.5 h-4 w-4 rounded border-white/20 bg-[#0d1b2a] text-[#f5a623] focus:ring-[#f5a623] focus:ring-offset-0"
+      />
+      <span className="flex-1 min-w-0">
+        <span className="block text-sm font-medium text-white">{label}</span>
+        <span className="block text-[11px] text-gray-500 leading-snug mt-0.5">{hint}</span>
+      </span>
+    </label>
   );
 }

--- a/src/lib/spaces/juke-api.test.ts
+++ b/src/lib/spaces/juke-api.test.ts
@@ -108,6 +108,7 @@ describe('createJukeSpace', () => {
       scheduled_at: '2026-06-01T18:00:00.000Z',
       announce_cast: true,
       allow_agents: true,
+      record: false,
     });
   });
 
@@ -122,6 +123,7 @@ describe('createJukeSpace', () => {
       scheduled_at: null,
       announce_cast: false,
       allow_agents: false,
+      record: false,
     });
   });
 

--- a/src/lib/spaces/juke-api.ts
+++ b/src/lib/spaces/juke-api.ts
@@ -46,6 +46,16 @@ export interface CreateJukeSpaceInput {
   announceCast?: boolean;
   /** When true, AI agents are permitted to join the room. */
   allowAgents?: boolean;
+  /**
+   * When true, Juke records the room. The recording.ready webhook fires when
+   * the file lands and `recording_url` populates on the juke_spaces row, which
+   * also drives the auto "Recording up" cast + /live/recordings shelf.
+   * Default OFF on Juke's side per llms.txt; ZAO defaults this ON in the UI
+   * because the recording is what powers the post-live discovery loop.
+   */
+  record?: boolean;
+  /** Optional space description shown inside the Juke embed. */
+  description?: string;
 }
 
 /** A Juke space created through the developer API. */
@@ -125,9 +135,11 @@ export async function createJukeSpace(
   // Translate the camelCase ZAO shape into Juke's documented snake_case body.
   const body = JSON.stringify({
     title: input.title,
+    description: input.description ?? undefined,
     scheduled_at: input.scheduledAt ?? null,
     announce_cast: input.announceCast ?? false,
     allow_agents: input.allowAgents ?? false,
+    record: input.record ?? false,
   });
 
   let response: Response;


### PR DESCRIPTION
## Why

Zaal noticed the Juke create modal exposed Title + Description only. Backend supports schedule/announce/agents but no UI. AND record wasn't wired at all - every space had recording OFF.

## What

- **Default provider = Juke** when no community override
- **Record** field added to API + UI (default ON in UI)
- **Description** plumbed through (was being dropped)
- **3 toggles** under Juke options block:
  - Record the space (default ON)
  - Allow agents - ZOE (default ON)
  - Announce on Farcaster (default OFF)

## Verifies

- 62/62 spaces tests pass
- tsc clean

## UX

Open /spaces → Go Live → Juke tile highlighted by default → title + description + 3 toggles → "Open Juke space". Same friction as before but recording artifact lands every time.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>