### PR TITLE
fix(zoe/770): close orchestrator HIGH findings H1/H3/H5 before trusted runs

### DIFF
--- a/bot/src/zoe/__tests__/approvals.test.ts
+++ b/bot/src/zoe/__tests__/approvals.test.ts
@@ -145,3 +145,27 @@ test('a live approval-bearing pending blocks a different-kind arm', () => {
   assert.equal(wouldClobber(pendingOf('learn'), 'plan'), true); // new plan: vs live learn
   assert.equal(wouldClobber(pendingOf('reflexion'), 'plan'), true);
 });
+
+// =========================
+// parseApprovalReply — doc 770 MED tightening
+// =========================
+
+test('an approval verb anywhere overrides a leading edit prefix', () => {
+  assert.equal(parseApprovalReply('actually yes do it').decision, 'approve-all');
+  assert.equal(parseApprovalReply('change nothing, ship it').decision, 'approve-all');
+});
+
+test('an approval verb anywhere overrides a leading reject ("no but go ahead")', () => {
+  assert.equal(parseApprovalReply('no but go ahead').decision, 'approve-all');
+});
+
+test('a bare edit keyword with no content is NOT an edit (leaves pending)', () => {
+  // "wait" alone used to become edit with empty text → empty re-decompose.
+  assert.equal(parseApprovalReply('wait').decision, 'not-an-approval');
+});
+
+test('edit with real instruction and no approval verb still parses as edit', () => {
+  const r = parseApprovalReply('actually research the pricing first');
+  assert.equal(r.decision, 'edit');
+  assert.equal(r.editText, 'research the pricing first');
+});

--- a/bot/src/zoe/__tests__/approvals.test.ts
+++ b/bot/src/zoe/__tests__/approvals.test.ts
@@ -4,9 +4,14 @@ import assert from 'node:assert/strict';
 import {
   parseApprovalReply,
   isPendingExpired,
+  wouldClobber,
   PENDING_TTL_MS,
 } from '../approvals.ts';
-import type { PendingApproval } from '../approvals.ts';
+import type { PendingApproval, PendingKind } from '../approvals.ts';
+
+function pendingOf(kind: PendingKind): PendingApproval {
+  return { kind, chatScope: 'private', createdAt: new Date().toISOString() } as PendingApproval;
+}
 
 // =========================
 // parseApprovalReply
@@ -109,4 +114,34 @@ test('per-item ttlMs override extends the lifetime', () => {
   };
   // Older than the 30-min default, but well within the 14h override.
   assert.equal(isPendingExpired(p, now), false);
+});
+
+// =========================
+// wouldClobber — doc 770 H2 regression
+// A new pending must not silently clobber a live approval-bearing one of a
+// different kind. Same-kind re-arm and superseding the passive await-reflection
+// slot are both allowed.
+// =========================
+
+test('no existing pending never clobbers', () => {
+  assert.equal(wouldClobber(undefined, 'plan'), false);
+});
+
+test('same-kind re-arm is allowed (e.g. plan -> plan after re-decompose)', () => {
+  assert.equal(wouldClobber(pendingOf('plan'), 'plan'), false);
+  assert.equal(wouldClobber(pendingOf('reflexion'), 'reflexion'), false);
+});
+
+test('a command/new pending may supersede the passive await-reflection slot', () => {
+  // await-reflection is not approval-bearing — arming over it is allowed so a
+  // plan: in the reflection window isn't blocked (keeps the H1 benefit).
+  assert.equal(wouldClobber(pendingOf('await-reflection'), 'plan'), false);
+  assert.equal(wouldClobber(pendingOf('await-reflection'), 'learn'), false);
+});
+
+test('a live approval-bearing pending blocks a different-kind arm', () => {
+  assert.equal(wouldClobber(pendingOf('plan'), 'await-reflection'), true); // scheduler vs live plan
+  assert.equal(wouldClobber(pendingOf('plan-gate'), 'learn'), true); // scheduler vs paused plan
+  assert.equal(wouldClobber(pendingOf('learn'), 'plan'), true); // new plan: vs live learn
+  assert.equal(wouldClobber(pendingOf('reflexion'), 'plan'), true);
 });

--- a/bot/src/zoe/__tests__/commands.test.ts
+++ b/bot/src/zoe/__tests__/commands.test.ts
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isZoeCommand, NOTE_PREFIX, PLAN_PREFIX } from '../commands.ts';
+
+// =========================
+// isZoeCommand — doc 770 H1 regression
+// A command sent during the evening-reflection window MUST be recognized so
+// handlePrivateMessage lets it through instead of swallowing it as the
+// reflection answer.
+// =========================
+
+test('plan: / decompose: are commands (bypass await-reflection capture)', () => {
+  for (const t of [
+    'plan: ship the onepager and post it',
+    'decompose: research pricing then draft a brief',
+    'PLAN: do the thing', // case-insensitive
+    'plan:\nmulti-line goal body', // dotall — body can span lines
+  ]) {
+    assert.equal(isZoeCommand(t), true, `"${t}" should be a command`);
+  }
+});
+
+test('note: / cc: / claude: are commands', () => {
+  for (const t of ['note: remember this', 'cc: idea for later', 'claude: fix the build']) {
+    assert.equal(isZoeCommand(t), true, `"${t}" should be a command`);
+  }
+});
+
+test('nudge toggles are commands', () => {
+  for (const t of ['stop nudges', 'start nudges', 'pause tips', 'resume tip', 'disable nudge']) {
+    assert.equal(isZoeCommand(t), true, `"${t}" should be a command`);
+  }
+});
+
+test('a real reflection answer is NOT a command (still gets captured)', () => {
+  for (const t of [
+    'today went well, shipped the relay and felt good about it',
+    'I struggled with focus this afternoon',
+    'biggest win was closing the audit',
+    'planning to rest tomorrow', // "planning" must not match the plan: prefix
+    'noted, will circle back', // "noted" must not match the note: prefix
+    '',
+  ]) {
+    assert.equal(isZoeCommand(t), false, `"${t}" should NOT be a command`);
+  }
+});
+
+test('prefix regexes capture the body in group 2', () => {
+  assert.equal(PLAN_PREFIX.exec('plan: do X')?.[2], 'do X');
+  assert.equal(NOTE_PREFIX.exec('note: do Y')?.[2], 'do Y');
+});

--- a/bot/src/zoe/__tests__/dispatch.test.ts
+++ b/bot/src/zoe/__tests__/dispatch.test.ts
@@ -110,3 +110,36 @@ test('cancellation stops before the first wave', async () => {
   assert.equal(report.status, 'cancelled');
   assert.equal(report.results.length, 0);
 });
+
+// =========================
+// doc 770 H3 — wave-concurrency cap + pre-flight budget
+// =========================
+
+test('pre-flight budget refuses to launch a batch it cannot afford (no worker runs)', async () => {
+  // research-worker estimates at its $1.00 hard per-invocation cap. A $0.50
+  // budget can't cover even one, so the wave is refused BEFORE any claude
+  // subprocess launches — the test stays pure (no CLI call).
+  const p = plan([st('st-1', { worker: 'research-worker' })]);
+  const report = await dispatchPlan(args(p, { maxPlanBudgetUsd: 0.5 }));
+  assert.equal(report.status, 'budget-exceeded');
+  assert.equal(report.results.length, 0);
+  assert.equal(report.totalCostUsd, 0);
+});
+
+test('a wave larger than the concurrency cap still completes every subtask', async () => {
+  // 7 independent task-dispatcher subtasks (cost 0) exceed WAVE_CONCURRENCY (3),
+  // so they run across multiple batches. Batching must not drop any.
+  const p = plan([
+    st('st-1'),
+    st('st-2'),
+    st('st-3'),
+    st('st-4'),
+    st('st-5'),
+    st('st-6'),
+    st('st-7'),
+  ]);
+  const report = await dispatchPlan(args(p));
+  assert.equal(report.status, 'completed');
+  assert.equal(report.results.length, 7);
+  assert.equal(report.completedIds.length, 7);
+});

--- a/bot/src/zoe/__tests__/dispatch.test.ts
+++ b/bot/src/zoe/__tests__/dispatch.test.ts
@@ -126,6 +126,15 @@ test('pre-flight budget refuses to launch a batch it cannot afford (no worker ru
   assert.equal(report.totalCostUsd, 0);
 });
 
+test('duplicate subtask ids fail fast with a clear diagnostic (not "unsatisfiable")', async () => {
+  // doc 770 MED: the completed-Set bound can never reach length with dup ids.
+  const p = plan([st('st-1'), st('st-1', { title: 'dup' })]);
+  const report = await dispatchPlan(args(p));
+  assert.equal(report.status, 'failed');
+  assert.equal(report.results.length, 0);
+  assert.match(report.summary, /duplicate subtask ids/);
+});
+
 test('a wave larger than the concurrency cap still completes every subtask', async () => {
   // 7 independent task-dispatcher subtasks (cost 0) exceed WAVE_CONCURRENCY (3),
   // so they run across multiple batches. Batching must not drop any.

--- a/bot/src/zoe/__tests__/learn.test.ts
+++ b/bot/src/zoe/__tests__/learn.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { summarizeRuns, renderLearnProposals } from '../learn.ts';
+import { summarizeRuns, renderLearnProposals, capLearnings } from '../learn.ts';
 import type { LearnProposal } from '../learn.ts';
 import type { RunRecord } from '../runs.ts';
 
@@ -74,4 +74,36 @@ test('renderLearnProposals handles empty + populated', () => {
   assert.match(out, /lp-1 \(research-worker\)/);
   assert.match(out, /Always cite the file path/);
   assert.match(out, /y all/);
+});
+
+// =========================
+// capLearnings — doc 770 MED (bounded + deduped worker-prompt learnings)
+// =========================
+
+test('capLearnings keeps the header and the most recent N bullets', () => {
+  const header = '# Learnings for research-worker\n\nAppended by ZOE.\n';
+  const bullets = Array.from({ length: 50 }, (_, i) => `- (2026-05-${String((i % 28) + 1).padStart(2, '0')}) lesson ${i}`);
+  const out = capLearnings(`${header}${bullets.join('\n')}\n`, 30);
+  assert.match(out, /# Learnings for research-worker/);
+  const kept = out.split('\n').filter((l) => l.trimStart().startsWith('- '));
+  assert.equal(kept.length, 30);
+  assert.match(out, /lesson 49/); // newest kept
+  assert.doesNotMatch(out, /lesson 0\b/); // oldest dropped
+});
+
+test('capLearnings dedupes identical learning text (ignoring the date prefix)', () => {
+  const raw = [
+    '# Learnings',
+    '- (2026-05-01) always cite sources',
+    '- (2026-05-20) Always cite sources', // dup (case-insensitive, different date)
+    '- (2026-05-21) keep it short',
+  ].join('\n');
+  const out = capLearnings(raw, 30);
+  const kept = out.split('\n').filter((l) => l.trimStart().startsWith('- '));
+  assert.equal(kept.length, 2);
+});
+
+test('capLearnings returns empty for empty input', () => {
+  assert.equal(capLearnings(''), '');
+  assert.equal(capLearnings('   \n  '), '');
 });

--- a/bot/src/zoe/__tests__/relay.test.ts
+++ b/bot/src/zoe/__tests__/relay.test.ts
@@ -1,0 +1,42 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveRelayChatId } from '../relay.ts';
+import type { GroupConfig } from '../groups.ts';
+import type { BotRelayOp } from '../types.ts';
+
+function group(chat_id: number, chat_title: string): GroupConfig {
+  return { chat_id, chat_title } as GroupConfig;
+}
+
+function op(over: Partial<BotRelayOp> = {}): BotRelayOp {
+  return { op: 'relay_to_bot', tag_bot: '@zabal_bonfire_bot', message: 'hi', ...over };
+}
+
+const GROUPS = [
+  group(-100, 'ZAO Civilization'),
+  group(-200, 'ZAO Devz'),
+  group(-300, 'ZAO'),
+];
+
+// =========================
+// resolveRelayChatId — doc 770 MED (exact match, not substring)
+// =========================
+
+test('exact title match wins (case-insensitive, trimmed)', () => {
+  assert.equal(resolveRelayChatId(GROUPS, op({ to_group: 'ZAO Civilization' })), -100);
+  assert.equal(resolveRelayChatId(GROUPS, op({ to_group: '  zao civilization  ' })), -100);
+});
+
+test('"ZAO" no longer matches "ZAO Devz"/"ZAO Civilization" by substring', () => {
+  // The old substring match would first-match-win onto "ZAO Civilization".
+  assert.equal(resolveRelayChatId(GROUPS, op({ to_group: 'ZAO' })), -300);
+});
+
+test('a non-existent group resolves to undefined (caller reports not-registered)', () => {
+  assert.equal(resolveRelayChatId(GROUPS, op({ to_group: 'ZAO Stock' })), undefined);
+});
+
+test('explicit to_chat_id short-circuits the title lookup', () => {
+  assert.equal(resolveRelayChatId(GROUPS, op({ to_chat_id: -999, to_group: 'ZAO Devz' })), -999);
+});

--- a/bot/src/zoe/__tests__/workers.test.ts
+++ b/bot/src/zoe/__tests__/workers.test.ts
@@ -1,0 +1,17 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { revisionBudget } from '../workers.ts';
+
+// =========================
+// revisionBudget — doc 770 MED (critic-fail no longer doubles the cap)
+// =========================
+
+test('revision gets the remaining budget under the cap', () => {
+  assert.equal(revisionBudget(1.0, 0.4), 0.6);
+});
+
+test('revision budget never goes negative when the first call hit the cap', () => {
+  assert.equal(revisionBudget(1.0, 1.0), 0);
+  assert.equal(revisionBudget(1.0, 1.5), 0);
+});

--- a/bot/src/zoe/approvals.ts
+++ b/bot/src/zoe/approvals.ts
@@ -170,28 +170,42 @@ const pendingByScope = new Map<string, PendingApproval>();
 const REJECT_RE = /^\s*(n|no|nope|cancel|stop|abort|skip|nah|nvm|never\s*mind)\b/i;
 const APPROVE_RE = /^\s*(y|yes|yep|yeah|yup|approve|approved|go|go ahead|ship it|ship|send it|do it|lgtm|sounds good)\b/i;
 const EDIT_RE = /^\s*(edit|revise|change|tweak|adjust|instead|actually|no but|wait)\b[:,]?\s*(.*)/i;
+// An explicit approval verb appearing ANYWHERE (not just at the start). Used to
+// override a leading edit/reject prefix (doc 770 MED): "actually yes do it" and
+// "no but go ahead" are approvals, not edits/rejects. Conservative — omits the
+// bare "y"/"go"/"ship" forms that would false-positive mid-sentence.
+const APPROVE_ANYWHERE_RE = /\b(yes|yep|yeah|yup|approved?|go ahead|ship it|send it|do it|lgtm|sounds good)\b/i;
 // Subtask / patch / proposal ids: st-1, patch-2, lp-3, etc.
 const ID_RE = /\b((?:st|patch|lp|sq|task)-[a-z0-9]+)\b/gi;
 
 /**
  * Parse a Telegram reply against a pending approval. Pure — no IO, no state.
- * Order matters: reject is checked first (so "no" never reads as approve),
- * then explicit edit, then approve (all vs ids), else not-an-approval.
+ *
+ * Precedence (doc 770 MED — fixes EDIT_RE/REJECT_RE swallowing approvals):
+ *   1. reject — unless an explicit approval verb is also present ("no but go ahead")
+ *   2. edit — only when there's real instruction content AND no approval present
+ *      ("actually research X" → edit; "actually yes do it" → approve below)
+ *   3. approve — leading approve verb OR an approval verb anywhere
+ *   4. otherwise not-an-approval (a bare "wait" with no content lands here, so
+ *      the pending is left in place rather than re-decomposed with empty text)
  */
 export function parseApprovalReply(text: string): ApprovalReply {
   const trimmed = text.trim();
   if (!trimmed) return { decision: 'not-an-approval', ids: [] };
 
-  if (REJECT_RE.test(trimmed)) {
+  const containsApprove = APPROVE_ANYWHERE_RE.test(trimmed);
+
+  if (REJECT_RE.test(trimmed) && !containsApprove) {
     return { decision: 'reject', ids: [] };
   }
 
   const editMatch = trimmed.match(EDIT_RE);
-  if (editMatch) {
-    return { decision: 'edit', ids: [], editText: editMatch[2]?.trim() || trimmed };
+  const editText = editMatch?.[2]?.trim();
+  if (editMatch && editText && !containsApprove) {
+    return { decision: 'edit', ids: [], editText };
   }
 
-  if (APPROVE_RE.test(trimmed)) {
+  if (APPROVE_RE.test(trimmed) || containsApprove) {
     const ids = extractIds(trimmed);
     // "y all" or a bare "y/yes/approve" with no specific ids = approve all.
     if (/\ball\b/i.test(trimmed) || ids.length === 0) {

--- a/bot/src/zoe/approvals.ts
+++ b/bot/src/zoe/approvals.ts
@@ -112,6 +112,56 @@ export interface ApprovalReply {
 /** Pending items older than this auto-expire. 30 min. */
 export const PENDING_TTL_MS = 30 * 60 * 1000;
 
+/**
+ * Kinds that carry an outstanding y/n Zaal must answer. A new pending may not
+ * silently clobber one of these (doc 770 H2). `await-reflection` is omitted on
+ * purpose: it's a passive "capture the next DM" slot, so an explicit command
+ * (which H1 already says is not a reflection answer) is allowed to supersede it.
+ */
+const APPROVAL_BEARING_KINDS: ReadonlySet<PendingKind> = new Set<PendingKind>([
+  'plan',
+  'plan-gate',
+  'reflexion',
+  'learn',
+]);
+
+/** Human-readable label for a pending kind, for refuse-when-busy messages. */
+export function pendingKindLabel(kind: PendingKind): string {
+  switch (kind) {
+    case 'plan':
+      return 'plan approval';
+    case 'plan-gate':
+      return 'paused plan (at its approval gate)';
+    case 'reflexion':
+      return 'memory-update approval';
+    case 'await-reflection':
+      return 'evening reflection';
+    case 'learn':
+      return 'learning-proposal approval';
+  }
+}
+
+/**
+ * Pure decision (doc 770 H2): would arming `newKind` clobber a live
+ * approval-bearing pending of a different kind? Re-arming the SAME kind
+ * (e.g. plan -> plan after a re-decompose) is always allowed.
+ */
+export function wouldClobber(
+  existing: PendingApproval | undefined,
+  newKind: PendingKind,
+): boolean {
+  return (
+    !!existing && existing.kind !== newKind && APPROVAL_BEARING_KINDS.has(existing.kind)
+  );
+}
+
+/** Outcome of an attempt to arm a pending item. */
+export interface SetPendingResult {
+  armed: boolean;
+  /** When armed=false, the live pending that blocked the arm. */
+  blockedBy?: PendingApproval;
+}
+
 const PENDING_FILE = join(ZOE_PATHS.home, 'pending-approvals.json');
 
 // In-memory store, one pending item per chat scope. Mirror of disk.
@@ -198,10 +248,19 @@ export function getPending(scope: string): PendingApproval | undefined {
   return p;
 }
 
-/** Set (replace) the pending item for a scope and persist. */
-export async function setPending(p: PendingApproval): Promise<void> {
+/**
+ * Arm the pending item for a scope and persist. Refuses (doc 770 H2) if a
+ * different live approval-bearing pending already occupies the scope, so
+ * concurrent flows can't silently clobber each other. Returns whether it armed.
+ */
+export async function setPending(p: PendingApproval): Promise<SetPendingResult> {
+  const existing = getPending(p.chatScope);
+  if (wouldClobber(existing, p.kind)) {
+    return { armed: false, blockedBy: existing };
+  }
   pendingByScope.set(p.chatScope, p);
   await persist();
+  return { armed: true };
 }
 
 /** Clear the pending item for a scope and persist. */

--- a/bot/src/zoe/commands.ts
+++ b/bot/src/zoe/commands.ts
@@ -1,0 +1,32 @@
+/**
+ * commands.ts — pure command-prefix detection for ZOE DMs.
+ *
+ * Extracted from index.ts so the routing predicates are unit-testable without
+ * importing index.ts (which calls main()/bot.start() on module load). Used by
+ * handlePrivateMessage to detect plan:/note: commands and — critically — to
+ * ensure a command sent during the evening-reflection window bypasses the
+ * await-reflection pending capture (doc 770 H1).
+ */
+
+/** `note:` / `cc:` / `claude:` capture prefix. Group 2 is the note body. */
+export const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
+
+/**
+ * Opt-in goal decomposition + dispatch (doc 759 Gaps 1+2). Zaal sends
+ * `plan: <goal>` / `decompose: <goal>` to get a routed plan; on "y" ZOE
+ * dispatches the workers. Group 2 is the goal. Default chat stays concierge.
+ */
+export const PLAN_PREFIX = /^(plan|decompose):\s*(.+)/is;
+
+/** Hourly-nudge on/off toggle (both phrasings handled in index.ts). */
+export const NUDGE_TOGGLE_RE = /^(stop|pause|disable|start|resume|enable)\s+(nudges?|tips?)$/i;
+
+/**
+ * True if a DM is a recognized ZOE command (plan:/note:/nudge toggle). Such
+ * messages must bypass the await-reflection pending capture (doc 770 H1): the
+ * evening reflection arms a long-TTL pending, and a `plan:` sent in that window
+ * would otherwise be swallowed as the reflection answer and never dispatched.
+ */
+export function isZoeCommand(text: string): boolean {
+  return NUDGE_TOGGLE_RE.test(text.trim()) || NOTE_PREFIX.test(text) || PLAN_PREFIX.test(text);
+}

--- a/bot/src/zoe/decompose.ts
+++ b/bot/src/zoe/decompose.ts
@@ -247,6 +247,11 @@ function coerceToPlan(raw: unknown): DecompositionPlan {
       `decompose: plan has ${subtasks.length} subtasks (max ${MAX_SUBTASKS}) - goal is too big; split it into smaller goals`,
     );
   }
+  // Duplicate ids corrupt the dispatch loop bound + depends_on resolution
+  // (doc 770 MED) — escalate so Zaal gets a re-decompose, not a stuck plan.
+  if (new Set(subtasks.map((s) => s.id)).size !== subtasks.length) {
+    throw new Error('decompose: plan has duplicate subtask ids - re-decompose');
+  }
   return { goal_summary, subtasks, execution_plan, ambiguities };
 }
 

--- a/bot/src/zoe/decompose.ts
+++ b/bot/src/zoe/decompose.ts
@@ -214,6 +214,13 @@ function findLastJsonObject(text: string): string | null {
 }
 
 /**
+ * Hard ceiling on the number of subtasks a single plan may carry (doc 770 H3).
+ * The decompose prompt targets <=8; this is the safety net above that. Override
+ * via ZOE_MAX_SUBTASKS.
+ */
+export const MAX_SUBTASKS = Math.max(1, Number(process.env.ZOE_MAX_SUBTASKS ?? 12));
+
+/**
  * Validate + narrow the parsed JSON into a DecompositionPlan. Throws on
  * obviously-bad shapes so the caller knows to escalate instead of silently
  * dispatching workers from a malformed plan.
@@ -231,6 +238,14 @@ function coerceToPlan(raw: unknown): DecompositionPlan {
   if (!goal_summary) throw new Error('decompose: plan.goal_summary missing');
   if (subtasks.length === 0 && ambiguities.length === 0) {
     throw new Error('decompose: plan has no subtasks AND no ambiguities - empty plan');
+  }
+  // Hard ceiling on subtask count (doc 770 H3). The system prompt already asks
+  // the model to return an ambiguity at 8+, so anything past MAX_SUBTASKS is a
+  // malformed/runaway plan — escalate to Zaal instead of dispatching it.
+  if (subtasks.length > MAX_SUBTASKS) {
+    throw new Error(
+      `decompose: plan has ${subtasks.length} subtasks (max ${MAX_SUBTASKS}) - goal is too big; split it into smaller goals`,
+    );
   }
   return { goal_summary, subtasks, execution_plan, ambiguities };
 }

--- a/bot/src/zoe/dispatch.ts
+++ b/bot/src/zoe/dispatch.ts
@@ -222,6 +222,20 @@ export async function dispatchPlan(args: DispatchPlanArgs): Promise<DispatchRepo
   const results: WorkerResult[] = [];
   let totalCost = 0;
 
+  // Duplicate ids break the completed-Set loop bound + outputsById (doc 770
+  // MED): the Set size can never reach plan.subtasks.length, so the loop would
+  // otherwise return a misleading 'dependency unsatisfiable' failure. Bail with
+  // a clear diagnostic instead.
+  if (new Set(plan.subtasks.map((s) => s.id)).size !== plan.subtasks.length) {
+    return {
+      status: 'failed',
+      results: [],
+      completedIds: [...completed],
+      totalCostUsd: 0,
+      summary: 'Stopped — the plan has duplicate subtask ids and cannot be dispatched safely. Re-decompose.',
+    };
+  }
+
   const finish = (status: DispatchReport['status'], gateAfterId?: string): DispatchReport => {
     const partial = {
       status,

--- a/bot/src/zoe/dispatch.ts
+++ b/bot/src/zoe/dispatch.ts
@@ -2,11 +2,12 @@
  * dispatch.ts — ZOE's Node-orchestrated dispatch loop (doc 759 Gap 2).
  *
  * Takes an APPROVED DecompositionPlan and runs it:
- *   - schedules subtasks in dependency waves (all deps-satisfied subtasks run
- *     concurrently via Promise.allSettled)
+ *   - schedules subtasks in dependency waves (deps-satisfied subtasks run
+ *     concurrently, capped at WAVE_CONCURRENCY per batch — doc 770 H3)
  *   - routes each subtask to its worker (workers.ts) or to Hermes for code-fix
  *   - records every run for the Gap 5 learning loop (runs.ts)
- *   - enforces a hard per-plan USD budget
+ *   - enforces a hard per-plan USD budget, pre-flighting each batch before it
+ *     launches and stopping the moment the cap is hit (doc 770 H3)
  *   - honors approval_gate_before_next: pauses the loop and returns
  *     'paused-for-gate' so the caller raises a fresh approval. On resume the
  *     caller re-invokes with alreadyCompleted set.
@@ -18,11 +19,35 @@
 
 import { dispatchHermesRun } from '../hermes/runner';
 import type { ZoeContext } from './types';
-import type { DecompositionPlan, Subtask } from './decompose';
-import { runClaudeWorker, type WorkerResult } from './workers';
+import type { DecompositionPlan, Subtask, WorkerKind } from './decompose';
+import {
+  runClaudeWorker,
+  workerMaxBudget,
+  type ClaudeWorkerKind,
+  type WorkerResult,
+} from './workers';
 import { recordRun, newRunId, type RunRecord } from './runs';
 
 const DEFAULT_PLAN_BUDGET_USD = Number(process.env.ZOE_PLAN_BUDGET_USD ?? 5);
+
+/**
+ * Max worker subprocesses launched at once within a single dependency wave
+ * (doc 770 H3). Without a cap an 8-subtask wave spawns 8 concurrent `claude`
+ * processes and can blow past the plan budget before the post-wave check ever
+ * runs. Override via ZOE_WAVE_CONCURRENCY.
+ */
+const WAVE_CONCURRENCY = Math.max(1, Number(process.env.ZOE_WAVE_CONCURRENCY ?? 3));
+
+/**
+ * Worst-case USD a subtask can spend against ZOE's plan budget, used to
+ * pre-flight a batch before launching it (doc 770 H3). Inline task-dispatcher
+ * runs spend nothing; Hermes accounts for its own spend in its own DB, so it
+ * is 0 against the plan budget here.
+ */
+function subtaskBudgetEstimate(worker: WorkerKind): number {
+  if (worker === 'task-dispatcher' || worker === 'hermes') return 0;
+  return workerMaxBudget(worker as ClaudeWorkerKind);
+}
 
 export interface DispatchHooks {
   onSubtaskStart?: (st: Subtask) => Promise<void> | void;
@@ -220,44 +245,62 @@ export async function dispatchPlan(args: DispatchPlanArgs): Promise<DispatchRepo
       return finish('failed');
     }
 
-    // Run the wave concurrently.
-    const settled = await Promise.allSettled(
-      runnable.map(async (st) => {
-        await args.hooks?.onSubtaskStart?.(st);
-        const res = await runOne(st, args, outputsById);
-        await args.hooks?.onSubtaskDone?.(st, res);
-        return res;
-      }),
-    );
+    // Run the wave in bounded-concurrency batches (doc 770 H3) so we never
+    // launch more than WAVE_CONCURRENCY worker subprocesses at once, and can
+    // stop the moment the budget is hit instead of after the whole wave runs.
+    let budgetHit = false;
+    for (let start = 0; start < runnable.length && !budgetHit; start += WAVE_CONCURRENCY) {
+      const batch = runnable.slice(start, start + WAVE_CONCURRENCY);
 
-    for (let i = 0; i < settled.length; i++) {
-      const st = runnable[i];
-      const s = settled[i];
-      const res: WorkerResult =
-        s.status === 'fulfilled'
-          ? s.value
-          : {
-              subtaskId: st.id,
-              worker: st.worker,
-              status: 'failed',
-              output: '',
-              critique: null,
-              revised: false,
-              model: 'unknown',
-              inputTokens: 0,
-              outputTokens: 0,
-              costUsd: 0,
-              durationMs: 0,
-              error: (s.reason as Error)?.message ?? String(s.reason),
-            };
-      results.push(res);
-      completed.add(st.id);
-      outputsById.set(st.id, { title: st.title, output: res.output });
-      totalCost += res.costUsd;
-      void recordRun(toRunRecord(goal, res));
+      // Pre-flight: refuse to launch a batch we can't afford. Each subtask is
+      // estimated at its worker's hard per-invocation cap. Inline/Hermes
+      // subtasks estimate to 0, so a batch of only those never trips here.
+      const batchEstimate = batch.reduce((sum, st) => sum + subtaskBudgetEstimate(st.worker), 0);
+      if (batchEstimate > 0 && totalCost + batchEstimate > budget) {
+        budgetHit = true;
+        break;
+      }
+
+      const settled = await Promise.allSettled(
+        batch.map(async (st) => {
+          await args.hooks?.onSubtaskStart?.(st);
+          const res = await runOne(st, args, outputsById);
+          await args.hooks?.onSubtaskDone?.(st, res);
+          return res;
+        }),
+      );
+
+      for (let i = 0; i < settled.length; i++) {
+        const st = batch[i];
+        const s = settled[i];
+        const res: WorkerResult =
+          s.status === 'fulfilled'
+            ? s.value
+            : {
+                subtaskId: st.id,
+                worker: st.worker,
+                status: 'failed',
+                output: '',
+                critique: null,
+                revised: false,
+                model: 'unknown',
+                inputTokens: 0,
+                outputTokens: 0,
+                costUsd: 0,
+                durationMs: 0,
+                error: (s.reason as Error)?.message ?? String(s.reason),
+              };
+        results.push(res);
+        completed.add(st.id);
+        outputsById.set(st.id, { title: st.title, output: res.output });
+        totalCost += res.costUsd;
+        void recordRun(toRunRecord(goal, res));
+      }
+
+      if (totalCost > budget) budgetHit = true;
     }
 
-    if (totalCost > budget) {
+    if (budgetHit) {
       return finish('budget-exceeded');
     }
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -68,14 +68,10 @@ import {
   type ApprovalReply,
 } from './approvals';
 import type { DecompositionPlan } from './decompose';
+import { NOTE_PREFIX, PLAN_PREFIX, isZoeCommand } from './commands';
 import { attachCaster, runCasterPipeline } from './caster';
 import { subscribeToCasts } from './farcaster/event-stream';
 
-const NOTE_PREFIX = /^(note|cc|claude):\s*(.+)/is;
-// Opt-in goal decomposition + dispatch (doc 759 Gaps 1+2). Zaal sends
-// `plan: <goal>` / `decompose: <goal>` to get a routed plan; on "y" ZOE
-// dispatches the workers. Default chat stays a normal concierge turn.
-const PLAN_PREFIX = /^(plan|decompose):\s*(.+)/is;
 const CLAUDE_NOTES_FILE = join(ZOE_PATHS.home, 'claude-code-notes.md');
 const VALID_GROUP_MODES: GroupMode[] = ['silent', 'mention', 'all'];
 
@@ -451,24 +447,32 @@ async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
   // item in place — it auto-expires via TTL.
   const pending = getPending('private');
   if (pending) {
-    // await-reflection: the next free-form DM is Zaal's reflection answer.
     if (pending.kind === 'await-reflection') {
-      await clearPending('private');
-      await handleReflectionAnswer(ctx, text);
-      return;
-    }
-    const reply = parseApprovalReply(text);
-    if (reply.decision !== 'not-an-approval') {
-      await resolvePendingApproval(ctx, pending, reply);
-      return;
-    }
-    // reflexion with outstanding voice-note requests: a free-form (non-y/n)
-    // reply is Zaal's clarification — re-run reflexion with it as the
-    // transcript (typed clarification stands in for an audio voice note).
-    if (pending.kind === 'reflexion' && pending.hasVoiceNoteRequests && text.trim().length > 10) {
-      await clearPending('private');
-      await runReflexionFlow(ctx, pending.answers, text);
-      return;
+      // The next free-form DM is Zaal's reflection answer — UNLESS it's a
+      // command (plan:/note:/nudge toggle). A command is not a reflection
+      // answer, so let it fall through to normal handling and leave the
+      // reflection pending armed (it auto-expires via TTL). Fixes doc 770 H1:
+      // a `plan:` sent in the long reflection window was being swallowed and
+      // never dispatched.
+      if (!isZoeCommand(text)) {
+        await clearPending('private');
+        await handleReflectionAnswer(ctx, text);
+        return;
+      }
+    } else {
+      const reply = parseApprovalReply(text);
+      if (reply.decision !== 'not-an-approval') {
+        await resolvePendingApproval(ctx, pending, reply);
+        return;
+      }
+      // reflexion with outstanding voice-note requests: a free-form (non-y/n)
+      // reply is Zaal's clarification — re-run reflexion with it as the
+      // transcript (typed clarification stands in for an audio voice note).
+      if (pending.kind === 'reflexion' && pending.hasVoiceNoteRequests && text.trim().length > 10) {
+        await clearPending('private');
+        await runReflexionFlow(ctx, pending.answers, text);
+        return;
+      }
     }
   }
 
@@ -707,8 +711,30 @@ async function handlePlanCommand(ctx: Context, goal: string): Promise<void> {
   }
 }
 
-/** Route a parsed y/n/edit reply against whatever ZOE is waiting to approve. */
+/**
+ * Route a parsed y/n/edit reply against whatever ZOE is waiting to approve.
+ * Wraps the resolver in a try/catch (doc 770 H5): the inner path clears the
+ * pending item before dispatching, so a throw from ctx.reply / setPending /
+ * dispatch would otherwise propagate to grammY and the user would see nothing
+ * with the plan already lost. On error we always reply so Zaal can re-send.
+ */
 async function resolvePendingApproval(
+  ctx: Context,
+  pending: PendingApproval,
+  reply: ApprovalReply,
+): Promise<void> {
+  try {
+    await doResolvePendingApproval(ctx, pending, reply);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[zoe/index] approval resolution failed:', msg);
+    await ctx
+      .reply(`(couldn't complete that — ${msg.slice(0, 200)}. Nothing is pending now; re-send when ready.)`)
+      .catch(() => {});
+  }
+}
+
+async function doResolvePendingApproval(
   ctx: Context,
   pending: PendingApproval,
   reply: ApprovalReply,

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -64,6 +64,8 @@ import {
   clearPending,
   loadPending,
   parseApprovalReply,
+  wouldClobber,
+  pendingKindLabel,
   type PendingApproval,
   type ApprovalReply,
 } from './approvals';
@@ -676,6 +678,16 @@ function zoeContext() {
 async function handlePlanCommand(ctx: Context, goal: string): Promise<void> {
   if (!ctx.chat) return;
   const chatId = ctx.chat.id;
+  // Refuse-when-busy (doc 770 H2): don't decompose (or clobber) a plan while a
+  // different approval is already waiting on Zaal's y/n. Checked before the
+  // decompose spend.
+  const busy = getPending('private');
+  if (wouldClobber(busy, 'plan')) {
+    await ctx.reply(
+      `You've got a pending ${pendingKindLabel(busy!.kind)} waiting on your y/n. Reply to it (or say "cancel") first, then re-send your plan.`,
+    );
+    return;
+  }
   await ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
   const typingInterval = setInterval(() => {
     ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
@@ -884,7 +896,7 @@ async function runReflexionFlow(
     // Stash high-confidence patches for y/n; low-confidence ones get a
     // voice-note request and are resolved on Zaal's next free-form reply.
     if (plan.highConfidence.length > 0 || plan.needsVoiceNote.length > 0) {
-      await setPending({
+      const armed = await setPending({
         kind: 'reflexion',
         chatScope: 'private',
         createdAt: new Date().toISOString(),
@@ -892,6 +904,15 @@ async function runReflexionFlow(
         answers,
         hasVoiceNoteRequests: plan.needsVoiceNote.length > 0,
       });
+      if (!armed.armed) {
+        // doc 770 H2: a live approval is already waiting — don't clobber it.
+        await ctx.reply(
+          `Reflection logged, but I couldn't queue the memory updates — you have a pending ${pendingKindLabel(
+            armed.blockedBy!.kind,
+          )} first. Resolve it and re-run reflect.`,
+        );
+        return;
+      }
     }
 
     if (plan.highConfidence.length > 0) {

--- a/bot/src/zoe/learn.ts
+++ b/bot/src/zoe/learn.ts
@@ -242,10 +242,52 @@ function learningsPath(target: string): string {
   return join(learningsDir(), `${safe}.md`);
 }
 
-/** Read the accrued learnings for a worker/persona, or '' if none. */
+/**
+ * Cap (doc 770 MED): worker learnings are spliced verbatim into every worker
+ * system prompt. Left unbounded they silently inflate input-token cost on every
+ * run. Defaults: keep the most recent 30 bullets, dedupe identical text, cap at
+ * ~4000 chars. Override via ZOE_MAX_LEARNING_LINES / ZOE_MAX_LEARNING_CHARS.
+ */
+export const MAX_LEARNING_LINES = Math.max(1, Number(process.env.ZOE_MAX_LEARNING_LINES ?? 30));
+export const MAX_LEARNING_CHARS = Math.max(200, Number(process.env.ZOE_MAX_LEARNING_CHARS ?? 4000));
+
+/** Pure cap+dedupe of a learnings file body. Keeps header lines + recent bullets. */
+export function capLearnings(
+  raw: string,
+  maxLines: number = MAX_LEARNING_LINES,
+  maxChars: number = MAX_LEARNING_CHARS,
+): string {
+  if (!raw.trim()) return '';
+  const header: string[] = [];
+  const bullets: string[] = [];
+  for (const line of raw.split('\n')) {
+    if (line.trimStart().startsWith('- ')) bullets.push(line);
+    else if (bullets.length === 0) header.push(line); // header precedes the bullets
+  }
+  // Dedupe by the learning text (strip the leading "- (YYYY-MM-DD) " prefix).
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const b of bullets) {
+    const key = b.replace(/^\s*-\s*(\(\d{4}-\d{2}-\d{2}\))?\s*/, '').trim().toLowerCase();
+    if (key && !seen.has(key)) {
+      seen.add(key);
+      deduped.push(b);
+    }
+  }
+  const kept = deduped.slice(-maxLines); // bullets are appended chronologically → keep the tail
+  let out = [...header, ...kept].join('\n').trim();
+  if (out.length > maxChars) {
+    out = out.slice(out.length - maxChars);
+    const nl = out.indexOf('\n');
+    if (nl >= 0) out = out.slice(nl + 1); // drop a partial leading line
+  }
+  return out;
+}
+
+/** Read the accrued learnings for a worker/persona, capped + deduped, or '' if none. */
 export async function readLearnings(target: string): Promise<string> {
   try {
-    return await fs.readFile(learningsPath(target), 'utf8');
+    return capLearnings(await fs.readFile(learningsPath(target), 'utf8'));
   } catch {
     return '';
   }

--- a/bot/src/zoe/relay.ts
+++ b/bot/src/zoe/relay.ts
@@ -12,7 +12,7 @@
  * authored the goal that produced the relay_op. No additional y/n gate.
  */
 
-import { readGroups } from './groups';
+import { readGroups, type GroupConfig } from './groups';
 import type { BotRelayOp } from './types';
 
 export interface RelayResult {
@@ -20,6 +20,19 @@ export interface RelayResult {
   status: 'sent' | 'group-not-registered' | 'send-failed';
   resolved_chat_id?: number;
   error?: string;
+}
+
+/**
+ * Resolve a relay op to a target chat id. Pure (doc 770 MED). Uses an EXACT
+ * case-insensitive title match, not a substring — `"ZAO"` must not silently
+ * resolve to `"ZAO Devz"` / `"ZAO Civilization"` and post to the wrong group.
+ */
+export function resolveRelayChatId(groups: GroupConfig[], op: BotRelayOp): number | undefined {
+  if (op.to_chat_id) return op.to_chat_id;
+  if (!op.to_group) return undefined;
+  const wanted = op.to_group.trim().toLowerCase();
+  const target = groups.find((g) => (g.chat_title ?? '').trim().toLowerCase() === wanted);
+  return target?.chat_id;
 }
 
 export async function runBotRelayOps(
@@ -31,16 +44,7 @@ export async function runBotRelayOps(
   const results: RelayResult[] = [];
 
   for (const op of ops) {
-    let chatId: number | undefined = op.to_chat_id;
-    if (!chatId && op.to_group) {
-      // Resolve by group title (case-insensitive)
-      const target = groups.find(
-        (g) => (g.chat_title ?? '')
-          .toLowerCase()
-          .includes(op.to_group!.toLowerCase()),
-      );
-      if (target) chatId = target.chat_id;
-    }
+    const chatId = resolveRelayChatId(groups, op);
     if (!chatId) {
       results.push({ op, status: 'group-not-registered' });
       continue;

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -23,7 +23,7 @@ import { generateEveningReflection } from './reflect';
 import { ZOE_PATHS } from './memory';
 import { nextNudge, nudgesEnabled } from './nudges';
 import { startPostsScheduler } from './posts';
-import { setPending } from './approvals';
+import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 
 /** await-reflection waits overnight for Zaal's reply, so a 14h TTL not 30m. */
@@ -92,13 +92,22 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           await markFired('evening-reflect');
           // Arm reflexion (Gap 4): Zaal's next free-form DM is captured as the
           // reflection answer and fed to the reflexion layer for memory patches.
-          await setPending({
+          const armed = await setPending({
             kind: 'await-reflection',
             chatScope: 'private',
             createdAt: new Date().toISOString(),
             ttlMs: AWAIT_REFLECTION_TTL_MS,
           });
-          console.log('[zoe/scheduler] evening reflection sent + reflexion armed');
+          if (armed.armed) {
+            console.log('[zoe/scheduler] evening reflection sent + reflexion armed');
+          } else {
+            // doc 770 H2: don't clobber a live approval Zaal is mid-way through.
+            console.log(
+              `[zoe/scheduler] evening reflection sent, capture NOT armed — ${pendingKindLabel(
+                armed.blockedBy!.kind,
+              )} pending`,
+            );
+          }
         } catch (err) {
           console.error('[zoe/scheduler] evening reflection failed:', (err as Error).message);
         }
@@ -155,12 +164,21 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             console.log(`[zoe/scheduler] learn cycle: ${result.runsAnalyzed} runs, no proposals`);
             return;
           }
-          await setPending({
+          const armed = await setPending({
             kind: 'learn',
             chatScope: 'private',
             createdAt: new Date().toISOString(),
             proposals: result.proposals,
           });
+          if (!armed.armed) {
+            // doc 770 H2: a live approval is waiting — defer rather than clobber.
+            console.log(
+              `[zoe/scheduler] learn cycle: deferring ${result.proposals.length} proposals — ${pendingKindLabel(
+                armed.blockedBy!.kind,
+              )} pending`,
+            );
+            return;
+          }
           await opts.bot.api.sendMessage(opts.zaalTgId, renderLearnProposals(result.proposals));
           console.log(`[zoe/scheduler] learn cycle: ${result.proposals.length} proposals sent`);
         } catch (err) {

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -31,22 +31,35 @@ const AWAIT_REFLECTION_TTL_MS = 14 * 60 * 60 * 1000;
 
 const SENTINEL_DIR = join(ZOE_PATHS.home, 'sentinels');
 
-async function alreadyFired(trigger: string): Promise<boolean> {
+function sentinelPath(trigger: string): string {
   const today = new Date().toISOString().slice(0, 10);
-  const sentinel = join(SENTINEL_DIR, `${trigger}-${today}.flag`);
+  return join(SENTINEL_DIR, `${trigger}-${today}.flag`);
+}
+
+/**
+ * Atomically claim a trigger for today (doc 770 MED). Writes the sentinel with
+ * O_EXCL ('wx') BEFORE the side-effecting send, so a restart mid-send can't
+ * double-fire and two racing ticks can't both proceed. Returns true iff THIS
+ * call won the claim. On send failure the caller calls releaseFire() so a later
+ * tick can retry.
+ */
+async function claimFire(trigger: string): Promise<boolean> {
+  await fs.mkdir(SENTINEL_DIR, { recursive: true });
   try {
-    await fs.access(sentinel);
+    await fs.writeFile(sentinelPath(trigger), new Date().toISOString(), { flag: 'wx' });
     return true;
   } catch {
-    return false;
+    return false; // sentinel already exists → already fired today
   }
 }
 
-async function markFired(trigger: string): Promise<void> {
-  const today = new Date().toISOString().slice(0, 10);
-  await fs.mkdir(SENTINEL_DIR, { recursive: true });
-  const sentinel = join(SENTINEL_DIR, `${trigger}-${today}.flag`);
-  await fs.writeFile(sentinel, new Date().toISOString(), 'utf8');
+/** Release a claim so a later tick can retry (used when the send itself fails). */
+async function releaseFire(trigger: string): Promise<void> {
+  try {
+    await fs.unlink(sentinelPath(trigger));
+  } catch {
+    // already gone — nothing to release
+  }
 }
 
 export interface SchedulerOptions {
@@ -66,13 +79,13 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
     cron.schedule(
       '0 9 * * *',
       async () => {
-        if (await alreadyFired('morning-brief')) return;
+        if (!(await claimFire('morning-brief'))) return;
         try {
           const brief = await generateMorningBrief({ repoDir: opts.repoDir });
           await opts.bot.api.sendMessage(opts.zaalTgId, brief);
-          await markFired('morning-brief');
           console.log('[zoe/scheduler] morning brief sent');
         } catch (err) {
+          await releaseFire('morning-brief');
           console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);
         }
       },
@@ -85,11 +98,10 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
     cron.schedule(
       '0 1 * * *',
       async () => {
-        if (await alreadyFired('evening-reflect')) return;
+        if (!(await claimFire('evening-reflect'))) return;
         try {
           const prompt = await generateEveningReflection({ repoDir: opts.repoDir });
           await opts.bot.api.sendMessage(opts.zaalTgId, prompt);
-          await markFired('evening-reflect');
           // Arm reflexion (Gap 4): Zaal's next free-form DM is captured as the
           // reflection answer and fed to the reflexion layer for memory patches.
           const armed = await setPending({
@@ -109,6 +121,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             );
           }
         } catch (err) {
+          await releaseFire('evening-reflect');
           console.error('[zoe/scheduler] evening reflection failed:', (err as Error).message);
         }
       },
@@ -150,7 +163,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
     cron.schedule(
       '0 18 * * 0',
       async () => {
-        if (await alreadyFired('learn-cycle')) return;
+        if (!(await claimFire('learn-cycle'))) return;
         try {
           const result = await runLearnCycle({
             context: {
@@ -159,7 +172,6 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
               current_date: new Date().toISOString().slice(0, 10),
             },
           });
-          await markFired('learn-cycle');
           if (result.proposals.length === 0) {
             console.log(`[zoe/scheduler] learn cycle: ${result.runsAnalyzed} runs, no proposals`);
             return;
@@ -182,6 +194,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           await opts.bot.api.sendMessage(opts.zaalTgId, renderLearnProposals(result.proposals));
           console.log(`[zoe/scheduler] learn cycle: ${result.proposals.length} proposals sent`);
         } catch (err) {
+          await releaseFire('learn-cycle');
           console.error('[zoe/scheduler] learn cycle failed:', (err as Error).message);
         }
       },

--- a/bot/src/zoe/workers.ts
+++ b/bot/src/zoe/workers.ts
@@ -49,14 +49,53 @@ interface WorkerConfig {
 // Read-only lockdown shared by every worker. No worker may push, commit,
 // reset, rm, or write files — anything that mutates state stays behind an
 // explicit Zaal approval at the ZOE layer, never inside an autonomous worker.
+//
+// doc 770 H4: a denylist is inherently leaky, so the per-worker `allowedTools`
+// whitelist above is the real authority — this list is defense-in-depth that
+// closes the obvious write/move/exec vectors the audit named (mv, chmod, git
+// clean, npx/node, …). One residual it CANNOT catch: shell redirection inside
+// an otherwise-allowed Bash prefix (e.g. `cat x > y` under `Bash(cat*)`). That
+// guarantee depends on the CLI treating `allowedTools` as authoritative under
+// permissionMode, which must be verified live, not asserted in config.
 const READ_ONLY_DISALLOW = [
+  // File / notebook mutation tools.
+  'Edit',
+  'Write',
+  'NotebookEdit',
+  // git state mutation.
   'Bash(git push*)',
   'Bash(git commit*)',
   'Bash(git reset*)',
+  'Bash(git clean*)',
+  'Bash(git checkout*)',
+  'Bash(git stash*)',
+  // Filesystem mutation / move / link.
   'Bash(rm*)',
-  'Edit',
-  'Write',
+  'Bash(mv*)',
+  'Bash(cp*)',
+  'Bash(chmod*)',
+  'Bash(chown*)',
+  'Bash(ln*)',
+  'Bash(mkdir*)',
+  'Bash(touch*)',
+  'Bash(dd*)',
+  'Bash(tee*)',
+  // Arbitrary code execution (can write/exfiltrate).
+  'Bash(npx*)',
+  'Bash(npm*)',
+  'Bash(pnpm*)',
+  'Bash(yarn*)',
+  'Bash(node*)',
+  'Bash(python*)',
+  'Bash(python3*)',
+  'Bash(bash*)',
+  'Bash(sh*)',
+  'Bash(zsh*)',
+  'Bash(eval*)',
 ];
+
+/** Floor below which a revision pass isn't worth launching (doc 770 MED). */
+const MIN_REVISION_BUDGET_USD = 0.05;
 
 const WORKER_CONFIG: Record<ClaudeWorkerKind, WorkerConfig> = {
   'research-worker': {
@@ -259,7 +298,7 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     };
   }
 
-  const call = async (criticFeedback?: string) =>
+  const call = async (criticFeedback?: string, budgetUsd: number = cfg.maxBudgetUsd) =>
     callClaudeCli({
       model: cfg.model,
       prompt: buildWorkerPrompt(args, criticFeedback),
@@ -269,7 +308,7 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
       disallowedTools: cfg.disallowedTools,
       permissionMode: 'auto',
       outputFormat: 'json',
-      maxBudgetUsd: cfg.maxBudgetUsd,
+      maxBudgetUsd: budgetUsd,
       bare: false,
     });
 
@@ -285,19 +324,25 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     let revised = false;
 
     if (critique && critique.score < CRITIQUE_PASS_THRESHOLD) {
-      // One revision pass with the critic's feedback.
-      revised = true;
-      const feedback = [
-        `Score ${critique.score}/100: ${critique.summary}`,
-        ...critique.issues.map((i) => `- [${i.severity}] ${i.location ?? ''} ${i.issue}`),
-      ].join('\n');
-      const second = await call(feedback);
-      output = second.text;
-      inTok += second.inputTokens;
-      outTok += second.outputTokens;
-      cost += second.totalCostUsd;
-      dur += second.durationMs;
-      critique = await runCriticFor(cfg.critic, args, output);
+      // One revision pass with the critic's feedback — but only within the
+      // REMAINING per-worker budget (doc 770 MED). Previously the revision got
+      // a fresh full cap, so a failing critique silently doubled the ceiling to
+      // ~2×maxBudget. Now total worker spend stays under cfg.maxBudgetUsd.
+      const remaining = revisionBudget(cfg.maxBudgetUsd, cost);
+      if (remaining >= MIN_REVISION_BUDGET_USD) {
+        revised = true;
+        const feedback = [
+          `Score ${critique.score}/100: ${critique.summary}`,
+          ...critique.issues.map((i) => `- [${i.severity}] ${i.location ?? ''} ${i.issue}`),
+        ].join('\n');
+        const second = await call(feedback, remaining);
+        output = second.text;
+        inTok += second.inputTokens;
+        outTok += second.outputTokens;
+        cost += second.totalCostUsd;
+        dur += second.durationMs;
+        critique = await runCriticFor(cfg.critic, args, output);
+      }
     }
 
     // Fold critic cost into the worker total.
@@ -330,4 +375,9 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
 /** Expose the config for tests / introspection (e.g. dispatch budget sums). */
 export function workerMaxBudget(worker: ClaudeWorkerKind): number {
   return WORKER_CONFIG[worker].maxBudgetUsd;
+}
+
+/** Budget for the single revision pass: whatever's left under the cap (doc 770 MED). */
+export function revisionBudget(cap: number, spentSoFar: number): number {
+  return Math.max(0, cap - spentSoFar);
 }


### PR DESCRIPTION
Audit doc 770 flagged five HIGH severity issues in the ZOE orchestrator
that block trusting it with autonomous, cost-incurring runs. This fixes
the three highest-leverage ones, each with a pure regression test.

H1 — await-reflection no longer swallows commands (index.ts, commands.ts)
  The evening reflection arms a long-TTL `await-reflection` pending that
  consumed the NEXT DM regardless of content, so a `plan:` sent in that
  window was eaten and never dispatched. Command-prefixed DMs
  (plan:/note:/nudge toggle) now bypass the capture and leave the
  reflection pending armed (TTL self-heals). Extracted the prefix
  predicates into a pure commands.ts so they're unit-testable without
  importing index.ts (which starts the bot on load).

H3 — hard wave-concurrency cap + pre-flight budget (dispatch.ts, decompose.ts)
  The whole runnable wave ran via Promise.allSettled with no parallelism
  cap and budget checked only AFTER it settled, so 8 subtasks could spawn
  8 concurrent claude processes and overspend. Now batched at
  WAVE_CONCURRENCY (default 3), each batch pre-flighted against remaining
  budget before launch, stopping the moment the cap is hit. Added a
  MAX_SUBTASKS ceiling (default 12) in decompose so a runaway plan
  escalates instead of dispatching.

H5 — approval resolution wrapped in try/catch (index.ts)
  resolvePendingApproval cleared the pending before dispatching, so a
  throw left the user with no reply and the plan lost. Now wraps the
  resolver and always replies on error.

Tests: 87 zoe tests pass (incl. new H1 routing + H3 pre-flight/cap tests);
bot tsc --noEmit clean.

https://claude.ai/code/session_01WAsaP6FDuctpPj6AY86QS5