### PR TITLE
docs: 783 - Tyler/Magnetic x Zaal - ZABAL Games magnet built live (2026-05-29)

### DIFF
--- a/research/events/783-tyler-magnetic-zabal-magnet-build-may29/README.md
+++ b/research/events/783-tyler-magnetic-zabal-magnet-build-may29/README.md
@@ -1,0 +1,65 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-29
+related-docs: "778, 714, 473, 776, 780"
+tier: STANDARD
+---
+
+# 783 - Tyler / Magnetic x Zaal: ZABAL Games magnet built live + Connector explainer recorded
+
+> **Goal:** Capture the 2026-05-29 working session where Zaal and Tyler Stambaugh (Magnetic) actually BUILT the ZABAL Games magnet live on Magnetic and recorded the demo - the exact thing planned in [doc 778](../778-tyler-magnetic-zabal-games-build-may27/) two days earlier. This is the build-execution follow-on: 778 was the plan, this is the magnet existing.
+
+Direct continuation of doc 778 (the 2026-05-27 plan: single magnet, intro under it, June 1 demo). Here the magnet gets created and the demo + ZABAL Connector explainer get recorded for clipping.
+
+## Attendees
+
+- **Zaal**
+- **Tyler Stambaugh** - Magnetic founder (docs 473, 714, 778). Drove the screen-share so the recording would showcase how simple the build is.
+
+## What got done in-call
+
+- **The ZABAL Games magnet was created live.** Tyler shared his screen, logged in (Google login), went to the ZABAL brand dashboard, hit "create magnet." Three inputs only: **thumbnail, name, description** (description editable anytime). Creating the magnet mints an NFT contract people then join/mint off of. Confirmed the doc-778 decision: kept under the ZABAL brand, as a single magnet.
+- **A UGC request was set live** with a brief, a start date and end date, scheduled to go live (11:15). Tested live end-to-end - submitted "add sunscreen" as a user to prove the flow.
+- **The session itself is the content.** It was recorded as the Magnetic demo + the ZABAL Connector explainer for June 1; Tyler will cut it into ~15-second clips and send them to the ZAO team. (Mid-section build fumbles get trimmed.)
+
+## The ZABAL Connector explainer (recorded)
+
+Tyler's recorded descriptor, with Zaal adding color: the **ZABAL Connector** is the home base for anyone Zaal collects at events or meets in the wild. Zaal used the **QR-activated badging** feature - each event gets a unique QR badge people scan, which proves they met Zaal and pulls them into the program. ~**67 people** are in it now. What Zaal has not leaned into yet: it doubles as an **email / notification channel** - post a ZABAL update in the Connector and it emails all 67 joined people to come check it out. So it is both an interactive event-join surface and an email list.
+
+## Magnetic mechanics covered (for the demo)
+
+- **Mementos / activations** inside a magnet: content (video / audio / gif / image / docs, shown as cards - title + description, click to expand into a grid), surveys, brand activations (discount codes, products), and the **UGC tool** (people upload content / fill forms, tied to any magnet program).
+- Tyler's guidance: **start with content** so people understand the purpose when they arrive.
+- **Launch defaults:** starts now, never ends, free - all toggleable (e.g. a 24-hour countdown timer before claim opens).
+- Back-end shows who interacted with what.
+
+## Key Decisions
+
+| # | Decision | Owner | Status | Confidence |
+|---|----------|-------|--------|------------|
+| 1 | ZABAL Games magnet created live on Magnetic, under the ZABAL brand (executes doc 778 decision 1) | Both | DONE | high |
+| 2 | The recorded session = the Magnetic demo + ZABAL Connector explainer for June 1, cut into ~15-sec clips | Tyler | TODO | high |
+| 3 | UGC request live with a brief + start/end date as the submission surface | Zaal | DONE | high |
+
+## Action Items
+
+| Title | Owner | Due | Category | Confidence |
+|-------|-------|-----|----------|------------|
+| Make the Fractal proof-of-meats for this week + next week (behind since the 24th); DM when sent; pull from the pin folder | Zaal | this week | Ops | high |
+| Fix the ZABAL Games magnet logo (the png says "ZABAL" not "ZABAL Games") + description | Zaal | - | Site / Tech | high |
+| Clip the recorded session into ~15-sec clips, send to the ZAO team | Tyler | - | Social | high |
+| Add a "now" button at the bottom of the schedule UI; look into a resubmit / multiple-submissions-per-person feature | Tyler | - | Site / Tech | medium |
+| Send Zaal the next QR proof-of-meat card updates (images + titles added) | Tyler | - | Site / Tech | medium |
+
+## Quotes
+
+- Tyler: "All you need to create one of these portals is a thumbnail, a name, and a description. And once you do that, we're creating an NFT contract and then people can mint off of it."
+- Tyler (on the Connector): "It's a home base for anyone you collect at events or meet in the wild... you create a QR badge for each event, unique to them, that proves they met you and brings them into the program."
+- Tyler: "It almost becomes an extension channel - if you have updates and put them in here, it'll shoot an email to all those people that have joined."
+- Zaal: "I had cowork go through and organize all my stuff so I knew what to delete - that was really helpful." [on prepping his machine mid-call]
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md).

--- a/research/events/783-tyler-magnetic-zabal-magnet-build-may29/transcript.md
+++ b/research/events/783-tyler-magnetic-zabal-magnet-build-may29/transcript.md
@@ -1,0 +1,55 @@
+# Transcript - Tyler / Magnetic x Zaal, 2026-05-29 11:02 EDT
+
+Attendees: Zaal, Tyler Stambaugh. Source: `catchup - 2026_05_29 11_02 EDT - Recording.mp4`. Recording shows Tyler's feed (screen-share build session). Diarization skipped (2-person); speakers attributed from content - Tyler is driving the Magnetic screen-share, Zaal is the brand owner. mlx-whisper large-v3-turbo.
+
+---
+
+[Zaal] I do not have a lot of time - that's why I wanted to just tap in, see what I needed to get to. This is our fundraising. I can do a lot of the basic stuff too - I'm just not going to do the deeper stuff. I can make the brand and pop the basic things I want. We keep it under the ZABAL brand but we just make it a magnet, right?
+
+[Tyler] Yes, exactly.
+
+[Zaal] So that's what I'm thinking. From what you've seen, what do you want to get through, any next steps?
+
+[Tyler] It's pretty straightforward. You have the thumbnail already - why don't we just make it right now? And we'll do it on the recording, so we can have it recorded.
+
+[Zaal] Yes, okay, amazing. I'm on my computer.
+
+[Tyler] Why don't you do the driving, just so we can showcase how simple it is.
+
+[Zaal] That's what I was saying. Cool.
+
+[Tyler] Okay, so I'm sharing my screen of Magnetic. We're going to log in, which is nice and easy. You're a Google login guy? Love that. So let's go to my brands - we have my ZABAL brand. This is going to be my dashboard, and we're going to create a new magnet here. So create magnet. All you need to create one of these portals is a thumbnail, a name, and a description - and the description can be edited at any time. And once you do that, we're basically creating an NFT contract, and then people can mint off of it.
+
+[Zaal] Amazing. Oh, you know what I didn't do - this logo, I don't think it says "games." Can we change this later?
+
+[Tyler] You can change the description later. Just give it to me later, I'll handle it. Create magnet - so, three things, and boom, we've created the magnet.
+
+[Tyler] So here are two things you can do. One, if you have content you want to put in before people come in, you can go to create memento and put activations in. You've got content, you can put surveys out, if you're a brand you have discount codes, products, whatever. Typically what we see with our clients is you want to start with content, because when people get in you want to give them something to experience - what am I doing here, what's the purpose. We host video, audio, gif, image, documents - they come in a card format, title and description, you click in and the content pops up in a nice grid. And then this is our UGC tool - you can have people upload content, forms, whatever, tied to any magnet program you've created.
+
+[Tyler] So what Zaal is doing right now is telling people the brief of what he wants them to do, setting a start date and end date. [UI feedback] Can you click to June - the right arrow - yeah. Clicking the 31st isn't possible, it's cutting off 30 seconds, that's fine for now. And then you select what program you want. Is there a button that says "now" at the bottom? No - that works too. That'd be a good button though. Yeah, I'll make sure.
+
+[Tyler] Okay, now we have that request. So someone comes in, they get that request, they can read it, type things in they want to do. If you go back quickly, refresh - so now if you click launch now... you don't have to do this right now, but our defaults are: starts right now, never ends, and it's free. You can untoggle those - if you wanted to start in 24 hours you could set that, and it has a countdown timer. This is where people come and join. I scheduled the UGC to go live at 11:15, so we'll see it in two minutes. I also just made this magnet for sale. That was all on the admin side; now as a user coming in, this is what I see - I'm going to join now, and in two minutes we'll see the UGC coming in, and anything you put there sits in this grid people interact with. On the back end you'll see what they've interacted with, who's in, all that.
+
+[Tyler] It's as simple as that. Do you want to share a couple words about the ZABAL Connector and what we've done here - the proof of meat?
+
+[Tyler] So I'll give a descriptor, you give some color. When we first jumped in, Zaal, you were going to events in person, doing Twitter Spaces, getting good vibes and connecting with people, but you wanted to collect that somewhere and give them a way to explore what ZABAL is about. So we made the ZABAL Connector - a home base for anyone you collect at events or meet in the wild. You started using our QR-activated badging: for every event you create a QR badge, unique to them, that people scan - it proves they met you and brings them into the program. Over time you've been bringing people together in this space - we have like 67 people in at this point. What you haven't leaned into yet but could: it almost becomes an extension channel - if you have updates and put them in here, it'll shoot an email to all those people who've joined and notify them to come check it out. So it doubles as an email list as well as an interactive thing that sticks out when you go to an event.
+
+[Zaal] Amazing. And our UGC request is live right now - this is where people can enter suggestions and put it forward. Do you have to draw? Oh, no, you just click the button, check the box. Add "sunscreen." Boom, that easy. Can you resubmit now? Is there a way to resubmit?
+
+[Tyler] We don't currently have a resubmit button - we're looking into it, because we do have the ability for you to reject a submission, and in that event we'd like to open it back up for people to resubmit.
+
+[Zaal] It'd be nice if people could submit multiple submissions as well.
+
+[Tyler] Yeah, right. Good explanation - we'll clip this, probably not the middle part, but we can cut good 15-second clips, put them together, send them to our team.
+
+[Tyler] Last thing before the end - if you could make the proof-of-meats for the Fractals for this week and next week, or one or two ahead, because I've missed sending those.
+
+[Zaal] Yes. Right now when I send them, I DM them all. So that would have been the 24th, and then the next two after that. I'll go right now and whatever's in our pin folder, I'll get those all up.
+
+[Tyler] Amazing. And by the way, if you go to your brands, into the ZABAL Connector dashboard, check out your stuff - go to the most recent QR ones and click view. Before, we didn't have the actual image - I've updated it to be this image and put the title, because remember you were like "I don't know what's on Twitch, it's cut off." So now that confusion is gone, you can see it.
+
+[Zaal] That's great. Cool. If you could do the next three I'll send you over in the next couple as well. That'd be sick, and then I think I'll be good to go. I'll let you know if I have any issues.
+
+[Tyler] Sounds good. Cheers.
+
+[Zaal] All right man, bye.

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -5,6 +5,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
 | 2026-05-31 | Iman x Zaal - Request for Collaborators walkthrough | ZAO Devz | Zaal, Iman | [779](779-iman-zaal-request-for-collaborators-may31/) | 3 |
+| 2026-05-29 11:02 | Tyler / Magnetic x Zaal - ZABAL Games magnet built live + Connector explainer recorded | ZABAL Games | Zaal, Tyler Stambaugh | [783](783-tyler-magnetic-zabal-magnet-build-may29/) | 5 |
 | 2026-05-27 16:30 | Tyler / Magnetic x Zaal + team - ZABAL Games build on Magnetic | ZABAL Games | Zaal, Tyler Stambaugh, Samantha, Shawn | [778](778-tyler-magnetic-zabal-games-build-may27/) | 9 |
 | 2026-05-25 14:26 | Leeward x Zaal WebRTC + Pion + LiveKit handoff (2nd call) | ZAO Devz | Zaal, Leeward (Lee Edward Bound) | [752](752-leeward-x-zaal-webrtc-pion-livekit-handoff-may25/) | 7 |
 | 2026-05-25 | Telamon Ardavanis x Zaal - Edge Esmeralda invite + Goa | Networking | Zaal, Telamon Ardavanis | [777](777-telamon-edge-esmeralda-may25/) | 4 |


### PR DESCRIPTION
Recorded screen-share working session on 2026-05-29, two days after doc 778 - the build-execution follow-on.

## What got done in-call
- The ZABAL Games magnet was created live on Magnetic (under the ZABAL brand; 3 inputs - thumbnail, name, description - mints an NFT contract people join off of)
- A UGC request was set live with a brief + start/end date, tested end-to-end ("add sunscreen")
- The session itself was recorded as the Magnetic demo + ZABAL Connector explainer for June 1; Tyler clips it into ~15-sec clips

## Connector explainer captured
ZABAL Connector = event home-base via QR proof-of-meat badging (~67 people in); doubles as an email/notification channel - post an update, it emails all joined.

## Actions
- Zaal: make Fractal proof-of-meats for this + next week (behind since the 24th); fix the magnet logo (png says "ZABAL" not "ZABAL Games")
- Tyler: clip the recording, send to team; add a "now" button + resubmit / multi-submission feature; send next QR card updates

## Distribution
- Recap + speaker-attributed transcript
- Meetings index row
- Bonfire: 3 episodes
- Memory: project_zabal_games_magnetic_build updated (planned -> built)

Continues docs 778 (plan) / 714 / 473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)