### PR TITLE
doc 837: ZAO Video Editor audit + livestream-to-clips roadmap (STANDARD)

### DIFF
--- a/research/agents/836-x-account-mining-agent-patterns/README.md
+++ b/research/agents/836-x-account-mining-agent-patterns/README.md
@@ -1,0 +1,88 @@
+---
+topic: agents
+type: market-research
+status: research-complete
+last-validated: 2026-06-09
+superseded-by:
+related-docs: "830, 829, 835"
+original-query: "can we go through all of the x accounts of the links we have to see other similar posts / x articles - mine the high-signal authors from the inbox for more"
+tier: DEEP
+---
+
+# 836 - X Account Mining: The Agent-Patterns the Inbox Authors Are Writing
+
+> **Goal:** Zaal asked to mine the X accounts from the inbox for more articles like the ones he saved. X gated guest-token timelines in 2026 (can't bulk-scrape feeds keyless), so this used semantic search on the high-signal authors + their themes. Three rich clusters surfaced - all directly relevant to ZAO's agent stack.
+
+## Method note (read first)
+
+Keyless X *timeline* mining is dead: guest-token `UserTweets` now returns an empty timeline (verified live 2026-06-09 - X returns clear-cache instructions, zero tweets). Single tweets/articles still fetch keyless via FxTwitter. So this round used **semantic search (exa) on the authors + their topics** rather than feed-scraping. That's the keyless way to "keep searching." For exhaustive timeline mining you'd need an auth cookie or a paid API (getxapi ~$0.001/call).
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **Add a cost-routing layer to ZAO's Workflow/Hermes: classify each task judgment-heavy vs execution-heavy, route to the right model** | The 0xRicker cluster's real lesson (the "$62k -> $129" articles) is NOT "Opus + Kimi" - it's the ROUTING rule: "if a clear machine-scorable rule can be written -> cheap executor; else -> Opus." ZAO runs Opus for everything. A routing layer (Opus plans/reviews, Haiku or Kimi-class executes the parallel bulk) is a 100-400x cost cut on execution-heavy fan-outs, same quality. Maps straight onto the Workflow tool's fan-out + the ZOE $50/day cap. |
+| 2 | **Audit ZAO's ~50 skills against Thariq's 9 categories + 9 tips; adopt "description = trigger", "gotchas section", and PreToolUse usage-logging immediately** | Thariq's "Lessons from Building Claude Code: How We Use Skills" is the authoritative skill-authoring playbook (Anthropic, hundreds of skills in prod). It operationalizes doc 829. Three immediately actionable: (a) every skill description is a *when-to-trigger*, not a summary; (b) a Gotchas section is the highest-signal content; (c) log skill usage via a PreToolUse hook to find undertriggering skills. |
+| 3 | **Validate Hermes's clean-context critic - Cognition proves a reviewer with NO shared context is SMARTER, not redundant** | Cognition's "Multi-Agents: What's Actually Working" found generator+verifier loops work BEST when the agents share no prior context (clean context dodges context-rot, forces reasoning backward from the diff). Devin Review catches ~2 bugs/PR, 58% severe. ZAO's Hermes (coder+critic) should ensure the critic starts clean, not from the coder's context. |
+| 4 | **Do NOT build unstructured agent swarms - the practical shape is map-reduce-and-manage with single-threaded writes** | Both Cognition (Walden Yan) and the Kimi-swarm crowd converge here: multi-agent works when WRITES stay single-threaded and extra agents contribute INTELLIGENCE not parallel write-actions. Unstructured swarms = "a distraction." ZAO's Workflow tool (pipeline/parallel with a synthesis stage) already follows this; keep it. |
+
+## Findings - three clusters
+
+### Cluster A - Opus-orchestrator + cheap-executor + a routing layer (mined from 0xRicker)
+
+The post Zaal saved (0xRicker, "300 agents built a SaaS," doc 830) is one node in a whole movement. The deeper articles (BestHub + Medium "$62,000 -> $129", zenn.dev Claude x Kimi hybrid):
+
+- **Architecture:** Opus 4.8 = brain (plan, judgment, quality control); Kimi K2.6 Agent Swarm = hands (300 parallel sub-agents, up to 4,000 steps, SWE-Bench Pro 58.6%, **$0.6/M tokens**). Kimi's own orchestrator is good at task decomposition but NOT high-level design - so Opus owns "what to build," Kimi owns "build it."
+- **The actual unlock is the routing layer:** classify every task first - judgment-heavy (no clear rubric -> Opus) vs execution-heavy (clear machine-scorable output spec -> cheap executor). "$62k -> $129" came from the routing, not just the model swap.
+- **Discipline that makes it safe:** Opus emits a `spec.md` (file paths, validation commands, completion criteria) so the executor doesn't wander; executor works on an isolated branch; Opus reviews against a quality rubric before merge. The BestHub piece ships 15 concrete prompts (plan / classify / rubric / review / assemble / handoff-template / cost-tracking) - a ready-made orchestration kit.
+- **ZAO fit:** this is a cost optimization for the Workflow tool + Hermes/ZOE. Today ZAO fans out Opus agents; routing the execution-heavy ones to Haiku (or a Kimi-class model) keeps quality and slashes cost on big drains like doc 832 (the 84-item re-fetch ran 22 Opus-class agents - prime routing candidate).
+
+### Cluster B - Thariq's skill-authoring playbook (mined from trq212) - operationalizes doc 829
+
+"Lessons from Building Claude Code: How We Use Skills" (Anthropic, hundreds of skills in prod):
+
+- **9 skill categories:** (1) Library/API Reference, (2) Product Verification, (3) Data Fetching/Analysis, (4) Business Process/Team Automation, (5) Code Scaffolding/Templates, (6) Code Quality/Review, (7) CI/CD/Deployment, (8) Runbooks (symptom -> multi-tool investigation -> report), (9) Infrastructure Operations.
+- **9 authoring tips:** don't state the obvious (push Claude out of defaults - e.g. the frontend skill kills Inter font + purple gradients); **Gotchas section is the highest-signal content**; use the file system + progressive disclosure (skill = folder, point to `references/*.md`); avoid railroading (give goal + constraints, not step-by-step); think through setup (`config.json` + AskUserQuestion for missing context); **the description field is the model-facing "when to trigger," not a summary**; memory via `${CLAUDE_PLUGIN_DATA}` (survives upgrades); store scripts so Claude composes instead of reconstructing boilerplate; on-demand hooks (`/careful` blocks rm -rf/DROP TABLE/force-push; `/freeze` blocks edits outside a dir).
+- **Distribution:** check into `.claude/skills` (small teams) or a plugin marketplace (scale); curate before release to avoid redundancy; reference other skills by name to compose them.
+- **Measurement:** a PreToolUse hook logs skill usage -> find popular + undertriggering skills.
+- **ZAO fit:** the operating manual for ZAO's skill library. The fetch trio + `/inbox` + `/zao-research` already match categories 1/2/3/8. Action: add a Gotchas section to each, rewrite descriptions as triggers, and wire usage-logging.
+
+### Cluster C - Cognition's "multi-agent that actually works" (mined from walden_yan) - validates Hermes/ZOE
+
+Walden Yan's "Multi-Agents: What's Actually Working" (2026-04-22, the sequel to "Don't Build Multi-Agents"):
+
+- **Core finding:** multi-agent works today when **writes stay single-threaded** and extra agents contribute **intelligence, not actions**. Parallel writers still fragment decisions (style/edge-cases conflict).
+- **The code-review loop "so stupid it shouldn't work":** generator + verifier where they share NO context beforehand. Clean context makes the reviewer *smarter* - dodges context-rot (attention math degrades long-context decisions), forces reasoning backward from the diff, openly questions choices. Devin Review: ~2 bugs/PR, 58% severe. The communication bridge back to the coder (filtering bugs against user intent) is what prevents looping.
+- **"Smart Friend":** a smaller primary calls out to a bigger model when stuck. Works well *cross-frontier* (Claude + GPT as a capability router - some debug better, some test better). The weak-primary -> strong-helper version (the big cost unlock) is still an open training problem.
+- **Higher-level delegation = map-reduce-and-manage:** a manager splits scope, children execute, manager synthesizes. Unstructured swarms are "a distraction."
+- **ZAO fit:** direct validation of Hermes (coder + critic) and ZOE (workers + critics). Two upgrades: (1) make the critic clean-context, (2) the "smart friend" pattern = a ZOE worker on Haiku that consults Opus on hard calls (the cost-routing tie-in to Cluster A).
+
+## ZAO Application (cross-cluster)
+
+The three clusters converge on one ZAO move: **a routed, single-threaded-write, clean-context-critic agent system, packaged as well-authored skills.** ZAO already has the shape (Workflow tool, Hermes, ZOE, skill library). The deltas: add cost-routing (Cluster A), apply the skill playbook (Cluster B), make critics clean-context + add a smart-friend router (Cluster C).
+
+## Also See
+
+- [Doc 830](../830-ai-coding-agent-discourse-inbox-cluster/) - the inbox cluster where 0xRicker/Thariq first surfaced
+- [Doc 829](../829-anthropic-agent-skills-talk/) - Anthropic Skills talk (Cluster B's foundation)
+- [Doc 835](../../governance/835-deep-funding-ai-pgf/) - "AI proposes, jury checks" (same review-rung pattern)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Prototype a cost-routing layer for the Workflow tool: classify execution-heavy stages -> Haiku, judgment -> Opus | @Zaal | Build | Next sprint |
+| Audit ZAO's ~50 skills vs Thariq's 9 categories + add Gotchas sections + trigger-style descriptions | @Zaal | Skill hygiene | Pre-July |
+| Make Hermes critic clean-context (no shared coder context); add a smart-friend Haiku->Opus consult to ZOE | @Zaal | Agent infra | Ongoing |
+| Keep mining: cyrilxbt, shawmakesmagic, shannholmberg, eng_khairallah1 next round (cookie or getxapi if timeline depth needed) | @Zaal | Research | Ad hoc |
+
+## Sources
+
+- [Cognition - Multi-Agents: What's Actually Working](https://cognition.ai/blog/multi-agents-working) `[FULL - exa web_fetch; clean-context review, smart-friend, map-reduce-and-manage, single-threaded writes]`
+- [Thariq - Lessons from Building Claude Code: How We Use Skills (GitHub mirror)](https://github.com/shanraisshan/claude-code-best-practice/blob/main/tips/claude-thariq-tips-17-mar-26.md) `[FULL - exa web_fetch; 9 categories + 9 tips + distribution/measurement]`
+- [BestHub - Cut Dynamic Workflows cost $62k -> $129](https://www.besthub.dev/articles/how-to-cut-dynamic-workflows-costs-from-62-000-to-129-with-ai-agents-e3957ed032ce) `[FULL - exa web_fetch; routing layer + 15 orchestration prompts + cost math]`
+- [zenn.dev - Claude Code x Kimi K2.5 hybrid (Opus designs, Kimi implements)](https://zenn.dev/shimo4228/articles/claude-kimi-hybrid-setup?locale=en) `[FULL via exa highlight; spec.md handoff, isolated branch, Claude review before merge]`
+- [Cognition - Don't Build Multi-Agents](https://cognition.ai/blog/dont-build-multi-agents) `[FULL via exa highlight; the original context-engineering principles]`
+- [Latent.Space - Walden Yan / The Age of Async Agents](https://www.latent.space/p/cognition) `[PARTIAL via exa highlight; podcast - brain/machine separation, repo setup, multi-agent maturity]`
+- [Thariq pinned writing thread (Rattibha mirror)](https://en.rattibha.com/thread/2035372716820218141) `[FULL via exa highlight; "skills are the abstraction all agents build on", bash is all you need, file system, prompt caching]`
+- Live test 2026-06-09: guest-token X timeline mining returns empty (verified the keyless-timeline wall) `[FULL - primary; UserTweets returned 0 entries]`

--- a/research/infrastructure/837-zao-video-editor-livestream-distribution/README.md
+++ b/research/infrastructure/837-zao-video-editor-livestream-distribution/README.md
@@ -1,0 +1,113 @@
+---
+topic: infrastructure
+type: audit
+status: research-complete
+last-validated: 2026-06-09
+superseded-by:
+related-docs: 836, 778, 741
+original-query: "Audit github.com/bettercallzaal/ZAOVideoEditor - full repo audit, identify what exists, what is broken, what is missing, surface PR-worthy fixes. Then: make the goal a clean video editor with all functions for ZAO and ZAO OS to distribute media from livestreams, best-in-class clipping for all."
+tier: STANDARD
+---
+
+# 837 - ZAO Video Editor: Audit + Livestream-to-Clips Roadmap
+
+> **Goal:** Audit `bettercallzaal/ZAOVideoEditor` as-is, then chart the path to make it THE clean editor ZAO/ZAO OS uses to turn livestreams into distributed, multi-platform clips.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | KEEP the repo. It is a real FastAPI + React app with 18 routers and 40 services, not a stub. Build on it, do not restart. | Transcription, captions, diarization, highlight detection, clip export, content gen, batch, Quick Process pipeline all implemented and wired. Verified by reading the code. |
+| 2 | SHIP the two audit PRs first (security #2, hygiene #3), then build the livestream + vertical-clip layer. | Path-traversal hole (arbitrary dir delete via `DELETE /api/projects/{name}`) is the one true CRITICAL. Fix before adding any public/multi-user surface. |
+| 3 | The product gap is INGEST + DISTRIBUTION, not editing. The editing core exists. What is missing: livestream pull, 9:16 vertical reframing, per-platform export presets, and push-to-platform. | Today the only input is a manual file upload (`POST /api/projects/{name}/upload`). "Distribute media from livestreams" needs the front and back ends of the pipeline, not the middle. |
+| 4 | Vertical auto-clip (16:9 -> 9:16 with speaker-tracked crop + burned captions) is the single highest-leverage feature for "best clipping for all". | Every distribution surface ZAO uses for clips (Farcaster, X, TikTok, Reels, Shorts) is vertical-first. The repo already detects highlights and burns captions; it cannot yet reframe. |
+| 5 | Restream is the livestream source of record. Pull VODs/recordings from Restream + YouTube Live + Twitch rather than re-build streaming. | Per ZAO glossary, Restream is the ZABAL Games default streaming surface. Do not rebuild ingest ZAO already pays for. |
+
+## Current State (verified by reading the repo, commit 8ec4a74)
+
+Stack: FastAPI backend (`backend/`, 18 routers, ~40 service modules), React 19 + Vite + Tailwind v4 frontend (`frontend/`), local-first (ffmpeg + faster-whisper, no cloud required). MIT licensed.
+
+What works (implemented, not stubbed):
+
+| Capability | Where | Notes |
+|-----------|-------|-------|
+| Project CRUD + chunked upload (10 GB cap, disk-space guard, auto-remux to mp4) | `routers/projects.py` | Upload is the ONLY ingest path today. |
+| Transcription, 3 engines | `routers/transcription.py`, `services/whisper_service.py`, `whisperx_service.py`, `groq_service.py` | faster-whisper (local), whisperx, groq (cloud). `auto` picks best available. |
+| Timestamp refinement | `services/stable_ts_service.py` | Optional stable-ts post-process. |
+| Speaker diarization | `services/diarization.py` | pyannote, needs `HF_TOKEN`. |
+| Correction dictionary (ZAO terms pre-loaded) | `services/dictionary.py`, `shared/dictionary.json` | ZAO, ZABAL, WaveWarZ, SongJam, Farcaster seeded; auto-learns from edits. |
+| Captions, 6 styles, burn-in | `routers/captions.py`, `services/caption_gen.py`, `ffmpeg_service.py` | SRT/ASS, pillow + moviepy renderers. |
+| Silence / filler removal | `routers/silence.py`, `fillers.py`, `services/auto_editor_service.py`, `filler_detection.py` | auto-editor based. |
+| Highlight detection + clip export | `routers/clips.py`, `services/highlights.py` | LLM-scored clippable moments -> ffmpeg clip cut. Horizontal only. |
+| Content generation (recap, show notes, social posts, clip suggestions) | `routers/content.py`, `services/content_gen.py` | Ollama-first, OpenAI fallback. |
+| YouTube metadata + SEO checklist + transcript grabber | `routers/youtube.py`, `metadata.py`, `services/youtube_service.py` | 3-tier transcript fetch. |
+| NotebookLM export, Google Drive upload | `routers/export.py`, `services/gdrive_service.py` | |
+| Batch + one-click Quick Process pipeline | `routers/batch.py`, `pipeline.py` | Full pipeline assemble->transcribe->correct->polish->content->captions->metadata. |
+| Background task system with polling | `services/task_manager.py` | `GET /api/tasks/{id}`. |
+| Extra AI tools (thumbnails, upscale, bg-removal, TTS, music-gen, video-gen, scene-detect) | `routers/ai_tools.py`, `services/*` | Tiered by CPU/GPU availability. |
+
+What is broken / weak (from the audit, see PRs):
+
+| Issue | Severity | Status |
+|-------|----------|--------|
+| Path traversal in `project_name` (create/delete/upload/read build raw `PROJECTS_DIR / name`, no containment) -> arbitrary dir create/delete/read | CRITICAL | Fixed in PR #2 |
+| String-prefix containment checks (`str.startswith`) on download/serve routes -> sibling-prefix bypass | MEDIUM | Fixed in PR #2 |
+| `Content-Disposition` header injection via `project_name` | MEDIUM | Fixed in PR #2 (validation closes it) |
+| README "Private project" vs committed MIT LICENSE; no `.env.example`; `GROQ_API_KEY`/`HF_TOKEN`/`OPENAI_API_KEY` undocumented | LOW | Fixed in PR #3 |
+| No tests, no CI, no CONTRIBUTING | LOW | Open (roadmap below) |
+| `backend/requirements.txt` has unpinned deps (openai, rapidfuzz, gtts, google-*); dual requirements files | LOW | Open |
+| Frontend: `setTimeout`/copy-state handlers without cleanup; one missing hook dep (`CaptionPanel`) | LOW | Open (React 19 no longer warns on unmounted setState; cosmetic) |
+
+## Gap Analysis: from "upload editor" to "livestream distribution engine"
+
+The pipeline today is `upload -> edit -> export file`. The goal pipeline is `pull livestream -> auto-clip vertical -> caption -> push to N platforms`. Three missing layers:
+
+### 1. Ingest layer (missing entirely)
+- Pull a finished livestream/VOD by URL: Restream recording, YouTube Live VOD, Twitch VOD, raw HLS/`.m3u8`, direct mp4.
+- New router `routers/ingest.py` + `services/ingest_service.py` using `yt-dlp` (handles YouTube/Twitch/HLS/generic) to download into a project's `input/` - reuse the existing project structure so everything downstream just works.
+- This is the single biggest unlock: it turns every ZAO livestream into a project automatically.
+
+### 2. Vertical clipping layer (partial - horizontal clips only)
+- Today `clips.py` cuts horizontal clips at highlight timestamps. "Best clipping for all" = vertical 9:16 clips ready for Farcaster/X/TikTok/Reels/Shorts.
+- Add a reframe stage: 16:9 -> 9:16 via ffmpeg crop, with optional active-speaker tracking (diarization data already exists) so the crop follows whoever is talking.
+- Burn the existing branded captions onto each vertical clip automatically (caption burn already exists; wire it into the clip export path).
+- Output presets: square 1:1, vertical 9:16, original 16:9 - one highlight -> three aspect ratios.
+
+### 3. Distribution layer (partial - Drive/NotebookLM only)
+- Today export = files + Google Drive + NotebookLM. Missing: push clips to the surfaces ZAO actually distributes on.
+- Generate the per-clip caption/title/hashtags (content_gen already drafts social posts - point it at each clip) and hand off to the existing ZAO distribution path: the `/socials` skill + Firefly for Farcaster/X. Keep the editor's job "produce the clip + the copy", let ZAO's posting stack publish.
+
+## Proposed Roadmap (PR-sized)
+
+| Phase | PR | Scope |
+|-------|----|-------|
+| 0 | #2, #3 (open) | Security + hygiene. Merge first. |
+| 1 | ingest router | `yt-dlp` pull from URL -> project `input/`. Restream/YouTube/Twitch/HLS/mp4. Background task + progress. |
+| 2 | vertical reframe | ffmpeg 16:9->9:16 crop service + aspect-ratio param on clip export. Speaker-tracked crop using diarization as a fast-follow. |
+| 3 | auto-captioned clips | wire caption burn into clip export; one highlight -> 3 aspect ratios, captions burned. |
+| 4 | per-clip copy | content_gen drafts title + caption + hashtags per clip; expose in ClipsPanel for one-click copy into `/socials`. |
+| 5 | tests + CI | pytest smoke tests on project CRUD + ingest + clip; GitHub Actions lint+test on PR. Hardens it for multi-user. |
+
+## Also See
+
+- [Doc 836](../836-zaoos-repo-estate-census/) - repo estate census (where ZAOVideoEditor sits in the ZAO repo map)
+- [Doc 778](../../) - ZABAL Games Magnetic build (Restream as default streaming surface)
+- [Doc 741](../../) - LiveKit pick (real-time media infra, adjacent)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Review + merge security PR #2 (path traversal) | @Zaal | PR | Before any shared/public deploy |
+| Review + merge hygiene PR #3 (license + .env.example) | @Zaal | PR | Next pass |
+| Confirm livestream sources to support (Restream + YouTube Live + Twitch?) | @Zaal | Decision | Before Phase 1 |
+| Build Phase 1 ingest router (`yt-dlp` URL pull) | @Claude | PR | After #2/#3 merge |
+| Build Phase 2 vertical reframe (9:16 clip export) | @Claude | PR | After Phase 1 |
+
+## Sources
+
+- [bettercallzaal/ZAOVideoEditor @ 8ec4a74](https://github.com/bettercallzaal/ZAOVideoEditor) [FULL - cloned and read backend/ (18 routers, 40 services), frontend/, README, requirements, configs; verified each capability claim against the code]
+- [PR #2 - security: path-traversal hardening](https://github.com/bettercallzaal/ZAOVideoEditor/pull/2) [FULL - authored this session]
+- [PR #3 - docs: license + env vars](https://github.com/bettercallzaal/ZAOVideoEditor/pull/3) [FULL - authored this session]
+- yt-dlp (`github.com/yt-dlp/yt-dlp`) - supported extractors for YouTube/Twitch/generic HLS [PARTIAL - cited from prior knowledge as the Phase 1 ingest tool; not re-fetched this session]
+- ZAO glossary (project `CLAUDE.md`) - Restream as ZABAL Games default streaming surface [FULL - in-repo]


### PR DESCRIPTION
## Summary

Audit of `bettercallzaal/ZAOVideoEditor` plus a roadmap to make it the editor ZAO uses to turn livestreams into distributed multi-platform clips.

Findings: the repo is real (18 routers, 40 services, all implemented not stubbed). One CRITICAL security hole (path traversal -> arbitrary dir delete) plus hygiene gaps, both already shipped as PRs against that repo (#2 security, #3 docs). The product gap is ingest + distribution, not editing - the editing core exists. Roadmap: yt-dlp livestream pull, vertical 9:16 auto-clip with speaker-tracked crop + burned captions, per-clip copy handed to the ZAO /socials path.

## Tier
STANDARD

## Sources
Primary FULL source = the cloned repo (read backend/frontend/docs/config end to end). Plus the two PRs authored this session. yt-dlp cited PARTIAL (prior knowledge, Phase 1 tool).

## Next Actions
See the Next Actions table in the doc - merge PRs #2/#3, confirm livestream sources, then build the ingest + vertical-clip phases.