### PR TITLE
doc 804: Colorado Artist Company Act / A-Corp research (STANDARD tier)

### DIFF
--- a/research/business/804-colorado-artist-corporation-acorp/README.md
+++ b/research/business/804-colorado-artist-corporation-acorp/README.md
@@ -1,0 +1,107 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-06
+superseded-by:
+related-docs: 612, 333, 622, 499, 051
+original-query: "Research the Colorado Artist Company Act / Artist Corporation (A-Corp) - the first US legal structure built for artists, signed into law by Gov. Polis June 2026. Source: Yancey Strickler / Metalabel Studios newsletter. What it is, the mechanics, and what it means for ZAO."
+tier: STANDARD
+---
+
+# 804 - Colorado Artist Company Act (A-Corp): first US legal structure built for artists
+
+> **Goal:** Understand the Colorado Artist Company Act (SB 26-133) and decide how The ZAO, BCZ Strategies, and ZAO-incubated artist projects should relate to it - as a future formation vehicle, a template to track, or both.
+
+## Key Decisions
+
+| # | Decision | Status |
+|---|---|---|
+| 1 | TRACK the A-Corp as the most ZAO-aligned legal primitive yet shipped in the US. Its three pillars (51% artist control locked in statute, IP reversion on dissolution, economic-rights-split-from-governance) are a near-exact legal mirror of ZAO's "artists keep ownership + outsiders fund without controlling" thesis. | DECIDED |
+| 2 | DO NOT form anything yet. First filings are not possible until early 2027 - the law is signed but the Colorado Secretary of State filing system and fill-in-the-blank forms do not exist until July 1, 2027. There is nothing to file before then. | LOCKED by statute |
+| 3 | A-Corp does NOT replace BCZ Strategies LLC (Delaware). Different jobs: BCZ Strategies = Zaal's commercial/legal hub; an A-Corp would be a Colorado-registered artist-mission vehicle. The ZAO itself still has no legal entity (per [[project_zao_brand_legal_architecture]]) - the A-Corp is a candidate for that gap, not for the existing LLC. | DECIDED |
+| 4 | PRE-REGISTER at artistcorporations.com to get in the filing queue + the educational sessions (ownership, governance, IP, tax) the foundation is running through 2026. Free, low-effort, first-in-line when filing opens. | ACTION - @Zaal |
+| 5 | Watch the 51% constraint before recommending it to any ZAO artist raising real outside capital. The hard floor makes it unsuitable for ventures that need to dilute artists below majority - same constraint that killed the only formal opposition's "just use a normal LLC" argument also caps its fundraising ceiling. | NOTED |
+
+## What it is (one paragraph)
+
+The Colorado Artist Company Act (Senate Bill 26-133) was signed by Governor Jared Polis on June 2, 2026 and takes effect August 12, 2026. It creates the "Artist Company" / "A-Corp" - the first US legal entity built specifically for how artists work. It is not a new corporate form from scratch; it is a dedicated part bolted onto Colorado's existing LLC statute (Part 12, C.R.S. Section 7-80-1201 et seq.), so it inherits LLC liability protection and tax flexibility while rewriting the default rules around artist control and IP. The Artist Corporations Foundation (led by Yancey Strickler of Metalabel and Lena Imamura) drove the two-year campaign; 5,000+ artists signed up to form one before it was law.
+
+## The three mechanics that matter
+
+### 1. 51% artist voting control, locked in statute
+
+Artists must hold at least 51% of all voting securities at all times. This is in the statute itself and cannot be overridden by the operating agreement - unlike a standard LLC where governance follows capital. Permitted entity designations: ALLC, ACORP, AC, or A.C.
+
+- **Why it matters for ZAO:** this is the legal version of ZAO's incubator thesis ([[project_zao_incubator_model]]) - community/artist cofounders keep control, the platform/investors do not take the wheel.
+- **The catch:** it is a hard ceiling on dilution. Any raise that would push artists below 51% is impossible inside an A-Corp. Best for artist-controlled creative businesses, not VC-scale plays.
+
+### 2. IP reversion on dissolution
+
+Artistic work assigned to an A-Corp retains a reversionary interest that is never fully transferred. On dissolution the work reverts automatically, by operation of law, to the creating artist. Creditors cannot seize it; non-artist investors cannot claim it. For joint works, parties specify reversion terms or federal IP co-ownership law applies. Departed members keep continuing royalty rights for work made during membership.
+
+- **Why it matters for ZAO:** directly relevant to ZAO Music ([[project_zao_music_entity]]), catalog ownership, and any music-NFT / distribution work. The nightmare scenario of "the label/entity dies and the catalog gets locked up by creditors" is statutorily prevented.
+
+### 3. Economic rights separated from governance rights
+
+Investors can hold distributions, royalties, revenue participation, and recoupment rights without getting any voting power or creative control. This is the A-Corp default rule, not custom drafting. Artists can also contribute existing catalogs as in-kind capital contributions, taking ownership based on the value of creative work rather than cash (independent valuation available at company expense on dispute). A-Corps accept grants, refundable grants, debt, equity, convertibles, program-related investments, royalty sharing, and in-kind IP.
+
+- **Why it matters for ZAO:** this is the cleanest legal articulation yet of the model ZAO has been approximating with tokens, Respect, and fractional ownership ([[project_four_pillars]], fractional-ownership-at-formation). It lets a band, film crew, or studio set ownership that matches who made the work - exactly the "ownership reflects reality" framing.
+
+## Variant: Public Benefit A-Corp
+
+Adds a formal public-benefit commitment on top. Managers must balance four things: member financial interests, the interests of those materially affected, the stated public benefits, and the artistic mission - with mandatory annual reporting. Positions the entity for B Corp certification. This is the variant closest to The ZAO's "decentralized impact network" self-description ([[project_zao_canonical_pitch]]).
+
+## Comparison to structures ZAO already uses or considered
+
+| Structure | Artist control | IP reversion | Econ/governance split | ZAO status |
+|-----------|---------------|--------------|----------------------|------------|
+| Standard LLC (BCZ Strategies, Delaware) | None by default; follows capital | No | Custom drafting only | LIVE - commercial hub |
+| AutoCo / on-chain LLC | None by default | No | Custom | Evaluated [[Doc 612]] for ZAO Festivals |
+| Nonprofit / fiscal sponsorship (NMC + Fractured Atlas) | N/A | No | N/A | LIVE for donations [[project_nmc_fractured_atlas]] |
+| Worker cooperative (CO law) | Member-based | No | Partial | Not used |
+| Benefit Corp | None by default | No | Custom | Not used |
+| **Colorado A-Corp** | **51% locked in statute** | **Yes, automatic** | **Default rule** | **Track / candidate for The ZAO entity** |
+
+The A-Corp is the only row that delivers all three ZAO-aligned properties as defaults rather than as expensive custom drafting.
+
+## The dissent (community / practitioner source)
+
+The bill drew one formal opponent at hearing: attorney Herrick Lidstone, speaking partly for the Colorado Bar Association, who testified "This statute is completely and totally unnecessary" and "There is nothing that the statute provides that cannot be done with an existing limited liability company." The Cardozo Arts and Entertainment Law Journal analysis adds the "Wall Street Rule" critique: shareholders can still "vote with their wallets" and sell, so it is contested whether governance can be truly separated from economics in practice, and individual investors might try to circumvent the 51% floor by claiming artist status.
+
+This dissent is real but cuts the ZAO way: the value of the A-Corp is not that it does something impossible in a normal LLC - it is that it makes the artist-protective defaults statutory and cheap, so an artist does not need a Susan Mac Cormac-tier lawyer to get them. For a 188-member community of independent artists, "you do not need an expensive lawyer to get artist-first defaults" is the whole point.
+
+## ZAO relevance summary
+
+- **Geography gate:** A-Corp is a Colorado registration. The ZAO is Maine/Delaware-centered. Forming one means a Colorado-registered entity (registered agent etc.) - non-trivial but not blocking; many out-of-state founders register in artist-friendly states the way they register in Delaware now.
+- **Best near-term ZAO use:** as a template and a tracked signal, not an immediate filing. Expect copycat bills in other states; ZAO should watch for a Maine or Delaware equivalent.
+- **Best long-term ZAO use:** candidate vehicle for the still-missing "The ZAO" legal entity ([[project_zao_brand_legal_architecture]]), specifically the Public Benefit A-Corp variant, once filing opens in 2027.
+- **Individual-artist use:** ZAO-incubated artists (WaveWarZ team, ZAO Music releases, festival artists) could each form their own A-Corp to hold catalog with reversion protection - a concrete piece of "ecosystem primitives for any digital creator" ([[project_zao_12mo_vision]]).
+- **Codebase touchpoint:** none yet. `community.config.ts` holds the current entity/brand/contract config; if ZAO ever forms an A-Corp, the entity reference would surface there alongside the existing BCZ Strategies / contract addresses.
+
+## Also See
+
+- [Doc 612](../612-autoco-llc-formation/) - AutoCo vs traditional LLC for ZAO Festivals (the prior legal-vehicle decision)
+- [Doc 333](../333-ai-music-licensing-sync-label-deep-dive/) - label / catalog / licensing structure
+- [Doc 622](../../community/622-impact-networks-david-ehrlichman/) - impact-network governance framing
+- [Doc 499](../../events/499-music-festival-collective-governance/) - collective governance for festivals
+- [Doc 051](../../community/051-zao-whitepaper-2026/) - ZAO whitepaper / ownership thesis
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Pre-register at artistcorporations.com to join filing queue + educational sessions | @Zaal | Web signup | This week |
+| Add "Maine / Delaware artist-company equivalent?" to the legal-watch list; set reminder to re-check state copycat bills | @Zaal | Watch / calendar | Quarterly |
+| Decide if The ZAO entity gap should be filled by a Public Benefit A-Corp vs Delaware PBC vs status quo | @Zaal | Decision (revisit when CO filing opens early 2027) | Q1 2027 |
+| Flag A-Corp + IP-reversion to ZAO Music / WaveWarZ artists as a catalog-protection option | @Zaal | Comms | After CO forms go live |
+| Re-validate this doc when Colorado SoS publishes the fill-in-the-blank forms (statutory deadline July 1, 2027) | @Zaal | Doc update | Jul 2027 |
+
+## Sources
+
+- [FULL] User-provided primary: Yancey Strickler / Metalabel Studios newsletter, "The first legal structure for artists in America is now law" (03 Jun 2026) - pasted in full, the seed for this doc.
+- [FULL] [Artist Corporations - artistcorporations.com](https://www.artistcorporations.com/) - official initiative site; 51% rule, IP reversion, fractional units, formation timeline, foundation leads (Strickler + Lena Imamura), 4,000+ pre-registered.
+- [FULL] [Colorado Just Invented the Artist Company - jason wiener p.c.](https://jrwiener.com/colorado-just-invented-the-artist-company-and-it-changes-so-much-for-creators/) - practitioner legal analysis; statute Part 12 C.R.S. Sec. 7-80-1201, mechanics, Public Benefit variant, dates, designations ALLC/ACORP/AC/A.C.
+- [FULL - synthesized] WebSearch across [Colorado Sun](https://coloradosun.com/2026/06/02/senate-bill-133-colorado-artist-companies/), [Pueblo Star Journal](https://pueblostarjournal.org/business/2026/06/02/colorado-creates-first-in-the-nation-business-structure-for-artists/), [ARTnews](https://www.artnews.com/art-news/news/colorado-passes-artist-corporation-bill-1234788275/), [Complete Music Update](https://completemusicupdate.com/colorado-creates-new-kind-of-limited-company-for-artists-and-creators/), [Sen. Catlin press release](https://www.catlinforcolorado.com/news-and-press-releases/2026/3/12/news/governor-polis-signs-catlins-first-in-the-nation-colorado-artist-company-act-sb26-133) - signing dates, effective Aug 12 2026, SoS deadline July 1 2027, bipartisan sponsors.
+- [PARTIAL - search snippet only, full article body not fetched] [Cardozo AELJ analysis of Bill 26-133](https://cardozoaelj.com/2026/04/27/a-corporation-for-artists-or-an-artists-corporation-an-analysis-of-colorado-bill-26-133/) and [CPR coverage](https://www.cpr.org/2026/04/10/colorado-artists-protect-intellectual-property-bill/) - Herrick Lidstone / Colorado Bar dissent quote ("completely and totally unnecessary") and Wall Street Rule critique captured via search synthesis; underlying academic article not fetched in full.
+- Note: no Reddit / HN / X discussion specific to the A-Corp surfaced in search as of 2026-06-06 - the conversation so far is press + practitioner blogs + the foundation's own DFOS space, not yet community forums.


### PR DESCRIPTION
## Summary
Research on the Colorado Artist Company Act (SB 26-133) - first US legal structure built specifically for artists, signed by Gov. Polis Jun 2 2026, effective Aug 12 2026. Three mechanics map almost exactly onto ZAO's artist-ownership thesis: 51% artist voting control locked in statute, automatic IP reversion to the creating artist on dissolution, and economic rights split from governance so outsiders fund without controlling.

## Recommendation
TRACK as the most ZAO-aligned legal primitive shipped in the US. Do NOT file - Colorado forms do not exist until July 1 2027 (first filings early 2027). Does not replace BCZ Strategies LLC; candidate vehicle for the missing "The ZAO" entity, esp. the Public Benefit A-Corp variant. Pre-register at artistcorporations.com.

## Tier
STANDARD

## Sources
6 sources: Metalabel/Strickler primary (FULL), artistcorporations.com (FULL), jason wiener legal analysis (FULL), multi-outlet press synthesis (FULL), Cardozo AELJ + CPR for Colorado Bar dissent (PARTIAL). No Reddit/HN/X coverage as of 2026-06-06.

## Next Actions
See doc Next Actions table: pre-register, Maine/Delaware copycat-bill watch, Q1 2027 entity decision, flag IP-reversion to ZAO Music / WaveWarZ artists, re-validate Jul 2027.

Generated with Claude Code