### PR TITLE
fix(zoe): use America/New_York TZ for current_date

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -499,7 +499,7 @@ async function dispatchConcierge(
       context: {
         zaal_tg_id: zaalId,
         workspace_dir: repoDir,
-        current_date: new Date().toISOString().slice(0, 10),
+        current_date: new Date().toLocaleString("en-US", { timeZone: "America/New_York", weekday: "short", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short" }),
       },
     });
 


### PR DESCRIPTION
ZOE was seeing UTC date (2026-05-29) when Zaal in Maine asked time at 9:59 PM EDT 2026-05-28. Hot-patched on VPS during smoke test; this PR captures for git. Single field change in bot/src/zoe/index.ts current_date construction. Backward compatible.