### PR TITLE
Estate-audit tooling + repo census (doc 836)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,11 @@ scripts/.stock-codes-iman-*.txt
 .claude/.private/
 .claude/private-queries/
 
+# estate-audit tokens (canonical home is ~/.zao/estate-tokens.env, off-repo).
+# Defensive guard in case a copy lands in the tree. See scripts/estate-audit/.
+*estate-tokens*
+*.estate.json
+
 # Build / CI artifacts (cleanup 2026-05-24, see /tmp/zao-os-audit-20260524.md)
 graphify-out/
 build-log/

--- a/research/infrastructure/836-zaoos-repo-estate-census/README.md
+++ b/research/infrastructure/836-zaoos-repo-estate-census/README.md
@@ -1,0 +1,170 @@
+# Doc 836 - ZAOOS Repo + Estate Census
+
+Date: 2026-06-09
+Status: Living snapshot (regenerate via `scripts/estate-audit/audit.sh` for the cloud half)
+Scope: Full overview of the ZAOOS monorepo - what it is, what is built, what is in flight, what is missing - plus the tooling to census the paid Vercel/Supabase estate.
+
+## 1. What this repo is
+
+ZAOOS is "the lab" for The ZAO ecosystem. Started as a gated Farcaster social
+client (188 members on Base), grew into a monorepo where many ZAO experiments
+live side by side. Things graduate to their own repo when production + public +
+new-user ready; on graduation the code is deleted from ZAOOS so there is no
+drift. Research stays forever (institutional memory).
+
+Stack: Next.js 16.2, React 19.2, Supabase (Postgres + RLS), Neynar + Farcaster
+hub, XMTP, Stream.io / 100ms (video), Wagmi 2 / Viem 2, Solana web3.js, Arweave,
+Tailwind v4, iron-session, Capacitor 8 (iOS/Android), Biome + Vitest +
+Playwright, Sentry.
+
+## 2. Repo scale (measured 2026-06-09)
+
+| Metric | Value |
+|--------|-------|
+| Total git commits | 2,659 (since 2026-03-12) |
+| Commits, last 30 days | 752 (~25/day) |
+| Merged PRs, last 90 days | ~522 |
+| Merged PRs, last 30 days | ~274 |
+| API route handlers | 302 across 54 domains |
+| React components | ~360 across 34 feature groups |
+| Custom hooks | 18 |
+| lib domains | 41 |
+| Audio providers | 9 (+ tests) |
+| SQL files in scripts/ | 129 (3 live, rest archived) |
+| Research docs | ~1,234 markdown across 18 categories |
+| Contributors | Zaal (dominant) + Claude/agents (~190 agent commits) |
+
+## 3. Backend - API surface (302 routes / 54 domains)
+
+Largest domains: music (39), admin (29), auth (21), users (15), social (13),
+spaces (12), cron (11), publish (10), chat (10), discord (8).
+
+Coverage: 16 of 54 domains have `__tests__` (admin, auth, crm, hats, juke,
+members, music, notifications, proposals, search, snapshot, spaces, streaks,
+users, wavewarz, 100ms). 38 domains have no dedicated tests - the biggest
+correctness gap in the repo.
+
+Status: every route has a real handler. No stub/dead endpoints. Graceful
+degradation throughout (discord -> 503 when unconfigured, fractals -> on-chain
+fallback when ornode down, music/generate -> mock when HF_TOKEN missing).
+
+## 4. Frontend - components / hooks / lib
+
+Biggest subsystems: music (64 components), spaces (58), social (22), admin (21),
+chat (18). Plus an "os" shell (phone shell, app drawer, dock, widgets).
+
+lib highlights: agents (autonomous treasury), publish (8-platform posting),
+spaces (Juke + RTMP + gating), music (filters, waveform, Audius/LastFM/Tidal/
+Songlink), hats, wavewarz, empire-builder, plus infra (db, auth, farcaster, ens,
+wagmi, xmtp, validation, security).
+
+Audio: 9 source providers (HTML5, Spotify, Apple Music, YouTube, Soundcloud,
+Tidal, Bandcamp, Radio) behind a single PlayerProvider.
+
+## 5. Agent stack (bot/)
+
+Matches the post-doc-601 "5 surfaces" model. All updated 2026-06-09.
+
+| Subsystem | Path | Status |
+|-----------|------|--------|
+| ZOE concierge | `bot/src/zoe/` | Active. 44 files - memory (25KB), proactive, decompose/dispatch, scheduler, critics, posts, farcaster, safety |
+| Hermes (fix-PR) | `bot/src/hermes/` | Active. 13 files - runner, claude-cli, coder, critic, git, pr-watcher, preflight |
+| ZAO Devz | `bot/src/devz/` | Active but minimal (index.ts 18KB). Phase-3 fold into Hermes still pending |
+| Teams (attabotty, magnetiq) | `bot/src/teams/` | Active. Persona blocks, shared brain/memory |
+| Fleet-agent | `bot/src/fleet-agent/` | Lightweight runner (3.4KB) |
+| Root bot (ZAOstock) | `bot/src/*.ts` | Active. index.ts 50KB dispatcher + actions/digest/circles/status |
+
+On-chain treasury agents live in `src/lib/agents/` (VAULT / BANKER / DEALER),
+all thin wrappers over a shared `runner.ts` (buy -> burn -> stake cycle, 0x
+swaps, config-driven spend caps). Trading is gated by `config.trading_enabled`.
+
+Confirmed dead/decommissioned (per doc 601, NOT in active code): openclaw,
+Composio AO, Agent Zero, the 7-agent squad, 10-bot branded fleet. Only
+historical comments remain.
+
+## 6. Contracts
+
+No `.sol` files / no `contracts/` dir in the repo (the project map lists one,
+but it is not present - all contract interaction is against external addresses
+configured in `community.config.ts`): Respect tokens OG+ZOR on Optimism, Hats
+Protocol v1 (treeId 226), ZOUNZ Nouns Builder DAO on Base, Snapshot (zaal.eth).
+
+DRIFT NOTE: CLAUDE.md / project map claims a `contracts/` directory with
+Solidity (staking, bounty board). It does not exist on disk. Either it
+graduated out or never landed - update the map.
+
+## 7. What is in flight (last 60 days churn)
+
+Most-churned dirs: `src/app/stock/team` (150), `docs/daily` (150),
+`bot/src/zoe` (135), `scripts` (100), `content/transcripts/bcz-yapz` (86),
+`src/components/spaces` (57), `bot/src/hermes` (51), `src/lib/agents` (48).
+
+Active threads:
+- ZAOstock spinout prep (stock/team) - graduates to its own repo/DB/domain.
+- Agent stack (ZOE 135 + Hermes 51 + lib/agents 48 = 234 changes).
+- Spaces/Juke hardening (ghost cleanup, live counts, room-id persist, pinned
+  links) + FISHBOWLZ removal.
+- CRM moved Supabase-native (away from Airtable; migrations 20260529 / 20260531).
+- Research capture at ~1.5 docs/day.
+
+## 8. What is missing / half-built (the honest gaps)
+
+Feature-incomplete (UI exists, backend not wired):
+- Music NFT minting - `MintTrack.tsx:110` throws "Arweave minting not yet
+  configured"; Arweave backend not deployed.
+- Ambient Mixer - "coming soon" placeholder (`AmbientMixer.tsx:286`).
+- Kick connect - "coming soon" (`KickConnect.tsx:136`).
+- Festivals photos - "coming soon" (`festivals/page.tsx:117`).
+
+Disabled integrations:
+- Lens + Hive publishing commented out in `PlatformToggles.tsx` (wallet
+  complexity / deferred, ref research/121).
+- OpenRank engagement scoring off - their SSL cert expired Mar 2026
+  (`members/[username]/route.ts:164`).
+- Tidal / Sopha silently null when unconfigured.
+
+Real TODOs worth tracking:
+- Agent event dead-letter queue not wired (`lib/agents/events.ts:24`,
+  doc-457) - failed agent events are dropped.
+- OrDAO client uses a partial ABI pending `@ordao/contracts` npm publish.
+- `music/generate` has no per-user rate limit on an expensive AI call.
+- miniapp auth: two routes need consolidation onto QuickAuth JWT
+  (`miniapp/auth-context/route.ts:13`) - currently accepts unsigned FID claims
+  (hardened against admin-grant, but still a refactor owed).
+- ZOE scheduler Phase-4 tip generation is a stub (`scheduler.ts:247`).
+
+Test debt: 38 of 54 API domains untested; whole-repo TODO/FIXME count is low
+(~10) so debt is concentrated in coverage, not littered comments.
+
+Stale branches: ~50 April worksession branches on origin, abandoned, safe to
+prune.
+
+## 9. The paid estate (Vercel + Supabase) - tooling shipped, run pending
+
+The cloud-cost half of this census needs read-only tokens that are not yet on
+the machine. Tooling is shipped at `scripts/estate-audit/`:
+
+- `audit.sh` lists every Vercel project (per scope, with last-deploy age ->
+  dead flag) and every Supabase project (status -> paused/abandoned flag),
+  maps Vercel projects to their linked git repo, and prints a kill-candidate
+  list for each.
+- Tokens read from `~/.zao/estate-tokens.env` (off-repo, gitignored, never
+  printed). Raw dumps -> `~/.zao/private/` per pii-hygiene rules.
+- API gap: neither Vercel nor Supabase public API returns per-project $ spend
+  or DB size. The script flags liveness; dollar cross-check is manual against
+  the usage dashboards (documented in the script output + README).
+
+To run: create 1-day read-only tokens, write the env file, then
+`bash scripts/estate-audit/audit.sh`. Revoke both tokens after (Supabase PATs
+are account-wide).
+
+## 10. Bottom line
+
+The repo is production-grade and extremely active. Backend is fully
+implemented, frontend is broad, the agent stack matches the locked 5-surface
+model with no zombie code. Real gaps are: (1) test coverage on ~70% of API
+domains, (2) a handful of UI-complete-but-backend-missing features (music mint,
+ambient mixer, a few connectors), (3) agent event dead-letter queue, (4) the
+cloud-cost kill-list still needs tokens to run. The institutional-memory bet
+(1,234 research docs) is paying off - this census was assembled almost entirely
+from the repo itself.

--- a/scripts/estate-audit/README.md
+++ b/scripts/estate-audit/README.md
@@ -1,0 +1,66 @@
+# estate-audit
+
+Census every Vercel project and every Supabase project on the account, map
+them to repos, and emit a costed kill-list. Built for the "what infra are we
+paying for and which is dead" sweep.
+
+## Why this exists
+
+The ZAO estate sprawls across many Vercel deploys and Supabase projects
+(ZAOOS, zaostock, zlank, WaveWarZ, COC Concertz, cowork trackers, demo sites).
+Some are live, some are abandoned but still billing. This tool lists them all
+so dead ones can be killed.
+
+## Security model (non-negotiable)
+
+- Tokens are **read-only** and **short-lived** (create with 1-day expiry).
+- Tokens live **off-repo** at `~/.zao/estate-tokens.env` (never committed).
+- Raw API output may contain billing data, so it is written to
+  `~/.zao/private/` per `.claude/rules/pii-hygiene.md`, never into the repo.
+- The script never prints or logs token values.
+- **Supabase PATs are account-wide (no read-only scope).** Revoke immediately
+  after the run.
+
+## Setup
+
+1. Vercel token: https://vercel.com/account/tokens -> create, scope = account,
+   expiry = 1 day.
+2. Supabase token: https://supabase.com/dashboard/account/tokens -> generate
+   (`sbp_...`).
+3. Write the token file (off-repo):
+
+   ```bash
+   printf 'VERCEL_TOKEN=PASTE_VERCEL\nSUPABASE_ACCESS_TOKEN=PASTE_SBP\n' \
+     > ~/.zao/estate-tokens.env && chmod 600 ~/.zao/estate-tokens.env
+   ```
+
+## Run
+
+```bash
+bash scripts/estate-audit/audit.sh
+```
+
+Prints two tables (Vercel, Supabase) plus a kill-candidate list for each.
+Raw JSON dumps land in `~/.zao/private/{vercel,supabase}-estate-<stamp>.json`.
+
+## After the run
+
+```bash
+rm -f ~/.zao/estate-tokens.env
+```
+
+Then revoke both tokens in their dashboards.
+
+## Limitations (API gaps)
+
+- Neither the Vercel nor Supabase public API exposes per-project **$ spend**
+  or DB size. The script flags *liveness* (last-deploy age, project status);
+  cross-check dollar figures against:
+  - Vercel: https://vercel.com/account/usage
+  - Supabase: https://supabase.com/dashboard/org/_/usage
+  - Supabase DB size: `select pg_size_pretty(pg_database_size(current_database()));`
+
+## Tunables
+
+- `DEAD_DAYS` (default 90) - a Vercel project with no deploy in this many days
+  is flagged dead.

--- a/scripts/estate-audit/audit.sh
+++ b/scripts/estate-audit/audit.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# estate-audit/audit.sh
+# -------------------------------------------------------------------
+# Census every Vercel project and every Supabase project on the
+# account, map them to repos, and emit a costed kill-list.
+#
+# Tokens are READ-ONLY, SHORT-LIVED, and live OFF-REPO at:
+#   ~/.zao/estate-tokens.env
+#     VERCEL_TOKEN=...
+#     SUPABASE_ACCESS_TOKEN=sbp_...
+#
+# NEVER commit the token file. NEVER print token values.
+# Raw API output (may contain billing/PII) is written to ~/.zao/private/
+# per .claude/rules/pii-hygiene.md. Only the synthesized table prints.
+#
+# Usage:
+#   bash scripts/estate-audit/audit.sh
+#
+# Requires: curl, jq
+# -------------------------------------------------------------------
+set -euo pipefail
+
+TOKENS_FILE="${HOME}/.zao/estate-tokens.env"
+OUT_DIR="${HOME}/.zao/private"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+DEAD_DAYS=90   # no deploy in N days => flagged dead
+
+mkdir -p "${OUT_DIR}"
+
+# ---- preflight ----------------------------------------------------
+command -v jq   >/dev/null || { echo "ERROR: jq not installed (brew install jq)"; exit 1; }
+command -v curl >/dev/null || { echo "ERROR: curl not installed"; exit 1; }
+
+if [[ ! -f "${TOKENS_FILE}" ]]; then
+  cat <<EOF
+ERROR: no token file at ${TOKENS_FILE}
+
+Create it (read-only, 1-day tokens), then re-run:
+  printf 'VERCEL_TOKEN=PASTE_VERCEL\nSUPABASE_ACCESS_TOKEN=PASTE_SBP\n' > ~/.zao/estate-tokens.env && chmod 600 ~/.zao/estate-tokens.env
+
+Token sources:
+  Vercel:   https://vercel.com/account/tokens  (expiry 1 day)
+  Supabase: https://supabase.com/dashboard/account/tokens (sbp_..., revoke after)
+EOF
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set +u; source "${TOKENS_FILE}"; set -u
+VERCEL_TOKEN="${VERCEL_TOKEN:-}"
+SUPABASE_ACCESS_TOKEN="${SUPABASE_ACCESS_TOKEN:-}"
+
+now_epoch=$(date +%s)
+
+echo "================================================================"
+echo " ZAO ESTATE CENSUS  ${STAMP}"
+echo " raw dumps -> ${OUT_DIR}/{vercel,supabase}-estate-${STAMP}.json"
+echo "================================================================"
+
+# ===================================================================
+# VERCEL
+# ===================================================================
+vercel_section() {
+  if [[ -z "${VERCEL_TOKEN}" ]]; then
+    echo; echo "VERCEL: no VERCEL_TOKEN set - skipped."; return
+  fi
+  local raw="${OUT_DIR}/vercel-estate-${STAMP}.json"
+  local auth="Authorization: Bearer ${VERCEL_TOKEN}"
+
+  # Resolve teams (projects can live under personal scope + each team)
+  curl -sf -H "${auth}" "https://api.vercel.com/v2/teams?limit=100" \
+    > "${OUT_DIR}/vercel-teams-${STAMP}.json" 2>/dev/null || echo '{"teams":[]}' > "${OUT_DIR}/vercel-teams-${STAMP}.json"
+
+  # Personal scope first, then each team
+  : > "${raw}"
+  echo "[" >> "${raw}"
+  local first=1
+
+  fetch_scope() {
+    local teamq="$1" scopelabel="$2"
+    local url="https://api.vercel.com/v9/projects?limit=100${teamq}"
+    while [[ -n "${url}" ]]; do
+      local page
+      page=$(curl -sf -H "${auth}" "${url}") || break
+      echo "${page}" | jq -c --arg scope "${scopelabel}" '.projects[] | {scope:$scope, name, id, framework, updatedAt, latestDeployments: (.latestDeployments // []), repo: (.link.repo // .link.org + "/" + .link.repo // null), link}' \
+        | while IFS= read -r line; do
+            if [[ ${first} -eq 1 ]]; then first=0; else echo "," >> "${raw}"; fi
+            echo "${line}" >> "${raw}"
+          done
+      local next
+      next=$(echo "${page}" | jq -r '.pagination.next // empty')
+      if [[ -n "${next}" ]]; then
+        url="https://api.vercel.com/v9/projects?limit=100&until=${next}${teamq}"
+      else
+        url=""
+      fi
+    done
+  }
+
+  fetch_scope "" "personal"
+  jq -r '.teams[]? | "\(.id)\t\(.slug)"' "${OUT_DIR}/vercel-teams-${STAMP}.json" 2>/dev/null \
+    | while IFS=$'\t' read -r tid tslug; do
+        [[ -z "${tid}" ]] && continue
+        fetch_scope "&teamId=${tid}" "${tslug}"
+      done
+  echo "]" >> "${raw}"
+
+  echo
+  echo "----------------------------------------------------------------"
+  echo "VERCEL PROJECTS"
+  echo "----------------------------------------------------------------"
+  local total dead
+  total=$(jq 'length' "${raw}")
+  echo "total projects: ${total}   (dead = no deploy in ${DEAD_DAYS}d)"
+  echo
+  printf "%-32s %-12s %-10s %-26s %s\n" "PROJECT" "SCOPE" "STATE" "LAST DEPLOY" "REPO"
+  jq -r --argjson now "${now_epoch}" --argjson dd "${DEAD_DAYS}" '
+    .[] |
+    (.latestDeployments[0].createdAt // .updatedAt // 0) as $ts |
+    (($ts/1000) | floor) as $tsec |
+    (($now - $tsec) / 86400 | floor) as $age |
+    (if $tsec == 0 then "NODEPLOY"
+     elif $age > $dd then "DEAD(" + ($age|tostring) + "d)"
+     else "live" end) as $state |
+    [ (.name // "?")[0:31],
+      (.scope // "?")[0:11],
+      $state,
+      (if $tsec==0 then "-" else ($tsec | strftime("%Y-%m-%d")) end),
+      (.repo // "-")
+    ] | @tsv' "${raw}" \
+    | sort -t$'\t' -k3 \
+    | while IFS=$'\t' read -r n s st ld r; do printf "%-32s %-12s %-10s %-26s %s\n" "$n" "$s" "$st" "$ld" "$r"; done
+
+  echo
+  echo "VERCEL KILL CANDIDATES (dead/no-deploy):"
+  jq -r --argjson now "${now_epoch}" --argjson dd "${DEAD_DAYS}" '
+    .[] |
+    (.latestDeployments[0].createdAt // .updatedAt // 0) as $ts |
+    (($ts/1000)|floor) as $tsec |
+    (($now-$tsec)/86400|floor) as $age |
+    select($tsec==0 or $age>$dd) |
+    "  - " + (.name // "?") + "  (" + (.scope//"?") + ")  last="
+      + (if $tsec==0 then "never" else ($tsec|strftime("%Y-%m-%d")) end)
+      + "  repo=" + (.repo // "none")' "${raw}"
+  echo
+  echo "NOTE: Vercel public API does not expose per-project \$ spend."
+  echo "      Cross-check the kill list against the billing dashboard:"
+  echo "      https://vercel.com/account/usage"
+}
+
+# ===================================================================
+# SUPABASE
+# ===================================================================
+supabase_section() {
+  if [[ -z "${SUPABASE_ACCESS_TOKEN}" ]]; then
+    echo; echo "SUPABASE: no SUPABASE_ACCESS_TOKEN set - skipped."; return
+  fi
+  local raw="${OUT_DIR}/supabase-estate-${STAMP}.json"
+  local auth="Authorization: Bearer ${SUPABASE_ACCESS_TOKEN}"
+
+  curl -sf -H "${auth}" "https://api.supabase.com/v1/projects" > "${raw}" \
+    || { echo "SUPABASE: API call failed (token bad/expired?)"; return; }
+
+  echo
+  echo "----------------------------------------------------------------"
+  echo "SUPABASE PROJECTS"
+  echo "----------------------------------------------------------------"
+  local total
+  total=$(jq 'length' "${raw}")
+  echo "total projects: ${total}"
+  echo
+  printf "%-34s %-14s %-22s %-14s %s\n" "PROJECT" "STATUS" "REF" "CREATED" "REGION"
+  jq -r '.[] | [ (.name//"?")[0:33], (.status//"?"), (.id//.ref//"?"), ((.created_at//"")[0:10]), (.region//"?") ] | @tsv' "${raw}" \
+    | while IFS=$'\t' read -r n s ref cr rg; do printf "%-34s %-14s %-22s %-14s %s\n" "$n" "$s" "$ref" "$cr" "$rg"; done
+
+  echo
+  echo "SUPABASE KILL CANDIDATES (paused/inactive):"
+  jq -r '.[] | select((.status // "") | test("ACTIVE_HEALTHY"; "i") | not)
+    | "  - " + (.name//"?") + "  status=" + (.status//"?") + "  ref=" + (.id//.ref//"?")' "${raw}" \
+    || echo "  (none - all ACTIVE_HEALTHY)"
+  echo
+  echo "NOTE: Supabase Management API does not return DB size or \$ spend per project."
+  echo "      Cross-check against: https://supabase.com/dashboard/org/_/usage"
+  echo "      DB size per project: run inside each project's SQL editor:"
+  echo "        select pg_size_pretty(pg_database_size(current_database()));"
+}
+
+vercel_section || echo "VERCEL section errored (continuing)."
+supabase_section || echo "SUPABASE section errored (continuing)."
+
+echo
+echo "================================================================"
+echo " DONE. Raw dumps in ${OUT_DIR} (off-repo, gitignored)."
+echo " REMINDER: revoke both tokens now (Supabase PATs are account-wide)."
+echo "================================================================"


### PR DESCRIPTION
## What

Full repo status census + tooling to census the paid cloud estate.

### Repo overview (doc 836)
research/infrastructure/836 - full ZAOOS overview assembled from the codebase:
- 2,659 commits, 752 in last 30d
- 302 API routes / 54 domains (16 tested, 38 untested = main gap)
- ~360 components, 18 hooks, 41 lib domains, 9 audio providers
- Agent stack matches locked 5-surface model (ZOE/Hermes/Devz/Teams/root), no zombie code
- Missing: music NFT mint (Arweave not wired), ambient mixer, Kick/festival stubs, Lens/Hive disabled, OpenRank dead (their SSL), agent dead-letter queue, music/generate rate limit

### Estate-audit tooling (scripts/estate-audit/)
- audit.sh: read-only census of every Vercel + Supabase project, maps to repos, emits kill-candidate lists
- Tokens off-repo at ~/.zao/estate-tokens.env, never printed/committed; raw dumps -> ~/.zao/private/ per pii-hygiene
- API gap noted: no per-project spend via API -> manual dashboard cross-check
- .gitignore guard for *estate-tokens*

🤖 Generated with [Claude Code](https://claude.com/claude-code)