### PR TITLE
refactor(zoe/crm): write CRM direct to Supabase — no bot secret needed

### DIFF
--- a/bot/src/zoe/__tests__/crm.test.ts
+++ b/bot/src/zoe/__tests__/crm.test.ts
@@ -1,0 +1,116 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runCrmOps, summarizeCrmResults } from '../crm.ts';
+import type { CrmOp } from '../types.ts';
+
+// A minimal chainable fake of the supabase-js client, capturing every
+// upsert/insert so we can assert the C-H1 / C-M2 guards on the direct-write
+// path. No network, no real DB.
+interface Recorded {
+  table: string;
+  kind: 'upsert' | 'insert' | 'select-like';
+  row?: Record<string, unknown>;
+}
+
+function makeFakeDb(opts: { existingSlugs?: string[]; contactId?: string } = {}) {
+  const calls: Recorded[] = [];
+  const existing = opts.existingSlugs ?? [];
+  const contactId = opts.contactId ?? 'contact-1';
+
+  function query(table: string) {
+    let row: Record<string, unknown> | undefined;
+    const builder: Record<string, unknown> = {
+      upsert(r: Record<string, unknown>) {
+        row = r;
+        calls.push({ table, kind: 'upsert', row: r });
+        return builder;
+      },
+      insert(r: Record<string, unknown>) {
+        row = r;
+        calls.push({ table, kind: 'insert', row: r });
+        return builder;
+      },
+      select() {
+        return builder;
+      },
+      like(_column: string, pattern: string) {
+        calls.push({ table, kind: 'select-like' });
+        const base = pattern.replace(/%$/, '');
+        const data = existing
+          .filter((s) => s.startsWith(base))
+          .map((slug) => ({ slug }));
+        return Promise.resolve({ data, error: null });
+      },
+      single() {
+        return Promise.resolve({
+          data: { id: contactId, slug: row?.slug ?? null },
+          error: null,
+        });
+      },
+    };
+    return builder;
+  }
+
+  return { client: { from: query } as never, calls };
+}
+
+function op(overrides: Partial<CrmOp['contact']> = {}, interaction: Partial<CrmOp['interaction']> = {}): CrmOp {
+  return {
+    op: 'log_crm',
+    contact: { name: 'Test Person', ...overrides },
+    interaction: { type: 'note', ...interaction },
+  };
+}
+
+test('C-H1: a bot write never publishes — is_public dropped, interaction forced private', async () => {
+  const { client, calls } = makeFakeDb();
+  const results = await runCrmOps(
+    [op({ farcaster_handle: 'zaal', is_public: true }, { visibility: 'public', public_summary: 'x' })],
+    client,
+  );
+  assert.equal(results[0].status, 'logged');
+
+  const contactWrite = calls.find((c) => c.table === 'crm_contacts');
+  assert.ok(contactWrite);
+  assert.equal('is_public' in (contactWrite.row ?? {}), false);
+
+  const interactionWrite = calls.find((c) => c.table === 'crm_interactions');
+  assert.ok(interactionWrite);
+  assert.equal(interactionWrite.row?.visibility, 'private');
+  assert.equal(interactionWrite.row?.created_by, 'zoe');
+  assert.equal(interactionWrite.row?.source, 'zoe');
+});
+
+test('C-M2: a name-only contact INSERTs with a uniquified slug (no overwrite)', async () => {
+  const { client, calls } = makeFakeDb({ existingSlugs: ['test-person'] });
+  const results = await runCrmOps([op()], client); // no handle => name-only
+  assert.equal(results[0].status, 'logged');
+
+  const contactWrite = calls.find((c) => c.table === 'crm_contacts' && c.kind !== 'select-like');
+  assert.ok(contactWrite);
+  assert.equal(contactWrite.kind, 'insert'); // never upsert for a name-only key
+  assert.equal(contactWrite.row?.slug, 'test-person-2');
+});
+
+test('a contact WITH a handle upserts (stable, idempotent)', async () => {
+  const { client, calls } = makeFakeDb();
+  await runCrmOps([op({ x_handle: 'someone' })], client);
+  const contactWrite = calls.find((c) => c.table === 'crm_contacts');
+  assert.equal(contactWrite?.kind, 'upsert');
+});
+
+test('runCrmOps([]) is a no-op', async () => {
+  const results = await runCrmOps([]);
+  assert.deepEqual(results, []);
+});
+
+test('summarizeCrmResults renders per-status lines', () => {
+  const o = op({ farcaster_handle: 'a' });
+  const text = summarizeCrmResults([
+    { op: o, status: 'logged', contact_id: 'c1' },
+    { op: op({ name: 'Two' }), status: 'failed', error: 'boom' },
+  ]);
+  assert.match(text, /Logged Test Person to CRM\./);
+  assert.match(text, /CRM write for Two failed: boom/);
+});

--- a/bot/src/zoe/crm.ts
+++ b/bot/src/zoe/crm.ts
@@ -1,60 +1,135 @@
 /**
- * ZOE -> ZAO CRM write path (doc 772).
+ * ZOE -> ZAO CRM write path (doc 772; direct-write refactor 2026-05-31).
  *
- * When ZOE emits a crm_op in her reply, this module POSTs it to the ZAOOS app
- * route `POST /api/crm/interactions`, authenticated with a Bearer shared secret
- * (CRM_BOT_SECRET). The app upserts the contact (by deterministic slug) and
- * logs the interaction. Fire-and-forget from ZOE's side - a one-line summary is
- * appended to her DM reply.
+ * ZOE runs on the VPS with the Supabase service-role key (bot/src/supabase.ts
+ * `db()`), so she writes CRM contacts/interactions STRAIGHT to Supabase instead
+ * of POSTing to the app behind a shared bearer secret. This drops CRM_BOT_SECRET
+ * + CRM_API_URL from the bot entirely and removes the dependency on the app
+ * being reachable. The app's POST /api/crm/interactions still exists for the
+ * admin browser form (iron-session auth); ZOE just no longer calls it.
  *
- * Env:
- *   CRM_API_URL    - base URL of the app (default https://zaoos.com)
- *   CRM_BOT_SECRET - shared bearer secret; must match the app's ENV.CRM_BOT_SECRET
- *
- * If CRM_BOT_SECRET is unset, ops are skipped (logged), never throws.
+ * The two security guards from the app route are PORTED here so they hold on
+ * this path too:
+ *   - C-H1: ZOE may NEVER publish. is_public is dropped and every interaction
+ *     is written `private`. Publishing stays an admin-only action in /crm.
+ *   - C-M2: a name-only contact is INSERTed with a uniquified slug, never
+ *     upserted onto a slug a different person already owns.
  */
 
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { db } from '../supabase';
 import type { CrmOp } from './types';
 
 export interface CrmResult {
   op: CrmOp;
-  status: 'logged' | 'skipped-no-secret' | 'failed';
+  status: 'logged' | 'skipped' | 'failed';
   contact_id?: string;
   error?: string;
 }
 
-const CRM_API_URL = process.env.CRM_API_URL ?? 'https://zaoos.com';
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/^@/, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
 
-export async function runCrmOps(ops: CrmOp[]): Promise<CrmResult[]> {
-  if (ops.length === 0) return [];
-  const secret = process.env.CRM_BOT_SECRET;
+function deriveContactSlug(c: CrmOp['contact']): string {
+  return slugify(c.farcaster_handle || c.x_handle || c.github_handle || c.name);
+}
+
+/** A handle uniquely identifies a person; a bare name does not (C-M2). */
+function hasStableContactKey(c: CrmOp['contact']): boolean {
+  return Boolean(c.farcaster_handle || c.x_handle || c.github_handle);
+}
+
+/** Pick a free slug for a name-only contact: john-smith, john-smith-2, … (C-M2). */
+async function uniqueNameSlug(client: SupabaseClient, base: string): Promise<string> {
+  const { data } = await client.from('crm_contacts').select('slug').like('slug', `${base}%`);
+  const taken = new Set((data ?? []).map((r) => (r as { slug: string | null }).slug));
+  if (!taken.has(base)) return base;
+  for (let i = 2; i < 1000; i++) {
+    const candidate = `${base}-${i}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${Date.now()}`;
+}
+
+function compact<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined),
+  ) as Partial<T>;
+}
+
+/**
+ * Write each CRM op directly to Supabase. `client` is injectable for tests;
+ * defaults to the bot's service-role client. Never throws — every op resolves
+ * into a CrmResult so the caller can always summarize for Zaal.
+ */
+export async function runCrmOps(ops: CrmOp[], client?: SupabaseClient): Promise<CrmResult[]> {
   const results: CrmResult[] = [];
+  if (ops.length === 0) return results;
+
+  let supabase: SupabaseClient;
+  try {
+    supabase = client ?? db();
+  } catch (err) {
+    // Supabase not configured on this box — skip, never throw.
+    for (const op of ops) results.push({ op, status: 'skipped', error: (err as Error).message });
+    return results;
+  }
 
   for (const op of ops) {
-    if (!secret) {
-      results.push({ op, status: 'skipped-no-secret' });
-      continue;
-    }
     try {
-      const res = await fetch(`${CRM_API_URL}/api/crm/interactions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${secret}`,
-        },
-        body: JSON.stringify({ contact: op.contact, interaction: op.interaction }),
-      });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        results.push({
-          op,
-          status: 'failed',
-          error: body.error ?? `HTTP ${res.status}`,
-        });
+      // C-H1: ZOE may never publish — drop is_public entirely.
+      const { is_public: _omitPublic, ...contactSafe } = op.contact;
+      void _omitPublic;
+
+      const stableKey = hasStableContactKey(op.contact);
+      const baseSlug = deriveContactSlug(op.contact);
+      const slug = stableKey ? baseSlug : await uniqueNameSlug(supabase, baseSlug);
+      const contactRow = compact({ ...contactSafe, slug });
+
+      const contactQuery = stableKey
+        ? supabase.from('crm_contacts').upsert(contactRow, { onConflict: 'slug' })
+        : supabase.from('crm_contacts').insert(contactRow);
+
+      const { data: contact, error: contactErr } = await contactQuery
+        .select('id, slug')
+        .single();
+
+      if (contactErr || !contact) {
+        results.push({ op, status: 'failed', error: contactErr?.message ?? 'contact upsert failed' });
         continue;
       }
-      const data = (await res.json().catch(() => ({}))) as { contact_id?: string };
-      results.push({ op, status: 'logged', contact_id: data.contact_id });
+      const contactId = (contact as { id: string }).id;
+
+      const { error: interactionErr } = await supabase
+        .from('crm_interactions')
+        .insert(
+          compact({
+            contact_id: contactId,
+            type: op.interaction.type ?? 'note',
+            title: op.interaction.title,
+            public_summary: op.interaction.public_summary,
+            private_notes: op.interaction.private_notes,
+            visibility: 'private', // C-H1: bot interactions are always private
+            occurred_at: op.interaction.occurred_at,
+            source: 'zoe',
+            created_by: 'zoe',
+          }),
+        )
+        .select('id')
+        .single();
+
+      if (interactionErr) {
+        results.push({ op, status: 'failed', contact_id: contactId, error: interactionErr.message });
+        continue;
+      }
+      results.push({ op, status: 'logged', contact_id: contactId });
     } catch (err) {
       results.push({ op, status: 'failed', error: (err as Error).message });
     }
@@ -69,10 +144,9 @@ export function summarizeCrmResults(results: CrmResult[]): string {
   for (const r of results) {
     const who = r.op.contact.name;
     if (r.status === 'logged') {
-      const pub = r.op.contact.is_public ? ' (public on /network)' : '';
-      lines.push(`Logged ${who} to CRM${pub}.`);
-    } else if (r.status === 'skipped-no-secret') {
-      lines.push(`Could not log ${who} - CRM_BOT_SECRET not set on this box.`);
+      lines.push(`Logged ${who} to CRM.`);
+    } else if (r.status === 'skipped') {
+      lines.push(`Could not log ${who} — CRM (Supabase) not configured on this box.`);
     } else {
       lines.push(`CRM write for ${who} failed: ${r.error ?? 'unknown error'}`);
     }


### PR DESCRIPTION
## Why
The bot already runs with `SUPABASE_SERVICE_ROLE_KEY` (`bot/src/supabase.ts` `db()`), so the `CRM_BOT_SECRET` + HTTP hop to `zaoos.com/api/crm/interactions` was redundant. This is the "skip the bot secret, do it another way" — ZOE writes straight to Supabase with the key she already has.

## What changed
`bot/src/zoe/crm.ts` `runCrmOps` now writes `crm_contacts` / `crm_interactions` directly via the service-role client. Result:
- **No `CRM_BOT_SECRET`** to generate or set anywhere.
- **No `CRM_API_URL`** on the bot.
- **No dependency** on the Next app being up for a write to land.

Both guards from the app route are **ported** so they still hold on the direct path:
- **C-H1** — ZOE never publishes: `is_public` dropped, every interaction written `private`. Publishing stays admin-only in `/crm`.
- **C-M2** — name-only contacts INSERT with a uniquified slug; only handle-keyed contacts upsert. No cross-person PII overwrite.

`runCrmOps` takes an optional injected client for testing. **5 new bot tests** (`crm.test.ts`) with a fake Supabase client cover the C-H1 strip, C-M2 unique-slug insert, handle-upsert, empty no-op, and summary lines.

The app route `POST /api/crm/interactions` is **unchanged** — still serves the admin browser form via iron-session. Its optional Bearer path just goes unused; leave `CRM_BOT_SECRET` unset and it stays dormant.

**Checks:** full zoe suite 113/113 · bot `tsc` clean.

## Revised setup steps (simpler now)
1. ~~Set `CRM_BOT_SECRET`~~ — **deleted**. Nothing to set.
2. Apply `scripts/20260529_crm.sql` in Supabase.
3. Confirm the VPS bot env has `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` (it already does — that's how ZOE works today).
4. Redeploy the bot. CRM writes work immediately.

🤖 Refactored + tested via Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_