### PR TITLE
fix(docs): renumber 6 collision docs 819/824-828 -> 830-835

### DIFF
--- a/research/agents/829-anthropic-agent-skills-talk/README.md
+++ b/research/agents/829-anthropic-agent-skills-talk/README.md
@@ -4,7 +4,7 @@ type: guide
 status: research-complete
 last-validated: 2026-06-09
 superseded-by:
-related-docs: "825, 819, 826"
+related-docs: "832, 830, 833"
 original-query: "Fwd: Post by Kirill on X - 'grab this 16 min video, get transcript and summarize it' (Anthropic 'Claude Skills from scratch' talk by Barry + Mahesh). Surfaced from the past-inbox drain (doc 826)."
 tier: STANDARD
 ---
@@ -17,7 +17,7 @@ tier: STANDARD
 
 | # | Decision | Why |
 |---|----------|-----|
-| 1 | **ZAO's skill library is the strategy, not a side-tool - this talk is the primary-source mandate for doc 825 Cluster 1** | Anthropic's own framing: "stop rebuilding agents, start building skills." ZAO already has 50+ skills (`/worksession`, `/zao-research`, `/inbox`, the fetch trio). Treat that library as the core asset and grow it deliberately - it's exactly the paradigm Anthropic is betting on. |
+| 1 | **ZAO's skill library is the strategy, not a side-tool - this talk is the primary-source mandate for doc 832 Cluster 1** | Anthropic's own framing: "stop rebuilding agents, start building skills." ZAO already has 50+ skills (`/worksession`, `/zao-research`, `/inbox`, the fetch trio). Treat that library as the core asset and grow it deliberately - it's exactly the paradigm Anthropic is betting on. |
 | 2 | **Adopt "MCP = connectivity, Skills = expertise" as ZAO's mental model** | The talk's cleanest line: MCP connects the agent to the outside world; skills carry the domain expertise. ZAO's stack already splits this way (MCP: context7/serena/supabase; skills: the ZAO library). Name it so new tooling lands in the right bucket. |
 | 3 | **Treat ZAO skills like software: testing, versioning, dependencies** | Anthropic's stated next focus. ZAO's session today proved the cost of NOT doing this (doc 564 skill rotted silently). The `zao-fetch-healthcheck.sh` weekly cron is the first instance of this discipline - extend it. |
 | 4 | **Use the skill-creator + "write-down-for-future-self" loop as ZAO's continuous-learning mechanic** | The talk: "anything Claude writes down can be used efficiently by a future version of itself." ZAO's feedback memories (`feedback_*.md`) + research docs ARE this. Lean in: every correction becomes a skill or memory, compounding across the org. |
@@ -46,15 +46,15 @@ tier: STANDARD
 
 ## ZAO Application
 
-- **Validates doc 825 Cluster 1 + doc 826 Cluster A** with the authoritative source. ZAO is already living this paradigm - the move is to be deliberate: a curated, versioned, tested skill library as institutional memory.
+- **Validates doc 832 Cluster 1 + doc 833 Cluster A** with the authoritative source. ZAO is already living this paradigm - the move is to be deliberate: a curated, versioned, tested skill library as institutional memory.
 - **ZABAL Games:** "non-technical people building skills" is the bootcamp thesis. Teach skill-authoring (folder + SKILL.md + progressive disclosure) as a core module.
 - **Continuous learning:** ZAO's `feedback_*.md` memories + research docs are the "write-down-for-future-self" loop. The skill-creator skill is the automation path.
 - **Today's session is a live example:** the keyless fetch trio = three skills/tools that encode expertise (how to read Reddit/X/Farcaster), versioned in `~/bin`, health-checked weekly. Exactly the talk's pattern.
 
 ## Also See
 
-- [Doc 825](../825-past-inbox-redrain/) - skill-library decision this talk mandates (Cluster 1)
-- [Doc 826](../../dev-workflows/826-past-inbox-nonsocial-drain/) - the drain that surfaced this video
+- [Doc 832](../832-past-inbox-redrain/) - skill-library decision this talk mandates (Cluster 1)
+- [Doc 833](../../dev-workflows/833-past-inbox-nonsocial-drain/) - the drain that surfaced this video
 
 ## Next Actions
 

--- a/research/agents/830-ai-coding-agent-discourse-inbox-cluster/README.md
+++ b/research/agents/830-ai-coding-agent-discourse-inbox-cluster/README.md
@@ -9,7 +9,7 @@ original-query: "/inbox cluster - drain 6 forwarded items (4 Reddit threads on C
 tier: STANDARD
 ---
 
-# 819 - AI Coding-Agent Discourse (June 2026 Inbox Cluster)
+# 830 - AI Coding-Agent Discourse (June 2026 Inbox Cluster)
 
 > **Goal:** Synthesize the cross-cutting signal across 6 AI-coding items Zaal forwarded to the ZOE inbox, and map it to where ZAO's agent stack already sits.
 

--- a/research/agents/832-past-inbox-redrain/README.md
+++ b/research/agents/832-past-inbox-redrain/README.md
@@ -4,22 +4,22 @@ type: market-research
 status: research-complete
 last-validated: 2026-06-09
 superseded-by:
-related-docs: "819, 824, 822, 823, 820, 759, 778"
+related-docs: "830, 831, 822, 823, 820, 759, 778"
 original-query: "How about past articles -> re-drain the PAST ZOE inbox (84 already-processed social items) properly now that the keyless fetch trio works"
 tier: DISPATCH
 ---
 
-# 825 - Past-Inbox Re-Drain (84 social items, keyless)
+# 832 - Past-Inbox Re-Drain (84 social items, keyless)
 
 > **Goal:** The ZOE inbox had 84+ already-processed social items (X, Reddit, Farcaster) indexed BEFORE today's keyless fetch trio existed - many off blocked or thin fetches. Re-fetch all of them with the working scripts and synthesize what they actually say.
 
 ## How this was produced
 
-Multi-agent workflow (22 agents, ~1M tokens, ~6 min): 12 parallel fetch agents re-pulled every item through the keyless trio - **Redlib** (Reddit, doc 824), **FxTwitter** (X, doc 822), **Haatz** (Farcaster, doc 823) - a cluster agent grouped them, 7 synthesis agents wrote one section each, a critic checked completeness.
+Multi-agent workflow (22 agents, ~1M tokens, ~6 min): 12 parallel fetch agents re-pulled every item through the keyless trio - **Redlib** (Reddit, doc 831), **FxTwitter** (X, doc 822), **Haatz** (Farcaster, doc 823) - a cluster agent grouped them, 7 synthesis agents wrote one section each, a critic checked completeness.
 
 **Result: 84 of 85 items fetched FULL, no keys, no env.** 1 failure (`x.com/mattepstein/status/2048190139055423779` - likely deleted/private; worth a manual retry only if you remember it being high-signal). This is the proof that the keyless trio works at backlog scale, not just on the 6 fresh items.
 
-The 84 items cluster into 7 themes below. The dominant two (Claude Code workflows + agentic orchestration, 49 of 84 items) extend and reinforce [doc 819](../819-ai-coding-agent-discourse-inbox-cluster/).
+The 84 items cluster into 7 themes below. The dominant two (Claude Code workflows + agentic orchestration, 49 of 84 items) extend and reinforce [doc 830](../830-ai-coding-agent-discourse-inbox-cluster/).
 
 ## Cluster Map
 

--- a/research/dev-workflows/820-reliable-inbox-url-fetching/README.md
+++ b/research/dev-workflows/820-reliable-inbox-url-fetching/README.md
@@ -11,7 +11,7 @@ tier: STANDARD
 
 # 820 - Reliable Inbox URL Fetching (Reddit OAuth + /s/ resolve + X article reality)
 
-> **Goal:** The 2026-06-08 inbox cluster (doc 819) fetched almost nothing - 4 Reddit threads came back title-only, 2 X articles body-less. Diagnose exactly why and ship the durable fix so inbox/research runs stop indexing off titles.
+> **Goal:** The 2026-06-08 inbox cluster (doc 830) fetched almost nothing - 4 Reddit threads came back title-only, 2 X articles body-less. Diagnose exactly why and ship the durable fix so inbox/research runs stop indexing off titles.
 
 ## TL;DR
 
@@ -22,8 +22,8 @@ The `old.reddit.com + .json + Mozilla UA` technique that doc 564 shipped on 2026
 | # | Decision | Why |
 |---|----------|-----|
 | 1 | **Add a Reddit OAuth script-app; rewrite `~/bin/zao-fetch-reddit.sh` to use `oauth.reddit.com` with a bearer token** | Reddit now gates on IP reputation AND TLS/client fingerprint at once. Authenticated `client_credentials` requests bypass both. Free tier = 100 QPM, no residential proxy, no browser. This is the only path that is not fragile. |
-| 2 | **Resolve `/s/` share links to the canonical `/comments/ID/slug` URL BEFORE fetching** | `old.reddit.com` 403s on `/s/` paths; the share URL must be followed on `www.reddit.com` first, then the query string dropped. The current script appends `.json` to the `/s/` URL directly - it can never work. Done manually in doc 819 (grep the interstitial for `/comments/`); automate it. |
-| 3 | **X long-form articles are login-walled - stop trying to fetch the body unauthenticated** | The syndication endpoint returns tweet text + article title + preview thesis, NOT the article body. Jina/exa return the X login shell. Either accept title+thesis (doc 819 did) or import a logged-in X session cookie via the `setup-browser-cookies` skill. Do not write a doc pretending the body was read. |
+| 2 | **Resolve `/s/` share links to the canonical `/comments/ID/slug` URL BEFORE fetching** | `old.reddit.com` 403s on `/s/` paths; the share URL must be followed on `www.reddit.com` first, then the query string dropped. The current script appends `.json` to the `/s/` URL directly - it can never work. Done manually in doc 830 (grep the interstitial for `/comments/`); automate it. |
+| 3 | **X long-form articles are login-walled - stop trying to fetch the body unauthenticated** | The syndication endpoint returns tweet text + article title + preview thesis, NOT the article body. Jina/exa return the X login shell. Either accept title+thesis (doc 830 did) or import a logged-in X session cookie via the `setup-browser-cookies` skill. Do not write a doc pretending the body was read. |
 | 4 | **Retire doc 564's "FIXED" claim; this doc is the current source of truth** | Doc 564 is now a historical postmortem of a fix that lasted ~3 weeks. Anyone trusting it will silently index off blocked HTML. |
 
 ## Findings - Why the inbox under-indexed
@@ -72,7 +72,7 @@ canon=$(curl -sL -A "Mozilla/5.0 (Macintosh)" "$SHARE_URL" \
 # -> /r/ClaudeCode/comments/1typ8fb/has_anyone_actually_replaced_claude_code_codex
 ```
 
-This is the manual step doc 819 used; fold it into `zao-fetch-reddit.sh` as a pre-pass whenever the URL matches `/r/[\w-]+/s/\w+`.
+This is the manual step doc 830 used; fold it into `zao-fetch-reddit.sh` as a pre-pass whenever the URL matches `/r/[\w-]+/s/\w+`.
 
 ### X long-form articles: tweet text yes, article body no
 
@@ -101,7 +101,7 @@ Only authentication changes the outcome.
 - `~/bin/zao-fetch-reddit.sh` - rewrite per Decisions 1 + 2. Add `/s/` resolve pre-pass + OAuth token mint + `oauth.reddit.com` host. Keep the HTML-shell sniff as a hard error, not a silent pass.
 - `~/.zao/zao.env` - add `REDDIT_CLIENT_ID` + `REDDIT_CLIENT_SECRET` (sits beside the AgentMail/Bonfire/Supabase keys; survives repo re-clones, unlike `.env.local`).
 - `/inbox` + `/zao-research` + `/fetch` skills - all call the same script, so the fix propagates automatically. Update doc 564's status line to point here.
-- Fetch-quality gate (doc 693, Hard Req #11) already forces FULL/PARTIAL/FAILED marking - doc 819 obeyed it. This doc removes the reason FAILED happens at all for Reddit.
+- Fetch-quality gate (doc 693, Hard Req #11) already forces FULL/PARTIAL/FAILED marking - doc 830 obeyed it. This doc removes the reason FAILED happens at all for Reddit.
 
 ## Also See
 
@@ -109,7 +109,7 @@ Only authentication changes the outcome.
 - [Doc 562](../562-reddit-x-scraping-meta-eval-last30days/) - original block discovery + last30days eval
 - [Doc 319](../319-x-twitter-scraping-tools-2026/) - X/Twitter scraping tool landscape
 - [Doc 693](../693-zao-research-fetch-quality-audit/) - fetch-quality gate (FULL/PARTIAL/FAILED)
-- [Doc 819](../../agents/819-ai-coding-agent-discourse-inbox-cluster/) - the under-indexed cluster that triggered this
+- [Doc 830](../../agents/830-ai-coding-agent-discourse-inbox-cluster/) - the under-indexed cluster that triggered this
 
 ## Next Actions
 
@@ -119,7 +119,7 @@ Only authentication changes the outcome.
 | Rewrite ~/bin/zao-fetch-reddit.sh: /s/ resolve pre-pass + OAuth token + oauth.reddit.com | @Zaal | PR | After creds exist |
 | Update doc 564 status -> "superseded by 820 for Reddit" | @Zaal | Edit | With the script PR |
 | Decide X-article posture: accept thesis-only, or wire setup-browser-cookies for logged-in body | @Zaal | Decision | When an article actually needs the body |
-| Re-run doc 819 cluster fetch once OAuth lands, upgrade FAILED sources to FULL | @Zaal | Research | After script PR |
+| Re-run doc 830 cluster fetch once OAuth lands, upgrade FAILED sources to FULL | @Zaal | Research | After script PR |
 
 ## Sources
 

--- a/research/dev-workflows/822-x-scraping-without-login/README.md
+++ b/research/dev-workflows/822-x-scraping-without-login/README.md
@@ -4,7 +4,7 @@ type: decision
 status: research-complete
 last-validated: 2026-06-08
 superseded-by:
-related-docs: "820, 819, 564, 562, 319, 660"
+related-docs: "820, 830, 564, 562, 319, 660"
 original-query: "is there any way other than an x session cookie that we can do that really think of the best ways to scrap x and then look online aswell"
 tier: STANDARD
 ---
@@ -44,7 +44,7 @@ curl -s "https://api.fxtwitter.com/status/2062149859394585061"
 
 ### Why the syndication endpoint missed it
 
-`cdn.syndication.twimg.com/tweet-result` (the old Tier 1) returns the article's `title` + `preview_text` + cover image but **not** the body - which is why doc 819 had to mark both X items PARTIAL. FxTwitter wraps X's richer internal data and exposes the full `content`.
+`cdn.syndication.twimg.com/tweet-result` (the old Tier 1) returns the article's `title` + `preview_text` + cover image but **not** the body - which is why doc 830 had to mark both X items PARTIAL. FxTwitter wraps X's richer internal data and exposes the full `content`.
 
 ### Full ranked landscape
 
@@ -66,14 +66,14 @@ Notes from the research:
 ## ZAO Application
 
 - **`~/bin/zao-fetch-x.sh` - PATCHED 2026-06-08** with FxTwitter as Tier 0 (article-body aware), syndication demoted to Tier 1. Verified on both inbox articles. `/inbox`, `/zao-research`, `/fetch` all call this script, so the fix propagates.
-- **Doc 819** - both X sources upgraded PARTIAL -> FULL using the re-fetched bodies (see that doc's revision).
+- **Doc 830** - both X sources upgraded PARTIAL -> FULL using the re-fetched bodies (see that doc's revision).
 - **Companion to doc 820** (Reddit OAuth fix). Together they close the inbox fetch wall: Reddit via OAuth, X via FxTwitter. Both cookie-free where it counts.
 - **Content signal:** 0xRicker's article body confirms the doc-819 read - Opus-4.8-as-planner + Kimi Agent Swarm (300 parallel sub-agents) is the org-chart pattern ZAO's Workflow/Hermes/ZOE already encode. 0xMorty's is a clean "build your first agent in 30 min" template - direct fuel for the ZABAL Games onboarding workshop (doc 778).
 
 ## Also See
 
 - [Doc 820](../820-reliable-inbox-url-fetching/) - the Reddit half of the inbox fetch fix (OAuth)
-- [Doc 819](../../agents/819-ai-coding-agent-discourse-inbox-cluster/) - the cluster whose X items this unblocks
+- [Doc 830](../../agents/830-ai-coding-agent-discourse-inbox-cluster/) - the cluster whose X items this unblocks
 - [Doc 660](../660-x-content-extraction-v2/) - prior X article "needs mirror search" workaround, now obsolete for bodies
 - [Doc 319](../319-x-twitter-scraping-tools-2026/) - earlier X scraping tool landscape
 
@@ -82,7 +82,7 @@ Notes from the research:
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
 | `zao-fetch-x.sh` Tier 0 FxTwitter patch - SHIPPED + verified | Claude | Done | 2026-06-08 |
-| Upgrade doc 819 X sources PARTIAL -> FULL with re-fetched bodies | Claude | Done (this session) | 2026-06-08 |
+| Upgrade doc 830 X sources PARTIAL -> FULL with re-fetched bodies | Claude | Done (this session) | 2026-06-08 |
 | Update `/fetch` skill + doc 660 to point at FxTwitter for article bodies | @Zaal | Edit | Next sprint |
 | If FxTwitter breaks, wire xquik/getxapi (`$0.001/call`) as Tier 2 article fallback | @Zaal | PR | On failure |
 | Pull both article bodies into the ZABAL Games agentic-workflows curriculum | @Zaal | Content | Pre-June demo |

--- a/research/dev-workflows/823-farcaster-fetch-haatz-free/README.md
+++ b/research/dev-workflows/823-farcaster-fetch-haatz-free/README.md
@@ -4,7 +4,7 @@ type: decision
 status: research-complete
 last-validated: 2026-06-08
 superseded-by:
-related-docs: "822, 820, 819"
+related-docs: "822, 820, 830"
 original-query: "for farcaster lets use https://haatz.quilibrium.com/ for free read"
 tier: STANDARD
 ---
@@ -72,7 +72,7 @@ Verified end-to-end: `zao-fetch-farcaster.sh farcaster.xyz/dwr.eth/0xd658bb46` r
 
 - [Doc 822](../822-x-scraping-without-login/) - X fetch fix (FxTwitter)
 - [Doc 820](../820-reliable-inbox-url-fetching/) - Reddit fetch fix (OAuth)
-- [Doc 819](../../agents/819-ai-coding-agent-discourse-inbox-cluster/) - the cluster that surfaced the fetch wall
+- [Doc 830](../../agents/830-ai-coding-agent-discourse-inbox-cluster/) - the cluster that surfaced the fetch wall
 
 ## Next Actions
 

--- a/research/dev-workflows/831-keyless-forkable-fetch-trio/README.md
+++ b/research/dev-workflows/831-keyless-forkable-fetch-trio/README.md
@@ -4,12 +4,12 @@ type: decision
 status: research-complete
 last-validated: 2026-06-08
 superseded-by:
-related-docs: "820, 822, 823, 819, 564"
+related-docs: "820, 822, 823, 830, 564"
 original-query: "can you find another way instead of using env variables i wanna make these shareable and easily forkable without much extra work"
 tier: STANDARD
 ---
 
-# 824 - Keyless, Forkable Fetch Trio (X + Farcaster + Reddit, no env vars)
+# 831 - Keyless, Forkable Fetch Trio (X + Farcaster + Reddit, no env vars)
 
 > **Goal:** Make the inbox/research fetchers clone-and-run. No API keys, no OAuth apps, no `~/.zao/zao.env`. Anyone can fork the three scripts and they work immediately.
 
@@ -83,7 +83,7 @@ Tradeoff vs OAuth: public Redlib instances are rate-limited and Reddit periodica
 - [Doc 822](../822-x-scraping-without-login/) - X via FxTwitter
 - [Doc 823](../823-farcaster-fetch-haatz-free/) - Farcaster via Haatz
 - [Doc 820](../820-reliable-inbox-url-fetching/) - Reddit diagnosis + OAuth (now the optional upgrade)
-- [Doc 819](../../agents/819-ai-coding-agent-discourse-inbox-cluster/) - all 6 items now FULL via this trio
+- [Doc 830](../../agents/830-ai-coding-agent-discourse-inbox-cluster/) - all 6 items now FULL via this trio
 
 ## Next Actions
 

--- a/research/dev-workflows/833-past-inbox-nonsocial-drain/README.md
+++ b/research/dev-workflows/833-past-inbox-nonsocial-drain/README.md
@@ -4,20 +4,20 @@ type: market-research
 status: research-complete
 last-validated: 2026-06-09
 superseded-by:
-related-docs: "825, 824, 822, 823, 778, 780"
+related-docs: "832, 831, 822, 823, 778, 780"
 original-query: "yes lets drain everything i'd like to rerun research on these - the ~23 non-social inbox items (newsletters, Spotify, substacks, GitHub, tool links)"
 tier: STANDARD
 ---
 
-# 826 - Past-Inbox Non-Social Drain (the tail)
+# 833 - Past-Inbox Non-Social Drain (the tail)
 
-> **Goal:** Finish the inbox drain. Doc 825 covered the 84 social items; this covers the remaining 25 non-social ones - forwarded newsletters, tool/skill links, GitHub repos, a podcast, and several of Zaal's own embedded ideas/requests. Content lived in the email bodies (key-gated AgentMail), so this was fetched inline, not via the workflow.
+> **Goal:** Finish the inbox drain. Doc 832 covered the 84 social items; this covers the remaining 25 non-social ones - forwarded newsletters, tool/skill links, GitHub repos, a podcast, and several of Zaal's own embedded ideas/requests. Content lived in the email bodies (key-gated AgentMail), so this was fetched inline, not via the workflow.
 
 ## Key Decisions
 
 | # | Decision | Why |
 |---|----------|-----|
-| 1 | **Adopt the `superpowers` skill + study the Anthropic "Claude Skills from scratch" build** | Two separate inbox items point here: Shann's post (808 likes) calls superpowers "the simplest way to level up any project in Claude, code or non-code, setup under 5 min"; Kirill's (5.3M views) is the Anthropic engineers' 16-min Claude Skills build. ZAO already uses superpowers - formalize a ZAO skill library (extends doc 825 Cluster 1). |
+| 1 | **Adopt the `superpowers` skill + study the Anthropic "Claude Skills from scratch" build** | Two separate inbox items point here: Shann's post (808 likes) calls superpowers "the simplest way to level up any project in Claude, code or non-code, setup under 5 min"; Kirill's (5.3M views) is the Anthropic engineers' 16-min Claude Skills build. ZAO already uses superpowers - formalize a ZAO skill library (extends doc 832 Cluster 1). |
 | 2 | **Empire Builder's `SKILL.md` is the reference pattern for any ZAO on-chain agent skill** | It's a clean ERC-4337 SmartVault treasury-orchestration skill (Base/Arbitrum: payouts, burns, airdrops, Clanker deploys) with the owner-signs-not-cosigners guard. Empire Builder is already a ZAO partner (docs 780/778). Copy its self-contained 4-file structure (SKILL + http-api + workflows + contracts) for ZAO treasury/bounty skills. |
 | 3 | **Steal "signal diversity" from the clear retrospective as ZAO's vibe-code QA doctrine** | The retrospective's core lesson: LLMs write code that passes tests while not working; the fix is MULTIPLE independent verification streams (design doc + review + independent tests + fuzz + mutation + multi-LLM review), never one metric (Goodhart's Law). This IS ZAO's GAN/`/qa`/`/verify` pattern - name it explicitly in agent prompts. |
 | 4 | **Two of Zaal's embedded ideas are worth real follow-up; the rest of the tail is personal reading** | The inbox tail carried Zaal's own notes: a Red Sox inspiration-account idea, a Crypto-Fam auto-caption photo tool, an Ellsworth-library Plural event, and a request to transcribe Kirill's 4hr->18min video. These become Next Actions. The daily briefings / substacks are reading, not research - logged, not deep-dived. |
@@ -64,8 +64,8 @@ Daily briefings + substacks - personal reading, not ZAO research: Beta Briefing 
 
 ## Also See
 
-- [Doc 825](../../agents/825-past-inbox-redrain/) - the social half of the inbox drain
-- [Doc 824](../824-keyless-forkable-fetch-trio/) - the keyless fetch trio used here
+- [Doc 832](../../agents/832-past-inbox-redrain/) - the social half of the inbox drain
+- [Doc 831](../831-keyless-forkable-fetch-trio/) - the keyless fetch trio used here
 - [Doc 780](../../events/780-adrian-empire-builder/) / [Doc 778](../../events/778-tyler-magnetic-zabal-games-build-may27/) - Empire Builder / ZABAL Games
 
 ## Next Actions

--- a/research/governance/835-deep-funding-ai-pgf/README.md
+++ b/research/governance/835-deep-funding-ai-pgf/README.md
@@ -9,7 +9,7 @@ original-query: "/zao-research https://www.deepfunding.org/ https://x.com/deep_f
 tier: STANDARD
 ---
 
-# 828 - Deep Funding (AI-PGF: a market of AI models, a human jury)
+# 835 - Deep Funding (AI-PGF: a market of AI models, a human jury)
 
 > **Goal:** Research Deep Funding (deepfunding.org + @deep_funding) - Vitalik's AI-assisted public-goods funding mechanism - and map its pattern to ZAO's ZABAL Games judging, POIDH bounties, and contribution-weighting.
 

--- a/research/infrastructure/834-metadyn-immersive-sdk/README.md
+++ b/research/infrastructure/834-metadyn-immersive-sdk/README.md
@@ -4,12 +4,12 @@ type: guide
 status: research-complete
 last-validated: 2026-06-09
 superseded-by:
-related-docs: "741, 826"
+related-docs: "741, 833"
 original-query: "https://x.com/MetaverseDyn/status/2062662268123328752 can you research this for me /zao-research"
 tier: QUICK
 ---
 
-# 827 - MetaDyn Immersive SDK
+# 834 - MetaDyn Immersive SDK
 
 > **Goal:** Research the MetaverseDyn (MetaDyn) post Zaal forwarded - an immersive/metaverse SDK - and judge its relevance to ZAO Spaces / COC virtual events.
 
@@ -38,7 +38,7 @@ So MetaDyn is a **multi-target 3D/immersive SDK** - one toolkit emitting to thre
 ## Also See
 
 - [Doc 741](../741-pion-livekit-webrtc-stack/) - LiveKit Spaces pick (ZAO's actual real-time stack)
-- [Doc 826](../../dev-workflows/826-past-inbox-nonsocial-drain/) - the inbox drain this follow-up came out of
+- [Doc 833](../../dev-workflows/833-past-inbox-nonsocial-drain/) - the inbox drain this follow-up came out of
 
 ## Next Actions
 


### PR DESCRIPTION
## Summary
Parallel terminals collided on 6 doc numbers (both already merged to main): 819, 824, 825, 826, 827, 828 each existed twice. Renumbered MY session docs to 830-835 (other terminal keeps theirs); updated headings, slugs, Doc-NNN refs, related-docs frontmatter (37 lines / 11 docs).

Map: 819->830 (ai-coding-discourse), 824->831 (keyless-trio), 825->832 (past-inbox-redrain), 826->833 (nonsocial-drain), 827->834 (metadyn), 828->835 (deep-funding).

Root cause patched in the /zao-research skill (local ~/.claude, not this PR): reservation now scans remote branches + open PRs for in-flight numbers, not just merged local dirs.

Cosmetic drift left as-is: tracker legacy_ids + merged PR titles still cite old numbers.