### PR TITLE
Estate census data fold-in (doc 836 + README overview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ The pattern: **Monorepo as Lab.**
 - **COC Concertz** — own repo, virtual concert community
 - **FISHBOWLZ** — was its own thing, paused 2026-04-16 (partnership with Juke). Code stays in ZAOOS as-is.
 
+### Repo & estate at a glance
+
+Full status census: [research/infrastructure/836](./research/infrastructure/836-zaoos-repo-estate-census/). Reproduce the cloud half with `scripts/estate-audit/audit.sh`.
+
+| Area | Snapshot (2026-06-10) |
+|---|---|
+| Code | 302 API routes / 54 domains, ~360 components, 18 hooks, 41 lib domains |
+| Tests | 16 of 54 API domains have suites (38 untested = top gap) |
+| Agents | 5-surface model (ZOE, Hermes, ZAO Devz, Teams, ZAOstock bot), no zombie code |
+| Half-built | Music NFT mint (Arweave not wired), ambient mixer, Kick/festival stubs, Lens/Hive disabled |
+| Vercel estate | 86 projects — 32 live, **54 dead** (12 old NEXUS iterations + ~5 dupes lead the kill-list) |
+| Supabase estate | 4 projects — 2 active (ZAOOS, ZAO STOCK), 2 inactive/paused |
+
 ---
 
 ## The original product still lives here: a gated Farcaster client

--- a/research/README.md
+++ b/research/README.md
@@ -13,7 +13,7 @@
 | [Music](./music/) | 85 | Player, NFTs, distribution, Arweave, audio APIs, FISHBOWLZ, AI generation, ElevenLabs, metadata/ISRC, games/interactive media |
 | [Business](./business/) | 78 | Revenue, payments, token economics, strategy, marketplace, brand kits, partnerships |
 | [Events](./events/) | 77 | Bootcamps, ZAOstock, ZABAL Games, meeting/call recaps, ship logs, big wins, status snapshots |
-| [Infrastructure](./infrastructure/) | 53 | Next.js 16, Supabase, streaming, mobile, notifications, admin, 3D portal hub |
+| [Infrastructure](./infrastructure/) | 54 | Next.js 16, Supabase, streaming, mobile, notifications, admin, 3D portal hub, repo+estate census (836) |
 | [Community](./community/) | 44 | ZAO guide, whitepaper, onboarding, member profiles, task forces, people/brands |
 | [Farcaster](./farcaster/) | 42 | Protocol, Mini Apps, XMTP, ecosystem, social graph, agentic bootcamp |
 | [Governance](./governance/) | 41 | Respect, ORDAO, Hats, ZOUNZ, fractals, Snapshot, BuilderOSS |

--- a/research/infrastructure/836-zaoos-repo-estate-census/README.md
+++ b/research/infrastructure/836-zaoos-repo-estate-census/README.md
@@ -1,8 +1,28 @@
+---
+topic: infrastructure
+type: audit
+status: research-complete
+last-validated: 2026-06-10
+superseded-by:
+related-docs: 819, 601, 471
+original-query: "can we do a full overview of this repo and how it all works look through all our git commits aswell and confirm what we have updated what is missing and we still need to build - a status on all the different parts of the repo. Plus a read-only Vercel + Supabase token census mapping projects to repos into a costed kill-list, and add that access to the repo."
+tier: STANDARD
+---
+
 # Doc 836 - ZAOOS Repo + Estate Census
 
-Date: 2026-06-09
-Status: Living snapshot (regenerate via `scripts/estate-audit/audit.sh` for the cloud half)
-Scope: Full overview of the ZAOOS monorepo - what it is, what is built, what is in flight, what is missing - plus the tooling to census the paid Vercel/Supabase estate.
+> **Goal:** Full overview of the ZAOOS monorepo (what is built, in flight, missing) plus a live census of the paid Vercel + Supabase estate mapped to repos, with a kill-list. The cloud half is reproducible via `scripts/estate-audit/audit.sh`.
+
+## Key Decisions
+
+| # | Decision |
+|---|----------|
+| 1 | KILL 54 dead Vercel projects (no deploy in 90+ days). Biggest cluster: 12 old NEXUS iterations (`nexusv-4` -> `nexusv-5-8-5`) + ~5 duplicate projects pointing at the same repo. |
+| 2 | DELETE the 2 INACTIVE Supabase projects (`zaalp99@gmail.com's Project`, `supabase-chestnut-pebble`) once confirmed no data is needed - they are auto-paused, cost $0, deletable. |
+| 3 | KEEP the 32 live Vercel projects + 2 active Supabase projects (ZAOOS, ZAO STOCK). |
+| 4 | FIX the CLAUDE.md / project-map drift: it claims a `contracts/` Solidity dir that does not exist on disk. All contracts are external addresses in `community.config.ts`. |
+| 5 | CLOSE the biggest code gap: 38 of 54 API domains have no `__tests__`. Test debt, not comment debt (whole-repo TODO count is ~10). |
+| 6 | $ caveat: neither Vercel nor Supabase public API exposes per-project spend. This census flags liveness; dollar cross-check is manual against the usage dashboards. |
 
 ## 1. What this repo is
 
@@ -24,7 +44,6 @@ Playwright, Sentry.
 | Total git commits | 2,659 (since 2026-03-12) |
 | Commits, last 30 days | 752 (~25/day) |
 | Merged PRs, last 90 days | ~522 |
-| Merged PRs, last 30 days | ~274 |
 | API route handlers | 302 across 54 domains |
 | React components | ~360 across 34 feature groups |
 | Custom hooks | 18 |
@@ -32,139 +51,126 @@ Playwright, Sentry.
 | Audio providers | 9 (+ tests) |
 | SQL files in scripts/ | 129 (3 live, rest archived) |
 | Research docs | ~1,234 markdown across 18 categories |
-| Contributors | Zaal (dominant) + Claude/agents (~190 agent commits) |
 
 ## 3. Backend - API surface (302 routes / 54 domains)
 
-Largest domains: music (39), admin (29), auth (21), users (15), social (13),
-spaces (12), cron (11), publish (10), chat (10), discord (8).
-
-Coverage: 16 of 54 domains have `__tests__` (admin, auth, crm, hats, juke,
-members, music, notifications, proposals, search, snapshot, spaces, streaks,
-users, wavewarz, 100ms). 38 domains have no dedicated tests - the biggest
-correctness gap in the repo.
-
-Status: every route has a real handler. No stub/dead endpoints. Graceful
-degradation throughout (discord -> 503 when unconfigured, fractals -> on-chain
-fallback when ornode down, music/generate -> mock when HF_TOKEN missing).
+Largest: music (39), admin (29), auth (21), users (15), social (13), spaces
+(12), cron (11), publish (10), chat (10), discord (8). Every route has a real
+handler; no stubs. 16 of 54 domains have tests - the 38 untested = the biggest
+correctness gap.
 
 ## 4. Frontend - components / hooks / lib
 
 Biggest subsystems: music (64 components), spaces (58), social (22), admin (21),
-chat (18). Plus an "os" shell (phone shell, app drawer, dock, widgets).
-
-lib highlights: agents (autonomous treasury), publish (8-platform posting),
-spaces (Juke + RTMP + gating), music (filters, waveform, Audius/LastFM/Tidal/
-Songlink), hats, wavewarz, empire-builder, plus infra (db, auth, farcaster, ens,
-wagmi, xmtp, validation, security).
-
-Audio: 9 source providers (HTML5, Spotify, Apple Music, YouTube, Soundcloud,
-Tidal, Bandcamp, Radio) behind a single PlayerProvider.
+chat (18), plus an "os" phone shell. 9 audio source providers behind one
+PlayerProvider. lib spans agents, publish (8 platforms), spaces, music, hats,
+wavewarz, empire-builder + infra.
 
 ## 5. Agent stack (bot/)
 
-Matches the post-doc-601 "5 surfaces" model. All updated 2026-06-09.
+Matches the locked 5-surface model (doc 601), all updated 2026-06-09: ZOE
+concierge (44 files), Hermes fix-PR (13), ZAO Devz (minimal), Teams (attabotty/
+magnetiq personas), root ZAOstock bot. Treasury agents VAULT/BANKER/DEALER in
+`src/lib/agents/` are thin wrappers over a shared runner. Confirmed dead and NOT
+in active code: openclaw, Composio AO, Agent Zero, 7-agent squad, 10-bot fleet.
 
-| Subsystem | Path | Status |
-|-----------|------|--------|
-| ZOE concierge | `bot/src/zoe/` | Active. 44 files - memory (25KB), proactive, decompose/dispatch, scheduler, critics, posts, farcaster, safety |
-| Hermes (fix-PR) | `bot/src/hermes/` | Active. 13 files - runner, claude-cli, coder, critic, git, pr-watcher, preflight |
-| ZAO Devz | `bot/src/devz/` | Active but minimal (index.ts 18KB). Phase-3 fold into Hermes still pending |
-| Teams (attabotty, magnetiq) | `bot/src/teams/` | Active. Persona blocks, shared brain/memory |
-| Fleet-agent | `bot/src/fleet-agent/` | Lightweight runner (3.4KB) |
-| Root bot (ZAOstock) | `bot/src/*.ts` | Active. index.ts 50KB dispatcher + actions/digest/circles/status |
+## 6. What is missing / half-built
 
-On-chain treasury agents live in `src/lib/agents/` (VAULT / BANKER / DEALER),
-all thin wrappers over a shared `runner.ts` (buy -> burn -> stake cycle, 0x
-swaps, config-driven spend caps). Trading is gated by `config.trading_enabled`.
+UI-complete-backend-missing: music NFT mint (Arweave not wired), ambient mixer,
+Kick connect, festival photos. Disabled: Lens + Hive publishing, OpenRank (their
+SSL expired Mar 2026). Real TODOs: agent dead-letter queue (events.ts:24,
+doc-457), OrDAO partial ABI, `music/generate` no rate limit, miniapp auth
+consolidation. Drift: `contracts/` dir claimed by map but absent.
 
-Confirmed dead/decommissioned (per doc 601, NOT in active code): openclaw,
-Composio AO, Agent Zero, the 7-agent squad, 10-bot branded fleet. Only
-historical comments remain.
+## 7. The paid estate - CENSUS COMPLETE (2026-06-10)
 
-## 6. Contracts
+Run with read-only, short-lived tokens via `scripts/estate-audit/audit.sh`.
+Raw dumps in `~/.zao/private/` (off-repo). Tokens revoked post-run.
 
-No `.sol` files / no `contracts/` dir in the repo (the project map lists one,
-but it is not present - all contract interaction is against external addresses
-configured in `community.config.ts`): Respect tokens OG+ZOR on Optimism, Hats
-Protocol v1 (treeId 226), ZOUNZ Nouns Builder DAO on Base, Snapshot (zaal.eth).
+### Vercel - 86 unique projects: 32 live, 54 dead
 
-DRIFT NOTE: CLAUDE.md / project map claims a `contracts/` directory with
-Solidity (staking, bounty board). It does not exist on disk. Either it
-graduated out or never landed - update the map.
+(A "project" is counted once after dedup-by-id; the API returns each under both
+personal scope and the `bettercallzaals-projects` team.)
 
-## 7. What is in flight (last 60 days churn)
+Dead = no deployment in 90+ days. Notable waste:
+- **12 old NEXUS iterations** (`nexusv-4` through `nexusv-5-8-5`), all dead since
+  July 2025. Only live `zaonexus` is current. Kill all 12.
+- **Duplicate projects, same repo:** `16statestreet` x3, `unifiedchatclient` x2,
+  `followingchurn` x2. ~5 extra projects that are pure dupes.
 
-Most-churned dirs: `src/app/stock/team` (150), `docs/daily` (150),
-`bot/src/zoe` (135), `scripts` (100), `content/transcripts/bcz-yapz` (86),
-`src/components/spaces` (57), `bot/src/hermes` (51), `src/lib/agents` (48).
+Full 54-project kill-list (name <- linked repo), newest-dead first:
+resumev-1, bettercallzaal-coding-hub, zounz, zski, ww, 16statestreet (x3),
+bettercallzaal-strategies, ethboulderjournal, zao-stock, zabalbot,
+zao-leaderboard, zabalnewsletter, zabalsocials, agencyweb3toolkit, zaoprojects,
+zaaltimelinev1, zaaltimelinev1-1, v0-solana-governance-d-app,
+v0-zao-music-marketplace-v1, unifiedchatclient (x2), cedartide,
+fractalbotnov2025, wwinfo1, artivisminmaine1, wwtest1, nexusv-4 ... nexusv-5-8-5
+(12), avaxpayments-v1, sideby-sidev2, v0-billable, monorepo-turborepo,
+whatgenreareyou, soundz-v1, followingchurn (x2), followertest, loanz-platform-1.
 
-Active threads:
-- ZAOstock spinout prep (stock/team) - graduates to its own repo/DB/domain.
-- Agent stack (ZOE 135 + Hermes 51 + lib/agents 48 = 234 changes).
-- Spaces/Juke hardening (ghost cleanup, live counts, room-id persist, pinned
-  links) + FISHBOWLZ removal.
-- CRM moved Supabase-native (away from Airtable; migrations 20260529 / 20260531).
-- Research capture at ~1.5 docs/day.
+32 live (keep): zaoos, zao-video-editor, zaonexus, bettercallzaalwebsite, zpoidh,
+zuke, co-c-concert-z, zaofractal, zabalart, zlank, riverside-group-demo, bcz-yapz,
+zaostock, imanprojects, wavewarzapp, farmdrop, zaal-donate-button, ltaesnap,
+crownvics, fishbowlz, duodo-snap, nouns-snap, zabalsnap1, aurdour, textsplitter,
+b-zbuild-2, plus 6 `v0-*` scratch deploys.
 
-## 8. What is missing / half-built (the honest gaps)
+### Supabase - 4 projects: 2 active, 2 inactive
 
-Feature-incomplete (UI exists, backend not wired):
-- Music NFT minting - `MintTrack.tsx:110` throws "Arweave minting not yet
-  configured"; Arweave backend not deployed.
-- Ambient Mixer - "coming soon" placeholder (`AmbientMixer.tsx:286`).
-- Kick connect - "coming soon" (`KickConnect.tsx:136`).
-- Festivals photos - "coming soon" (`festivals/page.tsx:117`).
+| Project | Status | Created | Region |
+|---------|--------|---------|--------|
+| ZAOOS | ACTIVE_HEALTHY | 2026-03-12 | us-west-2 |
+| ZAO STOCK | ACTIVE_HEALTHY | 2026-04-29 | us-west-2 |
+| zaalp99@gmail.com's Project | INACTIVE | 2025-12-26 | us-east-1 |
+| supabase-chestnut-pebble | INACTIVE | 2026-02-27 | us-east-1 |
 
-Disabled integrations:
-- Lens + Hive publishing commented out in `PlatformToggles.tsx` (wallet
-  complexity / deferred, ref research/121).
-- OpenRank engagement scoring off - their SSL cert expired Mar 2026
-  (`members/[username]/route.ts:164`).
-- Tidal / Sopha silently null when unconfigured.
+INACTIVE = Supabase auto-paused (free-tier idle pause). Paused = $0, data
+retained, deletable. The cowork tracker DB (`etwvzrmlxeobinrlytza`) is NOT here -
+it lives under Iman's account.
 
-Real TODOs worth tracking:
-- Agent event dead-letter queue not wired (`lib/agents/events.ts:24`,
-  doc-457) - failed agent events are dropped.
-- OrDAO client uses a partial ABI pending `@ordao/contracts` npm publish.
-- `music/generate` has no per-user rate limit on an expensive AI call.
-- miniapp auth: two routes need consolidation onto QuickAuth JWT
-  (`miniapp/auth-context/route.ts:13`) - currently accepts unsigned FID claims
-  (hardened against admin-grant, but still a refactor owed).
-- ZOE scheduler Phase-4 tip generation is a stub (`scheduler.ts:247`).
+### $ gap (both)
 
-Test debt: 38 of 54 API domains untested; whole-repo TODO/FIXME count is low
-(~10) so debt is concentrated in coverage, not littered comments.
+No per-project spend or DB size via either public API. Cross-check:
+- Vercel usage: https://vercel.com/account/usage
+- Supabase usage: https://supabase.com/dashboard/org/_/usage
+- Supabase DB size: `select pg_size_pretty(pg_database_size(current_database()));`
 
-Stale branches: ~50 April worksession branches on origin, abandoned, safe to
-prune.
+## 8. The tooling (shipped this PR)
 
-## 9. The paid estate (Vercel + Supabase) - tooling shipped, run pending
+`scripts/estate-audit/audit.sh` + README. Lists every Vercel project (last-deploy
+age -> dead flag, deduped by id, mapped to git repo) and every Supabase project
+(status -> paused flag), prints kill-candidate lists. Tokens read from
+`~/.zao/estate-tokens.env` (off-repo, gitignored via `*estate-tokens*`, never
+printed). Raw dumps -> `~/.zao/private/` per `.claude/rules/pii-hygiene.md`. Bug
+fixed during this run: bash-subshell comma corruption in JSON assembly -> rewrote
+to JSONL + `jq -s unique_by(.id)`.
 
-The cloud-cost half of this census needs read-only tokens that are not yet on
-the machine. Tooling is shipped at `scripts/estate-audit/`:
+## 9. Bottom line
 
-- `audit.sh` lists every Vercel project (per scope, with last-deploy age ->
-  dead flag) and every Supabase project (status -> paused/abandoned flag),
-  maps Vercel projects to their linked git repo, and prints a kill-candidate
-  list for each.
-- Tokens read from `~/.zao/estate-tokens.env` (off-repo, gitignored, never
-  printed). Raw dumps -> `~/.zao/private/` per pii-hygiene rules.
-- API gap: neither Vercel nor Supabase public API returns per-project $ spend
-  or DB size. The script flags liveness; dollar cross-check is manual against
-  the usage dashboards (documented in the script output + README).
+Production-grade, extremely active repo. Backend fully implemented, frontend
+broad, agent stack matches the locked model with no zombie code. Real gaps:
+(1) test coverage on ~70% of API domains, (2) a few UI-complete-backend-missing
+features, (3) agent dead-letter queue, (4) 54 dead Vercel projects + 2 paused
+Supabase projects to clean up. The cloud estate is now censused and reproducible.
 
-To run: create 1-day read-only tokens, write the env file, then
-`bash scripts/estate-audit/audit.sh`. Revoke both tokens after (Supabase PATs
-are account-wide).
+## Also See
 
-## 10. Bottom line
+- [Doc 819](../../agents/) - ZAOcowork architecture audit (sibling infra audit)
+- [Doc 601](../../agents/601-agent-stack-cleanup-decision/) - locked 5-surface agent model
+- [Doc 471](../../security/471-vercel-oauth-breach-apr2026/) - prior Vercel-side incident
 
-The repo is production-grade and extremely active. Backend is fully
-implemented, frontend is broad, the agent stack matches the locked 5-surface
-model with no zombie code. Real gaps are: (1) test coverage on ~70% of API
-domains, (2) a handful of UI-complete-but-backend-missing features (music mint,
-ambient mixer, a few connectors), (3) agent event dead-letter queue, (4) the
-cloud-cost kill-list still needs tokens to run. The institutional-memory bet
-(1,234 research docs) is paying off - this census was assembled almost entirely
-from the repo itself.
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Delete 54 dead Vercel projects (start with 12 NEXUS + 5 dupes) | @Zaal | Manual (Vercel dashboard) | Next cleanup |
+| Delete 2 INACTIVE Supabase projects after confirming no data needed | @Zaal | Manual (Supabase dashboard) | Next cleanup |
+| Cross-check live projects against Vercel usage dashboard for bandwidth/cron spend | @Zaal | Manual | Optional |
+| Fix CLAUDE.md / project-map `contracts/` drift (dir does not exist) | @Zaal | PR | Next docs pass |
+| Schedule test-coverage push for the 38 untested API domains | @Team | Planning | Backlog |
+
+## Sources
+
+- [FULL] Vercel REST API `/v9/projects` + `/v2/teams` - censused 2026-06-10, 86 unique projects (raw dump `~/.zao/private/vercel-estate-20260610-155641.json`)
+- [FULL] Supabase Management API `/v1/projects` - censused 2026-06-10, 4 projects (raw dump `~/.zao/private/supabase-estate-20260610-160236.json`)
+- [FULL] ZAOOS git history + working tree - 2,659 commits, scanned 2026-06-09 via 5 parallel exploration agents
+- [FULL] `scripts/estate-audit/audit.sh` - the reproducible census tool shipped in this PR

--- a/scripts/estate-audit/audit.sh
+++ b/scripts/estate-audit/audit.sh
@@ -72,10 +72,10 @@ vercel_section() {
   curl -sf -H "${auth}" "https://api.vercel.com/v2/teams?limit=100" \
     > "${OUT_DIR}/vercel-teams-${STAMP}.json" 2>/dev/null || echo '{"teams":[]}' > "${OUT_DIR}/vercel-teams-${STAMP}.json"
 
-  # Personal scope first, then each team
-  : > "${raw}"
-  echo "[" >> "${raw}"
-  local first=1
+  # Collect projects across personal + each team scope as JSONL (one obj per
+  # line), then slurp into a valid JSON array. Avoids subshell comma bugs.
+  local jsonl="${OUT_DIR}/vercel-estate-${STAMP}.jsonl"
+  : > "${jsonl}"
 
   fetch_scope() {
     local teamq="$1" scopelabel="$2"
@@ -83,11 +83,16 @@ vercel_section() {
     while [[ -n "${url}" ]]; do
       local page
       page=$(curl -sf -H "${auth}" "${url}") || break
-      echo "${page}" | jq -c --arg scope "${scopelabel}" '.projects[] | {scope:$scope, name, id, framework, updatedAt, latestDeployments: (.latestDeployments // []), repo: (.link.repo // .link.org + "/" + .link.repo // null), link}' \
-        | while IFS= read -r line; do
-            if [[ ${first} -eq 1 ]]; then first=0; else echo "," >> "${raw}"; fi
-            echo "${line}" >> "${raw}"
-          done
+      echo "${page}" | jq -c --arg scope "${scopelabel}" '
+        .projects[] | {
+          scope: $scope,
+          name, id, framework, updatedAt,
+          latestDeployments: (.latestDeployments // []),
+          repo: ((.link.org // "") as $o | (.link.repo // "") as $r |
+                 if $r == "" then null
+                 elif $o == "" then $r
+                 else $o + "/" + $r end)
+        }' >> "${jsonl}"
       local next
       next=$(echo "${page}" | jq -r '.pagination.next // empty')
       if [[ -n "${next}" ]]; then
@@ -104,7 +109,11 @@ vercel_section() {
         [[ -z "${tid}" ]] && continue
         fetch_scope "&teamId=${tid}" "${tslug}"
       done
-  echo "]" >> "${raw}"
+
+  # Slurp JSONL -> JSON array, dedupe by project id (a project is returned once
+  # under personal scope AND once per team the token can see - same id).
+  jq -s 'unique_by(.id)' "${jsonl}" > "${raw}"
+  rm -f "${jsonl}"
 
   echo
   echo "----------------------------------------------------------------"


### PR DESCRIPTION
Follow-up to #832 (which merged with only the tooling commit). This lands the full census: doc 836 Vercel (86 proj, 54 dead) + Supabase (4 proj, 2 inactive) data, kill-list, Next Actions; README 'Repo & estate at a glance' overview; audit.sh dedupe-by-id fix; research index registration.

Cherry-picked from the merged branch's second commit.

Generated with Claude Code