### PR TITLE
docs: commit leftover research (doc 801, 2 session handoffs, 791 edit)

### DIFF
--- a/research/agents/801-zoe-cowork-systems-audit-consolidation/README.md
+++ b/research/agents/801-zoe-cowork-systems-audit-consolidation/README.md
@@ -1,0 +1,191 @@
+---
+topic: agents
+type: audit + architecture-decision
+status: research-complete
+last-validated: 2026-05-29
+original-query: "Audit everything - ZOE, the cowork bot, the cowork dashboard. Where are we at, what can we use?"
+tier: DEEP
+related-docs: [288, 289, 669, 692, 717, 754, 759, 761, 762, 763, 765, 766]
+---
+
+# 801 - ZOE / Cowork Bot / Cowork Dashboard - Systems Audit + Consolidation Map
+
+> **Goal:** A single ground-truth audit of the three live ZAO agent/app systems - ZOE (concierge), the cowork bot (tracker agent), the cowork dashboard (Kanban web) - covering current state, what works, gaps, and a concrete reuse + consolidation map. Answers "where are we at, what can we use."
+
+## Executive summary
+
+Three systems, all LIVE:
+
+| System | Location | Deploy | Maturity | One-line |
+|--------|----------|--------|----------|----------|
+| ZOE | `ZAO OS V1/bot/src/zoe` | VPS `zaal@31.97.148.88`, systemd `zoe-bot`, @zaoclaw_bot | Most ambitious, least proven | Telegram concierge + cron scheduler + multi-agent dispatch + Farcaster caster |
+| Cowork bot | `ZAOcowork/agent` | VPS `root@187.77.3.104`, systemd `zaocoworking-bot` | Shipped, solid | Telegram tracker agent over the Supabase `tasks` table |
+| Cowork dashboard | `ZAOcowork` (Next.js) | Vercel `thezao.xyz` | Most polished | Kanban web UI over the same Supabase `tasks` table |
+
+Headline findings:
+1. **Two bots, one shape.** ZOE and the cowork bot independently re-implement the same four primitives: Letta-style memory blocks, claude-max CLI dispatch, Bonfire fire-and-forget spool, grammy polling + approval. Large duplication, ripe for a shared core.
+2. **The Supabase `tasks` table (project `etwvzrmlxeobinrlytza`) is the de-facto spine** - cowork bot + dashboard both read/write it. ZOE does NOT; it keeps its own `tasks.json`. Unifying ZOE onto that table is the single highest-leverage move.
+3. **Dashboard is the strongest product** (clean, no TODOs, steady ship cadence). Cowork bot is solid but untested. ZOE is the widest surface with the thinnest verification (untested concierge/scheduler/caster, relay never fired E2E).
+
+---
+
+## System 1 - ZOE (concierge bot)
+
+Repo: `ZAO OS V1/bot/src/zoe`. Entry `index.ts` (grammy polling as @zaoclaw_bot). Reasoning via Claude Code CLI subprocess.
+
+### Architecture (modules)
+- `index.ts` - entry; Telegram polling, routes DM/group/command; loads memory, recovers pending approvals, starts scheduler, attaches caster.
+- `concierge.ts:67` - one user turn: Claude CLI with memory blocks as context, parses JSON task/quest/relay ops from reply.
+- `memory.ts` - 4-block memory: persona.md (git-tracked voice), human.md (daily facts), recent/<chat_id>.json (history), tasks.json (queue), learnings/<worker>.md (runtime-only).
+- `decompose.ts:62` - goal -> DecompositionPlan (subtasks, deps, approval gates). Doc 759 Gap 1.
+- `dispatch.ts:36` - executes approved plan in dependency waves (Promise.allSettled), routes to workers/Hermes, records telemetry, honors approval gates. Gap 2.
+- `workers.ts:61` - per-worker runner for 8 agent types, tool lockdown, critic integration, cost caps.
+- `scheduler.ts` - cron: morning brief 09:00 UTC, evening reflection 01:00 UTC, hourly nudge, weekly learn 18:00 UTC Sun, posts. Devz-tip = Phase 4 stub.
+- `caster/index.ts` - Farcaster pipeline: draftCast (OpenRouter) -> Klearu PRE gate -> Telegram approval -> publishCast. Doc 761 Phase 2.
+- `farcaster/{write,signer,x402,read-node,event-stream}.ts` - Ed25519 sign + write-hub submit, Hypersnap read node, EIP-3009 USDC pay headers. Event-stream gated on FARCASTER_NODE_GRPC + CASTER_ENABLED=1.
+- `reflexion.ts` / `learn.ts` - evening reflection patches + weekly learning aggregation (runtime-only, never rewrites git). Gaps 4/5.
+- `recall.ts` / `relay.ts` - Bonfire bridge (write episodes, read w/ fallback) + cross-bot fire-forget relay (PR 727).
+- `approvals.ts` - PendingApproval state machine, TTL, restart recovery.
+- `critics/{research,comms,task-result}-critic.ts` - pluggable quality gates. Gap 3.
+- `safety/klearu.ts` - subprocess text/image classifier, fail-closed default.
+- `exec/ffx.ts` - FFX serverless STUB, throws unless FFX_VERIFY_OK=1.
+- `agents/{registry,ranker,guards,decay,newsletter,orchestrate}.ts` - Farcaster multi-agent registry/ranking/rate-limiting (Phase 3, dormant).
+
+### State - boot path
+- ALWAYS LIVE: Telegram polling, memory load, approval recovery, scheduler (brief/reflection/nudge/learn/posts), caster approval callback, Bonfire mirror per turn.
+- FLAG-GATED: caster event stream (CASTER_ENABLED=1 + FARCASTER_NODE_GRPC), Klearu (KLEARU_TEXT_CMD), FFX (FFX_VERIFY_OK=1).
+- DORMANT: Phase 3 multi-agent registry (built, not in boot path), devz-tip cron stub.
+
+### Works
+Concierge DMs, morning/evening loop, hourly nudges, per-group gating (/zg), plan decompose + dispatch with critics + cost caps, caster draft->safety->approval->publish, memory persistence, Bonfire mirroring, cross-bot relay emit, weekly learn cycle, posts scheduler.
+
+### Gaps / risks
+- Cross-bot relay has NEVER fired E2E (see doc handoff session-2026-05-29-zoe-phase2-bonfire-relay-smoke).
+- `agents/orchestrate.ts` imported but never called - multi-agent orchestration not actually live.
+- FFX unverified (private beta), throws by default.
+- Bonfire reads empty until admin labeling (doc 680).
+- Zero integration tests (unit tests only - see below). No coverage for concierge turn, scheduler, caster publish, Bonfire.
+- decompose.ts IS wired into dispatch but the concierge trigger path should be re-confirmed.
+
+### Tests
+`__tests__/`: agents, approvals, decompose, dispatch, learn, reflexion, sidequests. Meaningful unit tests on pure logic / data structures. No API/integration coverage. 11/11 agents tests pass.
+
+---
+
+## System 2 - Cowork bot (tracker agent)
+
+Repo: `ZAOcowork/agent` (~4500 LOC, no tests). Entry `src/index.ts` (grammy). Runtime Node 22 + tsx. Deploy VPS systemd `zaocoworking-bot`, America/New_York TZ. v2.5.
+
+### What it is
+Telegram concierge for the cowork action tracker. Reads/writes the unified Supabase `tasks` table (doc 692). Hermes pattern: per-message LLM subprocess (default claude-max). Proactive DMs via node-cron.
+
+### Architecture (modules)
+- `index.ts` - entry, grammy init, handler dispatch, 4096-char msg splitting.
+- `commands.ts` (~1050 LOC) - /start /mine /list /add /wip /blocked /done /assign /daily /setdue /setnote /setprio. Owner resolution Supabase > GitHub team.json > env.
+- `actions-store.ts` - Supabase wrapper: fetchActions/mutateActions, maps `tasks` rows to legacy ActionItem, UUID<->Owner enum.
+- `memory.ts` - 5-block Letta prompt (persona/human/working/tasks/actions) -> appendSystemPrompt.
+- `scheduler.ts` - cron: morning digest 06:00 ET, eod 17:00 ET, stale alert 09:00 ET, 4h nudge 8a-10p ET (Phase J). Sentinel files for idempotency.
+- `extraction.ts` - suggest-then-confirm: parse ```json-suggest, surface, execute on affirmative; supports bulk arrays + auto-confirm.
+- `users.ts` - per-user prefs (provider/model, BYOK keys, notify opt-out, quiet_until) at `~/.zaocoworking/users/<id>.json`.
+- `llm/{index,claude-max,claude-api,openai,minimax}.ts` - 4-provider dispatcher behind callLLM(). claude-max = local CLI subprocess, dontAsk, tools disallowed.
+- `roster.ts` / `supabase-roster.ts` - team.json (octokit, 5min TTL) + Supabase team_members (canonical post-713).
+- `notifications.ts` - per-channel opt-out DM dispatcher.
+- `transcripts.ts` - append-only jsonl archive + 20-turn ring buffer.
+- `teams/{bonfire,spool,types}.ts` - Bonfire episodes (doc 669) via jsonl spool + retry.
+- `juke-commands.ts` - /juke creates ZAO Live audio space via ZAOOS `/api/juke/space`.
+- `brands.ts` - parse/validate brand hashtags.
+
+### State
+Live v2.5. Recent: PR #33 Phase J /quiet + 4h nudges (2026-05-28). Steady velocity, no P1.
+WIP: Hermes v3 (bot opens PRs) deferred; BYOK encryption-at-rest; RLS not enforced.
+
+### Integrations
+Telegram (grammy, allowlists), Supabase (`etwvzrmlxeobinrlytza` tasks + team_members), GitHub (octokit roster), 4 LLM providers (claude-max default $0, +api/openai/minimax BYOK), Bonfires.ai (episodes, BONFIRE_ENABLED gate), ZAOOS Juke. Keys in `agent/.env` (chmod 600) + per-user json.
+
+### Gaps
+No RLS enforced, no rate limiting, no health endpoint, BYOK unencrypted (chmod 600 only), zero tests, no outbound webhooks on task change.
+
+---
+
+## System 3 - Cowork dashboard (Kanban web)
+
+Repo: `ZAOcowork` Next.js 15 + React 19 + Tailwind v3. Vercel `thezao.xyz`. Most mature, clean (no TODO/FIXME).
+
+### What it is
+Unified ops task tracker. TODO/WIP/BLOCKED/DONE Kanban. Six Sigma DMAIC, service classes, aging/cycle-time SLA, priority, due dates, approval flows. Owner badges, brand filter pills, per-column quick-add, TaskRoom edit modal.
+
+### Architecture
+- Routes `src/app/`: `page.tsx` (1231 LOC Kanban + public landing), `login`, `chat` (MiniMax board-aware), `admin/*` (users/brands/projects/triage/proposals/cleanup/feed), `todo/[id]` permalink, `api/{chat,digest,forecast,github/webhook,proposals}`.
+- Components: `Board.tsx` (1676 LOC), `TaskRoom.tsx` (916 LOC), `TodoPanel.tsx`, `Chat`, `FocusWidget`, `ForecastWidget`, `SlaGridChip`, `NavBar`, `NotificationBell`, `BulkActionBar`, 10 admin panels.
+- Data: `src/lib/data.ts` (Supabase service-role read/write, normalizeItem), `src/app/actions.ts` (1231 LOC server actions, requireSession auth), `src/lib/auth.ts` (password + HMAC httpOnly cookie, lead/worker roles).
+
+### Data model (the spine)
+Supabase `etwvzrmlxeobinrlytza`, `db/schema.sql` greenfield. Tables: `team_members`, `circles`, `circle_members`, `tasks` (uuid id, project, kind, title, status todo|in_progress|blocked|done, owner_id, created_by, category, priority, phase DMAIC, due, notes, completed_*, legacy_id, legacy_source, brands[], service_class, archived_at). `legacy_source` taxonomy enables multi-writer dedup: `cowork-actions.json` | `meeting:<slug>-<date>` | `pr-auto:<pr>` | `research-doc:<doc>` | `inbox:<msg>`.
+
+### State
+Live. Latest PR #33 (focus-widget brand-scope). Shipped phases: 1 (GitHub+HMAC), 2 (Supabase migrate), 2.5 (brands), F (Kanban best-practices doc 763), H (permalinks), I (projects doc 765), J (focus widget + 4h nudge). In flight: `ws/add-tyler-user`.
+
+### Gaps
+No realtime (stale reads across users), webhook secret validation unconfirmed, no saved views/subtasks/file-attach/metrics page/email notifications/keyboard-shortcuts/drag-drop (BACKLOG Phases 5-6).
+
+---
+
+## Cross-cutting finding: duplication
+
+ZOE and the cowork bot independently build the same four primitives:
+
+| Primitive | ZOE | Cowork bot | Note |
+|-----------|-----|-----------|------|
+| Memory blocks (Letta) | `memory.ts` (4-block) | `memory.ts` (5-block) | Same pattern, divergent block sets |
+| LLM dispatch | claude-max CLI only | `llm/` 4-provider + BYOK | Cowork is richer |
+| Bonfire spool | `recall.ts` / `relay.ts` | `teams/spool.ts` | Cowork retry queue more robust |
+| Telegram + approval | grammy + approvals.ts | grammy + extraction.ts | Both suggest/confirm |
+
+Two codebases, one shape. A shared `@zao/agent-core` package (memory, llm-dispatch, bonfire-spool, tg-approval) would cut maintenance in half and let each bot specialize.
+
+---
+
+## Reuse map (what we can use)
+
+**Take from cowork bot (battle-tested):**
+- `llm/` 4-provider dispatcher + per-user BYOK -> port to ZOE (ZOE is claude-max only).
+- `extraction.ts` suggest-then-confirm + bulk paste -> safer mutations everywhere.
+- `teams/spool.ts` Bonfire retry queue -> replace ZOE's lighter relay.
+
+**Take from ZOE (richer orchestration):**
+- `dispatch.ts` dependency-wave executor + approval gates -> cowork bot has no orchestration.
+- `workers.ts` 8-worker pluggable runner + tool lockdown + cost caps.
+- `critics/` quality-gate framework.
+- `caster/` + `farcaster/` (signer/write/x402) -> the only Farcaster implementation.
+- `reflexion.ts` / `learn.ts` self-improvement loop.
+
+**Take from dashboard (UI + data):**
+- `Board.tsx`, `TaskRoom.tsx`, `FocusWidget`, `ForecastWidget` -> extractable Kanban kit.
+- Supabase `tasks` schema + `legacy_source` multi-writer dedup -> the shared backbone.
+- HMAC cookie auth + `"use server"` mutation boundary.
+
+---
+
+## Biggest opportunity: unify ZOE onto the shared tasks table
+
+The Supabase `tasks` table already serves the cowork bot + dashboard. ZOE keeps a SEPARATE `tasks.json`. Wiring ZOE's task queue onto the shared table makes ZOE the reasoning brain over the same board the team already sees in the dashboard and edits via the cowork bot. ZOE's `legacy_source` would be e.g. `zoe:<chat>-<ts>`. This is the cleanest path from "three disconnected systems" to "one tracker, three surfaces (web / cowork bot / ZOE)."
+
+---
+
+## Gaps / risks roll-up
+- ZOE: relay unproven E2E; orchestrate.ts dead; FFX stub; no integration tests.
+- Cowork bot: no RLS, no rate limit, no health check, BYOK plaintext, zero tests.
+- Dashboard: no realtime, webhook secret unvalidated.
+- Shared: Bonfire reads dark until admin labeling (doc 680).
+
+## Recommended next actions
+1. Decide the consolidation thesis: extract `@zao/agent-core` (memory + llm + bonfire-spool + tg-approval) shared by both bots. (architecture decision)
+2. Wire ZOE onto the Supabase `tasks` table (retire ZOE's `tasks.json`), `legacy_source = zoe:*`. (highest leverage)
+3. Close ZOE Phase 2: fire the relay smoke test E2E (separate handoff bundle has the steps).
+4. Add a minimal test harness to the cowork bot (currently zero) before Hermes v3 PR-opening lands.
+5. Enforce Supabase RLS (doc 692 follow-up) now that three writers hit the table.
+
+---
+
+## Sources
+Internal codebase audit, 2026-05-29, three parallel read-only agent passes over: `ZAO OS V1/bot/src/zoe`, `ZAOcowork/agent`, `ZAOcowork` (web). Cross-referenced docs 669/692/717/754/759/761/762/763/765/766. Note: `cowork/` repo is DEPRECATED (moved to ZAODEVZ 2026-05-29); `thezao-tracker` is a stale clone of ZAOcowork.

--- a/research/business/791-charity-fund-token-mechanism-regen/README.md
+++ b/research/business/791-charity-fund-token-mechanism-regen/README.md
@@ -4,7 +4,7 @@ type: market-research
 status: research-complete
 last-validated: 2026-05-31
 superseded-by:
-related-docs: 674, 745, 790
+related-docs: 674, 745, 790, 794
 original-query: "/inbox - forwarded X post by +MemeForTrees: 'You can mint and redeem charity fund tokens here for 1USDC any time. If you hold a charity token you earn more of that charity token always redeemable 1:1 for USDC, while you hold a stream of funding is also going to the charity of your choice. For normies this still seems risky'"
 tier: STANDARD
 ---
@@ -33,6 +33,8 @@ Decoded mechanism (4 claims):
 4. **Self-aware risk flag** - the poster concedes "for normies this still seems risky", i.e. the UX/trust gap is unsolved.
 
 The mechanism is a **par-redeemable charity stablecoin with a yield + donation stream**. The open question (unanswered in the post): where does the "earn more" + "funding stream" yield come from? If from reserve yield (e.g. USDC lent / T-bill-backed), it is sustainable. If from token inflation or new mints, it is reflexive and fails.
+
+> **Update 2026-05-31 (Doc 794):** the actual mint/burn page (tasern.quest/fund/mint.html) answers this. Yield = Aave V3 USDC lending, split 33.33% holders / 33.33% Meme for Trees / 33.34% ops, principal redeemable 1:1 any time, immutable, no admin keys, "follows aUSDC legal precedent - deposit position, not a payment instrument." It is the SUSTAINABLE (reserve-funded) shape, and the charity vault is LIVE, not aspirational. See [Doc 794](../794-tasern-charity-vaults-refi-funding-pattern/).
 
 ## Who MemeForTrees is (grounding)
 

--- a/research/events/session-2026-05-31-cloud-resume-crm-orchestrator/README.md
+++ b/research/events/session-2026-05-31-cloud-resume-crm-orchestrator/README.md
@@ -1,0 +1,66 @@
+# Session handoff - 2026-05-31
+
+> from: Zaal mac (`~/Documents/ZAO OS V1`, iCloud-corrupted) -> to: fresh Claude Code CLOUD terminal
+> doc: research/events/session-2026-05-31-cloud-resume-crm-orchestrator/README.md
+> chain: sibling:research/events/session-2026-05-30-bonfires-kernel-deep-dive/README.md
+
+## Receiver instructions (read me FIRST, then do exactly this)
+
+You just received a handoff bundle. Do NOT start work yet:
+
+1. **CLONE FRESH. Do NOT pull the mac repo.** The source mac repo lives in `~/Documents`, which is iCloud-synced, and iCloud corrupted `.git` four times last session (truncated packfiles, broken `refs/stash 2`, dup `* 2.*` files). On a cloud container this is moot - just `git clone https://github.com/bettercallzaal/ZAOOS.git` clean. Everything below is pushed to origin; a fresh clone loses zero committed work.
+2. Read sections A-E before acting.
+3. Section C has NO diff to apply - clone fresh instead. All work is on origin in branches/PRs.
+4. Create TaskList entries from section A.
+5. Use section B as your "why" - do not re-litigate.
+6. Note the VPS SSH caveat (section D) before attempting any VPS command.
+7. Message back: "Ingested handoff cloud-resume-crm-orchestrator. N tasks queued. Ready."
+
+## A. Tasks to absorb (most are GATED on Zaal - check the gate)
+
+- [ ] (Zaal) **Verify + merge PR #745** - DM `@zaoclaw_bot` `plan: test routing` (expect "Decomposing into a routed plan - one moment.") + a recall question (e.g. "what do you remember about ZAOstock") to confirm the superseding orchestrator + recall work live. If good, merge #745. It's MERGEABLE (conflicts resolved this session).
+- [ ] (Zaal) **Merge PR #746** (doc 775 - 2026 capability synthesis) + **close PR #735** (Fileverse `#k=` is a public share key, not a secret - nothing to fix).
+- [ ] (VPS SSH) **After #745 merges: redeploy main to VPS** - `ssh zaal@31.97.148.88 'cd ~/zao-os && git fetch origin && git reset --hard origin/main && systemctl --user restart zoe-bot'`. Use `reset --hard origin/main`, NOT `git pull` (pull gets blocked by a dirty package-lock). VPS is currently on the `claude/amazing-cray-11bSV` (#745) branch ahead of main - this fast-forwards it clean.
+- [ ] (Zaal) **Apply `scripts/20260529_crm.sql`** in the Supabase SQL editor (no CLI on the box). Unblocks CRM live QA.
+- [ ] (Zaal + VPS SSH) **Set `CRM_BOT_SECRET`** (Vercel app env + VPS `~/zao-os/bot/.env`, same value) + **`CRM_API_URL=https://zaoos.com`** (VPS bot env) so ZOE can write to the CRM.
+- [ ] (Claude, after migration + secrets) **CRM end-to-end QA** - bot write, /crm admin dashboard, /network public feed, visibility enforcement.
+- [ ] (Claude, optional) **#6 Bonfire episode emit on public CRM interactions** - deferred, needs a design call (app-side poster + PII scan; `bonfire_episode_id` column already in schema).
+- [ ] (Zaal, optional) **Allow `@zabal_bonfire_bot`** in ZAO Civilization (app.bonfires.ai) - recall already works without it.
+- [ ] (Zaal, recommended) **Relocate the mac repo out of iCloud** to `~/dev/ZAOOS` (fresh clone) if you keep using the mac at all - otherwise corruption recurs. Moot if you stay on cloud.
+
+## B. Why - decisions + friction + ruled-out paths
+
+- **iCloud corrupts `.git`.** The mac repo is in `~/Documents` (iCloud-synced). iCloud copies `.git` files mid-write -> truncated packfiles + `* 2.*` dup artifacts (saw `.git/gc 2.pid`). Hit 4x: broken `refs/stash 2`, 2 corrupt packs (fixed via `git fetch --refetch` with `http.postBuffer 1048576000`), corrupt `node_modules/vitest` config (broke local `vitest`). FIX: work on cloud (clean) or relocate off `~/Documents`. This is the single biggest friction source - do not re-discover it.
+- **ZOE recall: root cause was the WRONG ENDPOINT, not labeling.** `recall.ts` used `POST /vector_store/search` (empty for this bonfire) instead of `POST /delve {bonfire_id, query}` (the SDK's real graph path, returns 51 episodes for "What is ZAO?"). The "needs admin labeling / doc 680" belief was wrong - labeling is platform-internal. Fixed (PR #740, merged) + WIRED into the concierge (PR #744, merged) as a `<bonfire_recall>` RAG block per DM turn. Proven live: journal showed `[zoe/recall] delve: 5 hit(s)`.
+- **PR #745 supersedes the already-merged-and-live #733.** Both implement the doc-770 orchestrator HIGH fixes; #745 is fuller (pure `commands.ts` predicates + all H1-H5 + 6 test files). Zaal chose resolve-and-supersede. Resolved 5 conflicts: 4 orchestrator files took #745's version; index.ts is a union (#745 structure + main's recall/CRM/relay wiring). Removed dead `isCommandPrefixed` (#745 uses `isZoeCommand`). Bot `tsc` clean. Deployed to VPS branch + boots clean. Behavioral verify (plan:routing) is the open gate.
+- **CRM auth model: NO Supabase Auth.** ZAOOS uses iron-session + service-role. Private layer enforced at app layer (isAdmin + service-role reads); anon only sees curated SECURITY DEFINER views; RLS denies anon on base tables. Differs from doc 772's first-draft `auth.uid()` design. Tables are `crm_contacts`/`crm_interactions` (crm_ prefix to avoid the dormant legacy `contacts` table).
+- **Bonfires FCG kernel is proprietary** (0 public NERDDAO code); substrate is the getzep/graphiti fork (GLiNER2 + Gemini + Neo4j bi-temporal). BUT the live API (190 endpoints) exposes typed intake (`/knowledge_graph/add_triples`, typed `/entity`+`/edge`, `/ontology/*`) - so ZAO is not stuck with prose episodes. Doc 771 corrected (trimtab is NOT the kernel - it's Tracery/n-gram/HDBSCAN). Highest-leverage next build per doc 775 = typed-triple ingestion.
+- **VPS SSH is the only mac-tether.** All VPS work goes through `ssh zaal@31.97.148.88`. A cloud container needs that key added once before it can run VPS commands; else Zaal runs them with `!` or from the mac.
+- **Use `git reset --hard origin/main` to redeploy the VPS, never `git pull`** - pull gets blocked by a dirty `bot/package-lock.json` on the box (discovered when a "merged all PRs" deploy silently left the VPS on stale main running the old recall code).
+
+## C. Git state
+
+- Source mac repo is iCloud-CORRUPTED - do not pull it. Clone fresh from `https://github.com/bettercallzaal/ZAOOS.git`.
+- All work is on origin. Open PRs: **#745** (orchestrator, MERGEABLE), **#746** (doc 775), **#735** (Fileverse key - close it). Merged this session: #733, #736 (doc 771 fix), #739 (CRM code), #740 (recall fix), #741 (doc 771 API findings), #744 (recall wiring).
+- Untracked on the mac (NOT committed, will not survive a fresh clone - mostly other sessions' WIP, low value): `research/agents/770-zoe-cowork-systems-audit-consolidation/`, `research/dev-workflows/2027-*`, `research/farcaster/2027-*`, prior session bundles. If any matter, they're on the mac only.
+
+## D. In-flight
+
+- Background bash jobs: none active.
+- VPS state: on branch `claude/amazing-cray-11bSV` (#745) at `6b873600`, booting clean. Redeploy main after #745 merges.
+- Open PRs awaiting Zaal: #745, #746, #735.
+- Scheduled wakeups: none. Open AskUserQuestion: none.
+
+## E. Cold-start map
+
+- Files touched this session (all pushed): `bot/src/zoe/{recall,concierge,index,types,crm,memory,relay}.ts`, `bot/src/hermes/claude-cli.ts`, `bot/src/zoe/{dispatch,scheduler,workers,commands}.ts` (via #745 merge), `src/app/{network,crm}/**`, `src/app/api/crm/interactions/route.ts`, `src/lib/crm/types.ts`, `src/lib/env.ts`, `scripts/20260529_crm.sql`, docs `research/identity/771-*`, `research/business/772-*`, `research/agents/{773,775}-*`.
+- Skills invoked: `/zao-research` x2 (docs 772, 775), `/clipboard`, `/handoff` (this).
+- Memory writes: `project_bonfire_delve_recall` (new - recall via /delve not vector_store).
+- Last-known mental model: Huge session - shipped CRM (Supabase-native), fixed + wired ZOE recall (live + proven), corrected doc 771, resolved PR #745 (supersedes live #733, deployed to VPS branch), wrote capability-synthesis doc 775. Everything is on origin in PRs. The remaining work is mostly Zaal merging PRs + applying the CRM migration + setting 2 secrets; then Claude runs CRM QA. The mac repo is iCloud-corrupted - resume on cloud with a fresh clone.
+- Open questions for receiver: none blocking - just wait on Zaal's merges/migration/secrets, then proceed.
+
+## Inline copy-paste block (for fast receiver paste)
+
+```
+Ingest the bundle at /Users/zaalpanthaki/Documents/ZAO OS V1/research/events/session-2026-05-31-cloud-resume-crm-orchestrator/README.md and follow receiver instructions at the top. Clone fresh (mac repo is iCloud-corrupted). ~9 tasks, most gated on Zaal.
+```

--- a/research/events/session-2026-05-31-zabal-submission-backend/README.md
+++ b/research/events/session-2026-05-31-zabal-submission-backend/README.md
@@ -1,0 +1,72 @@
+# Session handoff - 2026-05-31 13:20
+> from: ZAO OS V1, branch `ws/meeting-784` (mac) -> to: fresh CC terminal (same mac)
+> doc: research/events/session-2026-05-31-zabal-submission-backend/README.md
+> chain: none
+
+## Receiver instructions (read me FIRST, then do exactly this)
+
+You just received a handoff bundle. Do NOT start work yet. Do this:
+
+1. Read ALL sections below (A through E) before responding to anything.
+2. Section C has NO uncommitted diff - the prior work (doc 784) is committed + pushed. Nothing to `git apply`.
+3. Create TaskList entries from section A. These are the "to do" items.
+4. Use section B as your "why" - do NOT re-litigate decisions captured there unless new info surfaces.
+5. Use section D to know what is still open (PRs awaiting merge, the Ryan Kagy conflict).
+6. Use section E as your cold-start map for files, the architecture doc, memory state.
+7. Read `research/events/784-plat0x-bonfire-zabal-architecture-may29/README.md` IN FULL before writing any code - it is the architecture spec. This bundle summarizes it; that doc is the source of truth.
+8. Once integrated, message back: "Ingested handoff zabal-submission-backend. 5 tasks queued. Ready."
+
+## A. Tasks to absorb (paste these into your TODO list)
+
+- [ ] **Locate / confirm the ZABAL Games repo.** Zaal said he would build this "into the ZABAL Games repo." Confirm where it lives (likely a separate `zabalgames` / `zabal-games` repo under the bettercallzaal org, NOT ZAOOS - this graduates out). Ask Zaal if not obvious. Everything below lands there.
+- [ ] **Build the registration server.** A thin HTTP service: `POST /register {wallet, github_repo}` -> persists a `{wallet -> github_repo}` mapping (a JSON file or a small Supabase table is fine for v1). Idempotent on wallet. Returns 200. That is the entire write surface.
+- [ ] **Build the commit-watcher cron.** For each registered repo, detect new commits since the last-seen SHA (store last-seen per repo), pull the new commit messages + changed MD/report files, and create a Bonfire episode per batch. Reuse the POST shape in `~/.claude/skills/meeting/scripts/bonfire-episode.sh` (`POST /knowledge_graph/episode/create`, Bearer `$BONFIRE_API_KEY`, `$BONFIRE_ID`). Hourly or daily.
+- [ ] **Write the builder skill file.** A skill the builder drops into their own harness (Hermes / Codex / Claude). It does NOT call the Bonfire API. It instructs the agent to: (1) push work to GitHub with the builder's wallet address/hash in an MD file, (2) make ONE call to the register endpoint. That is it.
+- [ ] **Send the working scaffold to Plat0x + prep the July 1 LLMS.txt** (stretch). Plat0x (Carlos) is the Bonfires architect; he expects this back. The LLMS.txt = all ZAO brand info + assets, builders point their harness at it before open submission.
+
+## B. Why - decisions + pivots + ruled-out paths
+
+- **GitHub is the source of truth for builder work; Bonfires is the graph.** Decided with Plat0x (doc 784). Custom build shrinks to TWO things: the register-list + the scheduled push. Graph construction is already solved by pushing to Bonfires - do NOT build graph/indexing logic.
+- **The skill must NOT call the Bonfire API directly.** Intentional separation: builders push to GitHub + register once; the server-side cron is the only thing that talks to Bonfires. This keeps builder setup trivial and keeps API keys server-side.
+- **Builders bring their own harness + keys.** Cost scales with them, not Zaal. The skill assumes the builder already has Hermes/Codex/Claude + their own tokens.
+- **This IS the backend for the GitHub-auth judging committed with Tyler in doc 778.** Same system - do NOT build a second judging path. Signup (wallet/Farcaster + GitHub auth) -> commits scored. 784 is the how.
+- **Judging = Bonfire's existing rubric-agnostic pipeline.** Do NOT rebuild ranking. You feed it contributions + a rubric (uniqueness, integrity, etc.); it ranks. Ties into the ZAO Fractal Respect model (agent ranks vs criteria instead of humans voting).
+- **Knowledge-gathering phase = reports, not code.** Builders write reports to GitHub; indexed into the graph; the game is "whose reports get cited most" in the agent's daily summaries. This widens the audience beyond developers - keep the design report-friendly, not code-only.
+- **UNRESOLVED CONFLICT - do not assume:** Zaal said Bonfires founder = Josh, Carlos = Plat0x (team), Ryan Kagy = just associated. This contradicts prior docs 648/669/682 which call Ryan the founder + describe an "Option B" partnership (adopt Ryan's framework, Zaal helps fund). Flagged in `project_ryan_kagy` memory. Do NOT build on the Option B partnership premise until Zaal reconciles who is actually the Bonfires principal.
+- **Bonfire dependency risk:** the judging + graph are Bonfires-owned. Before building the whole submission flow on it, consider a "what if Bonfires changes terms / goes away before July" fallback. Not blocking v1, but note it.
+
+## C. Git state
+
+- Branch: `ws/meeting-784` (clean - all work committed)
+- Push status: PUSHED. PR #758 open (doc 784). No uncommitted diff.
+- This session shipped 6 PRs off `main`, all open awaiting merge: #748 (776/777), #749 (778... see note), #752 (780), #755 (782), #756 (783), #758 (784). The new build work has NOT started - it is all in Section A.
+- Untracked: pre-existing iCloud `" 2"` dupe files (ignore - not this session's).
+
+## D. In-flight
+
+- Background bash jobs: none running.
+- Subagents pending: none.
+- Scheduled wakeups: none.
+- Open AskUserQuestion: none.
+- **Open PRs awaiting Zaal merge:** the 6 meeting-recap PRs above. The build work does not depend on them merging.
+- **Open decision for Zaal:** the Ryan Kagy / Josh / Plat0x founder reconciliation (see Section B).
+
+## E. Cold-start map (read if you are confused)
+
+- **THE spec to read first:** `research/events/784-plat0x-bonfire-zabal-architecture-may29/README.md` (tier DEEP) + its `transcript.md`. This bundle is a summary; that is the source.
+- **Three-rail context for ZABAL Games:**
+  - Magnetic (identity / front door / 67-person email list) - docs 778, 783, memory `project_zabal_games_magnetic_build`
+  - Bonfires (graph + judging + knowledge-game) - doc 784, memory `project_plat0x_bonfire_zabal_architecture`
+  - Empire Builder (a buildable surface) - doc 780, memory `project_adrian_empire_builder`
+- **Files touched this session:** 6 meeting recap docs (776, 777, 778, 780, 782, 783, 784) + transcripts under `research/events/`; the `_meetings-index.md`; the `/meeting` skill improvement (doc 781 + edits to `~/.claude/skills/meeting/` scripts: new `trim-loops.sh`, transcribe/extract-frames/append-actions edits, SKILL.md).
+- **Skills invoked:** `/meeting` x6, `/clipboard` (running master at `~/.zao/meeting-top3-master.html`, slug `meeting-top3-master`), `/handoff` (this).
+- **Memory writes (new):** `project_plat0x_bonfire_zabal_architecture`, `project_ven_open_machine`, `project_adrian_empire_builder`, `project_telamon_edge_esmeralda`, `project_duo_do_musicians`, `project_zabal_games_magnetic_build` (updated), `project_ryan_kagy` (conflict flag added), `feedback_meeting_top3_master_clip`.
+- **Bonfire reference for the cron:** `~/.claude/skills/meeting/scripts/bonfire-episode.sh` - copy its POST shape + env loading (`~/.zao/zao.env` -> `BONFIRE_API_KEY`, `BONFIRE_ID`). Recall is via `POST /delve {bonfire_id, query}` (doc 740, memory `project_bonfire_delve_recall`).
+- **Last-known mental model:** ZABAL Games now has all three rails defined. The Bonfires rail (this build) is the unblock for the June workshops + July judging. The build is small by design - a register endpoint + a commit-watching cron that pushes to Bonfires. Plat0x is waiting on the scaffold.
+- **Open questions for the receiver:** (1) Which repo is "the ZABAL Games repo"? (2) JSON file or Supabase for the register list in v1? (3) Reconcile the Ryan Kagy founder question with Zaal before leaning on any Bonfires partnership terms.
+
+## Inline copy-paste block (for fast receiver paste)
+
+```
+Ingest the bundle at /Users/zaalpanthaki/Documents/ZAO OS V1/research/events/session-2026-05-31-zabal-submission-backend/README.md and follow receiver instructions at the top. 5 tasks to absorb. Read research/events/784-plat0x-bonfire-zabal-architecture-may29/README.md in full first.
+```


### PR DESCRIPTION
Cleanup of uncommitted work left in the tree from prior sessions. Doc 801 = ZOE/cowork systems audit (renumbered from a 770 collision). Two May-31 session handoffs. Small edit to doc 791. Also deleted 13 iCloud conflict-dupe files and a stray .git/gc 2.pid from the working tree (untracked, not in this diff).