### PR TITLE
doc 801: MCP usage audit + where to lean in (STANDARD tier)

### DIFF
--- a/research/dev-workflows/801-mcp-usage-audit-where-to-lean-in/README.md
+++ b/research/dev-workflows/801-mcp-usage-audit-where-to-lean-in/README.md
@@ -1,0 +1,139 @@
+---
+topic: dev-workflows
+type: audit
+status: research-complete
+last-validated: 2026-06-05
+superseded-by:
+related-docs: 232, 238, 242, 297, 663
+original-query: "MCP server usage patterns and underused MCP opportunities - which MCPs (gitnexus, serena, sequential-thinking, memory, context7, playwright, exa, supabase, github) deliver most value in Claude Code agentic workflows, and where in the ZAO OS dev workflow I should lean on them more. I currently use Bash/Edit/Read/Write for 99% of work and barely touch my connected MCPs."
+tier: STANDARD
+---
+
+# 801 — MCP Usage Audit: Where To Lean In
+
+> **Goal:** Measure which of Zaal's connected MCP servers actually earn their context cost, and name the specific ZAO OS workflows where leaning on the underused ones (chiefly Serena + context7) pays off.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **USE Serena for all code edits + refactors in ZAOOS** (`find_symbol` / `replace_symbol_body` / `find_referencing_symbols`), NOT raw Read/Edit | ZAOOS is a 301-route, 279-component monorepo - exactly the large codebase where Serena cuts 60-80% of tokens and catches every reference on rename. Currently used 1 time ever. |
+| 2 | **USE context7 by default on every Next.js 16 / React 19 / Wagmi / Tailwind v4 task** via a CLAUDE.md auto-invoke rule | Stack churns fast; context7 is the #1-ranked MCP across every 2026 best-of list for killing hallucinated APIs. Used 5 times ever. |
+| 3 | **KEEP supabase MCP as-is** (your real #1, 55 calls) | DB-native CRM + tracker work. Already the workhorse. Lock a read-only role for exploration, write-role only for migrations. |
+| 4 | **KEEP playwright** (wrapped by `/qa` + `/browse`) and **exa** (research fallback) | Both earn their slot through skills even though direct call counts look low. |
+| 5 | **DISABLE gitnexus, memory (ECC graph), sequential-thinking** - 0 real calls ever | Pure context tax. gitnexus overlaps Serena; ECC memory duplicates your file-memory + CLAUDE.md for 0 tokens; sequential-thinking is redundant with Opus 4.8 adaptive thinking. |
+| 6 | **DEMOTE github MCP to per-need** (9 calls) | Your `gh` CLI via Bash (6201 Bash calls) already covers ~90% of GitHub flows at lower context cost. Community consensus agrees. |
+
+## Ground Truth: Your Actual MCP Usage
+
+Measured from 629 session transcripts in `~/.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/*.jsonl`, counting real `tool_use` invocations (not the inflated tool-definition text that repeats in every system prompt). MCP config lives in `.claude/settings.json` + `.claude/settings.local.json`.
+
+Total tool calls across all sessions: **12,834**. MCP share: **~150 (1.2%)**. Native dominates: Bash 6201, Edit 1559, Read 1195, Write 1122, Agent 586.
+
+| MCP | Real calls | Top tool | Verdict |
+|-----|-----------:|----------|---------|
+| supabase | 55 | execute_sql (44) | Workhorse - keep |
+| exa | 61 | web_search (44) | Research fallback - keep |
+| grep | 11 | searchGitHub | Light, useful - keep |
+| github | 9 | get_file_contents (8) | Demote (gh CLI covers it) |
+| playwright | 6 | browser_navigate | Skill-wrapped - keep |
+| context7 | 5 | query-docs | UNDERUSED - lean in |
+| serena | 1 | onboarding check | UNDERUSED - lean in hard |
+| Gmail | 1 | search_threads | Niche, PII-gated |
+| Calendar | 1 | list_events | Niche, PII-gated |
+| gitnexus | 0 | - | DEAD - disable |
+| memory (ECC) | 0 | - | DEAD - disable |
+| sequential-thinking | 0 | - | DEAD - disable |
+
+The headline: you run a code-heavy monorepo almost entirely on file-level Read/Edit/Write, and the one MCP built to make that cheaper and safer (Serena) you have called once.
+
+## Findings
+
+### Serena is the biggest unrealized win for ZAOOS
+
+Serena exposes Language Server Protocol (go-to-definition, find-all-references, safe rename) as MCP tools, so the agent reads code at the symbol level instead of loading whole files. Reported savings are consistent across independent write-ups:
+
+- Firman Hanafi: **60-80% token drop** on large codebases; a 200-file Java trace went ~8000 tokens -> ~800 (10x).
+- MangoDriod (100k-line Android/KMP): "Find auth logic" was **15,000 tokens without Serena vs 4,500 with** (~70%). Monthly est. 4M -> 1.2M tokens.
+- ManoMano (36,407-line, 381-class Java payment service) head-to-head refactor: **Vanilla Claude** spun up 12 subagents, ran an hour, cost $23.54, **failed to build**. **Claude built-in LSP** gave up after 3 iterations with 9 tests failing. **Claude + Serena** finished in 45 min, $27.30, **building project, all tests passing** - and read 69M tokens against its own cache while keeping API cost contained.
+
+ZAOOS fits the profile that makes this pay: 301 API routes across 54 domains, 279 components, TypeScript monorepo. The exact case the benchmarks measure.
+
+The nuance that matters (ManoMano's deployment guide):
+- **Quick read-only lookup** ("where is business rule X?") - Serena was ~4x cost and 60% slower. Use native Read/Grep. Disable Serena temporarily via `/mcp`.
+- **Find function usage** - Serena and native tie; both beat Claude's built-in LSP which hallucinated same-named methods.
+- **Deep code modification / refactor / test-writing** - Serena is mandatory; reference-aware edits mean a 20-file rename misses nothing (the dynamic-usage-in-a-template-string case that text search-and-replace always breaks).
+
+Practical rule for ZAOOS: **Serena for write/refactor, native tools for quick reads.** Serena's `claude-code` context auto-disables tools that overlap Claude Code's native edit/shell, so it slots in without conflict. Your session-start hook already pushes Serena activation - you have just been ignoring it.
+
+### context7 is cheap insurance against stale-API code
+
+Ranked the single highest-leverage MCP in every 2026 best-of list reviewed (DevelopersDigest top-5, Totalum "install first", PromptWritingStudio). It injects version-pinned docs on demand, killing hallucinated APIs. ZAOOS runs Next.js 16, React 19, Tailwind v4, Wagmi/Viem - all fast-moving, all past the model's training edge for their newest releases.
+
+You have called it 5 times. The fix is a one-line CLAUDE.md rule so it auto-fires (per upstash's own recommendation):
+
+```
+Always use context7 when I need library/API documentation, code generation, setup, or
+configuration steps for Next.js, React, Wagmi, Viem, Supabase, or Tailwind - without me
+having to ask. Include a specific question in the query, not just the library name.
+```
+
+Gotcha: query it like a search ("Next.js 16 App Router middleware matcher config"), not a table of contents ("Next.js"). Max 3 calls per question; free tier has daily quotas.
+
+### sequential-thinking earns nothing on Opus 4.8
+
+The MCP adds an inspectable scratchpad - it does not make the model smarter, it makes reasoning visible and revisable, at a **20-60% token premium**. On Opus 4.7+ manual extended thinking returns HTTP 400; adaptive thinking is on by default and handles ~80% of what you'd reach for it on. One practitioner's logs: sequential-thinking fired in 38% of sessions but was clearly load-bearing in only ~8%. For a "ask, edit, commit" workflow like yours on Opus 4.8, it is overhead. Only value would be post-hoc auditing of agent reasoning - which you don't do. Disable.
+
+### gitnexus and ECC memory are duplicate surfaces
+
+- **gitnexus** (codebase-as-graph) overlaps what Serena does better and what your `/graphify` skill does for knowledge. 0 calls. Not on any best-of list. Disable until a concrete query need appears.
+- **ECC memory** (knowledge-graph entities/relations) duplicates your file-memory at `~/.claude/.../memory/` + CLAUDE.md, which cost 0 tool-schema tokens. Community verdict is blunt: "CLAUDE.md is your memory." You already run the file system well (206-line MEMORY.md index). Disable the graph MCP.
+
+### The context-budget principle behind all of this
+
+Every connected server ships its tool schemas into context every turn (~500-2,000 tokens each; a 15-server kitchen sink = 15-30k tokens before you type). On a 1M window that's small in raw terms, but the real cost is **cognitive: more tools means more wrong-tool picks.** Consensus sweet spot across every source: **3-6 servers.** Claude Code's MCP Tool Search now loads schemas lazily (you see this as ToolSearch in your own transcripts), which softens but doesn't eliminate the cost. Cutting 3 dead servers is free upside.
+
+## Recommended ZAOOS MCP Stack (target state)
+
+| Keep (daily) | Keep (task-specific) | Disable |
+|--------------|----------------------|---------|
+| supabase (DB work) | playwright (via /qa, /browse) | gitnexus |
+| context7 (auto-rule) | github (per-PR, else gh CLI) | memory (ECC) |
+| serena (code write/refactor) | exa + grep (research, via /zao-research) | sequential-thinking |
+
+That's 4 daily + 3 task-specific = within the 6-ish sweet spot, minus 3 dead weights.
+
+## Also See
+
+- [Doc 232](../232-mcp-server-development-guide/) - building MCP servers (the protocol side; this doc is the usage side)
+- [Doc 238](../238-claude-tools-top50-evaluation/) - broader Claude tooling eval
+- [Doc 242](../242-claude-20-underused-features-power-user/) - underused Claude Code features
+- [Doc 297](../297-graphify-knowledge-graph-codebase/) - graphify (the knowledge-graph surface gitnexus overlaps)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Add context7 auto-invoke rule to CLAUDE.md (Next.js/React/Wagmi/Tailwind/Supabase) | @Zaal | PR | This week |
+| Start using Serena symbol tools for next code refactor; measure token delta vs file-reads | @Zaal | Habit | Next code task |
+| Disable gitnexus + ECC memory + sequential-thinking in MCP config | @Zaal | Config | After approval |
+| Confirm supabase MCP uses read-only role for exploration, write-role only for migrations | @Zaal | Config audit | This week |
+| Re-measure MCP usage in 30 days to confirm Serena/context7 adoption rose | @Zaal | Audit | 2026-07-05 |
+
+## Sources
+
+- [Serena + MCP: How AI Reads a Codebase Without Burning Tokens - hanafifirman.dev](https://hanafifirman.dev/en/blog/serena-mcp-token-efficiency/) [FULL]
+- [Benchmarking AI Coding Agents: Claude vs Claude Code vs Serena on 36K Lines of Java - ManoMano Tech (Medium)](https://medium.com/manomano-tech/project-aegis-benchmarking-ai-agents-and-why-serena-is-our-new-must-have-311673db35dd) [FULL]
+- [Supercharging Claude Code with Serena - Save 70% on Tokens - MangoDriod](https://md.eknath.dev/posts/ai-ml/serena-claude-code-setup/) [FULL]
+- [Serena MCP: Giving Your AI Coding Tools an IDE Brain - Arda Kilicdagi](https://arda.pw/posts/serena-mcp-semantic-code-assistant/) [FULL]
+- [Serena vs Claude Code - aicoolies](https://aicoolies.com/comparisons/serena-vs-claude-code) [FULL]
+- [Navigating Claude Code: MCP Servers Worth Adding - HackerNoon](https://hackernoon.com/navigating-claude-code-mcp-servers-worth-adding) [FULL]
+- [271 MCP Servers Exist. These 5 Actually Make Claude Code Better - Developers Digest](https://www.developersdigest.tech/blog/271-mcp-servers-top-5-that-matter) [FULL]
+- [The Right MCP Stack: Five Servers - PromptWritingStudio](https://promptwritingstudio.com/claude-code-mcp-stack) [FULL]
+- [Best Claude Code MCP Servers in 2026 (Ranked) - DEV Community](https://dev.to/stravukarl/best-claude-code-mcp-servers-in-2026-ranked-466b) [FULL]
+- [Best MCP Servers in 2026: 12 Picks - Totalum](https://www.totalum.app/blog/best-mcp-servers-2026) [FULL]
+- [Best MCP Servers for Claude Code: 16 Ranked - buildtolaunch (Substack)](https://buildtolaunch.substack.com/p/best-mcp-servers-claude-code) [FULL]
+- [Context7 - upstash/context7 README](https://github.com/upstash/context7) [FULL]
+- [Sequential Thinking in Claude Code: A Practical MCP Guide - maketocreate](https://maketocreate.com/sequential-thinking-in-claude-code-a-practical-mcp-guide/) [FULL]
+- [Sequential Thinking MCP Guide 2026 - skiln.co](https://skiln.co/blog/sequential-thinking-mcp-guide-2026) [FULL]
+- [Sequential Thinking MCP Server: Setup, Features, Usage - Agentbrisk](https://agentbrisk.com/mcp/sequentialthinking/) [FULL]

--- a/research/events/800-jose-claude-code-onboarding-june5/README.md
+++ b/research/events/800-jose-claude-code-onboarding-june5/README.md
@@ -1,0 +1,57 @@
+# Jose Acabrera (Joseph Goats) x Zaal - Claude Code Onboarding + Mini-App Hackathon
+
+- **Date:** 2026-06-05 (Friday)
+- **Duration:** ~20 min
+- **Platform:** Video call + Discord screen-share
+- **Attendees:** Zaal, Jose Acabrera (Joseph Goats)
+- **Project:** ZAO Devz / general (onboarding, continuation)
+- **Related:** Jose profile - doc 745. First onboarding call - doc 795.
+
+## Summary
+
+Second onboarding session, two days after Jose came on as a paid contributor (doc 795). Zaal
+screen-shared the Claude co-work flow (claude.com cloud container, shared zao-devs account) and
+decided to get Jose his own Claude Code so he can learn and build independently. Backdrop: a
+Farcaster mini-app hackathon ends today and Jose is eligible for the free tier, so Zaal pushed him
+to ship something tonight. Zaal also demoed the cowork tracker's task-link workflow live (created a
+"watch workshop video" task and sent Jose the link) and sketched the ZAO Scribe project - automating
+the exact Craig-to-recap-to-DM pipeline this meeting is being run through.
+
+## Decisions
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | Jose gets his own Claude Code ($20/mo plan); Zaal sends the $20; set up on Jose's machine next week | Both | high |
+| 2 | Jose builds a mini app this weekend for the Farcaster hackathon (free tier) - idea: a songwriting-request app | Jose | high |
+| 3 | Async comms continue via Discord/Telegram + cowork tracker task-links; Zaal sends a meeting summary after each call | Both | high |
+| 4 | ZAO Scribe (Zaal + Iman) - automate the Craig download to GitHub recap to shortened-DM pipeline, plus an auto "public building" post | Zaal | medium |
+
+## Actions
+
+| Title | Owner | Due | Category |
+|-------|-------|-----|----------|
+| Try the mini app, build + submit something tonight for the Farcaster hackathon, post it to the timeline | Jose | 2026-06-05 | ZAO Devz |
+| Spend 15+ min in the cowork tracker, give feedback so Zaal can knock out fixes this weekend | Jose | 2026-06-07 | ZAO Devz |
+| Watch the workshop video + give feedback (tracker task already created by Zaal) | Jose | | ZAO Devz |
+| Send Zaal a written summary of today's call (Jose piloting the recap habit) | Jose | 2026-06-05 | ZAO Devz |
+| Send Jose $20 for his Claude Code plan | Zaal | | Ops |
+| Set a time next week to install Claude Code on Jose's machine | Zaal | | ZAO Devz |
+| Make the "Claude 101" onboarding video/course | Zaal | | ZAO Devz |
+
+## Key Quotes
+
+- "I would say I could toss you $20 and you should get Claude Code on your own computer and start playing with it... that would be a much better use of you learning while being able to create your own stuff." - Zaal, on funding Jose's own Claude Code.
+- "It's a tool that is going to be needed. Like, I need a computer to work. It's just another layer of scalability." - Jose, on adopting Claude Code.
+- "Post to the timeline, because the more you post the more they'll see it." - Zaal, pushing public-building reps for the hackathon submission.
+- "One of the projects Ayman and I are working on is called the ZAO Scribe... copy their tool but add a couple automations for the way we want to use it." - Zaal, describing the meeting-recap automation (Ayman = Iman, transcription artifact).
+- "You want high-agency autonomous pieces of the fractal... the more resources we can share through pictures. I'm talking about system theory, which is the real deal." - Jose, on the org design philosophy.
+
+## Context Notes
+
+- Jose referenced **August** - a musician + AI / system-theory researcher he's been connecting with ("a beautiful musician... exploring system theory research, making amazing progress"). New external contact, not yet ZAO-connected. Tracked as a research seed, not yet a memory - revisit if a concrete collaboration forms.
+- "Ayman" in the transcript = Iman (transcription mis-hearing).
+- The live tracker-link demo (Zaal created a task, sent Jose the link) is the real-world version of the `?task=` deep-link idea - currently done manually via a progress-update link, not a URL param. ZAO Scribe is the planned automation layer.
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md)

--- a/research/events/800-jose-claude-code-onboarding-june5/transcript.md
+++ b/research/events/800-jose-claude-code-onboarding-june5/transcript.md
@@ -1,0 +1,255 @@
+doing good, going good.
+Awesome.
+That's amazing.
+Howdy, I need one minute, and I'll be here.
+Happy Friday.
+Cool.
+Happy Friday.
+Hey, happy Friday, bro.
+Even though the Friday's coming to an end, don't be...
+You don't want to make it.
+Sorry?
+I know we have a lot of things to do, but there's a thing ending today, a hackathon,
+and I want to create this idea.
+I have it in my head and ready.
+So I was wondering if you wanted to watch me create an app or we wanted to...
+I can do it at any point.
+I wanted to show you how to also do the thing that I wanted to do, essentially.
+So let me share my screen.
+So what you can do here is if you go to cloud.ai-code and then there's a specific session I'll send to you for the code work.
+So that link will take you right to the session I'm working in and this is basically a auditing session section.
+So what I'm going to do is I'm actually just going to send it to me.
+I'm streaming on fucking discord.
+Yeah.
+Yeah.
+Okay.
+Okay.
+All right.
+So you can just talk to this Claude co-work about fixing things.
+Oh, cool.
+Word.
+I get that.
+I remember you mentioned something about it yesterday.
+Okay, I think I have to change from the speakers to my headphones and I'm ready.
+Okay, now it's good.
+yeah good to see you
+I'm in Sol
+I'm here to drive through
+one hour
+two hours
+I'm down to it
+actually I have
+to learn
+about Claude
+like do the process that
+Sol was already
+invested into me
+to learn
+so yeah so I think everything is
+on sync. That's basically what we will be like, one of the tools we will be like handling. So
+I appreciate it and I value it. Yeah, I'm here to listen.
+Awesome.
+That says, okay.
+So I'm just trying to move this from my cloud to our team cloud right now.
+So I can access to that like theme, Claude, or no?
+Not yet, not really.
+The challenge becomes that I'm basically using the info at the zao.com as the zao devs account.
+So Ayman and I are using that together, and we have Claude on that.
+I would say that I could toss you $20 and you should get cloud code on your own computer and device and start playing with it.
+Because I think that would be a much better use of you learning while being able to create your own stuff on your side.
+Because I think that'll help you understand how to, if and when we do have you, coding on the team cloud code, how to use it and how we have workflows.
+and we can even build those among the time right now we don't have that inbuilt so yeah i'd say um
+see if you can i need to create a clawed 101 of course um i have the video that i want to do it
+off of but i haven't sat down and done that yet so um i would say let's find a time next week for
+for us to get Claude on your machine a $20 plan a month,
+and then we can try it out and see how far you're going.
+Okay, okay.
+I think it's good because, yeah,
+I think everything points to that direction.
+Like you want it or not,
+it's a tool that is going to be needed.
+Like the same, I need a computer to work, you know?
+Like, it's just, like, another layer of scalability.
+It's not the word leverage in your coordination.
+And I see what you do, like, the creation of pages
+and application of, you know, issues.
+And I see, like, oh, my God, this is dreamed.
+Like, I remember, like, doing coordination on DAOs
+and needing that kind of maybe pacing
+or wanting to, like, maybe do it myself,
+but just having a learning curve that at least at the moment it was like not yeah a priority
+the mini app
+oh i saw it the other day but uh i thought the the image seemed like a slop and i was i i had
+not researched it looked like suspicious but if you are telling me it's a tool that it really
+works i'm going to check it out yeah i tagged you under it they have um a thing going this week for
+Farcaster batches.
+So they're doing some cool stuff.
+They're part of Farcaster batches.
+Super active.
+The two team members,
+I've had a couple conversations with them.
+Okay, I'm going to check that out.
+I'm just turning my Farcaster on.
+you need also credits and funds in order to like use this one
+oh actually i am eligible for a free tier
+oh yeah awesome so you can build one for free which is sick
+yeah i have six hours yeah i don't know exactly
+yeah because it ends today i think
+yeah i'd try it out do something simple try it and see how it goes and let me know how it is and
+honestly post to the timeline because the more you post the timeline the more they'll see it as well
+okay
+okay
+Okay.
+Okay.
+I have moved everything over.
+Thank you.
+Okay.
+Okay.
+I'm testing this app.
+I am thinking on a simple idea.
+I'm thinking on a songwriting request app.
+which is what I think I have mentioned that to you,
+that I wanted to work in one,
+and I was working with a friend,
+but yeah, he started doing more stuff.
+I totally understand it,
+but that's why I wanted to code,
+is to do this songwriting machine.
+So I'm doing just a prototype, you know?
+I'm not going to find the final product
+with this description,
+but I'm going to try to explain it short and sharp.
+Awesome.
+Awesome.
+I love it.
+So what did you think of the app?
+Other than the things you mentioned and sent over, I'm working on those.
+I'm curious if you have any other thoughts or ideas.
+Well, I had not invested my hour today of checking into the app.
+So everything I told you yesterday at the moment is, I think that I got inspired and like in momentum because you were checking it out live.
+So when you did it, you know, like I started bouncing the ball to you and then I told you like, oh, we should have like a emergent bubble in cyan color because I was seeing it and I saw where it fits on the UI.
+But then it was like, you know what?
+Just send me to the page because speed is what we really want.
+and i can think in those terms so i i will be i will be checking it out um yeah right now i'm i'm
+i'm just testing this one uh beanie app you sent me to this direction too but yeah so why don't we
+jump off for now because i still have to knock out some to-dos um take a look at that try and submit
+something tonight and if you can in the next example you could try at least even if you don't
+get all the way through just because the more things you try and test out and do the better
+you'll get it it's all a practice game and then the second thing is take another look at the
+the co-work today it doesn't even have to be a full hour even if it's 15 minutes and just give
+me your thoughts so that i can knock stuff out this weekend as well and then we'll um if you're
+free tomorrow or on sunday you know feel free to shoot a message over we can go back and forth
+they sync if not we can always relink up on monday um but yeah dude i appreciate the the hard work
+let's keep cooking i'm just grinding away over here um if you want to take a look at um i did
+i'm a i have i'm about to officially release the round the first um workshop um with empire builder
+if you want to look at it and give me any any like any feedback you're welcome but if you don't if
+get busy no worries okay sorry no no no i will uh when are you going to do this workshop
+so this one's already done i actually have so we've done four workshops already this is the
+first one i have ready to push to youtube so intro outro captions and description basically
+okay no send it forward yeah perfect so what i'm gonna do is i'm gonna actually make the link in
+the to do's so i'm gonna go i'm gonna make it to do i'll say jose watch workshop video and give
+feedback and then i'll press add and then it adds it up to here and i will put in the progress
+update i'll put it to in progress and i'll say here is the video and then once i do that and i
+I press submit update I'm gonna copy this link and I'm gonna send this link to you and discord
+this part I still have to make better I'll basically make it so that I can just tag you
+and do at Jose and then I don't even have to copy the link you'll just get a link sent to you from
+a bot but I just sent you the link to that specific to do so if you click on that to do you should be
+easily able to find watch workshop video and give feedback and here is the video okay
+How's that though for like communication? I feel like that's really solid because like we could easily have done that
+Yeah
+On the call so it can really be like okay like you have all the feedback you put it right there and it's like
+It's not like 20 messages ago in telegram or something. You know what I mean?
+I really know what you mean. I think you are
+I'm going to do the pilot. So okay. I received my link
+I will send you a summary of today's meeting as well.
+Oh, please do that every time because my head is still on Spanish.
+I'm doing my homework.
+But because it's interesting.
+I really appreciate it.
+But now that we have that tool, it's like I always wanted to have an assistant to be able to read.
+Perfect.
+Yeah, one of the projects Ayman and I are working on is called the Zao Scribe.
+and instead of right now what I do is I record these with Craig I go to the link I download the
+recording I put the recording in my clod and I have it put a make a github page basically make a
+make a summary of the work of the meeting and then I have it with that full summary in the url on
+github I say make a shortened message to send to the individual but a lot of those we can make it
+a lot faster and all automatic so i don't have to manually do those things with the zao scribes so
+basically i'm using a tool that someone else created i have to do a couple extra things so
+i want to essentially copy their tool but add in a couple automations for the way we want to
+customly use it if that makes sense yeah yeah i think it's a a great process and so then you can
+help me when we use it and you can be like, hey, we need to tweak it. I also want to like post about
+it. I want the bot to tell me, hey, make me a post that says I just talked to Zoll today and here's
+what we talked about. Right. And then you can post about it and we can get some public building,
+public reps as well, you know. So, yeah, I got a lot of ideas. Keep them coming. Anything you got,
+like we're in a manifesto
+it's great what you are
+being able to map
+the effort of
+everybody like you know pushing into
+that direction I think that
+the step
+because you know you want
+high agency
+autonomous pieces
+of the fractal
+so you want
+to be able to make
+a painting
+Sorry, it's not a painting, the word.
+It's like, draw the mental map of the...
+Thank you that you got it, because it was a fractal.
+So it's like, the more resources we can share through pictures...
+And I'm not talking about the tool.
+I'm talking about system theory, which is the real deal.
+Yeah, it's the real deal.
+So actually...
+I'm working with a guy in an artificial intelligence system theory machine.
+I guess that I cannot say too much, but I already have been thinking on how the bridge gene can go.
+Like, it's an awesome dude.
+And it's a beautiful musician.
+And it's exploring what tree, and he has also a given project.
+his name is August
+I don't know if you know him
+I don't know
+yeah so
+I know
+you know
+I have been reading
+like we have been connecting
+and talking
+and I have been checking
+also what he does
+he is also like
+an amazing guy
+having a skill set
+and working on
+multiple stuff
+like the same
+as a high agency fractal part of, you know, like I see he's a high talent guy. And yeah,
+like he is also looking to the same problem through the optics of system theory research.
+and he has been making an amazing progress on it.
+So maybe it's part of the mental design
+of how the information can flow, structure,
+that is not even the tool itself,
+but then the mental map to tackle it.
+Yeah.
+awesome i love it i'm gonna rock out here jose i'll send you i'll send you over the summary and
+then let me know if you whatever else you get into um and yeah thank you for your time and
+have a great weekend and we'll chat more asynchronous perfect yeah are you gonna send
+it on discord yeah discord if the discord's best telegram if telegram is good
+whatever you send it
+yeah I'll plan to do discord
+yeah okay cool
+I'll either do discord or telegram
+those are usually what I
+yeah whatever is faster
+depending on what you were doing so you don't have
+to lose that much time into this
+yeah whatever let's
+have adaptability but the information
+is going to flow really good because
+it's like it's going to be structured
+so it doesn't matter
+It's in a central it's the actual information that a centralized place. I'm notifying you. Yeah, we are receiving a hundred percent signal doesn't matter
+Yeah, yeah
+Amazing. Thank you Jose. I'll catch you soon be good

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-06-05 | Jose Acabrera (Joseph Goats) x Zaal - Claude Code onboarding + mini-app hackathon | ZAO Devz | Zaal, Jose Acabrera | [800](800-jose-claude-code-onboarding-june5/) | 7 |
 | 2026-06-03 | Jose Acabrera (Joseph Goats) x Zaal - ZAO contributor onboarding | ZAO Devz | Zaal, Jose Acabrera | [795](795-jose-acabrera-onboarding-zao-contributor/) | 6 |
 | 2026-05-31 | Iman x Zaal - Request for Collaborators walkthrough | ZAO Devz | Zaal, Iman | [779](779-iman-zaal-request-for-collaborators-may31/) | 3 |
 | 2026-05-30 11:01 | kmac.eth x Zaal - ZABAL Games + Farcaster distribution + JFS-signer ask | Farcaster / ZABAL Games | Zaal, kmac.eth | [788](788-kmac-zabal-farcaster-distribution-may30/) | 3 |


### PR DESCRIPTION
## Summary
Measured Zaal's real MCP usage across 629 session transcripts: ~150 MCP tool calls vs 12,834 total tool calls (1.2%). Native Bash/Edit/Read/Write does 99% of the work. Biggest unrealized win is Serena for code edits/refactors on the ZAOOS monorepo (60-80% token savings, benchmarked); add a context7 auto-invoke rule for the fast-moving Next.js 16 / React 19 / Wagmi / Tailwind v4 stack; disable 3 dead-weight servers (gitnexus, ECC memory, sequential-thinking) that have 0 real calls.

## Tier
STANDARD

## Sources
15 unique sources: Serena benchmarks (ManoMano 36K-line Java head-to-head, MangoDriod, Firman Hanafi, Arda), 6 "best MCP 2026" ranking lists (DevelopersDigest, Totalum, PromptWritingStudio, DEV, HackerNoon, buildtolaunch), context7 upstash README, 3 sequential-thinking deep dives. Ground-truth usage data from local transcripts.

## Next Actions
See doc Next Actions table - context7 CLAUDE.md rule, Serena adoption on next refactor, disable 3 dead servers, supabase read-only role audit, 30-day re-measure.