### PR TITLE
docs: 780 - Adrian (Empire Builder) x Zaal - workshop for ZABAL Games

### DIFF
--- a/research/events/780-adrian-empire-builder-zabal-workshop-may26/README.md
+++ b/research/events/780-adrian-empire-builder-zabal-workshop-may26/README.md
@@ -1,0 +1,71 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-26
+related-docs: "719, 654, 778, 714"
+tier: STANDARD
+---
+
+# 780 - Adrian (Empire Builder) x Zaal: Empire Builder workshop for ZABAL Games
+
+> **Goal:** Capture decisions + action items from the 2026-05-26 call between Zaal and Adrian (Empire Builder cofounder) lining up Adrian's June ZABAL Games workshop on the Empire Builder API - using V3 endpoints for an existing empire, integrating a leaderboard, and deploying a new tokenless empire - plus Zaal building a tokenless-empire-deployer button on his own site.
+
+Pairs with [doc 719](../719-jordan-empire-builder-zabal-games-may15/) (Jordan Oram - the "why an empire" front-of-house) and [doc 654](../654-zabal-games-empire-v3-yerbearzerker-meeting/) (where Adrian is identified as Empire Builder co + Jordan's Melbourne neighbor). This call is the API/technical complement: Adrian covers the endpoints, Jordan covers the pitch. Same June workshop month as [doc 778](../778-tyler-magnetic-zabal-games-build-may27/) (Magnetic) and [doc 776](../776-duo-do-clementine-santiago-zabal-games-may23/) (Duo Do).
+
+## Attendees
+
+- **Zaal** (host)
+- **Adrian** - Empire Builder cofounder, the API/technical side of Empire Builder (docs 654, 719). Leaving for Poland on Friday for a month with his wife (she's Polish), so he'll be in Europe through June. Recently took a second software job, transitioning to full-time.
+
+## Key Decisions
+
+| # | Decision | Owner | Status | Confidence |
+|---|----------|-------|--------|------------|
+| 1 | **Adrian presents an Empire Builder workshop at ZABAL Games in June** - #1: use V3 endpoints for an existing empire + integrate a leaderboard and surface it in an app; #2 (optional): deploy a new tokenless empire | Adrian | TODO | high |
+| 2 | **Workshop is recorded** (Adrian travelling/with family), under 30 min - even a tight 5-min demo works; ZAO team clips/edits it. July fallback = "extra episode" | Both | TODO | high |
+| 3 | **Zaal builds a tokenless-empire-deployer button on his small-games website** using the Empire deploy endpoint | Zaal | TODO | high |
+| 4 | **Adrian's Europe timezone is actually better** for the second-half-of-June conversation/space sessions | Both | DECIDED | medium |
+
+## Thread 1 - Adrian's workshop content
+
+Two pieces Adrian wants to demo:
+- **Existing empire:** how to use the endpoints for an empire you already have - integrate a leaderboard, surface it through your app/bot.
+- **New empire (deeper):** how to use the endpoints to *deploy* a new empire - "people don't realize you can just deploy."
+
+Zaal's framing back to Adrian: Jordan (June 1) covers "why you should have an empire"; Adrian covers "what's possible with the API now" - which is the angle for people who already have empires and want to tap deeper. Push that content piece toward those individuals. Watch Jordan's first so they do not overlap.
+
+## Thread 2 - The Empire API (technical)
+
+Adrian walked the deploy model:
+- **`deploy tokenless empire` is its own endpoint** - no wallet, no private key. You call the endpoint and it creates it for you.
+- **Two types:** pass a **FID** and it deploys for that Farcaster user (if they do not already have one); or a **pure blank/custom tokenless empire** ("you can make a million of those").
+- **create2 + 0xSplits:** the treasury address is *predicted* via create2 - a predictable address - but the contract is **not actually deployed on-chain yet**. Nothing on-chain happens until you start interacting with the contract; that first interaction is when funds initiation happens.
+- After that, treasury read/write: to interact with the contracts through your own interface you interact with the contracts directly.
+- Best way to learn it: chuck the docs into an LLM / point an agent at it. Adrian will send the exact docs link.
+
+## Thread 3 - Zaal's build
+
+Zaal wants a **tokenless empire deployer** on his small-games site - "just go to the website, that can start your submission." He already has an Empire **API key** (Adrian issued it, it is in Adrian's database); since Zaal will now create + deploy, Adrian may refresh it. Adrian offered to **jump in and help** Zaal build (start a repo, the nuts and bolts) given Zaal's load. Zaal's modality: build it live while streaming, turn the build into shareable content.
+
+## Action Items
+
+| Title | Owner | Due | Category | Confidence |
+|-------|-------|-----|----------|------------|
+| Record the Empire Builder workshop (existing-empire endpoints + leaderboard), <30 min, send to Zaal | Adrian | next week / week after / July | ZABAL Games | high |
+| Send Zaal the docs link for the tokenless-empire deploy endpoint (Empire Builder site, docs button at bottom) | Adrian | - | ZABAL Games | high |
+| Double-check / refresh Zaal's Empire API key if needed | Adrian | - | Site / Tech | medium |
+| Build the tokenless-empire-deployer button on the small-games site | Zaal | - | Site / Tech | high |
+| Write a semi-agenda/script for own workshop pieces, optionally share with Adrian | Zaal | - | ZABAL Games | medium |
+| Watch Jordan's June 1 workshop to avoid content overlap | Zaal | 2026-06-01 | ZABAL Games | medium |
+
+## Quotes
+
+- Zaal: "Keep the first month as low-friction as possible, and the second month as high and super curated, and then stream the whole last part of it - building in public with all the eight or 16 remaining people."
+- Adrian: "Deploy tokenless empire is its own endpoint... you don't need a wallet, it's just an endpoint, we create it for you. We predict through create2 what the treasury address will be, but we don't actually deploy the contract - so there's no on-chain thing happening yet."
+- Zaal: "A lot of people built cool open-source things but people just don't know how to use them... actually getting a demo and seeing how it's used, given examples of how they can use it immediately - that's very powerful."
+- Adrian: "People don't realize you can just deploy. So I could create the tokenless empire deployer on my small games website - your site, yeah, absolutely."
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md).

--- a/research/events/780-adrian-empire-builder-zabal-workshop-may26/transcript.md
+++ b/research/events/780-adrian-empire-builder-zabal-workshop-may26/transcript.md
@@ -1,0 +1,73 @@
+# Transcript - Adrian (Empire Builder) x Zaal, 2026-05-26 19:03 EDT
+
+Attendees: Zaal, Adrian (Empire Builder cofounder). Source: `AdrianxZaal - 2026_05_26 19_03 EDT - Recording.mp4`. Single-feed recording (Zaal's camera); Adrian audio-only. Unlabeled whisper transcript (mlx-whisper large-v3-turbo); speakers attributed from content - Adrian = the Empire Builder API owner travelling to Poland; Zaal = ZABAL Games host whose event is in Maine in October.
+
+---
+
+[Adrian] ...well in your world as well. Yeah, going really well - leaving to go overseas for a month with my wife, going to Poland on Friday, so it's really exciting.
+
+[Zaal] That's super fun. Is there a specific area you guys are going, or travelling all around?
+
+[Adrian] Yeah, my wife is from Poland, so we're just going to visit the family and everything over there. It's going to be nice. How are you doing?
+
+[Zaal] Good, I'm just running around trying to do a lot. Basically I took a second job doing software, excited to transition into full time, but I'll be at my other job for at least a month plus. [Note: this line's attribution is uncertain; the "second software job" speaker may be Adrian.] The challenge - a couple of challenges with being there for the Monday-ers and also having things tied to it in the US. But that's why I'm excited for this, because our event is in October here in Maine locally, and we're going to be streaming it, plus an event in my hometown, and trying to iterate on it for the next year. So this is just trying to get a bunch of attention towards that and also build ourselves in the Farcaster ecosystem.
+
+[Zaal] So the three-month session ended up turning out, and Jordan actually suggested doing something similar to what they did for the agentic workshop - doing a workshop before it. So we created the third month. He's having a talk on the first about Empire Builder - would love that in the first week of June. The idea with workshops is very fluid, just under 30 minutes. If we did multiple that's super okay; if you wanted to go super deep in one, or chat for a long time, we just need to split it up. Other than that, pretty fluid - recorded, live, AMA, whatever you're feeling. The goal ultimately is to get people excited about building. It'll give me the opportunity to write the prompt really explaining all the things we've done and all the projects people could build on top of - but also, if they have an idea of their own, propose it into our ecosystem. Keep the first month as low-friction as possible, the second month as high and super curated, then stream the whole last part of it - building in public with all the eight or 16 remaining people.
+
+[Adrian] So how many people are going to be participating? What's the exact structure? Anyone can just submit a build, right?
+
+[Zaal] Exactly. It's pretty undetermined. The goal is, because it'll be open for a month, to get into sharing on the Farcaster timeline that whole month, and make it super easy to collaborate with different builders doing things for vibe coders - having them come in and share how their tool helps builders. A lot of people don't have a great understanding of all the tools out there, especially new ones to Farcaster. So I'm compiling a content library of all this information, and a content library of all the things I've created with the Zao and all our projects, so people can point their agent at it - "look at this, tell me what's the interesting thing to me right now." I think that can be a much more prolific way of building and spreading throughout the ecosystem.
+
+[Adrian] Yeah, I think so too. I already have an idea of how I could go about it, but - from a low level, what is it going to look like in terms of actual logistics?
+
+[Zaal] Essentially I need to sign you in in June. I'd love to get people that are about it to do a workshop-based one in the front half, and in the second half of June do more of a conversation or a space with people - but that could also, because of your timezone, be more of "we ask people to generate questions beforehand and then we go through them," which could be an easier way to get people to contribute. My thought ultimately is we just need to schedule a 30-minute block - that's the logistics more than anything. In June I don't have a crazy set schedule, and any day I don't have someone set, I'm going to be building on top of the things I'm building and trying to live-stream that and share, so when people come in they can ask questions.
+
+[Adrian] Okay, so the workshop - let's say I come on and I'm showing how to use the Empire endpoints and stuff to build something. That's the way I'm thinking about it. Let me share what's possible with V3.
+
+[Zaal] That would be great, anything you show is amazing. You can watch Jordan's on the first and see what he's already covered. I was telling him it'd be really cool for him to push the tokenless empires - "okay, you've created your thing, now we want to share it so the mentors pick it in the final month, so how do we share that in the Zao ecosystem." We don't have to have too much of a plan logistically. If you have a semi-agenda written down for what you want to say, that'd be great - send it over, I'm welcome to look at it, but again, free to keep it what you think. I think the API endpoints and showing what's possible now, because Jordan will show why you should have an empire - but there are a lot of people with empires that might want to tap into that side of things. We could push this piece of content towards those individuals.
+
+[Adrian] Yeah, I think so too. Building a separate interface that brings up your empire, or a bot that has all the information about your empire. There's a lot that can be done - a couple things I've wanted to build on Empire for a while.
+
+[Zaal] So that conversation, for me - that next day I'm going to try and build something on top of that. That's my modality, because if I'm doing that while streaming I can also create the content, share it out. I don't have too much else. I don't want to take up too much of the time in the beginning of your day. Any questions, you're welcome.
+
+[Adrian] In terms of the date - I'm just trying to work on logistics in my mind, because you're going to be flying over.
+
+[Zaal] Logistics-wise you'll actually be better in terms of the timezone because I'll be in Europe. I have absolutely no issue, because it's set up so your first one especially is just going to be a presentation. We can always get the questions as part of that - an AMA in the middle - or have you be a bit more organized. There's no need to do it live, but we can react to it live and I can watch it there, and if people are there I can continue to ask. Then your timing doesn't have to be part of the challenge.
+
+[Adrian] All right, in that sense I might record it. Even recording - because I'm going to be with family next week, it's going to be a hectic week - so I might try and squeeze it in next week, for the week after. If not, I'll record it the week after and get it there.
+
+[Zaal] I understand, family comes first. Whenever you can record it, even if you get it in July, we'll pop it in - it's an extra episode. I'm not a very picky person. The goal is to get everyone a piece and an opportunity to distribute why people should use their app, and the tooling they've used - agentic workflows, ways other people can use what they've built. A lot of people built cool open-source things but people just don't know how to use them. Actually getting a demo, seeing how it's used and given examples of how they can use it immediately - that's very powerful.
+
+[Adrian] Yeah, I think so too. There are a couple ideas - I might even do two if it's possible, I'll see how it goes.
+
+[Zaal] If you're strapped for time at the beginning, do a five-minute one, I'll pop that. The literal only restriction is under 30 minutes. A five-minute one - more people might watch that. You might be able to blaze through all the things you can do in a quick demo. And if you don't want to edit it and you just do a full raw thing, send it over and we'll clip it and cut it - especially if you have an idea of how you want it done, just tell us what you're thinking, or if not, go for it and don't stress about that side. I get my team working on that.
+
+[Adrian] I probably wouldn't edit it - I'd come up with a bit of a script myself and go through it, so it shouldn't need too much editing.
+
+[Zaal] Whatever's best for you is best for me. We're pretty good async. If you have any ideas throughout, shoot me a message. And the offer's always open - if you share anything on Farcaster that you want to get out more, shoot it over my way.
+
+[Adrian] Absolutely. What I'll do is make a very simple demonstration of how to use the endpoints for your existing empire - integrate a leaderboard, surface that through your app. And the next one will be a bit more complex: how to use the endpoints to deploy a new empire, rather than just your existing ones. People don't realize you can just deploy. So I could create the tokenless empire deployer on my small games website - your site.
+
+[Zaal] Yeah, absolutely, that's what I should do. You have the endpoint - you need an API key, but you have one, right?
+
+[Adrian] I got you an API key. You definitely have one. I've got one recorded for you in my database. But if you need a new one, just let me know.
+
+[Zaal] I'll have to dive into that because that seems really fun - that'd be an easy way of just telling people, you could just go to the website, that can start your submission as well.
+
+[Adrian] I've got one recorded for you in my database in terms of your API key. If I need to refresh that one - I definitely tossed it through somewhere, probably should refresh it. It's not a crazy bad thing, but now that you have to create and deploy and fire something, maybe we should refresh it and put it back in wherever. I don't think we're using it too much. There's one specific place I want to play around with it more - that'll be one of my homework things. Definitely let me know if you have any questions.
+
+[Zaal] If there's anything you want to integrate and need assistance with from me - because obviously if you're working two jobs, I can jump in and help out with some stuff here and there. Start a repo, the nuts and bolts, and we can play around with that. I'll see what I can do this week when I chat more with the team, because it'd be really fun to have that button.
+
+[Zaal] Wait - do you have the documentation somewhere online? How does the API work for - can you create a button that specifically creates a tokenless empire, or is it create an empire then they choose tokenless throughout?
+
+[Adrian] No, deploy tokenless empire is its own endpoint. There are two types: you can pass it with a FID and it'll deploy it for that actual Farcaster user if they don't already have one - so a Farcaster one - and then there's also the pure custom blank empire, the tokenless one, where you can make a million of those, it doesn't matter. You don't need a wallet, it's just an endpoint, we create it for you. The way it works now with create2 - because we're using the splits - it's a predictable address. We predict through create2 what the treasury address will be, but we don't actually deploy the contract, so there's no actual on-chain thing happening yet. You're creating the empire, and once you actually start interacting with the contract, that's when the initiation of funds happens. That's also in the treasuries - the read and the write. If you want to interact with the contracts through your interface, you have to interact with the contracts directly from that stage. But creating the empire, you don't need any private key - you just call the endpoint and it'll create it.
+
+[Zaal] All this stuff we have - the AI skill and everything - the easiest way is just to chuck it in the LLM and it will explain it. I already have a couple specific small mini-builds from my builder that I've set up with API endpoints, and now that you have all this additional stuff I'm probably going to toss it at the things I've created already and beef those up while I'm playing around with it. Also this tokenless empire endpoint - if you could share with me in the docs where that specifically is, highlight it and send it over, that'd be huge.
+
+[Adrian] I'll send it to you now. It's on the Empire Builder site - at the bottom, click the docs button. It's all there, you can scroll through, but that's the exact one - the deploy tokenless empire.
+
+[Zaal] Awesome, thanks man. Enjoy the rest of your night.
+
+[Adrian] Thanks - I know it's the afternoon for you. Anytime you need anything, doors always open.
+
+[Zaal] Same here, anytime. Speak soon, enjoy man, have a good evening.

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -6,6 +6,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 |------|-------|---------|-----------|-----|---------|
 | 2026-05-31 | Iman x Zaal - Request for Collaborators walkthrough | ZAO Devz | Zaal, Iman | [779](779-iman-zaal-request-for-collaborators-may31/) | 3 |
 | 2026-05-27 16:30 | Tyler / Magnetic x Zaal + team - ZABAL Games build on Magnetic | ZABAL Games | Zaal, Tyler Stambaugh, Samantha, Shawn | [778](778-tyler-magnetic-zabal-games-build-may27/) | 9 |
+| 2026-05-26 19:03 | Adrian (Empire Builder) x Zaal - Empire Builder workshop for ZABAL Games | ZABAL Games | Zaal, Adrian | [780](780-adrian-empire-builder-zabal-workshop-may26/) | 6 |
 | 2026-05-25 14:26 | Leeward x Zaal WebRTC + Pion + LiveKit handoff (2nd call) | ZAO Devz | Zaal, Leeward (Lee Edward Bound) | [752](752-leeward-x-zaal-webrtc-pion-livekit-handoff-may25/) | 7 |
 | 2026-05-25 | Telamon Ardavanis x Zaal - Edge Esmeralda invite + Goa | Networking | Zaal, Telamon Ardavanis | [777](777-telamon-edge-esmeralda-may25/) | 4 |
 | 2026-05-23 12:05 | Duo Do (Clementine + Santiago) x Zaal - ZABAL Games musician talk format | ZABAL Games | Zaal, Clementine, Santiago | [776](776-duo-do-clementine-santiago-zabal-games-may23/) | 5 |


### PR DESCRIPTION
Call on 2026-05-26 with Adrian, Empire Builder cofounder (API/technical side; Jordan Oram is front-of-house, docs 654/719).

## Decisions
- Adrian presents a recorded Empire Builder workshop at ZABAL Games in June: #1 V3 endpoints for an existing empire + leaderboard integration; #2 (optional) deploy a new tokenless empire
- Recorded, under 30 min, ZAO team clips it, July fallback OK
- Zaal builds a tokenless-empire-deployer button on his small-games site
- Adrian's Europe timezone is better for the second-half-June conversation sessions

## Tech captured
deploy-tokenless-empire is its own endpoint, no wallet/private key. Two types (pass a FID, or a blank custom empire). create2 + 0xSplits = predictable treasury address; no on-chain deploy until first contract interaction. Docs on the Empire Builder site.

## Distribution
- Recap + speaker-attributed transcript
- Meetings index row
- Bonfire: 5 episodes
- Memory: project_adrian_empire_builder
- Cowork tracker: deferred (creds on VPS)

Same June workshop month as docs 776 (Duo Do) + 778 (Magnetic). Pairs with 719 (Jordan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)