### PR TITLE
Stage mode for 100ms rooms (raise hand → host approves → speak)

### DIFF
--- a/src/app/api/100ms/rooms/[id]/stage/__tests__/route.test.ts
+++ b/src/app/api/100ms/rooms/[id]/stage/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  makeGetRequest,
+  makePostRequest,
+  mockUnauthenticatedSession,
+  mockAuthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const {
+  mockGetSessionData,
+  mockGetMSRoomById,
+  mockGetSpeakerRequests,
+  mockCreateSpeakerRequest,
+  mockSetSpeakerRequestStatus,
+  mockAddMSRoomSpeaker,
+  mockRemoveMSRoomSpeaker,
+} = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetMSRoomById: vi.fn(),
+  mockGetSpeakerRequests: vi.fn(),
+  mockCreateSpeakerRequest: vi.fn(),
+  mockSetSpeakerRequestStatus: vi.fn(),
+  mockAddMSRoomSpeaker: vi.fn(),
+  mockRemoveMSRoomSpeaker: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/social/msRoomsDb', () => ({
+  getMSRoomById: mockGetMSRoomById,
+  isStageRoom: (room: { settings?: Record<string, unknown> }) => room.settings?.room_type === 'stage',
+  getRoomSpeakerFids: (room: { speakers?: unknown[] }) =>
+    Array.isArray(room.speakers) ? room.speakers.filter((s) => typeof s === 'number') : [],
+  getSpeakerRequests: mockGetSpeakerRequests,
+  createSpeakerRequest: mockCreateSpeakerRequest,
+  setSpeakerRequestStatus: mockSetSpeakerRequestStatus,
+  addMSRoomSpeaker: mockAddMSRoomSpeaker,
+  removeMSRoomSpeaker: mockRemoveMSRoomSpeaker,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+const STAGE_ROOM = {
+  id: 'room-1',
+  host_fid: 123,
+  state: 'active',
+  settings: { room_type: 'stage' },
+  speakers: [],
+};
+
+const ctx = { params: Promise.resolve({ id: 'room-1' }) };
+
+describe('POST /api/100ms/rooms/[id]/stage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession()); // fid 123 = host
+    mockGetMSRoomById.mockResolvedValue(STAGE_ROOM);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/x', { action: 'raise_hand' }), ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for a non-stage room', async () => {
+    mockGetMSRoomById.mockResolvedValue({ ...STAGE_ROOM, settings: { room_type: 'video' } });
+    const res = await POST(makePostRequest('/x', { action: 'raise_hand' }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('lets a listener raise their hand', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555, displayName: 'Lou' }));
+    const res = await POST(makePostRequest('/x', { action: 'raise_hand' }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockCreateSpeakerRequest).toHaveBeenCalledWith('room-1', 555, 'Lou');
+  });
+
+  it('approve adds the speaker (host only)', async () => {
+    const res = await POST(makePostRequest('/x', { action: 'approve', fid: 555 }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockSetSpeakerRequestStatus).toHaveBeenCalledWith('room-1', 555, 'approved');
+    expect(mockAddMSRoomSpeaker).toHaveBeenCalledWith('room-1', 555);
+  });
+
+  it('demote removes the speaker (host only)', async () => {
+    const res = await POST(makePostRequest('/x', { action: 'demote', fid: 555 }), ctx);
+    expect(res.status).toBe(200);
+    expect(mockRemoveMSRoomSpeaker).toHaveBeenCalledWith('room-1', 555);
+  });
+
+  it('forbids a non-host from approving', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555 }));
+    const res = await POST(makePostRequest('/x', { action: 'approve', fid: 555 }), ctx);
+    expect(res.status).toBe(403);
+    expect(mockAddMSRoomSpeaker).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown action', async () => {
+    const res = await POST(makePostRequest('/x', { action: 'destroy' }), ctx);
+    expect(res.status).toBe(400);
+  });
+
+  it('requires a fid for approve', async () => {
+    const res = await POST(makePostRequest('/x', { action: 'approve' }), ctx);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/100ms/rooms/[id]/stage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMSRoomById.mockResolvedValue({ ...STAGE_ROOM, speakers: [123, 555] });
+    mockGetSpeakerRequests.mockResolvedValue([{ id: 'r1', requester_fid: 777 }]);
+  });
+
+  it('returns pending requests and the approved speakers', async () => {
+    const res = await GET(makeGetRequest('/x'), ctx);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.speakers).toEqual([123, 555]);
+    expect(body.requests).toHaveLength(1);
+  });
+
+  it('returns 404 for a missing room', async () => {
+    mockGetMSRoomById.mockResolvedValue(null);
+    const res = await GET(makeGetRequest('/x'), ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/100ms/rooms/[id]/stage/route.ts
+++ b/src/app/api/100ms/rooms/[id]/stage/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getSessionData } from '@/lib/auth/session';
+import {
+  getMSRoomById,
+  isStageRoom,
+  getRoomSpeakerFids,
+  getSpeakerRequests,
+  createSpeakerRequest,
+  setSpeakerRequestStatus,
+  addMSRoomSpeaker,
+  removeMSRoomSpeaker,
+} from '@/lib/social/msRoomsDb';
+import { logger } from '@/lib/logger';
+
+const ActionSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('raise_hand') }),
+  z.object({ action: z.literal('approve'), fid: z.number().int().positive() }),
+  z.object({ action: z.literal('deny'), fid: z.number().int().positive() }),
+  z.object({ action: z.literal('demote'), fid: z.number().int().positive() }),
+]);
+
+// Current stage state — pending hand-raises + approved speaker FIDs. Used by the
+// host approval panel and to recompute a listener's role after promotion.
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const room = await getMSRoomById(id);
+    if (!room) return NextResponse.json({ error: 'Room not found' }, { status: 404 });
+    const requests = await getSpeakerRequests(id, 'pending');
+    return NextResponse.json({ requests, speakers: getRoomSpeakerFids(room) });
+  } catch (error) {
+    logger.error('Get 100ms stage state error:', error);
+    return NextResponse.json({ error: 'Failed to load stage state' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await getSessionData();
+    if (!session?.fid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { id } = await params;
+    const room = await getMSRoomById(id);
+    if (!room) return NextResponse.json({ error: 'Room not found' }, { status: 404 });
+    if (room.state === 'ended') return NextResponse.json({ error: 'Room has ended' }, { status: 409 });
+    if (!isStageRoom(room)) return NextResponse.json({ error: 'Not a stage room' }, { status: 400 });
+
+    const body = await req.json();
+    const parsed = ActionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input', details: parsed.error.flatten() }, { status: 400 });
+    }
+
+    const isHost = session.fid === room.host_fid;
+
+    if (parsed.data.action === 'raise_hand') {
+      await createSpeakerRequest(id, session.fid, session.displayName || `fid-${session.fid}`);
+      return NextResponse.json({ success: true });
+    }
+
+    // approve / deny / demote are host-only moderation actions.
+    if (!isHost) return NextResponse.json({ error: 'Only the host can manage the stage' }, { status: 403 });
+
+    if (parsed.data.action === 'approve') {
+      await setSpeakerRequestStatus(id, parsed.data.fid, 'approved');
+      await addMSRoomSpeaker(id, parsed.data.fid);
+    } else if (parsed.data.action === 'deny') {
+      await setSpeakerRequestStatus(id, parsed.data.fid, 'denied');
+    } else if (parsed.data.action === 'demote') {
+      await removeMSRoomSpeaker(id, parsed.data.fid);
+      await setSpeakerRequestStatus(id, parsed.data.fid, 'denied');
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    logger.error('100ms stage action error:', error);
+    return NextResponse.json({ error: 'Failed to update stage' }, { status: 500 });
+  }
+}

--- a/src/app/api/100ms/rooms/route.ts
+++ b/src/app/api/100ms/rooms/route.ts
@@ -21,6 +21,8 @@ const GateConfigSchema = z
 const CreateSchema = z.object({
   title: z.string().min(1).max(100),
   gate_config: GateConfigSchema,
+  // 'stage' = host speaks, listeners raise hand; anything else = open video room.
+  room_type: z.enum(['stage', 'voice_channel']).optional(),
 });
 
 // Public list of active 100ms rooms — powers the "Live on 100ms" section on
@@ -53,6 +55,7 @@ export async function POST(req: NextRequest) {
       hostFid: session.fid,
       hostName: session.displayName,
       gateConfig: parsed.data.gate_config ?? undefined,
+      roomType: parsed.data.room_type === 'stage' ? 'stage' : 'video',
     });
 
     return NextResponse.json({ room });

--- a/src/app/api/100ms/token/__tests__/stage-auth.test.ts
+++ b/src/app/api/100ms/token/__tests__/stage-auth.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { makePostRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockGetMSRoomById } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetMSRoomById: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/social/msRoomsDb', () => ({
+  getMSRoomById: mockGetMSRoomById,
+  isStageRoom: (room: { settings?: Record<string, unknown> }) => room.settings?.room_type === 'stage',
+  getRoomSpeakerFids: (room: { speakers?: unknown[] }) =>
+    Array.isArray(room.speakers) ? room.speakers.filter((s) => typeof s === 'number') : [],
+}));
+
+vi.mock('@/lib/db/supabase', () => ({ supabaseAdmin: {} }));
+vi.mock('@/lib/db/audit-log', () => ({
+  logAuditEvent: vi.fn(),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}));
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+const ROOM_NAME = '11111111-1111-1111-1111-111111111111';
+const stageRoom = (over: Record<string, unknown> = {}) => ({
+  id: ROOM_NAME,
+  host_fid: 123,
+  settings: { room_type: 'stage' },
+  speakers: [],
+  ...over,
+});
+
+/** Speaker request for a stage room. roomId is passed too so authorized paths
+ * mint the token without reaching the 100ms HTTP API. */
+function speakerReq(fid: number) {
+  return makePostRequest('/api/100ms/token', {
+    userId: String(fid),
+    role: 'speaker',
+    roomName: ROOM_NAME,
+    roomId: 'hms-room-abc',
+  });
+}
+
+describe('100ms token route — stage authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_100MS_ACCESS_KEY = 'ak_test';
+    process.env.HMS_APP_SECRET = 'secret_test';
+    process.env.NEXT_PUBLIC_100MS_TEMPLATE_ID = 'tpl_test';
+    mockGetMSRoomById.mockResolvedValue(stageRoom());
+  });
+
+  it('blocks a non-host, non-approved listener from minting a speaker token', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const res = await POST(speakerReq(999));
+    expect(res.status).toBe(403);
+  });
+
+  it('allows the host to speak', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const res = await POST(speakerReq(123));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.token).toBeTruthy();
+  });
+
+  it('allows an approved speaker (FID in speakers list)', async () => {
+    mockGetMSRoomById.mockResolvedValue(stageRoom({ speakers: [999] }));
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const res = await POST(speakerReq(999));
+    expect(res.status).toBe(200);
+  });
+
+  it('does not gate a non-stage (open video) room', async () => {
+    mockGetMSRoomById.mockResolvedValue(stageRoom({ settings: { room_type: 'video' } }));
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const res = await POST(speakerReq(999));
+    expect(res.status).toBe(200);
+  });
+
+  it('does not gate listeners', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const res = await POST(
+      makePostRequest('/api/100ms/token', {
+        userId: '999',
+        role: 'listener',
+        roomName: ROOM_NAME,
+        roomId: 'hms-room-abc',
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/100ms/token/route.ts
+++ b/src/app/api/100ms/token/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import jwt from 'jsonwebtoken';
 import { logAuditEvent, getClientIp } from '@/lib/db/audit-log';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { getMSRoomById, isStageRoom, getRoomSpeakerFids } from '@/lib/social/msRoomsDb';
 import { logger } from '@/lib/logger';
 
 const TokenSchema = z.object({
@@ -56,6 +57,24 @@ export async function POST(req: NextRequest) {
     }
     if ((role === 'host' || role === 'moderator') && !session.isAdmin && !isFishbowlHost) {
       return NextResponse.json({ error: 'Forbidden: only admins can request moderator role' }, { status: 403 });
+    }
+
+    // Stage rooms (100ms): only the host or an approved speaker may publish.
+    // roomName carries the ms_rooms UUID for these rooms; fishbowl rooms use a
+    // 'fishbowl-' prefix and the shared default uses 'zao-live-room'. Without
+    // this check any signed-in listener could mint a speaker token directly.
+    if (role === 'speaker' && roomName && !roomName.startsWith('fishbowl-') && roomName !== 'zao-live-room') {
+      const msRoom = await getMSRoomById(roomName);
+      if (msRoom && isStageRoom(msRoom)) {
+        const authorized =
+          session.fid === msRoom.host_fid || getRoomSpeakerFids(msRoom).includes(session.fid);
+        if (!authorized) {
+          return NextResponse.json(
+            { error: 'Not approved to speak in this room' },
+            { status: 403 },
+          );
+        }
+      }
     }
 
     // Generate management token

--- a/src/app/spaces/hms/[id]/page.tsx
+++ b/src/app/spaces/hms/[id]/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import dynamic from 'next/dynamic';
 import { useAccount } from 'wagmi';
 import { useAuth } from '@/hooks/useAuth';
-import type { MSRoom } from '@/lib/social/msRoomsDb';
+import { getSupabaseBrowser } from '@/lib/db/supabase';
+// Type-only imports — the msRoomsDb module itself is server-only (service role).
+import type { MSRoom, SpeakerRequest } from '@/lib/social/msRoomsDb';
 import type { TokenGateConfig } from '@/lib/spaces/tokenGate';
 
 const HMSVideoRoom = dynamic(() => import('@/components/spaces/HMSVideoRoom'), { ssr: false });
@@ -30,7 +32,30 @@ export default function HMSRoomPage() {
   const [loading, setLoading] = useState(true);
   const [gateBlocked, setGateBlocked] = useState(false);
 
+  // Stage state (only meaningful when room.settings.room_type === 'stage').
+  const [speakers, setSpeakers] = useState<number[]>([]);
+  const [pendingRequests, setPendingRequests] = useState<SpeakerRequest[]>([]);
+  const [handRaised, setHandRaised] = useState(false);
+
   const isHost = user?.fid === room?.host_fid;
+  const isStage = room?.settings?.room_type === 'stage';
+  // In a stage room only the host + approved speakers publish; everyone else
+  // joins as a 'listener' (subscribe-only, enforced by the 100ms role + the
+  // token route). Non-stage rooms keep the open "everyone speaks" behavior.
+  const canSpeak = !isStage || isHost || (user ? speakers.includes(user.fid) : false);
+  const hmsRole = canSpeak ? 'speaker' : 'listener';
+
+  const refreshStage = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/100ms/rooms/${roomId}/stage`);
+      if (!res.ok) return;
+      const data = await res.json();
+      setSpeakers((data.speakers as number[]) ?? []);
+      setPendingRequests((data.requests as SpeakerRequest[]) ?? []);
+    } catch {
+      // Non-fatal — the room still works without live stage state.
+    }
+  }, [roomId]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -75,6 +100,53 @@ export default function HMSRoomPage() {
       mounted = false;
     };
   }, [roomId, authLoading, walletAddress]);
+
+  // Stage rooms: load + live-subscribe to hand-raises and the approved-speaker
+  // list. Both tables are in the Supabase realtime publication. When the
+  // speakers list changes, canSpeak/hmsRole recompute and HMSVideoRoom rejoins
+  // with the new role (promotion = re-fetch a speaker token + rejoin).
+  useEffect(() => {
+    if (!isStage || !room) return;
+    refreshStage();
+
+    const supabase = getSupabaseBrowser();
+    const channel = supabase
+      .channel(`hms-stage-${roomId}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'speaker_requests', filter: `room_id=eq.${roomId}` }, () => refreshStage())
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'ms_rooms', filter: `id=eq.${roomId}` }, () => refreshStage())
+      .subscribe();
+
+    return () => { supabase.removeChannel(channel); };
+  }, [isStage, room, roomId, refreshStage]);
+
+  // Clear the local "hand raised" flag once the host acts (we're now a speaker)
+  // or the request is gone from the pending list.
+  useEffect(() => {
+    if (canSpeak) setHandRaised(false);
+  }, [canSpeak]);
+
+  const raiseHand = async () => {
+    setHandRaised(true);
+    try {
+      const res = await fetch(`/api/100ms/rooms/${roomId}/stage`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'raise_hand' }),
+      });
+      if (!res.ok) setHandRaised(false);
+    } catch {
+      setHandRaised(false);
+    }
+  };
+
+  const hostAction = async (action: 'approve' | 'deny', fid: number) => {
+    await fetch(`/api/100ms/rooms/${roomId}/stage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, fid }),
+    }).catch(() => {});
+    refreshStage();
+  };
 
   const handleLeave = async () => {
     if (isHost && room) {
@@ -145,8 +217,14 @@ export default function HMSRoomPage() {
           <div className="flex items-center gap-2">
             <h1 className="text-white font-bold">{room.title}</h1>
             <span className="text-[10px] bg-orange-500/20 text-orange-400 px-2 py-0.5 rounded-full">100ms</span>
+            {isStage && (
+              <span className="text-[10px] bg-[#f5a623]/20 text-[#f5a623] px-2 py-0.5 rounded-full">STAGE</span>
+            )}
           </div>
-          <p className="text-gray-400 text-xs">Hosted by {room.host_name}</p>
+          <p className="text-gray-400 text-xs">
+            Hosted by {room.host_name}
+            {isStage && !canSpeak && ' · listening'}
+          </p>
         </div>
         <div className="flex items-center gap-2">
           {!user && (
@@ -160,10 +238,63 @@ export default function HMSRoomPage() {
         </div>
       </header>
       <div className="mx-auto w-full max-w-3xl flex-1 px-4 py-6">
+        {/* Host stage controls: approve / deny raised hands. */}
+        {isStage && isHost && (
+          <div className="mb-4 rounded-xl border border-white/[0.08] bg-[#0d1b2a] p-4">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-gray-400 mb-3">
+              Requests to speak ({pendingRequests.length})
+            </h2>
+            {pendingRequests.length === 0 ? (
+              <p className="text-gray-500 text-sm">No raised hands right now.</p>
+            ) : (
+              <ul className="space-y-2">
+                {pendingRequests.map((r) => (
+                  <li key={r.id} className="flex items-center justify-between gap-3">
+                    <span className="text-white text-sm truncate">✋ {r.requester_name}</span>
+                    <div className="flex gap-2 flex-shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => hostAction('approve', r.requester_fid)}
+                        className="px-3 py-1 rounded-lg bg-[#f5a623] text-[#0a1628] text-xs font-semibold hover:bg-[#ffd700]"
+                      >
+                        Add to stage
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => hostAction('deny', r.requester_fid)}
+                        className="px-3 py-1 rounded-lg border border-white/20 text-white text-xs hover:bg-white/10"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+
+        {/* Listener raise-hand control. */}
+        {isStage && !canSpeak && user && (
+          <div className="mb-4 flex items-center justify-center">
+            {handRaised ? (
+              <p className="text-sm text-[#f5a623]">✋ Hand raised — waiting for the host to add you.</p>
+            ) : (
+              <button
+                type="button"
+                onClick={raiseHand}
+                className="rounded-lg bg-[#f5a623] px-5 py-2 text-sm font-semibold text-[#0a1628] hover:bg-[#ffd700]"
+              >
+                ✋ Raise hand to speak
+              </button>
+            )}
+          </div>
+        )}
+
         <HMSVideoRoom
           roomId={room.room_id_100ms ?? undefined}
           roomName={room.room_id_100ms ? undefined : room.id}
-          role="speaker"
+          role={hmsRole}
           onLeave={handleLeave}
         />
       </div>

--- a/src/lib/social/msRoomsDb.ts
+++ b/src/lib/social/msRoomsDb.ts
@@ -16,16 +16,35 @@ export interface MSRoom {
   participant_count: number;
 }
 
+export interface SpeakerRequest {
+  id: string;
+  room_id: string;
+  requester_fid: number;
+  requester_name: string;
+  status: 'pending' | 'approved' | 'denied';
+  created_at: string;
+}
+
+/** True when a room runs in stage mode (host speaks, listeners raise hand). */
+export function isStageRoom(room: Pick<MSRoom, 'settings'>): boolean {
+  return room.settings?.room_type === 'stage';
+}
+
 export async function createMSRoom(data: {
   title: string;
   hostFid: number;
   hostName: string;
   roomId100ms?: string;
   gateConfig?: TokenGateConfig | null;
+  roomType?: 'stage' | 'video';
 }): Promise<MSRoom> {
-  // Token gate lives in the `settings` jsonb column (no dedicated column /
-  // migration). Read back via room.settings.gate_config and enforced
-  // client-side at /spaces/hms/[id], mirroring the Stream room flow.
+  // Token gate + room_type live in the `settings` jsonb column (no dedicated
+  // column / migration). Read back via room.settings.*. The gate is enforced
+  // client-side at /spaces/hms/[id]; room_type drives stage mode.
+  const settings: Record<string, unknown> = {};
+  if (data.gateConfig) settings.gate_config = data.gateConfig;
+  if (data.roomType) settings.room_type = data.roomType;
+
   const { data: room, error } = await supabaseAdmin
     .from('ms_rooms')
     .insert({
@@ -34,7 +53,7 @@ export async function createMSRoom(data: {
       host_name: data.hostName,
       room_id_100ms: data.roomId100ms || null,
       state: 'active',
-      settings: data.gateConfig ? { gate_config: data.gateConfig } : {},
+      settings,
     })
     .select()
     .single();
@@ -75,4 +94,82 @@ export async function endMSRoom(id: string): Promise<void> {
     .from('speaker_requests')
     .delete()
     .eq('room_id', id);
+}
+
+/** Approved speaker FIDs for a room (the host is always implicitly a speaker). */
+export function getRoomSpeakerFids(room: Pick<MSRoom, 'speakers'>): number[] {
+  return Array.isArray(room.speakers)
+    ? room.speakers.filter((s): s is number => typeof s === 'number')
+    : [];
+}
+
+/** Add a FID to a room's approved-speakers list (idempotent). */
+export async function addMSRoomSpeaker(roomId: string, fid: number): Promise<void> {
+  const room = await getMSRoomById(roomId);
+  if (!room) throw new Error('Room not found');
+  const speakers = getRoomSpeakerFids(room);
+  if (speakers.includes(fid)) return;
+  const { error } = await supabaseAdmin
+    .from('ms_rooms')
+    .update({ speakers: [...speakers, fid] })
+    .eq('id', roomId);
+  if (error) throw new Error(`Failed to add speaker: ${error.message}`);
+}
+
+/** Remove a FID from a room's approved-speakers list. */
+export async function removeMSRoomSpeaker(roomId: string, fid: number): Promise<void> {
+  const room = await getMSRoomById(roomId);
+  if (!room) throw new Error('Room not found');
+  const speakers = getRoomSpeakerFids(room).filter((f) => f !== fid);
+  const { error } = await supabaseAdmin
+    .from('ms_rooms')
+    .update({ speakers })
+    .eq('id', roomId);
+  if (error) throw new Error(`Failed to remove speaker: ${error.message}`);
+}
+
+/** Listener raises their hand. Replaces any prior request from the same FID so
+ * a re-raise after a deny starts fresh as pending. */
+export async function createSpeakerRequest(
+  roomId: string,
+  fid: number,
+  name: string,
+): Promise<SpeakerRequest> {
+  await supabaseAdmin
+    .from('speaker_requests')
+    .delete()
+    .eq('room_id', roomId)
+    .eq('requester_fid', fid);
+
+  const { data, error } = await supabaseAdmin
+    .from('speaker_requests')
+    .insert({ room_id: roomId, requester_fid: fid, requester_name: name, status: 'pending' })
+    .select()
+    .single();
+  if (error) throw new Error(`Failed to create speaker request: ${error.message}`);
+  return data;
+}
+
+export async function getSpeakerRequests(
+  roomId: string,
+  status?: SpeakerRequest['status'],
+): Promise<SpeakerRequest[]> {
+  let query = supabaseAdmin.from('speaker_requests').select('*').eq('room_id', roomId);
+  if (status) query = query.eq('status', status);
+  const { data, error } = await query.order('created_at', { ascending: true });
+  if (error) throw new Error(`Failed to fetch speaker requests: ${error.message}`);
+  return data || [];
+}
+
+export async function setSpeakerRequestStatus(
+  roomId: string,
+  fid: number,
+  status: SpeakerRequest['status'],
+): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from('speaker_requests')
+    .update({ status })
+    .eq('room_id', roomId)
+    .eq('requester_fid', fid);
+  if (error) throw new Error(`Failed to update speaker request: ${error.message}`);
 }


### PR DESCRIPTION
## Summary

Implements **stage mode** for 100ms `/spaces` rooms — the "Stage" option the Go Live modal already advertised ("Host speaks; listeners raise hand to join") but which was never built. Listeners join muted/subscribe-only, **raise their hand**, the host **approves**, and they're promoted to speaker.

Turns out the schema was already scaffolded and unused: `ms_rooms.speakers` + a `speaker_requests` table, **both already in the Supabase realtime publication** with public-read RLS. So this needs **no migration** and **no 100ms template change**.

## How it works
Promotion mirrors the proven fishbowlz pattern — no 100ms dynamic role-change. The DB flips, the promoted client recomputes its role and **rejoins with a fresh speaker token**:

1. **Create** persists `room_type` (`stage` vs `video`) in the `settings` jsonb.
2. **Stage room**: host + approved speakers join 100ms as `speaker`; everyone else as `listener` (subscribe-only — enforced by both the 100ms role and the token route).
3. Listener taps **✋ Raise hand** → row in `speaker_requests`. Host sees it **live** (Supabase realtime) and taps **Add to stage** → FID added to `ms_rooms.speakers`.
4. The promoted listener's `canSpeak` recomputes → `HMSVideoRoom` rejoins as speaker with publish rights.
5. **Open "video" rooms keep the existing everyone-speaks behavior** — fully backward compatible.

## Security
The token route now **refuses to mint a `speaker` token for a stage room unless the requester is the host or an approved speaker** — without this, a listener could mint one directly and bypass the stage. Listeners, non-stage rooms, fishbowl rooms, and the default room are unaffected.

## Changes
- `POST/GET /api/100ms/rooms/[id]/stage` — `raise_hand` / `approve` / `deny` / `demote` (approve+ are host-only).
- `/api/100ms/token` — stage-room speaker authorization.
- `/api/100ms/rooms` POST + `createMSRoom` — persist `room_type`.
- `msRoomsDb` — `speakers` add/remove + `speaker_requests` helpers + `isStageRoom`.
- `/spaces/hms/[id]` — realtime stage controller: host approval panel, listener raise-hand button, dynamic role / rejoin-on-promote.

## Tests (23, all passing)
- Rooms create route (8, incl. gate + room_type).
- Stage route: raise_hand, approve (adds speaker), demote, host-only guards, bad input (10).
- **Token-route stage authorization**: unapproved listener → **403**; host / approved speaker / listener / non-stage → allowed (5).

## Verification
- `npx vitest run src/app/api/100ms` → **23/23**.
- `npm run typecheck` → 0 errors. Branch current with `main`.

## Note / follow-up
Promotion relies on the `roomName` carrying the `ms_rooms` UUID (current behavior, since `room_id_100ms` is created lazily and not persisted back). If we later persist `room_id_100ms`, the token-route stage lookup should also accept it. Worth a two-browser live test (host + listener) before relying on it in production.

https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcN2W3vm7RNXsnVED6Xn6w)_