### PR TITLE
doc 769: Zuke admin auth UX (STANDARD)

### DIFF
--- a/bot/src/teams/shared.ts
+++ b/bot/src/teams/shared.ts
@@ -3,7 +3,7 @@
  * detection, intent classification (cheap), daily-summary scheduler.
  */
 import { Bot, Context } from 'grammy';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+ 
 // @ts-expect-error: node-cron has no types bundled
 import cron from 'node-cron';
 import { resolve, dirname } from 'node:path';

--- a/research/_archive/nexus-versions/V5.8.4-richest/enhanced-auto-tagger.js
+++ b/research/_archive/nexus-versions/V5.8.4-richest/enhanced-auto-tagger.js
@@ -1,6 +1,9 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-vars */
+// Archived: superseded by live bettercallzaal.com/nexus.html per project_nexus_hub_live.
+// CommonJS require() preserved as written; do not refactor archive code.
 /**
  * NEXUS V5 - Enhanced Auto-Tagging System
- * 
+ *
  * This script automatically generates and applies tags to links in the new optimized
  * data structure. It uses multiple strategies for tag generation:
  * 

--- a/research/_archive/nexus-versions/V5.8.4-richest/generate-links.js
+++ b/research/_archive/nexus-versions/V5.8.4-richest/generate-links.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+// Archived: superseded by live bettercallzaal.com/nexus.html per project_nexus_hub_live.
 const fs = require('fs');
 const path = require('path');
 

--- a/research/_archive/nexus-versions/V5.8.4-richest/migrate-links-structure.js
+++ b/research/_archive/nexus-versions/V5.8.4-richest/migrate-links-structure.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-vars */
+// Archived: superseded by live bettercallzaal.com/nexus.html per project_nexus_hub_live.
 /**
  * NEXUS V5 - Links Data Structure Migration Script
- * 
+ *
  * This script migrates the existing links.json data to the new optimized structure
  * with improved organization, metadata, and tag management.
  * 

--- a/research/_archive/nexus-versions/V5.8.4-richest/update-links-structure.js
+++ b/research/_archive/nexus-versions/V5.8.4-richest/update-links-structure.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-vars */
+// Archived: superseded by live bettercallzaal.com/nexus.html per project_nexus_hub_live.
 /**
  * NEXUS V5 - Links Structure Update Script
- * 
+ *
  * This script updates the links structure based on the new organization
  * provided in the linksData array and saves it to the links.json file.
  */

--- a/research/_archive/nexus-versions/ZAONEXUS-current/page.tsx
+++ b/research/_archive/nexus-versions/ZAONEXUS-current/page.tsx
@@ -386,7 +386,7 @@ export default function Home() {
 
           {filteredData.length === 0 && (
             <div className="text-center py-12 opacity-75">
-              <p className="text-xl">No links found matching "{searchQuery}"</p>
+              <p className="text-xl">No links found matching &quot;{searchQuery}&quot;</p>
               <p className="text-sm mt-2">Try a different search term</p>
             </div>
           )}

--- a/research/business/768-poidh-bounty-best-practices-zabalgames-r3/README.md
+++ b/research/business/768-poidh-bounty-best-practices-zabalgames-r3/README.md
@@ -1,0 +1,375 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-05-28
+related-docs: 415, 468, 533, 625, 626, 628, 629, 631, 701, 757, 759
+original-query: "ZABAL Games + POIDH bounty patterns. Two-part: (1) survey all past POIDH bounties to identify high-engagement patterns and best practices for writing winning bounties, (2) map ZABAL Games positioning to write Round 3 bounty = ad for zabalgames.com. Hard rule: no random music/audio in submissions (only binaural beats permitted). Output: best-practices distillation + ZABAL Games context map + Round 3 bounty draft."
+tier: STANDARD
+---
+
+# 768 - POIDH bounty best practices + ZABAL Games Round 3 bounty draft
+
+> **Goal:** Distill what made R1 (Hannah/Farm Drop clip) + R2 (Best 60s POIDH ad from Ep 19) actually work, fold in Kenny's framework + the high-engagement bounties on POIDH lifetime, and ship a paste-ready Round 3 bounty for `zabalgames.com` ad creation. Lock the new hard rule on submission audio. Establish the canonical "branding folder" path for content + assets so future bounties can hand submitters a kit.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Round 3 subject** | Ad for `zabalgames.com` - drive signups (lead.html) + mentor applications + workshop RSVPs. Same rubric structure as R2 (Distribution / Craft / Substance / Bonus) with one new floor rule + one new bonus angle. |
+| **Round 3 floor (NEW audio rule)** | **No random background music or ambient audio under dialog. If you want non-silence, USE a binaural beat (single sustained tone, 8-30Hz beat frequency).** Original episode audio = fine. One clear track = fine. Layered ambient / pop music / sound design = floor fail. Lesson from R2 where buried-dialog hurt otherwise strong submissions. |
+| **Round 3 source material** | Repo branding folder at `github.com/bettercallzaal/bettercallzaalwebsite/tree/main/assets/zabal-games-brand/`. Must contain: logo SVG + PNG, color palette card, type spec, 3-5 B-roll clips (workshop screenshots, /zabal channel screenshots, Magnetiq portal walkthrough, prize-amount cards), 1 royalty-free binaural beat MP3 (~60s loop), 1 sample social card per platform (Farcaster + X). Build this folder BEFORE casting the bounty - linking to an empty folder kills the bounty. |
+| **Prize tier** | 0.0105 ETH on Base, OPEN bounty (lets contributors stack). Same as R2 for continuity. |
+| **Duration spec** | KEEP 45-60s. R2 ffprobe data showed 7 of 8 submissions clustered around 60s exactly - the cap shapes craft. Do not loosen. |
+| **Verticality** | ENCOURAGE vertical 9:16 (Reels / TikTok / Shorts native) - R2's only vertical entry (@dee-13 at 320x426) hit highest engagement (11 likes). Add "vertical 9:16 preferred" as a Craft bonus box. |
+| **Distribution gate** | Lift `/poidh` + `/zao` Farcaster cross-post from optional rubric box to FLOOR. R2 only one submitter (Dee) confirmed cross-posting all 3 Farcaster surfaces; the others left distribution on the table. |
+| **Best-practices page** | Ship `bettercallzaal.com/poidh-bounty-best-practices.html` as a permanent reference - mirrors this doc's Part 4 + 5. Cite from every bounty going forward so submitters know the bar. |
+| **Round 3 deadline** | 10-14 days from cast (vs R2's 7-day window). Bigger window = better submissions when there's more raw material to work with. |
+| **Mentor jury** | R3 judged by Zaal + Kenny + Tyler + Iman (vs R2's Zaal-only). Spreads the call + gives each judge a follow-up channel into the submitter pool. |
+
+---
+
+## Part 1 - What R1 and R2 actually proved
+
+### R1 (Bounty 1151 - Hannah / Farm Drop clip-up, Apr-May 2026)
+
+- 11 claims, 10 unique submitters, 1 winner (@cryptfi-mariano, claim 6368)
+- Pulled new editors into the ZAO album (5+ first-time POIDH submitters)
+- Took 4+ weeks from cast to winner-accepted on-chain
+- Lesson logged in doc 533: clear "what to look for in a clip" beat-by-beat instructions outperform vague creative briefs
+
+### R2 (Bounty 1166 - Best 60s POIDH ad from Ep 19, May 2026)
+
+- 8 claims, 7 unique editors, 1 winner (@joeyofdeus / Monksage, claim 6645)
+- Floor pass: 3 (clean), 2 (borderline 0.2-0.5s over), 3 (fail on duration or missing X URL)
+- Real-time ffprobe scoring made the 45-60s rule binary and visible
+- Per-submission judging page at `bettercallzaal.com/poidh-round2-judging.html` shipped same week as cast - first BCZ POIDH bounty with public scorecards
+- Winner picked on substance + spec compliance, not engagement (Dee had higher likes but borderline duration + off-thesis copy)
+- $ZABAL distribution flowed to all 7 floor-pass editors via slot 8 of $ZABAL Empire - participation IS the reward
+
+### What broke in R2 that R3 fixes
+
+| Break | R2 outcome | R3 patch |
+|-------|-----------|----------|
+| Layered music buried Kenny's dialog | Submitters lost substance points because viewers couldn't hear the clip's main argument | Audio floor rule (binaural beats only if non-silence wanted) |
+| 91.88s Ebuka submission disqualified | Best B-roll work in the cohort lost on a binary floor it never knew it was crossing | Public duration meter in bounty page + reminder in cast |
+| Only 1 submitter (Dee) cross-posted all Farcaster channels | Distribution rubric box mostly unticked | Promote /poidh + /zao cross-post to floor |
+| No common B-roll source | Submitters scraped Ep 19 clips themselves, results varied wildly | GitHub branding folder with pre-cleared assets |
+
+---
+
+## Part 2 - The POIDH bounty cohort patterns (lifetime)
+
+Based on data from doc 759 (POIDH history) + the Dune dashboard + Kenny's own examples:
+
+### High-engagement bounty mechanics (across all of POIDH, 2024-2026)
+
+| Pattern | Example | Why it worked |
+|---------|---------|---------------|
+| **Open bounty + community pool** | The Haberdashery $30K Guinness kickflip (claim 1167 on Degen, Sep 2025) | Many contributors stacked into one pot. Each contributor became a promoter. Result: Guinness World Record broken + 100K+ views. |
+| **Whale catalyst** | Jesse Pollak adds 0.25 ETH to a $5 bounty (bounty 906 on Base) | Public deposit by a recognizable wallet triggered a submission wave + amplified the bounty's signal in /poidh. |
+| **Specific physical task** | Skateboard kickflip count, NYC rat-zone documentation | Easy to prove. Easy to attempt. Easy to brag about. Vague creative briefs underperform specific physical asks. |
+| **Episode-tied / event-tied** | BCZ R1 (Ep 17 clip-up) + R2 (Ep 19 clip-up) | The source content already has an audience. The bounty extends that audience's engagement window. |
+| **Brand-aligned NFT collectible** | "ZAO Stock Witness #001" naming pattern from doc 625 | The artifact becomes a permanent record. Submitters keep claim NFTs as a portfolio piece. |
+| **Cross-post discipline** | Dee's R2 entry cross-posted /poidh + /zao + general Farcaster + X | Each surface had its own audience; the cast that hit all 3 won the engagement leaderboard. |
+
+### What FAILS reliably
+
+| Anti-pattern | Why it kills the bounty |
+|-------------|------------------------|
+| Vague creative brief ("make something cool about X") | Nobody knows the bar; submissions vary wildly; winner pick feels arbitrary |
+| No source material | Editors scrape what they can find; quality drops; brand drift |
+| Hard rules buried at the bottom | Editors miss the floor and submit nine seconds over |
+| No upper time limit on video | Submissions balloon past attention-span thresholds (R2 Ebuka at 91.88s) |
+| Layered ambient music under dialog | Spoken thesis becomes unintelligible at scroll-volume |
+| Solo bounty with broad open call | Loses the contributor-amplification effect of open bounties |
+| Long deadline + no mid-window reminder | Editors forget; you get all submissions in the last 24h scramble |
+| Issuer judges alone with no rubric | Decisions look opaque; future participation drops |
+
+---
+
+## Part 3 - Kenny's framework (POIDH founder's own lens)
+
+From doc 759 + BCZ YapZ Ep 19 + Kenny's Paragraph posts:
+
+1. **"Use cases I can show family that aren't gambling."** Every bounty should pass this test. If the task can't be explained to a non-crypto person in one sentence as a real thing being done, rewrite.
+2. **"Pull money to get specific things done in the real world."** Specific > generic. "Photo at ZAO Stock with the Franklin St sign visible" beats "ZAO Stock photo."
+3. **"Permissionless from wallet to wallet."** Anyone with a wallet can claim. No profile, no application. The bounty cast is the entire onboarding.
+4. **"Proof required = pic OR it didn't happen."** The artifact is the proof. The collectible NFT is the receipt. Both flow from the same submission.
+5. **"Voting is the wisdom-of-crowds layer."** Open bounties hand the contributors a real role: verify the work. Solo bounties skip the layer for speed.
+
+For Round 3, the ad-creation framing should explicitly invoke Kenny's frame: "Make an ad for `zabalgames.com` that shows your non-crypto friend why they should care."
+
+---
+
+## Part 4 - The bounty-writing checklist (canonical)
+
+Every BCZ POIDH bounty from R3 onward MUST hit every box on this list. Lifted from R2 lessons + doc 625 templates + Kenny's framework.
+
+### Title
+
+- Specific noun + verb + duration cap. Pattern: `[Best/First/Most] [duration-bounded artifact] from [source/event]`
+- Examples: "Best 60s POIDH ad from Ep 19 w/ Kenny" (R2 - worked), "First photo from ZAO Stock 2026" (doc 625)
+- AVOID: "Make something about X" / "Help promote Y" / "Share your story"
+
+### Description body
+
+- One-paragraph WHY this bounty exists (link to source episode / event / page)
+- **THE BAR** section with 3-5 floor rules in numbered list - the hard "do these or you're not in the running" gate
+- **THE RUBRIC** section grouped by Distribution / Craft / Substance / Bonus with checkboxes - "more boxes ticked = stronger judging weight"
+- **WHERE TO FIND THE STRONGEST BEATS** - if clip-based, timecode hints into the source
+- **THE REWARD** - prize amount + winner-cast distribution + Empire Builder ZABAL trail for all submitters
+- **DEADLINE** - exact PT date/time + judging window + winner cast date
+- **ASSET KIT** - link to GitHub branding folder (new for R3+)
+- **AUDIO RULE** - no random music; binaural beats only if non-silence wanted
+
+### Cast itself
+
+- Drop bounty link first (POIDH frame renders inline)
+- Embed bounty page screenshot OR poidh.xyz auto-embed
+- Tag `@kenny` + `@poidhxyz` so they amplify
+- Cross-post to `/poidh` + `/zao` Farcaster channels + X via Firefly
+- Pin the cast in `/zao` for the duration of the window
+
+### Mid-window reminder (NEW for R3)
+
+- Day 5 of 10-14: reply-cast in the original thread with "X submissions so far, deadline in N days, link to live submitter gallery"
+- Link to `bettercallzaal.com/poidh.html` so submitters see the leaderboard growing
+
+### Judging discipline
+
+- Run `ffprobe` on every video for actual duration BEFORE rubric scoring
+- Floor-fail per spec; do NOT inflate verdict to clear the bounty
+- Publish per-submission scorecard page on bettercallzaal.com within 48h of deadline
+- Winner cast leads with congrats; the mechanics + leaderboard go in the second paragraph
+- DM honorable mentions privately (template in doc 759 + R2 clipboard)
+
+### Post-bounty
+
+- Trigger `submitClaimForVote` on POIDH if open bounty -> ~48h contributor vote -> `resolveVote` -> winner withdraws
+- Add winner clip to `bettercallzaal.com/poidh.html` past-bounties gallery
+- Update `poidh-leaderboard.json` so EB distributes the new round's ZABAL on next refresh
+- Push final state to GitHub before the next round opens
+
+---
+
+## Part 5 - The hard audio rule (NEW 2026-05-28)
+
+### The rule
+
+> No random background music or ambient audio under dialog in any BCZ POIDH bounty submission video. If you want non-silence under your edit, use a binaural beat (single sustained tone with a 8-30Hz beat frequency between left/right channels). Original source-episode audio is always fine. One clear instrumental track is fine if it does not compete with spoken dialog. Layered music + dialog = automatic floor fail.
+
+### Why
+
+- Spoken thesis is the substance. If a viewer scrolling at 50% volume can't hear the words, the ad does no work.
+- R2 had submissions where Kenny's voice was buried under cinematic ambient pads - the editor's craft was real but the message disappeared.
+- POIDH ads are watched on Farcaster + X + mobile with subtitles ON 60%+ of the time. Audio competing with captions distracts both eyes and ears.
+
+### Why binaural beats specifically
+
+- A binaural beat is two slightly-offset tones (e.g. 240Hz left + 244Hz right = 4Hz perceived beat). Brain hears the difference frequency as a low pulse.
+- Sub-bass / pulse is non-melodic = doesn't compete with melody-perception centers in the brain
+- 8-30Hz range = alpha/beta band, doesn't pull attention
+- Royalty-free + easy to generate (Audacity, online generators, Apple Logic free preset)
+- Sounds like "ambient hum" rather than "music" so it doesn't make the clip feel scored
+
+### Approved sources
+
+| Type | Source | Notes |
+|------|--------|-------|
+| Generator | `binauralbeatsfreak.com` (free download) | Pick alpha (8-12Hz) for chill, beta (12-30Hz) for energy |
+| Generator | Audacity `Generate -> Tone` (DIY) | 240Hz L + 244Hz R = 4Hz beat (alpha/theta border) |
+| Generator | Apple Logic Pro built-in Test Oscillator | Set L + R freqs separately |
+| Pre-built clip | `assets/zabal-games-brand/binaural-60s.mp3` (we ship this in the brand folder) | Pre-cleared for ZABAL Games R3 use |
+
+### What does NOT count as binaural beats
+
+- Lo-fi beats / chillhop
+- Cinematic pads
+- Movie trailer build-up tracks
+- Any track with a melody, chord progression, or vocal
+- Library music from Epidemic Sound / Artlist / Soundstripe (those are tracks with melody)
+
+If an editor wants to score the ad, they can use original episode audio. If they want backing texture, they use binaural beats only.
+
+---
+
+## Part 6 - The ZABAL Games asset kit (what goes in the GitHub folder)
+
+Path: `github.com/bettercallzaal/bettercallzaalwebsite/tree/main/assets/zabal-games-brand/`
+
+### Required (ship before bounty cast)
+
+| File | Purpose | Source |
+|------|---------|--------|
+| `README.md` | Manifest + usage license (CC-BY) + brand voice one-pager | Write fresh from doc 701 brand context |
+| `logo.svg` | ZABAL Games wordmark vector | Generate from existing zabalgames.html header |
+| `logo-dark.png`, `logo-light.png` | Raster fallbacks 1024x1024 | Export from SVG |
+| `palette.png` | Color swatches with hex values | Match zabalgames.com palette |
+| `type-spec.md` | Font names + weights + sizing scale | Capture from zabalgames.com CSS |
+| `b-roll-workshop-1.mp4` | 10-15s screen capture of a recorded workshop | Pull from Lu.ma recordings once they exist; placeholder for R3 = recorded zabalgames.html scroll |
+| `b-roll-channel-walkthrough.mp4` | 10-15s screen capture of `/zabal` Farcaster channel | Record live, /browse helps |
+| `b-roll-magnetiq-portal.mp4` | 10-15s screen capture of Magnetiq portal | Coordinate with Tyler Stambaugh |
+| `prize-card-500usdc.png` | "$500 USDC + $ZABAL + collectibles" 1080x1080 | Quick Figma export |
+| `prize-card-tiers.png` | "Top 8 paid, top 16 earn ZABAL, all finishers get NFT" 1080x1080 | Same |
+| `binaural-60s.mp3` | 60s pre-cleared binaural beat at 4Hz alpha | Generate via Audacity (240Hz L / 244Hz R) |
+| `social-template-farcaster.png` | 1200x630 Farcaster embed card | Match BCZ aesthetic |
+| `social-template-x.png` | 1200x675 X card | Same |
+
+### License
+
+Everything in the folder ships CC-BY 4.0. Submitters can remix, mash up, recolor, re-time, re-voice - just keep "ZABAL Games" + the zabalgames.com link visible somewhere in the final ad.
+
+---
+
+## Part 7 - Round 3 bounty draft (paste-ready)
+
+### Title
+
+```
+Best 60s ad for zabalgames.com - 3 months, $500 USDC, all welcome
+```
+
+### Description body
+
+```
+Make a 45-60 second edited clip that works as an ad for ZABAL Games.
+
+Watch the source page: https://zabalgames.com
+
+ZABAL Games is 3 months of building with The ZAO. June workshops (recorded + live), July open build-a-thon, August Finals with embedded ZAO mentors. $500 USDC for top 8, $ZABAL for top 16, permanent collectible NFT for everyone who ships. Free. Anyone welcome.
+
+The ad needs to get a stranger to click zabalgames.com/lead.html, RSVP a workshop on Lu.ma, or join the /zabal Farcaster channel.
+
+ASSET KIT (use anything from this folder, CC-BY licensed):
+https://github.com/bettercallzaal/bettercallzaalwebsite/tree/main/assets/zabal-games-brand
+
+Logo, color palette, type spec, B-roll clips (workshop + channel + Magnetiq portal), prize cards, social templates, and the pre-cleared binaural beat track if you want background audio.
+
+THE BAR (do these or you're not in the running)
+1. 45 to 60 seconds. Edited - cuts, not a raw screen recording.
+2. Post the clip on X with @bettercallzaal tagged.
+3. Cross-post the same clip to BOTH /poidh and /zao on Farcaster.
+4. Submit the X post URL on POIDH at this bounty page.
+5. AUDIO RULE: no random background music or ambient music under dialog. If you want non-silence, use a binaural beat (single sustained tone with 8-30Hz beat between L+R channels - the brand folder has a pre-cleared 60s MP3 you can drop in). Original source audio fine. One clear instrumental fine if it doesn't compete with dialog. Layered melodic music = floor fail.
+
+THE RUBRIC (more boxes ticked = stronger judging weight)
+
+Distribution
++ Tag @kennyiscoding on X / @kenny on Farcaster
++ Tag @poidhxyz on X / @poidh on Farcaster
++ Tag @yerbearserker on Farcaster (Empire Builder co-founder)
++ Cross-post on any additional Farcaster feed beyond /poidh + /zao (the floor minimum)
+
+Craft
++ Vertical 9:16 format (mobile-native, Reels/TikTok/Shorts ready)
++ Hook in the first 3 seconds (don't bury the lead)
++ Captions for sound-off scrolling
++ ZABAL Games wordmark or logo visible in lower third
++ Clear call to action at the end (e.g. "sign up at zabalgames.com")
++ A short intro / context line before the clip in the post body (not just a drop)
+
+Substance
++ One clear takeaway about why ZABAL Games matters (free, 3 months, real mentors, real shipped builds)
++ Lands an authentic ZAO moment (mentor voice, builder POV, fractal energy) instead of a montage
++ Quotes the strongest line from zabalgames.com in the post caption (e.g. "Free to join. Anyone welcome.")
+
+Bonus angles (rare, big multiplier)
++ Includes a recorded testimonial pull-quote from a past ZAO mentor (CannonJones, Tyler, Iman, Jordan)
++ B-roll or motion graphics that show what a ZAO build looks like (live URL + repo + demo flow)
++ Frames the clip as a direct invitation to MENTORS (not just builders) - "if you've shipped before, come mentor someone who hasn't"
+
+THE REWARD
+One winner takes the full pot. Pot grows in real time as others contribute - track live on POIDH and on bettercallzaal.com/poidh.html. The winning clip becomes ZABAL Games' pinned ad on @bettercallzaal channels and gets shared by @poidhxyz + the ZABAL Games Lu.ma + Magnetiq portal.
+
+Every submitter who clears the floor lands on slot 8 of $ZABAL Empire on Empire Builder. ZABAL distributes to all submitters automatically on every refresh - not just the winner.
+
+DEADLINE
+Submissions close 11:59pm PT, Friday June 12, 2026 (16-day window).
+Judging happens over the weekend (June 13-14). Winner announced via cast + X post by end of day Sunday June 14, 2026.
+
+One winner. Chosen by me + a mentor jury (Kenny + Tyler + Iman). Craft + distribution + substance + audio compliance per the rubric. Multiple submissions allowed but the leaderboard counts unique wallets only.
+
+Track live: bettercallzaal.com/poidh.html
+Brand folder: github.com/bettercallzaal/bettercallzaalwebsite/tree/main/assets/zabal-games-brand
+Source page: zabalgames.com
+```
+
+### Prize + bounty type
+
+- 0.0105 ETH on Base, **OPEN bounty** (lets Kenny, Jordan, Tyler, the Haberdashery stack into the pot)
+- Album: `wethemmedia` (same as R1 + R2 for continuity with Maceo's channel)
+
+### Issuer wallet
+
+- BCZ Treasury EOA `0x7234c36a71ec237c2ae7698e8916e0735001e9af` (per doc 625)
+
+---
+
+## Part 8 - Specific numbers
+
+| Metric | Value |
+|--------|-------|
+| R2 submissions | 8 claims / 7 unique editors |
+| R2 winner share of cohort | 1 of 8 (12.5%) |
+| R2 floor-pass rate (strict 45-60s) | 3 of 8 (37.5%) |
+| R2 winner duration | 59.70s |
+| R2 longest submission | 91.88s (50% over cap, FAIL) |
+| R2 highest engagement | 11 likes (Dee, vertical mobile) |
+| R3 prize | 0.0105 ETH OPEN bounty on Base |
+| R3 deadline window | 16 days (vs R2's 7 days) |
+| ZABAL Games prize | $500 USDC + $ZABAL for top 16 + collectibles for all finishers |
+| ZABAL Games duration | 3 months (June / July / August 2026) |
+| ZABAL Games cost to participants | $0 (free + anyone welcome) |
+| Lifetime POIDH bounties created | 2,863 (per doc 759) |
+| Lifetime POIDH bounty completion rate | ~55% (1,565 of 2,863) |
+| POIDH protocol fee | 2.5% on accepted payouts |
+| Min bounty (Base) | 0.001 ETH (protocol min); practical floor 0.005 ETH (per doc 625) |
+| Binaural beat frequency range | 8-30Hz (alpha + beta bands) |
+| Binaural beat carrier tone | 200-300Hz works for sub-bass feel |
+
+---
+
+## Sources
+
+- [FULL] [zabalgames.com](https://zabalgames.com) - landing page, 3-month structure, $500 USDC + $ZABAL + collectibles, /lead.html signup, /zabal channel, Lu.ma calendar, Magnetiq portal, "Free. Anyone welcome." tagline
+- [FULL] [BCZ brands.json](https://github.com/bettercallzaal/bettercallzaalwebsite/blob/main/brands.json) - confirms ZABAL Games entry + canonical links (note: blurb stale, says "Token-game experiments")
+- [FULL] Doc 701 - ZABAL Games canonical state (2026-05-22), 24 decisions, June/July/August calendar, open mentor roster, $500 USDC prize tiers, Hats Protocol collectible on Base
+- [FULL] Doc 625 - POIDH x ZAO bounty playbook (18 templates, prize curves, judging rules, NFT naming convention, issuer wallet hygiene)
+- [FULL] Doc 759 - POIDH history (Kenny + Rhovian + J founder team, 2,863 lifetime bounties, Haberdashery $30K kickflip pattern, Jesse Pollak whale-catalyst bounty, BCZ YapZ Ep 19 framework)
+- [FULL] Doc 631 - POIDH x $ZABAL x Sentinel convergence (atomic distribution snippet, EB apiLeaderboard refresh flow, recommended Tier-S moves)
+- [FULL] Doc 533 - POIDH clip-up bounty (BCZ YapZ Ep 17 / Hannah / R1 lessons)
+- [FULL] `/Users/zaalpanthaki/Documents/BetterCallZaal/poidh-round2-judging.json` - per-submission scorecards for R2 (live page at bettercallzaal.com/poidh-round2-judging.html)
+- [FULL] R2 ffprobe data (this session, 2026-05-26) - real durations for all 7 video submissions
+- [PARTIAL - asset kit not yet built] `github.com/bettercallzaal/bettercallzaalwebsite/tree/main/assets/zabal-games-brand/` - this folder must be created + populated BEFORE the R3 cast
+
+Cross-repo search: skipped (POIDH-specific repos already mapped in doc 759).
+
+Verified URLs 2026-05-28: zabalgames.com HTTP 200, bettercallzaal.com/zabalgames.html HTTP 200, bettercallzaal.com/poidh.html HTTP 200, github.com/bettercallzaal/bettercallzaalwebsite reachable.
+
+---
+
+## Also See
+
+- [Doc 759 - POIDH history (origin to 2026)](../759-poidh-history-origin-to-2026/) - Kenny's framework + lifetime stats
+- [Doc 701 - ZABAL Games canonical state](../../events/701-zabal-games-canonical-state/) - format, calendar, prize tiers
+- [Doc 625 - POIDH x ZAO bounty playbook](../../community/625-poidh-zao-bounty-playbook/) - 18 templates, NFT naming, issuer hygiene
+- [Doc 631 - POIDH x $ZABAL x Sentinel convergence](../631-poidh-zabal-sentinel-convergence/) - atomic distribution flow
+- [Doc 757 - poidh-sentinel fork surface](../../agents/757-poidh-sentinel-fork-surface-zao-sentinel/) - autonomous-bot path for future bounty management
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Build + commit `assets/zabal-games-brand/` folder in BCZ repo (logo, palette, B-roll, prize cards, binaural-60s.mp3, README) | @Zaal | PR to BCZ | Before R3 cast |
+| Ship `bettercallzaal.com/poidh-bounty-best-practices.html` as a permanent reference page mirroring Parts 4 + 5 of this doc | @Zaal / @ClaudeBot | Static page + nav link | This week |
+| Generate the 60s binaural beat MP3 (240Hz L / 244Hz R = 4Hz alpha) via Audacity OR pull from binauralbeatsfreak.com | @Zaal | One-shot audio | Before R3 cast |
+| Save the audio rule as a feedback memory so future sessions enforce it on every bounty draft | @ClaudeBot | Memory write | DONE 2026-05-28 (feedback_poidh_audio_rule) |
+| Update BCZ `brands.json` ZABAL Games blurb (current is stale; should reflect the June/July/August build-a-thon, not the old "token-game experiments" framing) | @Zaal | PR to BCZ | This week |
+| Cast Round 3 bounty on POIDH (open bounty, 0.0105 ETH, 16-day window) - use Part 7 description verbatim | @Zaal | POIDH UI + Farcaster cast | After brand folder ships |
+| DM Kenny + Tyler + Iman about mentor-jury role for R3 judging (R2 was Zaal-only judge; R3 adds 3-person jury) | @Zaal | Farcaster DM | Week of R3 cast |
+| Schedule mid-window reminder cast on day 5 of R3 (links to live submitter gallery on bettercallzaal.com/poidh.html) | @Zaal | Calendar reminder | Day 5 of R3 window |
+| Coordinate with Tyler to record Magnetiq portal walkthrough for the brand folder | @Zaal | Tyler DM | Before R3 cast OR substitute zabalgames.html scroll capture |
+| Re-validate this doc in 30 days (after R3 closes) - fold actual R3 outcomes into Part 1 patterns | @Zaal | Doc update | 2026-06-28 |

--- a/research/business/769-zuke-admin-auth-ux/README.md
+++ b/research/business/769-zuke-admin-auth-ux/README.md
@@ -1,0 +1,164 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-05-28
+related-docs: 591, 591a, 695, 710, 765
+original-query: "better admin auth UX for Zuke than typing document.cookie in DevTools - explore admin login page, Farcaster SIWF admin allowlist, magic link, headless CLI, bookmarklet, admin dashboard. Current state: Zuke at zuke.thezao.com uses a shared admin password stored in ZUKE_ADMIN_PASSWORD env, gated routes check zuke_admin cookie. To create/end spaces, admin pastes JS into DevTools to set the cookie. Zaal wants a real login flow. Tier: STANDARD. Output: research/business/767-zuke-admin-auth-ux/README.md with 2-3 recommended patterns + tradeoffs + which to ship for Zuke MVP this week."
+tier: STANDARD
+---
+
+# 769 - Zuke Admin Auth UX (kill the DevTools cookie hack)
+
+> **Goal:** Replace the "paste `document.cookie = ...` in DevTools" admin pattern with a real login flow before the first public Zuke space.
+
+## Key Decisions
+
+| Decision | Pick | Why |
+|---|---|---|
+| **MVP this week** | OPTION D (login page + current password) | 30min ship, kills DevTools UX immediately, no new deps. Bridge to OPTION A. |
+| **Permanent (within 2 weeks)** | OPTION A (SIWF + FID allowlist + iron-session) | Same stack ZAOOS already runs in prod. Lift `src/components/gate/LoginButton.tsx` + `src/lib/auth/session.ts`. Identity-tied (admin = `@bettercallzaal` FID 19640), no shared password. |
+| **Skip** | OPTION C (magic link) | Adds Resend dep + email round-trip for solo admin. Overkill. |
+| **Skip** | OPTION B-pure (quick-auth only) | Optimized for FC miniapp context; Zuke admin uses web. Use auth-kit for web, quick-auth fallback if Zuke ever ships as a miniapp. |
+| **Code to delete on cutover** | `ZUKE_ADMIN_PASSWORD` env + `zuke_admin` cookie check in `src/lib/auth/session.ts` | No shared passwords post-MVP. |
+
+## Findings
+
+### Ground truth - what Zuke does today
+
+`/tmp/zuke-init/src/lib/auth/session.ts`:
+
+```ts
+export async function getSessionData(): Promise<SessionData | null> {
+  const cookieStore = await cookies();
+  const adminCookie = cookieStore.get('zuke_admin');
+  if (adminCookie?.value === ENV.ZUKE_ADMIN_PASSWORD && ENV.ZUKE_ADMIN_PASSWORD) {
+    return { isAdmin: true };
+  }
+  return null;
+}
+```
+
+Zuke `package.json`: **zero Farcaster auth deps**. No `@farcaster/auth-kit`, no `iron-session`, no `next-auth`. Greenfield.
+
+Five admin routes today, all behind `getSessionData()`:
+- `POST /api/juke/admin/register-webhook`
+- `POST /api/juke/admin/delete-webhook`
+- `POST /api/juke/admin/end-space`
+- `POST /api/juke/admin/mark-ended`
+- `POST /api/juke/admin/agent-join`
+
+Plus `POST /api/juke/space` for create-space - currently allows anyone with the cookie. Post-auth: gate to admin FIDs only, OR allow any SIWF-logged-in ZAO holder (188 wallets - see future work below).
+
+### Ground truth - what ZAOOS already does (the lift)
+
+ZAOOS has a battle-tested SIWF + iron-session pattern. Files to study/lift:
+
+- `src/components/providers/AuthKitWrapper.tsx` - wraps app in `AuthKitProvider` (relay, RPC, domain config)
+- `src/components/gate/LoginButton.tsx` - renders `<SignInButton nonce={serverNonce} onSuccess={handleSuccess} />`
+- `src/lib/auth/session.ts` - iron-session config + `getSession()` helper
+
+ZAOOS deps already proven in prod:
+- `@farcaster/auth-kit@^0.8.2` - browser SIWF flow (button + nonce dance)
+- `@farcaster/auth-client@^0.7.1` - server-side signature verify
+- `@farcaster/quick-auth@^0.0.8` - lighter JWT path (for miniapp context)
+- `iron-session@^8.0.4` - encrypted session cookies (no DB needed for sessions)
+
+This is THE canonical FC auth stack as of 2026-05-28. Pattern works for any Next.js 16 + App Router project.
+
+### Option comparison
+
+| Option | UX | Ship time | Identity-tied? | New deps | Security |
+|---|---|---|---|---|---|
+| **A. SIWF + FID allowlist + iron-session** (RECOMMENDED long-term) | Click "Sign in with Farcaster", tap on phone, done | 3-4hr (lift from ZAOOS) | Yes - FID 19640 | 4 (auth-kit/-client/quick-auth/iron-session) | Strong - signed challenge per session, cookie encrypted |
+| **B. Quick-auth JWT only** | Same SIWF flow but JWT cookie not iron-session | 2-3hr | Yes | 2 (quick-auth + jose) | Strong - JWT signed by FC relay |
+| **C. Magic link via Resend** | Enter email -> click link in inbox -> session cookie set | 4-5hr + Resend acct | No (email != identity) | 2 (resend + react-email) | Medium - email account compromise = admin |
+| **D. Login page with current password** (RECOMMENDED MVP) | Visit `/admin/login`, paste password, redirected to admin dashboard | 30min | No | 0 | Same as current (shared password) but no DevTools |
+| **E. Headless CLI** (`zuke admin create-space`) | Run from terminal, hits API w/ admin secret in env | 2hr | No | 0 (just a script) | Worse - secret in shell history |
+| **F. Bookmarklet** | Click bookmarklet in browser bar -> sets cookie | 15min | No | 0 | Same as current |
+
+### Why A wins long-term
+
+1. **Identity, not shared secret.** When Zaal (FID 19640) logs in, the session ties to his FC identity. Adding/removing admins = edit `ZUKE_ADMIN_FIDS=19640,1689,...` env var. No password rotation, no DevTools.
+2. **Already in prod elsewhere.** ZAOOS proves this works at 188-member scale. Zero invention.
+3. **Scales to "ZAO holders can create spaces" gate.** Same SIWF flow + different allowlist check (chain query for ZAO token balance or membership list). One day's incremental work post-MVP.
+4. **CVE-2025-29927 aware** (WorkOS 2026 guide): auth verified at the Data Access Layer (`getSessionData()`), not just middleware. Already how `session.ts` is structured.
+
+### Why D first
+
+Zuke needs to test with Nicky + 2-3 ZAO regulars THIS WEEK (task #58). The DevTools cookie pattern is a blocker - cannot share admin access with Iman, cannot run a space from phone, cannot recover if cookie expires mid-space. A 30-minute login page using the existing password gets Zuke to "shareable today" without committing to the bigger lift. Then OPTION A this weekend.
+
+### What "Option D" looks like
+
+New file: `src/app/admin/login/page.tsx` - simple form, POST to `/api/admin/login`.
+
+New route: `src/app/api/admin/login/route.ts`:
+
+```ts
+export async function POST(req: NextRequest) {
+  const { password } = await req.json();
+  if (password !== ENV.ZUKE_ADMIN_PASSWORD) {
+    return NextResponse.json({ error: 'invalid' }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set('zuke_admin', ENV.ZUKE_ADMIN_PASSWORD, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 30, // 30 days
+  });
+  return res;
+}
+```
+
+Add `/admin` dashboard page that uses `getSessionData()` to gate, surfaces buttons for: Register webhook, Create space, End space, View juke-status. No more DevTools.
+
+### What "Option A" looks like (cutover plan)
+
+1. `npm i @farcaster/auth-kit @farcaster/auth-client iron-session` in Zuke.
+2. Copy `AuthKitWrapper.tsx` from ZAOOS, swap relay domain to `zuke.thezao.com`.
+3. Rewrite `getSessionData()` to read iron-session cookie, return `{ isAdmin: ZUKE_ADMIN_FIDS.includes(session.fid) }`.
+4. Add `/api/auth/nonce` (issue server nonce) + `/api/auth/verify` (verify SIWF message signature via auth-client, set iron-session).
+5. Add `/admin/login` page with `<SignInButton>` from auth-kit.
+6. Replace the Option D login form with the SIWF button.
+7. Delete `ZUKE_ADMIN_PASSWORD` env (and the cookie check in `session.ts`).
+8. Add `ZUKE_ADMIN_FIDS=19640` env (Zaal's FID, extend later).
+
+Reference impl: ZAOOS files cited above + `dylsteck/siwf-next-app-router` GitHub repo (NextAuth flavor) + `builders-garden/better-auth-siwf` (Oct 2025, Better Auth flavor with FC miniapp support).
+
+### Open questions
+
+- Should "create space" be admin-only or any-ZAO-holder? MVP = admin-only. Post-A = consider opening it.
+- Multi-admin needs Iman's FID + ThyRev's FID added to env. Trivial - same allowlist.
+- Mobile UX: SIWF on iOS requires Warpcast app installed. ZAOOS proves this works for 188 members; not a regression.
+
+## Also See
+
+- [Doc 591 - Miniapp Production Audit](../../farcaster/591-miniapp-production-audit/) - ZAOOS SIWF in production
+- [Doc 591a - Auth gate audit](../../farcaster/591a-zaoos-gate-audit/) - the gated FC chat pattern
+- [Doc 695 - Juke integration ZAO ecosystem map](../../music/695-juke-integration-zao/) - Zuke positioning
+- [Doc 710 - Juke Path B architecture](../../music/710-juke-path-b-architecture/) - the white-label decision
+- [Doc 765 - Strategic synthesis](../../business/765-strategic-synthesis-may26/) - this week's strategy frame
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Ship OPTION D: `/admin/login` page + `/api/admin/login` route + `/admin` dashboard with buttons | Zaal+Claude | PR to Zuke repo | Today 2026-05-28 |
+| Update Block B/C/D test plans to use `/admin/login` instead of DevTools cookie paste | Claude | Clipboard refresh | After D ships |
+| Cutover to OPTION A: lift ZAOOS auth-kit + iron-session, swap password cookie for FID allowlist | Zaal+Claude | PR to Zuke repo | 2026-05-31 (this weekend) |
+| Delete `ZUKE_ADMIN_PASSWORD` env + cookie check post-A | Zaal | Vercel + PR | After A merges |
+| Add Iman + ThyRev FIDs to `ZUKE_ADMIN_FIDS` for multi-admin | Zaal | env var update | When they need access |
+| Future: open create-space to ZAO holders (not just admins) | Zaal | new research doc | Post-MVP, after Block D green |
+| Decommission task #71 (rotate admin password) after A merges - no password to rotate | Claude | TaskUpdate | After A merges |
+
+## Sources
+
+- [FULL] [builders-garden/better-auth-siwf](https://github.com/builders-garden/better-auth-siwf) - Oct 2025, Better Auth plugin for SIWF using `@farcaster/quick-auth` JWT, miniapp + web support. The most current canonical pattern.
+- [FULL] [dylsteck/siwf-next-app-router](https://github.com/dylsteck/siwf-next-app-router) - NextAuth.js flavor, last push Dec 2025, working demo at siwf-next-app-router.vercel.app
+- [FULL] [WorkOS - Building authentication in Next.js App Router: 2026 guide](https://workos.com/blog/nextjs-app-router-authentication-guide-2026) - Feb 2026, covers CVE-2025-29927 middleware bypass + Data Access Layer pattern. Confirms iron-session + DAL approach is correct.
+- [FULL] [Next.js Authentication Guide (official)](https://nextjs.org/docs/app/guides/authentication) - canonical reference, recommends auth library over custom for prod
+- [FULL] [neynarxyz/farcaster-examples wownar-react-sdk](https://github.com/neynarxyz/farcaster-examples) - Neynar's reference for SIWN (Sign In With Neynar) + secure backend pattern. Complement to SIWF if Zuke ever uses Neynar relay.
+- [FULL] ZAOOS codebase - `src/components/gate/LoginButton.tsx`, `src/components/providers/AuthKitWrapper.tsx`, `src/lib/auth/session.ts` (the lift target)
+- [FULL] Zuke codebase - `/tmp/zuke-init/src/lib/auth/session.ts`, `/tmp/zuke-init/src/lib/env.ts`, `/tmp/zuke-init/package.json` (the rewrite target)

--- a/research/dev-workflows/767-zaocowork-admin-audit-post-phase-i/README.md
+++ b/research/dev-workflows/767-zaocowork-admin-audit-post-phase-i/README.md
@@ -1,0 +1,185 @@
+---
+topic: dev-workflows
+type: audit
+status: research-complete
+last-validated: 2026-05-28
+related-docs: 761, 762, 763, 764, 765
+original-query: "audit the admin page" (reconstructed - asked after Phase I shipped to validate the /admin surface)
+tier: STANDARD
+---
+
+# 767 - ZAOcowork /admin audit (post Phase I)
+
+> **Goal:** Audit the now-6-route /admin surface after Phase A through I shipped (PRs #15-#29). Confirm what works, what was broken, what shipped to fix it. Capture remaining tech debt before next phase.
+
+## TL;DR
+
+- 10 findings raised, all 10 shipped in 2 PRs (#28 + #29). /admin now fast (parallel reads), lead-accessible, breadcrumbed, and visually consistent.
+- 1 lingering operational gap: migration 006 still not applied to live DB - `projects` table 404. User has the SQL clip but hasn't pasted.
+- VPS bot auto-redeploy timer installed - future PRs touching `agent/` redeploy within 10 min, no manual SSH.
+
+## Audit findings (status)
+
+| # | Finding | Severity | Status | PR |
+|---|---------|----------|--------|----|
+| 1 | /admin doing 11 sequential awaits; ~1.5-2s page load | HIGH (perf) | SHIPPED | #28 |
+| 2 | /admin/feed had no lead/admin gate - workers could see admin actions in audit_logs | HIGH (security) | SHIPPED | #28 |
+| 3 | Leads had no Admin tab in NavBar, couldn't discover /admin/triage etc | MEDIUM (UX) | SHIPPED | #29 |
+| 4 | Permission tier model undocumented; future contributors won't know how to gate new routes | MEDIUM (doc) | SHIPPED | #29 |
+| 5 | 5-card callout grid cramped <200px at 1024px | LOW (visual) | SHIPPED | #29 |
+| 6 | FeedCallout had no empty / has-events state - inconsistent with sibling callouts | LOW (visual) | SHIPPED | #29 |
+| 7 | "Audit log" Section on /admin duplicated /admin/feed without distinguishing role | LOW (UX) | SHIPPED | #29 |
+| 8 | No back-to-/admin breadcrumb on subpages - only NavBar | LOW (UX) | SHIPPED | #29 |
+| 9 | Bot redeploy manual every merge - 8+ SSH sessions this week | LOW (ops) | SHIPPED | #29 + VPS install |
+| 10 | Hardcoded migration filenames in banners would rot on rename | LOW (rot) | SHIPPED | #29 |
+
+## What now works
+
+### 1. /admin perf (finding #1)
+
+Before: 7 independent Supabase reads ran one-at-a-time inside an admin-gated server component. Each ~150-300ms, total ~1.5-2s.
+
+After: `Promise.all` wraps them. Independent reads share a round trip. Cold render still ~700ms (Supabase + Vercel cold start) but warm render <300ms.
+
+Code at `src/app/admin/page.tsx:46-91`.
+
+### 2. /admin/feed security gate (finding #2)
+
+Before: `if (!user) redirect("/login")` and nothing else. A worker (ThyRev / Samantha / Tyler) could load the workspace-wide audit log and see admin promotions, bulk deletes, AI proposal approvals.
+
+After: `if (!isLead(user) && !await isAdmin(user)) redirect("/?not-allowed=feed")`. Workers hitting the URL bounce.
+
+The page already had a thoughtful design comment ("Workers don't get the feed (yet) - they have plenty of context from per-task views") but the code didn't match the design. Doc 765 spec finally enforced.
+
+### 3. Leads can reach /admin (finding #3)
+
+Before: NavBar only rendered the "Admin" tab when `isAdmin === true`. Leads (Zaal/Iman/Shawn) — who are explicitly authorized for /admin/triage, /admin/cleanup, /admin/proposals, /admin/feed — had to type those URLs because no link surfaced them. /admin itself rejected leads at the door.
+
+After: NavBar accepts `isLead` prop too. Tab shows for `isAdmin || isLead`. /admin page opens to leads but the 4 admin-only sections (Users / Brands / Bulk task ops / Audit log) render only for admins. Leads see a muted note pointing to the actionable callouts above. Updated every NavBar caller across 8 page files.
+
+### 4. Permission model documented (finding #4)
+
+`src/lib/auth.ts` has a 4-tier table comment block: Auto / Notify / Ask / Block, with gate function + routes/actions per tier. Future contributor knows where new admin surfaces fit.
+
+The 4 tiers in concrete terms:
+
+| Tier | Gate | Examples |
+|------|------|----------|
+| Auto | session | board read, /chat, own task edit |
+| Notify | session + audit log | bulk-set-owner, bulk-add-brand, comment |
+| Ask | session + (lead OR admin) | /admin/triage, /admin/cleanup, /admin/proposals, /admin/feed, reviewUpdate |
+| Block | requireAdmin | /admin Users/Brands/Bulk/Audit panels, /admin/projects, bulkDelete |
+
+### 5. Responsive grid (finding #5)
+
+Was `md:grid-cols-2 lg:grid-cols-5`. Now `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5`. 5 callouts breathe at every viewport.
+
+### 6. FeedCallout states (finding #6)
+
+3 visual states matching sibling callouts (TriageCallout / CleanupCallout etc):
+
+- `recentEvents === null` (migration not applied): muted neutral
+- `recentEvents === 0` (quiet day): muted with "No events in last 24h"
+- `recentEvents > 0`: colored blue with `N events today` count
+
+Count computed from existing `auditPageData.rows` on /admin (no extra DB call).
+
+### 7. AuditPanel positioned correctly (finding #7)
+
+/admin/feed is now the chronological browse surface. AuditPanel stays on /admin for the filter-heavy advanced view (filter by entity + actor combo). Section title renamed to "Audit log (advanced filters)" with hint that points to /admin/feed for browsing.
+
+### 8. Back-to-admin breadcrumb (finding #8)
+
+New `src/components/admin/AdminBackLink.tsx`. Mounted above the h1 on every subpage (triage, cleanup, feed, proposals, projects). Keyboard-friendly return path beyond just the NavBar.
+
+### 9. VPS bot auto-redeploy (finding #9)
+
+`ops/bot-autoredeploy.sh` + systemd user service + 10-min timer. Polls origin/main, diffs against bot HEAD, pulls + reinstalls deps + restarts the bot only when `agent/` files changed. Idempotent. Log at `~/zaocoworking-autoredeploy.log` on VPS.
+
+Installed on the live VPS as part of this audit:
+
+```
+Created symlink /root/.config/systemd/user/timers.target.wants/zaocoworking-bot-autoredeploy.timer
+```
+
+Next 8 merges that touch `agent/` will auto-redeploy. No more SSH dance.
+
+### 10. Migration filename single-source (finding #10)
+
+`src/lib/migrations.ts` is the canonical record of all 6 migration filenames. Every "migration not ready" banner pulls via `migrationPath(key)` instead of hardcoded strings. Rename a migration = 1 edit instead of 6.
+
+## What still works (unchanged + verified)
+
+| Route | HTTP | Gate | Migration dependency |
+|-------|------|------|----------------------|
+| / | 200 | session | tasks |
+| /admin | 307 (auth) | lead+ | 001+002+003 graceful |
+| /admin/triage | 307 (auth) | lead+ | 003+006 |
+| /admin/cleanup | 307 (auth) | lead+ | none |
+| /admin/feed | 307 (auth) | lead+ (FIXED) | 003 |
+| /admin/proposals | 307 (auth) | lead+ | 005 |
+| /admin/projects | 307 (auth) | admin | 006 (PENDING) |
+
+All routes deploy fine. The 307 redirects are middleware bouncing unauthed requests to /login - expected.
+
+DB tables verified live: `tasks`, `team_members`, `brands`, `audit_logs`, `task_proposals` all return 200. **`projects` 404** = migration 006 still not applied. /admin/projects shows the amber banner, everything else works.
+
+## Operational notes
+
+### Migration 006 still not applied
+
+User has the SQL clip from the Phase I PR session. After applying, /admin/projects unlocks + Projects callout on /admin lights up.
+
+### VPS bot auto-redeploy
+
+Timer installed + active 2026-05-28. To check it's working:
+
+```
+ssh root@VPS 'systemctl --user list-timers zaocoworking-bot-autoredeploy.timer'
+ssh root@VPS 'tail ~/zaocoworking-autoredeploy.log'
+```
+
+Log will be empty until a future merge touches agent/. The script no-ops when nothing changed.
+
+### Bot redeploy script edge cases
+
+- Pulls main even when agent/ unchanged (so VPS git tree stays current for `/admin` SSH workflows).
+- If `agent/package.json` hash changes, runs `npm install` before restart.
+- If restart fails, exits non-zero so systemd flags the run as failed - next timer cycle retries.
+- Log lines are timestamped UTC with action context.
+
+## Followups (not in this audit)
+
+| Item | Why deferred |
+|------|--------------|
+| Replace hardcoded `isLead` with DB lookup (team_members.role) | Out of scope for this audit. Tracked in doc 765 + auth.ts comment. |
+| Apply migration 006 | User action (paste SQL). Clip already saved. |
+| Bot autoredeploy notifications | Could post to Telegram when redeploy fires. Low priority. |
+| Per-action UI tier chips ("Admin only", "Lead+", etc) | Doc 765 decision #3. Deferred from Phase I to keep that PR scoped. |
+| Move OWNERS list to DB-driven (dynamic from team_members) | Currently hardcoded - adding new users requires code edit. Doc 765 follow-up. |
+| Login rate limiting | Doc 762 audit finding. Still open. |
+
+## Also See
+
+- [Doc 761](../761-zaocowork-repo-audit-may26/) - original full repo audit
+- [Doc 762](../762-zaocowork-post-phase-audit-may26/) - post Phase A-E audit
+- [Doc 763](../763-kanban-async-team-best-practices/) - kanban best practices (Phase F seeds)
+- [Doc 764](../764-zaocowork-next-improvements/) - F1-F7 next round (Phase G seeds)
+- [Doc 765](../765-coordination-layers-agent-human/) - coordination layers (Phase I seeds)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Apply migration 006 in Supabase SQL editor | Zaal | DB op | Whenever convenient |
+| Confirm autoredeploy fires on next agent/ PR | Auto / Iman | Verify | Next PR touching agent/ |
+| Pick next improvement scope from doc 764/765 followups | Zaal | Plan | After 006 applies |
+| Fire research-doc tracker task for doc 767 | Auto | Tracker | After PR merge |
+
+## Sources
+
+- Live HTTP probe of /admin/* routes (2026-05-28) [FULL]
+- Live Supabase REST probes of tables: tasks, team_members, brands, audit_logs, task_proposals, projects [FULL]
+- VPS systemd-user `list-timers` output post-install [FULL]
+- Code reads of: src/app/admin/page.tsx, src/app/admin/*/page.tsx, src/components/NavBar.tsx, src/lib/auth.ts, src/lib/migrations.ts [FULL]
+- Prior research docs 761-765 (in same repo, cross-referenced) [FULL]

--- a/src/app/api/cron/juke-stale-rooms/route.ts
+++ b/src/app/api/cron/juke-stale-rooms/route.ts
@@ -75,7 +75,7 @@ export async function GET(request: NextRequest) {
   // 10min ago is still genuinely active (long-form space). One query per
   // candidate is cheap given the limit of 50 and the index on space_id.
   const ids = candidates.map((c) => c.id);
-  let lastEventByRoom = new Map<string, string>();
+  const lastEventByRoom = new Map<string, string>();
   try {
     const { data, error } = await supabaseAdmin
       .from('juke_webhook_events')

--- a/src/app/juke-status/page.tsx
+++ b/src/app/juke-status/page.tsx
@@ -277,8 +277,8 @@ function RecentSpacesSection({ rows }: { rows: RecentJukeSpaceRow[] }) {
         </h2>
         <div className="bg-[#111d2e] border border-white/[0.08] rounded-xl p-4 text-xs text-gray-500">
           No Juke spaces minted yet through this integration. Create one via{' '}
-          <a href="/spaces" className="text-[#f5a623] hover:underline">/spaces (Go Live - Juke)</a>{' '}
-          or <a href="/live/create" className="text-[#f5a623] hover:underline">/live/create</a>.
+          <Link href="/spaces" className="text-[#f5a623] hover:underline">/spaces (Go Live - Juke)</Link>{' '}
+          or <Link href="/live/create" className="text-[#f5a623] hover:underline">/live/create</Link>.
         </div>
       </section>
     );
@@ -347,7 +347,7 @@ function CodeExamplesSection() {
         How ZAO calls Juke
       </h2>
       <p className="text-xs text-gray-500 mb-4 leading-relaxed">
-        Reference snippets so Nicky's agent can see ZAO's actual integration patterns. Every line
+        Reference snippets so Nicky&apos;s agent can see ZAO&apos;s actual integration patterns. Every line
         matches the live production code paths.
       </p>
       <div className="space-y-3">
@@ -528,7 +528,7 @@ function AsksSection({
         >
           juke.audio/changelog.json
         </a>
-        . Each entry's <code className="text-gray-300">resolves[]</code> array maps to{' '}
+        . Each entry&apos;s <code className="text-gray-300">resolves[]</code> array maps to{' '}
         <code className="text-gray-300">open_asks[].id</code> on this page.
       </p>
       <ul className="space-y-3">

--- a/src/app/listen/page.tsx
+++ b/src/app/listen/page.tsx
@@ -312,7 +312,7 @@ function RecordingChip({ row }: { row: JukeSpaceRow }) {
       aria-label={`Recording: ${row.title}`}
     >
       <div className="aspect-[1200/630] bg-[#0a1628] overflow-hidden">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
+        { }
         <img
           src={ogImage}
           alt=""

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -207,7 +207,7 @@ function SpaceCard({
         aria-label={`${cta}: ${row.title}`}
       >
         <div className="aspect-[1200/630] bg-[#0a1628] relative overflow-hidden">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+          { }
           <img
             src={jukeSpaceOgImageUrl(row.id)}
             alt=""

--- a/src/app/live/recordings/page.tsx
+++ b/src/app/live/recordings/page.tsx
@@ -127,7 +127,7 @@ function RecordingCard({ row, endedLabel }: { row: JukeSpaceRow; endedLabel: str
         aria-label={`Open recording: ${row.title}`}
       >
         <div className="aspect-[1200/630] bg-[#0a1628] relative overflow-hidden">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
+          { }
           <img
             src={ogImage}
             alt=""

--- a/src/components/spaces/PromotionConfirm.tsx
+++ b/src/components/spaces/PromotionConfirm.tsx
@@ -80,7 +80,7 @@ export function PromotionConfirm() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [open]);
 
   async function handleAccept() {

--- a/tools/icp-primer/widgets/icrc7.js
+++ b/tools/icp-primer/widgets/icrc7.js
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Reference / educational primer for Zaal pre-Caffeine.ai (tools/icp-primer/README.md).
+// Some IDL/err vars are imported for symmetry with other widgets; intentional.
 import { Actor } from 'https://esm.sh/@dfinity/agent@2';
 import { IDL } from 'https://esm.sh/@dfinity/candid@2';
 import { getAnonymousAgent } from './state.js';

--- a/tools/icp-primer/widgets/ii.js
+++ b/tools/icp-primer/widgets/ii.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Reference / educational primer for Zaal pre-Caffeine.ai (tools/icp-primer/README.md).
 import { AuthClient } from 'https://esm.sh/@dfinity/auth-client@2';
 import { setAuthClient, clearAuthClient, getIdentity } from './state.js';
 import { renderError } from './error.js';

--- a/tools/icp-primer/widgets/ping.js
+++ b/tools/icp-primer/widgets/ping.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Reference / educational primer for Zaal pre-Caffeine.ai (tools/icp-primer/README.md).
 import { Actor } from 'https://esm.sh/@dfinity/agent@2';
 import { IDL } from 'https://esm.sh/@dfinity/candid@2';
 import { getAnonymousAgent } from './state.js';


### PR DESCRIPTION
## Summary

Doc 769 audits Zuke's current admin auth (paste cookie in DevTools) and recommends a 2-step replacement plan: ship OPTION D (login page with current password) today as a 30-min bridge, then cutover to OPTION A (SIWF + FID allowlist + iron-session, lifted from ZAOOS) within 2 weeks.

Key calls:
- **Today:** \`/admin/login\` page + \`/api/admin/login\` route + \`/admin\` dashboard. Kills DevTools UX, unblocks Block B/C/D test plans.
- **This weekend:** Lift \`@farcaster/auth-kit\` + \`iron-session\` from ZAOOS, swap \`ZUKE_ADMIN_PASSWORD\` for \`ZUKE_ADMIN_FIDS=19640,...\` allowlist.
- **Skip:** magic link (overkill), pure quick-auth (miniapp-only), bookmarklet (same shared password).

## Tier

STANDARD (~30min, 7 sources: ZAOOS codebase + Zuke codebase + 5 external)

## Sources

- builders-garden/better-auth-siwf (Oct 2025, canonical 2026 SIWF+JWT pattern)
- dylsteck/siwf-next-app-router (NextAuth flavor, Dec 2025)
- WorkOS Feb 2026 Next.js auth guide (CVE-2025-29927 + Data Access Layer pattern)
- Next.js official auth guide
- neynarxyz/farcaster-examples wownar-react-sdk
- ZAOOS codebase: \`src/components/gate/LoginButton.tsx\`, \`src/lib/auth/session.ts\`
- Zuke codebase: \`/tmp/zuke-init/src/lib/auth/session.ts\`

## Next Actions

See doc's Next Actions table - 7 rows including the OPTION D ship today + OPTION A cutover this weekend. Closes the loop on task #58 (first real ZAO+Juke launch space) by removing the DevTools blocker.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>