### PR TITLE
docs: meeting recaps 839 (Fellenz brand/org) + 840 (WIP x ZABAL Games event)

### DIFF
--- a/research/dev-workflows/838-media-capture-distribute-pipeline/README.md
+++ b/research/dev-workflows/838-media-capture-distribute-pipeline/README.md
@@ -1,0 +1,103 @@
+---
+topic: dev-workflows
+type: decision
+status: research-complete
+last-validated: 2026-06-10
+superseded-by:
+related-docs: "836, 829, 833, 832, 824"
+original-query: "Make the goal keep mining and find the best way to distribute and capture good information from media like this"
+tier: STANDARD
+---
+
+# 838 - Media Capture & Distribute Pipeline (the standing system)
+
+> **Goal:** Turn this session's ad-hoc "fetch -> read -> doc" motion into a repeatable ZAO pipeline: capture good information from media (X articles, videos, threads, Reddit, Farcaster, podcasts), synthesize it once, and distribute it everywhere - so mining compounds instead of evaporating.
+
+## The one-line answer
+
+**Capture -> Synthesize -> Distribute, with the inbox as the universal funnel, the research library + Bonfire as the synthesis store, and a routing layer to the social surfaces.** ZAO already owns every piece; the gap is they're disconnected. Wire them into one loop and the "keep mining" goal runs itself.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | **Keep the ZOE inbox (`zoe-zao@agentmail.to`) as the universal CAPTURE funnel - forward anything, anywhere** | It is the lowest-friction capture surface (forward from a phone). Now that the keyless trio fetches every link type FULL (docs 824/822/823), a forwarded link is a complete capture, not a title. One funnel, all media types. |
+| 2 | **Add a recurring MINING engine as the second capture source (push, not just pull)** | The inbox is pull (Zaal forwards). The doc-836 + round-2 mining workflows are push - they go find signal from known high-signal authors. Schedule the mining workflow weekly (cron, like the fetch-healthcheck) so new agent/AI content is captured without Zaal lifting a finger. |
+| 3 | **Route each capture to the RIGHT synthesis store by type: deep -> research doc, queryable -> Bonfire episode, durable fact -> memory** | Don't dump everything in one place. A 2,500-word talk -> a research doc (836/829). A one-line decision -> a memory. A "what did X say about Y" fact -> a Bonfire episode (agent-queryable). This is the synthesis layer that makes captures retrievable later. |
+| 4 | **Distribution is a routing layer, not a manual step: high-signal synthesis auto-drafts to `/socials` + `/newsletter` + Bonfire, queued for one-tap Zaal review** | The leak today is that good synthesis dies in a research doc nobody re-reads. Every doc with public-shareable signal should auto-generate a Farcaster/X draft (`/socials`) and a newsletter blurb, queued for approval. Distribution closes the loop: shared content attracts more captures. |
+
+## Findings - the pipeline, stage by stage
+
+### Stage 1 - CAPTURE (get the raw signal in)
+
+| Surface | What it captures | Status |
+|---------|------------------|--------|
+| ZOE inbox (forward to AgentMail) | any link/idea from phone | live; keyless-fetch now (doc 824) |
+| Keyless fetch trio | Reddit / X+Articles / Farcaster, FULL bodies | live (docs 822/823/824) |
+| `zao-ingest.sh` | YouTube / Spotify / podcast / video -> transcript | live (used for the Anthropic Skills talk, doc 829) |
+| Mining workflow | push-discovery from known authors | built this session (docs 836 + round 2); not yet recurring |
+| WebFetch / exa | articles, blogs, GitHub | live |
+
+**Gap:** the inbox is pull-only and mining is one-shot. Fix = schedule the mining workflow (Decision 2).
+
+### Stage 2 - SYNTHESIZE (turn signal into retrievable knowledge)
+
+| Store | For | Retrieval |
+|-------|-----|-----------|
+| Research library (`research/**/README.md`, 836+ docs) | deep synthesis, decisions, comparisons | grep / future MCP resource server |
+| Bonfire knowledge graph (`zabal.bonfires.ai`) | queryable episodes - "what did X say about Y" | POST /delve (doc on Bonfire recall) |
+| Memory files (`feedback_*`, `project_*`) | durable facts + corrections | loaded each session |
+| Cowork tracker | actions that fell out of a capture | Kanban |
+
+**This is the Thariq "compound knowledge base" vision (doc 829/836):** anything captured + written down is usable by a future agent. The research library + Bonfire + memory are exactly that - they compound. **Gap:** captures don't auto-flow to Bonfire (a research doc rarely becomes an episode), so the agent-queryable layer is under-fed.
+
+### Stage 3 - DISTRIBUTE (push the synthesis out)
+
+| Surface | Reach | Status |
+|---------|-------|--------|
+| `/socials` skill | Farcaster + X (Firefly), Telegram, Discord, LinkedIn | live, manual |
+| `/newsletter` | paragraph.xyz/@zao daily blog | live, manual |
+| ZOE Telegram posts | 4-category daily pings | live |
+| `/clipboard` | copy-ready share blocks | live |
+| Bonfire | agent-to-agent distribution (other ZAO bots query it) | live |
+
+**Gap:** distribution is fully manual and disconnected from synthesis. A doc ships, then someone separately decides to socialize it - usually never. Fix = Decision 4 (auto-draft from synthesis).
+
+### The closed loop (the "best way")
+
+```
+  forward / mine  ->  fetch FULL (keyless trio + ingest)  ->  synthesize
+       ^                                                          |
+       |                                                          v
+   more captures  <-  distribute (socials/newsletter/Bonfire)  <- route by value
+```
+
+The loop is what makes it a *system* rather than a chore: distributed content attracts new forwards + followers, which feed the next capture. Mining keeps the top of the funnel full even when Zaal is heads-down.
+
+## ZAO Application - what to build (smallest -> biggest)
+
+1. **Schedule the mining workflow weekly** (cron, mirrors `zao-fetch-healthcheck`). Push-capture runs itself. (small)
+2. **Capture -> Bonfire bridge:** every research doc's Key Decisions auto-post as a Bonfire episode (PII-scrubbed per `pii-hygiene`). Feeds the agent-queryable layer. (medium)
+3. **Synthesis -> `/socials` auto-draft:** a doc tagged shareable generates a Farcaster/X draft + newsletter blurb, queued in the inbox/clipboard for one-tap Zaal approval. (medium)
+4. **ZOE as the pipeline orchestrator:** ZOE runs the loop - mines, routes captures to the right store, queues distribution drafts. The standing "keep mining" engine. (big; the doc-759-class orchestrator job)
+
+## Also See
+
+- [Doc 836](../../agents/836-x-account-mining-agent-patterns/) - the mining that prompted this (capture in action)
+- [Doc 829](../../agents/829-anthropic-agent-skills-talk/) - Thariq/Anthropic "compound knowledge base" vision
+- [Doc 824](../824-keyless-forkable-fetch-trio/) - the keyless capture layer
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Schedule the round-2 mining workflow weekly (cron, like fetch-healthcheck) | @Zaal | Infra | This week |
+| Build the research-doc -> Bonfire episode bridge (PII-scrubbed) | @Zaal | Build | Next sprint |
+| Wire synthesis -> /socials auto-draft (queued for approval, not auto-post) | @Zaal | Build | Next sprint |
+| Decide ZOE's role as pipeline orchestrator (mines + routes + queues distribution) | @Zaal | Decision | When bandwidth |
+
+## Sources
+
+- This session's lived pipeline: inbox drain (docs 832/833), keyless fetch trio (824/822/823), ingest (829), mining (836 + round 2) `[FULL - primary; the system was run end-to-end this session]`
+- [Thariq - compound knowledge base / skills as memory](https://github.com/shanraisshan/claude-code-best-practice/blob/main/tips/claude-thariq-tips-17-mar-26.md) `[FULL - the "write it down for a future agent" thesis underpinning the synthesis layer]`
+- ZAO existing surfaces: `/socials`, `/newsletter`, `/clipboard`, `/bonfire`, `zao-ingest.sh`, the cowork tracker `[FULL - existing skill/tool inventory]`

--- a/research/events/839-fellenz-brand-org-strategy/README.md
+++ b/research/events/839-fellenz-brand-org-strategy/README.md
@@ -1,0 +1,181 @@
+# 839 - Fellenz x Zaal: Brand + Org-Structure Strategy Call
+
+FLAG: IMPORTANT. This is a high-signal brand/org-structure critique. Tom Fellenz - an experienced event producer and ZAOstock advisor - walked Zaal through a set of brand challenges he sees in how The ZAO, ZABAL, ZABAL Games, COC Concertz, and ZAOstock are being communicated. The explicit goal of this recap is to capture EVERY challenge he raised and pair each with a concrete way to address it.
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-06-10 |
+| Duration | ~52 min |
+| Platform | Discord / Craig (per-speaker multitrack) |
+| Attendees | Zaal Panthaki, Tom Fellenz |
+| Project | ZAOstock / The ZAO (brand + org strategy) |
+| Source | craig-aobWYvWS0JOC (1-zaal.wav + 2-fellenz.wav) |
+| Transcript | [transcript.md](transcript.md) |
+
+Note on transcript quality: per-speaker multitrack gives perfect speaker labels. Fellenz's track picked up whisper hallucination on his quiet/silent stretches (repeated "I'm going to go ahead and get some more of the stuff" lines) - those are noise, not speech. Every substantive Fellenz turn is intact and is the basis for the challenges below.
+
+---
+
+## The headline
+
+Fellenz's core thesis: **The ZAO is the brand, and it is being eclipsed by ZABAL in external communication.** Everything downstream (ZABAL Games scope, COC Concertz framing, the AI/Telegram overhead, the missing org chart) feeds that one problem. "Less is better. Get it back to natural."
+
+Quote that anchors it:
+
+> "Everything that you're communicating with the COC, you're not saying The ZAO anymore. You're saying ZABAL. Really, you're losing the brand." - Fellenz
+
+Zaal's own admission:
+
+> "I didn't specify that when he made the logo, so I ended up rolling with it without thinking too much." - Zaal
+
+---
+
+## Brand + org challenges (every one Fellenz raised) - paired with how to address
+
+### Challenge 1 - ZABAL is eclipsing The ZAO in external comms
+Fellenz: in comms with COC and partners, Zaal leads with "ZABAL," not "The ZAO." The brand he built (The ZAO - "really easy to say and really natural") is getting diluted by ZABAL Games showing up as the lead. Root cause Zaal named: the logo designer led with ZABAL Games and Zaal rolled with it un-deliberately.
+
+How to address:
+- Audit every external surface (COC comms, ZAOstock decks, event pamphlets, Telegram group names) and make **The ZAO the top-level brand** everywhere outward-facing.
+- ZABAL stays an internal builder/toolstack identity, not the marquee.
+- Fix the logo/lead-brand decision deliberately rather than by inertia.
+
+### Challenge 2 - ZABAL Games scope is muddled: hackathon/dev-engagement vs event-ops
+Fellenz expected ZABAL Games to be about **engaging outsiders in vibe coding / app development** - mentors sharing knowledge, people building apps - "kind of like WaveWarZ" where the participants are not all ZAO members. He sees the real opportunity as Zaal becoming a **"micro-ETH Denver / ETH Global"**: an environment of resources + technology where people build apps and even spin off new communities. Instead, Zaal has "stacked it full of all the Zao activities," which buries that engagement promise.
+
+How to address:
+- Pick the primary identity of ZABAL Games: a **dev/builder engagement program for outsiders** (the micro-ETH-Global framing) is what Fellenz sees as the win.
+- Stop loading internal ZAO operational activity into the ZABAL Games surface. Keep the Games about building, not running The ZAO's events.
+- Lean into the "Games = engagement" read (the WaveWarZ analogy): outsiders come IN to participate, they are not pre-existing members.
+
+### Challenge 3 - Internal org work is consuming the space meant for outside participants
+Tightly coupled to #2. Fellenz's delineation: Zaal's own team members are naturally active in ZABAL Games doing ZAO work - but that is **organizational work**, distinct from **outsiders participating in the Games**. Using ZABAL Games technology to run ZAO/festival projects "consumes the space" intended for people outside ZABAL. If the goal is to attract outsiders, the org-ops use and the open-participation use have to be separated.
+
+How to address:
+- Draw a hard line: **org operations (your team, doing ZAO work)** vs **the Games (outsiders building)**. Two different uses of the same toolstack, two different surfaces.
+- If you want non-DAO / outside builders in, make the entry point about building, not about ZAO internal coordination.
+
+### Challenge 4 - COC Concertz framing claims ownership it shouldn't
+Fellenz's "respect thing": the way it reads, The ZAO is claiming top-level ownership of COC's brand, making COC subservient. "It's not the Zao COC." COC is a **top-level organization equal to The ZAO**; the concerts are a **partnership**. He flagged a gut reaction that Zaal is "claiming top level ownership of COC Concertz."
+
+Clarification surfaced in the call: on the Hats chart, **Thy Revolution is the lead for COC Concertz** (he founded the COC and owns COC Concertz as his ZAO contribution); Zaal is a worker on that team. So the ownership Fellenz worried about is more nuanced than the comms imply - but the COMMS still read as ZAO-owns-COC.
+
+How to address:
+- Reframe COC Concertz as a **partnership**, side by side: e.g. "ZAO Festivals + COC Concertz," not "The ZAO's COC concerts."
+- Make Thy-Revolution-as-lead visible in how COC Concertz is presented externally (matches the actual Hats chart).
+- Have a deeper explicit ownership/branding conversation with Thy Rev + the COC core team (Zaal: "maybe I have been mis-assuming some portions of ownership with them, and maybe I should have this conversation deeper with them").
+
+### Challenge 5 - No shared org chart; hierarchy is unclear
+Fellenz repeatedly: "give me the org chart... you might want to do that and share with people." He distilled it live to keep it simple - it does not need to be complicated.
+
+Fellenz's proposed structure:
+- **The ZAO** = top level, community focus.
+- **Community projects** (the community collaborations) - do not need to name them individually.
+- **ZABAL** (the toolstack / builder org).
+- **WaveWarZ**.
+- **COC Concertz** and similar = **community partnerships** (his recommended label), NOT "projects under The ZAO."
+
+How to address:
+- Build a simple one-page org chart and **share it with the team + partners**.
+- Use Fellenz's "community partnerships" label for COC etc. instead of "project under The ZAO," to respect partner ownership.
+- This chart doubles as the missing entry-point map (see #7).
+
+### Challenge 6 - The AI/agent layer is overhead; Telegram is unreadable
+Fellenz: "you're embedding the organization into your AI app. It is overhead for a participant that isn't necessary." The Telegram breakout groups are "so dense with code... the content is lost in it." He has to scan past system prompts and agent thoughts hunting for "the human words that are of meaning." The agent interaction "interferes with quick communication."
+
+How to address (Fellenz's own prescription):
+- **Push agent/system-prompt activity into the background.** Keep the visible chat **natural language** only.
+- Let people **audit** the agent thoughts separately if they want to - but do not make them the default surface.
+- **Ingest the clear-text human chat in real time, generate action items / a daily summary** from it, rather than stacking the group full of system output.
+- Possible mechanic discussed: keep the existing per-department groups but reload/regrade them so bot messages are hidden, and **set the bots to silent**. Zaal's near-term lean: rather than fully restructure, just put the important people for a project into one group and decide whether to capture it after the fact.
+- Net: "get it back to natural."
+
+### Challenge 7 - "Build it and they will come" - no clear entry point
+Fellenz: "You've built it and you've arrived. And it's just like, where do I go?" People who want to help do not know where to plug in. The receptors/receivers of other people's work are not visible; they are cluttered by everything Zaal is generating.
+
+How to address:
+- Make the **entry point explicit**: where does a willing-but-new person go to add their time/energy?
+- Surface the **receivers of work** clearly and de-clutter them from the generation noise.
+- Zaal's resonance: "There's so many people around different brands right now that are willing and excited to support, but they don't know where to add their time, effort, and energy" - those are exactly the people the entry-point fix targets.
+
+### Challenge 8 - Onboarding/assessment + volunteer commitment are undefined
+Fellenz: put "a fine definition of onboarding / assessing." Once people commit to their groups, communication should just flow - with the assumption that an engaged person is watching their group. The accountability/engagement piece is the hardest part: setting the expectation that "if you're online, you should be looking at this." Zaal admitted the gap directly: "One of the things I have not done is made an agreement or an expectation of what someone else is doing when they want to volunteer, or where the lines lie in their commitment."
+
+How to address:
+- Define an **onboarding + assessment** step (who are you, what are your strengths/weaknesses, how much time can you give).
+- Set an **explicit volunteer commitment agreement / expectation** so accountability is possible.
+- Capture **time availability** as a parameter (Zaal noted he had not added that parameter yet).
+
+---
+
+## Decisions made on the call
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | Restart the team standup at **Tuesday 11:30am** (move off 10am, which collides with Zaal's day-job hours), and put it out publicly | Zaal | high |
+| 2 | Propose ZABAL Games as a **project under The ZAO** over the coming months and clean up the branding around it | Zaal | medium |
+| 3 | COC Concertz lead is **Thy Revolution** (COC founder owns it as his ZAO contribution); Zaal is a worker on that team | Both | high |
+| 4 | ZAOstock event basics confirmed: **stage + venue + tent via Wallace Events** (handshake, paperwork still to sign); after-party at **Black Moon** bar; rockumentary collab with a bar owner's band | Zaal | medium |
+
+---
+
+## Action items
+
+| Action | Owner | Confidence |
+|--------|-------|-----------|
+| Build a one-page **org chart** (The ZAO top / community focus; community partnerships labeled as such; ZABAL; WaveWarZ; COC Concertz) and share it with team + partners | Zaal | high |
+| Re-elevate **The ZAO as the lead brand** in all external comms; stop leading with ZABAL (esp. in COC comms) | Zaal | high |
+| Decide + document **ZABAL Games scope** (outsider dev/hackathon engagement vs internal event-ops) and delineate the two uses | Zaal | high |
+| Re-frame **COC Concertz as a partnership** ("ZAO Festivals + COC," side by side); have the deeper ownership/branding conversation with Thy Rev + COC core | Zaal | high |
+| **Restructure Telegram**: hide bot/system-prompt messages, set bots to silent, keep human chat natural-language; ingest clear-text -> daily summary / action items | Zaal | high |
+| Restart **Tuesday 11:30am standup**, publicly | Zaal | high |
+| Define **onboarding/assessment + volunteer commitment agreement**; add a **time-availability parameter** | Zaal | high |
+| Build a clear **entry point** ("where do I go") - surface receivers of work, de-clutter from generation | Zaal | medium |
+| Go **in person to Wallace Events** with a printed sponsorship pamphlet showing exactly where their emblem would appear on ZAO materials | Zaal | medium |
+| (Idea) Onboarding **Farcaster mini-app** that reads a person's social graph, researches their profile, and assigns them a couple of ZAO/hackathon projects + captures strengths + time | Zaal | low (idea stage) |
+
+---
+
+## Key quotes
+
+> "Everything that you're communicating with the COC, you're not saying The ZAO anymore. You're saying ZABAL. Really, you're losing the brand." - Fellenz
+
+> "When I hear games, I hear more engagement, kind of like WaveWarZ... You are becoming a micro-ETH Denver, ETH Global, where you are developing an environment of resources, technology, to actually build apps within, or spin off other communities from." - Fellenz
+
+> "You're embedding the organization into your AI app. And it is overhead for a participant that isn't necessary." - Fellenz
+
+> "You've built it and you've arrived. And it's just like, where do I go?" - Fellenz
+
+> "It seems like you're claiming top level ownership of COC Concertz... it's not the Zao COC. It's a partnership." - Fellenz
+
+> "Just to keep it really simple again, get it back to natural. Less is better." - Fellenz
+
+> "I think you're amazingly on the money, and I've been too busy in the weeds to look at that from one of the perspectives that you have." - Zaal
+
+---
+
+## Fellenz context (for the file)
+
+- Experienced event producer: "I've either run or been part of like 20 major events" - 200-300 person auditoriums, school cafeterias, full setup/teardown, feeding people. Core value: "leaving it better than you found it."
+- Performed for the COC years ago (the "meta builders" era, the "yeater fundraiser") - predates Zaal's 2023 arrival, so different from today's COC Concertz.
+- Thorough, asks structured questions; Zaal explicitly values it ("you're super thorough... it gives me the opportunity to explore what I'm actually thinking").
+- Considering coming to Maine for ZAOstock; flight cost has dropped to ~$600 (from ~$900).
+- Role: brand + org-structure advisor to Zaal; ZAOstock advisory (see doc 476, doc 722f people network).
+
+---
+
+## Cross-references
+
+- Doc 476 - ZAOstock Apr 22 team recap (Fellenz first logged as advisory)
+- Doc 722f - people network (Fellenz)
+- [[project_zao_vs_zabal_projects]] - the ZAO-vs-ZABAL taxonomy this call stress-tests
+- [[project_zao_brand_legal_architecture]] - BCZ Strategies LLC / ZABAL umbrella / The ZAO no-legal-entity-yet, which Fellenz probed ("is ZABAL going to be a legal entity?")
+- [[project_zao_festivals_umbrella]] - "ZAO Festivals presents" framing Fellenz endorsed for COC
+- [[project_dcoop]] - Zaoville, the event Zaal cited as a jump-off for ZAOstock
+- [[project_zao_incubator_model]] - the incubator framing Zaal used (ZAO = incubator, WaveWarZ = incubated, sub-DAO spinout)
+
+## Per Zaal's instruction for this run
+
+- No GitHub push of the transcript.
+- No Bonfire episode.
+- Recap + review only, flagged IMPORTANT.

--- a/research/events/839-fellenz-brand-org-strategy/transcript.md
+++ b/research/events/839-fellenz-brand-org-strategy/transcript.md
@@ -1,0 +1,845 @@
+# Transcript - Fellenz x Zaal Brand/Org Strategy Call (2026-06-10)
+
+Source: craig-aobWYvWS0JOC, per-speaker multitrack (1-zaal.wav + 2-fellenz.wav), merged by timestamp. Perfect speaker labels from multitrack export. Fellenz's track contains whisper hallucination noise on his silent stretches (repeated filler lines) - disregard those; substantive turns are intact.
+
+Brand-glossary corrections applied mentally when reading: Zal/Zalstock=ZAOstock, Philens/Flens=Fellenz, Ziball/Zaball/ballgames=ZABAL Games, ZOW/Zaos=The ZAO, wave wars=WaveWarZ, Hurricane=Hurric4n3ike, iMand=Iman, the revolution/Rev=Thy Revolution, CFC/coc=COC Concertz, Adabody=attabotty, Candy=candytoybox/Samantha, decoup=Dcoop, zauville=Zaoville.
+
+---
+
+[00:00] Zaal: technical side.
+
+[00:00] Fellenz: Well, I was just going to, if anything, say I might want to recap just a little bit.
+
+[00:03] Zaal: I think I can be more supportive. Sorry, if you wanted to say something before that, I'll see if I can pop them out. Yeah, okay. So, this is Zal, and I'm speaking with Philens, and we're having a quick meeting about Zalstock because today, Philens was at our 10 a.m. meeting, but I had canceled it a couple weeks ago, but maybe I hadn't communicated it well with everyone. So we are having a conversation about how Ziball Games will be helping support the Zao Stock venture in multiple different ways, specifically focused on the tech need and support that is needed in addition to project management that I can't do all on my own.
+
+[00:30] Fellenz: I'm going to use this for a long time.
+
+[00:53] Zaal: and without actually prodding people, which I don't want to do, I am at a little bit of an overwhelming point with Zao Stock.
+
+[01:00] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[01:04] Zaal: However, I believe that using the Zabal Games
+
+[01:07] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[01:08] Zaal: and everything I do for Zao Stock coming forward, being part of the Zabal Games and a part of a bigger thing,
+
+[01:14] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[01:14] Zaal: can really help now support this initiative and narrative in the Zao Festival's part of the conversation and coming back from these other things.
+
+[01:21] Fellenz: I'm going to go ahead and do a little bit.
+
+[01:22] Zaal: had a great conversation today with decoup and profit about the event zauville and i think it's going to be an unbelievably amazing opportunity to jump off of for zoustock as well so the goal is to uh just get all of that energy there whether that is virtually or in person as much as we can um get our artists out there ultimately is is the biggest cost that's going to be there because like I said in that conversation which I'm going to pull up here that's what I was pulling up
+
+[01:51] Fellenz: I'm going to go ahead and get some more of the things I've been doing.
+
+[01:55] Zaal: this is our festivals I mentioned that the venue and the stage hasn't been it's been confirmed but
+
+[01:58] Fellenz: I'm going to go ahead and get some more of the things I've been doing.
+
+[02:02] Zaal: it's a handshake agreement as of now still need to sign quote unquote paperwork but in the short
+
+[02:05] Fellenz: I'm going to go ahead and get some more of the things I've been doing.
+
+[02:08] Zaal: conversation I finally interesting I don't know why this one isn't open but in the short conversation
+
+[02:12] Fellenz: I'm going to go ahead and get some more of the things I've been doing.
+
+[02:17] Zaal: that I've had after emailing and confirming we will be able to have a stage a venue and a tent
+
+[02:19] Fellenz: I'm going to go to the next video.
+
+[02:26] Zaal: situated which is awesome and all the stage and the tent are both covered by Wallace events and one of my goals is to go in there in person with a printed pamphlet of like exactly where their emblem would be on some of our stuff like basically like give them the sponsorship back and be like hey if you have any financial support and you and you like have the support there we would love it
+
+[02:49] Fellenz: I'm going to go ahead and get some more of the things I've been doing here.
+
+[02:49] Zaal: but if not like we would love to put your name on this in you know respect of these three things and then like form that relationship especially because essentially we're using the city's already
+
+[02:56] Fellenz: I'm going to go ahead and get some more of the things I've been doing here. I'm going to go ahead and get some more of the things I've been doing here.
+
+[03:03] Zaal: two month three month project on uh this same concept of an event in this parklet area
+
+[03:10] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[03:12] Zaal: with bands is mostly what people see when they see music and then come for live music.
+
+[03:17] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[03:21] Zaal: So we're going to be a really interesting twist on that, especially with the different genres.
+
+[03:24] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[03:24] Zaal: I'm really excited about it. We have confirmed the bar for the after party.
+
+[03:30] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[03:30] Zaal: I'm working with one of the bar owners on a rockumentary of sorts with one of his bands,
+
+[03:36] Fellenz: I'm going to go ahead and put it in the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of the middle of
+
+[03:39] Zaal: which is exciting. So we're going to be producing and sharing that out, which is going to be fun. And basically, we'll be able to have a portion of the bar for that as well, which will be really a great opportunity to also have like more open mic style thing, but also a little bit formalized open mic. Right. Where some artists are also going to get an opportunity to put one of them inside at night. But it'll be like a lot more casual. Right. Because it's just like, OK, this is like a place where we get drinks.
+
+[04:06] Fellenz: I'm going to get tired.
+
+[04:08] Zaal: we go after we can do some night stuff outside like projection mapping and and some things like that but ultimately like the stuff will start ending at six seven the nice thing about uh that area is that there is no like apartments no one lives in the general vicinity so there isn't like uh there is a noise ordinance but there's not necessarily a lot of people that would be very upset about it so um yeah what's up
+
+[04:36] Fellenz: I'll let you know more of the details. Just really quick, what's the name of the restaurant or bar? Is it the Black Moon right next to her? Right on. Yeah, so did I send you the pictures that I took of that single square? I kind of did a little recon myself.
+
+[04:55] Zaal: you did at one point right uh well do you just remind me how long ago it was
+
+[04:59] Fellenz: Well, I'll just drop it anyway.
+
+[05:00] Zaal: Perfect.
+
+[05:01] Fellenz: But the bottom line is that looking at that street scene,
+
+[05:06] Zaal: Thank you.
+
+[05:07] Fellenz: that's why I asked about a stage, because when we have flat ground, it's always good to have a stage. But otherwise, just dropping thoughts here and there, and thinking through.
+
+[05:20] Zaal: Because you're super thorough.
+
+[05:20] Fellenz: Yeah.
+
+[05:23] Zaal: I always appreciate the questions because it gives me the opportunity to explore what I'm actually trying. what I'm actually thinking in my head and what I'm actually communicating to everyone else.
+
+[05:31] Fellenz: Thank you.
+
+[05:33] Zaal: And that's something I have a big challenge with because I think that everyone else is going to think like I am thinking, which doesn't lead well, but it can be very powerful. Yeah, like one of those like music individuals that's like a little bit on a different strengths and weaknesses that can help nudge some of those questions that I wasn't thinking about on that side. So I appreciate that.
+
+[06:01] Fellenz: Just to give you a little context, I've either run or been part of like 20 major events. so I've gone through massive strikes 200, 300 people little auditoriums
+
+[06:25] Zaal: Yes.
+
+[06:26] Fellenz: or school cafeterias just the whole thing of putting that together and feeding people and just doing all the set up and of course all the music stuff but more than anything else is being conscientious about leaving it better than you found it and you know just being able to assure that everybody's having a good time through the event and you know
+
+[06:55] Zaal: Okay.
+
+[06:57] Fellenz: just it's really interesting to watch how you're organizing things and I think the challenge that have is that you're embedding the organization into your AI app. And it is a, it's overhead for a participant that isn't necessary.
+
+[07:25] Zaal: I was thinking about an idea recently, and that's one of the challenges I have seen.
+
+[07:30] Fellenz: And so for somebody that's outside of what your flow is, maybe there's a way to program it to generate much more palatable, much more readable information because
+
+[07:54] Zaal: and I was thinking it'd be really cool as a Farcaster mini app that when you enter it, instead of a lot of people are doing like AI chatbots and like you come in and it's like, okay, like interact with our brand by telling us about you
+
+[08:08] Fellenz: I guess I'm just thinking about the event, not the hackathon.
+
+[08:10] Zaal: or copy of Facebook or whatever. I think it'd be really cool to capture the social graph, look through, do a research, have like a specific skill, right, that looks at that individual's profile and then gives them a couple projects in the ZOW for the hackathon. And, like, again, this could be... Sorry. Yes.
+
+[08:34] Fellenz: on or no yeah i would i would definitely
+
+[08:37] Zaal: The idea of, like, capturing an individual at, like, where they are, which I think is very powerful. And coming back to the event specifically, I was thinking, it could be beneficial to push back out to all of these individuals to capture the different strengths and weaknesses that they are interested in participating in how much time, which is another big factor that I didn't add a parameter for yet.
+
+[09:04] Fellenz: Right.
+
+[09:04] Zaal: And doing that can capture more data of like what information needs to be shared with what group, right? Versus like, okay, I'm going to join any circle at any point, right? So kind of capturing that into a little bit more consolidated groups could be really powerful.
+
+[09:22] Fellenz: Well, the one thing I suggest is just putting a fine definition of onboarding, slash assessing
+
+[09:34] Zaal: Thank you.
+
+[09:35] Fellenz: and then once the people have committed to being in their respective groups then the communication should just be in flow and I guess you would need to make some assumptions that once they are quote unquote engaged that they are watching the flow in that particular group. Now, just looking at the contents of all the different groups inside
+
+[10:04] Zaal: Okay.
+
+[10:10] Fellenz: the Telegram breakout, because it's so dense with code and at least the structuring, the content is lost in it. And so the communication, I think that needs to be made private, and then you have a, basically being able to extract the communication, just pure communication,
+
+[10:34] Zaal: Thank you.
+
+[10:40] Fellenz: be it if it's markup language, to just show text, right? And unless you're specifically having people engage with, you know, I guess the agents, which I think it actually interferes with quick communication.
+
+[11:04] Zaal: Thank you guys.
+
+[11:06] Fellenz: and so perhaps there's a way for you to ingest what's happening in real time in the other or the clear text chats and then from there you could generate action items from what's happening in the text over a day maybe do a daily summary but rather than having it stacked full of
+
+[11:34] Zaal: Thank you.
+
+[11:37] Fellenz: the system prompts, etc. You don't so far I'm not sure if this has any bearing to it, but so far there's little, if any, interaction with anybody else in it. And so I think it's just clogged full of all this other information that's not part of communication. And so the more that you can put that in the back end and just make it
+
+[12:04] Zaal: Thank you.
+
+[12:11] Fellenz: really easy to just have a regular conversation. And then, you know, the accountability part is always the hardest part, engagement level, setting expectations of, you know, if you're online, you should be looking at this. If you're anywhere on your device during the day one of the stocks needs to be in the group that you're part of you know it's really hard to say
+
+[12:34] Zaal: right yeah
+
+[12:39] Fellenz: that to somebody and i'm going through that right now in my own organization but bottom line is that it's um yeah i'm just just to keep it really simple again is to get it back to natural
+
+[12:53] Zaal: no that's perfect i honestly i appreciate that because that's something that you're super ready
+
+[12:56] Fellenz: working
+
+[12:59] Zaal: is super necessary and um i'm excited because i think that's a very clear delineation of why
+
+[13:02] Fellenz: And just the concept of your code generation, your projects, like I said a few days ago,
+
+[13:07] Zaal: uh you need to do that
+
+[13:19] Fellenz: make sure that you're clearly, you know, categorizing and or partitioning the work that you're doing for the benefit of Zal or Zabal.
+
+[13:29] Zaal: This is a ball yeah yeah like easy.
+
+[13:32] Fellenz: How do you pronounce it again? Zal? Zal, okay.
+
+[13:36] Zaal: That's what it's been with the AI sometimes for sure.
+
+[13:39] Fellenz: Zabal, no, I'm sorry. Bottom line is, so, you know, the main thing is, consume a space with your work in a place where you want people to participate.
+
+[13:59] Zaal: That's all.
+
+[14:02] Fellenz: And, you know, so I can just see that you're moving miles a minute, And so how does this work for people to get engaged in this environment? So it's kind of the concept of build it and they will come. You've built it and you've arrived. And it's just like, where do I go?
+
+[14:29] Zaal: I like that.
+
+[14:31] Fellenz: So being able to put the receptors or receivers of other people's work more clearly and less cluttered by what you're generating. Okay.
+
+[14:48] Zaal: Yeah, I like that a lot. Share what some of the other team members are doing in the back end that I'm having these one-on-one conversations with.
+
+[14:56] Fellenz: That's not what I mean.
+
+[14:57] Zaal: But...
+
+[14:59] Fellenz: I'm meaning for the...
+
+[14:59] Zaal: No, not me.
+
+[15:03] Fellenz: So you're trying to open up the Zabal games to outside the Zabal.
+
+[15:12] Zaal: Okay, yes. Yep.
+
+[15:14] Fellenz: Correct? Your team members are a natural, quote-unquote, should be, they're naturally active in Zabal games, And with that, if they are, quote-unquote, participants in the Zabala Games, that's where I need to delineate from your organizational people doing their work for them.
+
+[15:29] Zaal: Thank you.
+
+[15:50] Fellenz: the organization is not being involved in the games. Right?
+
+[15:59] Zaal: I'm a little bit confused as to what you mean in so much delineation.
+
+[16:00] Fellenz: Unless you see... Well...
+
+[16:06] Zaal: As from my perspective, one of the projects of the Zabal games would be the Zao festivals. And by essence, part of that would be like the work I am doing with Zao stock.
+
+[16:20] Fellenz: Right. Well, the main thing is that in the context of, you know,
+
+[16:22] Zaal: And bringing more people in and actually cleaning up the onboarding is kind of the idea. But I do also understand where you're coming from of like, okay, I do have some people onboarded. I can't just be like onboarding a bunch of different people to that same place. And that is something I have to flush out a little bit more. But I would love your feedback. That's all right.
+
+[16:50] Fellenz: Using Zabal Games technology for the projects that serve Zabal and the Zao and all the festivals is consuming the space of people outside of Zabal to, although I'm accidentally doing that.
+
+[16:56] Zaal: Thank you.
+
+[17:16] Fellenz: But the, you know, to participate in, you know, and it just depends on what you're trying to achieve, because right now, now that we're having this little conversation is that it's not clear that you're really going after people outside of your organization joining the ballgames, right?
+
+[17:26] Zaal: I'm more trying to clear up the...
+
+[17:43] Fellenz: And...
+
+[17:46] Zaal: Sorry, I don't want to interrupt you if you weren't finished. I'm trying to clear up the confusing bits of my brand by bringing things together with the Zabal game under Zabal, which I'm going to propose during this few months as a project of the Zao and then clean up. Okay, one of the things I'm building is a proper proposal website for people to use their Zabal respect. I mean, technically you can use Ornao in their front end,
+
+[18:13] Fellenz: I'm going to go ahead and get some more of the stuff I've been doing.
+
+[18:14] Zaal: but I want to also build a new front end for that and kind of combine those two as Zabal ultimately, because that is also really unusable. I'm the only one that uses that. but it's technically all contracts that are out there so like i can't build a different front end while i build this voting machine but the goal is um i can present it and kind of dog food my project through this now and really kind of explain the branding of like where i am going with all of the different things that i am doing together and how it is a consistent brand under this but like
+
+[18:43] Fellenz: I'm going to go to the next one.
+
+[18:46] Zaal: also being able to give opportunities for people to okay i've heard about this i have now like heard about all the other projects that are happening. There's something I'm interested in, and I've been around this community, but I don't know where to come in and support that. There's so many people, I think, that are around different brands right now that are willing and excited to support, but they don't know where to add their time, effort, and energy, and that's where,
+
+[19:13] Fellenz: So if you were to build a chart, so to speak, of, you know, you have your, now, I'm curious,
+
+[19:14] Zaal: those are the, I think, those are the people I'm trying to target for these kind of ideas. Yeah.
+
+[19:28] Fellenz: first off, where did Zabal come from? Why is it, why are you using it right now? I don't,
+
+[19:34] Zaal: Uh. So, I'm not going to be able to do that.
+
+[19:36] Fellenz: I don't, I didn't get the association when you first showed up. I was really perfectly happy with you guys just using Bazaar, because that's really easy to say and really natural.
+
+[19:50] Zaal: Yeah, so the Zao is the big organization. The goal is to make a doubt. No, in my opinion, no current, even the DUNA, no current, like, legal entity can really support the Zao. this out. So I haven't actually ever been able to create an entity for this out because we don't
+
+[20:06] Fellenz: 9 9
+
+[20:11] Zaal: acquire money. We don't have the money to pay for yearly DUNA. That in and of itself,
+
+[20:18] Fellenz: 9
+
+[20:19] Zaal: DUNA is the decentralized unincorporated entities in Wyoming and it's like what the DAOs,
+
+[20:22] Fellenz: 10 10 10
+
+[20:27] Zaal: like nouns and like the other big ones use.
+
+[20:28] Fellenz: 11 12
+
+[20:32] Zaal: But I had my own LLC that I was doing better calls off strategies,
+
+[20:32] Fellenz: All right.
+
+[20:36] Zaal: and that I was using as I'm consulting for all the projects that I'm personally building and working on, but then also as the Zao. And as the Zao grew, I decentralized my power, my power in the organization ultimately, as the goal, is to use this token as our governance token. And through that, I was very happy with what I built and wanted to, but I also wanted to expand into other pieces of crypto that are a lot more personal to me, like the Boston sports stuff, the trading card games, and these things that are a lot more like my personal brand and trying to build the Better Calls All brand.
+
+[21:02] Fellenz: Thank you.
+
+[21:14] Zaal: because through that distribution, I believe I can also help with the distribution of a lot of the artists that we now have within our community and ecosystem and actually be able to give them a place to come and get better distribution because the goal is to just keep increasing that. And I've seen... Yeah, sorry.
+
+[21:32] Fellenz: you know, the main thing you know,
+
+[21:36] Zaal: Zabal, sorry, I apologize. That is the reason I created it.
+
+[21:39] Fellenz: well, yeah, and so ultimately having
+
+[21:44] Zaal: Thank you.
+
+[21:44] Fellenz: Zao as an umbrella, but, you know, Zabal is now, I guess the question I still didn't quite address was, is that going to be a legal entity? Is that what you're intending for Zabal games? To have some sort of legal... ... ...
+
+[22:14] Zaal: But like, yeah, no, the Zao is the goal.
+
+[22:14] Fellenz: ... ...
+
+[22:18] Zaal: It was the ball for dog food for it.
+
+[22:18] Fellenz: ...
+
+[22:20] Zaal: It's like, I want people to join the Zao as community members with a brand.
+
+[22:20] Fellenz: ... ... ... ...
+
+[22:28] Zaal: And I didn't have that brand to like necessarily align with like, okay, I have Hurricane now with Wave Wars, which is a Zao specific brand, which is even better.
+
+[22:28] Fellenz: ... I'm going to go.
+
+[22:39] Zaal: Like that is what I would love is like, iMand is going to be creating Wave Force Africa, another Zao specific brand. That's like, ultimately, if you don't have a project, I would love to like bring you in and like have you do one of our things and take on a mantle. I think there's a lot of responsibility to be given a lot of individuals. But at the same time, if you've come in with an idea and you like are really passionate about something, I want to like to help you as an individual and entrepreneur,
+
+[23:02] Fellenz: I get it.
+
+[23:03] Zaal: but not do the whole guru thing where like, this is a networking like entrepreneurship group, like all this, Like you will get this stuff for a fee, right? Like that's not the goal. It's what you put into it. you
+
+[23:13] Fellenz: And I guess I'm surprised that the concert side of the Zao, really you have kind of tucked the Zao into a small corner when you're advertising. it's all about Zabal as being the top level in communication with the COC. It's really
+
+[23:35] Zaal: but
+
+[23:37] Fellenz: interesting. And so what I'm trying to get to is when you created the Zabal game, the
+
+[23:42] Zaal: Thank you.
+
+[23:50] Fellenz: concept that I thought you had was that you wanted to engage people in essentially vibe coding and or some app development in the umbrella of people sharing knowledge about creating apps and that, to some extent, not specifically managing events.
+
+[24:12] Zaal: yeah
+
+[24:18] Fellenz: And so, because when it was just not clear to me, you obviously had a vision in it, but It just wasn't. When I saw what you're trying to do, having mentors and people get engaged in helping others do things.
+
+[24:32] Zaal: so Thank you.
+
+[24:45] Fellenz: For me, if you're running an event for the benefit of the Zao, it is a Zao production, Zao stock. Zabal is an organization or a stack of tools, relationships, methods, means to do projects.
+
+[25:12] Zaal: Thank you.
+
+[25:12] Fellenz: And I guess the interesting piece is that you're using the technology that's being developed under the Zabal umbrella to perform things, to organize things for the Zao. And so I'm trying to help you delineate between what each organization and project can do. And so that'll help you if you really want to bring in non-DAO projects to be in the Zabal games.
+
+[25:42] Zaal: Thank you.
+
+[25:49] Fellenz: Because I think that's really your opportunity to be like a hackathon. You are becoming a micro-Eth Denver, right? ETH Global, where you are developing an environment of resources, technology, to actually build apps within, or who knows, spin off other communities from.
+
+[26:12] Zaal: Thank you.
+
+[26:19] Fellenz: But because you've stacked it full of all of the Zao activities, and so I'm clear that maybe that's all we're really supposed to do for. But when I hear games, I hear more engagement, kind of like wave wars.
+
+[26:42] Zaal: Thank you.
+
+[26:43] Fellenz: Wave wars, those people are not members of the Zao. It's people coming in and they're engaging with wave wars. And some are part of the Zao, so to speak. I guess when I think about the Zao, these are people who are engaged in the community aspect of the Respect Game primarily.
+
+[27:12] Zaal: Thank you.
+
+[27:15] Fellenz: And then, of course, during work, you've got your key members, Stoker, Candy, and a couple others. And then, of course, you have some crossover with COC. but that's I don't know how you wonder so I guess
+
+[27:42] Zaal: Thank you.
+
+[27:46] Fellenz: as far as the you know the telegram setup you've got all of your agents running inside the telegram groups each department so to speak of Zao stock that is using the tools that you developed under or maybe this is the question
+
+[28:12] Zaal: Thank you.
+
+[28:15] Fellenz: are you considering all the tools and what not that you've developed under the ballgames or under the ZAL because, you know, you have all these apps or the ZAL consulting. And so it's kind of an interesting opportunity to recognize what tools are being used for what.
+
+[28:42] Zaal: Yeah. My goal with the Zabal games is to put it under the umbrella of the Zao and help
+
+[28:55] Fellenz: Okay.
+
+[28:58] Zaal: use it as an infrastructure builder of other Zao projects. The Zabal and the delineation
+
+[29:04] Fellenz: Okay. Right.
+
+[29:08] Zaal: between the Zao and the Zao is the Zao is the umbrella.
+
+[29:10] Fellenz: Right.
+
+[29:11] Zaal: And the reason why, I mean, it could be called the Zao games as well, right?
+
+[29:12] Fellenz: Right.
+
+[29:14] Zaal: The reason why it's not is because I, as a personal individual, have a lot of projects that I've put out open source
+
+[29:22] Fellenz: Yeah.
+
+[29:24] Zaal: that, like, I wouldn't, I've now created the Zao into a brand that's, like, good enough to be
+
+[29:29] Fellenz: yeah
+
+[29:31] Zaal: at a specific threshold of content. And some of the stuff I make doesn't reach that threshold. But I still want to be able to share that. Like, that's my art, let's say. Right?
+
+[29:42] Fellenz: right next
+
+[29:42] Zaal: But it doesn't necessarily align with the whole Zao yet. Because it's not finished. I want Zao to be...
+
+[29:50] Fellenz: where are those
+
+[29:52] Zaal: No, no, no.
+
+[29:52] Fellenz: and you're putting those under Zabal or where are you putting them they're just separate.
+
+[29:58] Zaal: These are all projects under the Zao. So, like, so COC Concerts is a project under the Zao.
+
+[30:02] Fellenz: Huh? Right?
+
+[30:04] Zaal: So technically, MidiZonks is a project. Those are two community collaborations. Then we have Zao Festivals. We have Wave Wars, which has been finally the goal is ultimately as a DAO to create sub-DAOs that eventually can kind of be their own entity. So Wave Wars is going to turn into the three of us creating a company and spinning off
+
+[30:27] Fellenz: really
+
+[30:28] Zaal: and then hopefully creating a DAO in its place under the Zao with like a community like initiative
+
+[30:30] Fellenz: yeah
+
+[30:33] Zaal: of people being able to get involved. That's my envision of like an incubator. The Zao is the
+
+[30:34] Fellenz: totally yeah
+
+[30:40] Zaal: incubator and this is an incubated project. So that's the goal, if that makes sense.
+
+[30:41] Fellenz: what's interesting to me is how I see Zabal games
+
+[30:51] Zaal: I like that.
+
+[30:51] Fellenz: showing up as the lead what's the word for it? Yes. 100%.
+
+[31:05] Zaal: I never thought about that.
+
+[31:05] Fellenz: It's lost. I mean, everything that you're communicating with the
+
+[31:10] Zaal: I see.
+
+[31:11] Fellenz: COC, you're not
+
+[31:12] Zaal: I totally see.
+
+[31:14] Fellenz: saying bazao anymore. You're saying Zabal. I mean,
+
+[31:17] Zaal: Perfect.
+
+[31:17] Fellenz: really, you're losing the brand.
+
+[31:18] Zaal: Yes, yes, yes. Thank you. Yes, I didn't specify that when he made the logo, so I ended up rolling with it without thinking too much. So I appreciate that. Stop.
+
+[31:25] Fellenz: yeah yeah that's kind of i've been floundering through uh asking you these questions like give
+
+[31:32] Zaal: like
+
+[31:38] Fellenz: me the org chart and so you might want to do that and and share with people because right now it's
+
+[31:42] Zaal: all so it
+
+[31:46] Fellenz: well Well, oh, yeah, yeah.
+
+[31:48] Zaal: issue on so this is like
+
+[31:54] Fellenz: It's quite simple. You don't need to.
+
+[31:57] Zaal: and how I see it well
+
+[32:00] Fellenz: Well, you just listed out four.
+
+[32:02] Zaal: Yeah.
+
+[32:03] Fellenz: So, right, you've got the community projects, which you don't need to name.
+
+[32:04] Zaal: Yeah. Yeah. Yeah.
+
+[32:09] Fellenz: You've got Zabal, you've got Wave Wars, and the concerts.
+
+[32:10] Zaal: Yeah. Yeah.
+
+[32:13] Fellenz: so you could you know make it so that the zao has community focus but you've got the coc you've got
+
+[32:14] Zaal: Yeah. Yeah. Yeah. Mm-hmm. Mm-hmm.
+
+[32:24] Fellenz: the other things those are community partnerships i'd recommend you calling them that and putting it
+
+[32:26] Zaal: Can you take partnerships as opposed to part of the ZOW, a project under the ZOW with members
+
+[32:30] Fellenz: well the thing i don't know i guess i have a weird gut reaction with
+
+[32:36] Zaal: from those organizations? But the goal, yeah.
+
+[32:43] Fellenz: and don't take it wrong, but it seems like you're claiming top level ownership of COC concerts. Right. And so, yeah, well, you said that just a little while ago saying the Zao COC concerts. It's the Zao, right? It's a partnership, though. Right. And so, in fact, you know, it's it's like it's not the Zao COC.
+
+[33:08] Zaal: Well, my goal is to have the revolution run the CFC concerts and be the lead.
+
+[33:13] Fellenz: It's the Zao COC, side by side. Right.
+
+[33:24] Zaal: Ultimately, he can't be puzzle commitments right now.
+
+[33:26] Fellenz: Right. Well, maybe you're not understanding the question.
+
+[33:30] Zaal: No, I'm not.
+
+[33:31] Fellenz: Because the COC is a going concern all by itself, regardless of its concerts.
+
+[33:31] Zaal: I live hard. What do you mean by that?
+
+[33:40] Fellenz: Right. And the concert showed up, well, they're an organization.
+
+[33:44] Zaal: Yeah.
+
+[33:45] Fellenz: They're a top-level organization, equal to the ZOW.
+
+[33:49] Zaal: Yes.
+
+[33:51] Fellenz: So you have the entire staffs of each of your organizations. You've got events of each of your organizations.
+
+[33:57] Zaal: Yeah.
+
+[33:58] Fellenz: They've been doing COC concerts forever, for a long time, haven't they?
+
+[34:03] Zaal: Yeah. What do you mean? no I was the one that was there
+
+[34:04] Fellenz: okay I thought they've had because I've I've actually performed under you know for the COC
+
+[34:07] Zaal: that started the first one
+
+[34:14] Fellenz: like two or three years ago they don't remember right okay well
+
+[34:17] Zaal: yeah you might have with the C.O.C. but it wasn't C.O.C. concerts I don't know
+
+[34:22] Fellenz: okay that's new okay never mind so
+
+[34:22] Zaal: I wasn't there so I don't know I
+
+[34:26] Fellenz: well
+
+[34:27] Zaal: like what was it in a space but you know how long ago
+
+[34:30] Fellenz: man I you know what
+
+[34:34] Zaal: because I'm just curious because if I came in in 2023 so I'm curious if it was like pre-2023
+
+[34:40] Fellenz: actually it was with the meta builders
+
+[34:40] Zaal: mostly oh yeah
+
+[34:42] Fellenz: it was the
+
+[34:44] Zaal: that's why they also had a bad
+
+[34:46] Fellenz: it was the yeater
+
+[34:46] Zaal: because he was a
+
+[34:47] Fellenz: the fundraiser
+
+[34:49] Zaal: he was a cornerback
+
+[34:50] Fellenz: that was a clusterfuck
+
+[34:50] Zaal: in the COC that's why no
+
+[34:52] Fellenz: but don't tell anyone Are you going to post this on YouTube? I hope not.
+
+[34:59] Zaal: I'm not going to post it on YouTube.
+
+[35:00] Fellenz: Okay.
+
+[35:01] Zaal: I was going to grab the transcript and put, like,
+
+[35:03] Fellenz: Okay.
+
+[35:04] Zaal: you put transcripts up on GitHub. Again, like, people will not be reading them, but hypothetically speaking, they can be searched because the goal is so that they can be queried.
+
+[35:12] Fellenz: Anyway. Yeah, right on.
+
+[35:14] Zaal: If that's okay, I can not do it with this one.
+
+[35:16] Fellenz: Oh, no, I'm being just totally cool here. So ultimately, though, as far as the just the interaction, the the organization, I go global in this way of thinking and then go micro.
+
+[35:29] Zaal: Thank you.
+
+[35:33] Fellenz: And so I guess I'm sharing some concerns with how the Zao identity is either being diluted by Zabal games, and in the case of working with the other organizations, finding a way to...
+
+[35:59] Zaal: Thank you.
+
+[36:01] Fellenz: and clearly they're not you know arguing against it either i guess and so maybe there's nothing for me to say here but ultimately when you have the zao coc concerts it's the it's kind of an interesting thing you know where you and it's kind of more for me it's a respect thing right where uh you're not claiming ownership of their brand being subservient to yours.
+
+[36:29] Zaal: Yes, so my goal is that we have a partnership with the COC, and COC Card Service is a brand
+
+[36:35] Fellenz: And that's just the question. Yeah.
+
+[36:43] Zaal: that was created by the individuals that are a part of those two organizations, which is me and the core team with them, and then Sam, kind of, and then Hurricane is like part of
+
+[36:51] Fellenz: Right. Right.
+
+[36:56] Zaal: wave wars and we when we need wave wars like he'll come in but he's not doing other coc concert stuff right so that's where my kind of delineation of it is is like we do need a specific place with all of the zaos partners somewhere and the coc would be one of those where coc concerts would be a
+
+[37:14] Fellenz: Right.
+
+[37:16] Zaal: different idea but i understand where you're coming from of coming in and using the brand of of COC to brand the Metaverse Concerts for the Zao.
+
+[37:26] Fellenz: Right.
+
+[37:30] Zaal: And the goal that was gonna be what our partnership
+
+[37:30] Fellenz: Right.
+
+[37:33] Zaal: was between them, that this is something they,
+
+[37:35] Fellenz: Yeah.
+
+[37:36] Zaal: as the COC, wanted me to come in and help with. It's also something I suggested,
+
+[37:40] Fellenz: Right.
+
+[37:42] Zaal: but the push more than anything was on the COC community
+
+[37:42] Fellenz: Yeah.
+
+[37:49] Zaal: and those individuals. And that's how I believe, and maybe I have been mis-assuming some portions of ownership with them, and maybe I should have this conversation deeper with them.
+
+[37:56] Fellenz: Yeah.
+
+[38:06] Zaal: But that's where my mind goes with it. is like the reason I want it to be a sub brand and not just like a partnership between the two communities is if it does become a thing, we do need like XYZ capital towards it because we need XYZ resources for it.
+
+[38:21] Fellenz: Right.
+
+[38:23] Zaal: It needs to be able to stand on its own necessarily, right?
+
+[38:26] Fellenz: yeah like right now the way it reads in my mind is it's the co coc concerts brought to you by the
+
+[38:28] Zaal: It is, I mean, without either of those orgs, it probably won't survive, but it needs to be able to be like, okay, we are doing these things that both of these organizations are contributing towards. Thank you.
+
+[38:50] Fellenz: Zao, you know, festivals. You know, that's kind of, maybe that's a way of looking at it because your Zao festivals are really the ones that are running shows, right? Is that something you would consider or you want to, so Zao festivals or
+
+[39:10] Zaal: I mean, it's the COC is like the virtual side of the, that is what the reason I delineated
+
+[39:13] Fellenz: Zao branded festivals and then COC concert? Yep.
+
+[39:21] Zaal: two brands is like the Zalphazos is the IRL stuff, the COC concerts is the, for what I'm
+
+[39:23] Fellenz: Okay.
+
+[39:30] Zaal: going to continue to do since we've created it, I'm going to push people there because I have a place that is there to push, right? Like Rev was just even saying this week that without me being able to do the streaming portion of it, they wouldn't be able to do it. So that's kind of like coming in and supporting the like, okay, like we have musicians.
+
+[39:47] Fellenz: Got it.
+
+[39:53] Zaal: They want to have a bunch of musicians together in a place and being able to create a little bit of the event organization. But then also the actual like ability to do it, including like the website and stuff.
+
+[40:00] Fellenz: Yep.
+
+[40:04] Zaal: That's like the part that I'm contributing from the ZAL.
+
+[40:07] Fellenz: Well, I'm going to stop beating on it, but, you know, that's kind of the things that I, that came up for me just watching.
+
+[40:16] Zaal: Yeah.
+
+[40:17] Fellenz: And so definitely I would suggest getting on top of that branding, the naming sooner than later, because it is confusing for COC concerts to be untethered from COC because,
+
+[40:34] Zaal: Why would it be untethered?
+
+[40:37] Fellenz: and well, Well, you're saying it's a whole separate organization or separate. And so because it's branded CFC.
+
+[40:49] Zaal: Yeah. So it's going to...
+
+[40:52] Fellenz: And so it's not owned by them.
+
+[40:56] Zaal: Are you talking about IP or are you talking about what part is owned?
+
+[40:57] Fellenz: They're participants. There's only those out. Well, right.
+
+[41:04] Zaal: Yeah.
+
+[41:05] Fellenz: And that's kind of the interesting thing. In the world of Web3, quote unquote, I guess it's gray area, right? And so I come out of the world of if you've created something, it's under your umbrella.
+
+[41:16] Zaal: For sure.
+
+[41:23] Fellenz: And if it's got my name on it, then it's still under my umbrella. But somebody else is assisting with that. and so because it has my name associated on it
+
+[41:34] Zaal: Just for your reference on the Hats chart, Thy Revolution is the lead for COC Concerts.
+
+[41:36] Fellenz: it's not going to be ever be disassociated or clearly and that's it, I don't want to beat a dead yeah
+
+[41:56] Zaal: I am technically a worker on the team of CoC Concerts.
+
+[42:01] Fellenz: Gotcha.
+
+[42:01] Zaal: So like he, as a founder of the CoC, owns the CoC Concerts as his Zao contributor.
+
+[42:08] Fellenz: Right.
+
+[42:10] Zaal: I am on that team as well. Like that's his, like that was our way of finding a way to collaborate together because it aligns with our goals.
+
+[42:20] Fellenz: Interesting. Fascinating. So you're trying to insert the activities of people in the COC concerts in the umbrella of the Zao respect tokenization degree?
+
+[42:26] Zaal: I mean, I'm not necessarily the respect unless they come to that specifically. The goal is, of course, to invite them to that. But with the Zao respect, I mean, again, anyone can do it at any time technically, right? So my goal is to get more people.
+
+[42:47] Fellenz: Right. No, okay. So it's not actually being attached to the respect part.
+
+[42:52] Zaal: No, people aren't getting contributions. The goal is to keep the fractal respect as the way of people getting contributions.
+
+[42:55] Fellenz: Yeah, it's not specifically aligning with the effort, the tasks being performed in COC concert. But that's a whole other conversation we could talk about another time.
+
+[43:15] Zaal: Yeah.
+
+[43:16] Fellenz: So really just wrapping this up, the ultimate thing is that you've got just a good flow
+
+[43:24] Zaal: Yeah.
+
+[43:33] Fellenz: of perspectives. You've got so many people that are coordinating and supporting to make the shift for getting people involved and you know i guess my my observation interpretation of you know there
+
+[43:54] Zaal: Thank you.
+
+[43:55] Fellenz: not being a lot of activity in the telegram telegram groups is uh a just having some sort of regular uh and i you know clearly nobody was showing up for the meetings uh you wanted to to postpone it for when things are are ramping up more maybe you'll restart the the tuesday morning meeting is that the idea
+
+[44:24] Zaal: I'll do Tuesday at 11.30, right?
+
+[44:27] Fellenz: yep
+
+[44:27] Zaal: I have no problem with actually putting it out there and putting that as a stand-up. It's like 10 o'clock is technically when I'm supposed to be working. So if I am pushing this publicly,
+
+[44:37] Fellenz: hey
+
+[44:38] Zaal: I am not... I have a very specific thing on the internet
+
+[44:41] Fellenz: So, that's fine. Well, okay, so you'll find a new time. So ultimately, you'll go ahead and do that. And that's fine. So ultimately, getting people to, you know, participate or at least be active in the Telegram groups, I strongly recommend either restructuring it or creating a new version of it.
+
+[44:43] Zaal: that I'm not doing. Right? Yeah. Thank you.
+
+[45:11] Fellenz: so that it is natural language and not clogged full of agent. The agent interaction is really not conducive to conversation
+
+[45:24] Zaal: Thank you.
+
+[45:26] Fellenz: because I'm looking for the human words that are of meaning and I'm having to scan through it going, well, where was the prompt to get to somewhere? And then, okay, there it is. And so ultimately, if there's any way to mask that, push that into the background, that activity, you can let people audit it all they want if they want to go to where the agent thoughts are,
+
+[45:54] Zaal: I might instead of completely restructuring it and make new groups with the individuals
+
+[46:01] Fellenz: but mainly keep it natural language in the chat. And that way, Yeah.
+
+[46:14] Zaal: that offer circles basically and I will just whether I actually capture that or not can be decided upon after the fact. Just be like a group of groups in, do you mean in topics in Telegram?
+
+[46:25] Fellenz: Well, you can hide them, right? You can make, you know, certain groups invisible, right? Well, okay, the chat. Yeah, so you have Telegram as the parent, and then you have all the different groups, well, chat,
+
+[46:43] Zaal: Yeah.
+
+[46:44] Fellenz: you know, you can hide anything that you've built. So people that are going into, so you can still keep the groups
+
+[46:53] Zaal: I see this.
+
+[46:53] Fellenz: or the chats that you've created per, you know, department and you create new one.
+
+[46:59] Zaal: You're saying you can't save one, but regrade the load so it doesn't have the bot messages, and then move the bot to silent.
+
+[47:07] Fellenz: Yeah, exactly.
+
+[47:07] Zaal: I got what you mean.
+
+[47:09] Fellenz: I think you can. That way you can keep them there still churning away. But I know I'm making you consider it all worth it.
+
+[47:10] Zaal: Okay. I... my thing is i don't think how quickly i'll be able to get the bot to be silent versus i know i can put the people that are important to this project in a group right like especially because you want to be more involved and you want to see a little bit more of the other people at sharing rather than it being the one-on-one and then sharing the results of what everyone
+
+[47:39] Fellenz: Yeah.
+
+[47:43] Zaal: has been sharing with me. And that has been with more, I've basically been having the one-on-ones in addition to having the stand-ups. The stand-up and the delivery group for me is one of multiple places of distributing stuff. Right now, it's the only for Zao stock. But the goal is that it's one of multiple distribution points. I agree with you. One of the things I have not done is made an agreement or a expectation of what someone else is doing when they want to volunteer or where both lines lie in their commitment, right?
+
+[48:09] Fellenz: Thank you.
+
+[48:28] Zaal: That is something for the participation, like you were saying, of like, okay, I need to read this, but also not overwhelming them with the information you just have to read through and sift through.
+
+[48:39] Fellenz: yeah
+
+[48:40] Zaal: I think that's super valuable. I do have a meeting in a couple of minutes here, but I don't know if you had any finishing thoughts on that.
+
+[48:44] Fellenz: no basically you got my feedback and you know
+
+[48:51] Zaal: No, I appreciate it.
+
+[48:52] Fellenz: this
+
+[48:53] Zaal: Thank you so much.
+
+[48:53] Fellenz: worked yeah
+
+[48:53] Zaal: I'm super open
+
+[48:54] Fellenz: so that's pretty much it oh yeah
+
+[48:56] Zaal: like I'm very like feel comfortable to say what you want to me or even
+
+[49:01] Fellenz: likewise
+
+[49:02] Zaal: through a message I hope I am open enough that you can say whatever you think because I do appreciate it I I think you're
+
+[49:09] Fellenz: Right.
+
+[49:11] Zaal: amazingly on the money and I've been too busy in the weeds to look at that from one of the perspectives that you have which is amazing and see where I am having gaps in what I want to have out there, which you do see some of those in different capacities, as well as maybe missing something because I'm not clarifying that communication in the simplest form possible.
+
+[49:35] Fellenz: Less is better.
+
+[49:37] Zaal: Yeah, I appreciate it, Flens. I will catch you soon.
+
+[49:39] Fellenz: All right. Yeah. Yeah. And the good thing on the side of getting to Maine is that it's gotten much less expensive. So we're at like 50 percent back. You know, I was like 90 percent, 2 percent.
+
+[49:41] Zaal: Let me know if you ever need anything support-wise. I don't think I should have come for the event. I don't know. Where is it at from where it was? What number of dollars were you looking at?
+
+[50:04] Fellenz: now oh you mean cost wise I'm sorry it's about 600 versus 900 mm-hmm
+
+[50:11] Zaal: Okay. Because I was looking at flights, and it was too much for me, because I was also from trying to do two blood chains a short time, right?
+
+[50:16] Fellenz: you mean
+
+[50:20] Zaal: That's my issue always.
+
+[50:22] Fellenz: yeah
+
+[50:23] Zaal: So in the next month where I want to potentially come to this Edge event, I am not, right? But I'm okay with that. I'm basically glad I connected with the founder. He's going to be around somewhere in the future. I know I will run into him and will be a part of one in the future.
+
+[50:23] Fellenz: yep Good thing.
+
+[50:41] Zaal: like I love those ideas whether it's being a full part of it hopefully eventually just like come in speak in a couple and not have to even be there for a whole like month-long thing but be able to be invited right like that would be a very amazing opportunity so that's my goal trying to get this
+
+[50:54] Fellenz: Good.
+
+[50:58] Zaal: stuff out there and I've been recently DJing a little bit so I can also get some of our musician
+
+[50:59] Fellenz: What? Where? What? How?
+
+[51:03] Zaal: music out there.
+
+[51:03] Fellenz: What?
+
+[51:04] Zaal: Yup.
+
+[51:04] Fellenz: Where? What? How?
+
+[51:07] Zaal: This is the deck that Adabody used
+
+[51:07] Fellenz: What? Where? What?
+
+[51:10] Zaal: at Zowchella and Zappalooza
+
+[51:10] Fellenz: Yeah. Right on.
+
+[51:12] Zaal: that Candy donated to the Zow for that. And then Adabody used it for all of 2025 when he was out in East Denver and all the places and then sent it up to me at the beginning of 2026.
+
+[51:25] Fellenz: Okay.
+
+[51:26] Zaal: Yeah, that's why. That's like what I wanted with Zows. Like these immaterial things
+
+[51:29] Fellenz: Sure.
+
+[51:30] Zaal: that people are willing to donate and that's how we survive, right? Like kind of like a non-profit, but like not like with the terminology of the non-profit, but that's just some issue. Okay, it's 715.
+
+[51:39] Fellenz: Goodbye. Cheers.
+
+[51:40] Zaal: I'll catch you soon. Cheers.

--- a/research/events/840-wip-meetup-zabal-games-event-prep/README.md
+++ b/research/events/840-wip-meetup-zabal-games-event-prep/README.md
@@ -1,0 +1,83 @@
+# 840 - WIP Meetup x ZABAL Games: Co-Hosted Event Prep Call
+
+Planning call to lock the run-of-show for a co-hosted event on **2026-06-11**: Zaal presenting ZABAL Games inside The WIP Meetup (doc 796). Format, mechanics, and promo handoff agreed.
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-06-10 |
+| Duration | ~17 min |
+| Platform | Discord / Craig (mix recording) |
+| Attendees | Zaal Panthaki, rizzle (WIP Meetup host) |
+| Project | ZABAL Games / ZAO Devz |
+| Event date | 2026-06-11 (tomorrow) |
+| Source | craig-0csbFNmpOiwm-mix.wav |
+| Transcript | [transcript.md](transcript.md) |
+
+Note: 2-person call, mix recording (no multitrack export was available). Speakers attributed from content - Zaal is the one building ZABAL Games / theballgames.com / running the photocaster + Empire Builder mechanics; the counterparty is **rizzle**, a host of The WIP Meetup (doc 796, run by niftytime, rizzle, and Meme). "Rizzo" in the transcript = rizzle himself - Zaal scheduling rizzle's opening segment on the WIP.
+
+---
+
+## What the event is
+
+A co-hosted session inside **The WIP Meetup** (doc 796 - longest-running web3 metaverse meetup, ~370+ weekly sessions, highly educated web3 audience) where Zaal presents **ZABAL Games**. Roughly an hour, not a hard stop. The WIP host frames the audience as the ideal crowd: "these are your people... I don't have to do the 'this is too complicated, simplify it' conversation - they understand what you're doing."
+
+---
+
+## Decisions
+
+| # | Decision | Owner | Confidence |
+|---|----------|-------|-----------|
+| 1 | Two halves: **ZABAL Games first, WIP second** - or a workshop (both share) transitioning into a fireside chat. ~30 min per segment to hold attention | Both | high |
+| 2 | Run-of-show: intro -> Zaal gives broad overview of his **3 prongs** -> transition to **game portion** (kick off a live competition, let people tinker while Zaal explains) -> open **AMA / questions** | Both | high |
+| 3 | Format leans **AMA / fluid conversation** - host sets the stage, shouts out question-askers, keeps it general if no questions come | Both | high |
+| 4 | Zaal **builds a live game/demo overnight** on theballgames.com to put something in people's hands | Zaal | high |
+| 5 | **rizzle** (the host) takes a 5-10 min opening segment on the WIP, then hands to ZABAL Games | Both | high |
+
+---
+
+## The live mechanic (Zaal's plan)
+
+- **photocaster**: Zaal makes a thumbnail/post of him + the host, puts it up on photocaster for anyone to collect. Pricing tiers - starts at 5 cents, +5 cents each collect (10 collects = still only 50 cents).
+- **Empire Builder booster**: anyone holding that photocaster NFT gets a leaderboard booster in Empire Builder. Live raffle of everyone who collected in the first ~15 min.
+- **Collectibles / "pops"-style tool** (POAP-like, Web2 flow, data-focused, abstracted-away collectibles): Zaal pays for it, dogfooding it for the team; can attach a UGC submission (submit a video + your Farcaster) and see who interacted with what. Demoing "what I do that people normally keep behind the scenes, so my artists can benefit."
+- A WIP-specific UGC can be added on theballgames.com.
+
+---
+
+## Action items
+
+| Action | Owner | Due | Confidence |
+|--------|-------|-----|-----------|
+| Build the live ZABAL Games game/demo on theballgames.com overnight | Zaal | 2026-06-11 | high |
+| Set up the photocaster collectible (thumbnail of Zaal + host) + Empire Builder booster + first-15-min raffle | Zaal | 2026-06-11 | high |
+| Update the Luma + prep the promo post with WIP brand info; feed WIP brand assets to his AI to present them well | Zaal | 2026-06-11 | high |
+| Send Zaal any WIP details/assets (whipmeetup.com / thewipmeetup.com dropped in DMs) | rizzle | 2026-06-11 | high |
+| Send JPEGs / pictures / promo assets for the "promo vomit" in the 12 hrs before the event | rizzle | 2026-06-11 | high |
+| Pop into the event 5-10 min early | Zaal | 2026-06-11 | high |
+
+---
+
+## Key quotes
+
+> "ZABAL Games is my version of putting all my projects on one URL - all the documentation, how much status I've actually completed... and on July 1st, letting anyone use their harness, point at that URL and say 'tell me a project that might be interesting and I'll build it.'" - Zaal
+
+> "These are your people, man... I don't have to do this conversation I've had with so many people where they're like 'this is too complicated, you need to simplify.'" - rizzle
+
+> "My goal is to present everything I do that traditionally people have behind the scenes, so that my artists can benefit from it." - Zaal
+
+> "It'll be one giant promo vomit in the 12 hours leading up to the event." - rizzle
+
+---
+
+## Cross-references
+
+- Doc 796 - The WIP Meetup (the host community; niftytime, rizzle, Meme; Hyperfy; weekly Thursday ritual)
+- Doc 785 - Jonathan Colton / FounderCheck (prior photocaster reference)
+- [[project_zabal_games_magnetic_build]] - ZABAL Games = single magnet + July judging; this event is a live demo surface
+- [[project_zaal_builder_series_devcon]] - the "one URL of all my projects, point your harness at it July 1" thread
+- [[project_adrian_empire_builder]] - Empire Builder (the leaderboard-booster mechanic used here)
+
+## Open items for the session tomorrow
+
+- Lock the exact start time + Luma link.
+- Confirm final segment order + who opens.

--- a/research/events/840-wip-meetup-zabal-games-event-prep/transcript.md
+++ b/research/events/840-wip-meetup-zabal-games-event-prep/transcript.md
@@ -1,0 +1,213 @@
+# Transcript - WIP Meetup x ZABAL Games event prep (2026-06-10)
+
+Source: craig-0csbFNmpOiwm-mix.wav (mix, no multitrack export available). 2-person call, speakers attributed from content (not diarized). Zaal = ZABAL Games / theballgames.com / photocaster / Empire Builder. Counterparty = rizzle, WIP Meetup host (doc 796). "Rizzo" in the text = rizzle himself.
+
+---
+
+suggest
+uh
+Thank you.  [repeated 6x, trimmed]
+I don't know what is up with Discord right now.
+It seems like something's working.
+Can you hear me?
+Your audio is like cutting in and out, man.
+I don't know if it's on my end or on your end.
+I'm sorry.
+Motherfucker.
+Okay.
+No, I might be on my end.
+Let me...
+is it any better still cutting out uh no actually so far it sounds pretty good
+okay yeah that's the one fucking issue with this place is it's so fucking challenging to
+it's so challenging to like
+to get internet bro when I walk between buildings
+there's so many god damn connectivity issues and it's so annoying
+I would pay like an extra $50 to just not get cut out of space
+because X spaces are terrible for me at work because like I will
+literally have to bump up and down so many times because I need to like
+not be moving for me to have the ability to like um but yeah so you were sharing what some of your
+thoughts i'm very fluid with it i have three different types of workshops i'm running right
+now um a traditional workshop a fireside chat which is more of like the spaces style thing
+and then a workshop which is one of our zao projects so anywhere between that like fireside
+I would love it to be closer to like a whip conversation of like what tools you guys are using as a whole and like share what the community here is bringing to the table as well as doing across like, um, cross of like, okay, these are also the resources that I'm working towards building.
+Yes.
+Uh, dude, I think that would be a very cool way to frame it.
+Um, and, uh, I think that'd be cool, man.
+I think it would be
+I'm just sort of thinking about the flow of events
+I think we should do something
+if you want to do something where we get some audience participation
+or sort of like a fluid conversation
+going I can sort of
+do my best to set the stage for that
+at the beginning of the event
+we definitely get a bunch of people who are
+microphone shy
+but who are like regular
+I was about to say
+I'm cool making it more of an AMA
+style. Like you asked me questions, we just talk about it and vice versa.
+We can be like, okay, if a question comes in, we can easily be like, oh,
+shout out to XYZ person asking this question. And you know,
+we can get deep into their specific question. Right.
+But if no one's asking anything, then we just kind of keep, keep it general.
+Yeah, absolutely. Um, I think just in terms of like event flow, I think,
+you know, I would do like the regular intro intro, you,
+I'll sort of give people like,
+Oh, actually, you guys normally go for an hour, right?
+Yeah, about an hour.
+It's not a hard stop, but.
+No, no, no, no.
+That's perfect because I'm trying to keep all the workshops to 30 minutes.
+So let's do two themes.
+Let's do Zabal games for the first half and WIP as the second half.
+We could do that.
+I'm like, you know, I'm thinking.
+You know, it can be two topics, but there's a way we can do some sort of like change of energy at the 30 minute mark.
+So I could like denote it as a different, whether it's two different regular workshops or what we could do is the first one could be a workshop where, you know, you share a little bit about the whip.
+I share a little bit about the Zabal games.
+We end it and then we transition it into a fireside chat and that could work too.
+But that's kind of where I want to keep it if possible, because my goal is to not post too long things so that we can keep people's attention if they do want to catch up on stuff.
+100%. Yeah, let's, we could definitely chop it in half. Is there anything that you're working on
+or that you've got in your back pocket that would help demonstrate, showcase what's going off that
+we can like actually get the audience like participating in or like do a demo of or like,
+like we're going to have a lot more, we'll have a better result with like the fireside chat if we
+can like put something in people's hands for them yeah okay so we'll have a couple but what we can
+do is like tonight i can build one bro like it's not that hard it's the ballgames.com um i'm gonna
+do um what i'm gonna do is i'm gonna leverage some of the tools so photocaster i'm gonna make a
+a thumbnail of our, um, of me and you of my,
+the post that I'm going to do essentially,
+I'll put that up on photocaster for anyone to collect.
+And for people that collect that,
+I'll put it as a booster in the empire builder.
+So it's all part of this is a ball games thing.
+And I could walk people through the flow of things that you can do with some
+of the conversations we've had already. And, um,
+and then we can just give out a reward with empire builder live and just,
+okay like whoever's done this in this first 15 minutes um is is you know eligible for this or
+before this um and and we're gonna pick basically it's a raffle of all the people who've collected
+that i mean it photocaster is nice because you can set so many different things i don't know if
+you've played with it yet but um i like they do a very basic one where it's everyone collected
+after costs five cents more and it starts at five cents so like if you get like 10 it's still only
+up to 50 cents right right um and basically what you can do with empire builder is you can take
+anyone who has that nft and they get a booster in the leaderboard um based on if they have that nft
+or not versus other people who don't have the nft so there's a lot of things we could do we can play
+with a couple different things we can honestly do a lot of stuff on the fly um send me any details
+you can about the whip so that i can update the luma with more info and prep my post for tomorrow
+with more info and just basically just um the the things that you guys have for your brand so that i
+can basically feed it to my ai so that i can present you guys well yeah um check out the
+website i just dropped it in our uh dms the whipmeetup.com that should yeah cycle through
+that that should get you the majority of the stuff that you're looking for the cool thing is about
+these tools is i don't even need to cycle through it now yeah yeah i know i know it's being part of
+my artist in it now um okay yeah that is the ballgames.com try this out as well we can add a
+specific ugc as well for the whip and i think that'd be fun um this is a tooling that i'm using
+that's uh collectibles abstracted away yeah so it's like po app basically it's a person that i
+I mean, it is a paid service, but I've been using it for so long that I pay a significant amount less than it costs right now.
+But I really like the team is why I'm using it as I'm trying to help them dog food it because I also pay for it.
+But it's a really cool tool, basically.
+It's basically just like all of the stuff is a collectible on the blockchain, but it's all Web2 flow.
+It's meant for Web2 businesses.
+It's all about data.
+So like basically if we put up a collectible under this ball game,
+the only collectible during the hour for the win, right?
+Or you can only submit a UGC.
+And maybe if you submit a UGC, you can submit your farcaster.
+And like, I can make a post at the end saying like,
+thank you all for joining. Right.
+But the goal of that is that if you put up a video or whatever,
+or something like that,
+you can see like who's looked at what videos or who,
+how much of the like actual thing has someone interacted with?
+Um,
+and I can,
+that's cool.
+Or the backend too,
+because like,
+that's a beauty.
+My goal is to present everything I do that traditionally people have behind
+the scenes and you have to figure out upfront so that my artists can benefit
+from.
+So dude,
+this,
+this conversation that we're having right now and exactly what you're doing
+with the,
+this like thing similar to pops would be very interesting to the audience.
+tomorrow, just as an example.
+Amazing, yeah.
+Let me put that as a...
+Perfect.
+Showing off what you're doing on the front end,
+but also under the hood
+is right on point.
+I love it. I'm going to actually use
+part of this conversation as the
+starter. So I'll say,
+I popped the summary, basically, of this conversation
+into my ZBall Games AI
+with the WIP.com meetup
+and say, hey, help me make an agenda for
+tomorrow. Give me a portion
+of 10 minutes for Rizzo to talk or five minutes, let's say,
+at the beginning about the whip and then just go crazy with some ballgame stuff
+and share and answer questions basically.
+Yep.
+So I'm thinking like in terms of event flow,
+and you're saying you can throw together a game or whatever.
+I mean, even if it's like just something you throw together overnight,
+I think that would be dope just to like sort of show off what you're working on.
+So I think the play would be – so do the intro.
+you talk uh give like a broad overview of like you know just the stuff that you're working on
+but you know your sort of three prongs that you're focused on right now if we want to dive into
+the workshop or something like that in more detail but whenever we transition to talking
+about the game portion i think that's when we kick off whatever the competition is and we let
+people goof around with the game while you're talking about how it all works and your plans
+and everything right and then at the end of that portion then we'll open it up to like ama and
+questions and like that kind of thing but then then people have heard like the broad scope of
+everything that you're working on we'll put stuff in their hands like tinker around with while you're
+explaining the game portion everything and i think by the by the time that's all said and done we got
+you know some questions that have come in along the way because this this is cool shit man and
+it's and that's why i'm not worried about this at all this is like stuff this audience is already
+you know really interested in that's why that's why i like your audience it was i don't have to
+do this conversation that i've had with so many people where they're like this is too complicated
+you need to simplify it's like okay no i i need to make it more right
+like you don't understand but these are your people man i love that i love that energy because
+it's dude i am so i'm very happy with where i am and this is the thing that's going to bring
+things together basically those of all games is my version of putting all my projects on one
+url basically with all the documentation how much of status i've actually completed and is it just
+an idea that i've formed and i haven't even made a github for is it something that i tried to go
+through but like a half a year ago the model wasn't good enough to just do it so i didn't do
+it and someone could easily literally just paste it into the current model today and fix it like
+that's all you might need to do right right because so i know so that's my goal is bringing
+all this together basically putting it on all on one url and on july 1st uh letting anyone
+use their harness point at that url and say hey you know me you like tell me a project that might
+be interesting unless i build it good shit yeah um yeah dude this is perfect uh the the audience
+will be interested in it it's also like a good place to like uh and i guess we're sort of like
+heading in this direction anyway but if you like uh are you want something like you know genuine
+feedback or you know want to just get a pulse test on how the audience thinks uh you know this is
+playing out and everything yeah this is like a very like high highly educated web3 audience who's
+going to like understand what you're doing and understand how you're trying to like serve it up
+to a wider audience.
+This is cool, man. This is going to be easy.
+I'll let you get that before your
+heart stops. I'll catch you tomorrow.
+I'll try and pop in like 5-10 minutes
+before and yeah, let's cook.
+I appreciate it.
+Yeah, good shit, man. Alright, dude.
+Send me, when you have a chance, any
+JPEGs, pictures,
+anything that you want us to hang up or
+include in the promo stuff. It'll be like
+one giant promo vomit
+in the 12 hours leading up to the event.
+So we'll get that shit
+correct.
+Amazing. I'll send you something.
+And then more stuff.
+I'll send you something.
+Yep. Perfect, man.
+Well, good.
+Alright. Sounds good, man. I'll see you tomorrow.
+Cheers.
+Thanks.
+Thank you.

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,8 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-06-10 | WIP Meetup x ZABAL Games - co-hosted event prep (event Jun 11) | ZABAL Games / ZAO Devz | Zaal, rizzle | [840](840-wip-meetup-zabal-games-event-prep/) | 6 |
+| 2026-06-10 | Fellenz x Zaal - brand + org-structure strategy (IMPORTANT) | The ZAO / ZAOstock | Zaal, Tom Fellenz | [839](839-fellenz-brand-org-strategy/) | 10 |
 | 2026-06-09 | Zaal x civilmonkey - DevCon India music stage + builder series + ZABAL Games proto-DAO | ZAO Devz | Zaal, civilmonkey, Iman | [827](827-zaal-civilmonkey-devcon-india-builder-series-proto-dao-jun9/) | 5 |
 | 2026-06-08 | Zaal x Dcoop - ZABAL Games workshop invite + cowork onboarding + Zaoville prep | ZAO Devz | Zaal, Dcoop | [824](824-dcoop-zaal-zabalgames-workshop-cowork-zaoville-jun8/) | 6 |
 | 2026-06-08 | Iman x Zaal - ZABAL Games recordings pages + cowork board mentions | ZAO Devz | Zaal, Iman | [819](819-iman-zaal-zabalgames-recordings-cowork-mentions-jun8/) | 6 |


### PR DESCRIPTION
## Summary

Two meeting recaps from 2026-06-10, processed via /meeting.

- **839 - Fellenz x Zaal brand + org-structure strategy** (FLAGGED IMPORTANT). Tom Fellenz's brand critique: The ZAO is being eclipsed by ZABAL in external comms. 8 challenges, each paired with a fix; org-chart recommendation; COC-Concertz-as-partnership framing; Telegram/agent-overhead cleanup; onboarding + volunteer-commitment gaps. This is the strategic anchor for an upcoming per-brand branding cleanup.
- **840 - WIP Meetup x ZABAL Games co-hosted event prep** (with rizzle, WIP host). Run-of-show, photocaster + Empire Builder raffle mechanic, live demo plan. Event 2026-06-11.

Both include full transcripts; `_meetings-index.md` updated. Note: this session's branch is `ws/research-mining-r2` (the working branch in use).

## Next

Fellenz brand cleanup starts in ZAOOS (The ZAO lead-brand audit + org chart), then per-brand prompts one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)