### PR TITLE
fix(security): close auth/webhook fail-open holes (audit P0/P1)

### DIFF
--- a/src/app/api/cron/engagement-collect/route.ts
+++ b/src/app/api/cron/engagement-collect/route.ts
@@ -95,13 +95,15 @@ async function collectPlatform(
  */
 export async function GET(request: NextRequest) {
   try {
-    // Auth check: verify CRON_SECRET if set
+    // Auth check: require CRON_SECRET. Fail CLOSED if it's unset (was previously
+    // skipped = publicly callable when misconfigured), matching follower-snapshot.
     const cronSecret = process.env.CRON_SECRET;
-    if (cronSecret) {
-      const authHeader = request.headers.get('authorization');
-      if (authHeader !== `Bearer ${cronSecret}`) {
-        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-      }
+    if (!cronSecret) {
+      return NextResponse.json({ error: 'CRON_SECRET not configured' }, { status: 500 });
+    }
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${cronSecret}`) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
     const platformResults: CollectResult[] = [];

--- a/src/app/api/fishbowlz/webhook/privy/route.ts
+++ b/src/app/api/fishbowlz/webhook/privy/route.ts
@@ -10,7 +10,10 @@ function verifySignature(payload: string, signature: string): boolean {
   const hmac = crypto.createHmac('sha256', PRIVY_WEBHOOK_SECRET);
   hmac.update(payload);
   const expected = hmac.digest('hex');
-  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+  // Length-guard before timingSafeEqual — mismatched lengths throw RangeError.
+  return sigBuf.length === expBuf.length && crypto.timingSafeEqual(sigBuf, expBuf);
 }
 
 export async function POST(req: NextRequest) {
@@ -18,8 +21,11 @@ export async function POST(req: NextRequest) {
     const body = await req.text();
     const signature = req.headers.get('x-privy-signature') || '';
 
-    // Verify webhook signature
-    if (PRIVY_WEBHOOK_SECRET && !verifySignature(body, signature)) {
+    // Fail CLOSED: reject if the webhook secret isn't configured (was fail-open).
+    if (!PRIVY_WEBHOOK_SECRET) {
+      return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+    }
+    if (!verifySignature(body, signature)) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
     }
 

--- a/src/app/api/miniapp/auth-context/route.ts
+++ b/src/app/api/miniapp/auth-context/route.ts
@@ -7,6 +7,12 @@
  * gating an invite-only community where the alternative is a SIWF prompt
  * every miniapp launch. For sensitive ops, keep using /api/miniapp/auth
  * (QuickAuth/JWT-verified).
+ *
+ * HARDENED 2026-06: this path NEVER grants isAdmin (saveSession allowAdmin:false)
+ * because the FID is unsigned. Admin only comes from the JWT-verified sibling.
+ * TODO: consolidate both routes onto QuickAuth JWT (sdk.quickAuth.fetch) to also
+ * close the unsigned-FID account-impersonation surface — needs a real
+ * miniapp-launch test before flipping the client.
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -47,12 +53,18 @@ export async function POST(req: NextRequest) {
     }
 
     if (hasAccess) {
-      await saveSession({
-        fid,
-        username: neynarUser.username || '',
-        displayName: neynarUser.display_name || '',
-        pfpUrl: neynarUser.pfp_url || '',
-      });
+      // SECURITY: the FID here is UNSIGNED (client-supplied). Never grant admin
+      // from this path — otherwise POSTing the public admin FID would mint an
+      // admin session. Admin requires the JWT-verified /api/miniapp/auth path.
+      await saveSession(
+        {
+          fid,
+          username: neynarUser.username || '',
+          displayName: neynarUser.display_name || '',
+          pfpUrl: neynarUser.pfp_url || '',
+        },
+        { allowAdmin: false },
+      );
     }
 
     return NextResponse.json({

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -22,8 +22,16 @@ export async function POST(req: NextRequest) {
   try {
     const rawBody = await req.text();
 
+    // Fail CLOSED: if no signing key is configured we cannot verify the sender,
+    // and this endpoint writes into the Respect system — so reject rather than
+    // process an unauthenticated payload (was previously skipped = fail-open).
+    if (SIGNING_KEYS.length === 0) {
+      logger.error('[alchemy-webhook] no signing key configured — rejecting');
+      return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
+    }
+
     // Validate HMAC signature — try all configured signing keys
-    if (SIGNING_KEYS.length > 0) {
+    {
       const signature = req.headers.get('x-alchemy-signature') || '';
       let valid = false;
 

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -58,15 +58,24 @@ export const getSessionData = cache(async (): Promise<SessionData | null> => {
   };
 });
 
-export async function saveSession(data: {
-  fid: number;
-  username: string;
-  displayName: string;
-  pfpUrl: string;
-  walletAddress?: string;
-  authMethod?: 'farcaster' | 'wallet';
-  signerUuid?: string | null;
-}) {
+export async function saveSession(
+  data: {
+    fid: number;
+    username: string;
+    displayName: string;
+    pfpUrl: string;
+    walletAddress?: string;
+    authMethod?: 'farcaster' | 'wallet';
+    signerUuid?: string | null;
+  },
+  opts: { allowAdmin?: boolean } = {},
+) {
+  // allowAdmin defaults true. Callers that authenticate via an UNSIGNED claim
+  // (e.g. /api/miniapp/auth-context, which trusts a client-supplied FID) MUST
+  // pass allowAdmin:false — otherwise POSTing a known admin FID would mint an
+  // admin session (the public admin FID is in community.config.ts). Admin must
+  // only ever come from a signature/JWT-verified path.
+  const allowAdmin = opts.allowAdmin !== false;
   const session = await getSession();
   session.fid = data.fid;
   session.walletAddress = data.walletAddress || undefined;
@@ -75,8 +84,8 @@ export async function saveSession(data: {
   session.displayName = data.displayName;
   session.pfpUrl = data.pfpUrl;
   session.signerUuid = data.signerUuid || null;
-  session.isAdmin = ADMIN_FIDS.includes(data.fid) ||
-    (data.walletAddress ? ADMIN_WALLETS.includes(data.walletAddress.toLowerCase()) : false);
+  session.isAdmin = allowAdmin && (ADMIN_FIDS.includes(data.fid) ||
+    (data.walletAddress ? ADMIN_WALLETS.includes(data.walletAddress.toLowerCase()) : false));
   await session.save();
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,6 +25,10 @@ const RATE_LIMITS: [string, RateLimitConfig][] = [
   ['/api/fractals/webhook', { limit: 30, windowMs: MINUTE }],
   ['/api/fractals',         { limit: 20, windowMs: MINUTE }],
 
+  // Inbound webhooks (signed, but cap to blunt replay/DoS — see Alchemy hardening)
+  ['/api/webhooks',      { limit: 100, windowMs: MINUTE }],
+  ['/api/juke/webhooks', { limit: 100, windowMs: MINUTE }],
+
   // Users sub-routes
   ['/api/users/follow', { limit: 15, windowMs: MINUTE }],
   ['/api/users',        { limit: 20, windowMs: MINUTE }],
@@ -35,6 +39,7 @@ const RATE_LIMITS: [string, RateLimitConfig][] = [
   ['/api/proposals',         { limit: 5,  windowMs: MINUTE }],
 
   // Music sub-routes
+  ['/api/music/generate',    { limit: 5,  windowMs: 60 * MINUTE }], // expensive paid AI inference
   ['/api/music/submissions', { limit: 2,  windowMs: MINUTE }],
   ['/api/music/metadata',    { limit: 20, windowMs: MINUTE }],
   ['/api/music/radio',       { limit: 10, windowMs: MINUTE }],


### PR DESCRIPTION
## What
From the security audit — closes the **fail-open** holes (the audit's recurring root cause: optional-secret guards that skip enforcement when a secret is unset).

| Fix | File | Was |
|-----|------|-----|
| **Admin-takeover closed** | `auth/session.ts` + `miniapp/auth-context` | unsigned-FID silent login now passes `saveSession(allowAdmin:false)` — POSTing the public admin FID can no longer mint an admin session |
| **Alchemy webhook fail-closed** | `webhooks/alchemy` | skipped verification when no signing key → now 503 (closes unauthenticated write into the Respect system) |
| **engagement-collect cron fail-closed** | `cron/engagement-collect` | ran unauthenticated when `CRON_SECRET` unset → now 500 |
| **Privy webhook fail-closed + length-guard** | `fishbowlz/webhook/privy` | fail-open + `RangeError` soft-DoS |
| **Rate limits added** | `middleware.ts` | `/api/webhooks`, `/api/juke/webhooks` (replay/DoS), `/api/music/generate` (paid AI, 5/hr) |

Verified: `typecheck` clean, `eslint` 0 errors, **225 API tests pass**.

## ⚠️ CI note
This branch is off `main`, which still carries **2 pre-existing lint errors** (`useX402` hooks-rule + an `<a>`-vs-`<Link>`) whose fixes live in the **unmerged #768 branch**. So Lint & Typecheck may go red here on those two until #768 merges — they're **not** from this PR. Say the word and I'll fold the 2-line fix in to make this standalone-green.

## Still open (need care / sign-off)
Alchemy replay idempotency (derive balances from on-chain), `isAdmin`-recompute-per-request, and the agent-trading P0s (the 0x-v2/slippage/allowlist work — candidate for the repo extraction we discussed).

🤖 Audited + fixed via Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_