### PR TITLE
Audit Songjam-site + port secured ElevenLabs voice agent for spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@elevenlabs/react": "^1.6.4",
         "@farcaster/auth-client": "^0.7.1",
         "@farcaster/auth-kit": "^0.8.2",
         "@farcaster/hub-nodejs": "^0.16.0",
@@ -1597,6 +1598,12 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@capacitor/android": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-8.3.1.tgz",
@@ -2658,6 +2665,33 @@
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
       }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-1.9.0.tgz",
+      "integrity": "sha512-czkbwUv7n18DoH5L9YdAKr0ATlcPSYNxhVQTfnFvAUdijvWfhwn8Ct0WHbPxX1oGwH6s1hMbPPAK+CUURHyowg==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.14.0",
+        "livekit-client": "2.16.1"
+      }
+    },
+    "node_modules/@elevenlabs/react": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/react/-/react-1.6.4.tgz",
+      "integrity": "sha512-+5pF0BfLOShv0IJtGQWGLjG0kVYlfxRqpQlKmWPc8T8NzEzFX8hTCr+fjPNldAGEQSUsTGFiOvVNJHzpfQe4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/client": "1.9.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.14.0.tgz",
+      "integrity": "sha512-CfpxFyNtTq9Iwm1/Hfxk+FK0QlFgsHpXcNM9jMPYrjP/kAYMFi9rgFoosdJcBGYbgkvzUL7hwT9I6WzHyNyxDg=="
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
@@ -6654,6 +6688,21 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.42.2",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.2.tgz",
+      "integrity": "sha512-0jeCwoMJKcwsZICg5S6RZM4xhJoF78qMvQELjACJQn6/VB+jmiySQKOSELTXvPBVafHfEbMlqxUw2UR1jTXs2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@lukeed/csprng": {
@@ -31189,6 +31238,55 @@
         "@types/trusted-types": "^2.0.2"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.16.1.tgz",
+      "integrity": "sha512-PmOHiGdkzw2P/t0vLbJRwHU59+T+JcFlGTYDV7PObWmzvypIij1Vlj0WhZKDZ/Ac7CvwWinbiGCVw/Pb/OiYYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.2",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
+    "node_modules/livekit-client/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/livekit-client/node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/livekit-client/node_modules/webrtc-adapter": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
     "node_modules/livepeer": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/livepeer/-/livepeer-3.5.0.tgz",
@@ -37495,6 +37593,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
+    },
     "node_modules/ts-jest": {
       "version": "29.4.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
@@ -37739,6 +37843,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typeforce": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@elevenlabs/react": "^1.6.4",
     "@farcaster/auth-client": "^0.7.1",
     "@farcaster/auth-kit": "^0.8.2",
     "@farcaster/hub-nodejs": "^0.16.0",

--- a/research/dev-workflows/815-songjam-site-fork-audit/README.md
+++ b/research/dev-workflows/815-songjam-site-fork-audit/README.md
@@ -1,0 +1,99 @@
+# 815 — Songjam-Site Fork Audit + Voice-Agent Port
+
+**Date:** 2026-06-07
+**Source repo:** `github.com/SongjamSpace/songjam-site` (Next.js 15 / React 19 / Tailwind v4)
+**Ask:** Audit Songjam's public site and fork the useful parts into ZAO OS so ZABAL can use them to upgrade the dev environment.
+**Permission:** Songjam team gave verbal OK to reuse code (confirmed by Zaal 2026-06-07). No LICENSE file exists on the repo, so reuse is permission-based, not license-based — keep it internal to the lab until a license lands.
+
+---
+
+## TL;DR
+
+**A wholesale fork would be a downgrade.** ZAO OS already ships a more mature, more secure version of ~90% of what songjam-site does. The only genuinely additive capability is the **ElevenLabs conversational voice agent** that drops into a live space. That is the piece worth porting, and this doc ships a secured prototype of it.
+
+---
+
+## What Songjam-site actually is
+
+Public marketing/leaderboard site for Songjam ("agentic CRM for X Spaces"). Key surfaces:
+
+| Songjam feature | File(s) |
+|---|---|
+| Live audio rooms (100ms + Firestore) | `components/LiveAudioRoom.tsx` (~1,850 lines) |
+| ElevenLabs voice agent "$ADAM" | `components/agent-conversation.tsx` |
+| Mindshare / X-engagement leaderboard | `components/mindshare-leaderboard.tsx`, `hooks/useSpacePoints.ts` |
+| **$ZABAL Empire S2 page (already ZABAL-branded)** | `app/zabal/page.tsx` |
+| Staking balance checker (Alchemy) | `lib/staking.ts` |
+| Token routes (100ms / Stream) | `app/api/100ms/token`, `app/api/stream-token` |
+
+Stack: Next 15, React 19, Tailwind v4, Supabase, Neynar, Stream.io video, 100ms, ElevenLabs, Privy, Firebase, Solana kit, Ethers, OpenAI.
+
+## Overlap with ZAO OS — most of it is already here
+
+| Songjam dependency | Already in ZAO OS? |
+|---|---|
+| `@100mslive/react-sdk`, `hms-video-store` | ✅ yes (newer) |
+| `@stream-io/video-react-sdk`, `node-sdk` | ✅ yes (newer) |
+| `@privy-io/*` | ✅ `@privy-io/node` (we use iron-session + wagmi/rainbowkit on the client) |
+| Solana, Neynar, Supabase, react-query | ✅ yes |
+| `firebase` | ❌ — **redundant with Supabase, do NOT bring** |
+| `@elevenlabs/react` | ❌ — **the one genuine gap** |
+
+ZAO OS equivalents that already exist and are better:
+- `src/components/spaces/` — 40+ components: `HMSRoom`, `HMSFishbowlRoom`, `HMSRoomAdapter`, `AudioRoomAdapter`, `HandRaiseQueue`, `ClosedCaptions`, `RoomReactions`, `RoomMusicPanel`, `PermissionRequests`, … Songjam's single 1,850-line `LiveAudioRoom.tsx` is a less-decomposed subset of this.
+- `src/components/respect/SongjamLeaderboard.tsx` + `src/app/api/songjam/leaderboard/route.ts` — already consumes Songjam's own leaderboard worker for `bettercallzaal_s2`, with empire/staking multipliers, caching, Zod. The mindshare leaderboard is **already ported**.
+- `src/app/api/100ms/token/route.ts` — Zod + session guard + FID match + role validation + audit log + server-only `HMS_APP_SECRET`.
+
+## Security audit — do NOT copy Songjam's auth/secret patterns
+
+Songjam's code violates `.claude/rules/secret-hygiene.md` in several places. These are the things to explicitly NOT port:
+
+| Songjam pattern | Problem | ZAO rule |
+|---|---|---|
+| `NEXT_PUBLIC_STREAM_API_SECRET` in `stream-token/route.ts` | **Stream API *secret* exposed to the browser** | secrets are server-side only |
+| `NEXT_PUBLIC_ADAM_AGENT` agent id in `agent-conversation.tsx` | agent id shipped to client, session started client-side with no auth | server-mint short-lived tokens |
+| `NEXT_PUBLIC_API_KEY` (Alchemy) | API key in browser | server-side only |
+| `/api/100ms/token` mints on any `userId` | no auth, no ownership check | session guard + ownership |
+| client tools call `window.open(...)` on agent instruction | unvalidated redirects | allowlist actions |
+
+ZAO already does all of these correctly. The lesson: **reference Songjam's UX, re-implement the plumbing to our standards.**
+
+---
+
+## Decision
+
+1. **Do NOT** fork `LiveAudioRoom.tsx`, the Stream/100ms token routes, the Firebase room store, or the mindshare leaderboard — we have better versions.
+2. **Do NOT** add `firebase` or `@privy-io/react-auth` — redundant with Supabase / our existing auth.
+3. **DO** port the missing capability: an **ElevenLabs conversational voice agent** that can join a ZAO space, re-skinned as a ZOE persona and secured (server-minted signed URL, session-gated, no `NEXT_PUBLIC` secrets). This is the actual dev-environment upgrade ZABAL can build on.
+4. **New dependency:** `@elevenlabs/react` — the only new package. Needs Zaal's explicit approval per CLAUDE.md before merge (`npm install @elevenlabs/react`).
+
+## Prototype shipped in this branch
+
+| File | What | New dep? |
+|---|---|---|
+| `src/lib/agents/voice/elevenlabs.ts` | Server helper: mints a short-lived signed ElevenLabs ConvAI URL using server-only `ELEVENLABS_API_KEY` | none |
+| `src/app/api/spaces/voice-agent/token/route.ts` | Session-guarded, Zod-validated route returning the signed URL (agent allowlist, no client secrets) | none |
+| `src/app/api/spaces/voice-agent/token/__tests__/route.test.ts` | Vitest coverage: auth guard, validation, success, error paths | none |
+| `src/components/spaces/SpaceVoiceAgent.tsx` | Client widget: ElevenLabs `useConversation`, navy/gold, mobile-first, fetches signed URL from our route | `@elevenlabs/react` |
+
+### New env vars (add to `.env.example`, set server-side only)
+```
+ELEVENLABS_API_KEY=...           # server-only, NEVER NEXT_PUBLIC
+ELEVENLABS_SPACE_AGENT_ID=...    # ConvAI agent id for the ZOE space agent
+```
+
+### Verification status
+- Server route + helper + test follow `.claude/rules/api-routes.md` and `tests.md` and use zero new deps.
+- `SpaceVoiceAgent.tsx` imports `@elevenlabs/react`; **build/typecheck of that file is unverified until the dep is approved + installed.** It is not yet imported by any page, so it won't enter the production bundle until wired in.
+
+## Follow-ups (need Zaal approval)
+- Approve + `npm install @elevenlabs/react`, then `npm run typecheck`.
+- Create the ZOE ConvAI agent in the ElevenLabs dashboard; populate the two env vars.
+- Wire `SpaceVoiceAgent` into a space page (e.g. `src/app/spaces/[id]/page.tsx`) behind a feature flag for a ZABAL demo.
+- Define the agent's client-tool allowlist (raise hand, surface leaderboard, post capture to ZOE) — no raw `window.open`.
+
+## Related prior research
+- `research/_archive/119-songjam-audio-spaces-embed/` — earlier Songjam embed work
+- `research/infrastructure/741d-zoe-voice-agent-blueprint/`, `741c-voice-agent-stack-comparison/`
+- `research/agents/325-elevenlabs-agents-voice-ai-platform/`
+- `research/music/079-songjam-music-player-research/`

--- a/src/app/api/spaces/voice-agent/token/__tests__/route.test.ts
+++ b/src/app/api/spaces/voice-agent/token/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  makePostRequest,
+  mockUnauthenticatedSession,
+  mockAuthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockGetSignedConversationUrl } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetSignedConversationUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/agents/voice/elevenlabs', () => ({
+  getSignedConversationUrl: (agentId: string) =>
+    mockGetSignedConversationUrl(agentId),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+const ORIGINAL_AGENT_ID = process.env.ELEVENLABS_SPACE_AGENT_ID;
+
+describe('POST /api/spaces/voice-agent/token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ELEVENLABS_SPACE_AGENT_ID = 'agent_test_123';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockGetSignedConversationUrl.mockResolvedValue({
+      signedUrl: 'wss://api.elevenlabs.io/signed/abc',
+      agentId: 'agent_test_123',
+    });
+  });
+
+  afterEach(() => {
+    process.env.ELEVENLABS_SPACE_AGENT_ID = ORIGINAL_AGENT_ID;
+  });
+
+  describe('authorisation', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const req = makePostRequest('/api/spaces/voice-agent/token', {
+        agent: 'zoe',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(401);
+      expect(mockGetSignedConversationUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 400 for an unknown agent slug', async () => {
+      const req = makePostRequest('/api/spaces/voice-agent/token', {
+        agent: 'not-a-real-agent',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+    });
+
+    it('defaults to the zoe agent when no agent is supplied', async () => {
+      const req = makePostRequest('/api/spaces/voice-agent/token', {});
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      expect(mockGetSignedConversationUrl).toHaveBeenCalledWith('agent_test_123');
+    });
+  });
+
+  describe('configuration', () => {
+    it('returns 503 when the agent id env var is unset', async () => {
+      delete process.env.ELEVENLABS_SPACE_AGENT_ID;
+      const req = makePostRequest('/api/spaces/voice-agent/token', {
+        agent: 'zoe',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(503);
+      expect(mockGetSignedConversationUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success', () => {
+    it('returns the signed url for an authenticated caller', async () => {
+      const req = makePostRequest('/api/spaces/voice-agent/token', {
+        agent: 'zoe',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        success: true,
+        signedUrl: 'wss://api.elevenlabs.io/signed/abc',
+      });
+    });
+  });
+
+  describe('errors', () => {
+    it('returns 500 when the helper throws', async () => {
+      mockGetSignedConversationUrl.mockRejectedValue(
+        new Error('ElevenLabs signed-url request failed: 500'),
+      );
+      const req = makePostRequest('/api/spaces/voice-agent/token', {
+        agent: 'zoe',
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/spaces/voice-agent/token/route.ts
+++ b/src/app/api/spaces/voice-agent/token/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import { getSignedConversationUrl } from '@/lib/agents/voice/elevenlabs';
+import { logger } from '@/lib/logger';
+
+/**
+ * Mint a short-lived signed ElevenLabs ConvAI URL for a space voice agent.
+ *
+ * Session-gated and agent-allowlisted: a caller can only start a session for a
+ * known agent slug, and only the server ever sees the ElevenLabs API key.
+ */
+
+const BodySchema = z.object({
+  agent: z.enum(['zoe']).default('zoe'),
+});
+
+// Allowlist of agent slugs -> env-configured agent IDs. Resolved per-request so
+// the route returns 503 (not a load-time throw) when an agent is unconfigured,
+// and stays trivially testable. Prevents callers requesting arbitrary agents.
+function resolveAgentId(agent: 'zoe'): string | undefined {
+  const agents: Record<'zoe', string | undefined> = {
+    zoe: process.env.ELEVENLABS_SPACE_AGENT_ID,
+  };
+  return agents[agent];
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSessionData();
+    if (!session?.fid && !session?.walletAddress) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const parsed = BodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+
+    const agentId = resolveAgentId(parsed.data.agent);
+    if (!agentId) {
+      return NextResponse.json(
+        { error: 'Voice agent not configured' },
+        { status: 503 },
+      );
+    }
+
+    const { signedUrl } = await getSignedConversationUrl(agentId);
+    return NextResponse.json({ success: true, signedUrl });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    logger.error('[voice-agent/token] failed:', message);
+    return NextResponse.json(
+      { error: 'Failed to start voice session' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/spaces/SpaceVoiceAgent.tsx
+++ b/src/components/spaces/SpaceVoiceAgent.tsx
@@ -87,9 +87,11 @@ export function SpaceVoiceAgent({
         throw new Error(data.error || 'Could not start voice session');
       }
 
+      // Signed URLs use the WebSocket transport; WebRTC needs a separate
+      // conversation token. See @elevenlabs/client SessionConfig union.
       await conversation.startSession({
         signedUrl: data.signedUrl,
-        connectionType: 'webrtc',
+        connectionType: 'websocket',
       });
     } catch (error: unknown) {
       if (error instanceof DOMException && error.name === 'NotAllowedError') {

--- a/src/components/spaces/SpaceVoiceAgent.tsx
+++ b/src/components/spaces/SpaceVoiceAgent.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useConversation } from '@elevenlabs/react';
+
+/**
+ * Live voice agent for ZAO spaces, powered by ElevenLabs ConvAI.
+ *
+ * Adapted from Songjam's `agent-conversation.tsx` but secured to ZAO
+ * conventions: the agent id / API key never reach the browser — we fetch a
+ * short-lived signed URL from `/api/spaces/voice-agent/token` (session-gated)
+ * and hand it to the SDK. See `research/dev-workflows/815-songjam-site-fork-audit/`.
+ *
+ * NOTE: requires the `@elevenlabs/react` dependency (pending approval).
+ */
+
+type AgentStatus =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'error';
+
+interface SpaceVoiceAgentProps {
+  /** Agent slug; must match an allowlisted agent in the token route. */
+  agent?: 'zoe';
+  /** Display label under the orb. */
+  label?: string;
+  /** Optional client tool the agent can invoke to raise the caller's hand. */
+  onRaiseHand?: () => void;
+  /** Notified whenever the connection status changes. */
+  onStatusChange?: (status: AgentStatus) => void;
+}
+
+interface TokenResponse {
+  success?: boolean;
+  signedUrl?: string;
+  error?: string;
+}
+
+export function SpaceVoiceAgent({
+  agent = 'zoe',
+  label = 'ZOE',
+  onRaiseHand,
+  onStatusChange,
+}: SpaceVoiceAgentProps) {
+  const [status, setStatus] = useState<AgentStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const setAgentStatus = useCallback(
+    (next: AgentStatus) => {
+      setStatus(next);
+      onStatusChange?.(next);
+    },
+    [onStatusChange],
+  );
+
+  const conversation = useConversation({
+    onConnect: () => setAgentStatus('connected'),
+    onDisconnect: () => setAgentStatus('idle'),
+    onError: () => {
+      setErrorMessage('Voice connection error. Try again.');
+      setAgentStatus('error');
+    },
+    clientTools: {
+      // Controlled allowlist of actions — no raw window.open / redirects.
+      raiseHand: () => {
+        onRaiseHand?.();
+        return 'Hand raised';
+      },
+    },
+  });
+
+  const start = useCallback(async () => {
+    setErrorMessage(null);
+    setAgentStatus('connecting');
+    try {
+      await navigator.mediaDevices.getUserMedia({ audio: true });
+
+      const res = await fetch('/api/spaces/voice-agent/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent }),
+      });
+      const data = (await res.json()) as TokenResponse;
+      if (!res.ok || !data.signedUrl) {
+        throw new Error(data.error || 'Could not start voice session');
+      }
+
+      await conversation.startSession({
+        signedUrl: data.signedUrl,
+        connectionType: 'webrtc',
+      });
+    } catch (error: unknown) {
+      if (error instanceof DOMException && error.name === 'NotAllowedError') {
+        setErrorMessage('Enable microphone permissions to talk to the agent.');
+      } else {
+        setErrorMessage(
+          error instanceof Error ? error.message : 'Failed to connect',
+        );
+      }
+      setAgentStatus('error');
+    }
+  }, [agent, conversation, setAgentStatus]);
+
+  const stop = useCallback(async () => {
+    setAgentStatus('disconnecting');
+    await conversation.endSession();
+    setAgentStatus('idle');
+  }, [conversation, setAgentStatus]);
+
+  const handleClick = useCallback(() => {
+    if (status === 'connected') {
+      void stop();
+    } else if (status === 'idle' || status === 'error') {
+      void start();
+    }
+  }, [status, start, stop]);
+
+  const statusText: Record<AgentStatus, string> = {
+    idle: 'Tap to talk',
+    connecting: 'Connecting…',
+    connected: 'Listening — tap to end',
+    disconnecting: 'Ending…',
+    error: 'Tap to retry',
+  };
+
+  const isLive = status === 'connected';
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label={isLive ? 'End voice session' : 'Start voice session'}
+        className={`relative flex size-24 items-center justify-center rounded-full border-2 transition-all sm:size-28 ${
+          isLive
+            ? 'border-[#f5a623] bg-[#f5a623]/20 shadow-[0_0_24px_rgba(245,166,35,0.5)]'
+            : 'border-[#f5a623]/60 bg-[#0a1628] hover:border-[#f5a623]'
+        }`}
+      >
+        {isLive && (
+          <span className="absolute inset-0 animate-ping rounded-full bg-[#f5a623]/30" />
+        )}
+        <span className="text-lg font-semibold text-[#f5a623]">{label}</span>
+      </button>
+      <p className="text-sm text-white/70">{statusText[status]}</p>
+      {errorMessage && (
+        <p className="max-w-[14rem] text-center text-xs text-red-400">
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/agents/voice/elevenlabs.ts
+++ b/src/lib/agents/voice/elevenlabs.ts
@@ -1,0 +1,58 @@
+import { logger } from '@/lib/logger';
+
+/**
+ * ElevenLabs Conversational-AI (ConvAI) server helper.
+ *
+ * Mints a short-lived signed WebRTC/WebSocket URL for a ConvAI agent. The API
+ * key is read server-side only and is NEVER exposed to the browser.
+ *
+ * This deliberately fixes the pattern in Songjam's `agent-conversation.tsx`,
+ * which shipped the agent id to the client via `NEXT_PUBLIC_ADAM_AGENT` and
+ * started the session client-side with no auth. See
+ * `research/dev-workflows/815-songjam-site-fork-audit/`.
+ */
+
+const ELEVENLABS_API_BASE = 'https://api.elevenlabs.io/v1';
+
+export interface SignedConversationUrl {
+  signedUrl: string;
+  agentId: string;
+}
+
+interface SignedUrlResponse {
+  signed_url?: string;
+}
+
+/**
+ * Request a signed ConvAI conversation URL for the given agent.
+ *
+ * @throws if `ELEVENLABS_API_KEY` is unset or the upstream request fails.
+ */
+export async function getSignedConversationUrl(
+  agentId: string,
+): Promise<SignedConversationUrl> {
+  const apiKey = process.env.ELEVENLABS_API_KEY;
+  if (!apiKey) throw new Error('ELEVENLABS_API_KEY not configured');
+
+  const res = await fetch(
+    `${ELEVENLABS_API_BASE}/convai/conversation/get_signed_url?agent_id=${encodeURIComponent(agentId)}`,
+    {
+      method: 'GET',
+      headers: { 'xi-api-key': apiKey },
+      cache: 'no-store',
+    },
+  );
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    logger.error('[voice-agent] signed-url request failed', res.status, detail);
+    throw new Error(`ElevenLabs signed-url request failed: ${res.status}`);
+  }
+
+  const data = (await res.json()) as SignedUrlResponse;
+  if (!data.signed_url) {
+    throw new Error('ElevenLabs response missing signed_url');
+  }
+
+  return { signedUrl: data.signed_url, agentId };
+}


### PR DESCRIPTION
## Summary

Audited `SongjamSpace/songjam-site` for forking into ZAO OS (the lab) for ZABAL. **Key finding: a wholesale fork would be a downgrade.** ZAO OS already ships a more mature, more secure version of ~90% of Songjam:

| Songjam feature | ZAO OS already has |
|---|---|
| Live audio rooms (`LiveAudioRoom.tsx`, 1,850 lines) | full `src/components/spaces/` HMS/Stream stack (40+ components) |
| Mindshare leaderboard | `respect/SongjamLeaderboard.tsx` + `/api/songjam/leaderboard` (wired to `bettercallzaal_s2`) |
| 100ms / Stream token routes | `/api/100ms/token` with Zod + session auth + server-only secrets |
| 100ms, Stream, Privy, Solana, Neynar deps | already in `package.json` |

Songjam's token routes **leak secrets to the browser** (`NEXT_PUBLIC_STREAM_API_SECRET`, `NEXT_PUBLIC_ADAM_AGENT`) — explicitly *not* copied, per `.claude/rules/secret-hygiene.md`.

**The one genuine gap = an ElevenLabs conversational voice agent for live spaces.** Nothing in `src/` did live voice. This PR ships a secured prototype of that gap, fixing Songjam's auth/secret flaws.

## What's in this PR

- `research/dev-workflows/815-songjam-site-fork-audit/README.md` — full audit, security comparison, decision, follow-ups.
- `src/lib/agents/voice/elevenlabs.ts` — server helper that mints a short-lived signed ConvAI URL using a **server-only** `ELEVENLABS_API_KEY`.
- `src/app/api/spaces/voice-agent/token/route.ts` — session-gated, Zod-validated, agent-allowlisted token route. No client secrets.
- `src/app/api/spaces/voice-agent/token/__tests__/route.test.ts` — 6 cases (auth, validation, config, success, error), all passing.
- `src/components/spaces/SpaceVoiceAgent.tsx` — client widget (navy/gold, mobile-first) that fetches the server-minted URL and connects over WebSocket. ZOE persona, controlled client-tool allowlist (no raw `window.open`).
- `package.json` — adds `@elevenlabs/react` (the only new dependency, approved).

## New env vars (server-side only — never `NEXT_PUBLIC`)
```
ELEVENLABS_API_KEY=...
ELEVENLABS_SPACE_AGENT_ID=...
```

## Verification
- `npx vitest run src/app/api/spaces/voice-agent` → **6/6 passing**.
- `npm run typecheck` → all new files clean.

## Follow-ups (not in this PR)
- Add the two env vars to `.env.example` + create the ZOE ConvAI agent in the ElevenLabs dashboard.
- Wire `SpaceVoiceAgent` into a space page (e.g. `/spaces/[id]`) behind a feature flag for a ZABAL demo.

🤖 Audited and built with Claude Code.

https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w)_