### PR TITLE
docs: 788 - kmac.eth x Zaal - ZABAL Games + Farcaster distribution

### DIFF
--- a/research/events/788-kmac-zabal-farcaster-distribution-may30/README.md
+++ b/research/events/788-kmac-zabal-farcaster-distribution-may30/README.md
@@ -1,0 +1,63 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-05-30
+related-docs: "718, 785, 776, 547"
+tier: STANDARD
+---
+
+# 788 - kmac.eth x Zaal: ZABAL Games + Farcaster distribution + the JFS-signer ask
+
+> **Goal:** Capture the 2026-05-30 catch-up between Zaal and kmac.eth (Farcaster snap-builder, doc 718) - lining up kmac's ZABAL Games presentations, talking through Farcaster onboarding/distribution, a concrete technical ask for the Neynar devs (soften the JFS-signer requirement on snaps), and a live test of a Quorum audio space.
+
+kmac is a returning collaborator (doc 718 - Farcaster Snaps + ad networks + JFS). This call slots him into the June ZABAL Games workshop month and surfaces a reusable Farcaster-onboarding insight.
+
+## Attendees
+
+- **Zaal**
+- **kmac.eth** - Farcaster snap-builder, client-builder, JFS expertise (doc 718, [[project_kmac_eth]]).
+
+## Key Decisions / threads
+
+| # | Item | Owner | Status | Confidence |
+|---|------|-------|--------|------------|
+| 1 | Cassie is invited to do ZABAL Games presentations - she jumped on it immediately | Zaal | TODO | high |
+| 2 | kmac participates in ZABAL Games, framing it as a "mini Trojan horse" to onboard his community to Farcaster - using his distribution "for good" | kmac | TODO | high |
+| 3 | Tested a Quorum audio space together ("A show about probably nothing") - kmac hosts on mobile in Quorum, Zaal joins via Farcaster to test cross-client audio/screen-share | Both | DONE | medium |
+
+## Thread 1 - ZABAL Games as a Farcaster on-ramp
+
+kmac is excited about ZABAL Games as a way to grow in the space and put his distribution to good use - "so many people will learn what Farcaster has to offer through this. That's my mini Trojan horse for my community." Cassie replied fast to the presentation ask ("that was the reply I was hoping for"). Note: kmac flagged the new `.games` TLD (zabalgames - it's `.games`, not `.com`, and not a `.k`).
+
+## Thread 2 - Farcaster onboarding + distribution (the reusable insight)
+
+The shared diagnosis of why Farcaster onboarding is hard right now: people are busy, the economy + crypto sentiment are low, so everyone's conservative - they won't try something new unless a trusted individual tells them, repeatedly, why it benefits them.
+
+The load-bearing insight (kmac credited **JC / Jonathan Colton**, doc 785): people mistake "Farcaster users trying your app" for product-market fit. Apps get social-driven users from the cozy corner, misread that as PMF, and stall - instead of testing with a general-market random person who needs a normal call-to-action and knows nothing about the thing. This has now surfaced across multiple conversations (JC, kmac).
+
+Both converged on the killer mechanic: Farcaster's **one-tap social-share-to-feed** inside apps. "Everything I build will always have that in - one click, share my app to the feed, you don't even think about what words to say. Nowhere else can you do what we can do here, but people just don't know that." kmac ties patronage/social-capital-building (his 2023 buy-NFT-and-share-to-Twitter motion) to this. Zaal's angle: build his client community for initial traction (interns/squad in Zambia hitting Farcaster payment friction - hard to onboard even with an X account and a few dollars sent over).
+
+## Thread 3 - The JFS-signer technical ask (for Neynar)
+
+Zaal's concrete request: next time kmac connects 1:1 with the Neynar devs, ask them to **flip and soften the need to have a JFS signer on all the actions a snap has** - it is too restrictive right now. kmac agreed it is a good point and bets they would do it, but noted there is "zero incentive" for the devs to prioritize it. They vented about the Farcaster FIP process feeling dismissive - you build to "working code + general consensus," then at the next community call the direction changes (cf. how Cassie re-engineered the spaces for Quorum after a similar dynamic).
+
+## Action Items
+
+| Title | Owner | Due | Category | Confidence |
+|-------|-------|-----|----------|------------|
+| At the next 1:1 with the Neynar devs, ask them to soften/remove the JFS-signer requirement on all snap actions | kmac | - | Site / Tech | high |
+| Do ZABAL Games presentations (kmac + Cassie) | kmac | June | ZABAL Games | high |
+| Explore Quorum audio spaces for ZABAL Games (Cassie re-engineered spaces for Quorum; cross-client Farcaster <-> Quorum audio) | Both | - | Site / Tech | medium |
+
+## Quotes
+
+- kmac: "I think there's going to be so many people who learn so much more about what Farcaster has to offer through this. That's going to be my mini Trojan horse for my community."
+- kmac (crediting JC): "People misguidedly understand people trying out their app as product-market fit... and then it stalls out in this small world as opposed to being able to grow."
+- kmac: "The social share in the apps, to me, is the coolest thing. One click, tap, share my app to the feed - I can't imagine anyone wouldn't do that. Nowhere else can you do what we can do here on Farcaster, but people just don't know that."
+- Zaal: "Can we flip and soften the need to have a JFS signer on all the actions that a snap has? It's just so obvious that it's too restrictive right now. I bet you they would do it."
+- Zaal: "The folks that have stuck around - even the ones that drifted off and check back in - they all care. We're down to the core; the folks here want to see it work."
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md). The pair moved to a Quorum space partway through, so the back half of the recording is silence (auto-trimmed). A third-party reputational allegation mentioned in passing has been omitted per PII-hygiene.

--- a/research/events/788-kmac-zabal-farcaster-distribution-may30/transcript.md
+++ b/research/events/788-kmac-zabal-farcaster-distribution-may30/transcript.md
@@ -1,0 +1,39 @@
+# Transcript - kmac.eth x Zaal, 2026-05-30 11:01 EDT
+
+Attendees: Zaal, kmac.eth. Source: `Call with kmac - 2026_05_30 11_01 EDT - Recording.mp4`. Single-feed (Zaal's camera); kmac audio-only. Diarization skipped (2-person); speakers attributed from content. The pair moved to a Quorum audio space partway through, so the back half of the recording is silence (auto-trimmed by trim-loops.sh). One third-party reputational allegation said in passing has been omitted per PII-hygiene.
+
+---
+
+[Zaal] I made an easy way on my website to just look through the transcript of all the things, so you could get info from that. I've been pretty focused on this ZABAL Games idea, and I'm super excited to invite Cassie to do a couple presentations.
+
+[kmac] I saw her jump right on that - that was the reply I was hoping for. [re the URL] There's supposed to be an M at the end of that - it's not a K, it's not .com, it's a new TLD I didn't know about [.games]. I'm really excited - it's a great opportunity for me to grow in the space and use my distribution for good. There's going to be so many people who learn so much more about what Farcaster has to offer through this. That's my mini Trojan horse for my community.
+
+[Zaal] I wonder at times if people care. Sometimes I'm on Farcaster and I think they just don't know.
+
+[kmac] Everyone's so busy with their lives. And the economy's bad, crypto's bad, so everyone's huddled, being conservative. Unless a super-trusted individual tells them they need to try something else because it'll be beneficial, they won't do it from random things here or there - they need to see it a couple times and know why it could be beneficial.
+
+[kmac] Someone mentioned this - oh, John Colton, JC. Everyone's super happy with their Farcaster cozy corner, and it's good, you get users from your social. But people misguidedly understand people trying out their app as product-market fit. And then these apps that aren't necessarily something that would succeed in the general world - with a random person who needs a normal call-to-action and doesn't know anything about the thing - stall out in this small world instead of growing. I hadn't thought of that until he mentioned it, and I was like, wow, that's a really good point.
+
+[Zaal] I haven't suffered from that, luckily, because I came from a specific area and I'm still tapped in - we have 11 shows a week for Wave Wars, so I'm there, my team's always talking to me about the algo and whatnot. Every time I talk about Farcaster they're excited, but they don't hop on because it's not a direct one-to-one "yo, you've got to try this specific app I made." The social share in the apps, to me, has always been the coolest thing. Everything I build will always have that - a one-click tap to share my app to the feed. I'd do that, I can't imagine anyone in my community wouldn't, it's so easy and you don't even think about what words to say to promote it. When I was doing things with my wallet - buying an NFT in 2023 to build my social capital - the share-to-Twitter part was huge. So I love the ability to show patronage through that in a completely different format. Nowhere else can you do what we can do here on Farcaster, but people just don't know that.
+
+[kmac] Part of that is the friction to get in. Until recently it was "what do I have to do, and I have to pay?" I have a squad in Zambia, my interns trying to get people onboard, and he's having trouble - initially it was the payment, even with an X account, and even when we sent over a couple dollars to make the payment, it had trouble accepting it. And once you do get on, getting initial traction is its own challenge. That's why I like clients - I'm building my client community to get that initial traction, keep it "hey, I joined for this, I'm here," it's cozy, and then let them discover the rest of the network.
+
+[kmac] It's been entertaining watching everything this last week as a casual observer. Recently I talked to TopoHat and Arto about my ideas and they're really excited about all the things I want to bring to Farcaster. I only got that call because TopoHat was about to go on baby leave, literally the day before. I was in the Neynar dev call, he had his camera off and a hat that said "hats" - something to do with Hats Protocol. I asked if it was a Hats Protocol hat, he DMed me asking how I knew about it, and we got talking. I'm trying to get more known in this space, so to me anyone is anyone - I also haven't been burned by a lot of people yet. It's hard to know as a new person. [third-party reputational aside omitted] It's such a weird space when you get to the decentralized - everyone knows each other too. Anyway, I digress.
+
+[kmac] The point was, it was cool to see that the excitement is there because people care. It's not just shit being flung from one side to another to get views.
+
+[Zaal] You put your finger on it. The folks who've stuck around - even the ones who drifted off and check back in - they all care. We're down to the core; the folks here want to see it work. It's a good one, even if it's a little chill at the moment.
+
+[Zaal] Hey, do me a favor next time - this is the segue - if you connect one-on-one with the Neynar devs, the signer keys on those snaps: say "hey guys, can we flip and soften the need to have a JFS signer on all the actions that a snap has?" It's so obvious it's too restrictive right now. I bet you they would do it.
+
+[kmac] That's a good point. It's one of those things where there's zero incentive to go do it. In former times it was "working code and general consensus" - then you build something, get ready to post, you tested it on a hub and it should work, and then at the next community call it's "hey, we're not going to go this way." So dismissive. Like how Cassie re-engineered the spaces for Quorum.
+
+[Zaal] You want to slide over there, share screens, test it? I haven't used the app enough, I need more reviews to push over there.
+
+[kmac] We can try if you're game, we'll just have a chat. Give me two minutes, I'm making protein shakes. ... So you can share screen on Quorum - I heard you could go video and desktop. Let me start a space. What do we call the description? "A show about probably nothing" - nice crypto tie, but also like Seinfeld where it has sub-tones.
+
+[Zaal] I'm going to start it on my mobile in Quorum. I'll pop in on Farcaster and do the audio - it should be on both ends, that'll be the first test. Keep an eye on DMs; if we get stuck, we'll communicate over DMs.
+
+[kmac] Perfect, see you soon.
+
+[recording continues into the Quorum space - rest is silence, auto-trimmed]

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -5,6 +5,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
 | 2026-05-31 | Iman x Zaal - Request for Collaborators walkthrough | ZAO Devz | Zaal, Iman | [779](779-iman-zaal-request-for-collaborators-may31/) | 3 |
+| 2026-05-30 11:01 | kmac.eth x Zaal - ZABAL Games + Farcaster distribution + JFS-signer ask | Farcaster / ZABAL Games | Zaal, kmac.eth | [788](788-kmac-zabal-farcaster-distribution-may30/) | 3 |
 | 2026-05-29 17:03 | Iman x Zaal - Discord bot setup walkthrough | ZAO Devz | Zaal, Iman | [787](787-iman-discord-bot-setup-may29/) | 3 |
 | 2026-05-29 13:00 | JC (Jonathan Colton, FounderCheck) x Zaal - ZABAL Games talks + FounderCheck | ZABAL Games | Zaal, Jonathan Colton | [785](785-jonathan-colton-foundercheck-zabal-may29/) | 4 |
 | 2026-05-29 12:06 | Plat0x (Carlos, Bonfires) x Zaal - GitHub-to-Bonfire submission + judging architecture for ZABAL Games | ZABAL Games | Zaal, Plat0x (Carlos) | [784](784-plat0x-bonfire-zabal-architecture-may29/) | 4 |


### PR DESCRIPTION
Catch-up on 2026-05-30 with kmac.eth (Farcaster snap-builder, doc 718).

## Threads
- kmac is in for June ZABAL Games presentations; recruited Cassie (she jumped on it). Frames ZABAL Games as a "mini Trojan horse" to onboard his community to Farcaster
- Farcaster onboarding/distribution: people mistake app-tryouts for product-market fit (credited to JC) so apps stall in the cozy corner; one-tap social-share-to-feed is the killer mechanic
- Standing ask: next 1:1 with Neynar devs, get them to soften/remove the JFS-signer requirement on all snap actions (too restrictive)
- Tested a cross-client Quorum <-> Farcaster audio space ("A show about probably nothing")

## Distribution
- Recap + speaker-attributed transcript (Quorum-transition silence auto-trimmed; a third-party reputational aside omitted per PII-hygiene)
- Meetings index row
- Bonfire: 3 episodes
- Memory: project_kmac_eth updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)