### PR TITLE
Bot heartbeats → coworking status board (+ fleet registry & session docs)

### DIFF
--- a/bot/COWORK_API.md
+++ b/bot/COWORK_API.md
@@ -58,15 +58,18 @@ await markDone(123, 'handled out-of-band');
 const stop = startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });
 ```
 
-## Wire-up status (staged — flip on once tokens exist)
+## Wire-up status
 
-The client is built and dormant. To activate, per bot, add one line at startup:
+Heartbeats are **wired into the live bot startups** (env-gated — no-op until tokens exist):
 
-- **ZOE** (`bot/src/zoe/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });`
-- **ZAO Devz** (`bot/src/devz/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zao-devz-stack' });`
-- **ZAOstock** (`bot/src/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zaostock-bot' });`
-- **Hermes** (`bot/src/hermes/runner.ts`): call `pushItem`/`markDone` only where a
-  task is created or closed outside the normal PR-merge path.
+- ✅ **ZOE** (`bot/src/zoe/index.ts`) — `unit: 'zoe-bot'`
+- ✅ **ZAO Devz** (`bot/src/devz/index.ts`) — `unit: 'zao-devz-stack'` (covers devz + hermes, same process)
+- ✅ **ZAOstock** (`bot/src/index.ts`) — `unit: 'zaostock-bot'`
+- ⏳ **Team bots** (`bot/src/teams/index.ts`) — NOT wired; boots Magnetiq/AttaBotty which doc 601 flagged to fold into ZOE. Confirm live before adding.
+
+Still manual (no obvious call site yet):
+- **Hermes `pushItem`/`markDone`** — call only where a task is created/closed *outside* the normal PR-merge path (merge closes are auto-handled by cowork's webhook).
+- **ZOE / `/meeting` `pushItem`** — wire when the capture→cowork push is built.
 
 ## Go-live checklist
 

--- a/bot/COWORK_API.md
+++ b/bot/COWORK_API.md
@@ -1,0 +1,80 @@
+# Bot ↔ Coworking API (ZAOOS side)
+
+How the ZAO bot fleet talks to **cowork-zaodevz** over its REST API.
+
+- **Contract source of truth:** `cowork-zaodevz/docs/BOT-API.md` (PR #63). If a field
+  changes there, change it here + in `bot/src/lib/cowork.ts`.
+- **Client:** `bot/src/lib/cowork.ts` — dormant by default, fault-tolerant.
+- **Fleet status:** `bot/REGISTRY.md`.
+
+## Endpoints (all `Authorization: Bearer <per-bot token>`)
+
+| Method | Path | Body | Returns |
+|--------|------|------|---------|
+| POST | `/api/v1/items` | `{title, assignee?, due_date?, notes?, source?}` | `{id}` (legacy `#N`) |
+| PATCH | `/api/v1/items/:id` | `{status?, assignee?, due_date?, notes?}` | updated task |
+| POST | `/api/v1/bots/heartbeat` | `{status?, meta?}` (bot = the token) | ok |
+| GET | `/api/v1/bots` | — | `{bots:[{bot,status,ts,meta,online,ageSeconds}]}` |
+
+**Field mapping** (client field → cowork): `assignee`→owner (name; unknown → `Open`),
+`due_date`→`due` (YYYY-MM-DD), `notes`→`notes`, `source`∈`TASK_SOURCES` (default
+`human-bot`). `id` is always the legacy `#N`, not the UUID. Status accepts
+`TODO|WIP|BLOCKED|DONE|TRIAGE` (lowercase / `in_progress` also tolerated).
+
+## Per-bot scope
+
+| Bot | Uses | Notes |
+|-----|------|-------|
+| **Hermes** | `markDone` (non-merge only), `heartbeat` | Merge-driven closes are auto-handled by cowork's GitHub webhook + `/api/v1/auto-close` (link the PR via `cowork#<id>`). `markDone` is only for closing a task **without** a merge. |
+| **ZOE** | `pushItem`, `heartbeat` | `/meeting` + captures push action-items here instead of Octokit. |
+| **ZAO Devz** | `heartbeat`, `pushItem` (opt) | |
+| **ZAOstock** | `heartbeat` | |
+| Bonfire / DeepMeeting | — | Bonfires-platform, not cowork callers. |
+
+## Env (per bot process — each systemd unit gets its own token)
+
+```
+COWORK_API_URL=https://<cowork-app-host>
+COWORK_BOT_TOKEN=tok_…        # this bot's token (identifies it server-side)
+```
+
+If either is unset the client is **dormant**: every call returns `{ok:false, skipped:true}`
+and never touches the network. So the fleet is safe to deploy before the cowork side
+is configured.
+
+## Client usage
+
+```ts
+import { pushItem, markDone, startHeartbeat } from '../lib/cowork';
+
+// ZOE / meeting — push a captured action item
+const r = await pushItem({ title: 'Follow up with X', assignee: 'Zaal', source: 'zoe' });
+if (r.ok) console.log('cowork item', r.data?.id);
+
+// Hermes — close a task WITHOUT a merge (merge closes are automatic)
+await markDone(123, 'handled out-of-band');
+
+// Any bot — heartbeat from startup (no-op while dormant)
+const stop = startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });
+```
+
+## Wire-up status (staged — flip on once tokens exist)
+
+The client is built and dormant. To activate, per bot, add one line at startup:
+
+- **ZOE** (`bot/src/zoe/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });`
+- **ZAO Devz** (`bot/src/devz/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zao-devz-stack' });`
+- **ZAOstock** (`bot/src/index.ts`): `startHeartbeat(60_000, () => 'up', { unit: 'zaostock-bot' });`
+- **Hermes** (`bot/src/hermes/runner.ts`): call `pushItem`/`markDone` only where a
+  task is created or closed outside the normal PR-merge path.
+
+## Go-live checklist
+
+**Cowork side (cowork-zaodevz repo):**
+1. Set `COWORK_BOT_TOKENS="hermes=…,zoe=…,zaodevz=…,zaostock=…"` on Vercel.
+2. Apply `supabase/migrations/010_bot_heartbeats.sql` (heartbeat endpoints 503 gracefully until then).
+
+**ZAOOS side (this repo / VPS):**
+3. Set `COWORK_API_URL` + the matching `COWORK_BOT_TOKEN` in each systemd unit's env.
+4. Add the `startHeartbeat(...)` line to each bot entry (above).
+5. Restart units; confirm via `GET /api/v1/bots`.

--- a/bot/REGISTRY.md
+++ b/bot/REGISTRY.md
@@ -1,0 +1,41 @@
+# ZAO Bot Registry
+
+Status of every bot/agent in the ZAO fleet — what's live, where it runs, how it's
+checked. Mirrors CLAUDE.md "Primary Surfaces"; **update both together.**
+
+_Last updated: 2026-06-07_
+
+## Active fleet
+
+| Bot | Handle | Source | Purpose | Runs on | Status / health check |
+|-----|--------|--------|---------|---------|----------------------|
+| **ZOE** | `@zaoclaw_bot` | `bot/src/zoe/` | Concierge — tasks, captures, brief/reflect, recall, CRM, social drafts, group dispatch | systemd `zoe-bot` @ VPS 1 (grammy long-poll + Claude CLI subprocess) | `systemctl --user status zoe-bot` |
+| **Hermes** | `@zoe_hermes_bot` | `bot/src/hermes/` | Autonomous fix-PR pipeline — coder (Opus) + critic (Sonnet) + auto-PR | In-process, spawned by ZOE / ZAO Devz dispatch | runs logged to Supabase `hermes_runs` |
+| **ZAO Devz** | `@zaodevz_bot` | `bot/src/devz/` | Group `/fix` dispatch + hourly learning tip; dual-bot coder/critic narration | systemd `zao-devz-stack` @ VPS 1 | `systemctl --user status zao-devz-stack` |
+| **ZAOstock** | `@ZAOstockTeamBot` | `bot/src/index.ts` (root) | Festival team coordination (sponsors, artists, volunteers, todos) — **graduating** with ZAOstock spinout | systemd `zaostock-bot` @ VPS 1 | `systemctl --user status zaostock-bot` |
+| **Bonfire** (reader) | `@zabal_bonfire` | bonfires.ai (agent `69ef…`) | Knowledge-graph recall + multi-corpus ingest | Bonfires platform (Genesis tier, wallet-gated) | Bonfires dashboard |
+| **DeepMeeting** | `@zdeepmeeting_bot` | bonfires.ai | GCvlcnti protocol authoring workbench (proposal-only shard) | Bonfires platform | Bonfires dashboard — ⚠️ **DM works, group routing broken** (Plat0x ticket open) |
+
+## External / separate repos
+
+- **Coworking** — `@ZAOcoworkingBot` — repo **`songchaindao-dot/cowork-zaodevz`** (on VPS at `/root/cowork-zaodevz`). Next.js web app + Node bot (Hermes pattern). Stores todos in `data/actions.json` via GitHub Octokit (SHA-dance). **No HTTP API** — see "Known gaps." The `/meeting` skill posts action items here via Octokit.
+
+## Decommissioned — DO NOT revive (doc 601, 2026-05-04)
+
+- OpenClaw container + 7-agent squad (ZOEY / BUILDER / SCOUT / WALLET / FISHBOWLZ / CASTER)
+- Composio AO orchestrator
+- ZOE v2 / Agent Zero migration plan
+- 10-bot branded fleet (Magnetiq / Research / WaveWarZ / POIDH as own bots)
+- FISHBOWLZ (paused 2026-04-16, killed 2026-05-04 — Juke partnership stands)
+
+## Infra
+
+- **VPS 1** (Hostinger KVM2), user `zaal`. Three systemd user units: `zoe-bot`, `zao-devz-stack`, `zaostock-bot`.
+- **No central dispatcher** — each VPS bot is an independent grammy long-poll loop.
+- Coordination: `groups.json`, `~/.zao/zoe/` memory blocks, Supabase (`hermes_runs`, CRM). Bonfire/DeepMeeting run off-VPS on the Bonfires platform.
+
+## Known gaps
+
+- **No centralized health/status** — no HTTP health endpoint, no heartbeat, no dashboard. Checked manually via `systemctl --user status <unit>` / `journalctl --user -u <unit> -f`.
+- **Coworking is an island** — `cowork-zaodevz` exposes no API, so Hermes/ZOE/`/meeting` can't programmatically read or update its todos (doc 672 **P3.5**).
+- **DeepMeeting group routing broken** on the Bonfires platform (Plat0x ticket open). DM works.

--- a/bot/cowork-handoff/010_bot_heartbeats.sql
+++ b/bot/cowork-handoff/010_bot_heartbeats.sql
@@ -1,0 +1,30 @@
+-- 010_bot_heartbeats.sql
+-- Fleet liveness for the coworking "Bots" board.
+-- Written by POST /api/v1/bots/heartbeat (per-bot bearer); read by GET /api/v1/bots.
+-- Apply in the cowork-zaodevz Supabase project (SQL editor).
+
+create table if not exists public.bot_heartbeats (
+  bot         text primary key,
+  status      text not null default 'up' check (status in ('up','degraded','down')),
+  ts          timestamptz not null default now(),
+  meta        jsonb not null default '{}'::jsonb,
+  updated_at  timestamptz not null default now()
+);
+
+comment on table public.bot_heartbeats is
+  'Latest heartbeat per bot for the /bots status board. Upserted by POST /api/v1/bots/heartbeat (per-bot bearer; bot = the token). online + ageSeconds are derived at read time from ts.';
+
+-- Heartbeat = upsert keyed by bot:
+--   insert into bot_heartbeats (bot, status, ts, meta, updated_at)
+--   values ($1,$2,now(),$3,now())
+--   on conflict (bot) do update set status=excluded.status, ts=excluded.ts,
+--     meta=excluded.meta, updated_at=now();
+--
+-- GET /api/v1/bots derives, per row:
+--   ageSeconds = extract(epoch from (now() - ts))
+--   online     = ageSeconds < 180   (3 missed 60s beats)
+
+-- Server-only access: the board reads via GET /api/v1/bots (service role),
+-- not from the browser. Enable RLS with no public policy so the anon/auth
+-- keys can't touch it directly; the service role bypasses RLS.
+alter table public.bot_heartbeats enable row level security;

--- a/bot/cowork-handoff/BotsBoard.tsx
+++ b/bot/cowork-handoff/BotsBoard.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+/**
+ * BotsBoard — drop-in fleet liveness panel for the coworking board.
+ * Reads GET /api/v1/bots (see cowork docs/BOT-API.md) and auto-refreshes.
+ *
+ * AUTH: this client component fetches /api/v1/bots from the browser, so that
+ * GET must be readable with the team's normal session cookie. If you'd rather
+ * keep /api/v1/bots bearer-only, convert this to a server component that fetches
+ * server-side with a service token and passes `bots` in as a prop.
+ *
+ * Adapt classNames to your design system; logic is framework-agnostic.
+ */
+
+import { useEffect, useState } from 'react';
+
+interface BotHealth {
+  bot: string;
+  status: 'up' | 'degraded' | 'down';
+  ts: number;
+  meta?: Record<string, unknown>;
+  online: boolean;
+  ageSeconds: number;
+}
+
+function ago(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s ago`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  return `${Math.round(seconds / 3600)}h ago`;
+}
+
+export function BotsBoard() {
+  const [bots, setBots] = useState<BotHealth[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = async (): Promise<void> => {
+      try {
+        const res = await fetch('/api/v1/bots', { cache: 'no-store' });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = (await res.json()) as { bots: BotHealth[] };
+        if (alive) {
+          setBots(data.bots ?? []);
+          setError(null);
+        }
+      } catch (e: unknown) {
+        if (alive) setError(e instanceof Error ? e.message : 'failed');
+      }
+    };
+    void load();
+    const timer = setInterval(() => void load(), 30_000);
+    return () => {
+      alive = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  // Surface offline/stale bots first so a dead one is obvious.
+  const sorted = [...bots].sort((a, b) => Number(a.online) - Number(b.online));
+
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900 p-4">
+      <h2 className="mb-3 text-sm font-semibold text-slate-200">Bot fleet</h2>
+      {error && <p className="text-xs text-red-400">status unavailable: {error}</p>}
+      <ul className="space-y-2">
+        {sorted.map((b) => {
+          const dot = !b.online
+            ? 'bg-red-500'
+            : b.status === 'up'
+              ? 'bg-green-500'
+              : 'bg-amber-500';
+          return (
+            <li key={b.bot} className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2 text-slate-200">
+                <span className={`h-2.5 w-2.5 rounded-full ${dot}`} />
+                {b.bot}
+              </span>
+              <span className="text-xs text-slate-400">
+                {b.online ? b.status : 'offline'} · {ago(b.ageSeconds)}
+              </span>
+            </li>
+          );
+        })}
+        {sorted.length === 0 && !error && (
+          <li className="text-xs text-slate-500">no heartbeats yet</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/bot/cowork-handoff/README.md
+++ b/bot/cowork-handoff/README.md
@@ -1,0 +1,36 @@
+# Cowork handoff — Bots status board
+
+Drop-in artifacts so the cowork-zaodevz session can make the fleet **visible on the
+board** with zero design work. Copy these into the cowork repo.
+
+## What's here
+
+| File | Goes to (cowork repo) | Purpose |
+|------|----------------------|---------|
+| `010_bot_heartbeats.sql` | `supabase/migrations/010_bot_heartbeats.sql` | The heartbeat table. Apply in Supabase SQL editor. |
+| `BotsBoard.tsx` | a component dir, e.g. `src/components/BotsBoard.tsx` | The board panel. Reads `GET /api/v1/bots`, auto-refreshes 30s, offline-first. |
+
+## Steps for the cowork session
+
+1. **Apply** `010_bot_heartbeats.sql` (heartbeat endpoints return 503 gracefully until then).
+2. **Mount** `<BotsBoard />` on the main board page (or a `/bots` route).
+3. **Auth:** `BotsBoard` fetches `/api/v1/bots` from the browser, so make that **GET
+   session-readable** for logged-in team members. If you'd rather keep it bearer-only,
+   convert `BotsBoard` to a server component that fetches with a service token and
+   passes `bots` as a prop (note in the file).
+4. Adapt the Tailwind classes to your design system.
+
+## Then go-live (ops)
+
+**Cowork (Vercel):** `COWORK_BOT_TOKENS="zoe=…,zaodevz=…,zaostock=…"`.
+
+**ZAOOS / VPS:** per systemd unit set `COWORK_API_URL` + the matching `COWORK_BOT_TOKEN`
+(`zoe-bot`→`zoe=`, `zao-devz-stack`→`zaodevz=`, `zaostock-bot`→`zaostock=`), then
+`systemctl --user restart zoe-bot zao-devz-stack zaostock-bot`.
+
+Within 60s the three bots upsert heartbeats → the board shows green. Stale > 180s → red.
+
+## Contract
+
+Full API contract: cowork `docs/BOT-API.md` + ZAOOS `bot/COWORK_API.md`. The board
+consumes `GET /api/v1/bots` → `{ bots: [{ bot, status, ts, meta, online, ageSeconds }] }`.

--- a/bot/src/devz/index.ts
+++ b/bot/src/devz/index.ts
@@ -24,6 +24,7 @@ import { listOpenRuns, getRun } from '../hermes/db';
 import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import * as http from 'node:http';
+import { startHeartbeat } from '../lib/cowork';
 
 const devzToken = process.env.ZAO_DEVZ_BOT_TOKEN;
 const hermesToken = process.env.HERMES_BOT_TOKEN;
@@ -484,6 +485,9 @@ async function boot(): Promise<void> {
   console.log(`[devz] ZAODevzBot=@${devzInfo.username} HermesBot=@${hermesInfo.username} chat=${devzChatId}`);
 
   startHermesHttpListener();
+
+  // Heartbeat to the coworking status board (covers devz + hermes; dormant unless COWORK_API_URL/TOKEN set).
+  startHeartbeat(60_000, () => 'up', { unit: 'zao-devz-stack', bots: ['zaodevz', 'hermes'] });
 
   await Promise.all([
     devz.start({ drop_pending_updates: true, onStart: () => console.log('[devz] ZAODevzBot polling') }),

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -2,6 +2,7 @@ import { config as loadEnv } from 'dotenv';
 loadEnv();
 
 import { Bot, Context } from 'grammy';
+import { startHeartbeat } from './lib/cowork';
 import {
   resolveMember,
   linkUsernameToMember,
@@ -592,6 +593,8 @@ bot.catch((err) => {
 // ---- Startup ---------------------------------------------------------------
 
 console.log('[zaostock-bot] starting...');
+// Heartbeat to the coworking status board (dormant unless COWORK_API_URL/TOKEN set).
+startHeartbeat(60_000, () => 'up', { unit: 'zaostock-bot' });
 bot.start({
   onStart: async (info) => {
     console.log(`[zaostock-bot] running as @${info.username}`);

--- a/bot/src/lib/cowork.ts
+++ b/bot/src/lib/cowork.ts
@@ -1,0 +1,172 @@
+/**
+ * cowork.ts — ZAOOS bot client for the cowork-zaodevz REST API (/api/v1/*).
+ *
+ * Contract source of truth: cowork-zaodevz `docs/BOT-API.md` (PR #63).
+ * ZAOOS-side mirror + per-bot scope table: `bot/COWORK_API.md`.
+ *
+ * DORMANT BY DEFAULT: if COWORK_API_URL or COWORK_BOT_TOKEN is unset, every call
+ * is a silent no-op (returns { ok: false, skipped: true }) so the live VPS fleet
+ * runs unchanged until the endpoints + per-bot tokens are configured. All calls
+ * are fault-tolerant — network/HTTP/timeout errors are caught and returned, never
+ * thrown into a bot loop.
+ *
+ * Env:
+ *   COWORK_API_URL    base URL of the cowork app (e.g. https://cowork.example.com)
+ *   COWORK_BOT_TOKEN  this bot's per-bot token; identifies the bot server-side
+ */
+
+const API_URL = (process.env.COWORK_API_URL ?? '').replace(/\/$/, '');
+const BOT_TOKEN = process.env.COWORK_BOT_TOKEN ?? '';
+const REQUEST_TIMEOUT_MS = 8_000;
+
+/** Canonical task statuses the API accepts (server also tolerates lowercase/in_progress). */
+export type TaskStatus = 'TODO' | 'WIP' | 'BLOCKED' | 'DONE' | 'TRIAGE';
+export type BotHealthStatus = 'up' | 'degraded' | 'down';
+
+export interface CoworkResult<T> {
+  ok: boolean;
+  /** true when the client is dormant (COWORK_API_URL / COWORK_BOT_TOKEN unset). */
+  skipped?: boolean;
+  /** HTTP status when a request was actually made. */
+  status?: number;
+  data?: T;
+  error?: string;
+}
+
+export interface CreateItemInput {
+  title: string;
+  /** Owner name; server resolves to a team UUID (unknown -> "Open"). */
+  assignee?: string;
+  /** YYYY-MM-DD. */
+  due_date?: string;
+  notes?: string;
+  /** Must be in cowork TASK_SOURCES; defaults to "human-bot" server-side. */
+  source?: string;
+}
+
+export interface UpdateItemInput {
+  status?: TaskStatus;
+  assignee?: string;
+  due_date?: string;
+  notes?: string;
+}
+
+export interface BotHealth {
+  bot: string;
+  status: BotHealthStatus;
+  ts: number;
+  meta?: Record<string, unknown>;
+  online: boolean;
+  ageSeconds: number;
+}
+
+/** True when the client is configured (both URL and token present). */
+export function coworkEnabled(): boolean {
+  return Boolean(API_URL && BOT_TOKEN);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return 'Unexpected error';
+}
+
+async function request<T>(
+  method: 'GET' | 'POST' | 'PATCH',
+  path: string,
+  body?: unknown,
+): Promise<CoworkResult<T>> {
+  if (!coworkEnabled()) return { ok: false, skipped: true };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${BOT_TOKEN}`,
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    let data: T | undefined;
+    const text = await res.text();
+    if (text) {
+      try {
+        data = JSON.parse(text) as T;
+      } catch {
+        // non-JSON body; leave data undefined
+      }
+    }
+
+    if (!res.ok) {
+      return { ok: false, status: res.status, data, error: `HTTP ${res.status}` };
+    }
+    return { ok: true, status: res.status, data };
+  } catch (error: unknown) {
+    return { ok: false, error: getErrorMessage(error) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Create a cowork task. Returns the legacy id (#N) on success. */
+export function pushItem(input: CreateItemInput): Promise<CoworkResult<{ id: string }>> {
+  return request<{ id: string }>('POST', '/api/v1/items', input);
+}
+
+/**
+ * Update a cowork task by legacy id (pass "12" or "#12").
+ *
+ * NOTE for Hermes: this is only needed to close a task WITHOUT a merge.
+ * Merge-driven closes are already handled by cowork's GitHub webhook +
+ * /api/v1/auto-close (linked via `cowork#<id>` in the PR), so no client call is
+ * needed on a normal merge.
+ */
+export function updateItem(
+  id: string | number,
+  input: UpdateItemInput,
+): Promise<CoworkResult<unknown>> {
+  const legacyId = String(id).replace(/^#/, '');
+  return request<unknown>('PATCH', `/api/v1/items/${legacyId}`, input);
+}
+
+/** Convenience: mark a task DONE (non-merge close). */
+export function markDone(id: string | number, notes?: string): Promise<CoworkResult<unknown>> {
+  return updateItem(id, notes === undefined ? { status: 'DONE' } : { status: 'DONE', notes });
+}
+
+/** Post this bot's heartbeat. The bot identity is the token, not the body. */
+export function heartbeat(
+  status: BotHealthStatus = 'up',
+  meta?: Record<string, unknown>,
+): Promise<CoworkResult<unknown>> {
+  return request<unknown>('POST', '/api/v1/bots/heartbeat', meta === undefined ? { status } : { status, meta });
+}
+
+/** Read the fleet status board. */
+export function getBots(): Promise<CoworkResult<{ bots: BotHealth[] }>> {
+  return request<{ bots: BotHealth[] }>('GET', '/api/v1/bots');
+}
+
+/**
+ * Start a periodic heartbeat. Returns a stop() function.
+ * No-op (returns a noop stop) when the client is dormant, so it is safe to call
+ * unconditionally from any bot's startup.
+ */
+export function startHeartbeat(
+  intervalMs = 60_000,
+  statusFn: () => BotHealthStatus = () => 'up',
+  meta?: Record<string, unknown>,
+): () => void {
+  if (!coworkEnabled()) return () => {};
+  const tick = (): void => {
+    void heartbeat(statusFn(), meta);
+  };
+  tick();
+  const handle = setInterval(tick, intervalMs);
+  // Don't keep the event loop alive solely for heartbeats.
+  (handle as { unref?: () => void }).unref?.();
+  return () => clearInterval(handle);
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -18,6 +18,7 @@ import { config as loadEnv } from 'dotenv';
 loadEnv();
 
 import { Bot, Context } from 'grammy';
+import { startHeartbeat } from '../lib/cowork';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
@@ -1310,6 +1311,8 @@ async function main(): Promise<void> {
     console.warn('[zoe/index] task seed failed (nbd):', (err as Error).message);
   }
 
+  // Heartbeat to the coworking status board (dormant unless COWORK_API_URL/TOKEN set).
+  startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });
   await bot.start({
     onStart: (info) => {
       console.log(`[zoe/index] polling as @${info.username}`);

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -52,6 +52,25 @@ Purpose: Zaal's personal assistant on Telegram. Morning briefs, voice memos, con
 - [ ] **P2** Evaluate MPP for streaming payments (fractal meetings, live rooms)
 - [ ] **P3** Multi-agent coordination via Quilibrium (await Session 10 transcript)
 
+### Flow-Aware Intake (Rian Doris flow cycle + capture)
+
+Note (2026-06-07): Design frame for how ZOE takes in info from people. Core idea —
+ZOE is Zaal's *smart impulsivity outlet* (Rian Doris's "paper notebook beside you
+during a flow block"): frictionless one-way capture in the moment, structure async
+later, surface for review during recovery windows. Flow cycle = struggle -> release
+-> flow -> recovery. Zaal's ask on "flow": just be *reminded* of the framework, not
+detect a flow state. Captured from Rian Doris / FlowState emails. Builds on doc 796.
+
+- [ ] **P1** Ingest Rian Doris flow framework into ZABAL Bonfire (flow cycle, 3 levers, Flow Fortress, impulsivity outlet, allostatic load, active recovery) so it is recallable
+- [ ] **P1** ZOE capture = dumb-at-capture: silent/minimal ack (✓ reaction, no chatty reply), structure async — a chatty reply re-creates the distraction portal + resets the struggle clock
+- [ ] **P1** Flow-aware timing: hold + batch non-urgent, release only at recovery windows (morning brief / EOD reflect), never mid-block (reframes doc 796 gate: cost of a mistimed ping = 10-20min reload tax, not 30s)
+- [ ] **P2** Brief outputs 3-10 specific next-actions (first-step-of-first-step), never vague projects — Rian's clear-goals lever
+- [ ] **P2** Reminder role: ZOE surfaces flow concepts on grind days / when recovery skipped (answers the "just remind me" ask; auto-enabled once framework is ingested + recallable)
+- [ ] **P2** Commitment extraction from sent mail ("what did I commit to this week that's still open?")
+- [ ] **P2** Granola-style silent call transcription -> ZOE structures commitments/decisions after, no bot in the room
+- [ ] **P2** Save the reusable auto-structure ingest prompt as a snippet/skill (paste + raw dump -> graph, with fidelity/provenance/dedupe/supersede rails)
+- [ ] **P3** ZOE guards the active-recovery calendar (5min/hr, 1hr/day, 1day/wk, 1wk/quarter) — the thing cut first under pressure
+
 ---
 
 ## BOOTCAMP (Farcaster Agentic Bootcamp - Feed Full Transcripts)

--- a/research/agents/798-bonfire-graph-quality-audit/README.md
+++ b/research/agents/798-bonfire-graph-quality-audit/README.md
@@ -1,0 +1,149 @@
+---
+topic: agents
+type: audit
+status: drafted-2026-06-06 (audit + 1 fix shipped: PII gate; calibration + provenance recommendations pending Zaal greenlight)
+last-validated: 2026-06-06
+related-docs: "665, 669, 673, 734, 796"
+original-query: "look thru bonfire stuff — graph quality audit"
+tier: STANDARD (codebase audit of scripts/bonfire-ingest + bot/src/zoe Bonfire path + live-transcript evidence)
+---
+
+# 798 - ZABAL Bonfire: graph data-quality audit
+
+> **Trigger (Zaal, 2026-06-06):** a long live transcript from the `@zabal_bonfire_bot`
+> group. Inside one session the bot surfaced **three** factual errors — all
+> previously stamped `Confidence: 1.0` — and ingested a third party's full legal
+> name + a health diagnosis as foundational nodes. This audit asks: how trustworthy
+> is the graph, and what's the cheapest path to making confidence mean something?
+
+## What this audit covers
+
+The ingest + recall surface that ZAOOS actually controls:
+
+- `scripts/bonfire-ingest/` — `bonfire_client.py` (the POST pipeline), `secret_scan.py`,
+  `pii_scan.py` (new, this doc), the four `ingest_*.py` sources, `verify_manifest.py`.
+- `bot/src/zoe/thread-memory.ts` + `bonfire-queue.ts` — ZOE's emit path into the graph.
+- The live transcript as ground-truth evidence of failure modes.
+
+What it does **not** cover: the Bonfires.ai server internals (entity-resolution,
+the `/labeling/hybrid` vector store, how `Confidence` is computed server-side).
+Those live in Josh's infra; we can only observe behavior, not source.
+
+## Finding 1 — Confidence is decorative (highest priority)
+
+Every recall answer in the transcript carried `Confidence: 1.0`, **including the
+three that were wrong**:
+
+| Claimed at 1.0 | Reality | How it was caught |
+|---|---|---|
+| "TreeUnix Protocol" is GCvlcnti's term | He never used it — his term is "gap filling axioma." The bot minted the phrase | Gustavo happened to be in the room |
+| joshua.eth and Ryan are the same person | Two distinct people | Zaal corrected by hand |
+| ZAO Music Entity doc at `research/business/475` | Real path is `research/music/475` (other 404'd) | Zaal clicked the link |
+
+The pattern: **confidence is not calibrated to correctness.** A 1.0 stamp is
+applied to fabricated relations as readily as to sourced facts. Every catch came
+from a human who already knew the answer — meaning the graph is currently only as
+reliable as the person reading it, which defeats the point of a memory layer.
+
+This is the same failure class as the persona/seed drift fixed in doc 796 and the
+hallucinated-source 404: **the system asserts provenance it hasn't earned.**
+
+**Recommendations (cheapest first):**
+
+1. **Stop trusting server `Confidence` as correctness.** Treat it as "retrieval
+   score," not "truth probability." Document this so nobody downstream gates on it.
+2. **Source-class confidence floor at ingest.** Our pipeline already has the right
+   signal — `source_description` — but doesn't use it to bound confidence. Stamp
+   ingested episodes with a *provenance tier* in the body so recall can cite it:
+   - `tier:canonical` — ZAOOS research README, repo code, a doc Zaal authored
+   - `tier:reported` — meeting summary, chat assertion (single human, unverified)
+   - `tier:inferred` — the bot connected two facts itself (lowest trust)
+   The transcript's three errors were all `inferred` masquerading as `canonical`.
+3. **Human-correction episodes should *supersede*, not append.** The transcript
+   shows the bot doing this well for the 475 path (explicit `supersedes` edge,
+   old node downgraded to 0.1). Make that the *required* shape for every
+   correction, and surface "this was corrected by <human> on <date>" in recall.
+
+## Finding 2 — No PII gate at ingest (FIXED in this doc)
+
+The transcript commits a real person's **full legal name + Hyper-IgE Syndrome
+diagnosis** into the graph as foundational nodes. `.claude/rules/pii-hygiene.md`
+already flagged this exact gap as an open follow-up:
+
+> "The `BonfireMemory` adapter ... does NOT currently scan for PII. **Open
+> follow-up:** add PII regex to the adapter's pre-POST scan."
+
+**Shipped here:** `scripts/bonfire-ingest/pii_scan.py` — a second gate alongside
+`secret_scan.py`, wired into `IngestPipeline.ingest()`. Severity is asymmetric on
+purpose (the graph legitimately holds people, so over-blocking the 670-doc bulk
+ingest is the failure mode to avoid):
+
+- **HIGH → block:** formatted phone, US SSN, Luhn-valid credit card, labeled DOB.
+- **MED → log + post:** non-allowlisted email, personal Telegram handle, address.
+- **skip:** allowlisted emails + `*_bot` handles.
+
+**The honest limitation — and why this is a floor, not a fix:** regex catches
+*structured* PII only. The transcript's actual leak — a name and a free-text
+health disclosure — is **just words**; no regex detects it. Catching that needs
+one of:
+
+- **(a) Human-in-the-loop** — the bot *already* asks "Approve all?" before
+  committing manifests. Today that's the only real backstop for names/health
+  data. It works only when a vigilant human reviews each manifest. *Recommend:
+  make the approval prompt explicitly call out person-nodes and any
+  health/biographical free-text so the reviewer's eye is drawn to them.*
+- **(b) LLM classifier** at ingest — a cheap pass ("does this episode contain a
+  third party's name + sensitive personal attribute they didn't consent to
+  share?") gated to MED/HIGH. This is the real fix; tracked as a follow-up,
+  not built here (needs Zaal's call on cost + which model).
+
+Per pii-hygiene.md, none of the name/diagnosis content is reproduced in this doc.
+
+## Finding 3 — Ingest provenance is thin and unverifiable
+
+- `verify_manifest.py` notes GET-by-UUID returns 404 even for confirmed episodes
+  (Bonfires stores under internal UUIDs ≠ the supplied one). **We cannot verify
+  what we ingested.** The manifest is a record of *attempts*, not *graph state*.
+  Until the API exposes a stable read-back, we're ingesting blind.
+- `ingest_research_library.py` pipes ~670 docs with `source_description` =
+  `zaoos-research:<path>`. Good — but the 475 error shows even canonical paths
+  drift. **Recommend:** the ingester should `HEAD`-check each `source_url` it
+  emits and refuse to stamp a 404 path as canonical.
+
+## Finding 4 — Recall has no "I don't know" floor
+
+The "meaning of life" exchange shows the bot improvising a plausible answer from
+adjacent nodes (Proof of Meaningful Work, Contribution Circles) rather than
+saying "not in the graph." Confident improvisation is exactly how the three
+Finding-1 errors entered. **Recommend:** a recall instruction to distinguish
+"here's what the graph says" from "here's me reasoning past the graph," and to
+prefer an explicit gap over a synthesized answer.
+
+## Priority / effort
+
+| # | Fix | Effort | Status |
+|---|---|---|---|
+| 2 | PII gate at ingest (structured) | done | ✅ shipped this doc |
+| 1a | Stop gating on server `Confidence`; document it | doc-only | recommend |
+| 1b | Provenance tier (`canonical`/`reported`/`inferred`) in episode body | S | recommend |
+| 3b | `HEAD`-check `source_url` before stamping canonical | S | recommend |
+| 1c | Require `supersedes` shape for corrections | S | recommend |
+| 4 | Recall "I don't know" floor (prompt) | S | recommend — bot-prompt, lives on VPS |
+| 2b | LLM PII classifier (names + health free-text) | M | needs Zaal greenlight (cost/model) |
+
+## Open questions for Zaal
+
+1. **Provenance tiers** — adopt the 3-tier (`canonical`/`reported`/`inferred`)
+   stamp in episode bodies? It's the highest-leverage, lowest-cost calibration fix.
+2. **LLM PII classifier** — worth a cheap per-ingest classification pass for
+   names + sensitive free-text? Which model (Minimax local vs hosted)?
+3. The recall-prompt fixes (Findings 1a, 4) live in the bot's system prompt on
+   the VPS, not in this repo. Want those folded into the doc-799 DeepMeeting
+   prompt work, or patched into the main `@zabal_bonfire_bot` prompt separately?
+
+## Source
+
+- Live `@zabal_bonfire_bot` transcript, 2026-06-06 (Zaal-supplied).
+- `scripts/bonfire-ingest/` — pipeline code (audited + extended).
+- `.claude/rules/pii-hygiene.md`, `.claude/rules/secret-hygiene.md`.
+- Docs 665 / 669 / 673 (Bonfire integration), 734 (BonfireMemory adapter), 796 (drift precedent).

--- a/research/agents/798-bonfire-graph-quality-audit/README.md
+++ b/research/agents/798-bonfire-graph-quality-audit/README.md
@@ -124,8 +124,8 @@ prefer an explicit gap over a synthesized answer.
 | # | Fix | Effort | Status |
 |---|---|---|---|
 | 2 | PII gate at ingest (structured) | done | ✅ shipped this doc |
+| 1b | Provenance tier (`canonical`/`reported`/`inferred`) in episode body | done | ✅ shipped (Zaal greenlit 2026-06-06) |
 | 1a | Stop gating on server `Confidence`; document it | doc-only | recommend |
-| 1b | Provenance tier (`canonical`/`reported`/`inferred`) in episode body | S | recommend |
 | 3b | `HEAD`-check `source_url` before stamping canonical | S | recommend |
 | 1c | Require `supersedes` shape for corrections | S | recommend |
 | 4 | Recall "I don't know" floor (prompt) | S | recommend — bot-prompt, lives on VPS |

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -270,6 +270,95 @@ prompts drafted above. Remaining — all on the Bonfires dashboard, not this rep
 
 Both prompts are paste-ready; the steps above are dashboard actions for Zaal.
 
+## Bonfires (Delve) agent-config schema — observed 2026-06-06
+
+Captured from Zaal's dashboard screenshots so the platform's parameters live in
+ZAOOS even though the agents run on Bonfires. Tabs on each agent:
+
+| Tab | Fields |
+|---|---|
+| General | Agent Name · Username (IMMUTABLE after creation) · System Prompt · Timezone |
+| Platform | Telegram bot token · Chat ID · Topic ID · "don't ignore reporting group" |
+| Chat | Group Policy · DM Policy · Silent Mode · Disable Storing Group/DM Messages · Allowed Users · Scheduling Allowed Users · DMs Store Allowed Users · Server Configs |
+| Features | Image/Audio/Document Input · Image Generation · Task Scheduling · Default Image Model · (admin) Max Tool Iterations, Max Parallel Tool Calls |
+| Tools | MCP tool checkboxes — see below |
+| Skills | Judging skills (hackathon/synthesis/celebrity/dev3pack) — all writer-irrelevant |
+| Personality | Discrete editable traits, injected into every response (the 12 constraints live here as 15 traits) |
+| LLM Config | **Internal Model** (think/decide/label flow) · Default Response Model · Allowed Response Models |
+
+**Tools available** (current `@zabal_bonfire` has 9 enabled): Firecrawl Web
+Scraper, Fireflies Meeting Transcripts, **Bonfires Delve** (KG tools + insights),
+Cross-Bonfire Search, Twitter Get Tweets, Message Search, User Lookup, Scheduling
+Tools, Trimtab Tools — enabled. Off: Hackathon Review, **Agent Personality**
+(self-edits traits — keep OFF), Document Store, **REST API** (arbitrary
+http_request), Error Reporting, ClickUp, Moltbook, Surf AI, Schelling Point,
+sheeets, **Delve Knowledge Graph (Write episodes)**, judging tools, HubSpot.
+
+**Open crux:** does "Bonfires Delve" write, or only read? "Delve Knowledge Graph
+(Write episodes)" is a separate, currently-unchecked tool, yet the bot writes
+today — so "Bonfires Delve" likely bundles read+write. This decides whether the
+READER can be hardened structurally (uncheck write tools) or only by prompt. The
+bot can answer this itself (it has the tools) — see generation prompt below.
+
+**`@zabal_bonfire` current 15 personality traits:** extraction_discipline,
+dedupe_policy, edge_direction, title_normalization, scope_constraint,
+bot_self_reference, state_truthfulness, verbatim_preservation, provenance,
+identity_facets, speaker_routing, temporal_evolution, batch_paraphrase_gate,
+voice, recall_format. (provenance already mandates confidence 0.6-1.0 — the
+always-1.0 problem in doc 798 is adherence, not a missing rule.)
+
+## Writer build kit — `@zabal_deepthink`
+
+- **General:** name `ZABAL Deep Think`; username `zabal_deepthink` (immutable);
+  system prompt = the deliberate-writer prompt (Prompt 2, deep-think protocol).
+- **Platform:** own @BotFather token; same Chat ID `1003940147360` (shared room).
+- **Chat:** Allowed Users = bettercallzaal + GCvlcnti.
+- **Features:** Document Input on; Image Gen + Task Scheduling off.
+- **Tools:** Bonfires Delve + Delve Knowledge Graph (Write episodes) + Firecrawl
+  + Fireflies + Cross-Bonfire Search + Message Search + User Lookup + Twitter +
+  Trimtab. OFF: Agent Personality, REST API, Scheduling.
+- **Skills:** none.
+- **Personality:** copy the 15, add 4 — `deep_think_gate`,
+  `confidence_calibration` (default 0.7; 0.9+ only with retrieved source; 1.0 only
+  on-chain/official; inference 0.6), `pii_guard`, `vocabulary_fidelity` ("gap
+  filling axioma" canonical, "TreeUnix Protocol" superseded alias).
+- **LLM Config:** Internal Model = most capable reasoning preset (the deep-think
+  lever). Confirm available presets with the bot.
+
+## Generation prompt — paste to `@zabal_bonfire` (Zaal's dogfood idea)
+
+Have the bot generate the writer config using its live platform knowledge,
+WITHOUT writing any of it to the graph (respects `bot_self_reference`):
+
+```
+Context, do NOT ingest any of this to the graph (this is operational
+configuration, not graph content - your bot_self_reference rule applies):
+
+I'm creating a sibling agent on Bonfires: @zabal_deepthink, the deliberate
+WRITER for our knowledge graph. You will become RETRIEVAL-ONLY; it becomes the
+only agent that writes facts. It must "think before it writes."
+
+Using your knowledge of THIS Bonfires platform, generate its full config:
+1. Which exact Tools must be enabled for it to WRITE episodes/nodes, and which
+   tool you currently use to write - does "Bonfires Delve" write, or is it
+   "Delve Knowledge Graph (Write episodes)"? Tell me the truth about your own
+   write path.
+2. The Internal Model presets available in LLM Config, and which is the most
+   capable for a think/decide/label flow.
+3. A full system prompt for it that adds a deep-think protocol on top of our 12
+   constraints: restate facts in the speaker's own words (never coin a term and
+   attribute it), triage chatter, dedupe + contradiction-check, verify any
+   source_url resolves, calibrate confidence honestly (default 0.7, 1.0 only for
+   on-chain/official), and a PII guard (no third-party personal/health data
+   without consent). Commit only on "approve all".
+4. Which of your 15 personality traits it should inherit, plus any new traits.
+
+Output as a config spec I can paste tab-by-tab. Do not write anything to the graph.
+```
+
+The bot's answers to #1 and #2 close the gaps in the build kit above (the write
+tool + the model presets). Reconcile its output with the kit; they should agree.
+
 ## Source
 
 - Live `@zabal_bonfire_bot` / DeepMeeting transcript, 2026-06-06 (Zaal-supplied).

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -1,0 +1,141 @@
+---
+topic: agents
+type: design-proposal
+status: proposal-2026-06-06 (REQUIRED gate per CLAUDE.md "no new bots without doc" — needs explicit Zaal greenlight before any bot is created)
+last-validated: 2026-06-06
+related-docs: "601, 665, 669, 673, 734, 798"
+original-query: "spec the DeepMeeting agent properly"
+tier: STANDARD (proposal synthesizing live transcript + CLAUDE.md governance + bonfire architecture)
+---
+
+# 799 - DeepMeeting agent / shard architecture
+
+> **This doc exists to satisfy a hard rule.** CLAUDE.md → Primary Surfaces:
+> *"no new bots without doc. Before adding a new Telegram bot, agent process, or
+> autonomous loop, write a numbered research doc + get explicit Zaal approval."*
+> The 2026-06-06 transcript has Zaal mid-flight on a dedicated DeepMeeting agent
+> (`@treemojo_bonfire` / `@deepmeeting_bot`, GCvlcnti as admin). Before that bot
+> exists, this is the required gate. **No bot should be created until Zaal
+> explicitly greenlights an option below.**
+
+## What's being proposed (from the transcript)
+
+A dedicated DeepMeeting agent, separate from the main `@zabal_bonfire_bot`:
+
+- **Scope:** the TreeUnix / "gap filling axioma" / Kanzi work with GCvlcnti — a
+  distinct vocabulary and protocol set that Zaal flagged as a *bad-data risk* when
+  it bled into the main graph (the "TreeUnix Protocol" fabrication, doc 798
+  Finding 1).
+- **Admin:** GCvlcnti designated as ZABAL Bonfire admin for that shard.
+- **Architecture (as discussed):** hybrid dispatcher — `@zabal_bonfire_bot` as
+  `/root` orchestrator routing tasks to specialized shards, which sync results
+  back atomically to one unified graph.
+- **Suggested handles:** `@treemojo_bonfire` or `@deepmeeting_bot`.
+- **Open item the bot is still waiting on:** confirmation to update the
+  DeepMeeting agent's draft prompt to reflect its subordinate shard role.
+
+## The tension this proposal has to resolve
+
+CLAUDE.md just spent doc 601 *collapsing* the agent fleet from 12+ surfaces to 5,
+and the decommission list is explicit:
+
+> "10-bot branded fleet (Magnetiq/Research/WaveWarZ/POIDH as own bots) — folds
+> into ZOE memory blocks ... New brand voices = persona block ... NOT a new bot."
+
+A new `@deepmeeting_bot` runs directly against that grain. **But** DeepMeeting is
+arguably not "a new brand voice" — it's a different *surface* (different group,
+different admin/human, different protocol scope, an explicit data-isolation
+requirement). The whole point in the transcript is to *keep TreeUnix vocabulary
+OUT of the main graph until it's validated.* That's a real architectural need.
+The question is whether a separate Telegram **bot** is the right unit to meet it,
+or whether a namespace/shard *inside the existing bot* meets it more cheaply.
+
+## Three options
+
+### Option A — Namespace/shard inside `@zabal_bonfire_bot` (no new bot) ✅ recommended
+One bot, one token, one process. DeepMeeting is a **partition/context tag** on the
+existing pipeline: episodes from the DeepMeeting group get `source_description:
+deepmeeting:<topic>` and a `scope:deepmeeting` marker, and recall can be filtered
+to include/exclude that scope. GCvlcnti gets admin on the *group*, not a new bot.
+
+- **Pros:** zero new infra, no token/process to manage, satisfies the
+  data-isolation need (scope filter), aligns with the doc-601 collapse, nothing
+  new to decommission later. The "keep TreeUnix out of the main graph" goal is met
+  by *scope*, not by a separate bot.
+- **Cons:** isolation is logical, not physical — a bug in the scope filter could
+  leak DeepMeeting vocab into general recall (the exact failure that started this).
+  Mitigation: make `scope` a hard filter on both ingest labeling and recall.
+
+### Option B — Separate bot, shared graph (the transcript's "hybrid dispatcher")
+A real `@deepmeeting_bot` process, its own token, writing to the *same* Bonfire
+graph with a shard tag; `@zabal_bonfire_bot` orchestrates.
+
+- **Pros:** physical process isolation; GCvlcnti can fully own his surface;
+  matches the mental model in the transcript.
+- **Cons:** a new bot + token + systemd unit + monitoring; **directly trips the
+  no-new-bots collapse**; two processes writing one graph need careful atomic
+  sync (the transcript hand-waved "sync back atomically" — that's non-trivial).
+  Requires explicit Zaal sign-off against his own consolidation rule.
+
+### Option C — Separate bot, separate graph (true shard)
+`@deepmeeting_bot` writes to its *own* Bonfire (a separate `BONFIRE_ID`), promoted
+into the main graph only on explicit approval.
+
+- **Pros:** strongest isolation — TreeUnix data physically cannot contaminate the
+  main graph until promoted; best fit for "facts at a time / situational
+  prototypes" (DvlsMojo's own framing of the v0.01–v0.05 work).
+- **Cons:** most infra; a promotion pipeline to build; two graphs to keep coherent.
+
+## Recommendation
+
+**Start with Option A.** It meets the actual stated need — *keep unvalidated
+TreeUnix vocabulary out of the trusted graph* — with a scope filter, zero new
+bots, and full alignment with the doc-601 collapse. If logical isolation proves
+insufficient in practice (vocab leaks despite the scope filter, or GCvlcnti needs
+genuine independent ownership), graduate to **Option C** (separate graph) rather
+than B — physical data isolation is the thing worth paying infra for; a second
+bot sharing one graph (B) is the worst of both (new infra *and* contamination
+risk).
+
+## Hard constraints (regardless of option)
+
+1. **One token per agent — never shared.** The transcript raised "same Telegram
+   bot token for manus + bonfires agent." Zaal's "prob not best" is correct: two
+   pollers on one token fight over `getUpdates` and silently drop each other's
+   updates. If any new bot is created, it gets its own token from `@BotFather`.
+2. **Scope isolation is the requirement, not the bot.** Whatever option, the
+   testable goal is: TreeUnix/"gap filling axioma" vocabulary must not surface in
+   general `@zabal_bonfire_bot` recall unless explicitly promoted.
+3. **GCvlcnti admin scope must be bounded.** Admin on the DeepMeeting
+   surface/group ≠ owner of the main graph. The transcript shows confusion about
+   view-vs-edit/config permissions — define this explicitly before granting.
+4. **Correct vocabulary at the source.** Per doc 798, seed the DeepMeeting scope
+   with "gap filling axioma" as canonical and the bot-minted "TreeUnix Protocol"
+   as a downgraded/superseded alias, so the shard doesn't re-import the error.
+
+## If Zaal greenlights a new bot (B or C): prompt scope checklist
+
+The draft system prompt the bot is waiting to finalize should cover:
+
+- Core protocol definitions in GCvlcnti's *actual* terms (not bot-coined ones).
+- Explicit scope exclusions (e.g. Stigmergy excluded from this shard, per transcript).
+- Subordinate-shard role: how it reports up to `/root`, atomic sync semantics.
+- Data-isolation guarantee: what it may and may not write to the main graph.
+- The `pii_scan` + `secret_scan` gates (doc 798) apply to its ingest too.
+- Governance: who approves promotion of shard facts into the main graph.
+
+## Decision needed from Zaal
+
+- [ ] **Option A** (scope inside existing bot — recommended), **B**, or **C**?
+- [ ] If B/C: confirm against the no-new-bots collapse, and provision a *separate* token.
+- [ ] GCvlcnti admin scope — group-level only, or graph-level?
+- [ ] Greenlight to draft the actual system prompt (currently the bot's open item)?
+
+No implementation proceeds until these are answered — that's the rule this doc exists to honor.
+
+## Source
+
+- Live `@zabal_bonfire_bot` / DeepMeeting transcript, 2026-06-06 (Zaal-supplied).
+- CLAUDE.md → Primary Surfaces (the no-new-bots rule + doc-601 collapse).
+- Doc 798 (graph quality audit — the bad-data risk that motivates isolation).
+- Docs 601 (agent-stack cleanup), 665/669/673 (Bonfire architecture), 734 (BonfireMemory adapter).

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -1,7 +1,7 @@
 ---
 topic: agents
 type: design-proposal
-status: decided-architecture-2026-06-06 (read/write split chosen; reader-hardening = Bonfires dashboard config; writer bot = our code, needs Zaal greenlight on name+token before build — no-new-bots gate)
+status: decided-architecture-2026-06-06 (read/write split; both bots Bonfires-hosted; both system prompts drafted + paste-ready; remaining steps are Bonfires-dashboard actions for Zaal)
 last-validated: 2026-06-06
 related-docs: "601, 665, 669, 673, 734, 798"
 original-query: "spec the DeepMeeting agent properly"
@@ -76,54 +76,108 @@ below. **The split axis is capability, not topic:**
    tool, "ingest this: …" from a group member can't land. Writes funnel through
    one deliberate, gated path.
 
-### Critical implementation fact: the reader is NOT our code
+### Both bots are Bonfires-hosted (Zaal, 2026-06-06)
 
 Per doc 673d, `@zabal_bonfire` is an LLM agent **hosted inside Bonfires.ai**
-(app.bonfires.ai dashboard, ERC-8004 #32009), with its intake+recall behavior
-defined by a system prompt + 15 personality traits **on Josh's platform.** So:
+(app.bonfires.ai dashboard, ERC-8004 #32009), configured by a system prompt +
+personality traits on Josh's platform. Zaal's call: **the writer is the same
+kind of thing** — a second Bonfires-hosted Telegram agent (own handle, optional
+API key), NOT a process in our `bot/src/` fleet. So:
 
-- **Hardening the reader = a Bonfires-dashboard config change**, not a repo edit.
-  Strip the write half of its system prompt (the "say 'ingest' to add a fact"
-  behavior, the "Approve all?" manifest-commit flow). Draft below.
-- **The writer = our code.** Writes go through `POST /knowledge_graph/episode/
-  create` — exactly what `scripts/bonfire-ingest/` already does, now with the
-  PII gate (doc 798) + provenance tiers. The writer is a Telegram bot (own
-  token) wrapping that pipeline with a deliberate reasoning step.
+- **Both bots are configured on the Bonfires dashboard**, not in this repo. The
+  deliverable is two system prompts (below). The audit findings (provenance
+  tiers, dedup/supersede, PII/secret discipline) have to be expressed as
+  *prompt instructions* — the hosted agent can't import our Python gates.
+- **Our `scripts/bonfire-ingest/` pipeline stays** for *programmatic bulk*
+  ingest (research library, GitHub READMEs, brand kit) where the Python
+  `pii_scan` + `secret_scan` + provenance tiers do run. The conversational
+  writer is the dashboard agent; the pipeline is the batch path. Same graph.
+- **No-new-bots burden is light:** Bonfires hosts it, so it adds no systemd unit
+  / no ops to our VPS fleet. The doc requirement is honored by this file.
+- **One token per agent** still holds — the writer gets its own Bonfires agent
+  identity, never shares `@zabal_bonfire`'s.
 
-### Reader-hardening prompt edits (for the Bonfires dashboard)
+This makes the institutional memory live in ZAOOS even though the bots run on
+Bonfires — per CLAUDE.md, "research stays in ZAOOS forever."
 
-Paste-ready direction for the `@zabal_bonfire` system prompt:
+---
+
+## The two system prompts (paste into the Bonfires dashboard)
+
+### PROMPT 1 — Reader: `@zabal_bonfire` (hardened, retrieval-only)
 
 ```
-ROLE CHANGE — RETRIEVAL ONLY.
-You answer questions from the knowledge graph and cite sources. You do NOT
-write to the graph. You have no ingest, no node creation, no edge creation,
-no supersede, no "Approve all?" flow. Remove those capabilities entirely.
+You are the ZABAL Bonfire retrieval agent. You answer questions from the
+knowledge graph and cite your sources. You are READ-ONLY.
 
-When a user asks you to add / ingest / correct / build a fact, do NOT propose
-a manifest. Instead reply: "Writes go through the deep-thinking writer —
-tag @<writer_handle> to add or correct a fact." Then, if useful, summarize
-what they'd want to capture so they can hand it to the writer.
+HARD CONSTRAINTS — you have NO write capability:
+- No ingest. No node creation. No edge creation. No supersede. No "new fact
+  proposal." No "Approve all?" manifest flow. These are removed entirely.
+- If a user asks you to add / ingest / commit / correct / build / update a
+  fact, DO NOT propose a manifest and DO NOT claim you updated anything.
+  Reply: "Writes go through the deep-thinking writer — tag @<WRITER_HANDLE>
+  to add or correct a fact." If useful, summarize in 1-2 lines what they'd
+  want captured so they can hand it off cleanly.
 
-When you answer, lead with the provenance tier of your top sources
-(canonical / reported / inferred) and prefer an explicit "not in the graph"
-over improvising an answer from adjacent nodes. (doc 798 Findings 1 + 4)
+ANSWER DISCIPLINE:
+- Cite sources for every claim. Lead with the PROVENANCE TIER of your top
+  source(s): [canonical] verifiable repo/doc/URL · [reported] one human said
+  it, unverified · [inferred] connected by an agent. If an episode carries a
+  "[provenance: ...]" tag, surface it. Prefer citing the tier over the raw
+  Confidence number.
+- The server's "Confidence" is a RETRIEVAL score, not a truth probability.
+  Never present 1.0 as "this is definitely true."
+- If the graph does not contain the answer, SAY SO: "That's not in the graph."
+  Do NOT improvise an answer by stitching together adjacent nodes. An explicit
+  gap is more useful than a confident guess. (This is how three wrong facts
+  entered the graph — see the audit.)
+- Distinguish "here's what the graph says" from "here's me reasoning past the
+  graph" and label the second clearly when you do it.
+- Be concise. Normalize entity titles to their canonical form. Flag when two
+  results look like duplicates of the same entity.
 ```
 
-### Writer bot scope (our code — needs Zaal greenlight to build)
+### PROMPT 2 — Writer: `@<WRITER_HANDLE>` (deep-thinking, sole graph-writer)
 
-A new Telegram bot, own token, single writer. On a write request it:
+```
+You are the ZABAL Bonfire WRITER — the single agent permitted to add or change
+facts in the knowledge graph. You are deliberate by design. You THINK before
+you write, and you never auto-commit.
 
-1. **Thinks first** (the "deep thinking"): classifies the fact, decides the
-   provenance tier it can honestly vouch for, checks the graph for an existing
-   / contradicting node, runs `secret_scan` + `pii_scan`.
-2. **Proposes a structured manifest** (the shape `@zabal_bonfire` uses today)
-   with the tier attached, and asks for approval.
-3. **Commits via the ingest pipeline** on approval — the only write path.
+DEEP-THINKING PROTOCOL — run every step BEFORE proposing a write:
+1. RESTATE the candidate fact in one line, in the speaker's ACTUAL words. Do
+   not coin a new term and attribute it to someone. (e.g. use "gap filling
+   axioma" — the term its author used — never invent "TreeUnix Protocol.")
+2. TRIAGE: is this a durable fact worth persisting, or chatter / a question /
+   your own output? Only persist real facts about the world. Drop the rest.
+3. TIER it honestly — the provenance you can DEFEND:
+     [canonical] a verifiable source exists (repo path, doc, URL you checked)
+     [reported]  one human asserted it; unverified
+     [inferred]  you connected two facts yourself
+   Default to the LOWEST tier you can't rule up from. NEVER stamp [inferred]
+   as [canonical] — that is the exact failure this role exists to prevent.
+4. DEDUP + CONTRADICTION: search the graph for an existing or conflicting node
+   first. If it exists, propose a SUPERSEDE (explicit supersedes edge + downgrade
+   the old node), never a duplicate. If it contradicts, surface the conflict to
+   the human instead of silently overwriting.
+5. SOURCE CHECK: if you cite a URL or path, you must have actually verified it
+   resolves. Never invent a path. An unverifiable claim is [reported] at best.
+6. SECRET + PII DISCIPLINE (you have no automated scanner — this is on you):
+   - NEVER write an API key, token, private key, seed phrase, or connection
+     string. Use [REDACTED] if you must reference one.
+   - NEVER write a third party's personal email, phone, home address, or a
+     sensitive personal/health disclosure about a real person without their
+     explicit in-thread consent. Redact to <redacted-email> / <redacted-phone>.
+     Names of ZAO ecosystem people are fine; sensitive attributes are not.
 
-This is the Hermes coder+critic pattern applied to graph writes. It still trips
-the no-new-bots rule, but with airtight justification: least-privilege
-capability isolation. **Build needs Zaal's explicit go on name + token.**
+OUTPUT: a structured manifest — nodes, edges, each with its [provenance: tier]
+and source — then ask "Approve?". COMMIT ONLY on explicit human approval.
+Corrections use SUPERSEDE, never append. If you cannot tier it, source it, or
+clear the PII bar, DO NOT WRITE IT — say what's missing instead.
+```
+
+> Replace `@<WRITER_HANDLE>` in both prompts with the writer's real handle once
+> Zaal creates the Bonfires agent.
 
 ---
 
@@ -201,20 +255,20 @@ The draft system prompt the bot is waiting to finalize should cover:
 
 ## Decision needed from Zaal
 
-Architecture is decided (read/write split). Remaining gates before build:
+Architecture decided (read/write split); both bots Bonfires-hosted; both
+prompts drafted above. Remaining — all on the Bonfires dashboard, not this repo:
 
 - [x] **Split axis** — capability (read vs write), not topic. ✅ Zaal 2026-06-06
-- [ ] **Harden the reader** — apply the dashboard prompt edits above to
-      `@zabal_bonfire` (Zaal/Josh, on the Bonfires platform). Out of repo scope.
-- [ ] **Writer bot greenlight** — name + a *separate* `@BotFather` token. Trips
-      no-new-bots; justified by least-privilege. Where does it live —
-      `bot/src/` as its own surface, or folded under ZOE's process?
-- [ ] **GCvlcnti scope** — admin on the DeepMeeting group / writer surface, not
-      the main graph. Define view-vs-edit explicitly (transcript confusion).
-- [ ] **Vocabulary seed** — load "gap filling axioma" as canonical, the
+- [x] **Where the writer lives** — Bonfires-hosted agent, like the reader. ✅
+- [ ] **Apply Prompt 1** to `@zabal_bonfire` (hardens it to read-only).
+- [ ] **Create the writer agent** on Bonfires (own identity, optional API key),
+      paste Prompt 2, set its real handle into both prompts.
+- [ ] **GCvlcnti scope** — admin on the writer/DeepMeeting surface, not the main
+      graph. Define view-vs-edit explicitly (transcript showed confusion).
+- [ ] **Vocabulary seed** — via the writer: "gap filling axioma" as canonical,
       bot-minted "TreeUnix Protocol" as a superseded alias (doc 798 Finding 1).
 
-No writer code proceeds until the greenlight — that's the rule this doc honors.
+Both prompts are paste-ready; the steps above are dashboard actions for Zaal.
 
 ## Source
 

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -1,7 +1,7 @@
 ---
 topic: agents
 type: design-proposal
-status: proposal-2026-06-06 (REQUIRED gate per CLAUDE.md "no new bots without doc" — needs explicit Zaal greenlight before any bot is created)
+status: decided-architecture-2026-06-06 (read/write split chosen; reader-hardening = Bonfires dashboard config; writer bot = our code, needs Zaal greenlight on name+token before build — no-new-bots gate)
 last-validated: 2026-06-06
 related-docs: "601, 665, 669, 673, 734, 798"
 original-query: "spec the DeepMeeting agent properly"
@@ -50,7 +50,84 @@ OUT of the main graph until it's validated.* That's a real architectural need.
 The question is whether a separate Telegram **bot** is the right unit to meet it,
 or whether a namespace/shard *inside the existing bot* meets it more cheaply.
 
-## Three options
+## DECISION (Zaal, 2026-06-06): read/write split, not topic-sharding
+
+Zaal reframed the whole thing, and it's a better cut than the A/B/C options
+below. **The split axis is capability, not topic:**
+
+> "Harden the zabal bonfire bot to be just knowledge retrieval, and if it needs
+> to build / add a node it uses a different bot starting with deep thinking."
+
+- **Reader = `@zabal_bonfire`** → retrieval ONLY. No write capability. This is
+  the bot everyone in the group talks to.
+- **Writer = a new deep-thinking bot** → the SOLE thing that can add/supersede
+  nodes. Leads with a reasoning pass (provenance tier, dedup, contradiction
+  check, secret+PII scan) and only commits on approval.
+
+**Why this beats topic-sharding (and dissolves the Option B sync problem):**
+
+1. Fixes doc 798 Finding 1 at the root. Fabricated facts got stamped 1.0
+   because the *same* agent that retrieves also improvises writes. Remove the
+   write tool from the reader and it **structurally cannot** corrupt the graph.
+2. **Single writer.** My Option-B worry was "two processes writing one graph
+   need atomic sync." A read/write split has exactly one writer — no contention,
+   no sync. The shared graph is safe by construction.
+3. Prompt-injection resistance: anyone can message the reader; with no write
+   tool, "ingest this: …" from a group member can't land. Writes funnel through
+   one deliberate, gated path.
+
+### Critical implementation fact: the reader is NOT our code
+
+Per doc 673d, `@zabal_bonfire` is an LLM agent **hosted inside Bonfires.ai**
+(app.bonfires.ai dashboard, ERC-8004 #32009), with its intake+recall behavior
+defined by a system prompt + 15 personality traits **on Josh's platform.** So:
+
+- **Hardening the reader = a Bonfires-dashboard config change**, not a repo edit.
+  Strip the write half of its system prompt (the "say 'ingest' to add a fact"
+  behavior, the "Approve all?" manifest-commit flow). Draft below.
+- **The writer = our code.** Writes go through `POST /knowledge_graph/episode/
+  create` — exactly what `scripts/bonfire-ingest/` already does, now with the
+  PII gate (doc 798) + provenance tiers. The writer is a Telegram bot (own
+  token) wrapping that pipeline with a deliberate reasoning step.
+
+### Reader-hardening prompt edits (for the Bonfires dashboard)
+
+Paste-ready direction for the `@zabal_bonfire` system prompt:
+
+```
+ROLE CHANGE — RETRIEVAL ONLY.
+You answer questions from the knowledge graph and cite sources. You do NOT
+write to the graph. You have no ingest, no node creation, no edge creation,
+no supersede, no "Approve all?" flow. Remove those capabilities entirely.
+
+When a user asks you to add / ingest / correct / build a fact, do NOT propose
+a manifest. Instead reply: "Writes go through the deep-thinking writer —
+tag @<writer_handle> to add or correct a fact." Then, if useful, summarize
+what they'd want to capture so they can hand it to the writer.
+
+When you answer, lead with the provenance tier of your top sources
+(canonical / reported / inferred) and prefer an explicit "not in the graph"
+over improvising an answer from adjacent nodes. (doc 798 Findings 1 + 4)
+```
+
+### Writer bot scope (our code — needs Zaal greenlight to build)
+
+A new Telegram bot, own token, single writer. On a write request it:
+
+1. **Thinks first** (the "deep thinking"): classifies the fact, decides the
+   provenance tier it can honestly vouch for, checks the graph for an existing
+   / contradicting node, runs `secret_scan` + `pii_scan`.
+2. **Proposes a structured manifest** (the shape `@zabal_bonfire` uses today)
+   with the tier attached, and asks for approval.
+3. **Commits via the ingest pipeline** on approval — the only write path.
+
+This is the Hermes coder+critic pattern applied to graph writes. It still trips
+the no-new-bots rule, but with airtight justification: least-privilege
+capability isolation. **Build needs Zaal's explicit go on name + token.**
+
+---
+
+## (superseded) Three topic-sharding options
 
 ### Option A — Namespace/shard inside `@zabal_bonfire_bot` (no new bot) ✅ recommended
 One bot, one token, one process. DeepMeeting is a **partition/context tag** on the
@@ -86,16 +163,14 @@ into the main graph only on explicit approval.
   prototypes" (DvlsMojo's own framing of the v0.01–v0.05 work).
 - **Cons:** most infra; a promotion pipeline to build; two graphs to keep coherent.
 
-## Recommendation
+## Recommendation (superseded by the read/write split above)
 
-**Start with Option A.** It meets the actual stated need — *keep unvalidated
-TreeUnix vocabulary out of the trusted graph* — with a scope filter, zero new
-bots, and full alignment with the doc-601 collapse. If logical isolation proves
-insufficient in practice (vocab leaks despite the scope filter, or GCvlcnti needs
-genuine independent ownership), graduate to **Option C** (separate graph) rather
-than B — physical data isolation is the thing worth paying infra for; a second
-bot sharing one graph (B) is the worst of both (new infra *and* contamination
-risk).
+Original recommendation was Option A (scope inside the existing bot). The
+read/write split supersedes the topic-sharding framing entirely: it isolates by
+*capability* (who can write) rather than by *topic* (what's written), which is
+the stronger guarantee. Topic isolation (keeping TreeUnix vocab quarantined) can
+still ride on top — as a `provenance: inferred` tier + a scope tag on the
+writer's path — without needing a separate bot per topic.
 
 ## Hard constraints (regardless of option)
 
@@ -126,12 +201,20 @@ The draft system prompt the bot is waiting to finalize should cover:
 
 ## Decision needed from Zaal
 
-- [ ] **Option A** (scope inside existing bot — recommended), **B**, or **C**?
-- [ ] If B/C: confirm against the no-new-bots collapse, and provision a *separate* token.
-- [ ] GCvlcnti admin scope — group-level only, or graph-level?
-- [ ] Greenlight to draft the actual system prompt (currently the bot's open item)?
+Architecture is decided (read/write split). Remaining gates before build:
 
-No implementation proceeds until these are answered — that's the rule this doc exists to honor.
+- [x] **Split axis** — capability (read vs write), not topic. ✅ Zaal 2026-06-06
+- [ ] **Harden the reader** — apply the dashboard prompt edits above to
+      `@zabal_bonfire` (Zaal/Josh, on the Bonfires platform). Out of repo scope.
+- [ ] **Writer bot greenlight** — name + a *separate* `@BotFather` token. Trips
+      no-new-bots; justified by least-privilege. Where does it live —
+      `bot/src/` as its own surface, or folded under ZOE's process?
+- [ ] **GCvlcnti scope** — admin on the DeepMeeting group / writer surface, not
+      the main graph. Define view-vs-edit explicitly (transcript confusion).
+- [ ] **Vocabulary seed** — load "gap filling axioma" as canonical, the
+      bot-minted "TreeUnix Protocol" as a superseded alias (doc 798 Finding 1).
+
+No writer code proceeds until the greenlight — that's the rule this doc honors.
 
 ## Source
 

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -405,10 +405,10 @@ Twitter + Trimtab. OFF: Agent Personality, REST API, Scheduling, autonomous trig
 **LLM Config:** Internal Model = highest-capability reasoning preset (bot
 recommends "Claude Opus tier"). Still need the actual dropdown preset names.
 
-**OPEN — Zaal decides (changes Chat tab + Telegram policy):** does the writer
-take messages directly (gated to Zaal + GCvlcnti via Allowed Users), or only
-structured hand-offs routed from the reader / Zaal? Direct-but-gated is less
-friction; hand-off-only is more controlled. Pending Zaal.
+**RESOLVED — intake (Zaal, 2026-06-06):** direct, gated to two. The writer
+processes messages only from `bettercallzaal` + GCvlcnti (Allowed Users);
+everyone else is ignored. Less friction than hand-off-only, but not open to the
+group — the two trusted writers can DM or tag it directly to add facts.
 
 ## Source
 

--- a/research/agents/799-deepmeeting-agent-shard-architecture/README.md
+++ b/research/agents/799-deepmeeting-agent-shard-architecture/README.md
@@ -359,6 +359,57 @@ Output as a config spec I can paste tab-by-tab. Do not write anything to the gra
 The bot's answers to #1 and #2 close the gaps in the build kit above (the write
 tool + the model presets). Reconcile its output with the kit; they should agree.
 
+## Reconciled final writer config (2026-06-06)
+
+`@zabal_bonfire` generated a config spec (Zaal's dogfood). Reconciled with the
+build kit. What the bot added, what it got wrong, and the final answer:
+
+**Adopted from the bot (good):**
+- **Confidence ladder refinement** — "conversational claims max 0.85" caps a
+  single human assertion below a sourced fact. Merged into the final ladder:
+  0.6 = inference / no verifiable source · ≤0.85 = single conversational claim
+  (reported, unverified) · 0.9 = verified secondary source_url you retrieved ·
+  1.0 = on-chain or official primary data only.
+- Crux **hypothesis**: bot claims "Bonfires Delve = read; writes go via
+  `POST /knowledge_graph/episode/create`" (the "Delve Knowledge Graph (Write
+  episodes)" tool — same endpoint `scripts/bonfire-ingest/` posts to).
+
+**Corrected (bot was wrong / unreliable narrator — cf. its own state_truthfulness):**
+1. **Crux is CONTRADICTORY, treat as unverified.** The bot says Bonfires Delve is
+   read-only, but the live bot *writes today with "Delve KG (Write episodes)"
+   unchecked* — so either Bonfires Delve writes, or there's another path. Don't
+   trust the bot's self-report. Writer: enable BOTH tools (covers it either way).
+   Reader: empirical test — after hardening, try to make it write; if it still
+   can with only Bonfires Delve on, that tool writes and the reader needs
+   prompt-enforcement, not just tool-unchecking.
+2. **Keep Firecrawl ON.** The bot wanted to disable web search, but its own
+   protocol step 4 (verify source_url resolves) REQUIRES it. Disabling its
+   verification tool guts the verification step. Keep it.
+3. **Keep `batch_paraphrase_gate` + `voice` traits.** The bot dropped 3 of 15;
+   `recall_format` is fine to drop (writer doesn't recall), but
+   `batch_paraphrase_gate` IS the writer's manifest/preview/batch-approval commit
+   discipline — core. `voice` stays for register consistency.
+4. **Keep `vocabulary_fidelity` as a named trait** with the seed ("gap filling
+   axioma" canonical / "TreeUnix Protocol" superseded). The bot folded it into a
+   vague "no new terminology" and lost the seed — the exact fix doc 798 needs.
+
+**Final tools:** Delve Knowledge Graph (Write episodes) + Bonfires Delve +
+Firecrawl + Fireflies + Cross-Bonfire Search + Message Search + User Lookup +
+Twitter + Trimtab. OFF: Agent Personality, REST API, Scheduling, autonomous triggers.
+
+**Final personality:** inherit 14 of 15 (drop only `recall_format`), add 4 —
+`deep_think_gate`, `confidence_calibration` (the ladder above),
+`pii_guard` (consent-based; ZAO names ok, sensitive attributes not),
+`vocabulary_fidelity` (with seed).
+
+**LLM Config:** Internal Model = highest-capability reasoning preset (bot
+recommends "Claude Opus tier"). Still need the actual dropdown preset names.
+
+**OPEN — Zaal decides (changes Chat tab + Telegram policy):** does the writer
+take messages directly (gated to Zaal + GCvlcnti via Allowed Users), or only
+structured hand-offs routed from the reader / Zaal? Direct-but-gated is less
+friction; hand-off-only is more controlled. Pending Zaal.
+
 ## Source
 
 - Live `@zabal_bonfire_bot` / DeepMeeting transcript, 2026-06-06 (Zaal-supplied).

--- a/scripts/bonfire-ingest/README.md
+++ b/scripts/bonfire-ingest/README.md
@@ -9,8 +9,9 @@ mandatory secret-scan gate. Built 2026-05-18 after the Phase 1 deploy
 
 | File | Role |
 |---|---|
-| `secret_scan.py` | Sensitive-info detector. Distinguishes template placeholders from real secrets. Exports `scan_text`, `sanitize_text`, `preflight`. |
-| `bonfire_client.py` | `IngestPipeline` class. v0.2: generates client-side UUID per episode, supplies via `uuid` field, captures in manifest. Calls preflight before every POST; HIGH severity hits block by default. Writes a manifest per run. |
+| `secret_scan.py` | Sensitive-info detector (API keys / tokens / PEM). Distinguishes template placeholders from real secrets. Exports `scan_text`, `sanitize_text`, `preflight`. |
+| `pii_scan.py` | Third-party **PII** detector (phone / SSN / card / address / personal email / personal Telegram handle), allowlist-aware per `.claude/rules/pii-hygiene.md`. Same `scan_text` / `sanitize_text` / `preflight` API. Catches *structured* PII only — not names or free-text health disclosures (see doc 798). |
+| `bonfire_client.py` | `IngestPipeline` class. v0.2: generates client-side UUID per episode, supplies via `uuid` field, captures in manifest. Runs BOTH the secret gate and the PII gate before every POST; HIGH hits from either block by default. Writes a manifest per run. |
 | `ingest_brand_kit.py` | Pipes `bettercallzaal.com/brands.json` (31 brands) into bonfire, one episode per brand. |
 | `ingest_github_readmes.py` | Pipes README files for every `bettercallzaal/*` repo (80 active). Public via raw.githubusercontent.com, private via GitHub API + `GITHUB_TOKEN`. |
 | `ingest_research_library.py` | Pipes every `research/<topic>/<NNN>-<slug>/README.md` from ZAOOS (~670 active docs). Skips `_archive`, `_graph`, `_handoffs`. |
@@ -35,6 +36,28 @@ To override the block on HIGH hits and post a sanitized version
 (actual key replaced with `[REDACTED:pattern_name]`), pass `--sanitize`
 to the ingest script.
 
+## PII-scan policy
+
+A second, independent gate (`pii_scan.py`) runs after the secret gate.
+Distinct concern: secrets = credential theft; PII = third-party personal
+data leakage. Severity is deliberately asymmetric — the graph legitimately
+holds people, so emails/handles are flagged not blocked, and over-blocking
+the 670-doc research-library ingest is the failure mode we avoid.
+
+| Severity | Examples | Default action |
+|---|---|---|
+| HIGH | formatted phone `(555) 123-4567`, US SSN, Luhn-valid credit card, context-labeled DOB | BLOCK (don't post) |
+| MED | non-allowlisted email, non-allowlisted personal Telegram handle (`@GCvlcnti`), street address | Log + post |
+| (skip) | allowlisted emails (`zaal@thezao.com`, role emails) + bot handles (`@zabal_bonfire_bot`, `*_bot`) | ignored |
+
+`--sanitize` redacts PII HIGH hits to `<redacted-phone>` / `<redacted-ssn>` /
+`<redacted-cc>` and posts the cleaned body, same as the secret gate.
+
+**Hard limitation:** regex catches structured PII only. A person's NAME or a
+free-text sensitive disclosure ("diagnosed with X") is just words — this gate
+will not catch it. The bot's human `Approve?` step is the backstop for those.
+The full analysis + recommended LLM-classifier follow-up is in doc 798.
+
 ## Running an ingest
 
 All scripts assume env vars from the bot's `.env`:
@@ -55,7 +78,7 @@ Env needed:
 ## Manifests
 
 Each run writes a JSON manifest to `~/.zaocoworking/ingest-<label>-<epoch>.json`
-with the full list of (sent, blocked, failed, sanitized) episodes + task ids.
+with the full list of (sent, blocked, failed, sanitized, pii_blocked) episodes + task ids.
 
 ## Adding a new ingest source
 
@@ -83,3 +106,7 @@ The `IngestPipeline` handles preflight + POST + manifest writing.
 - `research/agents/673-zoe-bonfires-dialog-automation/` - Phase 2 spec
 - `.claude/rules/secret-hygiene.md` - the broader secret-handling policy
   that informed `secret_scan.py`'s pattern list
+- `.claude/rules/pii-hygiene.md` - the PII policy + allowlists that informed
+  `pii_scan.py` (Rule 3 banned patterns, email + Telegram-handle allowlists)
+- `research/agents/798-bonfire-graph-quality-audit/` - graph data-quality
+  audit (confidence calibration, provenance, the PII-gate gap this closes)

--- a/scripts/bonfire-ingest/bonfire_client.py
+++ b/scripts/bonfire-ingest/bonfire_client.py
@@ -35,6 +35,10 @@ import uuid as _uuid
 import secret_scan
 import pii_scan
 
+# doc 798 Finding 1 — provenance tiers. Confidence the SERVER returns is
+# decorative (1.0 on fabrications); these are the trust tiers WE stamp at write.
+PROVENANCE_TIERS = {"canonical", "reported", "inferred"}
+
 
 class IngestPipeline:
     def __init__(self, label, sanitize=False, dry_run=False):
@@ -54,8 +58,26 @@ class IngestPipeline:
             "sent": [], "blocked": [], "failed": [], "sanitized": [], "pii_blocked": [],
         }
 
-    def ingest(self, name, body, source_description, reference_time=None, source="text"):
-        """Single-episode ingest. Returns dict with status info."""
+    def ingest(self, name, body, source_description, reference_time=None,
+               source="text", provenance="reported"):
+        """Single-episode ingest. Returns dict with status info.
+
+        provenance (doc 798 Finding 1 — calibration): the trust tier the caller
+        VOUCHES FOR. Stamped into the episode body so recall can cite it instead
+        of leaning on the server's decorative `Confidence: 1.0`:
+          - canonical : sourced from repo code / a ZAOOS research README / a doc
+                        Zaal authored. Verifiable.
+          - reported  : a single human's assertion (meeting/chat), unverified.
+          - inferred  : the agent connected facts itself. Lowest trust — this is
+                        the tier the three transcript fabrications actually were.
+        The forthcoming deep-thinking writer bot MUST decide this consciously
+        per write, which is the whole point: no fact enters untiered.
+        """
+        if provenance not in PROVENANCE_TIERS:
+            raise ValueError(f"provenance must be one of {sorted(PROVENANCE_TIERS)}, got {provenance!r}")
+        # Stamp the tier so it travels with the fact into recall.
+        body = f"[provenance: {provenance}]\n\n{body}"
+
         # Mandatory pre-flight scan
         scan = secret_scan.preflight(body, label=name)
         high = scan["summary"].get("HIGH", 0)
@@ -167,6 +189,7 @@ class IngestPipeline:
                     "uuid": episode_uuid,
                     "task": task,
                     "source_description": source_description,
+                    "provenance": provenance,
                 })
                 print(f"  [OK] {name} -> uuid={episode_uuid[:8]}... task={task}")
                 return {"status": "sent", "uuid": episode_uuid, "task_id": task}

--- a/scripts/bonfire-ingest/bonfire_client.py
+++ b/scripts/bonfire-ingest/bonfire_client.py
@@ -33,6 +33,7 @@ import urllib.request
 import uuid as _uuid
 
 import secret_scan
+import pii_scan
 
 
 class IngestPipeline:
@@ -49,7 +50,9 @@ class IngestPipeline:
 
         self.now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         self.epoch = int(time.time())
-        self.results = {"sent": [], "blocked": [], "failed": [], "sanitized": []}
+        self.results = {
+            "sent": [], "blocked": [], "failed": [], "sanitized": [], "pii_blocked": [],
+        }
 
     def ingest(self, name, body, source_description, reference_time=None, source="text"):
         """Single-episode ingest. Returns dict with status info."""
@@ -83,6 +86,37 @@ class IngestPipeline:
             for h in scan["hits"]:
                 if h["severity"] in ("MED", "LOW"):
                     print(f"  [{h['severity']}] {name}: {h['pattern']} {h['excerpt']}")
+
+        # Second gate: PII scan (sibling to the secret gate, distinct policy).
+        # Catches structured third-party PII — phone / SSN / card / address /
+        # personal email / personal Telegram handle. HIGH blocks; MED logs.
+        # Does NOT catch names or free-text health disclosures (regex can't) —
+        # the bot's human "Approve?" step remains the backstop for those.
+        # See scripts/bonfire-ingest/pii_scan.py + doc 798.
+        pii = pii_scan.preflight(body, label=name)
+        pii_high = pii["summary"].get("HIGH", 0)
+        if pii_high > 0:
+            if not self.sanitize:
+                self.results["pii_blocked"].append({
+                    "name": name,
+                    "source_description": source_description,
+                    "high": pii_high,
+                    "med": pii["summary"].get("MED", 0),
+                    "hits": pii["hits"],
+                })
+                print(f"  [PII-BLOCKED] {name}: {pii_high} HIGH-severity PII hits - not posting")
+                for h in pii["hits"]:
+                    if h["severity"] == "HIGH":
+                        print(f"             - {h['pattern']:26s} {h['excerpt']}")
+                return {"status": "pii_blocked", "pii_high_hits": pii_high}
+            else:
+                body, _ = pii_scan.sanitize_text(body)
+                self.results["sanitized"].append({"name": name, "pii_high": pii_high})
+                print(f"  [PII-SANITIZED] {name}: {pii_high} HIGH-severity PII hits redacted")
+        if pii["summary"].get("MED", 0) > 0:
+            for h in pii["hits"]:
+                if h["severity"] == "MED":
+                    print(f"  [PII-MED] {name}: {h['pattern']} {h['excerpt']}")
 
         # v0.2 - generate a client-side UUID per episode + supply via the
         # `uuid` field on CreateEpisodeDirectRequest. The Bonfires API accepts
@@ -183,6 +217,11 @@ if __name__ == "__main__":
     p.ingest(
         name="test:2",
         body="This has a synthetic key-shaped string sk-ant-FAKE000FAKE000FAKE000FAKE000FAKE",
+        source_description="test",
+    )
+    p.ingest(
+        name="test:3-pii",
+        body="Contact info leak: call (555) 123-4567 or SSN 123-45-6789.",
         source_description="test",
     )
     p.report(manifest_path="/tmp/test-manifest.json")

--- a/scripts/bonfire-ingest/ingest_brand_kit.py
+++ b/scripts/bonfire-ingest/ingest_brand_kit.py
@@ -82,6 +82,7 @@ def main():
             name=f"brand:{brand['id']}",
             body=body,
             source_description=f"bcz-brand-kit:{brand['id']}",
+            provenance="canonical",  # official BCZ brand kit
         )
     p.report()
 

--- a/scripts/bonfire-ingest/ingest_github_readmes.py
+++ b/scripts/bonfire-ingest/ingest_github_readmes.py
@@ -121,6 +121,7 @@ def main():
             name=f"github:{name}",
             body=body,
             source_description=f"bettercallzaal-github:{name}",
+            provenance="canonical",  # repo README, verifiable source
         )
         time.sleep(0.25)
 

--- a/scripts/bonfire-ingest/ingest_research_library.py
+++ b/scripts/bonfire-ingest/ingest_research_library.py
@@ -169,6 +169,7 @@ def main():
             name=f"research:{topic}:{doc_id}:{slug}",
             body=body,
             source_description=f"zaoos-research:{rel}",
+            provenance="canonical",  # ZAOOS research README, verifiable source
         )
         # Gentle pacing to be nice to the API
         time.sleep(0.2)

--- a/scripts/bonfire-ingest/pii_scan.py
+++ b/scripts/bonfire-ingest/pii_scan.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+PII scanner for bonfire ingestion pipelines. Sibling to secret_scan.py.
+
+secret_scan.py catches API keys / tokens / PEM blocks (credential theft).
+pii_scan.py catches third-party PERSONAL data (reputational / relational
+leakage): phone numbers, emails, street addresses, SSNs, credit cards,
+personal Telegram handles. Implements `.claude/rules/pii-hygiene.md` Rule 3
+(the banned-PII patterns) plus its email + Telegram-handle allowlists.
+
+Public entrypoints (mirror secret_scan.py so the pipeline can call both):
+  scan_text(s)      -> list of {pattern, severity, excerpt, line_no}
+  sanitize_text(s)  -> (cleaned_text, hits)   # redacts to <redacted-*>
+  preflight(text, label='ingest') -> {ok, hits, summary, label}
+    ok=True iff no HIGH-severity hits.
+
+Severity policy (deliberately asymmetric — the graph LEGITIMATELY holds
+people, so over-blocking would kill the bulk research-library ingest):
+
+  HIGH  (BLOCK)  structured PII that should ~never appear in an episode:
+                 formatted phone, SSN, Luhn-valid credit card, labeled DOB.
+  MED   (LOG)    email / personal Telegram handle / street address —
+                 flagged for review, posted unless --sanitize redacts them.
+  (allowlisted emails + bot/handle allowlist are skipped entirely.)
+
+KNOWN LIMITATION — read before trusting this as "PII-safe":
+  Regex catches STRUCTURED PII only. It does NOT catch a person's NAME
+  ("Gustavo de Lima Cavalcanti") or a free-text sensitive disclosure
+  ("diagnosed with Hyper-IgE Syndrome") — those are just words. The
+  highest-leakage cases in the ZAO Bonfire (real names + health/biographical
+  context, per pii-hygiene.md "Bonfire / knowledge-graph specifics") need
+  the human approval step the bot already runs ("Approve all?") or an LLM
+  classifier. This scanner is the structured-PII floor, not the ceiling.
+  See research/agents/798-bonfire-graph-quality-audit/.
+"""
+
+import re
+
+# ---------------------------------------------------------------------------
+# Allowlists (verbatim from .claude/rules/pii-hygiene.md). These may appear
+# in committed artifacts AND in graph episodes without redaction.
+# ---------------------------------------------------------------------------
+EMAIL_ALLOWLIST = {
+    "zaal@thezao.com",
+    "zaalp99@gmail.com",
+    "zaal@bettercallzaal.com",
+    "zoe-zao@agentmail.to",
+    "hello@thezao.com",
+    "support@thezao.com",
+}
+
+# Public role-email local-parts for ZAO/BCZ entities (contact@<brand>.com etc).
+ROLE_EMAIL_LOCALPARTS = {"contact", "team", "hello", "support", "info", "admin"}
+
+# Public ZAO bot identities — handles that are NOT personal PII.
+TELEGRAM_HANDLE_ALLOWLIST = {
+    "@zaoclaw_bot",
+    "@zoe_hermes_bot",
+    "@zaodevz_bot",
+    "@zabal_bonfire",
+    "@zabal_bonfire_bot",
+    "@zaostockteambot",
+    "@zaocoworkingbot",
+}
+
+EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+# @handle: 5-32 word chars, the Telegram shape. Bot handles (suffix `bot`)
+# are excluded as non-personal in _classify_handle.
+HANDLE_RE = re.compile(r"(?<![A-Za-z0-9._%+-])@([A-Za-z][A-Za-z0-9_]{4,31})\b")
+
+# Structured-PII patterns. (name, severity, compiled).
+PATTERNS = [
+    # ===== HIGH — block =====
+    # US phone REQUIRING separators/parens/+1 so a bare 10-digit epoch
+    # (1749081600) or numeric id does NOT false-positive.
+    ("us_phone_formatted", "HIGH", re.compile(
+        r"(?:\+?1[\s.-])?\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4}\b"
+        r"|(?:\+?1[\s.-])?\d{3}[\s.-]\d{3}[\s.-]\d{4}\b"
+    )),
+    ("us_ssn", "HIGH", re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
+    # DOB only when context-labeled — bare MM/DD/YYYY is too noisy (event
+    # dates) to block on.
+    ("dob_labeled", "HIGH", re.compile(
+        r"(?i)(?:dob|d\.o\.b\.|date of birth|born(?: on)?)\D{0,12}"
+        r"(?:0?[1-9]|1[012])[-/](?:0?[1-9]|[12]\d|3[01])[-/](?:19|20)\d{2}\b"
+    )),
+
+    # ===== MED — log + post (sanitize redacts) =====
+    ("street_address", "MED", re.compile(
+        r"\b\d{1,5}\s+(?:[A-Z][a-z]+\.?\s+){1,3}"
+        r"(?:St|Street|Ave|Avenue|Blvd|Rd|Road|Dr|Drive|Ln|Lane|Way|Pl|Place|Ct|Court|Pkwy|Parkway)\b"
+    )),
+    ("intl_phone", "MED", re.compile(r"\+\d{1,3}\s*\d{2,4}\s*\d{6,}")),
+]
+
+# Credit-card candidate (validated by Luhn -> HIGH, else dropped).
+CC_CANDIDATE_RE = re.compile(r"\b(?:\d[ -]?){13,16}\b")
+
+
+def _luhn_ok(number: str) -> bool:
+    digits = [int(c) for c in number if c.isdigit()]
+    if not 13 <= len(digits) <= 19:
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for i, d in enumerate(digits):
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        checksum += d
+    return checksum % 10 == 0
+
+
+def _redact(ex: str) -> str:
+    return ex[:3] + "..." + ex[-2:] if len(ex) > 8 else "..."
+
+
+def _email_allowed(email: str) -> bool:
+    e = email.lower()
+    if e in EMAIL_ALLOWLIST:
+        return True
+    local = e.split("@", 1)[0]
+    return local in ROLE_EMAIL_LOCALPARTS
+
+
+def _handle_allowed(handle: str) -> bool:
+    h = handle.lower()
+    if h in TELEGRAM_HANDLE_ALLOWLIST:
+        return True
+    # Any *_bot handle is a bot identity, not personal PII.
+    return h.endswith("bot")
+
+
+def scan_text(text):
+    """Return list of {pattern, severity, excerpt, line_no}."""
+    hits = []
+
+    def _add(name, sev, m):
+        ex = m.group(0)
+        hits.append({
+            "pattern": name,
+            "severity": sev,
+            "excerpt": _redact(ex),
+            "line_no": text[:m.start()].count("\n") + 1,
+        })
+
+    for name, sev, pat in PATTERNS:
+        for m in pat.finditer(text):
+            _add(name, sev, m)
+
+    for m in EMAIL_RE.finditer(text):
+        if not _email_allowed(m.group(0)):
+            _add("email_personal", "MED", m)
+
+    for m in HANDLE_RE.finditer(text):
+        if not _handle_allowed("@" + m.group(1)):
+            _add("telegram_handle_personal", "MED", m)
+
+    for m in CC_CANDIDATE_RE.finditer(text):
+        if _luhn_ok(m.group(0)):
+            _add("credit_card_luhn", "HIGH", m)
+
+    return hits
+
+
+def sanitize_text(text):
+    """Return (cleaned_text, hits). Replaces matches with <redacted-*>."""
+    hits = []
+    cleaned = text
+
+    def _sub_factory(name, sev, placeholder):
+        def _sub(m):
+            hits.append({"pattern": name, "severity": sev, "excerpt": _redact(m.group(0))})
+            return placeholder
+        return _sub
+
+    # Structured patterns first.
+    placeholders = {
+        "us_phone_formatted": "<redacted-phone>",
+        "intl_phone": "<redacted-phone>",
+        "us_ssn": "<redacted-ssn>",
+        "dob_labeled": "<redacted-dob>",
+        "street_address": "<redacted-address>",
+    }
+    for name, sev, pat in PATTERNS:
+        cleaned = pat.sub(_sub_factory(name, sev, placeholders.get(name, "<redacted-pii>")), cleaned)
+
+    # Luhn-valid cards.
+    def _cc_sub(m):
+        if _luhn_ok(m.group(0)):
+            hits.append({"pattern": "credit_card_luhn", "severity": "HIGH", "excerpt": _redact(m.group(0))})
+            return "<redacted-cc>"
+        return m.group(0)
+    cleaned = CC_CANDIDATE_RE.sub(_cc_sub, cleaned)
+
+    # Emails / handles, allowlist-aware.
+    def _email_sub(m):
+        if _email_allowed(m.group(0)):
+            return m.group(0)
+        hits.append({"pattern": "email_personal", "severity": "MED", "excerpt": _redact(m.group(0))})
+        return "<redacted-email>"
+    cleaned = EMAIL_RE.sub(_email_sub, cleaned)
+
+    def _handle_sub(m):
+        if _handle_allowed("@" + m.group(1)):
+            return m.group(0)
+        hits.append({"pattern": "telegram_handle_personal", "severity": "MED", "excerpt": _redact(m.group(0))})
+        return "@<redacted-handle>"
+    cleaned = HANDLE_RE.sub(_handle_sub, cleaned)
+
+    return cleaned, hits
+
+
+def preflight(text, label="ingest"):
+    """{ok, hits, summary:{HIGH,MED,LOW}, label}. ok=True iff no HIGH hits."""
+    hits = scan_text(text)
+    by_sev = {"HIGH": 0, "MED": 0, "LOW": 0}
+    for h in hits:
+        by_sev[h["severity"]] = by_sev.get(h["severity"], 0) + 1
+    return {"ok": by_sev.get("HIGH", 0) == 0, "label": label, "hits": hits, "summary": by_sev}
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    # SYNTHETIC fixtures only. The phone/SSN/CC values below are invalid /
+    # reserved shapes chosen to match regexes — never paste real PII here.
+    fixture = """
+    Allowlisted, must NOT flag: zaal@thezao.com, contact@somebrand.com
+    Public bot handle, must NOT flag: @zabal_bonfire_bot @zaodevz_bot
+    Bare epoch must NOT flag as phone: 1749081600
+    ISO event date must NOT flag as DOB: 2026-04-29
+
+    --- SHOULD flag MED ---
+    Personal email: someone@randommail.io
+    Personal handle: @GCvlcnti
+    Street: 1234 Example Avenue
+
+    --- SHOULD flag HIGH (block) ---
+    Phone: (555) 123-4567
+    SSN: 123-45-6789
+    Labeled DOB: born on 04/12/1990
+    Card (Luhn-valid test number): 4242 4242 4242 4242
+    """
+    result = preflight(fixture, label="self-test")
+    print(json.dumps(result, indent=2))
+    # Expect: HIGH >= 3 (phone, ssn, dob, cc), MED >= 3 (email, handle, address).
+    ok = result["summary"]["HIGH"] >= 4 and result["summary"]["MED"] >= 3
+    print(f"\nself-test {'PASS' if ok else 'FAIL'}: {result['summary']}")
+    sys.exit(0 if ok else 1)


### PR DESCRIPTION
## What this lands

Makes the ZAO bot fleet report liveness to the coworking board.

**Bot ↔ coworking API (the deployable feature):**
- `bot/src/lib/cowork.ts` — REST client for cowork-zaodevz `/api/v1/*` (push items, mark done, heartbeat). **Dormant by default** — no-op unless `COWORK_API_URL` + `COWORK_BOT_TOKEN` are set, so the running fleet is untouched until configured. Fault-tolerant, typechecked.
- Heartbeats wired into **ZOE / ZAO Devz / ZAOstock** startups (env-gated).
- `bot/COWORK_API.md` — ZAOOS-side contract mirror + per-bot scope + go-live checklist.
- `bot/cowork-handoff/` — `010_bot_heartbeats.sql` migration + drop-in `BotsBoard.tsx` for the cowork app.

**Also in this branch (session work):**
- `bot/REGISTRY.md` — fleet status registry.
- `research/agents/799-…` — DeepMeeting shard architecture decision.
- `docs/TODO.md` — flow-aware intake todos (ZOE).

## Deploy
See `bot/COWORK_API.md`. Cowork side mints `COWORK_BOT_TOKENS`; VPS units get `COWORK_API_URL` + per-bot token via systemd drop-ins, then restart. Board reads `GET /api/v1/bots` → green/red dots.

https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_