### PR TITLE
feat(crm): category + tags structure for the Airtable import

### DIFF
--- a/scripts/20260531_crm_category_tags.sql
+++ b/scripts/20260531_crm_category_tags.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- ZAO CRM - add structured category + tags to crm_contacts (doc 772 follow-up).
+--
+-- The Airtable "Music/Tech/Other" field was 114 free-text values that are really
+-- ~11 real segments. This adds a clean `category` (single canonical segment) and
+-- `tags` (text[] for the granular original label + acquisition channel), so the
+-- CRM can segment/filter instead of relying on free-text role + a notes dump.
+--
+-- Additive + idempotent. category/tags are public-safe (segments, not PII) so
+-- they're added to the public view too. Safe to run on the existing CRM.
+-- ============================================================================
+
+alter table public.crm_contacts add column if not exists category text;
+alter table public.crm_contacts add column if not exists tags text[] not null default '{}';
+
+create index if not exists crm_contacts_category_idx on public.crm_contacts(category);
+create index if not exists crm_contacts_tags_gin_idx on public.crm_contacts using gin(tags);
+
+-- category + tags are segments, not private data — expose them on the public
+-- view. Appended at the END so `create or replace view` accepts the change
+-- (Postgres only allows adding columns, not reordering, on replace).
+create or replace view public.crm_contacts_public as
+  select id, slug, name, handle, farcaster_handle, x_handle, github_handle,
+         role, org, how_we_met, public_summary, created_at,
+         category, tags
+  from public.crm_contacts
+  where is_public = true;
+
+grant select on public.crm_contacts_public to anon, authenticated;
+
+comment on column public.crm_contacts.category is
+  'Single canonical segment (Musician / Web3 / Founder / …). Public-safe.';
+comment on column public.crm_contacts.tags is
+  'Free multi-labels: granular original category + acquisition channel. Public-safe.';

--- a/src/app/api/crm/interactions/route.ts
+++ b/src/app/api/crm/interactions/route.ts
@@ -38,6 +38,8 @@ const contactSchema = z.object({
   github_handle: z.string().max(120).optional(),
   telegram_handle: z.string().max(120).optional(),
   role: z.string().max(200).optional(),
+  category: z.string().max(64).optional(),
+  tags: z.array(z.string().max(64)).max(30).optional(),
   org: z.string().max(200).optional(),
   how_we_met: z.string().max(2000).optional(),
   public_summary: z.string().max(4000).optional(),

--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -90,10 +90,22 @@ export default async function CrmPage() {
                       </span>
                     </span>
                   </div>
-                  {(c.role || c.org) && (
+                  {(c.category || c.org) && (
                     <p className="mt-0.5 text-sm text-white/60">
-                      {[c.role, c.org].filter(Boolean).join(' - ')}
+                      {[c.category, c.org].filter(Boolean).join(' - ')}
                     </p>
+                  )}
+                  {c.tags && c.tags.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {c.tags.slice(0, 6).map((t) => (
+                        <span
+                          key={t}
+                          className="rounded bg-[#f5a623]/10 px-1.5 py-0.5 text-[10px] text-[#f5a623]/80"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                    </div>
                   )}
                   <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-white/40">
                     {c.farcaster_handle && <span>@{c.farcaster_handle}</span>}

--- a/src/lib/crm/types.ts
+++ b/src/lib/crm/types.ts
@@ -12,6 +12,28 @@ export type InteractionType =
 
 export type Visibility = 'public' | 'private';
 
+/**
+ * The canonical CRM segments (doc 772 follow-up). The Airtable import had 114
+ * free-text categories with heavy spelling drift; these are the ~11 real ones
+ * everything normalizes to. `category` holds one of these; `tags` keeps the
+ * granular original label + acquisition channel.
+ */
+export const CANONICAL_CATEGORIES = [
+  'Musician',
+  'Music Industry',
+  'Web3 / Onchain',
+  'Founder / Business',
+  'Visual / Creative',
+  'Developer / Tech',
+  'Games',
+  'DAO / Regen',
+  'Local / Maine',
+  'Community / Personal',
+  'Other',
+] as const;
+
+export type CrmCategory = (typeof CANONICAL_CATEGORIES)[number];
+
 /** A contact row as stored privately (service-role reads only). */
 export interface CrmContact {
   id: string;
@@ -23,6 +45,8 @@ export interface CrmContact {
   x_handle: string | null;
   github_handle: string | null;
   role: string | null;
+  category: string | null;
+  tags: string[];
   org: string | null;
   how_we_met: string | null;
   public_summary: string | null;
@@ -48,6 +72,8 @@ export interface CrmContactPublic {
   x_handle: string | null;
   github_handle: string | null;
   role: string | null;
+  category: string | null;
+  tags: string[];
   org: string | null;
   how_we_met: string | null;
   public_summary: string | null;


### PR DESCRIPTION
## What
Prep + structure for migrating the **858-contact** "ZABAL CRM Database 2026" Airtable base into the Supabase CRM — without carrying its mess in.

I analyzed the export first: its category field had **114 free-text values** with heavy spelling drift ("Musical Artist" = "Music Artist" = "Music"), normalizing to ~**11 real segments**. Company/Location/Bio are only ~40–48% filled. So we structure on import rather than raw-dumping.

## Changes
- **`scripts/20260531_crm_category_tags.sql`** — adds `category` (text) + `tags` (text[]) to `crm_contacts`, btree index on category, GIN index on tags. Both are public-safe segments, so appended to `crm_contacts_public`. Additive + idempotent.
- **`src/lib/crm/types.ts`** — `CrmContact` / `CrmContactPublic` gain `category` + `tags`; exports `CANONICAL_CATEGORIES` (the 11) + `CrmCategory`.
- **`route.ts`** — write API accepts optional `category` + `tags`.
- **`/crm` dashboard** — shows category + a row of tag chips per contact.

## The import data (separate, off-repo)
The 858 rows are imported via a generated SQL file that's **kept out of git (it's PII)**. Mapping:
- `category` = canonical segment (Musician / Web3 / Founder / …)
- `tags` = `[granular original label, acquisition channel]`
- `relationship_strength` = Priority rounded + clamped 0–5 (one 9.0 outlier fixed)
- everything else folded into private notes; all `is_public=false`

**Run order:** this migration first, then the import SQL.

**Checks:** `typecheck` clean; CRM route tests 6/6.

🤖 Analyzed + built via Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_