### PR TITLE
docs: meeting recaps 818 + 819 (Logesh/SongJam audio extension; Iman ZABAL Games recordings)

### DIFF
--- a/research/events/818-logesh-zaal-xspace-audio-extension-jun8/README.md
+++ b/research/events/818-logesh-zaal-xspace-audio-extension-jun8/README.md
@@ -1,0 +1,78 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-06-08
+related-docs: "241, 736"
+original-query: "/meeting logeshxzaalcraig - testing X Space audio: streaming computer audio into the Space"
+tier: STANDARD
+---
+
+# 818 - Logesh x Zaal: X Space audio extension test (SongJam)
+
+> **Goal:** Test Logesh's Chrome extension that streams computer/tab audio (music) into an X Space, and decide the UI/feature direction.
+
+- **Date:** 2026-06-08
+- **Duration:** ~10 min
+- **Attendees:** Zaal, Logesh ([SongJam](../241-q1-2026-big-wins/) - Adam & Logesh; merged Zaal's SongJam PR #21)
+- **Platform:** Discord/Craig recording (screen-share working session)
+- **Project:** ZAO Devz / general
+
+## What happened
+
+Logesh shipped Zaal a Chrome extension (loaded unpacked via developer mode -> unzip -> "load whole folder") that injects audio controls into X Spaces. In the session they:
+
+- Loaded the extension, launched a fresh Space (it auto-connected), confirmed the mic button detected + active, and enabled "share tab audio."
+- Played music ("fractalgram") from a browser tab into the Space. Audio came through clean once mic was set to 0 and tab audio to 100%.
+- Found the built-in audio **mixer** unnecessary and decided to remove it in favor of a simpler tab-audio passthrough plus a **soundboard** (load short SFX clips, click-to-play).
+- Logesh framed the build philosophy: free small tools for the community drive goodwill + future connections; paid pricing is reserved for a genuinely higher-value service (auto X-Spaces transcription).
+
+Zaal can now load/test the extension on his own, asynchronously.
+
+## Decisions
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | Remove the audio mixer; keep mic at 0% + tab audio at 100% (mixer is unnecessary) | Logesh | high |
+| 2 | Add a soundboard (load short SFX clips, click-to-play) - "soundboard is a lot better than a mixer" | Logesh | high |
+| 3 | Add in-extension play/pause controls + a repositionable icon | Logesh | high |
+| 4 | Ship the tool free to the community; reserve paid pricing for a higher-value auto-transcription service | Logesh | medium |
+
+## Actions
+
+| Title | Owner | Category | Confidence |
+|-------|-------|----------|-----------|
+| Remove mixer, simplify audio routing (tab 100 / mic 0), add an SFX soundboard | Logesh | Site/Tech | high |
+| Add play/pause controls + repositionable icon to the extension UI | Logesh | Site/Tech | high |
+| Test the extension asynchronously now that loading works | Zaal | Site/Tech | high |
+| Scope an auto X-Spaces transcription -> email-to-WaveWarZ tool as a paid product (~$10-15/mo) | Zaal | Other | medium |
+
+(Logesh's three tool-build actions are external/SongJam and live here only; Zaal's two went to the cowork tracker.)
+
+## The transcription opportunity
+
+The most commercially interesting thread: WaveWarZ currently loses data because X Spaces are not being captured. Logesh would pay ~$10-15/month for a tool that **automatically** pulls each Space's transcript and emails it to the WaveWarZ account ("Wave Wars Afterspace is done, transcribe it and send that in an email") - zero manual steps. He is unsure of the broader market but believes some would pay. This is a concrete, self-funding wedge product distinct from the free audio extension.
+
+## Key quotes
+
+- Logesh: "Soundboard is a lot better than a mixer."
+- Logesh: "build small tools like this, give it out for free... teach them how to use it themselves... that leads to a lot more goodwill down the line."
+- Logesh: "the WaveWarZ team would be willing to pay 10-15 a month for a tool that automatically pulled all of our transcriptions from the X spaces."
+- Logesh: "we're losing a lot in data loss... we're not capturing a lot of the spaces."
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Test the SongJam X-Space audio extension async | Zaal | Tracker | This week |
+| Scope the auto X-Spaces transcription -> WaveWarZ-email tool (paid ~$10-15/mo) | Zaal | Tracker | Next |
+| Ship extension v2 (no mixer, soundboard, play/pause, movable icon) | Logesh | External | Logesh's call |
+
+## Also See
+
+- [Doc 241](../241-q1-2026-big-wins/) - SongJam collaboration (Adam & Logesh), Zaal's SongJam PR #21
+- [Doc 736](../../events/736-shriyash-soni-apnacoding-jun/) - adjacent X Spaces / dev-tooling collaborators
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md)

--- a/research/events/818-logesh-zaal-xspace-audio-extension-jun8/transcript.md
+++ b/research/events/818-logesh-zaal-xspace-audio-extension-jun8/transcript.md
@@ -1,0 +1,108 @@
+# Transcript - Logesh x Zaal, X Space audio extension test (2026-06-08)
+
+> 2-person Craig recording, ~10 min. Single unlabeled transcript (diarization skipped per 1-2 person rule); attribution from content.
+
+---
+
+I'm doing good just grinding away getting up ready today let me pull this up
+Okay, let me see what you sent me.
+All right, step by steps, open extensions.
+Let me download the zip.
+You.
+Go to our extensions manage extensions.
+Enable developer mode.
+Got it. Let me show my screen as well.
+OK. So now
+Select the directory.
+Oh, okay.
+One sec, I haven't unzipped.
+Yes.
+I just load the whole folder, right?
+Correct.
+Now, you will have to launch a new space.
+It's there.
+It's the first one.
+I haven't named it yet.
+It just says React.
+oh okay
+oh amazing is this it yeah
+okay so you're gonna you're gonna check the audio quality
+perfect all right let me get a let me get a song up too
+Okay, I just opened it. It looks like it automatically connected to it, so that's great.
+Check mic button, mic button detected, active, oh that's great too. Share tab audio. Okay,
+so let's go into this fractal gram and let's play some music. Let me know when you're in and I can start
+Yeah, I'm in.
+Yeah, I'm in.
+Okay, here we go.
+Can you hear it?
+I guess it'll take a second.
+Yeah, I can hear you.
+Let me just check the audio.
+It's clean?
+Maybe I should have recorded it.
+Were you able to hear it a little better or no?
+Yeah, yeah.
+Move the microphone to zero.
+Okay.
+I paused it also by the way
+Yep
+yeah i think
+cool
+it'd be nice to be able to move this
+also on your screen
+click the minus ones
+do you know what i mean though move the icon
+yeah we can do all that
+yeah so the audio cam is good through
+for me i don't know i think you'd have to check uh can you join your space from
+someone that is stuck on
+i think yeah it's good it's good i think i can do it i can do it uh i have another phone but i
+don't have it with me um what we can do is i could just record i could just record the space
+and then play it out loud and we could go back through the recording too
+It's fine. So I think I should get rid of that mixing.
+That is there for no reason. I get rid of the mixing and completely share the tab audio. I think
+that way, I think when you moved microphone to zero and tab audio to 100%, so it was good. Maybe
+that is the thing that I'm missing. We don't need a mixer, right, of this kind. So I'll simply keep
+the audio to piano.
+yeah no but a play pause from here would be great
+like um
+i mean i guess i can just yeah yeah i guess i can just press it i'm trying to think of the best way
+to do it no i guess this works for me okay so i'll get rid of some of the content at the top
+...  [repeated 24x, trimmed]
+And then maybe a soundboard?
+Soundboard is a lot better than a mixer.
+A quick sound.
+Is what you mean by soundboard?
+The one that we...
+Yeah, so like,
+like the, I guess you,
+I guess in, I guess a lot of the sounds are on here.
+Although you can't see it on desktop.
+But just kind of like, there's a,
+even if it just add a sound, like,
+uh fs sfx sounds those kind of sounds like just adding a button here for me to load up a five
+second uh sound and then i can click that whenever i want do you know what i mean yeah
+yeah it's all good so any anything i mean i mean do we can mind this somehow uh any of this or
+even by adding transcripts any any literally anything or should we simply keep it open and
+this Saturday. I think that it is I think it leads personally to like building things like this that
+are small and putting them out there leads to future connections for an actual job. Again that's
+my opinion personally I don't like to monetize small things plus like I have a pretty small
+community so if I share like tools like this out with our community I know they'll use it
+versus I know most of the people can't use it even at like a $1 a month barrier unfortunately
+um that's just like the way the world right now so that's my my opinion with it I don't
+think that that doesn't mean that like if we if we get a really good transcription service
+like I think the Wave Wars team would be willing to pay a certain amount per month I just don't
+know how much that is and like what we would need right but i mean we're losing a lot in um in data
+loss of like okay we're not capturing a lot of the spaces so i don't i think that we would be
+willing to pay like even you know 10 15 a month for a tool that like automatically pulled all of
+our transcriptions from the x spaces like if i didn't even have to go into my x space and i just
+said, hey, Wave Wars Afterspace is done, transcribe it and send that in an email to the Wave Wars
+account. I think that would be worthwhile because it's completely automatic and it's just like
+in addition to everything I'm doing, but it net benefits me and it saves me time.
+So I do think that there's things there and I don't know who else would pay for that,
+but I'm sure some people would. But my general philosophy is like build small tools like this,
+give it out for free let people try it let people show people that you're like willing to customize
+it for them dash teach them how to use it themselves and i think that leads to a lot more
+goodwill um down the line fine awesome sounds good yeah i'm just thank you for making this
+yeah just tell me tell me whenever to test now that i know how to load that i can always do we
+contest asynchronously now too so awesome thank you have a good rest of your day cheers

--- a/research/events/819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/README.md
+++ b/research/events/819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/README.md
@@ -1,0 +1,74 @@
+---
+topic: events
+type: meeting-recap
+status: research-complete
+last-validated: 2026-06-08
+related-docs: "778, 650, 818"
+original-query: "/meeting imanxzaalcraig - ZABAL Games recordings pages + cowork board mentions"
+tier: STANDARD
+---
+
+# 819 - Iman x Zaal: ZABAL Games recordings pages + cowork board mentions
+
+> **Goal:** Walk the cowork board's mentions/activity surface with Iman, and scope the ZABAL Games recordings-page improvements he is about to build.
+
+- **Date:** 2026-06-08
+- **Duration:** ~13 min
+- **Attendees:** Zaal, Iman ([[project_iman_role]])
+- **Platform:** Discord/Craig recording
+- **Project:** ZAO Devz / general
+
+## What happened
+
+Two threads:
+
+**1. Cowork board - mentions + activity.** Iman asked about the small red "mentioned" badge on the menu. They traced it to the **Activity** tab / "My mentions" view (not the task list). Agreed the @mention signal should also surface on the **My Work / Activity** page, not just the menu badge. Iman noticed Jose's posts were not showing in his activity feed - flagged but not resolved on the call.
+
+**2. ZABAL Games recordings pages.** Iman is building out the recordings pages (recordings-1/2/3, fireside-1; about to upload recordings-4 with Ohnahji). The direction Zaal set: **keep people on the ZABAL Games platform** rather than bouncing them to YouTube/Luma. Concretely - embed each recording as an in-page video viewer and remove the "watch on YouTube" button; add workshop-to-workshop navigation; make the main recordings page a fast jump-board of buttons. Fireside = a conversation (spaces-style), not a workshop; usually audio, but today's will be video.
+
+## Decisions
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | Embed recordings as an in-page viewer; remove the "watch on YouTube" button - keep people on the ZABAL Games platform | Iman | high |
+| 2 | Add "next workshop / previous workshop" navigation at the top of all ZABAL Games pages | Iman | high |
+| 3 | Main recordings page: a row of jump-to buttons at the top for each recording (recordings-1/2/3, fireside-1, ...) | Iman | high |
+| 4 | Surface @mentions on the "My Work" / Activity page, not just the menu badge | Iman | medium |
+
+## Actions
+
+| Title | Owner | Category | Confidence |
+|-------|-------|----------|-----------|
+| Embed recordings as in-page viewer + remove "watch on YouTube" across the recordings pages | Iman | Site/Tech | high |
+| Add next/previous-workshop nav at the top of all ZABAL Games pages | Iman | Site/Tech | high |
+| Rebuild the main recordings page with a top row of jump-to buttons | Iman | Site/Tech | high |
+| Upload the Ohnahji recording (recordings-4) | Iman | Content | high |
+| Add @mention surfacing to the My Work / Activity page | Iman | Site/Tech | medium |
+| Send Zaal a screenshot/spec of the desired back-button nav so he can build it | Iman | Site/Tech | medium |
+
+(A 7th item - adding "good clip spots" to the recordings page - was raised as optional and is intentionally left out of the tracker.)
+
+## Key quotes
+
+- Zaal: "we should just have our own stuff on our own platform pretty much as much as we can."
+- Zaal: "remove the watch on YouTube button, focus on bringing people to these websites under the recordings page."
+- Iman: "Is there a way we could get our recordings embedded onto our own site without having them to open the other sites... could it just be a viewer kind of thing here."
+- Zaal: "the very top should just be a bunch of buttons where you can click on different videos and go right into the recordings."
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Ship recordings-page v2 (in-page viewer, no YouTube button, jump-board, prev/next nav) | Iman | Build | This week |
+| Upload Ohnahji recording (recordings-4) | Iman | Content | This week |
+| Send Zaal the back-button screenshot/spec | Iman | Handoff | Next |
+| Surface @mentions on My Work/Activity + investigate why Jose's posts are missing from activity | Iman | Build | Next |
+
+## Also See
+
+- [Doc 778](../778-zabal-games-magnetic-build/) - ZABAL Games build (Magnetic, judging, demo)
+- [Doc 818](../818-logesh-zaal-xspace-audio-extension-jun8/) - prior meeting this session (Logesh/SongJam audio extension)
+
+## Transcript
+
+Full transcript: [transcript.md](transcript.md)

--- a/research/events/819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/transcript.md
+++ b/research/events/819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/transcript.md
@@ -1,0 +1,194 @@
+# Transcript - Iman x Zaal, ZABAL Games recordings + cowork mentions (2026-06-08)
+
+> 2-person Craig recording, ~13 min. Single unlabeled transcript (diarization skipped per 1-2 person rule); attribution from content.
+
+---
+
+What have I mentioned?
+It's good, bro.
+How's it going?
+It's going good.
+It's going good.
+Awesome.
+Perfect.
+Quick one, bro.
+Yeah.
+On the menu where it shows me that I've been mentioned,
+you remember that one line, that red one that shows I've been mentioned?
+What do you mean?
+Where is that?
+On the task.
+Sorry.
+the Zelda
+okay
+on there
+you're saying
+what is red?
+oh it's not red
+on the menu
+where it shows
+the one
+in the small
+red
+circle
+yeah I don't know
+what that is
+to be honest with you
+I have a two
+I didn't figure that out
+I thought it was
+it would only happen
+when
+you get mentioned
+or anything
+we can change it that's what the the report kind of showed me but we should actually put the mention
+on these as well on my work activity okay so if you it's under activity if you go to activity
+it'll oh okay activity ah that's what it is that's exactly what i was talking about so it's cool
+yeah so this is good because now you can go to my mentions in the top like this might not be perfect
+yet but like the idea here is we could scroll through oh it doesn't even have yesterday's
+activity that's annoying oh no it does it's just cleaner okay so yeah so you post why don't we
+have jose that's what i'm not seeing interesting okay let me
+Let me find...
+Thank you.
+Was that your only question?
+Yeah, for now.
+All right, I'm going to download the Onadri thing right now.
+Okay, cool.
+Cool.  [repeated 5x, trimmed]
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cool.
+
+Cool.
+
+
+
+Cool.
+Cool.
+
+
+Cool.
+Cool.
+
+Cool.
+Cool.
+
+
+Cool.
+
+Cool.
+
+
+
+Cool.
+
+Cool.
+
+
+
+
+Thank you.
+um you don't have to for these last bits but if you happen to do any of the clipping stuff
+for like good clip spots.
+We should add that to the recordings page.
+Essentially, if we go to zballgames.com-recordings-1,
+tell me what else we can improve to our past like posts,
+like our past YouTubes essentially.
+And take a look at this and tell me what else we can improve on this page.
+So look at recordings one, look at recordings two, look at recordings three.
+and I'm about to upload recordings for with Onaji.
+So take a look at one, two, three.
+Tell me what we can improve.
+Keep on looking through Zao, Zabal Games,
+and tell me what we can improve there.
+I'm going to upload the Onaji video right now.
+I'm going to check this out.
+I'm there now.
+Okay.
+Okay.
+Oh, and a quick question, bro.
+Is it like a general one or do I have to create some for my channel?
+Or is there a way to add it?
+It's a general one.
+Just right click on it, do press profile.
+And then add.
+Cool.
+Word.
+Interesting.
+OK.
+That was quicker than I imagined.
+Yeah, very easy.
+Thank you.  [repeated 3x, trimmed]
+quick one bro
+on the recordings
+fireside one
+where are audio recordings
+am I right
+not always
+but this next one was
+today's will be a video
+cool
+that's like the spaces more
+you know just like
+a conversation, not like a workshop.
+That's what a fireside means.
+Right.
+Gotcha.
+Okay.
+And just, where's that?
+Where is it?
+You're transcribed.
+What?
+Okay.
+Not that it's really that important or anything,
+but like on the navigation just a quick back button or feature like i can just press there
+and it takes me back to yeah send me a screenshot send me a screenshot of what you want and type it
+in and i'll ask it to make that
+Is there a way we could get our recordings embedded onto our own site without having
+them to open the other sites like could it just be a viewer kind of thing here tell me more what
+you mean um you see how uh when you want to post like a visual site and you just pull a link from
+youtube per se and you have like a viewer um viewer in your app and you can view that video that's
+coming in from youtube or another source and but it's in your uh it's on your and all that stuff
+Yeah, now I'm talking about like the YouTube video is embedded in the website
+Yes, so when I hit watch now or watch recording instead of watch recording on luma
+I want to watch it here where there's all this information for me about it. You're saying instead of press watch on youtube
+Yeah, I watched it here. I have the video right here
+Well, but isn't that what
+Isn't that like the whole button is to watch it on YouTube, you press this and then you go to the YouTube.
+But if you don't want to go to the YouTube, you just press play in the thing.
+Yes, exactly.
+Or without the option to actually watch it on YouTube.
+So you're saying remove that completely?
+Yeah, we should just have our own stuff on our own platform pretty much as much as we can.
+That's the suggestion.
+okay i'm good with that let's also add in uh next workshop previous workshop at the top
+that's going to be something else i would like to do it would be great to have at the very top
+of the ball games all of the different pages i don't think we clearly show all of them and um
+and yeah i like that idea remove the watch on youtube button focus on bringing people to these
+websites under the recordings page.
+I like that a lot.
+And on the main recordings page,
+make it easier to click on buttons
+to get to the specific recordings.
+The first, the very top should just
+be a bunch of buttons where you can click on different
+videos and go right
+into the recordings-1,
+recordings-2, recordings-
+fireside-1, etc.
+That would be really cool.
+Cool.
+Okay, cool. I'm going to end this call, make those changes and come back soon, okay?

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-06-08 | Logesh x Zaal - X Space audio extension test (SongJam) | ZAO Devz | Zaal, Logesh | [818](818-logesh-zaal-xspace-audio-extension-jun8/) | 4 |
 | 2026-06-06 | ZABAL Games workshop - ZAO Fractal intro (solo teaching, Respect Game + Discord tooling) | ZABAL Games | Zaal | [808](808-zabal-games-zao-fractal-intro-workshop-jun6/) | 3 |
 | 2026-06-06 | ZABAL Games fireside - Carlos (Plat0x / Bonfires) x Zaal - vibe-coding + Bonfires workshop | ZAO Devz | Zaal, Carlos (Plat0x) | [807](807-zabal-games-fireside-carlos-bonfires-jun6/) | 5 |
 | 2026-06-06 | Arun Phillips x Zaal - collaboration catch-up (DreamStarter, ZABAL Games, WaveWarZ India) | ZAO Devz | Zaal, Arun Phillips | [805](805-arun-phillips-collab-jun6/) | 10 |

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-06-08 | Iman x Zaal - ZABAL Games recordings pages + cowork board mentions | ZAO Devz | Zaal, Iman | [819](819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/) | 6 |
 | 2026-06-08 | Logesh x Zaal - X Space audio extension test (SongJam) | ZAO Devz | Zaal, Logesh | [818](818-logesh-zaal-xspace-audio-extension-jun8/) | 4 |
 | 2026-06-06 | ZABAL Games workshop - ZAO Fractal intro (solo teaching, Respect Game + Discord tooling) | ZABAL Games | Zaal | [808](808-zabal-games-zao-fractal-intro-workshop-jun6/) | 3 |
 | 2026-06-06 | ZABAL Games fireside - Carlos (Plat0x / Bonfires) x Zaal - vibe-coding + Bonfires workshop | ZAO Devz | Zaal, Carlos (Plat0x) | [807](807-zabal-games-fireside-carlos-bonfires-jun6/) | 5 |


### PR DESCRIPTION
Two meeting recaps from the 2026-06-08 session (one branch / one PR per doc 789).

- 818: Logesh (SongJam) x Zaal - tested the Chrome extension that streams tab audio into an X Space; drop mixer for a soundboard; the real wedge is a paid auto X-Spaces transcription tool for WaveWarZ.
- 819: Iman x Zaal - ZABAL Games recordings pages (embed in-page viewer, remove watch-on-YouTube, jump-board + prev/next nav) + cowork board @mentions on the Activity page.

Actions written to the cowork tracker (Zaal x2, Iman x6); Bonfire episodes posted for both.

Generated with Claude Code