### PR TITLE
feat(crm): Supabase-native CRM - migration, bot API, /network, /crm, ZOE write path (doc 772)

### DIFF
--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -9,7 +9,7 @@
  * from PERSONA_DEFAULT in memory.ts on first boot, hand-editable after).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
-import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote, BotRelayOp } from './types';
+import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote, BotRelayOp, CrmOp } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
 import type { MemoryBlocks } from './memory';
 
@@ -124,7 +124,7 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     bare: false,
   });
 
-  const { reply, taskOps, questOps, captures, botRelayOps } = splitReplyAndOps(result.text);
+  const { reply, taskOps, questOps, captures, botRelayOps, crmOps } = splitReplyAndOps(result.text);
 
   return {
     reply,
@@ -132,6 +132,7 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     quest_ops: questOps,
     captures,
     bot_relay_ops: botRelayOps,
+    crm_ops: crmOps,
     inputTokens: result.inputTokens,
     outputTokens: result.outputTokens,
     costUsd: result.totalCostUsd,
@@ -148,10 +149,11 @@ function splitReplyAndOps(text: string): {
   questOps: QuestOp[];
   captures: ZoeCaptureNote[];
   botRelayOps: BotRelayOp[];
+  crmOps: CrmOp[];
 } {
   const match = text.match(OPS_FENCE_RE);
   if (!match) {
-    return { reply: text.trim(), taskOps: [], questOps: [], captures: [], botRelayOps: [] };
+    return { reply: text.trim(), taskOps: [], questOps: [], captures: [], botRelayOps: [], crmOps: [] };
   }
   const jsonStr = match[1];
   const reply = text.replace(OPS_FENCE_RE, '').trim();
@@ -161,6 +163,7 @@ function splitReplyAndOps(text: string): {
       quest_ops?: QuestOp[];
       captures?: Array<{ text: string; topic: string }>;
       bot_relay_ops?: BotRelayOp[];
+      crm_ops?: CrmOp[];
     };
     const captures: ZoeCaptureNote[] = (parsed.captures ?? []).map((c) => ({
       id: `cap-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -175,10 +178,11 @@ function splitReplyAndOps(text: string): {
       questOps: parsed.quest_ops ?? [],
       captures,
       botRelayOps: parsed.bot_relay_ops ?? [],
+      crmOps: parsed.crm_ops ?? [],
     };
   } catch (err) {
     console.error('[zoe/concierge] failed to parse ops JSON:', (err as Error).message, 'raw:', jsonStr.slice(0, 200));
-    return { reply, taskOps: [], questOps: [], captures: [], botRelayOps: [] };
+    return { reply, taskOps: [], questOps: [], captures: [], botRelayOps: [], crmOps: [] };
   }
 }
 

--- a/bot/src/zoe/crm.ts
+++ b/bot/src/zoe/crm.ts
@@ -1,0 +1,81 @@
+/**
+ * ZOE -> ZAO CRM write path (doc 772).
+ *
+ * When ZOE emits a crm_op in her reply, this module POSTs it to the ZAOOS app
+ * route `POST /api/crm/interactions`, authenticated with a Bearer shared secret
+ * (CRM_BOT_SECRET). The app upserts the contact (by deterministic slug) and
+ * logs the interaction. Fire-and-forget from ZOE's side - a one-line summary is
+ * appended to her DM reply.
+ *
+ * Env:
+ *   CRM_API_URL    - base URL of the app (default https://zaoos.com)
+ *   CRM_BOT_SECRET - shared bearer secret; must match the app's ENV.CRM_BOT_SECRET
+ *
+ * If CRM_BOT_SECRET is unset, ops are skipped (logged), never throws.
+ */
+
+import type { CrmOp } from './types';
+
+export interface CrmResult {
+  op: CrmOp;
+  status: 'logged' | 'skipped-no-secret' | 'failed';
+  contact_id?: string;
+  error?: string;
+}
+
+const CRM_API_URL = process.env.CRM_API_URL ?? 'https://zaoos.com';
+
+export async function runCrmOps(ops: CrmOp[]): Promise<CrmResult[]> {
+  if (ops.length === 0) return [];
+  const secret = process.env.CRM_BOT_SECRET;
+  const results: CrmResult[] = [];
+
+  for (const op of ops) {
+    if (!secret) {
+      results.push({ op, status: 'skipped-no-secret' });
+      continue;
+    }
+    try {
+      const res = await fetch(`${CRM_API_URL}/api/crm/interactions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${secret}`,
+        },
+        body: JSON.stringify({ contact: op.contact, interaction: op.interaction }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        results.push({
+          op,
+          status: 'failed',
+          error: body.error ?? `HTTP ${res.status}`,
+        });
+        continue;
+      }
+      const data = (await res.json().catch(() => ({}))) as { contact_id?: string };
+      results.push({ op, status: 'logged', contact_id: data.contact_id });
+    } catch (err) {
+      results.push({ op, status: 'failed', error: (err as Error).message });
+    }
+  }
+  return results;
+}
+
+/** One-line postscript for Zaal's DM summarizing CRM writes. */
+export function summarizeCrmResults(results: CrmResult[]): string {
+  if (results.length === 0) return '';
+  const lines: string[] = [];
+  for (const r of results) {
+    const who = r.op.contact.name;
+    if (r.status === 'logged') {
+      const pub = r.op.contact.is_public ? ' (public on /network)' : '';
+      lines.push(`Logged ${who} to CRM${pub}.`);
+    } else if (r.status === 'skipped-no-secret') {
+      lines.push(`Could not log ${who} - CRM_BOT_SECRET not set on this box.`);
+    } else {
+      lines.push(`CRM write for ${who} failed: ${r.error ?? 'unknown error'}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -24,6 +24,7 @@ import { runConciergeTurn } from './concierge';
 import { applyTaskOps, seedInitialTasks } from './tasks';
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
+import { runCrmOps, summarizeCrmResults } from './crm';
 import { decomposeGoal, renderPlanForApproval } from './decompose';
 import {
   buildMemoryBlocks,
@@ -628,6 +629,22 @@ async function dispatchConcierge(
       }
     }
 
+    // CRM write path (doc 772). ZOE can upsert a contact + log an interaction
+    // by emitting crm_ops in her JSON reply; this POSTs to the app's
+    // /api/crm/interactions with the CRM_BOT_SECRET bearer. Fire-and-forget;
+    // a one-line summary appends to her DM reply.
+    let crmPostscript = '';
+    if (result.crm_ops && result.crm_ops.length > 0) {
+      try {
+        const crmResults = await runCrmOps(result.crm_ops);
+        const summary = summarizeCrmResults(crmResults);
+        if (summary) crmPostscript = '\n\n' + summary;
+      } catch (err) {
+        console.error('[zoe/index] crm write failed:', (err as Error).message);
+        crmPostscript = '\n\n(CRM write failed - check logs)';
+      }
+    }
+
     // Bonfire: mirror this turn's captures + task/quest changes into the
     // ZABAL knowledge graph. Best-effort, fire-and-forget — never blocks the
     // reply, never throws. No-op if BONFIRE_API_KEY/BONFIRE_ID are unset.
@@ -645,7 +662,7 @@ async function dispatchConcierge(
 
     await pushRecent({ from: 'zoe', text: result.reply }, scope);
 
-    const safeReply = result.reply.trim() + relayPostscript;
+    const safeReply = result.reply.trim() + relayPostscript + crmPostscript;
     if (safeReply.length < 5) {
       await ctx.reply('(empty reply guarded - check logs)');
       console.error(

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -205,6 +205,22 @@ v1 is fire-and-forget. When the target bot replies in the group, Zaal pastes the
 
 If target group isn't registered, the runtime tells Zaal to /zg enable it first. Always emit the relay_op; runtime handles the check.
 
+## CRM (NEW per doc 772 - people Zaal meets)
+
+When Zaal tells you he met / talked to / had a call with someone, or wants to log a contact or conversation, emit a crm_op. The runtime upserts the person + logs the interaction in the ZAO CRM (Supabase). Do NOT ask him to fill a form - capture what he said.
+
+Op shape (append alongside the other ops in the JSON ops fence):
+
+{
+  "crm_ops": [
+    {"op": "log_crm",
+     "contact": {"name": "Full Name", "farcaster_handle": "handle", "role": "Founder", "org": "Company", "how_we_met": "where/how", "public_summary": "one public-safe line", "email": "only if given", "location": "city", "is_public": false},
+     "interaction": {"type": "meeting", "title": "short title", "public_summary": "public-safe summary", "private_notes": "confidential context", "visibility": "private"}}
+  ]
+}
+
+Rules: contact.name is the only required field - fill the rest from what Zaal says, omit unknowns. visibility defaults to "private"; only use "public" for the interaction (and is_public:true for the contact) when Zaal clearly wants it shown on the public /network feed. Keep email / phone / location / private_notes in the PRIVATE fields, never in public_summary. The runtime appends a one-line confirmation to your reply.
+
 `;
 
 const HUMAN_DEFAULT = `# Zaal Panthaki

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -47,6 +47,38 @@ export interface BotRelayOp {
   await_reply_seconds?: number;
 }
 
+export interface CrmOp {
+  op: "log_crm";
+  /** Person record. Upserted by a deterministic slug (handle/name). */
+  contact: {
+    name: string;
+    farcaster_handle?: string;
+    x_handle?: string;
+    github_handle?: string;
+    telegram_handle?: string;
+    role?: string;
+    org?: string;
+    how_we_met?: string;
+    /** Public-safe one-liner shown on /network. */
+    public_summary?: string;
+    email?: string;
+    location?: string;
+    /** Default false. Only true if Zaal OK'd showing this contact publicly. */
+    is_public?: boolean;
+  };
+  /** The interaction to log against the contact. */
+  interaction: {
+    type?: "meeting" | "call" | "email" | "message" | "gcal" | "github" | "note";
+    title?: string;
+    /** Shown on /network only if visibility=public. */
+    public_summary?: string;
+    private_notes?: string;
+    /** Default private. */
+    visibility?: "public" | "private";
+    occurred_at?: string;
+  };
+}
+
 export interface ConciergeOptions {
   /** User message text */
   message: string;
@@ -71,6 +103,8 @@ export interface ConciergeResult {
   captures: ZoeCaptureNote[];
   /** Cross-bot relay ops (e.g. ZOE asks @zabal_bonfire_bot in ZAO Civilization). */
   bot_relay_ops: BotRelayOp[];
+  /** CRM ops - upsert a contact + log an interaction via the app API (doc 772). */
+  crm_ops: CrmOp[];
   /** Cost stats from Claude CLI call */
   inputTokens: number;
   outputTokens: number;

--- a/scripts/20260529_crm.sql
+++ b/scripts/20260529_crm.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- ZAO CRM - Supabase-native public/private relationship CRM
+-- Doc 772. Supersedes the Airtable CRM (doc 737).
+--
+-- AUTH MODEL NOTE (important - differs from doc 772's first draft):
+-- ZAOOS uses iron-session (FID/wallet + isAdmin), NOT Supabase Auth. There is
+-- no auth.uid(). Therefore:
+--   * PRIVATE protection is enforced at the APP layer: /crm pages + the write
+--     API check getSessionData().isAdmin, and read via the service-role client
+--     (which bypasses RLS). Zaal is the single owner.
+--   * PUBLIC exposure is via curated views granted to anon. The base tables
+--     deny anon entirely. The view's column projection + WHERE filter IS the
+--     security boundary.
+-- The views are intentionally SECURITY DEFINER (security_invoker NOT set) so
+-- they can read the RLS-locked base tables and return only the public subset.
+-- Supabase's linter flags security-definer views; that warning is ACCEPTED here
+-- because the views expose only public-safe columns of opted-in rows. Do not
+-- grant anon any direct SELECT on the base tables - that would leak private
+-- columns of is_public rows.
+--
+-- Table names are crm_* to avoid colliding with the dormant legacy `contacts`
+-- table from scripts/archive/supabase-applied/20260406_contacts.sql.
+-- ============================================================================
+
+-- ---------- updated_at trigger helper (idempotent) --------------------------
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ---------- crm_contacts (private base table) -------------------------------
+create table if not exists public.crm_contacts (
+  id                    uuid primary key default gen_random_uuid(),
+  owner_fid             integer,                       -- admin who owns the row (single-owner today)
+  -- public-safe columns
+  name                  text not null,
+  slug                  text unique,                   -- for /network/[slug]
+  handle                text,                          -- primary handle (display)
+  farcaster_handle      text,
+  x_handle              text,
+  github_handle         text,
+  role                  text,
+  org                   text,
+  how_we_met            text,
+  public_summary        text,
+  is_public             boolean not null default false,
+  -- private columns (never exposed to anon)
+  telegram_handle       text,
+  email                 text,
+  phone                 text,
+  location              text,
+  private_notes         text,
+  relationship_strength integer check (relationship_strength between 0 and 5),
+  -- migration reconciliation
+  legacy_airtable_id    text,
+  created_at            timestamptz not null default now(),
+  updated_at            timestamptz not null default now()
+);
+
+create index if not exists crm_contacts_is_public_idx on public.crm_contacts(is_public) where is_public = true;
+create index if not exists crm_contacts_slug_idx       on public.crm_contacts(slug);
+create unique index if not exists crm_contacts_legacy_airtable_idx
+  on public.crm_contacts(legacy_airtable_id) where legacy_airtable_id is not null;
+
+drop trigger if exists crm_contacts_updated_at on public.crm_contacts;
+create trigger crm_contacts_updated_at before update on public.crm_contacts
+  for each row execute function public.set_updated_at();
+
+-- ---------- crm_interactions (private base table, per-row visibility) -------
+create table if not exists public.crm_interactions (
+  id                 uuid primary key default gen_random_uuid(),
+  contact_id         uuid not null references public.crm_contacts(id) on delete cascade,
+  type               text not null default 'note',   -- meeting | call | email | message | gcal | github | note
+  occurred_at        timestamptz not null default now(),
+  title              text,
+  public_summary     text,                            -- shown on the public feed
+  private_notes      text,                            -- never leaves the private layer
+  visibility         text not null default 'private' check (visibility in ('public','private')),
+  source             text,                            -- gmail-mcp | meeting-skill | manual | zoe
+  bonfire_episode_id text,
+  created_by         text,                            -- 'zoe' | 'admin:<fid>' | 'migration'
+  created_at         timestamptz not null default now()
+);
+
+create index if not exists crm_interactions_contact_idx    on public.crm_interactions(contact_id);
+create index if not exists crm_interactions_occurred_idx    on public.crm_interactions(occurred_at desc);
+create index if not exists crm_interactions_public_idx      on public.crm_interactions(visibility) where visibility = 'public';
+
+-- ---------- RLS: lock base tables; service-role bypasses, anon denied -------
+alter table public.crm_contacts     enable row level security;
+alter table public.crm_interactions enable row level security;
+
+-- No anon/authenticated policies are created. With RLS enabled and no policy,
+-- those roles get ZERO rows. The service-role key (server-side only) bypasses
+-- RLS, which is how the app reads/writes the private layer after an
+-- iron-session isAdmin check. Revoke direct grants for belt-and-suspenders.
+revoke all on public.crm_contacts     from anon, authenticated;
+revoke all on public.crm_interactions from anon, authenticated;
+
+-- ---------- Public views (curated projection, granted to anon) --------------
+-- SECURITY DEFINER (no security_invoker) on purpose - see header note.
+create or replace view public.crm_contacts_public as
+  select id, slug, name, handle, farcaster_handle, x_handle, github_handle,
+         role, org, how_we_met, public_summary, created_at
+  from public.crm_contacts
+  where is_public = true;
+
+create or replace view public.crm_interactions_public as
+  select i.id, i.contact_id, i.type, i.occurred_at, i.title, i.public_summary
+  from public.crm_interactions i
+  join public.crm_contacts c on c.id = i.contact_id
+  where i.visibility = 'public' and c.is_public = true;
+
+grant select on public.crm_contacts_public     to anon, authenticated;
+grant select on public.crm_interactions_public to anon, authenticated;
+
+comment on view public.crm_contacts_public is
+  'Public projection of crm_contacts (is_public=true, safe columns only). Security boundary is this projection - never expose private columns here.';
+comment on view public.crm_interactions_public is
+  'Public projection of crm_interactions (visibility=public AND parent contact is_public). Safe columns only.';

--- a/src/app/api/crm/interactions/route.ts
+++ b/src/app/api/crm/interactions/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import { ENV } from '@/lib/env';
+import { logger } from '@/lib/logger';
+import { deriveContactSlug, type InteractionType } from '@/lib/crm/types';
+
+// POST /api/crm/interactions
+// Upserts a contact (by deterministic slug) then logs one interaction.
+// Dual auth: ZOE (Telegram bot) via `Authorization: Bearer <CRM_BOT_SECRET>`,
+// or an admin browser session (iron-session isAdmin). Service-role client
+// bypasses RLS; the private layer is protected here at the app layer.
+
+const contactSchema = z.object({
+  name: z.string().min(1).max(200),
+  slug: z.string().max(64).optional(),
+  handle: z.string().max(120).optional(),
+  farcaster_handle: z.string().max(120).optional(),
+  x_handle: z.string().max(120).optional(),
+  github_handle: z.string().max(120).optional(),
+  telegram_handle: z.string().max(120).optional(),
+  role: z.string().max(200).optional(),
+  org: z.string().max(200).optional(),
+  how_we_met: z.string().max(2000).optional(),
+  public_summary: z.string().max(4000).optional(),
+  email: z.string().email().max(320).optional(),
+  phone: z.string().max(40).optional(),
+  location: z.string().max(200).optional(),
+  private_notes: z.string().max(8000).optional(),
+  relationship_strength: z.number().int().min(0).max(5).optional(),
+  is_public: z.boolean().optional(),
+});
+
+const interactionSchema = z.object({
+  type: z
+    .enum(['meeting', 'call', 'email', 'message', 'gcal', 'github', 'note'])
+    .default('note'),
+  title: z.string().max(300).optional(),
+  public_summary: z.string().max(4000).optional(),
+  private_notes: z.string().max(8000).optional(),
+  visibility: z.enum(['public', 'private']).default('private'),
+  occurred_at: z.string().datetime().optional(),
+  source: z.string().max(40).optional(),
+});
+
+const bodySchema = z.object({
+  contact: contactSchema,
+  interaction: interactionSchema,
+});
+
+type Caller = { kind: 'bot' } | { kind: 'admin'; fid: number };
+
+async function authenticate(req: NextRequest): Promise<Caller | null> {
+  const authHeader = req.headers.get('authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.slice(7);
+    if (ENV.CRM_BOT_SECRET && token === ENV.CRM_BOT_SECRET) {
+      return { kind: 'bot' };
+    }
+    return null; // a Bearer was offered but it was wrong - reject, don't fall through
+  }
+  const session = await getSessionData();
+  if (session?.fid && session.isAdmin) {
+    return { kind: 'admin', fid: session.fid };
+  }
+  return null;
+}
+
+/** Strip undefined so an upsert never overwrites existing columns with null. */
+function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as Partial<T>;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const caller = await authenticate(req);
+    if (!caller) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const raw = await req.json().catch(() => null);
+    const parsed = bodySchema.safeParse(raw);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const { contact, interaction } = parsed.data;
+
+    const slug = deriveContactSlug(contact);
+    const supabase = getSupabaseAdmin();
+
+    // 1. Upsert the contact by slug. Only provided fields are written, so a
+    // re-upsert never nulls out columns set on a prior touch.
+    const contactRow = compact({
+      ...contact,
+      slug,
+      owner_fid: caller.kind === 'admin' ? caller.fid : undefined,
+    });
+
+    const { data: upserted, error: contactErr } = await supabase
+      .from('crm_contacts')
+      .upsert(contactRow, { onConflict: 'slug' })
+      .select('id, slug, is_public')
+      .single();
+
+    if (contactErr || !upserted) {
+      logger.error('[crm/interactions] contact upsert failed:', contactErr);
+      return NextResponse.json(
+        { error: 'Failed to upsert contact' },
+        { status: 500 },
+      );
+    }
+
+    // 2. Insert the interaction linked to the contact.
+    const { data: loggedInteraction, error: interactionErr } = await supabase
+      .from('crm_interactions')
+      .insert(
+        compact({
+          contact_id: upserted.id,
+          type: interaction.type as InteractionType,
+          title: interaction.title,
+          public_summary: interaction.public_summary,
+          private_notes: interaction.private_notes,
+          visibility: interaction.visibility,
+          occurred_at: interaction.occurred_at,
+          source: interaction.source ?? (caller.kind === 'bot' ? 'zoe' : 'manual'),
+          created_by:
+            caller.kind === 'bot' ? 'zoe' : `admin:${caller.fid}`,
+        }),
+      )
+      .select('id')
+      .single();
+
+    if (interactionErr || !loggedInteraction) {
+      logger.error('[crm/interactions] interaction insert failed:', interactionErr);
+      return NextResponse.json(
+        { error: 'Contact saved but interaction failed', contact_id: upserted.id },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        contact_id: upserted.id,
+        slug: upserted.slug,
+        interaction_id: loggedInteraction.id,
+      },
+      { status: 201 },
+    );
+  } catch (error: unknown) {
+    logger.error('[crm/interactions] unexpected error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/crm/CrmAddForm.tsx
+++ b/src/app/crm/CrmAddForm.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import type { InteractionType, Visibility } from '@/lib/crm/types';
+
+const INTERACTION_TYPES: InteractionType[] = [
+  'meeting',
+  'call',
+  'email',
+  'message',
+  'gcal',
+  'github',
+  'note',
+];
+
+const inputCls =
+  'w-full rounded-md border border-white/15 bg-white/[0.04] px-3 py-2 text-sm text-white placeholder-white/30 focus:border-[#f5a623] focus:outline-none';
+const labelCls = 'block text-xs font-medium text-white/60 mb-1';
+
+export default function CrmAddForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  // contact fields
+  const [name, setName] = useState('');
+  const [farcaster, setFarcaster] = useState('');
+  const [x, setX] = useState('');
+  const [role, setRole] = useState('');
+  const [org, setOrg] = useState('');
+  const [howWeMet, setHowWeMet] = useState('');
+  const [contactPublicSummary, setContactPublicSummary] = useState('');
+  const [email, setEmail] = useState('');
+  const [location, setLocation] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+
+  // interaction fields
+  const [type, setType] = useState<InteractionType>('note');
+  const [title, setTitle] = useState('');
+  const [intPublicSummary, setIntPublicSummary] = useState('');
+  const [privateNotes, setPrivateNotes] = useState('');
+  const [visibility, setVisibility] = useState<Visibility>('private');
+
+  function reset() {
+    setName('');
+    setFarcaster('');
+    setX('');
+    setRole('');
+    setOrg('');
+    setHowWeMet('');
+    setContactPublicSummary('');
+    setEmail('');
+    setLocation('');
+    setIsPublic(false);
+    setType('note');
+    setTitle('');
+    setIntPublicSummary('');
+    setPrivateNotes('');
+    setVisibility('private');
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErr(null);
+    setMsg(null);
+    if (!name.trim()) {
+      setErr('Name is required');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const body = {
+        contact: {
+          name: name.trim(),
+          farcaster_handle: farcaster.trim() || undefined,
+          x_handle: x.trim() || undefined,
+          role: role.trim() || undefined,
+          org: org.trim() || undefined,
+          how_we_met: howWeMet.trim() || undefined,
+          public_summary: contactPublicSummary.trim() || undefined,
+          email: email.trim() || undefined,
+          location: location.trim() || undefined,
+          is_public: isPublic,
+        },
+        interaction: {
+          type,
+          title: title.trim() || undefined,
+          public_summary: intPublicSummary.trim() || undefined,
+          private_notes: privateNotes.trim() || undefined,
+          visibility,
+        },
+      };
+      const res = await fetch('/api/crm/interactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error || `Request failed (${res.status})`);
+      }
+      setMsg(`Saved ${name.trim()}.`);
+      reset();
+      router.refresh();
+    } catch (error: unknown) {
+      setErr(error instanceof Error ? error.message : 'Failed to save');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-md bg-[#f5a623] px-4 py-2 text-sm font-semibold text-[#0a1628] hover:opacity-90"
+      >
+        + Add contact / log interaction
+      </button>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-xl border border-white/10 bg-white/[0.02] p-4"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Add contact + log interaction</h2>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-xs text-white/40 hover:text-white/70"
+        >
+          close
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <label className={labelCls}>Name *</label>
+          <input className={inputCls} value={name} onChange={(e) => setName(e.target.value)} placeholder="Ryan Kagy" />
+        </div>
+        <div>
+          <label className={labelCls}>Farcaster handle</label>
+          <input className={inputCls} value={farcaster} onChange={(e) => setFarcaster(e.target.value)} placeholder="rskagy" />
+        </div>
+        <div>
+          <label className={labelCls}>X handle</label>
+          <input className={inputCls} value={x} onChange={(e) => setX(e.target.value)} />
+        </div>
+        <div>
+          <label className={labelCls}>Role</label>
+          <input className={inputCls} value={role} onChange={(e) => setRole(e.target.value)} placeholder="Founder" />
+        </div>
+        <div>
+          <label className={labelCls}>Org</label>
+          <input className={inputCls} value={org} onChange={(e) => setOrg(e.target.value)} placeholder="Bonfires" />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelCls}>How we met</label>
+          <input className={inputCls} value={howWeMet} onChange={(e) => setHowWeMet(e.target.value)} />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelCls}>Public summary (shows on /network)</label>
+          <input className={inputCls} value={contactPublicSummary} onChange={(e) => setContactPublicSummary(e.target.value)} />
+        </div>
+        <div>
+          <label className={labelCls}>Email (private)</label>
+          <input className={inputCls} value={email} onChange={(e) => setEmail(e.target.value)} type="email" />
+        </div>
+        <div>
+          <label className={labelCls}>Location (private)</label>
+          <input className={inputCls} value={location} onChange={(e) => setLocation(e.target.value)} />
+        </div>
+        <label className="flex items-center gap-2 text-sm text-white/70 sm:col-span-2">
+          <input type="checkbox" checked={isPublic} onChange={(e) => setIsPublic(e.target.checked)} className="accent-[#f5a623]" />
+          Show this contact publicly on /network
+        </label>
+      </div>
+
+      <div className="my-4 border-t border-white/10" />
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div>
+          <label className={labelCls}>Interaction type</label>
+          <select className={inputCls} value={type} onChange={(e) => setType(e.target.value as InteractionType)}>
+            {INTERACTION_TYPES.map((t) => (
+              <option key={t} value={t} className="bg-[#0a1628]">
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className={labelCls}>Visibility</label>
+          <select className={inputCls} value={visibility} onChange={(e) => setVisibility(e.target.value as Visibility)}>
+            <option value="private" className="bg-[#0a1628]">private</option>
+            <option value="public" className="bg-[#0a1628]">public</option>
+          </select>
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelCls}>Title</label>
+          <input className={inputCls} value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Intro call" />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelCls}>Public summary (shows on /network if interaction is public)</label>
+          <input className={inputCls} value={intPublicSummary} onChange={(e) => setIntPublicSummary(e.target.value)} />
+        </div>
+        <div className="sm:col-span-2">
+          <label className={labelCls}>Private notes</label>
+          <textarea className={inputCls} value={privateNotes} onChange={(e) => setPrivateNotes(e.target.value)} rows={3} />
+        </div>
+      </div>
+
+      {err && <p className="mt-3 text-sm text-red-400">{err}</p>}
+      {msg && <p className="mt-3 text-sm text-[#f5a623]">{msg}</p>}
+
+      <div className="mt-4 flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-md bg-[#f5a623] px-4 py-2 text-sm font-semibold text-[#0a1628] hover:opacity-90 disabled:opacity-50"
+        >
+          {submitting ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -1,0 +1,114 @@
+import { redirect } from 'next/navigation';
+import { getSessionData } from '@/lib/auth/session';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import type { CrmContact } from '@/lib/crm/types';
+import CrmAddForm from './CrmAddForm';
+
+// Private CRM dashboard. Admin-only (iron-session isAdmin). Reads the full
+// private tables via the service-role client - the app layer is the security
+// boundary here (ZAOOS has no Supabase Auth). Doc 772.
+export const dynamic = 'force-dynamic';
+
+export const metadata = { title: 'CRM - The ZAO', robots: { index: false } };
+
+interface ContactWithCount extends CrmContact {
+  interaction_count: number;
+}
+
+async function getContacts(): Promise<ContactWithCount[]> {
+  const supabase = getSupabaseAdmin();
+  const { data: contacts, error } = await supabase
+    .from('crm_contacts')
+    .select('*')
+    .order('updated_at', { ascending: false })
+    .limit(500);
+  if (error || !contacts) return [];
+
+  // Per-contact interaction counts (one grouped query).
+  const { data: counts } = await supabase
+    .from('crm_interactions')
+    .select('contact_id');
+  const countMap = new Map<string, number>();
+  for (const row of counts ?? []) {
+    const id = (row as { contact_id: string }).contact_id;
+    countMap.set(id, (countMap.get(id) ?? 0) + 1);
+  }
+
+  return (contacts as CrmContact[]).map((c) => ({
+    ...c,
+    interaction_count: countMap.get(c.id) ?? 0,
+  }));
+}
+
+export default async function CrmPage() {
+  const session = await getSessionData();
+  if (!session?.fid || !session.isAdmin) {
+    redirect('/');
+  }
+
+  const contacts = await getContacts();
+  const publicCount = contacts.filter((c) => c.is_public).length;
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] text-white px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold sm:text-3xl">CRM</h1>
+          <p className="mt-1 text-sm text-white/60">
+            {contacts.length} contacts - {publicCount} public on{' '}
+            <a href="/network" className="text-[#f5a623] hover:underline">
+              /network
+            </a>
+          </p>
+        </header>
+
+        <CrmAddForm />
+
+        <section className="mt-8">
+          <h2 className="mb-3 text-lg font-semibold">Contacts</h2>
+          {contacts.length === 0 ? (
+            <p className="text-sm text-white/50">No contacts yet - add one above.</p>
+          ) : (
+            <ul className="space-y-2">
+              {contacts.map((c) => (
+                <li
+                  key={c.id}
+                  className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="font-medium">{c.name}</span>
+                    <span className="flex shrink-0 items-center gap-2 text-xs">
+                      <span
+                        className={
+                          c.is_public ? 'text-[#f5a623]' : 'text-white/30'
+                        }
+                      >
+                        {c.is_public ? 'public' : 'private'}
+                      </span>
+                      <span className="text-white/40">
+                        {c.interaction_count} log{c.interaction_count === 1 ? '' : 's'}
+                      </span>
+                    </span>
+                  </div>
+                  {(c.role || c.org) && (
+                    <p className="mt-0.5 text-sm text-white/60">
+                      {[c.role, c.org].filter(Boolean).join(' - ')}
+                    </p>
+                  )}
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-white/40">
+                    {c.farcaster_handle && <span>@{c.farcaster_handle}</span>}
+                    {c.email && <span>{c.email}</span>}
+                    {c.location && <span>{c.location}</span>}
+                    {c.relationship_strength != null && (
+                      <span>strength {c.relationship_strength}/5</span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/network/[slug]/page.tsx
+++ b/src/app/network/[slug]/page.tsx
@@ -1,0 +1,168 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import type { CrmContactPublic, CrmInteractionPublic } from '@/lib/crm/types';
+
+// Public per-contact detail page. Reads only the *_public views (safe columns,
+// is_public=true). Server-rendered, no auth. Doc 772.
+export const revalidate = 300;
+export const dynamicParams = true; // allow on-demand render for new public contacts
+
+async function getContact(slug: string): Promise<CrmContactPublic | null> {
+  const { data, error } = await getSupabaseAdmin()
+    .from('crm_contacts_public')
+    .select('*')
+    .eq('slug', slug)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data as CrmContactPublic;
+}
+
+async function getInteractions(contactId: string): Promise<CrmInteractionPublic[]> {
+  const { data, error } = await getSupabaseAdmin()
+    .from('crm_interactions_public')
+    .select('*')
+    .eq('contact_id', contactId)
+    .order('occurred_at', { ascending: false })
+    .limit(100);
+  if (error) return [];
+  return (data ?? []) as CrmInteractionPublic[];
+}
+
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  const { data } = await getSupabaseAdmin()
+    .from('crm_contacts_public')
+    .select('slug')
+    .not('slug', 'is', null)
+    .limit(200);
+  return (data ?? [])
+    .map((r) => r.slug as string | null)
+    .filter((s): s is string => Boolean(s))
+    .map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const contact = await getContact(slug);
+  if (!contact) return { title: 'Not found - The ZAO Network' };
+  const desc = contact.public_summary || contact.how_we_met || `${contact.name} in the ZAO orbit.`;
+  return {
+    title: `${contact.name} - The ZAO Network`,
+    description: desc.slice(0, 160),
+  };
+}
+
+function fmtDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return iso.slice(0, 10);
+  }
+}
+
+interface HandleLink {
+  label: string;
+  href: string;
+}
+
+function handleLinks(c: CrmContactPublic): HandleLink[] {
+  const links: HandleLink[] = [];
+  if (c.farcaster_handle) links.push({ label: `@${c.farcaster_handle}`, href: `https://farcaster.xyz/${c.farcaster_handle}` });
+  if (c.x_handle) links.push({ label: `@${c.x_handle} (X)`, href: `https://x.com/${c.x_handle}` });
+  if (c.github_handle) links.push({ label: `${c.github_handle} (GitHub)`, href: `https://github.com/${c.github_handle}` });
+  return links;
+}
+
+export default async function ContactPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const contact = await getContact(slug);
+  if (!contact) notFound();
+
+  const interactions = await getInteractions(contact.id);
+  const links = handleLinks(contact);
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] text-white px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-2xl">
+        <Link href="/network" className="text-sm text-[#f5a623] hover:underline">
+          &larr; Network
+        </Link>
+
+        <header className="mt-4 border-b border-white/10 pb-5">
+          <h1 className="text-2xl font-bold sm:text-3xl">{contact.name}</h1>
+          {(contact.role || contact.org) && (
+            <p className="mt-1 text-white/70">
+              {[contact.role, contact.org].filter(Boolean).join(' - ')}
+            </p>
+          )}
+          {links.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-3">
+              {links.map((l) => (
+                <a
+                  key={l.href}
+                  href={l.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-[#f5a623] hover:underline"
+                >
+                  {l.label}
+                </a>
+              ))}
+            </div>
+          )}
+          {contact.how_we_met && (
+            <p className="mt-3 text-sm text-white/50">
+              <span className="text-white/40">How we met:</span> {contact.how_we_met}
+            </p>
+          )}
+          {contact.public_summary && (
+            <p className="mt-3 text-white/80">{contact.public_summary}</p>
+          )}
+        </header>
+
+        <section className="mt-6">
+          <h2 className="mb-3 text-lg font-semibold">Interactions</h2>
+          {interactions.length === 0 ? (
+            <p className="text-sm text-white/50">No public interactions yet.</p>
+          ) : (
+            <ul className="space-y-3">
+              {interactions.map((i) => (
+                <li
+                  key={i.id}
+                  className="rounded-lg border border-white/10 bg-white/[0.03] p-3"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-sm font-medium text-white">
+                      {i.title || i.type}
+                    </span>
+                    <span className="shrink-0 text-xs text-white/40">
+                      {fmtDate(i.occurred_at)}
+                    </span>
+                  </div>
+                  {i.public_summary && (
+                    <p className="mt-1 text-sm text-white/70">{i.public_summary}</p>
+                  )}
+                  <span className="mt-1 inline-block text-[10px] uppercase tracking-wide text-[#f5a623]/70">
+                    {i.type}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/network/page.tsx
+++ b/src/app/network/page.tsx
@@ -1,0 +1,90 @@
+import Link from 'next/link';
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+import type { CrmContactPublic } from '@/lib/crm/types';
+
+// Public "who I've met" feed. Reads only the crm_contacts_public view (safe
+// columns, is_public=true). Server-rendered, no auth. Doc 772.
+export const revalidate = 300; // ISR: refresh every 5 min
+
+export const metadata = {
+  title: 'Network - The ZAO',
+  description: 'People in the ZAO orbit - who we have met and what we are building together.',
+};
+
+async function getPublicContacts(): Promise<CrmContactPublic[]> {
+  const { data, error } = await getSupabaseAdmin()
+    .from('crm_contacts_public')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(200);
+  if (error) return [];
+  return (data ?? []) as CrmContactPublic[];
+}
+
+function handleLine(c: CrmContactPublic): string | null {
+  if (c.farcaster_handle) return `@${c.farcaster_handle}`;
+  if (c.x_handle) return `@${c.x_handle}`;
+  if (c.github_handle) return c.github_handle;
+  return c.handle;
+}
+
+export default async function NetworkPage() {
+  const contacts = await getPublicContacts();
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] text-white px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-8">
+          <h1 className="text-2xl font-bold sm:text-3xl">Network</h1>
+          <p className="mt-2 text-sm text-white/60">
+            People in the ZAO orbit - who we have met and what we are building together.
+          </p>
+        </header>
+
+        {contacts.length === 0 ? (
+          <p className="text-white/50">No public contacts yet.</p>
+        ) : (
+          <ul className="space-y-3">
+            {contacts.map((c) => {
+              const handle = handleLine(c);
+              const card = (
+                <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 transition-colors hover:border-[#f5a623]/40">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <h2 className="font-semibold text-white">{c.name}</h2>
+                    {handle && (
+                      <span className="shrink-0 text-xs text-[#f5a623]">{handle}</span>
+                    )}
+                  </div>
+                  {(c.role || c.org) && (
+                    <p className="mt-1 text-sm text-white/70">
+                      {[c.role, c.org].filter(Boolean).join(' - ')}
+                    </p>
+                  )}
+                  {c.how_we_met && (
+                    <p className="mt-2 text-sm text-white/50">
+                      <span className="text-white/40">How we met:</span> {c.how_we_met}
+                    </p>
+                  )}
+                  {c.public_summary && (
+                    <p className="mt-2 text-sm text-white/70">{c.public_summary}</p>
+                  )}
+                </div>
+              );
+              return (
+                <li key={c.id}>
+                  {c.slug ? (
+                    <Link href={`/network/${c.slug}`} className="block">
+                      {card}
+                    </Link>
+                  ) : (
+                    card
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/lib/crm/types.ts
+++ b/src/lib/crm/types.ts
@@ -1,0 +1,96 @@
+// Shared CRM types + helpers. Doc 772. Backed by crm_contacts / crm_interactions
+// (see scripts/20260529_crm.sql). Public reads go through the *_public views.
+
+export type InteractionType =
+  | 'meeting'
+  | 'call'
+  | 'email'
+  | 'message'
+  | 'gcal'
+  | 'github'
+  | 'note';
+
+export type Visibility = 'public' | 'private';
+
+/** A contact row as stored privately (service-role reads only). */
+export interface CrmContact {
+  id: string;
+  owner_fid: number | null;
+  name: string;
+  slug: string | null;
+  handle: string | null;
+  farcaster_handle: string | null;
+  x_handle: string | null;
+  github_handle: string | null;
+  role: string | null;
+  org: string | null;
+  how_we_met: string | null;
+  public_summary: string | null;
+  is_public: boolean;
+  telegram_handle: string | null;
+  email: string | null;
+  phone: string | null;
+  location: string | null;
+  private_notes: string | null;
+  relationship_strength: number | null;
+  legacy_airtable_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Public projection of a contact (crm_contacts_public view). */
+export interface CrmContactPublic {
+  id: string;
+  slug: string | null;
+  name: string;
+  handle: string | null;
+  farcaster_handle: string | null;
+  x_handle: string | null;
+  github_handle: string | null;
+  role: string | null;
+  org: string | null;
+  how_we_met: string | null;
+  public_summary: string | null;
+  created_at: string;
+}
+
+/** Public projection of an interaction (crm_interactions_public view). */
+export interface CrmInteractionPublic {
+  id: string;
+  contact_id: string;
+  type: InteractionType;
+  occurred_at: string;
+  title: string | null;
+  public_summary: string | null;
+}
+
+/**
+ * Deterministic slug from the best available identifier. Lets the bot upsert a
+ * contact by a stable key without first reading the DB. Order: explicit slug,
+ * then farcaster/x/github handle, then the name.
+ */
+export function deriveContactSlug(input: {
+  slug?: string | null;
+  farcaster_handle?: string | null;
+  x_handle?: string | null;
+  github_handle?: string | null;
+  name: string;
+}): string {
+  const raw =
+    input.slug ||
+    input.farcaster_handle ||
+    input.x_handle ||
+    input.github_handle ||
+    input.name;
+  return slugify(raw);
+}
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/^@/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -107,4 +107,10 @@ export const ENV = {
   // a random 32+ byte hex value (`openssl rand -hex 32`) and pass the same
   // value to Juke when registering the webhook at POST /v1/developer/webhooks.
   JUKE_WEBHOOK_SECRET: optionalEnv('JUKE_WEBHOOK_SECRET'),
+  // Bearer secret shared with ZOE (Telegram bot) so it can write CRM
+  // contacts/interactions via POST /api/crm/interactions without an admin
+  // session. Generate `openssl rand -hex 32`; set the same value in the bot's
+  // env (CRM_BOT_SECRET). Unset = the bot write path is disabled (an admin
+  // iron-session still works on the same route).
+  CRM_BOT_SECRET: optionalEnv('CRM_BOT_SECRET'),
 } as const;


### PR DESCRIPTION
## Summary
Implements the Supabase-native public/private CRM from doc 772 (PR #734). Migration SQL + dual-auth bot API + public /network feed + private /crm dashboard + ZOE write path.

## What's included
- **Migration** `scripts/20260529_crm.sql` - crm_contacts + crm_interactions + 2 SECURITY DEFINER public views + RLS. NEEDS Zaal to apply in the Supabase SQL editor (no CLI on the box).
- **Bot API** `POST /api/crm/interactions` - dual auth (CRM_BOT_SECRET bearer for ZOE, iron-session isAdmin for browser), Zod, service-role, upsert-by-slug + log interaction.
- **/network** + **/network/[slug]** - public feed + detail, reads *_public views only, ISR.
- **/crm** - admin-gated dashboard + add-contact/log-interaction form.
- **ZOE write path** - crm_op type + bot/src/zoe/crm.ts + concierge parse + index execute + persona section. Gated on CRM_BOT_SECRET + CRM_API_URL env on the VPS.

## Auth model note
ZAOOS has no Supabase Auth - it's iron-session + service-role. Private protection is enforced at the app layer (isAdmin + service-role reads); anon only sees curated SECURITY DEFINER views. RLS denies anon on base tables. Differs from doc 772's first-draft auth.uid() design - documented in the migration header.

## Checks
- App `npm run typecheck`: 0 errors. Bot `tsc --noEmit`: 0 errors.

## Gating / follow-ups
- [ZAAL] Apply the migration SQL before the routes work.
- [ZAAL] Set CRM_BOT_SECRET (app + bot env) + CRM_API_URL (bot) for the ZOE path.
- Migrate Airtable -> Supabase (one-shot script, follow-up).
- Bonfire episode emit on public interactions (doc 772 step 7) deferred - needs app-side poster + PII scan; bonfire_episode_id column ready.