### PR TITLE
docs: 778 - Tyler/Magnetic x Zaal - ZABAL Games build on Magnetic

### DIFF
--- a/research/events/778-tyler-magnetic-zabal-games-build-may27/README.md
+++ b/research/events/778-tyler-magnetic-zabal-games-build-may27/README.md
@@ -1,0 +1,84 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-27
+related-docs: "714, 473, 776, 701"
+tier: STANDARD
+---
+
+# 778 - Tyler / Magnetic x Zaal + team: ZABAL Games build on Magnetic
+
+> **Goal:** Capture decisions + action items from the 2026-05-27 working session where Zaal, Tyler Stambaugh (Magnetic), Samantha, and Shawn architected how ZABAL Games actually gets built on Magnetic - a single magnet with an intro, videos hosted as cards, a GitHub-auth judging system, and a June 1 live demo + AMA.
+
+Direct build-step follow-on to [doc 714](../714-tyler-zabal-zaostock-may22/) (the May 22 plan) and [doc 473](../473-road-to-zaostock-magnetic-portal/) (the April Magnetic-portal spec). Where 714 set the plan, this call turns it into a 4-day build sprint. Also see [doc 776](../776-duo-do-clementine-santiago-zabal-games-may23/) (the musician-talk format that feeds the same June session month).
+
+## Attendees
+
+- **Zaal** (host)
+- **Tyler Stambaugh** - Magnetic founder (docs 473, 714)
+- **Samantha** ("Sam", candytoybox) - WaveWarZ cofounder
+- **Shawn** - collaborator joining to learn the Magnetic side
+
+Phone-then-desktop call (Zaal started on mobile dropping his kid off, moved to computer). Tyler walked the group through the live Magnetic backend.
+
+## How Magnetic works (the walkthrough)
+
+- **Magnet = container, "mems" = the content pieces inside** (welcome video, a card linking out, a poll, UGC upload, social shares). Tyler initially said "mementos" then corrected to "mems."
+- **Login is email / Google - no wallet** - but the backend mints on-chain, abstracted away. Authentication is on-chain; the front-end DB just makes it fast.
+- **Analytics-first.** A member dashboard shows everyone who joined any Zabal program, what they engaged with (polls, content), which Fractal proof-of-meat they came in through, and who the high-participation members are. Claims have **expiration windows** (~4 weeks).
+- The existing **Zabal Connector** magnet already has **67 people** joined - it becomes the channel to point people at the new games space.
+- Data is **S3-hosted**; every card has an S3 link. EVM-queryable. On-chain = Magnetic is the platform of record (SaaS to mint), but the data stays portable to your own ecosystem - "not hold the data from you."
+
+## Key Decisions
+
+| # | Decision | Owner | Status | Confidence |
+|---|----------|-------|--------|------------|
+| 1 | **ZABAL Games is a single magnet on Magnetic** (not one per project), with an intro magnet under it | Zaal | TODO | high |
+| 2 | **One combined list, include everybody, minimal segregation** - keep it simple, don't add complexity that needs explaining | Samantha | DECIDED | high |
+| 3 | **Videos hosted on Magnetic cards link out to YouTube** to get around the storage limit | Both | TODO | high |
+| 4 | **June 1 (Mon): live Magnetic demo (2:30 ready) + AMA with Zaal**, plus a ZABAL-Games-specific walkthrough - tentative, it is NY Tech Week | Both | TODO | medium |
+| 5 | **Build a GitHub-auth judging system** - authenticate GitHub, July commits evaluated for Zao-ecosystem value, points weighted by contribution, rolling admission | Zaal | TODO | high |
+| 6 | **Other brands (WaveWarZ, Zao Fractal, Zao Festivals, COC Concerts) become their own magnets later** with explainer intros | Zaal | TODO | medium |
+
+## Thread 1 - The magnet structure
+
+Zaal's analogy: Magnetic is like a "super interactive, content-heavy Discord." You need an intro/announcements program (the anchor = "this is the starting line, this is the ecosystem"), then a space per branch. Considered calling the hub "Zabal University," landed on just **Zabal Games**. The Zabal Connector behaves like Discord's "general" channel; other magnets are the side channels (consistent with doc 714 decision 5). Build the one Zabal Games magnet first as the way to figure out exactly what the ecosystem wants, then graduate the rest.
+
+## Thread 2 - Road to ZAOstock
+
+The **12-week Road to ZAOstock** series (3 months pre-event, doc 714 decision 3) gets a magnet hub: all 12 weeks sit as cards, each with content or a promotion behind it. The win over email: if you only caught week 3, weeks 1-2 are still there to catch up on - everything lives in one interactive place. Emails are still captured (same as the magnet flow).
+
+## Thread 3 - API / widgets / portability (Zaal's ask)
+
+Zaal wants more than an iframe - **widgets / an API** to drop a customizable Magnetic claim onto his own site (e.g. claim while already Google-logged-in), then deep-link to the full experience. Tyler: data is structured + S3-hosted + EVM-queryable, so it is doable - "put it on the list," talk it through from a design perspective. Zaal to research **Flow** (and EVM) to pull/query ownership into anything he builds - a "magnetic bridge" gating his ecosystem by magnet ownership. Also flagged **OAuth other socials** (X already OAuth'd and is the most expensive API; others cheaper) for a future chat.
+
+## Thread 4 - The GitHub-auth judging build
+
+Zaal's 4-day build: signup = wallet/Farcaster login + authenticate GitHub (multiple GitHub accounts allowed - personal + Web3 org). July commits get looked at and scored, weighted by value delivered to the Zao ecosystem - rolling admission. Built in public during the first month with help from the Farcaster-ecosystem people Zaal is recruiting ("all a hell yes"). Magnetic feature in dev that helps: rank-order / rearrangeable grid per mem + pinning for featured, so upload order does not matter.
+
+## Action Items
+
+| Title | Owner | Due | Category | Confidence |
+|-------|-------|-----|----------|------------|
+| Write up the ecosystem / magnet plan and send Tyler async | Zaal | this week | ZABAL Games | high |
+| Build the GitHub-auth ZABAL Games judging system | Zaal | ~4 days | Site / Tech | high |
+| Get the intro magnet up | Zaal | ~4 days | ZABAL Games | high |
+| Make ZABAL Games logo on Canva (square + vertical + horizontal) | Samantha | - | Social | high |
+| Send Tyler the real logo | Zaal | - | ZABAL Games | high |
+| Set up the ZABAL Games magnet/space on Magnetic | Tyler | - | ZABAL Games | high |
+| Add API/widget embedding + social OAuth to the Magnetic roadmap list | Tyler | - | Site / Tech | medium |
+| Research Flow + API/widget embed (vs iframe) for own-site use | Zaal | - | Site / Tech | medium |
+| June 1 live Magnetic demo + AMA (tentative, NY Tech Week) | Both | 2026-06-01 | ZABAL Games | medium |
+
+## Quotes
+
+- Tyler: "The whole point of putting it on chain is to not have the platform lock you in. We'd like to be the platform of record where you make it... but the whole point is to not hold the data from you."
+- Zaal: "The goal of ZABAL Games ultimately is to create a prompt that, through GitHub and folders and markdown files, explains all of our different projects - what the Zao ultimately is."
+- Zaal: "Instead of an email where you just get it and it sits in your box... this is the place where everything is. So you can catch up, get exposure to stuff in a more interactive way."
+- Samantha: "I think we should include everybody, get them all on one list... I wouldn't add extra complexity to it if I didn't have to."
+- Tyler: "Platforms are getting greedy now, man. They're starting to turn the crank on the monetization."
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md) (looping "Cheers" tail artifact trimmed).

--- a/research/events/778-tyler-magnetic-zabal-games-build-may27/transcript.md
+++ b/research/events/778-tyler-magnetic-zabal-games-build-may27/transcript.md
@@ -1,0 +1,99 @@
+# Transcript - Tyler / Magnetic x Zaal + team, 2026-05-27 16:30 EDT
+
+Attendees: Zaal, Tyler Stambaugh (Magnetic), Samantha (Sam), Shawn. Source: `Tyler x zaal - 2026_05_27 16_30 EDT - Recording.mp4`. Unlabeled whisper transcript (mlx-whisper large-v3-turbo); speakers attributed from content. The looping "Cheers" tail (lines ~477-582 of raw output) has been trimmed.
+
+---
+
+Hey, how's it going? Can you hear me? Hey, is there a lot of glare? You're in the car? Yeah, yeah. I'm just dropping the kid off to buy a new monitor for his computer. Nice, nice. I did message Tyler. You did what? I did it. Gotcha, gotcha.
+
+Been a long day. Got three meetings back to back to back. Got a busy schedule. Always up to something. What up, Tyler? Hello? Cranking away, man. Cranking away. How you doing? Good. Hey, Shawn. How's it going? Hey, how's it going? Sorry, just pouring well. All good.
+
+[Zaal] I got an ad from Iman today that I'm going to play here in a second, which is exciting, because he basically explained ZABAL Games all in an audio clip, which is awesome, because I can start using this in all of our live stuff. So I'm feeling good. I'm excited. I got a lot of heavy hitters ready to do a workshop. So, Tyler, I think we're ready to really rock out. One of the things I want to do, and I haven't done yet, I have a logo, which we'll use as a temporary logo. Sam, I'll send you what I have right now. But ultimately, I would love to start having people sign up for the magnet, which is the collectible. We'll try and keep all of the videos uploaded to there. You said there was a certain storage limit in total, right? So if I did a YouTube [link] step, everything, would that solve that problem?
+
+[Tyler] Yeah, we could do the card that comes in, and then in the copy of the description, you can link to YouTube if you want to. We'll be able to see if they clicked on the card. We won't know necessarily if they clicked the link, I don't think.
+
+[Zaal] Cool. Why don't you share with Shawn and Sam what we'll need to get started and some of the things we've talked about. With the Magnetic side, the reason why it can be beneficial to do it on Magnetic could be really helpful.
+
+[Tyler] So the Zabal is already here on Magnetic. The brand's already established. Zaal has a Zabal connector program that's already here. But all we have to do to build this out and then have people start claiming into it... all we need to do to create something like the Zabal connector is, literally, an image, a name, a description.
+
+[Zaal] Question. Can we make a Zabal connector method - I don't know if it's Magnet or Collectible or what the exact word is - that links you to then collect the second one. Like, we can launch something to the Zabal Connect that links it to that page.
+
+[Tyler] We can do that.
+
+[Zaal] I think that would be cool because then I could invite people specifically to the Zabal Connector and say, hey, we're starting the Zabal Games content hub here. I might call it just Zabal University is what I was thinking. And we're going to put all of the videos from these workshops in here, but you could get the Collectible for participating in the Zabal Games as a Zabal connector piece here. And that's an easy way to start.
+
+[Tyler] So just to show you right now, in your Zabal connector, you've got a welcome video. You've got a card that links out to your Zao ecosystem. You've got a poll. And then you've got a bunch of these Pell apps that you've launched. So Shawn and Sam, when you think about this, the Zabal connector is the container. We call it a magnet. And in that container is where you put all of the things you do to engage with people - content, polls, social shares to X, UGC upload. We already have 67 people that have joined into this thing. So let's create a dedicated space for the games and use this also as a channel to point people to it because they already have magnetic accounts.
+
+[Tyler] The really nice thing here, Shawn, is that to make the account you only log in with Google or an email - you're not asking for a wallet. But back-end-wise they're actually putting it all on-chain. Using the database on the front end to make it fast, but still having the authentication side on-chain. It's very well abstracted away, which a lot of crypto projects haven't done well. And their focus is on analytics. So this is your members - everybody who's ever connected to any Zabal program. Should you do the games, people that join through the games will also show up here. And then we can see who owns the Zabal connector, who owns the games. We can dig deeper - this person joined in the Fractals proof of meat 5.11, they got the welcome video, the ecosystem, they haven't looked at either yet. We can see where people are engaging. We also put expiration dates on when you can claim those things - a four-week window or something. The whole goal is to understand over time what a typical user journey is, what people interact with, who the highest active participants are. With you guys, you have a whole ecosystem, so you can create all these different magnets, and see if people are flowing through your ecosystem across everything or just coming for one thing.
+
+[Zaal] That's actually kind of a crazy idea, Tyler - popping a lot more of our brands on there. How hard would it be? The goal of ZABAL Games, ultimately, for me, is to create a prompt that sufficiently - through GitHub and folders and markdown files - explains all of our different projects, what the Zao ultimately is. All of our projects: Zao Fractal, WaveWarZ, Zao Festivals, COC Concerts, the Let's Talk About Web3 (which is no more), Let's Talk About ETH (continuing in a different vein). For the three or four main ones we already have going - specifically COC Concerts, where in the last month or two we've created the website - it'd be really good to have something like this because their community is super engaged. So if I can add the other person I'm working on this project with as a manager, or have us in a group chat... we just have to do a morning call because he's in the UK.
+
+[Tyler] You can add anyone to have access to make any of this stuff on the backend. You enter their emails, click send, they come in, make an account, and they have access to build anything and launch from here.
+
+[Tyler] So, the way it sounds - I've been using Discord as an analogy. Think of this as a super interactive, content-heavy Discord type thing. You need a program that's almost like announcements/general - an intro program you come into. This is our ecosystem. You'd have a video for WaveWarZ, a video for COC Concerts. It sounds like you want an anchor place where it's "this is the starting line, this is the ecosystem," and then build out a space for each branch. And then from that member dashboard you can see where everyone's connecting in and who's in multiple. It's really about architecting what you want your ecosystem to be.
+
+[Zaal] Yeah, I'm going to write something up and send it to you. I'm going to work async because I have a good idea of what I want to do. It needs to get done this week if I really want it done well. We're going to get a lot of attention and awareness on this anyway, so we really want a place to flow people to.
+
+[Tyler] It's really good to get those emails too, because then you're not chasing down X handles and all that stuff, which can be a nightmare.
+
+[Zaal] Plus I could integrate other things with other socials. I'm curious if at some point we can chat more about OAuth-ing other socials.
+
+[Tyler] Yeah, we OAuth X right now, so it's possible. X is the most expensive API. All the others are a lot cheaper.
+
+[Zaal] It used to be free. Now it's whatever cents. I had to reconfigure the whole thing a month ago.
+
+[Zaal, to the group] I wanted to get you guys in here because this is going to be a big part of this, and also the Road to ZAOstock, which Tyler and I have been chatting about - essentially a 12-week series, three months leading up to the event. We have a weekly newsletter series, but it can be amplified a lot more.
+
+[Tyler] So this is what a general magnet/hub looks like. All 12 weeks would be sitting as cards. They'd have content behind it, or a promotion. But instead of an email where you only caught week three and weeks one and two are gone - this is the place where everything is. So you can catch up, get exposure to stuff in a more interactive way. And you're getting people's emails anyway.
+
+[Zaal] I did have another question. Is there an API we can make so I can put functionality on my website? I know I can iframe it in. But if I want to customize one thing, I don't think there's an easy way. So if I had a way to not just iframe it but give everything widgets - customizability, pop a certain portion on my page that maybe leads to the full website. It'd be nice to have some of the initial claim at least, because maybe I already have them logged in with Google.
+
+[Tyler] We can put it on the list and talk about it from a design perspective. We have all the data, it's structured, we pull the APIs. We have an S3 where we host all the data. Every card has an S3 link to the image or video. And we have our own overlay on our front end that feeds from all that data. Whether or not someone can access it is where NFT ownership comes in - the front end acts as the portal that unlocks when you have that ownership tied to your account.
+
+[Zaal] I'm curious if I can do that same functionality on my website. We all have multiple things - Magnetic, but also XYZ. If it's EVM, I can pull it and query it from something else. I'm going to research Flow more. But ultimately I'd love to be able to pull it into anything I build - a magnetic bridge. "Oh, you're in a magnetic program, now you get access to this part of my ecosystem."
+
+[Tyler] That's definitely a future we want to see. That's the whole point of putting it on chain - to not have the platform lock you in. We'd like to be the platform of record where you make it, and the SaaS you pay us is to make it on our contract, which has a network effect. But once you do it, the point is to not hold the data from you - you can use it in your ecosystem. Platforms are getting greedy now, man. They're turning the crank on monetization.
+
+[Zaal] Samantha, I'd like your thoughts. What are your thoughts on popping in some of these other brands like WaveWarZ, Zao Fractal, Zao Festivals all as different magnets with a basic explainer video as an intro, and leaving it as an opportunity for people to build on top of - or do you think it'd be better to just pop all the information in one prompt?
+
+[Samantha] I definitely think it's beneficial to include everybody. Most of our community overlaps a lot of them anyway. I'd just keep it not complicated so you don't have to explain much. Segregating stuff is always good for data, but I think we should include everybody, get them all on one list. Separate it if you want, but I wouldn't add extra complexity if I didn't have to.
+
+[Zaal] So should I just do one Zabal Games one then and put it all in that? I was thinking ZAOstock... I know we'll make a ZAOstock one after this. If you're going to do one before, then do ZAOstock / Zabal Games.
+
+[Tyler] Think about it as an anchor - that's their digital identity if they join. I think Zabal Games might make sense. Doing a specific magnet for each project, for you explaining where it's at right now, that'll be perfect.
+
+[Zaal] I think we got the plan. Mickey didn't send anything else back, but I should just go with ChatGPT and play around with it. I need a proper logo for it. Sam?
+
+[Samantha] What, for Zabal Games? Okay. I'm on Canva. You want a square or what?
+
+[Zaal] Both a square, vertical, and horizontal. But honestly, if you just pop the camera over to me once you make it, I can make the other two.
+
+[Zaal] So making the logo, then the words, then those videos overlaid... the sub magnets?
+
+[Tyler] The things underneath, the content stuff, we call them mementos... mems. Yeah, mems. It's like you receive it, you get something out of it, and then it's that digital anchor that you have. Think of it as: what's the journey you want people to go on when they join, and how does it tie into the Zabal Games. We just need to get the intro one up in the next four days, which I can do on my end.
+
+[Zaal] So just to recap, from a container perspective you want a Zabal Games one. A single box of Zabal Games, and then an intro one under that. For that I'll probably have at least three or four about the different projects, and then I'll leave a UGC submission there so people can submit along the way to get reviewed.
+
+[Zaal] I was thinking, by the way, for all three of you and the recording - my goal is to build something in the next four days that lets you input and authenticate your GitHub, and then any GitHub commits you do during the course of July will get looked at and evaluated for consideration, getting more points the more value you've done for the Zao ecosystem specifically. The signing up is just logging in with a wallet or your Farcaster, then authenticating your GitHub, and boom, you're in - a rolling admission style thing.
+
+[Shawn] Do you use a business GitHub, or does it have to be personal?
+
+[Zaal] I don't think it matters. I have my personal, but also Web3 [org]. You could put two in, authenticate with multiple. I'm going to have to build it anyway. The cool thing is I'll build it in public during this first month, with all the help of these awesome people coming. I'm reaching out to people in the Farcaster ecosystem and they're all a hell yes. The goal is to leave a fully open calendar. If I'm not available I'll rock a quick intro, have everything asynchronous enough that they can record it or go live, sign up any time. First half of the month: more one-off workshops, presentation style. Second half: a bunch of talks with a bunch of people, invite people to come have a conversation.
+
+[Zaal] Tyler, I'll send you a real logo when I get there, and we'll make the Zabal Games overall, and then the next four days I'll send you whatever I can, asynchronously.
+
+[Tyler] I'm also working on a feature where it doesn't matter the order we upload everything - we can rearrange the grid however we want. I'm putting a rank order number to each mem. So if you just have stuff, throw it in there, and we don't have to worry it's not in the right order. We have a pinning capability for featured, but sometimes it goes deeper than the first three things. Don't know if it'll roll out in the next week, but we're working on it.
+
+[Tyler] The last thing - is now the time for you to share about Magnetic? Do you have something you want to record?
+
+[Tyler] I have a two-minute-30-second demo ready right now that I could share, and then if you want something more bespoke. We can do the first at 5pm. Can you be free?
+
+[Zaal] The first is Monday? Yeah, I should be able to. I'm also planning out my calendar - that's New York Tech Week, so I don't know if there'll be an event.
+
+[Tyler] Put it in tentatively, and if something comes up, no worries. As soon as we can on the first, we'll roll that out with me and you live, then do an AMA, say a couple things after it. There's a Zabal Games one specifically - do a little walkthrough and demo, and that'll be its own one for Magnetic.
+
+[Zaal] Okay, I got to go to a meeting. So async, we'll put up this Zabal Games, use it as a centering place for people to enter and capture all the information, and go from there.
+
+Cheers, guys. Cheers.
+
+[transcript ends - remainder was a looping "Cheers" transcription artifact, trimmed]

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-05-27 16:30 | Tyler / Magnetic x Zaal + team - ZABAL Games build on Magnetic | ZABAL Games | Zaal, Tyler Stambaugh, Samantha, Shawn | [778](778-tyler-magnetic-zabal-games-build-may27/) | 9 |
 | 2026-05-25 14:26 | Leeward x Zaal WebRTC + Pion + LiveKit handoff (2nd call) | ZAO Devz | Zaal, Leeward (Lee Edward Bound) | [752](752-leeward-x-zaal-webrtc-pion-livekit-handoff-may25/) | 7 |
 | 2026-05-23 9:12 | ZAO coworking - 1h17m, mostly background music + brief Discord-bot-on-VPS chat | ZAO Devz | Zaal, Iman, ThyRev, z3rodol | [753](753-may23-zaal-iman-thyrev-z3rodol-coworking/) | 3 |
 | 2026-05-23 8:39 | Zaal + Iman silent / idle session | ZAO Devz | Zaal, Iman | [749](749-zaal-iman-may23-silent-session/) | 0 |


### PR DESCRIPTION
Working session on 2026-05-27 (Zaal, Tyler Stambaugh/Magnetic, Samantha, Shawn) turning the doc 714 plan into a build sprint.

## Decisions
- ZABAL Games = a single magnet on Magnetic (not one per project), intro magnet under it
- One combined list, include everybody, minimal segregation (Samantha)
- Videos hosted as Magnetic cards linking out to YouTube (storage workaround)
- June 1 (Mon) live Magnetic demo (2:30 ready) + AMA, plus ZABAL Games walkthrough - tentative (NY Tech Week)
- Build a GitHub-auth judging system: July commits scored by Zao-ecosystem value, rolling admission
- Other brands (WaveWarZ, Fractal, Festivals, COC) become their own magnets later

## Distribution
- Recap + speaker-attributed transcript (looping "Cheers" tail trimmed)
- Meetings index row
- Bonfire: 6 episodes posted
- Memory: project_zabal_games_magnetic_build
- Cowork tracker: deferred (creds on VPS, not local) - extracted actions JSON kept for a later VPS run

Follows docs 714 (plan) + 473 (Magnetic-portal spec) + 776 (musician-talk format).

🤖 Generated with [Claude Code](https://claude.com/claude-code)