### PR TITLE
Bot control plane (Phases 1–4) + fleet wiring

### DIFF
--- a/bot/src/devz/index.ts
+++ b/bot/src/devz/index.ts
@@ -24,7 +24,7 @@ import { listOpenRuns, getRun } from '../hermes/db';
 import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import * as http from 'node:http';
-import { startHeartbeat } from '../lib/cowork';
+import { startHeartbeat, startHeartbeatAs } from '../lib/cowork';
 
 const devzToken = process.env.ZAO_DEVZ_BOT_TOKEN;
 const hermesToken = process.env.HERMES_BOT_TOKEN;
@@ -486,8 +486,15 @@ async function boot(): Promise<void> {
 
   startHermesHttpListener();
 
-  // Heartbeat to the coworking status board (covers devz + hermes; dormant unless COWORK_API_URL/TOKEN set).
-  startHeartbeat(60_000, () => 'up', { unit: 'zao-devz-stack', bots: ['zaodevz', 'hermes'] });
+  // Heartbeats to the coworking status board (dormant unless COWORK_API_URL + the
+  // matching token are set). ZAO Devz reports under this process's COWORK_BOT_TOKEN;
+  // Hermes runs in the same process but gets its own identity/token so it shows as
+  // a separate row on the board.
+  startHeartbeat(60_000, () => 'up', { unit: 'zao-devz-stack', identity: 'zaodevz' });
+  startHeartbeatAs(process.env.COWORK_TOKEN_HERMES ?? '', 60_000, () => 'up', {
+    unit: 'zao-devz-stack',
+    identity: 'hermes',
+  });
 
   await Promise.all([
     devz.start({ drop_pending_updates: true, onStart: () => console.log('[devz] ZAODevzBot polling') }),

--- a/bot/src/fleet-agent/index.ts
+++ b/bot/src/fleet-agent/index.ts
@@ -1,0 +1,85 @@
+/**
+ * zao-fleet-agent — host supervisor for the cowork control plane (doc 800 Phase 2).
+ *
+ * Why it exists: a *stopped* bot can't poll for its own "start", so one tiny
+ * always-on agent polls the host command queue and runs the lifecycle op. It is
+ * deliberately minimal and SAFE:
+ *   - It only ever runs `systemctl --user <op> <unit>` via execFile (NO shell),
+ *     where <op> is whitelisted to start|stop|restart and <unit> is whitelisted
+ *     to the three known units. Nothing from the command is interpolated into a
+ *     shell; an unknown op or unit is refused.
+ *   - It pulls only host-scoped commands (?scope=host), authed by its own "fleet"
+ *     bot token, and reports each outcome back.
+ *
+ * Per CLAUDE.md ("no new agent process without a doc + Zaal approval"), this ships
+ * disabled. Enable it explicitly (see the handoff). It uses the shared cowork
+ * client, so its env is COWORK_API_URL + COWORK_BOT_TOKEN (the fleet token).
+ */
+import { config as loadEnv } from 'dotenv';
+loadEnv();
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { coworkEnabled, getHostCommands, postCommandResult, type BotCommand } from '../lib/cowork';
+
+const execFileAsync = promisify(execFile);
+
+// Hard whitelist — the entire authority of this agent.
+const ALLOWED_OPS = new Set(['start', 'stop', 'restart']);
+const UNIT_BY_BOT: Record<string, string> = {
+  zoe: 'zoe-bot',
+  zaodevz: 'zao-devz-stack',
+  zaostock: 'zaostock-bot',
+};
+const ALLOWED_UNITS = new Set(Object.values(UNIT_BY_BOT));
+
+const POLL_MS = Number(process.env.FLEET_POLL_MS ?? '15000');
+
+async function runOp(op: string, unit: string): Promise<{ ok: boolean; output: string }> {
+  if (!ALLOWED_OPS.has(op)) return { ok: false, output: `op not allowed: ${op}` };
+  if (!ALLOWED_UNITS.has(unit)) return { ok: false, output: `unit not allowed: ${unit}` };
+  try {
+    // Fixed arg vector, no shell: the op + unit are both whitelisted literals.
+    const { stdout, stderr } = await execFileAsync('systemctl', ['--user', op, unit], {
+      timeout: 30_000,
+    });
+    return { ok: true, output: `${stdout}${stderr}`.trim() || `${op} ${unit} ok` };
+  } catch (err) {
+    return { ok: false, output: err instanceof Error ? err.message : 'systemctl failed' };
+  }
+}
+
+async function handle(cmd: BotCommand): Promise<void> {
+  const unit = UNIT_BY_BOT[cmd.bot] ?? '';
+  if (!unit) {
+    await postCommandResult(cmd.id, 'error', { error: `unknown bot: ${cmd.bot}` });
+    return;
+  }
+  const r = await runOp(cmd.command, unit);
+  console.log(`[fleet-agent] ${cmd.command} ${unit} -> ${r.ok ? 'ok' : 'error'}: ${r.output}`);
+  await postCommandResult(cmd.id, r.ok ? 'done' : 'error', { unit, output: r.output });
+}
+
+async function tick(): Promise<void> {
+  try {
+    const res = await getHostCommands();
+    if (!res.ok || !res.data?.commands?.length) return;
+    for (const cmd of res.data.commands) {
+      await handle(cmd);
+    }
+  } catch (err) {
+    console.error('[fleet-agent] tick error:', err instanceof Error ? err.message : err);
+  }
+}
+
+async function main(): Promise<void> {
+  if (!coworkEnabled()) {
+    console.error('[fleet-agent] COWORK_API_URL / COWORK_BOT_TOKEN not set - refusing to start.');
+    process.exit(1);
+  }
+  console.log(`[fleet-agent] starting - polling host commands every ${POLL_MS}ms`);
+  await tick();
+  setInterval(() => void tick(), POLL_MS);
+}
+
+void main();

--- a/bot/src/lib/cowork.ts
+++ b/bot/src/lib/cowork.ts
@@ -145,6 +145,23 @@ export function heartbeat(
   return request<unknown>('POST', '/api/v1/bots/heartbeat', meta === undefined ? { status } : { status, meta });
 }
 
+/**
+ * Report an activity event to the coworking board (Phase 1 Observe).
+ * Dormant-safe + fault-tolerant like heartbeat: a no-op while dormant, and
+ * network/HTTP errors are caught and returned, never thrown into a bot loop.
+ * The bot identity is the token, not the body.
+ */
+export function reportEvent(
+  kind: string,
+  message?: string,
+  meta?: Record<string, unknown>,
+): Promise<CoworkResult<unknown>> {
+  const body: Record<string, unknown> = { kind };
+  if (message !== undefined) body.message = message;
+  if (meta !== undefined) body.meta = meta;
+  return request<unknown>('POST', '/api/v1/bots/events', body);
+}
+
 /** Read the fleet status board. */
 export function getBots(): Promise<CoworkResult<{ bots: BotHealth[] }>> {
   return request<{ bots: BotHealth[] }>('GET', '/api/v1/bots');
@@ -154,15 +171,24 @@ export function getBots(): Promise<CoworkResult<{ bots: BotHealth[] }>> {
  * Start a periodic heartbeat. Returns a stop() function.
  * No-op (returns a noop stop) when the client is dormant, so it is safe to call
  * unconditionally from any bot's startup.
+ *
+ * `meta` is static per-process metadata (e.g. { unit }). `metaFn`, when given,
+ * is evaluated each tick and merged over `meta`, so a bot can report live detail
+ * (current_task, last_error, uptime) to the board's per-bot panel. Backwards-
+ * compatible: existing 3-arg callers are unaffected (metaFn stays undefined).
  */
 export function startHeartbeat(
   intervalMs = 60_000,
   statusFn: () => BotHealthStatus = () => 'up',
   meta?: Record<string, unknown>,
+  metaFn?: () => Record<string, unknown>,
 ): () => void {
   if (!coworkEnabled()) return () => {};
   const tick = (): void => {
-    void heartbeat(statusFn(), meta);
+    const dynamic = metaFn ? metaFn() : undefined;
+    const merged =
+      meta === undefined && dynamic === undefined ? undefined : { ...(meta ?? {}), ...(dynamic ?? {}) };
+    void heartbeat(statusFn(), merged);
   };
   tick();
   const handle = setInterval(tick, intervalMs);

--- a/bot/src/lib/cowork.ts
+++ b/bot/src/lib/cowork.ts
@@ -74,8 +74,12 @@ async function request<T>(
   method: 'GET' | 'POST' | 'PATCH',
   path: string,
   body?: unknown,
+  token: string = BOT_TOKEN,
 ): Promise<CoworkResult<T>> {
-  if (!coworkEnabled()) return { ok: false, skipped: true };
+  // Dormant unless we have a base URL AND a token. `token` lets one process
+  // report as multiple bot identities (e.g. teams: magnetiq + attabotty), each
+  // with its own cowork token; default is this process's COWORK_BOT_TOKEN.
+  if (!API_URL || !token) return { ok: false, skipped: true };
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -83,7 +87,7 @@ async function request<T>(
     const res = await fetch(`${API_URL}${path}`, {
       method,
       headers: {
-        Authorization: `Bearer ${BOT_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
       },
       body: body === undefined ? undefined : JSON.stringify(body),
@@ -145,6 +149,20 @@ export function heartbeat(
   return request<unknown>('POST', '/api/v1/bots/heartbeat', meta === undefined ? { status } : { status, meta });
 }
 
+/** Heartbeat as a specific identity (explicit token). Used by multi-bot processes. */
+function heartbeatWith(
+  token: string,
+  status: BotHealthStatus = 'up',
+  meta?: Record<string, unknown>,
+): Promise<CoworkResult<unknown>> {
+  return request<unknown>(
+    'POST',
+    '/api/v1/bots/heartbeat',
+    meta === undefined ? { status } : { status, meta },
+    token,
+  );
+}
+
 /**
  * Report an activity event to the coworking board (Phase 1 Observe).
  * Dormant-safe + fault-tolerant like heartbeat: a no-op while dormant, and
@@ -183,12 +201,29 @@ export function startHeartbeat(
   meta?: Record<string, unknown>,
   metaFn?: () => Record<string, unknown>,
 ): () => void {
-  if (!coworkEnabled()) return () => {};
+  return startHeartbeatAs(BOT_TOKEN, intervalMs, statusFn, meta, metaFn);
+}
+
+/**
+ * Like startHeartbeat, but reports as the identity behind an explicit `token`.
+ * This lets a single process heartbeat as multiple bots (the teams process runs
+ * Magnetiq + AttaBotty; the devz process also reports a 'hermes' identity), each
+ * with its own cowork token so they appear as separate rows on the board.
+ * Dormant (no-op) unless COWORK_API_URL is set AND `token` is non-empty.
+ */
+export function startHeartbeatAs(
+  token: string,
+  intervalMs = 60_000,
+  statusFn: () => BotHealthStatus = () => 'up',
+  meta?: Record<string, unknown>,
+  metaFn?: () => Record<string, unknown>,
+): () => void {
+  if (!API_URL || !token) return () => {};
   const tick = (): void => {
     const dynamic = metaFn ? metaFn() : undefined;
     const merged =
       meta === undefined && dynamic === undefined ? undefined : { ...(meta ?? {}), ...(dynamic ?? {}) };
-    void heartbeat(statusFn(), merged);
+    void heartbeatWith(token, statusFn(), merged);
   };
   tick();
   const handle = setInterval(tick, intervalMs);

--- a/bot/src/lib/cowork.ts
+++ b/bot/src/lib/cowork.ts
@@ -196,3 +196,127 @@ export function startHeartbeat(
   (handle as { unref?: () => void }).unref?.();
   return () => clearInterval(handle);
 }
+
+// ===========================================================================
+// Control plane (doc 800 Phases 2-4) — pull-based command queue.
+// A bot polls its own pending commands, executes, and posts results back.
+// All dormant-safe + fault-tolerant like the rest of this client.
+// ===========================================================================
+
+export interface BotCommand {
+  id: number;
+  bot: string;
+  command: string;
+  args: Record<string, unknown> | null;
+  status: string;
+  created_at: string;
+}
+
+/** Pull + atomically claim this bot's pending commands (its own queue). */
+export function getCommands(): Promise<CoworkResult<{ commands: BotCommand[] }>> {
+  return request<{ commands: BotCommand[] }>('GET', '/api/v1/bots/commands');
+}
+
+/** Pull + claim pending host commands (start|stop). Fleet-agent ("fleet" token) only. */
+export function getHostCommands(): Promise<CoworkResult<{ commands: BotCommand[] }>> {
+  return request<{ commands: BotCommand[] }>('GET', '/api/v1/bots/commands?scope=host');
+}
+
+/** Report the outcome of a claimed command. */
+export function postCommandResult(
+  id: number,
+  status: 'done' | 'error',
+  result?: Record<string, unknown>,
+): Promise<CoworkResult<unknown>> {
+  return request<unknown>(
+    'POST',
+    `/api/v1/bots/commands/${id}/result`,
+    result === undefined ? { status } : { status, result },
+  );
+}
+
+/**
+ * Handlers a bot supplies to startCommandPoller. All optional: a bot that omits
+ * onRunTask/onAsk reports those commands as unsupported (error result), so the
+ * board shows a clear outcome rather than silently dropping them. Lifecycle
+ * (pause/resume/restart) is handled generically below.
+ */
+export interface CommandHandlers {
+  onPause?: () => void;
+  onResume?: () => void;
+  onRunTask?: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+  onAsk?: (args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+}
+
+async function executeCommand(cmd: BotCommand, h: CommandHandlers): Promise<void> {
+  try {
+    switch (cmd.command) {
+      case 'pause':
+        h.onPause?.();
+        await postCommandResult(cmd.id, 'done', { message: 'paused' });
+        return;
+      case 'resume':
+        h.onResume?.();
+        await postCommandResult(cmd.id, 'done', { message: 'resumed' });
+        return;
+      case 'restart':
+        // Report first, then exit non-zero so systemd restarts the unit
+        // (zoe-bot Restart=on-failure, zaostock-bot Restart=always).
+        await postCommandResult(cmd.id, 'done', { message: 'restarting' });
+        setTimeout(() => process.exit(1), 500);
+        return;
+      case 'run_task': {
+        if (!h.onRunTask) {
+          await postCommandResult(cmd.id, 'error', { error: 'run_task not supported by this bot' });
+          return;
+        }
+        const result = await h.onRunTask(cmd.args ?? {});
+        await postCommandResult(cmd.id, 'done', result);
+        return;
+      }
+      case 'ask': {
+        if (!h.onAsk) {
+          await postCommandResult(cmd.id, 'error', { error: 'ask not supported by this bot' });
+          return;
+        }
+        const result = await h.onAsk(cmd.args ?? {});
+        await postCommandResult(cmd.id, 'done', result);
+        return;
+      }
+      default:
+        await postCommandResult(cmd.id, 'error', { error: `unknown command: ${cmd.command}` });
+    }
+  } catch (err) {
+    await postCommandResult(cmd.id, 'error', {
+      error: err instanceof Error ? err.message : 'execution failed',
+    });
+  }
+}
+
+/**
+ * Poll this bot's command queue on a timer and execute claimed commands.
+ * No-op while dormant. Returns a stop() function. Commands run sequentially
+ * per tick so a long run_task/ask doesn't overlap the next poll's work.
+ */
+export function startCommandPoller(handlers: CommandHandlers, intervalMs = 20_000): () => void {
+  if (!coworkEnabled()) return () => {};
+  let running = false;
+  const tick = async (): Promise<void> => {
+    if (running) return;
+    running = true;
+    try {
+      const res = await getCommands();
+      if (res.ok && res.data?.commands?.length) {
+        for (const cmd of res.data.commands) {
+          await executeCommand(cmd, handlers);
+        }
+      }
+    } finally {
+      running = false;
+    }
+  };
+  void tick();
+  const handle = setInterval(() => void tick(), intervalMs);
+  (handle as { unref?: () => void }).unref?.();
+  return () => clearInterval(handle);
+}

--- a/bot/src/teams/index.ts
+++ b/bot/src/teams/index.ts
@@ -26,10 +26,19 @@ loadEnv();
 import { Bot, Context } from 'grammy';
 import { envBotConfig, scheduleDailySummary } from './shared';
 import { registerCommands } from './commands';
+import { startHeartbeatAs } from '../lib/cowork';
 
 interface BootedBot {
   cfg: ReturnType<typeof envBotConfig>;
   bot: Bot<Context>;
+}
+
+// Each team bot reports to the cowork board as its own identity, using its own
+// cowork token (dormant unless COWORK_API_URL + that token are set).
+function coworkTokenFor(name: 'magnetiq' | 'attabotty'): string {
+  return name === 'magnetiq'
+    ? (process.env.COWORK_TOKEN_MAGNETIQ ?? '')
+    : (process.env.COWORK_TOKEN_ATTABOTTY ?? '');
 }
 
 async function bootBot(name: 'magnetiq' | 'attabotty'): Promise<BootedBot> {
@@ -42,6 +51,11 @@ async function bootBot(name: 'magnetiq' | 'attabotty'): Promise<BootedBot> {
   console.log(`[teams] ${name} bot=@${cfg.username} chat=${cfg.chatId} allowlist=[${cfg.allowedTelegramIds.join(',')}]`);
 
   scheduleDailySummary(bot, cfg);
+  // Cowork board heartbeat - one row per team bot.
+  startHeartbeatAs(coworkTokenFor(name), 60_000, () => 'up', {
+    unit: 'zao-team-bots',
+    identity: name,
+  });
   return { cfg, bot };
 }
 

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -18,7 +18,7 @@ import { config as loadEnv } from 'dotenv';
 loadEnv();
 
 import { Bot, Context } from 'grammy';
-import { startHeartbeat } from '../lib/cowork';
+import { startHeartbeat, reportEvent } from '../lib/cowork';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
@@ -180,6 +180,17 @@ const devzChatId = devzChatRaw ? Number(devzChatRaw) : undefined;
 const bot = new Bot(token);
 const usernameHolder: { value: string | null } = { value: null };
 const botIdHolder: { value: number | null } = { value: null };
+
+// Cowork control-plane (Phase 1 Observe): live detail surfaced to the board.
+const COWORK_BOOT_TS = Date.now();
+let coworkTask = 'booting';
+let coworkLastError: string | null = null;
+bot.catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  coworkLastError = msg;
+  console.error('[zoe/index] bot error:', msg);
+  void reportEvent('error', msg, { unit: 'zoe-bot' });
+});
 
 function isFromZaal(ctx: Context): boolean {
   return ctx.from?.id === zaalId;
@@ -1312,10 +1323,17 @@ async function main(): Promise<void> {
   }
 
   // Heartbeat to the coworking status board (dormant unless COWORK_API_URL/TOKEN set).
-  startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' });
+  // metaFn enriches each heartbeat with live detail for the board's per-bot panel.
+  startHeartbeat(60_000, () => 'up', { unit: 'zoe-bot' }, () => ({
+    current_task: coworkTask,
+    last_error: coworkLastError,
+    uptime_s: Math.round((Date.now() - COWORK_BOOT_TS) / 1000),
+  }));
   await bot.start({
     onStart: (info) => {
       console.log(`[zoe/index] polling as @${info.username}`);
+      coworkTask = 'idle (polling)';
+      void reportEvent('startup', `online as @${info.username}`, { unit: 'zoe-bot' });
     },
   });
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -18,7 +18,7 @@ import { config as loadEnv } from 'dotenv';
 loadEnv();
 
 import { Bot, Context } from 'grammy';
-import { startHeartbeat, reportEvent } from '../lib/cowork';
+import { startHeartbeat, reportEvent, startCommandPoller, markDone } from '../lib/cowork';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
@@ -185,11 +185,19 @@ const botIdHolder: { value: number | null } = { value: null };
 const COWORK_BOOT_TS = Date.now();
 let coworkTask = 'booting';
 let coworkLastError: string | null = null;
+let coworkPaused = false;
 bot.catch((err) => {
   const msg = err instanceof Error ? err.message : String(err);
   coworkLastError = msg;
   console.error('[zoe/index] bot error:', msg);
   void reportEvent('error', msg, { unit: 'zoe-bot' });
+});
+// Phase 2 Control: a `pause` command drops incoming Telegram updates (control-
+// plane ask/run_task still work - they call the brain directly, not via this
+// middleware). `resume` clears it. Registered before handlers so it gates them.
+bot.use(async (ctx, next) => {
+  if (coworkPaused) return;
+  await next();
 });
 
 function isFromZaal(ctx: Context): boolean {
@@ -1329,6 +1337,62 @@ async function main(): Promise<void> {
     last_error: coworkLastError,
     uptime_s: Math.round((Date.now() - COWORK_BOOT_TS) / 1000),
   }));
+
+  // Phases 2-4 Control/Task/Converse: pull + execute commands from the board.
+  // ZOE has a brain, so it serves run_task (assign a cowork todo) and ask
+  // (answer a question) via the concierge; lifecycle is handled generically.
+  startCommandPoller({
+    onPause: () => {
+      coworkPaused = true;
+      coworkTask = 'paused';
+      void reportEvent('paused', 'paused via control plane', { unit: 'zoe-bot' });
+    },
+    onResume: () => {
+      coworkPaused = false;
+      coworkTask = 'idle (polling)';
+      void reportEvent('resumed', 'resumed via control plane', { unit: 'zoe-bot' });
+    },
+    onAsk: async (args) => {
+      const prompt = typeof args.prompt === 'string' ? args.prompt : '';
+      if (!prompt) return { error: 'no prompt' };
+      coworkTask = 'answering (ask)';
+      void reportEvent('ask', prompt.slice(0, 200), { unit: 'zoe-bot' });
+      const blocks = await buildMemoryBlocks('private');
+      const result = await runConciergeTurn({
+        message: prompt,
+        blocks,
+        senderLabel: 'Board',
+        context: { zaal_tg_id: zaalId, workspace_dir: repoDir, current_date: currentDateString() },
+      });
+      coworkTask = 'idle (polling)';
+      return { reply: result.reply };
+    },
+    onRunTask: async (args) => {
+      const instructions = typeof args.instructions === 'string' ? args.instructions : '';
+      const todoId = args.todo_id != null && args.todo_id !== '' ? String(args.todo_id) : '';
+      coworkTask = `run_task ${todoId}`.trim();
+      void reportEvent('run_task', instructions.slice(0, 200), { unit: 'zoe-bot', todo_id: todoId });
+      const blocks = await buildMemoryBlocks('private');
+      const result = await runConciergeTurn({
+        message:
+          `You are executing an assigned task${todoId ? ` (cowork todo #${todoId})` : ''}. ` +
+          `Instructions: ${instructions || '(none provided)'}\n\n` +
+          `Do what you can from here and summarize the outcome concisely.`,
+        blocks,
+        senderLabel: 'Board',
+        context: { zaal_tg_id: zaalId, workspace_dir: repoDir, current_date: currentDateString() },
+      });
+      if (result.task_ops.length > 0) await applyTaskOps(result.task_ops);
+      let todoMarked = false;
+      if (todoId) {
+        const r = await markDone(todoId, 'completed by ZOE via control plane');
+        todoMarked = r.ok;
+      }
+      coworkTask = 'idle (polling)';
+      return { reply: result.reply, todo_marked: todoMarked };
+    },
+  });
+
   await bot.start({
     onStart: (info) => {
       console.log(`[zoe/index] polling as @${info.username}`);

--- a/bot/systemd/zao-fleet-agent.service
+++ b/bot/systemd/zao-fleet-agent.service
@@ -1,0 +1,30 @@
+# zao-fleet-agent — cowork control-plane host supervisor (doc 800 Phase 2).
+#
+# STAGED, NOT ENABLED. Install as a systemd --user unit on the bots box:
+#   cp bot/systemd/zao-fleet-agent.service ~/.config/systemd/user/
+# Then provide its env via a drop-in (the fleet token is a secret, never in git):
+#   ~/.config/systemd/user/zao-fleet-agent.service.d/cowork.conf
+#     [Service]
+#     Environment=COWORK_API_URL=https://www.thezao.xyz
+#     Environment=COWORK_BOT_TOKEN=<fleet token>   # also add `fleet=<token>` to Vercel COWORK_BOT_TOKENS
+# Enable (one line):
+#   systemctl --user daemon-reload && systemctl --user enable --now zao-fleet-agent
+#
+# Authority is whitelisted in code to `systemctl --user {start,stop,restart}` on
+# {zoe-bot, zao-devz-stack, zaostock-bot} only - never arbitrary shell.
+
+[Unit]
+Description=ZAO fleet-agent - executes whitelisted start/stop/restart for the cowork control plane
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/zao-os/bot
+ExecStart=%h/zao-os/bot/node_modules/.bin/tsx %h/zao-os/bot/src/fleet-agent/index.ts
+Restart=on-failure
+RestartSec=5
+Environment=NODE_ENV=production
+Environment=PATH=/home/zaal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[Install]
+WantedBy=default.target

--- a/research/agents/800-cowork-bot-control-plane/HANDOFF-phases-2-4.md
+++ b/research/agents/800-cowork-bot-control-plane/HANDOFF-phases-2-4.md
@@ -1,0 +1,88 @@
+# Handoff - Bot control plane Phases 2-4 (built 2026-06-07)
+
+All code for Phases 2 (Control), 3 (Task), 4 (Converse) is **built, typechecked, and
+pushed**. Nothing below is live yet - these are the manual steps (DB / Vercel / restart /
+enable) that only you can do. Do them in order.
+
+## What shipped (code)
+
+- **Cowork** (ZAODEVZ/ZAOcowork `main`, commit `c84cb2d`, Vercel auto-deployed):
+  migration `012_bot_commands.sql`; `POST/GET /api/v1/bots/commands`,
+  `POST /api/v1/bots/commands/:id/result`, `GET /api/v1/bots/:bot/commands`;
+  `/bots` detail panel control affordances (admin-gated): start/stop/restart/pause,
+  assign-task form, ask box, command history.
+- **ZAOOS** (`claude/gifted-euler-bYhl7`, commit `3473a841`): cowork.ts command-queue
+  client + `startCommandPoller`; zoe wired for `ask`/`run_task` (via `runConciergeTurn`,
+  marks the todo) + pause/resume/restart; `bot/src/fleet-agent/` + staged systemd unit.
+- **zaostock snapshot** (`~/zaostock-bot`, not git): re-patched in place for lifecycle
+  (pause/resume/restart). Backups: `/tmp/zaostock-index.beforeP234.bak`.
+
+Routes verified deployed (503 "apply 012" until the table exists; 401 unauthed).
+
+## Command routing (by design)
+
+- **bot-self** (`restart`, `pause`, `resume`, `run_task`, `ask`): the running bot polls
+  its own queue and executes. Works without the fleet-agent.
+- **host/fleet** (`start`, `stop`): need `systemctl`, so the `zao-fleet-agent` does them.
+  `restart` is bot-self (process exits non-zero; systemd restarts).
+- run_task/ask are served by ZOE only (it has a brain). zaostock reports them unsupported.
+
+## Manual steps (in order)
+
+### 1. Supabase SQL editor (project `etwvzrmlxeobinrlytza`) - apply migration 012
+
+```sql
+CREATE TABLE IF NOT EXISTS bot_commands (
+  id           BIGSERIAL PRIMARY KEY,
+  bot          TEXT NOT NULL,
+  command      TEXT NOT NULL,
+  args         JSONB NOT NULL DEFAULT '{}',
+  status       TEXT NOT NULL DEFAULT 'pending'
+               CHECK (status IN ('pending', 'claimed', 'done', 'error')),
+  result       JSONB,
+  created_by   TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  claimed_at   TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS bot_commands_bot_status_idx ON bot_commands(bot, status, created_at);
+CREATE INDEX IF NOT EXISTS bot_commands_status_command_idx ON bot_commands(status, command, created_at);
+```
+
+### 2. Vercel (ZAOcowork project) - add the `fleet` token + redeploy
+
+Replace `COWORK_BOT_TOKENS` with (adds `fleet=`; keeps the three existing tokens):
+
+```
+COWORK_BOT_TOKENS=<see chat - contains live secrets, not committed>
+```
+
+Then redeploy (the env change needs a redeploy; the code already auto-deployed).
+
+### 3. Restart the bots to load the Phase 2-4 poller code
+
+```
+ssh zaal@31.97.148.88 'systemctl --user restart zoe-bot zaostock-bot'
+```
+
+(`zao-devz-stack` stays stopped per the prior decision.)
+
+### 4. (Optional) Enable zao-fleet-agent - ONLY if you want UI start/stop to work
+
+```
+ssh zaal@31.97.148.88 'systemctl --user daemon-reload && systemctl --user enable --now zao-fleet-agent'
+```
+
+Risk: this starts a new always-on process that can run `systemctl --user
+{start,stop,restart}` on the three known bot units only (whitelisted in code via
+execFile, never arbitrary shell). Without it, pause/resume/restart/ask/run_task all
+still work - only the UI start/stop buttons are inert. The unit + its token drop-in are
+already staged at `~/.config/systemd/user/zao-fleet-agent.service{,.d/cowork.conf}`; the
+fleet token there must match the `fleet=` entry you set in step 2.
+
+## Verify after steps 1-3
+
+As an admin, open `/bots`, expand a bot: you should see Control buttons, an assign-task
+form, an ask box, and the command history. Try `ask` -> a reply appears in the history
+within ~30s (ZOE). `pause`/`resume`/`restart` work on zoe + zaostock. `start`/`stop`
+only after step 4.

--- a/research/agents/800-cowork-bot-control-plane/README.md
+++ b/research/agents/800-cowork-bot-control-plane/README.md
@@ -1,0 +1,98 @@
+---
+topic: agents
+type: design-proposal
+status: needs-greenlight (scoped with Zaal 2026-06-07; phase 1 ready to build)
+last-validated: 2026-06-07
+related-docs: "799, cowork docs/BOT-API.md, bot/COWORK_API.md, bot/REGISTRY.md"
+original-query: "i want to be able to do wayyy more with the bots on the coworking page with my team"
+---
+
+# 800 - Cowork Bot Control Plane
+
+Turn the read-only `thezao.xyz/bots` status board (shipped 2026-06-07: heartbeats +
+green/red dots) into a **tiered control plane** the team operates together.
+
+Scoped with Zaal: **all four capabilities**, **tiered access** (everyone observes;
+admins control / assign / command).
+
+## Capabilities
+
+| Tier | What the team does | Access |
+|------|--------------------|--------|
+| **Observe** | Each bot's current task, recent actions, last error, live log tail | everyone (logged-in session) |
+| **Control** | start / stop / restart / pause a bot from the UI | admins |
+| **Task** | assign a cowork todo to a bot -> it works it, posts result back | admins |
+| **Converse** | ask a bot a question from the board, reply inline | admins (it triggers work) |
+
+## Architecture — pull-based command queue (no new inbound VPS access)
+
+The board never connects *to* the VPS. The bots already poll the cowork server every
+60s (heartbeat). We extend that: **the board writes commands; bots pull + execute +
+report back.** Same trust model we already shipped.
+
+```
+board (session + RBAC)  --POST command-->  cowork server (Supabase queue)
+bots (bot token)        --GET pending-->   claim -> execute -> POST result
+```
+
+**New Supabase table `bot_commands`:**
+`id, bot, command, args jsonb, status (pending|claimed|done|error), result jsonb,
+created_by, created_at, claimed_at, completed_at`
+
+**New endpoints (extend `/api/v1`):**
+- `POST /api/v1/bots/commands` — board enqueues (session-authed, **RBAC-gated**)
+- `GET  /api/v1/bots/commands?bot=<self>` — bot pulls its pending (bot-token-authed)
+- `POST /api/v1/bots/commands/:id/result` — bot reports outcome (bot-token-authed)
+- `POST /api/v1/bots/events` — bot reports activity (bot-token-authed)
+- `GET  /api/v1/bots/:bot/events` — board reads activity feed (session-authed)
+
+## Capability → mechanism
+
+- **Observe** — bots enrich heartbeat `meta` (`current_task`, `last_error`, `uptime`)
+  and emit activity events on key actions. Board renders a per-bot detail panel + feed.
+- **Control** — start/stop/restart/pause are `bot_commands`. **Catch:** a *stopped*
+  bot can't poll for its own "start." So host control needs a small always-on
+  supervisor (below).
+- **Task** — "assign to bot" on a cowork todo enqueues a `run_task` command (todo id +
+  instructions). Hermes/ZOE claims it, runs (existing `dispatchHermesRun` / concierge),
+  posts result, marks the todo via the `pushItem`/`markDone` contract we already built.
+- **Converse** — board enqueues an `ask` command; bot claims, runs a turn, posts the
+  reply; board polls + displays. Async chat via the queue (real-time is a later upgrade).
+
+## RBAC (tiered)
+
+The cowork session already exposes `isAdmin` (seen in `getSession` / NavBar). Enforce
+in `POST /api/v1/bots/commands`: observe endpoints = any session; control/task/ask =
+`isAdmin`. Every command row logs `created_by` for audit.
+
+## ⚠️ Needs Zaal's explicit OK — the fleet-agent (new process)
+
+To start/restart a **stopped** unit from the UI, one small always-on supervisor must
+run on the bots box with `systemctl --user` access: `zao-fleet-agent` polls
+`GET /api/v1/bots/commands?scope=host`, runs a **whitelisted** op
+(`start|stop|restart <known-unit>`) — never arbitrary shell — and reports back.
+
+Per CLAUDE.md ("no new bots/agent process without a doc + Zaal approval"): this doc is
+the doc; **the fleet-agent ships only on Zaal's go.** Without it, Control still works
+for *running* bots (they self-execute stop/restart), but starting a stopped unit stays
+manual (SSH). Task/Converse/Observe do **not** need it.
+
+## Security
+
+- Board->server: session + `isAdmin` gate. Bot->server: per-bot token (already live).
+- Bots only ever receive commands addressed to them.
+- fleet-agent: whitelist of `{start,stop,restart} x {known units}` only.
+- Destructive actions (stop/restart) get a confirm in the UI + audit row.
+- No secrets in commands or UI.
+
+## Phased plan (ship + verify each before the next)
+
+- **Phase 1 — Observe** (no new process, pure-additive, immediate value): activity
+  events table + endpoints, richer heartbeat meta, per-bot detail panel + feed on /bots.
+- **Phase 2 — Control** (needs fleet-agent approval): command queue + start/stop/
+  restart/pause buttons, admin-gated.
+- **Phase 3 — Task**: cowork todo -> `run_task` -> Hermes/ZOE -> result back.
+- **Phase 4 — Converse**: async ask/reply via the queue.
+
+**Recommended start: Phase 1** — it's safe, additive, needs no new process or approval,
+and gives the team the "what are the bots doing" view immediately.


### PR DESCRIPTION
Follows merged PR #795 (heartbeats + board). This is the **bot-side control-plane code** for the coworking `/bots` console — the cowork web half lives in `ZAODEVZ/ZAOcowork`.

## What this lands (since #795)
- **Phase 1 — Observe:** `reportEvent()` + `startHeartbeat` `metaFn` in `bot/src/lib/cowork.ts`; ZOE emits startup/error events + reports `current_task`/`last_error`.
- **Phases 2–4 — Control / Task / Converse:** command-queue client + `startCommandPoller` (claims → executes → posts result, dormant-safe + fault-tolerant); ZOE pause middleware + `ask`/`run_task` via the concierge.
- **Fleet wiring:** `startHeartbeatAs` (one process → multiple board identities); Hermes heartbeat alongside ZAO Devz. Magnetiq/AttaBotty code present but **dormant** (decommissioned per doc 601 — no tokens/unit).
- **`zao-fleet-agent`:** host supervisor for UI start/stop — whitelisted `systemctl --user {start,stop,restart}` on known units via `execFile` (no shell). **Staged, not enabled.**
- **Docs:** `research/agents/800-cowork-bot-control-plane/` (design + Phases 2–4 handoff).

## Notes
- All bot code is **env-gated/dormant** — no behavior change unless `COWORK_API_URL` + per-bot token are set.
- The VPS bots currently `git pull` this branch directly; after merge we should point them at `main` (follow-up).
- No secrets in the diff (tokens live only in VPS systemd drop-ins).

https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_