### PR TITLE
docs: 802 UPDATES - cowork MCP + tracker cleanup (2026-06-06)

### DIFF
--- a/research/dev-workflows/802-zao-skill-stack-starter-guide/UPDATES.md
+++ b/research/dev-workflows/802-zao-skill-stack-starter-guide/UPDATES.md
@@ -26,3 +26,21 @@ Format per entry: `## YYYY-MM-DD - <what changed>` + what / why / where the conf
 - Archive `fractal`/`design`/`cold-outreach` (marginal).
 - Research-skill overlap (zao-research vs bcz/bandz/autoresearch/last30days) - collapse to zao-research front door.
 - context7 auto-invoke rule still to add to CLAUDE.md.
+
+---
+
+## 2026-06-06 - Read-only cowork MCP + tracker cleanup
+
+**New MCP: `supabase-cowork` (read-only).** Added to `~/.claude.json` global `mcpServers` + permitted in `~/.claude/settings.json`:
+```
+https://mcp.supabase.com/mcp?project_ref=etwvzrmlxeobinrlytza&read_only=true
+```
+The official Supabase MCP pointed at the cowork tracker project, read-only. No bespoke server built (would have been the thin-wrapper anti-pattern doc 801 warns against). Verified live: SELECT returns task rows; UPDATE rejected with "cannot execute UPDATE in a read-only transaction". Note: `read_only=true` sandboxes SQL writes but still exposes Supabase management tools (branch/edge-function/migration) - optional hardening is `&features=database,docs` to drop them.
+
+**Tracker cleanup - 98 stale tasks closed.** Cowork tracker (project etwvzrmlxeobinrlytza, `public.tasks`) had 407 rows, 354 todo, 115 overdue. Closed 98 as `done` (reversible, history kept): todo 354 -> 256, done 41 -> 139, overdue 115 -> 19. Buckets: 39 `pr-auto` (PRs long merged) + 36 overdue `research-doc` (docs shipped) auto-cruft, then the overdue `meeting` + `cowork-actions.json` set reviewed oldest-first one by one. The 19 overdue remaining were all explicitly KEPT (cold-outreach cluster, Leeward a-g, ZAOscribe, Magnetiq videos, ElizaOS decisions, etc - real open work). 273 non-overdue `cowork-actions.json` backlog untouched. Writes went through `~/bin/zao-tracker` service key (MCP is read-only by design).
+
+**Stack changes from CLAUDE.md / config (now merged):** PRs #780 (doc 801), #782 (doc 802 + this UPDATES), #783 (CLAUDE.md context7 + Serena rules) all merged to main. Serena verified live (traced getSession across ~17 call sites). ECC skill prune live (200 unique skills off). Corruption memory updated with the definitive iCloud root cause (Documents was iCloud-synced -> "file 2" conflicts inside .git; fixed by turning sync off + moving 41 repos to ~/Desktop/repos).
+
+**Systemic fixes surfaced (not yet done):**
+- Tracker writers not idempotent on `legacy_id` - `meeting-1..5` each inserted twice; `232`/`closeout-a` and `234`/`closeout-d` are the same task from two sources. Fix: unique constraint or upsert in `~/bin/zao-tracker`.
+- `pr-auto` + `research-doc` auto-tasks are created on PR/doc creation but never auto-closed on merge - that's why 75 cruft tasks accumulated. Fix: auto-close on merge.


### PR DESCRIPTION
Appends the 2026-06-06 entry to doc 802's UPDATES log: the read-only `supabase-cowork` MCP, the 98-task tracker cleanup (354->256 todo, history preserved), and 2 systemic fixes surfaced (idempotent tracker writes; auto-close pr-auto/research-doc on merge). Per the ship-stack-changes-to-starter-guide rule.