### PR TITLE
CLAUDE.md: context7 auto-rule + Serena-for-edits (doc 801/802 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,12 @@ Env vars: see `.env.example`. App wallet: `npx tsx scripts/generate-wallet.ts`.
 
 See [Doc 154](research/154-skills-commands-master-reference/) for complete reference. Key commands: `/worksession`, `/z`, `/qa`, `/ship`, `/review`, `/zao-research`, `/autoresearch`, `/vps`.
 
+## MCP Tooling (see Doc 801 audit, Doc 802 starter guide)
+
+- **context7 (auto):** Always use context7 for library/API docs, code generation, setup, or config steps on Next.js, React, Wagmi, Viem, Supabase, or Tailwind - without being asked. Query it like a search ("Next.js 16 App Router middleware matcher config"), not a library name. Kills hallucinated APIs on the fast-moving stack.
+- **Serena for code edits:** Use Serena's symbol tools (`find_symbol`, `replace_symbol_body`, `find_referencing_symbols`, `rename_symbol`) for editing/refactoring ZAOOS code instead of whole-file Read/Edit - 60-80% fewer tokens, reference-safe renames. Use native Read/Grep only for quick read-only lookups.
+- **Disabled (do not propose):** gitnexus, ECC memory, sequential-thinking - 0 use, pure context cost.
+
 ## Primary Surfaces (post-doc-601 cleanup, 2026-05-04)
 
 ZAO operating surfaces collapsed from 12+ systems to 5. When proposing automation or new bots, check this list first.


### PR DESCRIPTION
Adds an MCP Tooling section to CLAUDE.md: context7 auto-invoke on the fast-moving stack, Serena symbol tools for code edits, and a do-not-propose list (gitnexus/ECC-memory/sequential-thinking). Implements the open follow-ups from doc 801 (MCP audit) + 802 (starter guide). Serena verified live this session - traced getSession across ~17 call sites in one call.