### PR TITLE
Enforce token gates on 100ms rooms

### DIFF
--- a/src/app/api/100ms/rooms/__tests__/route.test.ts
+++ b/src/app/api/100ms/rooms/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  makePostRequest,
+  mockUnauthenticatedSession,
+  mockAuthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockCreateMSRoom, mockGetActiveMSRooms } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockCreateMSRoom: vi.fn(),
+  mockGetActiveMSRooms: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/social/msRoomsDb', () => ({
+  createMSRoom: mockCreateMSRoom,
+  getActiveMSRooms: mockGetActiveMSRooms,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+const GATE = {
+  type: 'erc721' as const,
+  contractAddress: '0xabc0000000000000000000000000000000000def',
+  chainId: 8453,
+};
+
+describe('POST /api/100ms/rooms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockCreateMSRoom.mockResolvedValue({ id: 'room-1', title: 'ZAO Video' });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/100ms/rooms', { title: 'ZAO Video' }));
+    expect(res.status).toBe(401);
+    expect(mockCreateMSRoom).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an empty title', async () => {
+    const res = await POST(makePostRequest('/api/100ms/rooms', { title: '' }));
+    expect(res.status).toBe(400);
+    expect(mockCreateMSRoom).not.toHaveBeenCalled();
+  });
+
+  it('creates a room with the host from the session', async () => {
+    const res = await POST(makePostRequest('/api/100ms/rooms', { title: 'ZAO Video' }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.room.id).toBe('room-1');
+    expect(mockCreateMSRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'ZAO Video', hostFid: 123, hostName: 'Test User' }),
+    );
+  });
+
+  it('persists the token gate so gated rooms are actually gated', async () => {
+    await POST(makePostRequest('/api/100ms/rooms', { title: 'Gated', gate_config: GATE }));
+    expect(mockCreateMSRoom).toHaveBeenCalledWith(
+      expect.objectContaining({ gateConfig: GATE }),
+    );
+  });
+
+  it('ignores extra fields the client sends (slug, theme, provider)', async () => {
+    const res = await POST(
+      makePostRequest('/api/100ms/rooms', {
+        title: 'ZAO Video',
+        slug: 'zao-video',
+        theme: 'default',
+        provider: '100ms',
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a malformed gate config', async () => {
+    const res = await POST(
+      makePostRequest('/api/100ms/rooms', {
+        title: 'Bad gate',
+        gate_config: { type: 'erc999', contractAddress: '0x1', chainId: 8453 },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreateMSRoom).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/100ms/rooms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the active rooms', async () => {
+    mockGetActiveMSRooms.mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+    const res = await GET();
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.rooms).toHaveLength(2);
+  });
+
+  it('returns 500 when the lookup fails', async () => {
+    mockGetActiveMSRooms.mockRejectedValue(new Error('db down'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/100ms/rooms/route.ts
+++ b/src/app/api/100ms/rooms/route.ts
@@ -4,8 +4,23 @@ import { getSessionData } from '@/lib/auth/session';
 import { createMSRoom, getActiveMSRooms } from '@/lib/social/msRoomsDb';
 import { logger } from '@/lib/logger';
 
+// Mirrors the Stream room create schema so a token gate set in HostRoomModal is
+// actually persisted (previously the 100ms route accepted only `title` and
+// silently dropped gate_config — gated 100ms rooms were not gated).
+const GateConfigSchema = z
+  .object({
+    type: z.enum(['erc20', 'erc721', 'erc1155']),
+    contractAddress: z.string().min(1),
+    chainId: z.number().int(),
+    minBalance: z.string().optional(),
+    tokenId: z.string().optional(),
+  })
+  .optional()
+  .nullable();
+
 const CreateSchema = z.object({
   title: z.string().min(1).max(100),
+  gate_config: GateConfigSchema,
 });
 
 // Public list of active 100ms rooms — powers the "Live on 100ms" section on
@@ -37,6 +52,7 @@ export async function POST(req: NextRequest) {
       title: parsed.data.title,
       hostFid: session.fid,
       hostName: session.displayName,
+      gateConfig: parsed.data.gate_config ?? undefined,
     });
 
     return NextResponse.json({ room });

--- a/src/app/spaces/hms/[id]/page.tsx
+++ b/src/app/spaces/hms/[id]/page.tsx
@@ -4,8 +4,10 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
+import { useAccount } from 'wagmi';
 import { useAuth } from '@/hooks/useAuth';
 import type { MSRoom } from '@/lib/social/msRoomsDb';
+import type { TokenGateConfig } from '@/lib/spaces/tokenGate';
 
 const HMSVideoRoom = dynamic(() => import('@/components/spaces/HMSVideoRoom'), { ssr: false });
 
@@ -21,10 +23,12 @@ export default function HMSRoomPage() {
   const router = useRouter();
   const roomId = params.id as string;
   const { user, loading: authLoading } = useAuth();
+  const { address: walletAddress } = useAccount();
 
   const [room, setRoom] = useState<MSRoom | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [gateBlocked, setGateBlocked] = useState(false);
 
   const isHost = user?.fid === room?.host_fid;
 
@@ -38,6 +42,26 @@ export default function HMSRoomPage() {
         const roomData = await fetchMSRoom(roomId);
         if (roomData.state === 'ended') throw new Error('This room has ended');
         if (mounted) setRoom(roomData);
+
+        // Enforce token gate before joining (mirrors the Stream room flow).
+        // gate_config is stored in the room's settings jsonb at create time.
+        const gateConfig = (roomData.settings?.gate_config ?? null) as TokenGateConfig | null;
+        if (gateConfig) {
+          if (!walletAddress) {
+            if (mounted) { setGateBlocked(true); setLoading(false); }
+            return;
+          }
+          const gateRes = await fetch('/api/spaces/gate-check', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ walletAddress, gateConfig }),
+          });
+          const gateData = await gateRes.json();
+          if (!gateData.allowed) {
+            if (mounted) { setGateBlocked(true); setLoading(false); }
+            return;
+          }
+        }
       } catch (err) {
         if (mounted) setError(err instanceof Error ? err.message : 'Failed to load room');
       } finally {
@@ -50,7 +74,7 @@ export default function HMSRoomPage() {
     return () => {
       mounted = false;
     };
-  }, [roomId, authLoading]);
+  }, [roomId, authLoading, walletAddress]);
 
   const handleLeave = async () => {
     if (isHost && room) {
@@ -79,6 +103,35 @@ export default function HMSRoomPage() {
         >
           Back to Spaces
         </button>
+      </div>
+    );
+  }
+
+  if (gateBlocked) {
+    const gate = (room?.settings?.gate_config ?? null) as { type?: string; contractAddress?: string } | null;
+    return (
+      <div className="min-h-[100dvh] bg-[#0a1628] flex flex-col items-center justify-center gap-4 px-4">
+        <div className="bg-[#0d1b2a] border border-white/[0.08] rounded-2xl p-6 max-w-sm w-full text-center">
+          <div className="text-4xl mb-3">🔒</div>
+          <h2 className="text-white font-bold text-lg mb-2">Token-Gated Room</h2>
+          <p className="text-gray-400 text-sm mb-1">
+            This room requires a {gate?.type?.toUpperCase() || 'token'} to enter.
+          </p>
+          {gate?.contractAddress && (
+            <p className="text-gray-500 text-xs font-mono mb-4">
+              {gate.contractAddress.slice(0, 6)}...{gate.contractAddress.slice(-4)}
+            </p>
+          )}
+          {!walletAddress && (
+            <p className="text-[#f5a623] text-xs mb-4">Connect your wallet to check eligibility.</p>
+          )}
+          <button
+            onClick={() => router.push('/spaces')}
+            className="px-6 py-2 bg-[#f5a623] text-[#0a1628] rounded-lg font-semibold text-sm"
+          >
+            Back to Spaces
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/lib/social/msRoomsDb.ts
+++ b/src/lib/social/msRoomsDb.ts
@@ -1,4 +1,5 @@
 import { supabaseAdmin } from '@/lib/db/supabase';
+import type { TokenGateConfig } from '@/lib/spaces/tokenGate';
 
 export interface MSRoom {
   id: string;
@@ -20,7 +21,11 @@ export async function createMSRoom(data: {
   hostFid: number;
   hostName: string;
   roomId100ms?: string;
+  gateConfig?: TokenGateConfig | null;
 }): Promise<MSRoom> {
+  // Token gate lives in the `settings` jsonb column (no dedicated column /
+  // migration). Read back via room.settings.gate_config and enforced
+  // client-side at /spaces/hms/[id], mirroring the Stream room flow.
   const { data: room, error } = await supabaseAdmin
     .from('ms_rooms')
     .insert({
@@ -29,6 +34,7 @@ export async function createMSRoom(data: {
       host_name: data.hostName,
       room_id_100ms: data.roomId100ms || null,
       state: 'active',
+      settings: data.gateConfig ? { gate_config: data.gateConfig } : {},
     })
     .select()
     .single();


### PR DESCRIPTION
## Summary

The next set from the Spaces audit — closes the 🔴 **"token gating silently ignored on 100ms rooms"** finding (which also resolves the 🟠 access-control concern: the gate *is* the access control; un-gated rooms are public by design).

A token gate set in HostRoomModal was being dropped for 100ms rooms because `/api/100ms/rooms` accepted only `title` — so a "gated" 100ms room let anyone in. `/spaces` was already *sending* `gate_config`; it just wasn't persisted or enforced.

## What changed
- **Persist the gate** — `/api/100ms/rooms` POST now accepts `gate_config` (same Zod schema as the Stream route) and stores it on the `ms_rooms` row via the existing **`settings` jsonb column — no migration**.
- **Enforce the gate** — `/spaces/hms/[id]` now mirrors the Stream room flow: reads `settings.gate_config`, checks the viewer's wallet via the existing `/api/spaces/gate-check`, and shows the same 🔒 token-gated block screen on failure. A gate with no connected wallet blocks with a connect-wallet prompt.
- **Tests (8)** for the rooms route: auth (401), validation (400), host-from-session, **gate_config passthrough**, malformed-gate rejection, extra-field tolerance, and the GET list (success + 500).

## Design notes
- Mirrors ZAO's existing **client-side gate enforcement at the room page** (exactly how `/spaces/[id]` does it for Stream) rather than inventing token-route enforcement — consistent, lower-risk.
- Gate stored in `settings` jsonb to avoid a schema change.
- Un-gated rooms still allow public join (these are public spaces); only rooms with a gate are restricted.

## Still deferred (smaller follow-up)
- **Dead-code cleanup**: `AudioRoomAdapter → HMSRoomAdapter → HMSRoom` (the old buggy audio-only join) is unreachable for the current flow and can be retired. Kept out of this PR to keep the security change focused.

## Verification
- `npx vitest run src/app/api/100ms/rooms` → **8/8 passing**.
- `npm run typecheck` → 0 errors. Branch is current with `main`.

https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w)_