### PR TITLE
Add Songjam room type + isolated multiplayer test room

### DIFF
--- a/src/app/spaces/audit-test/page.tsx
+++ b/src/app/spaces/audit-test/page.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * Isolated multiplayer test room. Open this page in two browsers (or share the
+ * URL with a teammate) to verify live audio, presence, and speaking detection
+ * end-to-end — without touching the main /spaces flow. ElevenLabs is not
+ * involved here. See research/dev-workflows/815-songjam-site-fork-audit/.
+ */
+
+const AuditTestRoom = dynamic(
+  () => import('@/components/spaces/AuditTestRoom'),
+  { ssr: false },
+);
+
+type Role = 'speaker' | 'listener';
+
+export default function AuditTestPage() {
+  const { user, loading } = useAuth();
+  const [role, setRole] = useState<Role>('speaker');
+  const [joined, setJoined] = useState(false);
+
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628] text-white">
+      <header className="flex items-center justify-between border-b border-white/[0.08] bg-[#0d1b2a] px-4 py-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="font-bold text-white">Spaces — Audit Test Room</h1>
+            <span className="rounded-full bg-orange-500/20 px-2 py-0.5 text-[10px] text-orange-400">
+              100ms
+            </span>
+          </div>
+          <p className="text-xs text-gray-400">Isolated room for multiplayer QA</p>
+        </div>
+        <Link
+          href="/spaces"
+          className="rounded-lg border border-white/[0.12] px-3 py-1.5 text-xs font-medium text-gray-300 transition-colors hover:bg-white/[0.04] hover:text-white"
+        >
+          Back to Spaces
+        </Link>
+      </header>
+
+      <div className="mx-auto w-full max-w-lg flex-1 px-4 py-6">
+        {loading ? (
+          <p className="py-10 text-center text-gray-400">Loading…</p>
+        ) : !user ? (
+          <div className="flex flex-col items-center gap-4 py-16 text-center">
+            <p className="text-gray-300">Sign in to join the test room.</p>
+            <Link
+              href="/"
+              className="rounded-xl bg-[#f5a623] px-6 py-2.5 font-bold text-[#0a1628] transition-colors hover:bg-[#ffd700]"
+            >
+              Sign in
+            </Link>
+          </div>
+        ) : !joined ? (
+          <div className="flex flex-col gap-5">
+            <div className="rounded-xl border border-white/[0.08] bg-[#0d1b2a] p-4 text-sm text-gray-300">
+              <p className="mb-2 font-semibold text-white">How to test multiplayer</p>
+              <ol className="list-decimal space-y-1 pl-5 text-gray-400">
+                <li>Join as a speaker below.</li>
+                <li>
+                  Open <code className="text-[#f5a623]">/spaces/audit-test</code>{' '}
+                  in a second browser, an incognito window, or send it to a
+                  teammate.
+                </li>
+                <li>
+                  Both join the same room — talk, watch the speaking indicator
+                  light up, and check the participant count.
+                </li>
+              </ol>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">
+                Join as
+              </span>
+              <div className="flex gap-2">
+                {(['speaker', 'listener'] as const).map((r) => (
+                  <button
+                    key={r}
+                    type="button"
+                    onClick={() => setRole(r)}
+                    className={`flex-1 rounded-lg border px-4 py-2 text-sm font-medium capitalize transition-colors ${
+                      role === r
+                        ? 'border-[#f5a623] bg-[#f5a623]/10 text-[#f5a623]'
+                        : 'border-white/[0.12] text-gray-300 hover:bg-white/[0.04]'
+                    }`}
+                  >
+                    {r}
+                  </button>
+                ))}
+              </div>
+              <p className="text-xs text-gray-500">
+                Speakers can talk; listeners can only hear. Use two speakers to
+                test two-way audio.
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => setJoined(true)}
+              className="rounded-xl bg-[#f5a623] px-6 py-2.5 font-bold text-[#0a1628] transition-colors hover:bg-[#ffd700]"
+            >
+              Join test room
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <AuditTestRoom role={role} />
+            <button
+              type="button"
+              onClick={() => setJoined(false)}
+              className="self-start rounded-lg border border-white/20 px-4 py-1.5 text-sm text-white transition-colors hover:bg-white/10"
+            >
+              Leave room
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/spaces/page.tsx
+++ b/src/app/spaces/page.tsx
@@ -14,6 +14,7 @@ import SpacesTabs from '@/components/spaces/SpacesTabs';
 import CategoryFilter from '@/components/spaces/CategoryFilter';
 import ScheduledRooms from '@/components/spaces/ScheduledRooms';
 import PastRooms from '@/components/spaces/PastRooms';
+import { SongjamSpaceCard } from '@/components/spaces/SongjamSpaceCard';
 import type { Room, AudioProvider } from '@/lib/spaces/roomsDb';
 
 export default function PublicSpacesPage() {
@@ -189,7 +190,10 @@ export default function PublicSpacesPage() {
 
       <div className="flex-1 px-4 pb-6 max-w-4xl mx-auto w-full">
         {activeTab === 'live' && (
-          <LiveTab loading={loading} stages={filteredStages} jukeRooms={jukeRooms} myRooms={myRooms} otherRooms={otherRooms} user={user} onHost={() => setShowHostModal(true)} onJoin={handleJoinStage} />
+          <>
+            <SongjamSpaceCard />
+            <LiveTab loading={loading} stages={filteredStages} jukeRooms={jukeRooms} myRooms={myRooms} otherRooms={otherRooms} user={user} onHost={() => setShowHostModal(true)} onJoin={handleJoinStage} />
+          </>
         )}
         {activeTab === 'upcoming' && <ScheduledRooms category={category} />}
         {activeTab === 'past' && <PastRooms category={category} />}

--- a/src/app/spaces/songjam/page.tsx
+++ b/src/app/spaces/songjam/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  SONGJAM_SPACE_URL,
+  SONGJAM_SPACE_LABEL,
+  SONGJAM_SPACE_DESCRIPTION,
+  SONGJAM_IFRAME_ALLOW,
+  SONGJAM_IFRAME_SANDBOX,
+} from '@/lib/spaces/songjam';
+import { communityConfig } from '@/../community.config';
+
+export const metadata: Metadata = {
+  title: `${SONGJAM_SPACE_LABEL} - ${communityConfig.name}`,
+  description: SONGJAM_SPACE_DESCRIPTION,
+  robots: { index: false },
+};
+
+/**
+ * /spaces/songjam — the $ZABAL live audio space, hosted on Songjam, embedded as
+ * a branded full-page window. A "type" of room you can open alongside the
+ * native ZAO Stream/100ms rooms and the Juke embed. Hosting and joining happen
+ * inside Songjam's own UI (sign in with Farcaster in the iframe).
+ */
+export default function SongjamSpacePage() {
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-[#0a1628]">
+      <header className="border-b border-white/[0.08] bg-[#0d1b2a]">
+        <div className="flex items-center gap-3 px-4 py-3">
+          <Link
+            href="/spaces"
+            aria-label="Back to Spaces"
+            className="rounded-md p-1 text-gray-500 transition-colors hover:bg-gray-800 hover:text-[#f5a623]"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <h1 className="truncate text-sm font-bold text-white sm:text-base">
+                {SONGJAM_SPACE_LABEL}
+              </h1>
+              <span className="rounded-full bg-[#22d3ee]/15 px-2 py-0.5 text-[10px] font-semibold text-[#22d3ee]">
+                Songjam
+              </span>
+            </div>
+            <p className="truncate text-xs text-gray-500">{SONGJAM_SPACE_DESCRIPTION}</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        <iframe
+          src={SONGJAM_SPACE_URL}
+          title={SONGJAM_SPACE_LABEL}
+          className="h-full min-h-[calc(100dvh-61px)] w-full border-0"
+          allow={SONGJAM_IFRAME_ALLOW}
+          sandbox={SONGJAM_IFRAME_SANDBOX}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/components/spaces/AuditTestRoom.tsx
+++ b/src/components/spaces/AuditTestRoom.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  HMSRoomProvider,
+  useHMSActions,
+  useHMSStore,
+  selectIsConnectedToRoom,
+  selectPeers,
+  selectIsLocalAudioEnabled,
+  selectDominantSpeaker,
+} from '@100mslive/react-sdk';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * Isolated multiplayer test room for spaces QA. Everyone who opens
+ * /spaces/audit-test joins the SAME pinned 100ms room, so opening the page in
+ * two browsers (or with a teammate) is a full multiplayer test — without
+ * touching the main /spaces flow or the `rooms` Supabase table.
+ *
+ * Unlike `HMSRoom`, this passes the caller's FID as `userId` (the token route
+ * requires `userId === session.fid`) and requests the `speaker` role so any
+ * authenticated tester can actually talk during the test.
+ */
+
+// Fixed room name → all testers share one room. Auto-provisioned 100ms-side by
+// the token route; no DB row needed.
+const TEST_ROOM_NAME = 'zao-audit-test';
+
+type Role = 'speaker' | 'listener';
+
+function PeerList() {
+  const peers = useHMSStore(selectPeers);
+  const dominantSpeaker = useHMSStore(selectDominantSpeaker);
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {peers.map((peer) => {
+        const isSpeaking = dominantSpeaker?.id === peer.id;
+        return (
+          <li
+            key={peer.id}
+            className={`flex items-center justify-between rounded-lg border px-3 py-2 transition-colors ${
+              isSpeaking
+                ? 'border-[#f5a623] bg-[#f5a623]/10'
+                : 'border-white/[0.08] bg-[#0d1b2a]'
+            }`}
+          >
+            <span className="flex items-center gap-2 text-sm text-white">
+              <span
+                className={`h-2 w-2 rounded-full ${
+                  isSpeaking ? 'bg-[#f5a623]' : 'bg-gray-600'
+                }`}
+              />
+              {peer.name}
+              {peer.isLocal && (
+                <span className="text-[10px] text-gray-500">(you)</span>
+              )}
+            </span>
+            <span className="text-[10px] uppercase tracking-wider text-gray-500">
+              {peer.roleName}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function AuditTestRoomInner({ role }: { role: Role }) {
+  const { user } = useAuth();
+  const hmsActions = useHMSActions();
+  const isConnected = useHMSStore(selectIsConnectedToRoom);
+  const isLocalAudioEnabled = useHMSStore(selectIsLocalAudioEnabled);
+  const peers = useHMSStore(selectPeers);
+  const [status, setStatus] = useState<'joining' | 'connected' | 'error'>(
+    'joining',
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user?.fid) return;
+    let cancelled = false;
+
+    const join = async () => {
+      setStatus('joining');
+      setErrorMessage(null);
+      try {
+        const res = await fetch('/api/100ms/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            userId: String(user.fid),
+            role,
+            roomName: TEST_ROOM_NAME,
+          }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.token) {
+          throw new Error(data.error || 'Failed to get room token');
+        }
+        if (cancelled) return;
+        await hmsActions.join({
+          userName: user.displayName || user.username || `fid-${user.fid}`,
+          authToken: data.token,
+        });
+      } catch (err: unknown) {
+        if (cancelled) return;
+        setErrorMessage(err instanceof Error ? err.message : 'Failed to join');
+        setStatus('error');
+      }
+    };
+
+    join();
+    return () => {
+      cancelled = true;
+      hmsActions.leave().catch(() => {});
+    };
+  }, [user?.fid, user?.displayName, user?.username, role, hmsActions]);
+
+  useEffect(() => {
+    if (isConnected) setStatus('connected');
+  }, [isConnected]);
+
+  const toggleMute = async () => {
+    await hmsActions.setLocalAudioEnabled(!isLocalAudioEnabled);
+  };
+
+  if (status === 'error') {
+    return (
+      <div className="flex flex-col items-center gap-3 py-10 text-center">
+        <p className="text-red-400">{errorMessage}</p>
+        <p className="max-w-sm text-xs text-gray-500">
+          If this says configuration missing, the 100ms env vars
+          (NEXT_PUBLIC_100MS_ACCESS_KEY, HMS_APP_SECRET,
+          NEXT_PUBLIC_100MS_TEMPLATE_ID) are not set on this environment.
+        </p>
+      </div>
+    );
+  }
+
+  if (status === 'joining') {
+    return (
+      <div className="flex items-center justify-center py-10 text-gray-400">
+        Joining the test room…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between rounded-xl border border-white/[0.08] bg-[#0d1b2a] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="relative flex h-2 w-2">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+          </span>
+          <span className="text-sm font-medium text-white">Live</span>
+          <span className="text-xs text-gray-500">{peers.length} in room</span>
+        </div>
+        {role === 'speaker' && (
+          <button
+            type="button"
+            onClick={toggleMute}
+            className={`rounded-lg px-4 py-1.5 text-sm font-semibold transition-colors ${
+              isLocalAudioEnabled
+                ? 'bg-[#f5a623] text-[#0a1628] hover:bg-[#ffd700]'
+                : 'border border-white/20 text-white hover:bg-white/10'
+            }`}
+          >
+            {isLocalAudioEnabled ? 'Mute' : 'Unmute'}
+          </button>
+        )}
+      </div>
+
+      <PeerList />
+    </div>
+  );
+}
+
+interface AuditTestRoomProps {
+  role: Role;
+}
+
+export default function AuditTestRoom({ role }: AuditTestRoomProps) {
+  return (
+    <HMSRoomProvider>
+      <AuditTestRoomInner role={role} />
+    </HMSRoomProvider>
+  );
+}

--- a/src/components/spaces/SongjamSpaceCard.tsx
+++ b/src/components/spaces/SongjamSpaceCard.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import { SONGJAM_SPACE_LABEL, SONGJAM_SPACE_DESCRIPTION } from '@/lib/spaces/songjam';
+
+/**
+ * Persistent entry point to the Songjam-hosted $ZABAL live audio space, shown
+ * on the Spaces "Live" tab. Unlike Stream/100ms/Juke rooms (created per-event),
+ * this is one always-available community space embedded at /spaces/songjam.
+ */
+export function SongjamSpaceCard() {
+  return (
+    <section className="mb-6">
+      <h3 className="mb-3 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-[#22d3ee]">
+        <span className="h-1.5 w-1.5 rounded-full bg-[#22d3ee]" aria-hidden="true" />
+        Live on Songjam
+      </h3>
+      <Link
+        href="/spaces/songjam"
+        aria-label={`Open ${SONGJAM_SPACE_LABEL} on Songjam`}
+        className="group block rounded-xl border border-[#22d3ee]/30 bg-gradient-to-br from-[#0d1b2a] to-[#0e2230] p-4 transition-all hover:border-[#22d3ee]/60 hover:shadow-lg hover:shadow-[#22d3ee]/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#22d3ee]"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <div className="mb-1 flex items-center gap-2">
+              <h4 className="truncate font-bold text-white">{SONGJAM_SPACE_LABEL}</h4>
+              <span className="rounded-full bg-[#22d3ee]/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#22d3ee]">
+                Songjam
+              </span>
+            </div>
+            <p className="line-clamp-2 text-xs text-gray-400">{SONGJAM_SPACE_DESCRIPTION}</p>
+          </div>
+          <span className="inline-flex flex-shrink-0 items-center rounded-lg bg-[#22d3ee] px-4 py-2 text-xs font-bold text-[#0a1628] transition-colors group-hover:bg-[#67e8f9]">
+            Open
+          </span>
+        </div>
+      </Link>
+    </section>
+  );
+}

--- a/src/lib/spaces/songjam.ts
+++ b/src/lib/spaces/songjam.ts
@@ -1,0 +1,31 @@
+/**
+ * Songjam live audio space integration.
+ *
+ * Songjam hosts the $ZABAL community's live audio room at songjam.space/zabal.
+ * Rather than rebuild it (ZAO already has its own 100ms/Stream rooms), we embed
+ * it as a branded "type" of room you can open — the same pattern as the Juke
+ * embed (/live/[spaceId]). See research/_archive/119-songjam-audio-spaces-embed/
+ * and research/dev-workflows/815-songjam-site-fork-audit/.
+ *
+ * The `www.songjam.space` origin is already allowlisted for iframe embedding
+ * (CSP frame-src) and mic/camera (Permissions-Policy) in src/middleware.ts —
+ * no middleware change is needed.
+ */
+
+// Use the `www` origin so it matches the Permissions-Policy mic/camera
+// allowlist exactly (Permissions-Policy origin matching is exact).
+export const SONGJAM_SPACE_URL = 'https://www.songjam.space/zabal';
+
+export const SONGJAM_SPACE_LABEL = 'ZABAL Live';
+
+export const SONGJAM_SPACE_DESCRIPTION =
+  'Live audio space for the $ZABAL community, hosted on Songjam.';
+
+// iframe attributes required for Songjam's 100ms audio room to function inside
+// the embed (mic for speaking, autoplay for incoming audio). Mirrors the Juke
+// embed + the recommendation in research doc 119.
+export const SONGJAM_IFRAME_ALLOW =
+  'clipboard-write; microphone; camera; autoplay; fullscreen';
+
+export const SONGJAM_IFRAME_SANDBOX =
+  'allow-scripts allow-same-origin allow-popups allow-forms allow-top-navigation-by-user-activation allow-modals';


### PR DESCRIPTION
## Summary

Follow-up to #791 (which merged the Songjam audit + ElevenLabs voice-agent foundation). These two commits landed on the branch *after* #791 was merged, so they're not yet on `main`. This PR ships them.

Adds **Songjam as a room type you can open** on the Spaces page, plus an isolated multiplayer test room for QA.

## What's in this PR

### Songjam audio room type
- `src/lib/spaces/songjam.ts` — Songjam `$ZABAL` space URL + iframe allow/sandbox config.
- `src/app/spaces/songjam/page.tsx` — branded full-page embed of `www.songjam.space/zabal` (mic/camera enabled so you can host/join inside it).
- `src/components/spaces/SongjamSpaceCard.tsx` — "Live on Songjam" entry card on the Spaces "Live" tab.
- `src/app/spaces/page.tsx` — renders the card (2-line change).

Mirrors the existing Juke embed pattern (external hosted audio → branded `/spaces` window), per research doc 119. **No middleware change needed**: `songjam.space` is already in CSP `frame-src` and the Permissions-Policy mic/camera allowlist. No new deps, no DB, no keys.

### Isolated multiplayer test room
- `src/app/spaces/audit-test/page.tsx` + `src/components/spaces/AuditTestRoom.tsx` — a fixed-name 100ms room so opening `/spaces/audit-test` in two browsers is a full multiplayer audio test, without touching the main `/spaces` flow. Calls the existing secure `/api/100ms/token` correctly (FID as `userId`, `speaker` role).

## Verification
- `npm run typecheck` → 0 errors (branch is up to date with `main`).
- Additive: new files + a 2-line edit to `src/app/spaces/page.tsx`.

https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w)_