### PR TITLE
feat(zoe): ZABAL Bonfire submission drain loop (doc 781 Phase 2)

### DIFF
--- a/bot/src/zoe/__tests__/bonfire-queue.test.ts
+++ b/bot/src/zoe/__tests__/bonfire-queue.test.ts
@@ -1,0 +1,77 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseSubmission,
+  buildEpisode,
+  isBonfireSteward,
+  renderSubmission,
+  type BonfireSubmission,
+} from '../bonfire-queue.ts';
+
+const valid: BonfireSubmission = {
+  id: 'zg-1748736000000-abc',
+  fid: 19640,
+  username: 'bettercallzaal',
+  type: 'project',
+  title: 'WaveWarZ v2',
+  body: 'Building the bracket engine.',
+  url: 'https://example.com/x',
+  source: 'zabalgames-web',
+  status: 'pending',
+  ts: 1748736000000,
+};
+
+test('parseSubmission accepts a well-formed item', () => {
+  const s = parseSubmission(JSON.stringify(valid));
+  assert.ok(s);
+  assert.equal(s.type, 'project');
+  assert.equal(s.fid, 19640);
+  assert.equal(s.title, 'WaveWarZ v2');
+});
+
+test('parseSubmission rejects bad type / empty body / junk', () => {
+  assert.equal(parseSubmission(JSON.stringify({ ...valid, type: 'spam' })), null);
+  assert.equal(parseSubmission(JSON.stringify({ ...valid, body: '   ' })), null);
+  assert.equal(parseSubmission(JSON.stringify({ ...valid, id: 123 })), null); // id must be string
+  assert.equal(parseSubmission('not json'), null);
+});
+
+test('parseSubmission coerces a string fid + defaults username', () => {
+  const s = parseSubmission(JSON.stringify({ ...valid, fid: '777', username: undefined }));
+  assert.ok(s);
+  assert.equal(s.fid, 777);
+  assert.equal(s.username, null);
+});
+
+test('buildEpisode adds provenance + a stable name + title head', () => {
+  const ep = buildEpisode(valid);
+  assert.equal(ep.name, 'zg-submission:project:zg-1748736000000-abc');
+  assert.equal(ep.sourceTag, 'zabalgames-web');
+  assert.match(ep.body, /^WaveWarZ v2/); // title heads the body
+  assert.match(ep.body, /Building the bracket engine\./);
+  assert.match(ep.body, /Reference: https:\/\/example\.com\/x/);
+  assert.match(ep.body, /Submitted by @bettercallzaal \(fid 19640\) via ZABAL Gamez, \d{4}-\d{2}-\d{2}/);
+});
+
+test('buildEpisode falls back to fid when no username', () => {
+  const ep = buildEpisode({ ...valid, username: null });
+  assert.match(ep.body, /Submitted by fid 19640/);
+});
+
+test('isBonfireSteward reads the env allowlist', () => {
+  process.env.BONFIRE_STEWARD_FIDS = '19640, 42';
+  assert.equal(isBonfireSteward(19640), true);
+  assert.equal(isBonfireSteward(42), true);
+  assert.equal(isBonfireSteward(99), false);
+  delete process.env.BONFIRE_STEWARD_FIDS;
+  assert.equal(isBonfireSteward(19640), false);
+});
+
+test('renderSubmission shows who, body, and the y/n prompt', () => {
+  const text = renderSubmission({ item: valid, raw: '{}' }, 3);
+  assert.match(text, /3 in queue/);
+  assert.match(text, /@bettercallzaal \(fid 19640\)/);
+  assert.match(text, /Building the bracket engine/);
+  assert.match(text, /Reply "y" to promote/);
+});

--- a/bot/src/zoe/approvals.ts
+++ b/bot/src/zoe/approvals.ts
@@ -24,13 +24,15 @@ import { ZOE_PATHS } from './memory';
 import type { DecompositionPlan } from './decompose';
 import type { ProposedPatch, ReflectionAnswers } from './reflexion';
 import type { LearnProposal } from './learn';
+import type { QueueEntry } from './bonfire-queue';
 
 export type PendingKind =
   | 'plan'
   | 'plan-gate'
   | 'reflexion'
   | 'await-reflection'
-  | 'learn';
+  | 'learn'
+  | 'bonfire-submission';
 
 interface PendingBase {
   kind: PendingKind;
@@ -85,12 +87,20 @@ export interface PendingLearn extends PendingBase {
   proposals: LearnProposal[];
 }
 
+/** A ZABAL Gamez community submission under steward review (doc 781 Phase 2). */
+export interface PendingBonfireSubmission extends PendingBase {
+  kind: 'bonfire-submission';
+  /** The submission under review + its exact raw string (for LREM). */
+  entry: QueueEntry;
+}
+
 export type PendingApproval =
   | PendingPlan
   | PendingPlanGate
   | PendingReflexion
   | PendingAwaitReflection
-  | PendingLearn;
+  | PendingLearn
+  | PendingBonfireSubmission;
 
 export interface ApprovalReply {
   /**
@@ -123,6 +133,7 @@ const APPROVAL_BEARING_KINDS: ReadonlySet<PendingKind> = new Set<PendingKind>([
   'plan-gate',
   'reflexion',
   'learn',
+  'bonfire-submission',
 ]);
 
 /** Human-readable label for a pending kind, for refuse-when-busy messages. */
@@ -138,6 +149,8 @@ export function pendingKindLabel(kind: PendingKind): string {
       return 'evening reflection';
     case 'learn':
       return 'learning-proposal approval';
+    case 'bonfire-submission':
+      return 'ZABAL Bonfire submission review';
   }
 }
 

--- a/bot/src/zoe/bonfire-queue.ts
+++ b/bot/src/zoe/bonfire-queue.ts
@@ -1,0 +1,169 @@
+/**
+ * bonfire-queue.ts — ZOE drains the ZABAL Gamez community submission queue.
+ * Phase 2 of doc 781 (Option A: the website owns the Upstash queue, ZOE promotes).
+ *
+ * The zabalgames website (Vercel edge + Upstash) LPUSHes pending submissions —
+ * with the submitter's FID VERIFIED server-side via Farcaster Quick Auth — onto
+ * the Upstash LIST `zg:bonfire:pending`. ZOE reads them (LRANGE), a steward
+ * approves via the approval machine (see index.ts / approvals.ts), and on approve
+ * ZOE promotes the item into the canonical ZABAL Bonfire graph (episode/create,
+ * reusing recall.remember — which carries the secret-scan) then removes it
+ * (LREM the exact value). Reject = LREM + log, no write.
+ *
+ * Env:
+ *   ZG_UPSTASH_REST_URL    dedicated Upstash DB REST URL for the queue
+ *   ZG_UPSTASH_REST_TOKEN  read-write REST token (needs write for LREM)
+ *   BONFIRE_STEWARD_FIDS   comma-separated FIDs allowed to approve (v1: just Zaal)
+ */
+
+import { remember, type RememberResult } from './recall';
+
+const QUEUE_KEY = 'zg:bonfire:pending';
+const REST_URL = process.env.ZG_UPSTASH_REST_URL ?? '';
+const REST_TOKEN = process.env.ZG_UPSTASH_REST_TOKEN ?? '';
+const CMD_TIMEOUT_MS = 10_000;
+
+export type SubmissionType = 'fact' | 'project' | 'doc';
+
+/** The pending-item contract shared with the website (doc 781 Phase 2). */
+export interface BonfireSubmission {
+  id: string;
+  fid: number;
+  username: string | null;
+  type: SubmissionType;
+  title?: string;
+  body: string;
+  url?: string;
+  source: string; // 'zabalgames-web'
+  status: string; // 'pending'
+  ts: number;
+}
+
+/** A queue entry plus the EXACT raw string — needed for an LREM-by-value. */
+export interface QueueEntry {
+  item: BonfireSubmission;
+  raw: string;
+}
+
+export function queueConfigured(): boolean {
+  return !!REST_URL && !!REST_TOKEN;
+}
+
+function stewardFids(): Set<number> {
+  return new Set(
+    (process.env.BONFIRE_STEWARD_FIDS ?? '')
+      .split(',')
+      .map((s) => Number(s.trim()))
+      .filter((n) => Number.isFinite(n) && n > 0),
+  );
+}
+
+/** v1: approval is also gated to Zaal's DM in index.ts; this is the FID list. */
+export function isBonfireSteward(fid: number): boolean {
+  return stewardFids().has(fid);
+}
+
+// --- Upstash REST (POST-array command form; safe for arbitrary values) -------
+async function upstash(cmd: (string | number)[]): Promise<unknown> {
+  const res = await fetch(REST_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${REST_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(cmd),
+    signal: AbortSignal.timeout(CMD_TIMEOUT_MS),
+  });
+  if (!res.ok) throw new Error(`Upstash ${cmd[0]} failed: HTTP ${res.status}`);
+  const json = (await res.json()) as { result?: unknown; error?: string };
+  if (json.error) throw new Error(`Upstash ${cmd[0]} error: ${json.error}`);
+  return json.result;
+}
+
+/** Parse + validate one raw queue string into a submission, or null if junk. */
+export function parseSubmission(raw: string): BonfireSubmission | null {
+  let o: Record<string, unknown>;
+  try {
+    o = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const type = o.type;
+  if (
+    typeof o.id !== 'string' ||
+    typeof o.body !== 'string' ||
+    !o.body.trim() ||
+    (type !== 'fact' && type !== 'project' && type !== 'doc')
+  ) {
+    return null;
+  }
+  return {
+    id: o.id,
+    fid: typeof o.fid === 'number' ? o.fid : Number(o.fid) || 0,
+    username: typeof o.username === 'string' ? o.username : null,
+    type,
+    title: typeof o.title === 'string' ? o.title : undefined,
+    body: o.body,
+    url: typeof o.url === 'string' ? o.url : undefined,
+    source: typeof o.source === 'string' ? o.source : 'unknown',
+    status: typeof o.status === 'string' ? o.status : 'pending',
+    ts: typeof o.ts === 'number' ? o.ts : Number(o.ts) || 0,
+  };
+}
+
+/** Read all pending submissions. Never throws on bad items (skips them). */
+export async function fetchPending(): Promise<QueueEntry[]> {
+  if (!queueConfigured()) return [];
+  const result = (await upstash(['LRANGE', QUEUE_KEY, 0, -1])) as string[] | null;
+  const out: QueueEntry[] = [];
+  for (const raw of result ?? []) {
+    const item = parseSubmission(raw);
+    if (item) out.push({ item, raw });
+  }
+  return out;
+}
+
+/** Remove an exact entry from the queue (LREM count=1 by value). */
+export async function removeFromQueue(raw: string): Promise<number> {
+  const result = (await upstash(['LREM', QUEUE_KEY, 1, raw])) as number;
+  return typeof result === 'number' ? result : 0;
+}
+
+/** Build the canonical episode (with provenance) for a submission. */
+export function buildEpisode(item: BonfireSubmission): {
+  body: string;
+  name: string;
+  sourceTag: string;
+} {
+  const who = item.username ? `@${item.username}` : `fid ${item.fid}`;
+  const date = new Date(item.ts || Date.now()).toISOString().slice(0, 10);
+  const ref = item.url ? `\nReference: ${item.url}` : '';
+  const head = item.title ? `${item.title}\n\n` : '';
+  const provenance = `\n\n(Submitted by ${who} (fid ${item.fid}) via ZABAL Gamez, ${date}.)`;
+  return {
+    body: `${head}${item.body}${ref}${provenance}`,
+    name: `zg-submission:${item.type}:${item.id}`,
+    sourceTag: item.source || 'zabalgames-web',
+  };
+}
+
+/** Promote a submission into the canonical graph (episode/create). */
+export async function promoteSubmission(item: BonfireSubmission): Promise<RememberResult> {
+  return remember(buildEpisode(item));
+}
+
+/** Telegram render of a submission under review. */
+export function renderSubmission(entry: QueueEntry, remaining: number): string {
+  const { item } = entry;
+  const who = item.username ? `@${item.username}` : `fid ${item.fid}`;
+  const lines = [
+    `📥 ZABAL Bonfire submission (${remaining} in queue)`,
+    `From: ${who} (fid ${item.fid})`,
+    `Type: ${item.type}`,
+  ];
+  if (item.title) lines.push(`Title: ${item.title}`);
+  lines.push('', item.body.slice(0, 1200));
+  if (item.url) lines.push('', `Ref: ${item.url}`);
+  lines.push('', 'Reply "y" to promote to the graph, "n" to reject.');
+  return lines.join('\n');
+}

--- a/bot/src/zoe/farcaster/write.ts
+++ b/bot/src/zoe/farcaster/write.ts
@@ -15,7 +15,7 @@
  */
 import { makeCastAdd, FarcasterNetwork, Message, CastType } from '@farcaster/hub-nodejs';
 import { makeSigner } from './signer';
-import { buildX402Header, useX402 } from './x402';
+import { buildX402Header, isX402Enabled } from './x402';
 
 export interface PublishResult {
   hash: `0x${string}`;
@@ -67,7 +67,7 @@ export async function publishCast(input: CastInput): Promise<PublishResult> {
   const headers: Record<string, string> = { 'Content-Type': 'application/octet-stream' };
   // Neynar hub is paid per call via x402 (EIP-3009 USDC on Base) - NOT a bearer key (doc 762).
   // Set FARCASTER_WRITE_MODE=bearer only for a self-hosted/3rd-party hub that uses key auth.
-  if (useX402()) {
+  if (isX402Enabled()) {
     headers['X-PAYMENT'] = await buildX402Header();
   } else if (process.env.FARCASTER_WRITE_API_KEY) {
     headers['api_key'] = process.env.FARCASTER_WRITE_API_KEY;

--- a/bot/src/zoe/farcaster/x402.ts
+++ b/bot/src/zoe/farcaster/x402.ts
@@ -90,6 +90,6 @@ export async function buildX402Header(): Promise<string> {
 }
 
 /** True when the write endpoint should be paid via x402 (default) rather than a bearer key. */
-export function useX402(): boolean {
+export function isX402Enabled(): boolean {
   return (process.env.FARCASTER_WRITE_MODE ?? 'x402').toLowerCase() !== 'bearer';
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -72,6 +72,14 @@ import {
 } from './approvals';
 import type { DecompositionPlan } from './decompose';
 import { NOTE_PREFIX, PLAN_PREFIX, isZoeCommand } from './commands';
+import {
+  fetchPending,
+  removeFromQueue,
+  promoteSubmission,
+  renderSubmission,
+  queueConfigured,
+} from './bonfire-queue';
+import type { PendingBonfireSubmission } from './approvals';
 import { attachCaster, runCasterPipeline } from './caster';
 import { subscribeToCasts } from './farcaster/event-stream';
 
@@ -245,6 +253,20 @@ bot.callbackQuery(/^post-(approve|regen|skip):/, async (ctx) => {
     return;
   }
   await handlePostCallback({ ctx, repoDir, zaalTgId: zaalId });
+});
+
+// /bonfire — review the ZABAL Gamez community submission queue (doc 781 Phase 2).
+// v1 steward gate = Zaal's DM (the only allowed DM); BONFIRE_STEWARD_FIDS is the
+// forward-looking multi-steward list. Surfaces one pending item; reply y/n.
+bot.command('bonfire', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  if (!queueConfigured()) {
+    await ctx.reply(
+      'Bonfire queue not configured — set ZG_UPSTASH_REST_URL + ZG_UPSTASH_REST_TOKEN.',
+    );
+    return;
+  }
+  await showNextSubmission(ctx);
 });
 
 bot.command('notes', async (ctx) => {
@@ -799,6 +821,13 @@ async function doResolvePendingApproval(
   pending: PendingApproval,
   reply: ApprovalReply,
 ): Promise<void> {
+  // Bonfire submissions have their own promote/reject/LREM lifecycle (doc 781
+  // Phase 2) — route the whole decision there before the generic plan handling.
+  if (pending.kind === 'bonfire-submission') {
+    await resolveBonfireSubmission(ctx, pending, reply);
+    return;
+  }
+
   if (reply.decision === 'reject') {
     await clearPending(pending.chatScope);
     await ctx.reply('Cancelled. Nothing dispatched.');
@@ -839,6 +868,81 @@ async function doResolvePendingApproval(
       await clearPending(pending.chatScope);
       return;
   }
+}
+
+// --- ZABAL Bonfire submission queue (doc 781 Phase 2) ----------------------
+
+/** Fetch the queue and arm the oldest pending submission for y/n review. */
+async function showNextSubmission(ctx: Context): Promise<void> {
+  let pending;
+  try {
+    pending = await fetchPending();
+  } catch (err) {
+    await ctx.reply(`(bonfire queue read failed — ${(err as Error).message.slice(0, 160)})`);
+    return;
+  }
+  if (pending.length === 0) {
+    await ctx.reply('ZABAL Bonfire queue is empty — nothing to review.');
+    return;
+  }
+  // LPUSH puts newest at the head, so the last element is the oldest (FIFO).
+  const entry = pending[pending.length - 1];
+  const armed = await setPending({
+    kind: 'bonfire-submission',
+    chatScope: 'private',
+    createdAt: new Date().toISOString(),
+    entry,
+  });
+  if (!armed.armed) {
+    await ctx.reply(
+      `Can't review yet — you have a pending ${pendingKindLabel(armed.blockedBy!.kind)}. Resolve that first, then /bonfire.`,
+    );
+    return;
+  }
+  await replyChunked(ctx, renderSubmission(entry, pending.length));
+}
+
+/** Promote / reject one reviewed submission, then advance to the next. */
+async function resolveBonfireSubmission(
+  ctx: Context,
+  pending: PendingBonfireSubmission,
+  reply: ApprovalReply,
+): Promise<void> {
+  await clearPending(pending.chatScope);
+  const { item, raw } = pending.entry;
+  const who = item.username ? `@${item.username}` : `fid ${item.fid}`;
+
+  if (reply.decision === 'edit') {
+    // No meaningful "edit" for a submission — leave it queued, re-arm for y/n.
+    await setPending({
+      kind: 'bonfire-submission',
+      chatScope: 'private',
+      createdAt: new Date().toISOString(),
+      entry: pending.entry,
+    });
+    await ctx.reply('Left in the queue (submissions are promote/reject only — reply y or n).');
+    return;
+  }
+
+  if (reply.decision === 'reject') {
+    await removeFromQueue(raw).catch(() => 0);
+    console.log(`[zoe/bonfire] rejected ${item.id} from ${who}`);
+    await ctx.reply(`Rejected ${item.type} from ${who} — removed from the queue.`);
+    await showNextSubmission(ctx);
+    return;
+  }
+
+  // approve-all / approve-ids -> promote into the canonical graph.
+  const result = await promoteSubmission(item);
+  if (!result.ok) {
+    const why = result.skipped ?? result.error ?? 'unknown';
+    await ctx.reply(`Could not promote ${item.type} from ${who} (${why}). Left in the queue.`);
+    return;
+  }
+  await removeFromQueue(raw).catch(() => 0);
+  console.log(`[zoe/bonfire] promoted ${item.id} from ${who} to the graph`);
+  await ctx.reply(`✅ Promoted ${item.type} from ${who} to the ZABAL Bonfire graph.`);
+  await showNextSubmission(ctx);
 }
 
 /** Dispatch an approved plan with live Telegram progress, then report. */

--- a/research/agents/781-zabal-bonfire-contribution-architecture/README.md
+++ b/research/agents/781-zabal-bonfire-contribution-architecture/README.md
@@ -1,0 +1,178 @@
+---
+topic: agents
+type: architecture
+status: proposed
+last-validated: 2026-05-31
+related-docs: "601, 734, 771, 772, 773"
+original-query: "how should ZAO agents interconnect around one shared Bonfire graph + a soft barrier for community contribution to the ZABAL Gamez knowledge graph"
+tier: STANDARD (design synthesis grounded in the live ZOE/Bonfire/CRM stack)
+---
+
+# 781 - ZABAL Bonfire contribution architecture (shared graph + soft barrier)
+
+> **Goal:** let EVERYONE in the ZABAL Gamez 3-month buildathon contribute to the
+> ZABAL Bonfire knowledge graph so it becomes a shared source of truth (who is
+> building what, project states, facts, docs) queryable by any person or agent -
+> open enough that the community contributes, gated enough that it does not get
+> spammed or polluted.
+
+## TL;DR
+
+- **Topology:** the *graph* is the hub (blackboard / shared memory), NOT the
+  Bonfire bot. Agents are read/write spokes through a single ingestion gateway
+  where the soft barrier lives. No agent-to-agent (x402) calls in v1.
+- **Soft barrier:** don't pick one moderation model - layer all three on a
+  contribution lifecycle. Anyone can submit (open); submissions land
+  author-tagged + pending; queries default to canonical only (pollution never
+  surfaces); trust tier sets the start point + who can promote.
+- **Identity:** reuse existing ZAO signals - Farcaster FID (iron-session),
+  ZAO Respect, Bonfire score, and promoted-vs-rejected track record. Build no
+  new identity system. Agents act as their human and inherit that human's tier.
+- **v1 (June):** the CRM pattern (doc 772) repointed at Bonfire - a Supabase
+  `bonfire_submissions` pending table -> curator promote -> write canonical
+  episode via ZOE's existing `remember()`/`episode/create` path, gated by ZOE's
+  existing approval state machine (doc 770/773).
+
+## 1. Topology - graph-as-blackboard, single write-gateway
+
+```
+   people (Telegram/web)        their agents          ZOE / music bot
+          |                          |                      |
+          +------------- submit -----+----------------------+
+                                |
+                    +-----------v------------+
+                    |   Ingestion Gateway    |  <- the soft barrier lives HERE
+                    |  trust + rate-limit +  |
+                    |  pending -> promote    |
+                    +-----------+------------+
+                       promoted | (episode/create, typed triples)
+                    +-----------v------------+
+                    |   ZABAL Bonfire graph  |  <- single source of truth
+                    +-----------+------------+
+                       query    | (/delve, typed reads)
+          +--------------+------+-------+--------------+
+        ZOE          music bot   participant      any person
+                                  agents
+```
+
+**Decisions + rationale:**
+
+- **Shared memory (blackboard) over agent-to-agent.** Direct a2a is N^2 coupling;
+  a participant's agent should not need to know ZOE/the music bot exist. They all
+  read/write *the graph*. This generalizes the pattern ZOE already uses
+  (`remember()` episodes + `/delve` reads, see doc 771 + `bot/src/zoe/recall.ts`).
+- **The graph is the hub, not the bot.** The Bonfire *bot* is one privileged
+  client. Making the bot the orchestrator creates a bottleneck + single point of
+  failure. The *gateway* enforces rules; the *graph* is authoritative.
+- **x402 / metered a2a: deferred.** Real future fit (premium cross-org queries,
+  compensating curators) but adds payment friction to a buildathon whose goal is
+  *more* contribution. v2+: monetized query tier / cross-DAO federation.
+- **Read subscriptions / notifications: v2.** Webhook/pub-sub so agents react to
+  graph changes is valuable but not load-bearing for June; query-on-demand first.
+
+ZOE's place: both a privileged curator-client (it owns the approval machine) and
+Zaal's personal query/intake agent. It is NOT the gateway and NOT the sole writer.
+
+## 2. Soft barrier - layer all three options on a lifecycle
+
+The three candidate models are stages of one contribution's life, not rivals:
+
+| Candidate | Role in the combined model |
+|-----------|----------------------------|
+| (c) confidence-weighted, everyone writes | the DEFAULT - submission never bounces; lands as a pending/low-confidence, author-attributed stub |
+| (a) submission queue + reviewer | the PROMOTION gate for untrusted authors - a curator raises it to canonical (reuses Bonfire's existing manifest-approve) |
+| (b) reputation / trust tiers | sets the START point: trusted authors auto-promote / start high-confidence; stewards can promote others |
+
+**Why the combination beats any single option:**
+
+- Open-feel, zero rejection friction (community contributes freely - c).
+- Pollution is *contained, not prevented* - the lever is **visibility**, not
+  blocking. Canonical queries see only promoted items, so a spam stub sits inert
+  in "pending" and never poisons answers (fixes c's weakness).
+- Reviewer load scales DOWN - trusted contributors self-serve, so curators touch
+  only newcomers + disputes (fixes a's bottleneck).
+- Matches the graph's native shape - Bonfire/FCG is confidence + bi-temporal
+  already (doc 771), so "raise confidence / mark canonical" is the grain of the
+  system, not a bolt-on.
+
+The single axis: a contribution's **`status` (pending -> canonical)** +
+**`confidence`**, with **trust tier** setting the start point and promotion rights.
+
+## 3. Identity & trust - compose existing ZAO signals
+
+Build no new identity system. Compose what exists:
+
+- **Farcaster FID** = primary identity (iron-session already does FID/wallet auth;
+  188 members). Sign-in-with-Farcaster is near-zero friction + non-anonymous ->
+  kills drive-by spam.
+- **ZAO Respect score** = native reputation -> drives trust tier.
+- **Bonfire / Genesis score** = second reputation input as it matures.
+- **Contribution track record** = promoted-vs-rejected ratio; earn your way up.
+
+**Rate-limit without friction:** cap *pending* items per FID (tier-1 = few open
+pending; tier-2 = unlimited because they auto-promote). Stale unpromoted stubs
+decay. Everything is FID-attributable -> spam is revocable.
+
+**"Everyone gets their own agent":** an agent acts AS its human, carrying the
+principal's FID and inheriting their tier. No separate agent-trust system in v1.
+(That is where agent-identity / x402 returns later.)
+
+## 4. Minimal v1 (June) - the CRM pattern repointed at Bonfire
+
+Loop: `submit -> lands pending (Supabase) -> curator promotes -> written to
+Bonfire as canonical episode`.
+
+1. **Submit** - lowest friction: a Telegram command (`/contribute project: X,
+   status: Y`) or a tiny web form. Attribution = sender FID/Telegram ID.
+2. **Pending store = Supabase `bonfire_submissions`** (NOT the graph yet):
+   `author_fid, type (fact|project|doc), body, status (pending|approved|rejected),
+   created_at`. Near-verbatim the `crm_contacts` pattern (doc 772), RLS-locked,
+   admin view. **Why Supabase not the graph:** keeps the canonical graph spotless
+   and sidesteps any uncertainty about whether FCG exposes a first-class
+   confidence/canonical query filter today. Only promoted items touch Bonfire.
+3. **Curate** - a `/curate` view lists pending; approve writes to Bonfire via the
+   path ZOE already uses (`remember()` -> `episode/create`, including the existing
+   secret-scan). Reject -> marked, author notified.
+4. **Query** - unchanged; `/delve` already serves canonical truth to ZOE + anyone.
+
+**ZOE's role (mostly already built):**
+- Curator interface - surfaces the pending queue and, on Zaal's "approve" (the
+  exact propose->y/n flow in `bot/src/zoe/approvals.ts`), fires the Bonfire write.
+- Intake helper - accepts Zaal's own contributions conversationally (auto-promote
+  since tier-3).
+- Query agent - already answers from the graph via `/delve`.
+
+**v1 trust tiers = binary:** everyone pending; a hardcoded steward FID list can
+approve. Defer Respect-weighted auto-promote + in-graph confidence to v2.
+
+## Tradeoffs / deferred
+
+| Decision | v1 choice | Cost | Revisit |
+|----------|-----------|------|---------|
+| Pending location | Supabase table | two stores to reconcile; pending not graph-queryable | v2: in-graph low-confidence once FCG confidence-filter confirmed |
+| Promotion | manual curator | reviewer bottleneck (fine for 188 + cohort) | v2: Respect-tier auto-promote |
+| Trust tiers | binary (steward list) | no self-serve for trusted yet | v2: wire Respect/Bonfire score |
+| Submit channel | Telegram | less structured than a form | add light web form if needed |
+| a2a / x402 | none | agents contribute as their human only | v2+: agent identity, metered queries, federation |
+| Notifications | poll/query | no real-time reactions | v2: webhook/pub-sub on graph changes |
+
+**Throughline:** v1 changes almost no architecture - it reuses ZOE's approval
+machine + the CRM pending-table pattern, with the graph as the one source of
+truth. That is what makes it shippable in June and lets tiers/confidence/
+federation layer on without a rewrite.
+
+## Open questions (need verification before v2)
+
+- Does Bonfire/FCG expose a first-class `confidence` + `canonical/status` field
+  that queries can filter on? (Determines when pending can move in-graph.)
+- Does Bonfire support webhooks / change subscriptions? (Gates the notification
+  layer.)
+- Typed intake (`/knowledge_graph/add_triples`, `/entity`, `/edge`, `/ontology`
+  per doc 771) vs prose episodes for structured project/state records - which the
+  promote step should emit.
+
+## Source
+
+Design synthesis (2026-05-31) grounded in the live stack: `bot/src/zoe/`
+(approvals, recall, crm), doc 771 (Bonfires FCG kernel), doc 772 (Supabase CRM
+pattern), doc 601 (agent-stack cleanup / "no new bots without doc").

--- a/research/agents/781-zabal-bonfire-contribution-architecture/README.md
+++ b/research/agents/781-zabal-bonfire-contribution-architecture/README.md
@@ -161,6 +161,48 @@ machine + the CRM pending-table pattern, with the graph as the one source of
 truth. That is what makes it shippable in June and lets tiers/confidence/
 federation layer on without a rewrite.
 
+## Phase 2 wire-up - Option A contract (BUILT 2026-05-31)
+
+Phase 1 (read) shipped on the zabalgames website (separate repo: Vercel edge +
+Upstash Redis, verifies Farcaster Quick Auth). Phase 2 (submit -> pending ->
+promote) uses **Option A**: the website owns the Upstash queue; ZOE drains it.
+
+**Why A over a ZOE-hosted HTTP ingest (B):** Quick Auth lives on the website, so
+the website is an unavoidably-trusted authenticated producer in either design.
+Given that, the cleanest boundary is website = authenticated intake, ZOE = the
+promotion gate (the part that protects canonical truth). A also avoids standing
+up a new public inbound endpoint on the VPS - ZOE stays outbound-only. Migrate to
+B if/when there are multiple producers or a Supabase admin dashboard is wanted.
+
+### The contract (both repos reference this)
+
+- **Queue:** Upstash LIST key `zg:bonfire:pending`. Website `LPUSH`es items with
+  the FID **verified server-side** from Quick Auth (never client-sent).
+- **Item shape:**
+  ```jsonc
+  { "id":"zg-<ts>-<rand>", "fid":1234, "username":"name|null",
+    "type":"fact|project|doc", "title":"opt", "body":"required",
+    "url":"opt", "source":"zabalgames-web", "status":"pending", "ts":1748736000000 }
+  ```
+- **ZOE loop** (`bot/src/zoe/bonfire-queue.ts` + `index.ts` `/bonfire` command):
+  `LRANGE zg:bonfire:pending 0 -1` -> surface oldest item in the approval machine
+  (kind `bonfire-submission`, gated by Zaal's DM in v1; `BONFIRE_STEWARD_FIDS` is
+  the forward-looking multi-steward list) -> on **y** promote via
+  `episode/create` (reusing `recall.remember`, incl. its secret-scan) with a
+  provenance line `(Submitted by @user (fid) via ZABAL Gamez, <date>.)` +
+  `sourceTag: zabalgames-web`, then `LREM` the exact item -> on **n**, `LREM` +
+  log, no write.
+- **Creds (ZOE env):** `ZG_UPSTASH_REST_URL` + `ZG_UPSTASH_REST_TOKEN`
+  (read-write; LREM needs write) for a **dedicated** Upstash DB.
+- **Steward env:** `BONFIRE_STEWARD_FIDS` (v1 = `19640`).
+
+### v1 known limits (documented, not bugs)
+- Steward gate is Zaal's DM in practice; `BONFIRE_STEWARD_FIDS` becomes the real
+  gate in v2 once steward FIDs are mapped to Telegram ids.
+- `LREM`-by-value relies on the item's exact serialized string (ZOE keeps the raw
+  it read). The unique `id` keeps items distinct.
+- Promotion emits a prose episode for all types; typed intake for `project` is v2.
+
 ## Open questions (need verification before v2)
 
 - Does Bonfire/FCG expose a first-class `confidence` + `canonical/status` field

--- a/src/app/crm/page.tsx
+++ b/src/app/crm/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getSessionData } from '@/lib/auth/session';
 import { getSupabaseAdmin } from '@/lib/db/supabase';
@@ -56,9 +57,9 @@ export default async function CrmPage() {
           <h1 className="text-2xl font-bold sm:text-3xl">CRM</h1>
           <p className="mt-1 text-sm text-white/60">
             {contacts.length} contacts - {publicCount} public on{' '}
-            <a href="/network" className="text-[#f5a623] hover:underline">
+            <Link href="/network" className="text-[#f5a623] hover:underline">
               /network
-            </a>
+            </Link>
           </p>
         </header>
 


### PR DESCRIPTION
## What
Phase 2 of doc 781 — ZOE drains the **website-owned Upstash queue** and promotes approved community submissions into the canonical ZABAL Bonfire graph. Built to the **Option A** contract you confirmed.

## The drain loop
- **`bot/src/zoe/bonfire-queue.ts`** (new) — Upstash REST client (`LRANGE`/`LREM` via POST-array form, safe for arbitrary JSON values), submission parse + validate, episode build with provenance (reuses `recall.remember`, so the secret-scan applies), steward-FID helper.
- **`approvals.ts`** — new pending kind `bonfire-submission` (approval-bearing; won't clobber or be clobbered by a live plan).
- **`index.ts`** — `/bonfire` command (Zaal-gated in v1) surfaces the **oldest** pending item; the existing approval resolver promotes on **y** (`episode/create` → `LREM`) or removes on **n** (`LREM` + log), then advances to the next item.
- **doc 781** — "Phase 2 wire-up" section with the final contract so both repos reference one spec.

## Matches your contract exactly
- Queue: LIST `zg:bonfire:pending`, FID verified server-side by the website
- Item: `{ id, fid, username, type, title, body, url, source, status, ts }`
- Promote → `episode/create` with provenance `(Submitted by @user (fid) via ZABAL Gamez, <date>.)` + `sourceTag: zabalgames-web` → `LREM`; reject → `LREM` + log
- Env: `ZG_UPSTASH_REST_URL`, `ZG_UPSTASH_REST_TOKEN`, `BONFIRE_STEWARD_FIDS` (v1 = `19640`)

## v1 limits (documented)
- Steward gate is Zaal's DM in practice; `BONFIRE_STEWARD_FIDS` becomes the real gate in v2 (needs steward FID→Telegram-id mapping).
- Prose episode for all types; typed intake for `project` is v2.

**Checks:** 7 new tests, full zoe suite **120/120**, bot `tsc` clean.

🤖 Built + tested via Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_