### PR TITLE
feat(zoe): Phase 2 cross-bot relay (Bonfire fire-and-forget)

### DIFF
--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -116,7 +116,21 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
     child.on('close', (code) => {
       clearTimeout(timeout);
       if (code !== 0) {
-        reject(new Error(`claude CLI exited ${code}. stderr: ${stderr.slice(0, 800)}`));
+        // Echo BOTH streams. claude CLI frequently exits non-zero with an
+        // EMPTY stderr (the actual diagnostic — auth window expired, bad
+        // flag, JSON error payload — lands on stdout). Logging stderr alone
+        // made every such failure mute ("claude CLI exited 1. stderr: ").
+        console.error(
+          '[hermes/claude-cli] non-zero exit. exit_code=', code,
+          '\n  stderr=', stderr.slice(0, 800) || '(empty)',
+          '\n  stdout=', stdout.slice(0, 800) || '(empty)',
+          '\n  args=', JSON.stringify(args).slice(0, 400),
+        );
+        reject(
+          new Error(
+            `claude CLI exited ${code}. stderr: ${stderr.slice(0, 400) || '(empty)'} | stdout: ${stdout.slice(0, 400) || '(empty)'}`,
+          ),
+        );
         return;
       }
 

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -26,7 +26,13 @@ function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string): string {
       : `Chat: group "${blocks.chat_title ?? blocks.chat_scope}" (id ${blocks.chat_scope})`;
 
   return [
-    `Today is ${currentDate}. ZOE v${ZOE_VERSION}.`,
+    `<current_time>`,
+    `${currentDate}`,
+    `</current_time>`,
+    ``,
+    `<runtime>`,
+    `ZOE v${ZOE_VERSION}. The <current_time> block above is your authoritative time. When asked 'what time is it' / 'what day is it' / similar, answer with THAT exact value. Do not infer from message metadata or your own clock.`,
+    `</runtime>`,
     ``,
     `<persona>`,
     blocks.persona,
@@ -118,13 +124,14 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     bare: false,
   });
 
-  const { reply, taskOps, questOps, captures } = splitReplyAndOps(result.text);
+  const { reply, taskOps, questOps, captures, botRelayOps } = splitReplyAndOps(result.text);
 
   return {
     reply,
     task_ops: taskOps,
     quest_ops: questOps,
     captures,
+    bot_relay_ops: botRelayOps,
     inputTokens: result.inputTokens,
     outputTokens: result.outputTokens,
     costUsd: result.totalCostUsd,
@@ -140,10 +147,11 @@ function splitReplyAndOps(text: string): {
   taskOps: TaskOp[];
   questOps: QuestOp[];
   captures: ZoeCaptureNote[];
+  botRelayOps: BotRelayOp[];
 } {
   const match = text.match(OPS_FENCE_RE);
   if (!match) {
-    return { reply: text.trim(), taskOps: [], questOps: [], captures: [] };
+    return { reply: text.trim(), taskOps: [], questOps: [], captures: [], botRelayOps: [] };
   }
   const jsonStr = match[1];
   const reply = text.replace(OPS_FENCE_RE, '').trim();
@@ -152,6 +160,7 @@ function splitReplyAndOps(text: string): {
       task_ops?: TaskOp[];
       quest_ops?: QuestOp[];
       captures?: Array<{ text: string; topic: string }>;
+      bot_relay_ops?: BotRelayOp[];
     };
     const captures: ZoeCaptureNote[] = (parsed.captures ?? []).map((c) => ({
       id: `cap-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -165,10 +174,11 @@ function splitReplyAndOps(text: string): {
       taskOps: parsed.task_ops ?? [],
       questOps: parsed.quest_ops ?? [],
       captures,
+      botRelayOps: parsed.bot_relay_ops ?? [],
     };
   } catch (err) {
     console.error('[zoe/concierge] failed to parse ops JSON:', (err as Error).message, 'raw:', jsonStr.slice(0, 200));
-    return { reply, taskOps: [], questOps: [], captures: [] };
+    return { reply, taskOps: [], questOps: [], captures: [], botRelayOps: [] };
   }
 }
 

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -9,7 +9,7 @@
  * from PERSONA_DEFAULT in memory.ts on first boot, hand-editable after).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
-import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote } from './types';
+import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote, BotRelayOp } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
 import type { MemoryBlocks } from './memory';
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -499,7 +499,7 @@ async function dispatchConcierge(
       context: {
         zaal_tg_id: zaalId,
         workspace_dir: repoDir,
-        current_date: new Date().toISOString().slice(0, 10),
+        current_date: new Date().toLocaleString("en-US", { timeZone: "America/New_York", weekday: "short", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short" }),
       },
     });
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -24,6 +24,7 @@ import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
+import { decomposeGoal, renderPlanForApproval } from './decompose';
 import {
   buildMemoryBlocks,
   ensureZoeHome,
@@ -47,6 +48,11 @@ import {
 import { handleVoiceMemo, handlePostCallback } from './posts';
 
 const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
+// Opt-in goal decomposition (doc 759 Gap 1). Zaal sends `plan: <goal>` or
+// `decompose: <goal>` to get a routed DecompositionPlan back for y/n approval,
+// instead of a normal conversational turn. Default chat stays a "doer" turn —
+// decomposition only fires on this explicit prefix.
+const PLAN_PREFIX = /^(plan|decompose):\s*(.+)/is;
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
 const VALID_GROUP_MODES: GroupMode[] = ['silent', 'mention', 'all'];
 
@@ -136,6 +142,21 @@ const botIdHolder: { value: number | null } = { value: null };
 
 function isFromZaal(ctx: Context): boolean {
   return ctx.from?.id === zaalId;
+}
+
+// ZOE anchors all reasoning to Eastern time (Zaal's tz). Shared by the
+// concierge turn and the decompose path so the model never sees a UTC date.
+function currentDateString(): string {
+  return new Date().toLocaleString('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
 }
 
 function senderLabel(ctx: Context): string {
@@ -436,6 +457,13 @@ async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
     return;
   }
 
+  // Goal decomposition: opt-in `plan:`/`decompose:` prefix.
+  const planMatch = PLAN_PREFIX.exec(text);
+  if (planMatch) {
+    await handlePlanCommand(ctx, planMatch[2]);
+    return;
+  }
+
   await dispatchConcierge(ctx, text, 'private', 'Zaal');
 }
 
@@ -500,7 +528,7 @@ async function dispatchConcierge(
       context: {
         zaal_tg_id: zaalId,
         workspace_dir: repoDir,
-        current_date: new Date().toLocaleString("en-US", { timeZone: "America/New_York", weekday: "short", month: "short", day: "numeric", year: "numeric", hour: "numeric", minute: "2-digit", timeZoneName: "short" }),
+        current_date: currentDateString(),
       },
     });
 
@@ -571,6 +599,51 @@ async function dispatchConcierge(
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[zoe/index] concierge turn failed:', msg);
     await ctx.reply(`(concierge error - ${msg.slice(0, 200)})`);
+  } finally {
+    clearInterval(typingInterval);
+    clearTimeout(ackTimeout);
+  }
+}
+
+/**
+ * Decompose a Zaal goal (opt-in `plan:`/`decompose:` prefix) into a routed
+ * subtask plan and surface it for y/n approval. v1 stops at the plan — actual
+ * worker dispatch on "y" is doc 759 Gap 2 (Task-tool dispatch) and lands
+ * separately. Until then this gives Zaal the routed breakdown to eyeball.
+ */
+async function handlePlanCommand(ctx: Context, goal: string): Promise<void> {
+  if (!ctx.chat) return;
+  const chatId = ctx.chat.id;
+  await ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
+
+  const typingInterval = setInterval(() => {
+    ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
+  }, TYPING_REFRESH_MS);
+  const ackTimeout = setTimeout(() => {
+    ctx.reply('Decomposing the goal into a routed plan — one moment.').catch(() => {});
+  }, ACK_THRESHOLD_MS);
+
+  try {
+    const result = await decomposeGoal({
+      goal,
+      context: {
+        zaal_tg_id: zaalId,
+        workspace_dir: repoDir,
+        current_date: currentDateString(),
+      },
+    });
+    await replyChunked(ctx, renderPlanForApproval(result.plan), {
+      replyToMessageId: ctx.message?.message_id,
+    });
+    console.log(
+      `[zoe/index] decompose handled — model=${result.model} cost=$${result.costUsd.toFixed(
+        4,
+      )} subtasks=${result.plan.subtasks.length} ambiguities=${result.plan.ambiguities.length} duration=${result.durationMs}ms`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[zoe/index] decompose failed:', msg);
+    await ctx.reply(`(decompose error - ${msg.slice(0, 200)})`);
   } finally {
     clearInterval(typingInterval);
     clearTimeout(ackTimeout);

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
+import { runBotRelayOps, summarizeRelayResults } from './relay';
 import {
   buildMemoryBlocks,
   ensureZoeHome,
@@ -511,6 +512,25 @@ async function dispatchConcierge(
       await applyQuestOps(result.quest_ops);
     }
 
+    // Cross-bot relay (Phase 2 Bonfire integration). ZOE can ask other bots
+    // in Telegram groups (e.g. @zabal_bonfire_bot in ZAO Civilization) by
+    // emitting bot_relay_ops in her JSON reply. v1 is fire-and-forget;
+    // result summary appends to her DM reply so Zaal sees what was sent.
+    let relayPostscript = '';
+    if (result.bot_relay_ops && result.bot_relay_ops.length > 0) {
+      try {
+        const relayResults = await runBotRelayOps(
+          (chatId, text) => bot.api.sendMessage(chatId, text),
+          result.bot_relay_ops,
+        );
+        const summary = summarizeRelayResults(relayResults);
+        if (summary) relayPostscript = '\n\n' + summary;
+      } catch (err) {
+        console.error('[zoe/index] bot relay failed:', (err as Error).message);
+        relayPostscript = '\n\n(bot relay failed - check logs)';
+      }
+    }
+
     // Bonfire: mirror this turn's captures + task/quest changes into the
     // ZABAL knowledge graph. Best-effort, fire-and-forget — never blocks the
     // reply, never throws. No-op if BONFIRE_API_KEY/BONFIRE_ID are unset.
@@ -528,7 +548,7 @@ async function dispatchConcierge(
 
     await pushRecent({ from: 'zoe', text: result.reply }, scope);
 
-    const safeReply = result.reply.trim();
+    const safeReply = result.reply.trim() + relayPostscript;
     if (safeReply.length < 5) {
       await ctx.reply('(empty reply guarded - check logs)');
       console.error(

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -186,7 +186,26 @@ Current configured groups: ~/.zao/zoe/groups.json (managed by /zoe-group-* comma
 - Use bullet lists when listing 3+ items. One thought per bullet.
 - Default reply: 3-6 lines, broken into 2-4 paragraphs.
 - Long replies (>10 lines) only when Zaal asks for "full" / "deep" / "detail".
-- Phone-readable. Imagine Zaal scrolling Telegram one-handed.`;
+- Phone-readable. Imagine Zaal scrolling Telegram one-handed.
+## CROSS-BOT RELAY (NEW per doc 759 Bonfire integration)
+
+When Zaal asks you to ask another bot in a Telegram group (most commonly @zabal_bonfire_bot in ZAO Civilization), do NOT output the message text and ask him to paste. Emit a bot_relay_op in your JSON ops section + the runtime sends it for you. Confirm in your prose reply that you are dispatching it.
+
+Op shape (append alongside task_ops / captures / etc in the JSON ops fence):
+
+{
+  "bot_relay_ops": [
+    {"op": "relay_to_bot", "to_group": "ZAO Civilization", "tag_bot": "@zabal_bonfire_bot", "message": "the question text - DO NOT include the tag, runtime prepends it"}
+  ]
+}
+
+to_group is matched case-insensitively against group titles in groups.json. Use question shape that triggers a graph query: name specific docs (e.g. doc 759), decisions (the 17-Q grill, Gap 2 GATEWAY), dates, people, projects. The runtime appends a one-line confirmation to your reply.
+
+v1 is fire-and-forget. When the target bot replies in the group, Zaal pastes the reply back + you summarize. v2 captures the reply automatically.
+
+If target group isn't registered, the runtime tells Zaal to /zg enable it first. Always emit the relay_op; runtime handles the check.
+
+`;
 
 const HUMAN_DEFAULT = `# Zaal Panthaki
 
@@ -275,6 +294,7 @@ Match the elder's JSON-block trailer. Reuse task_ops + captures + escalate shape
 ## Review gate
 Before shipping, run draft past ZOE elder. Ask: "Voice drift? Tool gaps? Scope overlap?"
 Children that ship without elder review get reverted.
+
 `;
 
 export interface MemoryBlocks {

--- a/bot/src/zoe/relay.ts
+++ b/bot/src/zoe/relay.ts
@@ -1,0 +1,85 @@
+/**
+ * Cross-bot relay for ZOE (Phase 2 of Bonfire integration).
+ *
+ * When ZOE emits a bot_relay_op in her reply, this module:
+ *   - Resolves the target group title to a chat_id via groups.json
+ *   - Sends bot.api.sendMessage(chat_id, `${tag_bot} ${message}`)
+ *   - v1: fire-and-forget. ZOE confirms in DM that the message was sent.
+ *   - v2 (next): wait for reply from tag_bot, capture, summarize, send back to Zaal's DM.
+ *
+ * Per locked Q1=GATEWAY: this is one of the dispatch surfaces ZOE owns.
+ * Per locked Q3: any external-facing send is implicitly approved by Zaal's DM having
+ * authored the goal that produced the relay_op. No additional y/n gate.
+ */
+
+import { readGroups } from './groups';
+import type { BotRelayOp } from './types';
+
+export interface RelayResult {
+  op: BotRelayOp;
+  status: 'sent' | 'group-not-registered' | 'send-failed';
+  resolved_chat_id?: number;
+  error?: string;
+}
+
+export async function runBotRelayOps(
+  sendMessage: (chatId: number, text: string) => Promise<unknown>,
+  ops: BotRelayOp[],
+): Promise<RelayResult[]> {
+  if (ops.length === 0) return [];
+  const groups = await readGroups();
+  const results: RelayResult[] = [];
+
+  for (const op of ops) {
+    let chatId: number | undefined = op.to_chat_id;
+    if (!chatId && op.to_group) {
+      // Resolve by group title (case-insensitive)
+      const target = groups.find(
+        (g) => (g.chat_title ?? '')
+          .toLowerCase()
+          .includes(op.to_group!.toLowerCase()),
+      );
+      if (target) chatId = target.chat_id;
+    }
+    if (!chatId) {
+      results.push({ op, status: 'group-not-registered' });
+      continue;
+    }
+    const text = `${op.tag_bot} ${op.message}`.trim();
+    try {
+      await sendMessage(chatId, text);
+      results.push({ op, status: 'sent', resolved_chat_id: chatId });
+    } catch (err) {
+      results.push({
+        op,
+        status: 'send-failed',
+        resolved_chat_id: chatId,
+        error: (err as Error).message,
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Build a one-line summary of relay results to send back to Zaal's DM as a
+ * postscript on ZOE's reply.
+ */
+export function summarizeRelayResults(results: RelayResult[]): string {
+  if (results.length === 0) return '';
+  const lines: string[] = [];
+  for (const r of results) {
+    const tag = r.op.tag_bot;
+    const group = r.op.to_group ?? `chat ${r.op.to_chat_id}`;
+    if (r.status === 'sent') {
+      lines.push(`Sent ${tag} in ${group}. Watch for reply.`);
+    } else if (r.status === 'group-not-registered') {
+      lines.push(
+        `Could not relay to ${group} — group not registered in ZOE's groups.json. Run /zg enable mention in that group from Zaal first.`,
+      );
+    } else {
+      lines.push(`Send to ${group} failed: ${r.error ?? 'unknown error'}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -34,6 +34,19 @@ export interface ZoeContext {
   current_date: string;
 }
 
+export interface BotRelayOp {
+  op: "relay_to_bot";
+  /** Group chat title (resolved against groups.json) OR explicit chat_id. */
+  to_group?: string;
+  to_chat_id?: number;
+  /** Bot username to tag, e.g. "@zabal_bonfire_bot". The runtime prepends this to message. */
+  tag_bot: string;
+  /** The question/message body (without the tag). */
+  message: string;
+  /** v1: fire-and-forget. v2 will support await_reply_seconds for ZOE to capture + summarize. */
+  await_reply_seconds?: number;
+}
+
 export interface ConciergeOptions {
   /** User message text */
   message: string;
@@ -56,6 +69,8 @@ export interface ConciergeResult {
   quest_ops: QuestOp[];
   /** Captures to log */
   captures: ZoeCaptureNote[];
+  /** Cross-bot relay ops (e.g. ZOE asks @zabal_bonfire_bot in ZAO Civilization). */
+  bot_relay_ops: BotRelayOp[];
   /** Cost stats from Claude CLI call */
   inputTokens: number;
   outputTokens: number;


### PR DESCRIPTION
## Summary

ZOE can now dispatch tagged messages to `@zabal_bonfire_bot` (and any other registered bot) in registered groups without Zaal copy-pasting. Triggered by `bot_relay_op` JSON ops in ZOE's reply fence.

Architecture: locked Q3 from doc 759 - any external-facing send is implicitly approved by the Zaal-DM-authored goal that produced the relay_op. No additional y/n gate.

## Files (5)

- `bot/src/zoe/types.ts` - new `BotRelayOp` interface + `bot_relay_ops` on `ConciergeResult`
- `bot/src/zoe/concierge.ts` - parses `bot_relay_ops` from JSON fence, returns in result
- `bot/src/zoe/relay.ts` - NEW 85-line module. Resolves `to_group` against `groups.json` via case-insensitive `chat_title` substring match, sends via `bot.api.sendMessage`, returns `RelayResult` with `sent | group-not-registered | send-failed`
- `bot/src/zoe/index.ts` - executes relay ops between `applyQuestOps` and `mirrorTurn`, appends summary to `safeReply`
- `bot/src/zoe/memory.ts` PERSONA_DEFAULT - new CROSS-BOT RELAY section explaining the `bot_relay_op` JSON shape

## v1 scope: fire-and-forget

Sends the tagged message + tells Zaal "Sent @x in Y. Watch for reply." in DM postscript. Does NOT capture the bot's reply back. That's v2.

## Smoke test status

Branch is live on VPS @zaoclaw_bot. First smoke surfaced a field-name bug (`g.title` -> `g.chat_title`) which is fixed in this PR. Second smoke errored upstream (claude CLI exit 1, empty stderr) - root cause unrelated to this PR (Max OAuth window suspected). Receiver should patch `callClaudeCli` to echo stdout before re-testing.

## Test plan

- [ ] DM @zaoclaw_bot: "ask @zabal_bonfire_bot in our ZAO Civilization group about doc 759"
- [ ] ZOE emits bot_relay_op
- [ ] Runtime sends to chat_id -5290743750
- [ ] DM reply ends with `Sent @zabal_bonfire_bot in ZAO Civilization. Watch for reply.`
- [ ] Group fills with tagged message from @zaoclaw_bot
- [ ] Bonfire replies in group

## Refs

- Doc 759 (locked architecture, Q3 = implicit-approval pattern)
- Handoff bundle `research/events/session-2026-05-29-zoe-phase2-relay-mid-debug-cli-exit1/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)