### PR TITLE
doc 819: AI coding-agent discourse inbox cluster (STANDARD tier)

### DIFF
--- a/research/agents/819-ai-coding-agent-discourse-inbox-cluster/README.md
+++ b/research/agents/819-ai-coding-agent-discourse-inbox-cluster/README.md
@@ -1,0 +1,87 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-06-08
+superseded-by:
+related-docs: "759, 547, 364, 778"
+original-query: "/inbox cluster - drain 6 forwarded items (4 Reddit threads on Claude Code / AI coding, 2 X long-form articles on multi-agent orchestration) into one synthesis doc"
+tier: STANDARD
+---
+
+# 819 - AI Coding-Agent Discourse (June 2026 Inbox Cluster)
+
+> **Goal:** Synthesize the cross-cutting signal across 6 AI-coding items Zaal forwarded to the ZOE inbox, and map it to where ZAO's agent stack already sits.
+
+## FETCH-WALL DISCLOSURE (read first)
+
+This whole environment is hard-blocked from Reddit (Anthropic WebSearch UA refuses reddit.com; curl/old.reddit/exa web_fetch/Jina Reader all 403/429 IP-blocked; no Playwright bridge; no Wayback snapshots - threads too recent). The 2 X items are X long-form **articles**, which are login-walled - the syndication endpoint yields title + preview thesis but not the body.
+
+Result: **4 Reddit sources are title-only (FAILED), 2 X sources are title+thesis-only (PARTIAL)** after exhausting the full fetch ladder. The synthesis below reads the cross-cutting pattern from titles + verified X article theses + one WebSearch thematic confirmation. It is honest about that limit. To deepen any single item, Zaal opens the link on his phone and pastes the body.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | ZAO is AHEAD of this discourse on multi-agent orchestration, not behind - do not chase it as "new" | 0xRicker's "model as org chart / 300 agents / 4000 steps per run" (275 likes) is the exact pattern ZAO already runs: the Workflow tool, Hermes (coder+critic+auto-PR), and the locked ZOE orchestrator (8 workers, 3 critics, doc 759). Validation, not a gap. |
+| 2 | PUBLISH a "Build your first ZAO agent in 30 minutes" guide off the ZABAL Games rail | 0xMorty's "agents are not just for developers" article (283 likes) is the exact non-dev onboarding framing ZABAL Games needs. The `zabal-games-context` skill + doc 778 are the substrate. Steal the 30-minute promise. |
+| 3 | TRACK Claude-Code-vs-Codex parity as ZABAL Games stack guidance, stay Claude-native internally | r/ClaudeCode thread "has anyone actually replaced Claude Code with Codex" signals migration pressure in the field. ZAOOS is Claude-native (CLAUDE.md, Opus 4.8). No reason to switch; reason to have an answer when a Games participant asks. |
+| 4 | Live feedback loop is the quality unlock - ZAO's `/qa` + `/browse` + GAN harness already are this | r/vibecoding "vibe coding gets better when the agent has a live [preview/feedback loop]" + WebSearch confirms: the live preview / iterative refine loop is the core effectiveness driver. ZAO's verification skills are this pattern; lean into them in agent prompts. |
+
+## Source Items (the 6 forwarded)
+
+| # | Source | Title | Signal | Fetch |
+|---|--------|-------|--------|-------|
+| 1 | r/ClaudeCode (1typ8fb) | "Has anyone actually replaced Claude Code with Codex?" | Tool-war / migration pressure Claude Code <-> OpenAI Codex CLI | FAILED (title only) |
+| 2 | r/ClaudeAI (1twkht5) | "9 things about using Claude for actual work that..." | Practical daily-driver operational wisdom listicle | FAILED (title only) |
+| 3 | r/git (1tx2tkg) | "What's the most surprising thing you've learned [about git]" | Git fundamentals TIL thread - tangential to the AI cluster, Zaal's git-workflow interest | FAILED (title only) |
+| 4 | r/vibecoding (1tomshw) | "Vibe coding gets better when the agent has a live [feedback loop]" | Live preview / iterative refine loop = effectiveness driver | FAILED title; theme confirmed via WebSearch |
+| 5 | X / 0xRicker (Jun 3, 275 likes) | "I gave Opus 4.8 an army of 300 agents and built a working SaaS in one afternoon" | Multi-agent at scale: model-as-org-chart, 300 parallel agents, 4000 steps/run, 1 afternoon | PARTIAL (title + thesis preview; article body login-walled) |
+| 6 | X / 0xMorty (May 31, 283 likes) | "How to Build Your First AI Agent in Claude in 30 Minutes (Full Setup)" | Democratization: "agents are not just for developers," 30-min setup | PARTIAL (title + thesis preview; article body login-walled) |
+
+## Findings - The Cross-Cutting Pattern
+
+Six items, one through-line: **June 2026 AI-coding discourse has moved from "can the model write code" to "how do you run a fleet of agents and keep the loop tight."** Five sub-themes:
+
+1. **Multi-agent orchestration went mainstream-hype (items 5, 1).** 0xRicker's "300 agents = an org chart" post is the loudest version: stop using one model as a chatbot, run hundreds as a structured org. This is precisely the abstraction ZAO already encodes - the Workflow tool fans out/pipelines agents; Hermes runs coder+critic+auto-PR; the doc-759 ZOE orchestrator is 8 workers + 3 critics with a $50/day split cap. **ZAO built the thing the timeline is now discovering.**
+
+2. **Democratization / non-developer onboarding (item 6).** 0xMorty's angle - agents are not just for developers - is the ZABAL Games thesis. The gap the field feels (most people think agents are dev-only) is the exact gap ZABAL Games + the `zabal-games-context` skill exist to close.
+
+3. **Tool wars: Claude Code vs Codex (item 1).** Real migration pressure exists. ZAO's posture is settled (Claude-native), but Games participants will ask, so ZAO needs a one-paragraph answer rather than a shrug.
+
+4. **Live feedback loops as the quality lever (item 4).** The vibe-coding crowd has found that a live preview / tight iterate loop beats one-shot generation. ZAO's `/qa`, `/browse`, `/verify`, and GAN harness ARE this loop - they should be named explicitly in agent prompts as the verification rung.
+
+5. **Operational wisdom is the new content genre (item 2).** "9 things nobody tells you about using Claude for real work" is the format that travels. ZAO has 540+ research docs of exactly this - institutional operational wisdom. A distilled public "things we learned running AI agents for a 188-person org" post would land in this slipstream.
+
+Item 3 (git TIL) is off-cluster - filed as `research`, not folded into the synthesis theme.
+
+## ZAO Application
+
+- **Hermes / ZOE / Workflow** (`bot/src/hermes/`, `bot/src/zoe/`, doc 759): the multi-agent-as-org-chart pattern is locked and running. Item 5 is external validation of the locked architecture - cite it next time the orchestrator spend or complexity gets questioned.
+- **ZABAL Games** (doc 778, `zabal-games-context` skill): items 6 + 4 are content + curriculum fuel. "Build your first ZAO agent in 30 min" workshop + "tight feedback loop" as a teaching principle.
+- **Brand voice / content engine**: item 2's listicle format + ZAO's research corpus = a publishable "operational wisdom" post series.
+
+## Also See
+
+- [Doc 759](../759-zoe-orchestrator-architecture/) - locked ZOE orchestrator (8 workers, 3 critics) - the item-5 pattern, already specced
+- [Doc 547](../547-multi-agent-coordination-bonfire-zoe-hermes/) - multi-agent coordination Bonfire/ZOE/Hermes
+- [Doc 364](../364-multi-harness-agent-orchestration/) - multi-harness orchestration
+- [Doc 778](../778-zabal-games-magnetic-build/) - ZABAL Games build (items 6 + 4 land here)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Draft "Build your first ZAO agent in 30 min" workshop outline off ZABAL Games rail | @Zaal | Content | Pre-June Games demo |
+| Write 1-paragraph "Claude Code vs Codex - why ZAO stays Claude-native" stock answer for Games Q&A | @Zaal | Doc snippet | Next sprint |
+| Open items 1, 2, 4, 5, 6 on phone and paste bodies if any one warrants a deep doc | @Zaal | Manual | Ad hoc |
+| Persist AGENTMAIL_API_KEY into ~/.zao/zao.env + point inbox skill at it (repo re-clone wiped .env.local 2026-06-04) | @Zaal | Fix | Now |
+
+## Sources
+
+- [r/ClaudeCode - replaced Claude Code with Codex](https://www.reddit.com/r/ClaudeCode/comments/1typ8fb/has_anyone_actually_replaced_claude_code_codex/) `[FAILED - reddit IP/UA-blocked across curl, old.reddit, exa, Jina, WebSearch UA; no Wayback snapshot. Title only.]`
+- [r/ClaudeAI - 9 things using Claude for actual work](https://www.reddit.com/r/ClaudeAI/comments/1twkht5/9_things_about_using_claude_for_actual_work_that/) `[FAILED - same reddit block. Title only.]`
+- [r/git - most surprising thing you've learned](https://www.reddit.com/r/git/comments/1tx2tkg/whats_the_most_surprising_thing_youve_learned/) `[FAILED - same reddit block. Title only.]`
+- [r/vibecoding - agent has a live feedback loop](https://www.reddit.com/r/vibecoding/comments/1tomshw/vibe_coding_gets_better_when_the_agent_has_a_live/) `[FAILED for body - reddit block; theme corroborated via WebSearch on vibe-coding live-feedback-loop research.]`
+- [X / 0xRicker - 300 agents built a SaaS in one afternoon](https://x.com/0xricker/status/2062149859394585061) `[PARTIAL - syndication endpoint gave title + thesis preview (300 parallel agents, 4000 steps/run, model-as-org-chart); X article body login-walled, Jina returns the X login shell.]`
+- [X / 0xMorty - build your first AI agent in Claude in 30 min](https://x.com/0xmortyx/status/2061106244610408566) `[PARTIAL - syndication gave title + preview (agents not just for devs, 30-min setup); article body login-walled.]`


### PR DESCRIPTION
## Summary
Drained 6 forwarded ZOE-inbox items (4 Reddit threads on Claude Code / AI coding, 2 X long-form articles on multi-agent orchestration) into one synthesis doc. Cross-cutting read: June 2026 AI-coding discourse converged on multi-agent orchestration + tight feedback loops - which ZAO's Hermes / ZOE / Workflow stack already implements. ZAO is ahead here, not behind.

## Tier
STANDARD

## Sources
6 forwarded items: 4 Reddit (FAILED - environment is reddit IP/UA-blocked; titles only), 2 X articles (PARTIAL - login-walled, title + thesis preview only). Full fetch ladder exhausted and disclosed in doc.

## Next Actions
See doc Next Actions - 'build first ZAO agent in 30 min' workshop, Claude-vs-Codex stock answer, persist AGENTMAIL_API_KEY to ~/.zao/zao.env (repo re-clone wiped .env.local 2026-06-04).