### PR TITLE
Overview dashboard + bot registry refresh

### DIFF
--- a/bot/REGISTRY.md
+++ b/bot/REGISTRY.md
@@ -3,39 +3,52 @@
 Status of every bot/agent in the ZAO fleet — what's live, where it runs, how it's
 checked. Mirrors CLAUDE.md "Primary Surfaces"; **update both together.**
 
-_Last updated: 2026-06-07_
+_Last updated: 2026-06-08_
 
 ## Active fleet
 
-| Bot | Handle | Source | Purpose | Runs on | Status / health check |
-|-----|--------|--------|---------|---------|----------------------|
-| **ZOE** | `@zaoclaw_bot` | `bot/src/zoe/` | Concierge — tasks, captures, brief/reflect, recall, CRM, social drafts, group dispatch | systemd `zoe-bot` @ VPS 1 (grammy long-poll + Claude CLI subprocess) | `systemctl --user status zoe-bot` |
-| **Hermes** | `@zoe_hermes_bot` | `bot/src/hermes/` | Autonomous fix-PR pipeline — coder (Opus) + critic (Sonnet) + auto-PR | In-process, spawned by ZOE / ZAO Devz dispatch | runs logged to Supabase `hermes_runs` |
-| **ZAO Devz** | `@zaodevz_bot` | `bot/src/devz/` | Group `/fix` dispatch + hourly learning tip; dual-bot coder/critic narration | systemd `zao-devz-stack` @ VPS 1 | `systemctl --user status zao-devz-stack` |
-| **ZAOstock** | `@ZAOstockTeamBot` | `bot/src/index.ts` (root) | Festival team coordination (sponsors, artists, volunteers, todos) — **graduating** with ZAOstock spinout | systemd `zaostock-bot` @ VPS 1 | `systemctl --user status zaostock-bot` |
-| **Bonfire** (reader) | `@zabal_bonfire` | bonfires.ai (agent `69ef…`) | Knowledge-graph recall + multi-corpus ingest | Bonfires platform (Genesis tier, wallet-gated) | Bonfires dashboard |
-| **DeepMeeting** | `@zdeepmeeting_bot` | bonfires.ai | GCvlcnti protocol authoring workbench (proposal-only shard) | Bonfires platform | Bonfires dashboard — ⚠️ **DM works, group routing broken** (Plat0x ticket open) |
+| Bot | Handle | Source | Purpose | Runs on | On board? |
+|-----|--------|--------|---------|---------|-----------|
+| **ZOE** | `@zaoclaw_bot` | `bot/src/zoe/` | Concierge — tasks, captures, brief/reflect, recall, CRM, social drafts, group dispatch | systemd `zoe-bot` @ bots VPS (from `~/zao-os`, git) | ✅ heartbeat + ask/run_task/pause |
+| **Hermes** | `@zoe_hermes_bot` | `bot/src/hermes/` | Autonomous fix-PR pipeline — coder (Opus) + critic (Sonnet) + auto-PR | In-process inside `zao-devz-stack` | ⏳ heartbeat code wired (`hermes` identity); needs token + redeploy |
+| **ZAO Devz** | `@zaodevz_bot` | `bot/src/devz/` | Group `/fix` dispatch + hourly tip; dual-bot coder/critic narration | systemd `zao-devz-stack` (from `~/zaostock-bot` snapshot) | ✅ heartbeat + lifecycle |
+| **ZAOstock** | `@ZAOstockTeamBot` | `bot/src/index.ts` (root) | Festival team coordination — **graduating** with ZAOstock spinout | systemd `zaostock-bot` (from `~/zaostock-bot` snapshot) | ✅ heartbeat + lifecycle |
+| **Team bots** | `@zao_magnetiq_bot`, `@z_attabotty_bot` | `bot/src/teams/` | Magnetiq (design) + AttaBotty (music) personas | systemd `zao-team-bots` (**not running** — no tokens/unit on box) | ⚪ code-ready, dormant (decommissioned, see below) |
+| **Bonfire** (reader) | `@zabal_bonfire` | bonfires.ai (agent `69ef…`) | Knowledge-graph recall + ingest | Bonfires platform (Genesis tier, wallet-gated) | ❌ off-VPS (no heartbeat path) |
+| **DeepMeeting** | `@zdeepmeeting_bot` | bonfires.ai | GCvlcnti protocol authoring workbench (proposal-only shard) | Bonfires platform | ❌ off-VPS — ⚠️ **DM works, group routing broken** (Plat0x ticket) |
 
-## External / separate repos
+## Control plane (the `/bots` console — doc 800, shipped 2026-06-07)
 
-- **Coworking** — `@ZAOcoworkingBot` — repo **`songchaindao-dot/cowork-zaodevz`** (on VPS at `/root/cowork-zaodevz`). Next.js web app + Node bot (Hermes pattern). Stores todos in `data/actions.json` via GitHub Octokit (SHA-dance). **No HTTP API** — see "Known gaps." The `/meeting` skill posts action items here via Octokit.
+Live team console at **`thezao.xyz/bots`** (session-gated; observe = any teammate, control/task = admins). Pull-based — bots poll the cowork server; the board never reaches into the VPS.
+
+- **Observe:** heartbeats + activity events → green/red dots, per-bot task/last-error/feed. (`startHeartbeat` / `startHeartbeatAs` / `reportEvent` in `bot/src/lib/cowork.ts`.)
+- **Control / Task / Converse:** command queue (`startCommandPoller` claims → executes → posts result). ZOE serves `ask` + `run_task` via the concierge; all bots do `pause`/`resume`/`restart`.
+- **`zao-fleet-agent`** (`bot/src/fleet-agent/`, `bot/systemd/zao-fleet-agent.service`): host supervisor for UI **start/stop** — whitelisted `systemctl --user {start,stop,restart}` on known units via `execFile` (no shell). **STAGED + DISABLED** — enable only deliberately.
+- Contract: `bot/COWORK_API.md` (mirrors `cowork-zaodevz/docs/BOT-API.md`).
+
+## Coworking app (separate repo)
+
+- **`@ZAOcoworkingBot`** + the web board — repo **`ZAODEVZ/ZAOcowork`** (on the cowork VPS at `/root/cowork-zaodevz`). Next.js, **deploys to `thezao.xyz` via Vercel** (Supabase backend). Now exposes the `/api/v1/bots*` fleet API + `/bots` board (no longer "an island").
 
 ## Decommissioned — DO NOT revive (doc 601, 2026-05-04)
 
-- OpenClaw container + 7-agent squad (ZOEY / BUILDER / SCOUT / WALLET / FISHBOWLZ / CASTER)
-- Composio AO orchestrator
-- ZOE v2 / Agent Zero migration plan
-- 10-bot branded fleet (Magnetiq / Research / WaveWarZ / POIDH as own bots)
-- FISHBOWLZ (paused 2026-04-16, killed 2026-05-04 — Juke partnership stands)
+- OpenClaw container + 7-agent squad (ZOEY / BUILDER / SCOUT / WALLET / FISHBOWLZ / CASTER) — code gone
+- Composio AO orchestrator · ZOE v2 / Agent Zero migration
+- 10-bot branded fleet (Magnetiq / Research / WaveWarZ / POIDH as own bots) — **⚠️ Magnetiq/AttaBotty code still present** in `bot/src/teams/`; cleanup pending (delete/archive or formally un-decommission)
+- FISHBOWLZ (killed 2026-05-04) — **⚠️ code still present** in `src/components/fishbowlz`, `src/lib/fishbowlz`, `skills/fishbowlz`
 
 ## Infra
 
-- **VPS 1** (Hostinger KVM2), user `zaal`. Three systemd user units: `zoe-bot`, `zao-devz-stack`, `zaostock-bot`.
-- **No central dispatcher** — each VPS bot is an independent grammy long-poll loop.
-- Coordination: `groups.json`, `~/.zao/zoe/` memory blocks, Supabase (`hermes_runs`, CRM). Bonfire/DeepMeeting run off-VPS on the Bonfires platform.
+- **Bots VPS** `zaal@31.97.148.88` — systemd `--user` units: `zoe-bot`, `zao-devz-stack`, `zaostock-bot` (+ `zao-team-bots` dormant, `zao-fleet-agent` staged/off). Each an independent grammy long-poll loop; no central dispatcher.
+- **Cowork VPS** `root@187.77.3.104` — runs `cowork-zaodevz` (→ Vercel/Supabase). **Different machine** from the bots.
+- Coordination: `groups.json`, `~/.zao/zoe/` memory, Supabase (`hermes_runs`, CRM, `bot_heartbeats`/`bot_events`/`bot_commands`).
+- Per-bot cowork tokens live **only** in VPS systemd drop-ins (`~/.config/systemd/user/<unit>.service.d/cowork.conf`) — never in git.
 
-## Known gaps
+## Known gaps / tech-debt (priority order)
 
-- **No centralized health/status** — no HTTP health endpoint, no heartbeat, no dashboard. Checked manually via `systemctl --user status <unit>` / `journalctl --user -u <unit> -f`.
-- **Coworking is an island** — `cowork-zaodevz` exposes no API, so Hermes/ZOE/`/meeting` can't programmatically read or update its todos (doc 672 **P3.5**).
-- **DeepMeeting group routing broken** on the Bonfires platform (Plat0x ticket open). DM works.
+1. **⚠️ Untracked snapshot (top risk).** `zaostock-bot` *and* `zao-devz-stack`/`hermes` run from `~/zaostock-bot`, which is **not a git repo** — control-plane code there was hand-patched, so it can drift from `main` and isn't reproducible. Reconcile to a real git checkout.
+2. **VPS runs a feature branch.** `~/zao-os` (zoe-bot) tracks `claude/gifted-euler-bYhl7`; point it at `main` now that PRs #795/#804 are merged.
+3. **Hermes on the board** — code wired; needs `hermes=` token added to `COWORK_BOT_TOKENS` (Vercel) + `restart zao-devz-stack`. Blocked on the Vercel daily-deploy cap (~24h).
+4. **Decommissioned code lingering** — Magnetiq/AttaBotty + FISHBOWLZ (above).
+5. **Un-wired exports** — `pushItem` (ZOE capture→cowork) and Hermes `markDone` exist in the client but have no callsites yet.
+6. **Bonfires bots off the board** — `@zabal_bonfire` / `@zdeepmeeting_bot` need a separate heartbeat path (different platform).

--- a/src/app/(auth)/overview/OverviewPanel.tsx
+++ b/src/app/(auth)/overview/OverviewPanel.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import {
+  repoMap,
+  botFleet,
+  controlPlane,
+  tooling,
+  toolingNote,
+  improvements,
+  type BotStatus,
+  type Priority,
+} from './data';
+
+type Tab = 'repo' | 'bots' | 'tooling' | 'fixes';
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: 'repo', label: 'Repo map' },
+  { id: 'bots', label: 'Bots' },
+  { id: 'tooling', label: 'Tooling' },
+  { id: 'fixes', label: 'Improvements' },
+];
+
+const BOT_STATUS_STYLE: Record<BotStatus, string> = {
+  live: 'bg-green-500/15 text-green-400 ring-green-500/30',
+  pending: 'bg-amber-500/15 text-amber-400 ring-amber-500/30',
+  dormant: 'bg-slate-500/15 text-slate-400 ring-slate-500/30',
+  decommissioned: 'bg-red-500/15 text-red-400 ring-red-500/30',
+  external: 'bg-sky-500/15 text-sky-400 ring-sky-500/30',
+};
+
+const PRIORITY_STYLE: Record<Priority, string> = {
+  P0: 'bg-red-500/15 text-red-400 ring-red-500/30',
+  P1: 'bg-amber-500/15 text-amber-400 ring-amber-500/30',
+  P2: 'bg-sky-500/15 text-sky-400 ring-sky-500/30',
+  P3: 'bg-slate-500/15 text-slate-400 ring-slate-500/30',
+};
+
+function Badge({ label, className }: { label: string; className: string }) {
+  return (
+    <span className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[11px] font-medium uppercase ring-1 ${className}`}>
+      {label}
+    </span>
+  );
+}
+
+export default function OverviewPanel() {
+  const [tab, setTab] = useState<Tab>('repo');
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] px-4 pb-24 pt-8 text-white sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl">
+        <header className="mb-6">
+          <h1 className="text-3xl font-bold sm:text-4xl">Project Overview</h1>
+          <p className="mt-2 text-sm text-white/60">
+            A live map of the ZAO OS repo, the bot fleet, the tooling, and what to improve next.
+          </p>
+        </header>
+
+        <nav className="mb-6 flex gap-1 overflow-x-auto border-b border-white/10">
+          {TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={`shrink-0 px-4 py-2 text-sm font-medium transition-colors ${
+                tab === t.id
+                  ? 'border-b-2 border-[#f5a623] text-[#f5a623]'
+                  : 'text-white/60 hover:text-white'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
+
+        {tab === 'repo' && <RepoMap />}
+        {tab === 'bots' && <Bots />}
+        {tab === 'tooling' && <Tooling />}
+        {tab === 'fixes' && <Fixes />}
+      </div>
+    </main>
+  );
+}
+
+function Card({ children }: { children: ReactNode }) {
+  return <div className="rounded-xl border border-white/10 bg-[#0d1b2a] p-4">{children}</div>;
+}
+
+function RepoMap() {
+  return (
+    <div className="space-y-5">
+      {repoMap.map((group) => (
+        <section key={group.group}>
+          <h2 className="mb-2 text-sm font-semibold text-[#f5a623]">{group.group}</h2>
+          <Card>
+            <ul className="divide-y divide-white/5">
+              {group.areas.map((a) => (
+                <li key={a.path} className="flex flex-col gap-1 py-2 first:pt-0 last:pb-0 sm:flex-row sm:items-baseline sm:justify-between">
+                  <div className="min-w-0">
+                    <span className="text-sm font-medium">{a.area}</span>
+                    <code className="ml-2 break-all text-xs text-white/40">{a.path}</code>
+                    <p className="mt-0.5 text-xs text-white/60">{a.desc}</p>
+                  </div>
+                  {a.count && <span className="shrink-0 text-xs text-white/40">{a.count}</span>}
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function Bots() {
+  return (
+    <div className="space-y-5">
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-[#f5a623]">Control plane</h2>
+        <Card>
+          <p className="text-xs text-white/60">{controlPlane.summary}</p>
+          <ul className="mt-3 grid gap-1.5 sm:grid-cols-2">
+            {controlPlane.capabilities.map((c) => (
+              <li key={c} className="text-xs text-white/80">• {c}</li>
+            ))}
+          </ul>
+          <a
+            href={controlPlane.url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-3 inline-block text-xs font-medium text-[#f5a623] hover:text-[#ffd700]"
+          >
+            Open the board ↗
+          </a>
+        </Card>
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-[#f5a623]">Fleet</h2>
+        <Card>
+          <ul className="divide-y divide-white/5">
+            {botFleet.map((b) => (
+              <li key={b.name} className="flex items-start justify-between gap-3 py-2.5 first:pt-0 last:pb-0">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium">{b.name}</span>
+                    <code className="text-xs text-white/40">{b.handle}</code>
+                  </div>
+                  <p className="mt-0.5 text-xs text-white/60">{b.board}</p>
+                  <code className="text-[11px] text-white/30">{b.source}</code>
+                </div>
+                <Badge label={b.status} className={BOT_STATUS_STYLE[b.status]} />
+              </li>
+            ))}
+          </ul>
+        </Card>
+      </section>
+    </div>
+  );
+}
+
+function Tooling() {
+  return (
+    <div className="space-y-5">
+      {tooling.map((group) => (
+        <section key={group.group}>
+          <h2 className="mb-2 text-sm font-semibold text-[#f5a623]">{group.group}</h2>
+          <Card>
+            <ul className="space-y-2">
+              {group.skills.map((s) => (
+                <li key={s.name} className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
+                  <code className="shrink-0 text-sm font-medium text-white">{s.name}</code>
+                  <span className="text-xs text-white/60">{s.desc}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </section>
+      ))}
+      <p className="text-xs text-white/40">{toolingNote}</p>
+    </div>
+  );
+}
+
+function Fixes() {
+  return (
+    <div className="space-y-3">
+      {improvements.map((imp) => (
+        <Card key={imp.title}>
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <Badge label={imp.priority} className={PRIORITY_STYLE[imp.priority]} />
+              <span className="text-sm font-medium">{imp.title}</span>
+            </div>
+            {imp.effort && <span className="shrink-0 text-xs text-white/40">{imp.effort}</span>}
+          </div>
+          <p className="mt-1.5 text-xs text-white/60">{imp.detail}</p>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/app/(auth)/overview/data.ts
+++ b/src/app/(auth)/overview/data.ts
@@ -1,0 +1,211 @@
+// Structured content for the /overview project dashboard.
+// Hand-maintained snapshot — update as the repo evolves. Sources: CLAUDE.md
+// Project Map, bot/REGISTRY.md, the .claude/skills catalog, and the bot audit.
+// Last refreshed: 2026-06-08.
+
+export interface RepoArea {
+  area: string;
+  path: string;
+  desc: string;
+  count?: string;
+}
+
+export const repoMap: { group: string; areas: RepoArea[] }[] = [
+  {
+    group: 'App & API',
+    areas: [
+      { area: 'API routes', path: 'src/app/api/', desc: 'Route handlers across 56 domains', count: '336 files' },
+      { area: 'Gated pages', path: 'src/app/(auth)/', desc: 'Logged-in surfaces — home, chat, music, governance, admin, this page', count: '28 pages' },
+      { area: 'Public pages', path: 'src/app/', desc: 'Landing, research, members, network, spaces, live, juke, stake', count: '18 pages' },
+    ],
+  },
+  {
+    group: 'UI',
+    areas: [
+      { area: 'Components', path: 'src/components/', desc: 'React components by feature', count: '304 files / 37 domains' },
+      { area: 'Hooks', path: 'src/hooks/', desc: 'useAuth, useChat, useRadio, …', count: '19 hooks' },
+      { area: 'Providers', path: 'src/providers/', desc: 'Audio player + context providers' },
+    ],
+  },
+  {
+    group: 'Business logic — src/lib (42 domains)',
+    areas: [
+      { area: 'auth / db', path: 'src/lib/{auth,db}', desc: 'iron-session (FID + wallet + admin) + Supabase RLS (service-role server-only)' },
+      { area: 'social', path: 'src/lib/{farcaster,bluesky,social,publish}', desc: 'Neynar, Bluesky, cross-platform posting (Farcaster / X / Bluesky)' },
+      { area: 'on-chain', path: 'src/lib/{respect,hats,zounz,staking,wagmi,solana,ens}', desc: 'Respect tokens, Hats roles, Nouns DAO, staking, wallets' },
+      { area: 'media', path: 'src/lib/{music,livepeer,jina}', desc: 'Audius radio, video streaming, content extraction' },
+      { area: 'governance', path: 'src/lib/{snapshot,ordao}', desc: 'Snapshot gasless voting, DAO governance' },
+      { area: 'agents', path: 'src/lib/agents/', desc: 'VAULT / BANKER / DEALER autonomous trading bots' },
+    ],
+  },
+  {
+    group: 'Bot fleet — bot/',
+    areas: [
+      { area: 'ZOE', path: 'bot/src/zoe/', desc: 'Concierge — tasks, captures, brief/reflect, recall' },
+      { area: 'Hermes', path: 'bot/src/hermes/', desc: 'Autonomous fix-PR pipeline (coder Opus + critic Sonnet)' },
+      { area: 'ZAO Devz', path: 'bot/src/devz/', desc: 'Group /fix dispatch + dual-bot narration' },
+      { area: 'Control plane', path: 'bot/src/lib/cowork.ts · bot/src/fleet-agent/', desc: 'Heartbeats, activity events, command queue, host supervisor' },
+      { area: 'ZAOstock', path: 'bot/src/index.ts', desc: 'Festival team coordination (graduating spinout)' },
+    ],
+  },
+  {
+    group: 'Knowledge & infra',
+    areas: [
+      { area: 'Research', path: 'research/', desc: 'Institutional memory across every product', count: '1,183 docs / 30 categories' },
+      { area: 'Skills', path: '.claude/skills/', desc: 'Custom Claude Code tooling (see Tooling tab)', count: '28 skills' },
+      { area: 'Scripts', path: 'scripts/', desc: 'SQL migrations, wallet generation, webhooks, bonfire ingest' },
+      { area: 'Config', path: 'community.config.ts', desc: 'Branding, channels, contracts, admin FIDs, theme' },
+    ],
+  },
+];
+
+// --- Bots --------------------------------------------------------------------
+
+export type BotStatus = 'live' | 'pending' | 'dormant' | 'decommissioned' | 'external';
+
+export interface BotRow {
+  name: string;
+  handle: string;
+  source: string;
+  status: BotStatus;
+  board: string;
+}
+
+export const botFleet: BotRow[] = [
+  { name: 'ZOE', handle: '@zaoclaw_bot', source: 'bot/src/zoe/', status: 'live', board: 'On board — full ask / run_task / lifecycle' },
+  { name: 'ZAO Devz', handle: '@zaodevz_bot', source: 'bot/src/devz/', status: 'live', board: 'On board — lifecycle' },
+  { name: 'Hermes', handle: '@zoe_hermes_bot', source: 'bot/src/hermes/ (in zao-devz-stack)', status: 'pending', board: 'Wired — needs token + Vercel redeploy' },
+  { name: 'ZAOstock', handle: '@ZAOstockTeamBot', source: 'bot/src/index.ts', status: 'live', board: 'On board — lifecycle (graduating)' },
+  { name: 'Magnetiq', handle: '@zao_magnetiq_bot', source: 'bot/src/teams/', status: 'decommissioned', board: 'Off — doc 601, fold into ZOE' },
+  { name: 'AttaBotty', handle: '@z_attabotty_bot', source: 'bot/src/teams/', status: 'decommissioned', board: 'Off — doc 601, fold into ZOE' },
+  { name: 'Bonfire', handle: '@zabal_bonfire', source: 'bonfires.ai', status: 'external', board: 'Off-VPS (Bonfires platform)' },
+  { name: 'DeepMeeting', handle: '@zdeepmeeting_bot', source: 'bonfires.ai', status: 'external', board: 'Off-VPS — group routing broken' },
+];
+
+export const controlPlane = {
+  url: 'https://www.thezao.xyz/bots',
+  summary:
+    'Pull-based: bots poll the cowork server, the board never reaches into the VPS. Observe = any teammate; control / task / converse = admins. The fleet-agent (host start/stop) is staged but disabled.',
+  capabilities: [
+    'Observe — heartbeats + activity feed, per-bot task & last error',
+    'Control — start / stop / restart / pause',
+    'Task — assign a cowork todo to a bot; it works it & posts back',
+    'Converse — ask a bot a question from the board',
+  ],
+};
+
+// --- Tooling -----------------------------------------------------------------
+
+export interface SkillItem {
+  name: string;
+  desc: string;
+}
+
+export const tooling: { group: string; skills: SkillItem[] }[] = [
+  {
+    group: 'Session & dev',
+    skills: [
+      { name: '/worksession', desc: 'Start a session in an isolated git worktree (parallel-safe)' },
+      { name: '/z', desc: 'Quick status dashboard — what needs attention' },
+      { name: '/catchup', desc: 'Restore session context (changes, commits, branches)' },
+      { name: '/new-route', desc: 'Scaffold an API route (Zod + session + NextResponse)' },
+      { name: '/new-component', desc: 'Scaffold a React component (dark theme, mobile-first)' },
+    ],
+  },
+  {
+    group: 'Research & knowledge',
+    skills: [
+      { name: '/zao-research', desc: 'Search 1,183 research docs + code + web, save a numbered doc' },
+      { name: '/autoresearch', desc: 'Autonomous modify→verify→keep/discard loop on any metric' },
+      { name: '/deep-research', desc: 'Fan-out web search, verify claims, cited report' },
+      { name: '/bonfire', desc: 'Post episodes to the ZABAL knowledge graph (via VPS)' },
+    ],
+  },
+  {
+    group: 'Ops & bots',
+    skills: [
+      { name: '/vps', desc: 'Manage the Telegram bot fleet on the VPS via SSH' },
+      { name: '/meeting', desc: 'Process a transcript → cowork, bonfire, calendar, memory' },
+      { name: '/inbox', desc: "Process ZOE's email inbox (zoe-zao@agentmail.to)" },
+      { name: '/morning', desc: 'Morning kickoff — status, brief, top priorities' },
+      { name: '/reflect', desc: 'End-of-day reflection → running journal' },
+    ],
+  },
+  {
+    group: 'Content & product',
+    skills: [
+      { name: '/onepager', desc: 'Draft a ZAOstock one-pager → Supabase' },
+      { name: '/design-steal', desc: "Adapt 55 companies' design language to navy/gold" },
+      { name: '/big-win', desc: 'Document a Big Win → quarterly docs + index' },
+      { name: '/lean', desc: 'Lean waste audit on a process (7 wastes)' },
+    ],
+  },
+  {
+    group: 'Quality, ship & safety',
+    skills: [
+      { name: '/code-review', desc: 'Review the diff for bugs + cleanups' },
+      { name: '/qa', desc: 'Full test-fix-verify loop for UI features' },
+      { name: '/verify', desc: 'Run the app and confirm a change actually works' },
+      { name: '/security-review', desc: 'STRIDE + OWASP audit of pending changes' },
+      { name: '/ship', desc: 'Detect → test → review → version → PR' },
+    ],
+  },
+];
+
+export const toolingNote =
+  'Plus the full built-in superpowers set (brainstorming, writing-plans, TDD, parallel agents, git worktrees) and the Claude API reference. Invoke any with a leading slash.';
+
+// --- Improvements / tech-debt ------------------------------------------------
+
+export type Priority = 'P0' | 'P1' | 'P2' | 'P3';
+
+export interface Improvement {
+  priority: Priority;
+  title: string;
+  detail: string;
+  effort?: string;
+}
+
+export const improvements: Improvement[] = [
+  {
+    priority: 'P0',
+    title: 'Untracked VPS snapshot',
+    detail:
+      'zaostock-bot and zao-devz-stack/hermes run from ~/zaostock-bot, which is NOT a git repo. Control-plane code there was hand-patched — it can drift from main and is not reproducible. Reconcile to a real git checkout.',
+    effort: '~2h',
+  },
+  {
+    priority: 'P1',
+    title: 'VPS runs a feature branch',
+    detail:
+      "zoe-bot's ~/zao-os clone tracks claude/gifted-euler-bYhl7 instead of main, even though the PRs are merged. Point it at main so prod isn't on a dev branch.",
+    effort: '~5min',
+  },
+  {
+    priority: 'P1',
+    title: 'Hermes not yet on the board',
+    detail:
+      'Hermes heartbeat code is wired (separate identity) but its token isn’t in the cowork COWORK_BOT_TOKENS env. Add hermes= token + redeploy + restart zao-devz-stack. Blocked on the Vercel daily-deploy cap.',
+    effort: '~10min',
+  },
+  {
+    priority: 'P2',
+    title: 'Decommissioned code lingering',
+    detail:
+      'Magnetiq/AttaBotty (bot/src/teams/) and FISHBOWLZ (src/components/fishbowlz, src/lib/fishbowlz, src/app/api/fishbowlz, skills/fishbowlz) are decommissioned per doc 601 but still in the tree. Archive or delete.',
+    effort: '1–2h',
+  },
+  {
+    priority: 'P2',
+    title: 'Un-wired cowork callsites',
+    detail:
+      'pushItem (ZOE capture → cowork todo) and Hermes markDone (non-merge close) are exported in bot/src/lib/cowork.ts but have no callsites yet. Wire when the capture / Hermes flows need them.',
+    effort: '~3h',
+  },
+  {
+    priority: 'P3',
+    title: 'Defense-in-depth + reach',
+    detail:
+      "Hermes' /hermes-dispatch secret check isn't constant-time (loopback-only, low sev) — use crypto.timingSafeEqual. And the Bonfires-platform bots (@zabal_bonfire, @zdeepmeeting_bot) need a separate heartbeat path to appear on the board.",
+  },
+];

--- a/src/app/(auth)/overview/page.tsx
+++ b/src/app/(auth)/overview/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getSessionData } from '@/lib/auth/session';
+import OverviewPanel from './OverviewPanel';
+
+export const metadata: Metadata = {
+  title: 'Project Overview - ZAO OS',
+  robots: { index: false },
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function OverviewPage() {
+  const session = await getSessionData();
+  if (!session?.isAdmin) {
+    redirect('/home');
+  }
+  return <OverviewPanel />;
+}

--- a/src/components/navigation/BottomNav.tsx
+++ b/src/components/navigation/BottomNav.tsx
@@ -69,10 +69,11 @@ const MORE_ITEMS = [
   { label: 'Assistant', href: '/assistant', icon: '🤖' },
   { label: 'Notifications', href: '/notifications', icon: '🔔' },
   { label: 'Library', href: '/library', icon: '📚' },
+  { label: 'Overview', href: '/overview', icon: '🗺️' },
   { label: 'Settings', href: '/settings', icon: '⚙️' },
 ] as const;
 
-const MORE_MATCH_PATHS = ['/ecosystem', '/tools', '/contribute', '/settings', '/social', '/fishbowlz', '/spaces', '/wavewarz', '/members', '/assistant', '/notifications', '/calls', '/library'];
+const MORE_MATCH_PATHS = ['/overview', '/ecosystem', '/tools', '/contribute', '/settings', '/social', '/fishbowlz', '/spaces', '/wavewarz', '/members', '/assistant', '/notifications', '/calls', '/library'];
 
 export function BottomNav() {
   const pathname = usePathname();


### PR DESCRIPTION
Follows the merged control-plane PRs (#795, #804). Adds the bot-fleet documentation refresh and a new internal overview dashboard.

## `/overview` dashboard (new, admin-gated)
A single internal page at `zaoos.com/overview` (in the **More** nav menu) with four tabs:
- **Repo map** — `src/app/api` (336 routes / 56 domains), components, `src/lib` (42 domains), the bot fleet, research (1,183 docs), skills, config.
- **Bots** — control-plane summary + link to `thezao.xyz/bots`, and the full fleet with status badges.
- **Tooling** — the skills/commands catalog, grouped.
- **Improvements** — the prioritized tech-debt from the bot audit (P0 snapshot drift → P3) with effort estimates.

Content lives in a structured data file (`src/app/(auth)/overview/data.ts`) so it's easy to keep current. Server component gated by `getSessionData()` + `isAdmin` (mirrors `/admin`). Navy/gold, mobile-first. Typechecks clean.

## `bot/REGISTRY.md` refresh
Reflects the shipped control plane, the staged `zao-fleet-agent`, the confirmed **untracked-snapshot drift** (top tech-debt), corrected cowork repo/Vercel facts, and a prioritized gaps list.

## Notes
- No secrets; no behavior change to running bots.
- ZAOOS deploys on its own Vercel project (separate from cowork) — unaffected by the cowork deploy cap.

https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01GtTSz7ZGmD6N3QAhrKCMJ2)_