### PR TITLE
doc 829: Anthropic Agent Skills talk, transcribed (STANDARD)

### DIFF
--- a/research/agents/829-anthropic-agent-skills-talk/README.md
+++ b/research/agents/829-anthropic-agent-skills-talk/README.md
@@ -1,0 +1,72 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-06-09
+superseded-by:
+related-docs: "825, 819, 826"
+original-query: "Fwd: Post by Kirill on X - 'grab this 16 min video, get transcript and summarize it' (Anthropic 'Claude Skills from scratch' talk by Barry + Mahesh). Surfaced from the past-inbox drain (doc 826)."
+tier: STANDARD
+---
+
+# 829 - Anthropic's Agent Skills Talk (Barry + Mahesh) - Transcribed
+
+> **Goal:** Transcribe + synthesize the Anthropic "we stopped building agents and started building skills" talk Zaal forwarded (via Kirill, 5.3M views). Full transcript: [transcript.txt](transcript.txt) (16-min talk, locally whisper-transcribed - no captions existed).
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **ZAO's skill library is the strategy, not a side-tool - this talk is the primary-source mandate for doc 825 Cluster 1** | Anthropic's own framing: "stop rebuilding agents, start building skills." ZAO already has 50+ skills (`/worksession`, `/zao-research`, `/inbox`, the fetch trio). Treat that library as the core asset and grow it deliberately - it's exactly the paradigm Anthropic is betting on. |
+| 2 | **Adopt "MCP = connectivity, Skills = expertise" as ZAO's mental model** | The talk's cleanest line: MCP connects the agent to the outside world; skills carry the domain expertise. ZAO's stack already splits this way (MCP: context7/serena/supabase; skills: the ZAO library). Name it so new tooling lands in the right bucket. |
+| 3 | **Treat ZAO skills like software: testing, versioning, dependencies** | Anthropic's stated next focus. ZAO's session today proved the cost of NOT doing this (doc 564 skill rotted silently). The `zao-fetch-healthcheck.sh` weekly cron is the first instance of this discipline - extend it. |
+| 4 | **Use the skill-creator + "write-down-for-future-self" loop as ZAO's continuous-learning mechanic** | The talk: "anything Claude writes down can be used efficiently by a future version of itself." ZAO's feedback memories (`feedback_*.md`) + research docs ARE this. Lean in: every correction becomes a skill or memory, compounding across the org. |
+
+## Findings - the talk, distilled
+
+**Thesis: code is the universal interface, so the agent is more universal than expected - the missing piece is expertise.**
+
+1. **"Code is all we need."** After building Claude Code, Anthropic realized it's a *general-purpose* agent. Generate a financial report = call APIs (data), organize in filesystem, analyze with Python, synthesize - all through code. The core scaffolding collapses to "as thin as bash + filesystem." Scalable, but exposes the real gap: **domain expertise.**
+
+2. **The Barry vs Mahesh analogy.** Who does your taxes - Mahesh (300-IQ genius deriving the tax code from first principles) or Barry (experienced tax pro)? You pick Barry. Today's agents are Mahesh: brilliant, but lacking expertise, missing up-front context, and they don't learn over time. **Skills fix that.**
+
+3. **Skills = organized folders of composable procedural knowledge.** Deliberately simple: anyone (human or agent) with a computer can make one. Version in Git, drop in Google Drive, zip and share. Files-as-primitive, on purpose.
+
+4. **Scripts as tools, inside skills.** Traditional tools have ambiguous instructions, can't be modified mid-struggle, and always sit in the context window. Code is self-documenting, modifiable, and lives in the filesystem until needed. Example: Claude kept rewriting the same slide-styling Python -> saved it as a skill tool for its future self -> consistent + efficient.
+
+5. **Progressive disclosure** is the scaling trick. At runtime only the skill's *metadata* loads (just enough to know it exists); the full `SKILL.md` + directory load only when the agent picks it. That's how you fit hundreds of composable skills without blowing the context window.
+
+6. **Three skill types** (ecosystem, 5 weeks post-launch, thousands of skills): foundational (new general/domain capabilities - e.g. Anthropic's document skills, Cadence's bio/EHR skills), third-party/partner (BrowserBase StageHand browser automation, Notion workspace skills), and enterprise/team (Fortune-100 org best-practices, dev-productivity teams teaching code-style to thousands of devs).
+
+7. **Trends:** skills are getting more complex (some will take weeks/months to build + maintain, like real software); skills *complement* MCP, not replace it; and - the part Anthropic is most excited about - **non-technical people** (finance, recruiting, legal) are building skills, extending general agents into their daily work.
+
+8. **The converging architecture:** agent loop (manages context/tokens) + runtime (filesystem + read/write code) + MCP servers (outside data/tools) + a library of hundreds/thousands of skills pulled into context only at runtime. This pattern already let Anthropic ship financial-services + life-sciences verticals right after the skills launch.
+
+9. **The analogy that lands it:** models = processors (huge investment, limited alone), agent runtime = the OS (orchestrates resources around the processor), **skills = applications** (where millions of developers encode domain expertise and points of view). "A few build processors and operating systems; millions build software."
+
+## ZAO Application
+
+- **Validates doc 825 Cluster 1 + doc 826 Cluster A** with the authoritative source. ZAO is already living this paradigm - the move is to be deliberate: a curated, versioned, tested skill library as institutional memory.
+- **ZABAL Games:** "non-technical people building skills" is the bootcamp thesis. Teach skill-authoring (folder + SKILL.md + progressive disclosure) as a core module.
+- **Continuous learning:** ZAO's `feedback_*.md` memories + research docs are the "write-down-for-future-self" loop. The skill-creator skill is the automation path.
+- **Today's session is a live example:** the keyless fetch trio = three skills/tools that encode expertise (how to read Reddit/X/Farcaster), versioned in `~/bin`, health-checked weekly. Exactly the talk's pattern.
+
+## Also See
+
+- [Doc 825](../825-past-inbox-redrain/) - skill-library decision this talk mandates (Cluster 1)
+- [Doc 826](../../dev-workflows/826-past-inbox-nonsocial-drain/) - the drain that surfaced this video
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| 16-min Anthropic talk transcribed + summarized - DONE | Claude | Done | 2026-06-09 |
+| Decide: transcribe the 4.2hr "Claude full course" quote-tweet video too, or skip (generic course, low marginal signal vs this talk) | @Zaal | Decision | Ad hoc |
+| Build a ZABAL Games "author your first skill" module from this talk's structure (folder + SKILL.md + progressive disclosure) | @Zaal | Curriculum | Pre-July |
+| Add testing/versioning discipline to the ZAO skill library (extend the fetch-healthcheck pattern) | @Zaal | Infra | Ongoing |
+
+## Sources
+
+- [transcript.txt](transcript.txt) - the full 16-min talk, whisper-transcribed locally (mlx-whisper large-v3-turbo) from the X-hosted video `[FULL - primary; 2,577 words, no captions existed so transcribed from audio]`
+- [Kirill post linking the talk](https://x.com/kirillk_web3/status/2043037616979759465) `[FULL - FxTwitter; 5.3M views, the video that carried it]`
+- 4.2hr "Claude full course" quote-tweet video `[NOT FETCHED - 15,042s runtime; deferred per Next Actions, low marginal signal vs this talk]`

--- a/research/agents/829-anthropic-agent-skills-talk/transcript.txt
+++ b/research/agents/829-anthropic-agent-skills-talk/transcript.txt
@@ -1,0 +1,171 @@
+I'm Barry, this is Mahesh.
+We created agent skills.
+In this talk, we'll show you why we stopped building agents and started building
+skills instead.
+A lot of things have changed since our last talk.
+MCP became the standard for agent connectivity.
+Cloud Code, our first coding agent, launched through the world.
+And our Cloud Agent SDK now provides a production-ready agent out of the box.
+We have a more mature ecosystem, and we're moving towards a new paradigm for
+agents.
+That paradigm is a tighter coupling between the model and the runtime environment.
+Put simply, we think code is all we need.
+We used to think agents in different domains would look very different.
+Each one would need its own tools and scaffolding, and that means we'll have a
+separate agent for each use case for each domain.
+While customization is still important for each domain, the agent underneath is
+actually more universal than we thought.
+What we realized is that code is not just a use case, but a universal interface to the
+digital world.
+After we built Cloud Code, we realized that Cloud Code is actually a general
+purpose agent.
+Think about generating a financial report.
+The model can call the API to pull in data and do research.
+It can organize that data in the file system.
+It can analyze it with Python and then synthesize the insight in all file format, all through code.
+The core scaffolding can suddenly become as thin as just bash and file system, which is great and really scalable, but we very quickly run into a different problem.
+And that problem is domain expertise.
+Who do you want doing your taxes?
+Is it going to be Mahesh, the 300 IQ mathematical genius, or is it Barry, an experienced tax professional?
+Right?
+I would pick Barry every time.
+I don't want Mahesh to figure out the 2025 tax code from first principles.
+I need consistent execution from a domain expert.
+Agents today are a lot like Mahesh.
+They're brilliant, but they lack expertise.
+They can do amazing things when you really put in effort and give proper guidance, but they're often missing the important context up front.
+They can't really absorb your expertise super well, and they don't learn over time.
+That's why we created Agent Skills.
+Skills are organized collections of files that package composable procedural knowledge for agents.
+In other words, they're folders.
+This simplicity is deliberate.
+We want something that anyone, human or agent, can create and use as long as they have a computer.
+These also work with what you already have.
+You can version them in Git, you can throw them in Google Drive, and you can zip them up and share it with your team.
+We have used files as a primitive for decades, and we like them, so why change now?
+Because of that, skills can also include a lot of scripts as tools.
+Traditional tools have pretty obvious problems.
+Some tools have poorly written instructions that are pretty ambiguous, and when the model is struggling, it can't really make a change to the tool.
+So it's just kind of stuck with a code start problem.
+And they always live in the context window.
+Code solves some of these issues.
+It's self-documenting, it is modifiable, and it can live in the file system until they're really needed and used.
+Here's an example of a script inside of a skill.
+We kept seeing Cloud write the same Python script over and over again to apply styling to slides.
+So we just asked Cloud to save it instead of the skill as a tool for its future self.
+Now we can just run the script, and that makes everything a lot more consistent and a lot more efficient.
+At this point, skills can contain a lot of information, and we want to protect the context window so that we can fit in hundreds of skills and make them truly composable.
+That's why skills are progressively disclosed.
+At runtime, only this metadata is shown to the model just to indicate that it has this skill.
+When an agent needs to use a skill, you can read in the rest of the skill.md, which contains the core instruction and directory for the rest of the folder.
+Everything else is just organized for ease of access.
+So that's all skills are.
+They're organized folders with scripts as tools.
+Since our launch five weeks ago, this very simple design has translated into a very quickly growing ecosystem of thousands of skills.
+And we've seen this be split across a couple of different types of skills.
+There are foundational skills, third-party skills created by partners in the ecosystem, and skills built within an enterprise and within teams.
+To start, foundational skills are those that give agents new general capabilities or domain-specific capabilities that it didn't have before.
+We ourselves, with our launch, built document skills that give Claude the ability to create and edit professional quality office documents.
+We're also really excited to see people like Cadence built scientific research skills that give Claude new capabilities like EHR data analysis,
+and using common Python bioinformatics libraries better than it could before.
+We've also seen partners in the ecosystem build skills that help Claude better with their own software and their own products.
+BrowserBase is a pretty good example of this.
+They built a skill for their open source browser automation tooling, StageHand.
+And now Claude equipped this skill with StageHand, can now go navigate the web and use a browser more effectively to get work done.
+And Notion launched a bunch of skills that help Claude better understand your Notion workspace,
+and do deep research over your entire workspace.
+And I think where I've seen the most excitement and traction with skills is within large enterprises.
+These are company and team specific skills built for an organization.
+We've been talking to Fortune 100s that are using skills as a way to teach agents about their organizational best practices,
+and the weird and unique ways that they use this bespoke internal software.
+We're also talking to really large developer productivity teams.
+These are teams serving thousands or even tens of thousands of developers in an organization
+that are using skills as a way to deploy agents like Claude code and teach them about code style best practices
+and other ways that they want their developers to work internally.
+So all of these different types of skills are created and consumed by different people inside of an organization or in the world,
+but what they have in common is anyone can create them,
+and they give agents the new capabilities that they didn't have before.
+So as this ecosystem has grown, we've started to observe a couple of interesting trends.
+First, skills are starting to get more complex.
+The most basic skill today can still be a skill.md markdown file,
+with some prompts and some really basic instructions.
+But we're starting to see skills that package software, executables, binaries, files, code, scripts, assets, and a lot more.
+And a lot of the skills that are being built today might take minutes or hours to build and put into an agent.
+But we think that increasingly, much like a lot of the software we use today,
+these skills might take weeks or months to build and be maintained.
+We're also seeing that this ecosystem of skills is complementing the existing ecosystem of MCP servers that was built up over the course of this year.
+Developers are using and building skills that orchestrate workflows of multiple MCP tools stitched together to do more complex things with external data and connectivity.
+And in these cases, MCP is providing the connection to the outside world while skills are providing the expertise.
+And finally, and I think most excitingly for me personally, is we're seeing skills that are being built by people that aren't technical.
+These are people in functions like finance, recruiting, accounting, legal, and a lot more.
+And I think this is pretty early validation of our initial idea that skills help people that aren't doing coding work extend these general agents.
+And they make these agents more accessible for the day to day of what these people are working on.
+So tying this all together, let's talk about how these all fit into this emerging architecture of general agents.
+First, we think this architecture is converging on a couple of things.
+The first is this agent loop that helps manage the model's internal context and manages what tokens are going in and out.
+And this is coupled with a runtime environment that provides the agent with a file system and the ability to read and write code.
+This agent, as many of us have done throughout this year, can be connected to MCP servers.
+And these are tools and data from the outside world that make the agent more relevant and more effective.
+And now we can give the same agent a library of hundreds or thousands of skills that it can decide to pull into context only at runtime when it's deciding to work on a particular task.
+Today, giving an agent a new capability in a new domain might just involve equipping it with the right set of MCP servers and the right library of skills.
+And this emerging pattern of an agent with an MCP server and a set of skills is something that's already helping us at Anthropic deploy Claude to new verticals.
+Just after we launched skills five weeks ago, we immediately launched new offerings in financial services and life sciences.
+And each of these came with a set of MCP servers and a set of skills that immediately make Claude more effective for professionals in each of these domains.
+We're also starting to think about some of the other open questions and areas that we want to focus on for how skills evolve in the future.
+As they start to become more complex, we really want to support developers, enterprises and other skill builders by starting to treat skills like we treat software.
+This means exploring testing and evaluation.
+Better tooling to make sure that these agents are loading and triggering skills at the right time and for the right task.
+And tooling to help measure the output quality of an agent equipped with the skill to make sure that's on par with what the agent is supposed to be doing.
+We'd also like to focus on versioning.
+As a skill evolves and the resulting agent behavior evolves, we want this to be clearly tracked and to have a clear lineage over time.
+And finally, we'd also like to explore skills that can explicitly depend on and refer to either other skills, MCP servers, and dependencies and packages within the agent's environment.
+We think that this is going to make agents a lot more predictable in different runtime environments.
+And the composability of multiple skills together will help agents like Claude elicit even more complex and relevant behavior from these agents.
+Overall, these set of things should hopefully make skills easier to build and easier to integrate into agent products, even those besides Claude.
+Finally, a huge part of the value of skills, we think, is going to come from sharing and distribution.
+Barry and I think a lot about the future of companies that are deploying these agents at scale.
+And the vision that excites us most is one of a collective and evolving knowledge base of capabilities that's curated by people and agents inside of an organization.
+We think skills are a big step towards this vision.
+They provide the procedural knowledge for your agents to do useful things.
+And as you interact with an agent and give it feedback and more institutional knowledge, it starts to get better.
+And all of the agents inside your team and your org get better as well.
+And when someone joins your team and starts using Claude for the first time, it already knows what your team cares about.
+It knows about your day to day and it knows about how to be most effective for the work that you're doing.
+And as this grows and this ecosystem starts to develop even more, this compound value is going to extend outside of just your org and into the broader community.
+So, just like when someone else across the world builds an MCP server that makes your agent more useful,
+a skill built by someone else in the community will help make your own agents more capable, reliable, and useful as well.
+This vision of an evolving knowledge base gets even more powerful when Claude starts to create these skills.
+We design skills specifically as concrete steps towards continuous learning.
+When you first start using Claude, this standardized format gives a very important guarantee.
+Anything that Claude writes down can be used efficiently by a future version of itself.
+This makes the learning actually transferable.
+As you build up the context, skills makes the concept of memory more tangible.
+They don't capture everything.
+They don't capture every type of information.
+Just procedural knowledge that Claude can use on specific tasks.
+We have worked with Claude for quite a while.
+The flexibility of skills matters even more.
+Claude can acquire new capabilities instantly, evolve them as needed, and then drop the ones that become obsolete.
+This is what we have always known.
+The power of in-context learning makes this a lot more cost effective for information that change on a daily basis.
+Our goal is that Claude on day 30 of working with you is going to be a lot better on Claude on day one.
+Claude can already create skills for you today using our skill creator skill, and we're going to continue pushing in that direction.
+Claude can already create a lot of the tools that we're going to do.
+We're going to conclude by comparing the agent stack to what we have already seen in computing.
+In a rough analogy, models are like processors.
+Both require massive investment and contain immense potential, but only so useful by themselves.
+Then we start building an operating system.
+The OS made processors far more valuable by orchestrating the processes, resources, and data around the processor.
+In AI, we believe that agent runtime is starting to play this role.
+We're all trying to build the cleanest, most efficient, and most scalable abstractions to get the right tokens in and out of the model.
+But once we have a platform, the real value comes from applications.
+A few companies build processors and operating systems, but millions of developers like us have built softwares that encoded domain expertise and our unique points of view.
+We hope that skills can help us open up this layer for everyone.
+This is where we get creative and solve concrete problems for ourselves, for each other, and for the world just by putting stuff in the folder.
+So skills are just the starting point.
+To close out, we think we're now converging on this general architecture for general agents.
+We've created skills as a new paradigm for shipping and sharing new capabilities.
+So we think it's time to stop rebuilding agents and start building skills instead.
+And if you're excited about this, come work with us and start building some skills today.
+Thank you.
+Thank you.


### PR DESCRIPTION
## Summary
Transcribed (locally, mlx-whisper - no captions existed) + synthesized the Anthropic 'we stopped building agents and started building skills' talk (Barry + Mahesh) that Zaal forwarded via Kirill (5.3M views). Surfaced from the past-inbox drain.

Thesis: code is the universal interface, so the agent is universal; the missing piece is domain expertise -> Skills (organized folders of composable procedural knowledge, progressive disclosure, scripts-as-tools). MCP = connectivity, Skills = expertise. Architecture: agent loop + runtime + MCP + skill library. Models=processors, runtime=OS, skills=applications.

Validates ZAO's skill-library strategy (docs 825/826) with the authoritative source. Full transcript in transcript.txt (2,577 words).

## Tier
STANDARD

## Sources
Local whisper transcript (FULL primary) + Kirill tweet (FxTwitter). 4.2hr quote-tweet course deferred (low marginal signal).

## Next Actions
ZABAL 'author your first skill' module; skill testing/versioning discipline; decide on 4hr video. See doc.