### PR TITLE
doc 843 + /artizen page: ZAO Fund for Emerging Culture full S6 roster (DEEP)

### DIFF
--- a/research/business/843-zao-fund-artizen-roster-june2026/README.md
+++ b/research/business/843-zao-fund-artizen-roster-june2026/README.md
@@ -1,0 +1,146 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-06-11
+related-docs: 674, 683, 760, 745, 805
+original-query: "artizen https://artizen.thezao.com/ every single fund that has been accepted to our artizen group and then lets make a zaoos.com/artizen page with all we have learned and include a bit about all projects in the artizen (+ pasted Rene Pinnell June 2026 newsletters: Phoenix Fund Drive $270K in 3 days, DWeb Camp Village, 36 Cinema/RZA fund, Lilly Wachowski fund, season closes July 9, ART relaunch)"
+tier: DEEP
+---
+
+# 843 — ZAO Fund for Emerging Culture: Full Season 6 Roster + Artizen June 2026 State
+
+> **Goal:** Capture every project accepted into Zaal's ZAO Fund for Emerging Culture on Artizen (Season 6), the fund's live standings, and the June 2026 Artizen platform moment - the canonical source for the `zaoos.com/artizen` page.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | SHIP the `zaoos.com/artizen` page from this roster | Zaal asked for it. The 32 projects + fund About/Eligibility + platform context are all captured here. Page = `src/app/artizen/page.tsx` (route did not exist; `grep -ri artizen src/` = 0 hits before this work). |
+| 2 | FEATURE the ZAO-ecosystem ties on the page | #1 InfiniteZero Network = the DIN project from [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/). Top supporter "Arun Philips" = [Arun Phillips](../../../) (DreamStarter, ZABAL Games, doc 805). #32 The Impact Concerts likely ties to Jose Acabrera's monthly Impact Concert (doc 745) - VERIFY before asserting publicly. These cross-links are the story: the fund is already wired into ZAO's own network. |
+| 3 | DRIVE artifact sales in the next 6 days | Fund page shows "Frontier Fund Drive Ends in 6 days" (so ~2026-06-17) with **$3,205 match remaining**. Match only fires on artifact sales. Every unsold dollar of that $3,205 is left on the table. This is the single highest-leverage action this week. |
+| 4 | The season got extended to July 9 | Per Rene's 2026-06-10 email: S6 now closes **July 9 2026** (~2 weeks later than planned) to ride Phoenix Fund Drive momentum. "One extension, will not move again." Plan grantee outreach + the DWeb Village around this. |
+| 5 | EVALUATE co-sponsoring or applying to a new Artizen fund | Two marquee funds just launched: **36 Cinema (RZA / Wu-Tang)** and a **Lilly Wachowski** fund. A ZAO project curated into a second fund gets match from both - the multiplier is the whole game. |
+
+## What "our Artizen group" is
+
+`artizen.thezao.com` 302-redirects to `artizen.fund/index/mf/zao-fund-for-emerging-culture?season=6`. The "group" = the **ZAO Fund for Emerging Culture**, a community match fund Zaal directs on Artizen (a Bubble.io-built Web3 match-funding platform). Season 6, **$10,000** total, Curator-run.
+
+**Fund About (verbatim from the page):** "The ZAO Fund for Emerging Culture supports independent musicians, visual artists, technologists, and community organizers creating collaborative cultural experiences that bridge digital coordination and real-world activation. We back projects that use emerging technologies - such as blockchain, AI, and immersive systems - not as gimmicks, but as infrastructure for shared ownership, fair compensation, and vibrant community participation."
+
+**Eligibility (verbatim):** creator-owned and independently operated; integrate emerging tech (blockchain, AI, decentralized tools, immersive media) meaningfully; demonstrate active collaboration / community participation; build in public; operate within a non-extractive, fair-compensation framework; culminate in a public-facing, real-world activation (performance, installation, gathering, exhibition, release, or showcase).
+
+## Live fund standings (as of 2026-06-11)
+
+| Metric | Value |
+|---|---|
+| Season | 6 |
+| Projects in Competition | **32** |
+| Projects in Curation | 15 |
+| Fund total | $10,000 |
+| Fund rank among all Artizen funds | **#2** (score 11.33) |
+| Fund prize pool shown | $45,584 |
+| Total raised across fund | $45,584 |
+| **Match remaining (unspent)** | **$3,205** |
+| Drive deadline shown | "Frontier Fund Drive - Ends in 6 days" (~2026-06-17) |
+| Top supporters (boost units) | Arun Philips (7,807), Aziz Motomoto (511), Zaal (7) |
+
+## The full roster - all 32 accepted projects (ranked by artifact sales, 2026-06-11)
+
+| # | Project | Creator | Sales | Match | Category | One-line |
+|---|---|---|---|---|---|---|
+| 1 | **InfiniteZero Network** | Abraham Nash | $45,108 | $502 | DeSci/AI | Decentralized AI training network (= DIN, [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/)) |
+| 2 | **Edge Esmeralda 2026** | Telamon Ardavanis | $30,569 | $2,677 | Human Flourishing | Month-long Northern California gathering, May 30-Jun 27 2026 ([Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/)) |
+| 3 | Voices of the Land | Yessie | $23,236 | $0 | Music | From women to the world: voice, vibration, ancestral frequencies |
+| 4 | Edge City Fellowship | Telamon Ardavanis | $10,567 | $1,557 | Fellowship | Funds exceptional under-25 builders for a month at Edge City |
+| 5 | Gaian Temple | NAOBA | $7,797 | $939 | Sound | Temple of Sound: listening experiments, concerts, biosphere comms |
+| 6 | Coralverse - Reef Revival | ZCreative Media | $7,464 | $0 | Gaming | Adventure gaming + real-world reef conservation |
+| 7 | Memethology | Colton | $6,684 | $508 | Community | Trading card game about tech, culture, human flourishing |
+| 8 | HERITAGE COLLECTION: Fashion, Music & Blockchain Show | Gneric | $5,810 | $634 | Fashion | Multidisciplinary fashion + music + blockchain showcase |
+| 9 | ToGather Project, Documenting Living Systems | Sharon | $5,712 | $45 | Community | Platform turning community-building experience into the commons |
+| 10 | HOPE | JED XO | $5,665 | $669 | Discovery | EP of five experimental tracks ministering hope out of brokenness |
+| 11 | ENTERTAINMENT EVOLVED | Matthew Chan | $4,910 | $200 | 360-experience | "You will believe a man can become content" |
+| 12 | The Owl's Nest: Regenerative Arts Gathering | Eska | $4,549 | $0 | Regenerative Culture | 5-day gathering of 50 makers on a reforestation site |
+| 13 | Regen Reef | MesoReefDAO | $4,469 | $50 | ReFi | Marine biotech + socio-ecological restoration + ReFi, modular wet labs |
+| 14 | Cinemetropolis | Jeff Desom | $3,645 | $615 | Mixed Reality | AR expands real miniatures into one connected movie universe |
+| 15 | Sonic Sanctuary: A Journey Through Sound | Plexonerz | $3,562 | $270 | Electronic Music | Electronic music as a sonic journey for introspection |
+| 16 | International Artists Project | International Artists Project | $3,215 | $270 | Community | Global music community uplifting artists from every country |
+| 17 | CHAINWARS .wtf \|\| Cypherpunk Space-Opera | Fly you fools .wtf | $2,072 | $107 | Journalism | Docu-myth from inside crypto's war room |
+| 18 | THE NEW VANGUARD | Enrico | $1,965 | $250 | Photography | Cinematic archive of Nigerian identity + Web3 cultural preservation |
+| 19 | DeSci Asia | Swift Evo | $1,870 | $0 | DeSci | Bridges + knowledge-sharing for DeSci communities in Asia |
+| 20 | Participatory Spatial Music Show | Joel DeJong | $1,375 | $0 | Participatory Art | Live, co-created entertainment series |
+| 21 | HuRya Empowerment Foundation (Poly Raiders) | Poly Raiders | $1,190 | $40 | Impact | Web3 art funding pads, kids' education, vocational center for girls |
+| 22 | The Creator Block | KOSBAA | $1,080 | $500 | Creator Economy | Two-day summit: creators showcase + learn to own work onchain |
+| 23 | THE ART FACTORY | Gidzeey | $978 | $58 | Music | One stage play a month telling Nigerian stories, paying creatives |
+| 24 | The MOTHERLand Project | Tarzaa Gerald Caesar (CZA OF REM) | $950 | $0 | Infrastructure | Women-led cultural infra: music, film, AI tools, digital ownership |
+| 25 | The Space - a Home for Activists in Israel-Palestine | Sapirs55 | $925 | $0 | Peacebuilding | Protected community space for justice + solidarity activists |
+| 26 | Ear of Dionysus: Listening as a Frontier Technology | The Decentralised Cult of Quantum Listening | $480 | $80 | Sound | Immersive sound lab + sonic theater at ancient sites |
+| 27 | Artisanal Intelligence | KNOTTO | $400 | $0 | Craftsmanship | Exhibition world tour on endangered crafts, Europe <-> Japan |
+| 28 | America 250 - Echoes of Freedom AR Art/History Tour | Trishgiaart | $385 | $0 | Augmented Reality | Site-specific AR public-art + history XR project |
+| 29 | Thread of Hope | whyldwanderer | $215 | $0 | Women Empowerment | Palestinian women in Cairo rebuilding identity through Tatreez |
+| 30 | Hip-Hop Africa: Building Pan-African Hip-Hop | Hiphop Africa | $110 | $0 | Multi-Media | Unified platform for African hip hop: radio, events, awards |
+| 31 | ANFT | Amin | $80 | $0 | Digital Art | Authorship-first digital painting marketplace, paint within the platform |
+| 32 | The Impact Concerts | EZinCrypto | $30 | $30 | Music | Awareness for social-good projects via live music + cultural exchange (likely tie to [Jose Acabrera's Impact Concert](../../../), doc 745 - VERIFY) |
+
+> Sales sum across the roster is ~$192k of artifact volume; the fund's own $45,584 figure is its prize/raise scoping, not the sum of project sales. Numbers are a live snapshot - they move every time someone buys an artifact.
+
+## ZAO-ecosystem ties already inside the fund
+
+- **#1 InfiniteZero Network (Abraham Nash)** is the same DIN / Oxford federated-learning project just re-researched in [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/). It is the top seller in Zaal's fund at $45,108. The fund and the agents-research thread converge here.
+- **Arun Philips** is the #1 supporter by boost (7,807). Almost certainly Arun Phillips - longtime friend, DreamStarter founder, ZABAL Games presenter, WaveWarZ India lead (doc 805).
+- **#2 + #4 are both Telamon Ardavanis** (Edge Esmeralda + Edge City Fellowship) - the grantee Zaal already opened a collaboration channel with (doc 674).
+- **#32 The Impact Concerts (EZinCrypto)** matches the shape of Jose Acabrera's monthly Impact Concert (doc 745, "Impact Concert on the 22nd, ETH + QF"). VERIFY the creator identity before claiming it publicly.
+
+## Artizen platform - the June 2026 moment (from Rene Pinnell's newsletters, pasted by Zaal 2026-06-11)
+
+Artizen rebuilt the whole platform (Rene, Nate Van Cleve, Venus). The relaunch landed mid-June 2026 as the **Phoenix Fund Drive**:
+
+| Fact | Detail |
+|---|---|
+| Phoenix Fund Drive raise | **$212,002 in first 24h**, **$270,852 in 3 days** (goal was $250k) |
+| Match this drive | 3x match multiple locked for the week; $1.4M match funding; $125k cash prizes |
+| New prize mechanic | Prize = **Boost Score = total raised x boosts received** (need both sales AND boosts to rank) |
+| Season 6 close | **Extended to July 9 2026** (~2 weeks later, "one extension, will not move again") |
+| Stretch goals | $10M season goal; Rene targets a **$100M endowment** by end of 2026 |
+| New fund: **36 Cinema Creative Fund** | Launched with **RZA (Wu-Tang)**; curated by Abazar Khayami; brokered by Sam Pressman. "Forging new worlds through film, sound, and future tools." |
+| New fund: **Lilly Wachowski** (The Matrix) | Launching same week per the 2026-06-10 email |
+| ART smart contract | Anthropic's "Mythos" model found a critical bug; fix built; **ART relaunches** that week. ART token shown: minting $0.000100, floor $0.000134, Cycle 5 (5/1/2026) |
+| Weekly show | "Showcase" renamed **Artizen LIVE** (#77, Thu Jun 11, 10am PT); produced by Wadooah Wali (New Canvas); live music Summer Krinsky; $120k+ awarded live |
+| **Artizen Village at DWeb Camp** | July 8-12 2026, forest outside Berlin, run by Internet Archive; room for 20 Artizens (food + glamping covered, travel scholarship); featured guest Mai Ishikawa Sutton (DWeb steward) |
+| Rene Pinnell | 5th-generation artist, "raised over $50M for creators" |
+
+## How Artizen mechanics work (recap from Doc 683, still current)
+
+- **Artifact** = open-edition NFT, **$10** flat, 100% to the creator (note: new ART token + sub-cent pricing now also in play post-relaunch - mechanics are shifting, verify before quoting).
+- **Match** = 1:1 instant. Every $1 in artifact sales unlocks $1 from each fund backing the project, while that fund's pool lasts.
+- **Multiple funds** = a project in 2+ funds gets match from each. The multiplier is the incentive to seek broad backing.
+- **Founder/raise:** Rene Pinnell; $2.2M raised 2023 (ConsenSys, Animoca, Protocol Labs); $750k+ awarded historically (now far higher post-Phoenix).
+
+## Also See
+
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Edge Esmeralda grantee outreach (Telamon, #2 + #4 on the roster)
+- [Doc 683](./../683-artizen-platform-fund-director-guide/) - Artizen platform mechanics + fund-director guide
+- [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/) - InfiniteZero / DIN (#1 on the roster)
+- [Doc 745] - Jose Acabrera / Impact Concert (possible #32 tie)
+- [Doc 805] - Arun Phillips (top fund supporter)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Ship `src/app/artizen/page.tsx` (zaoos.com/artizen) from this roster | @Claude | PR | This PR |
+| Verify whether #32 "The Impact Concerts / EZinCrypto" is Jose Acabrera before featuring the tie publicly | @Zaal | Verification | Before page goes public |
+| Push grantees to sell artifacts before the drive ends (~Jun 17) - $3,205 match left unspent | @Zaal | Outreach | 2026-06-17 |
+| Decide whether to apply a ZAO project into 36 Cinema (RZA) or Lilly Wachowski fund for the double-match | @Zaal | Decision | Before S6 closes Jul 9 |
+| Evaluate applying for an Artizen Village @ DWeb Camp slot (Berlin, Jul 8-12) | @Zaal | Decision | ASAP (20 slots) |
+| Re-snapshot the roster + standings before any public quote (numbers are live) | @Claude | Verification | At page publish |
+
+## Sources
+
+- [FULL] [ZAO Fund for Emerging Culture S6](https://artizen.fund/index/mf/zao-fund-for-emerging-culture?season=6) - full 32-project roster + About + Eligibility + standings rendered via headless browser (gstack browse), 2026-06-11. Bubble.io app; curl/exa/WebFetch all return an empty JS shell or time out - only a real browser renders it.
+- [FULL] `artizen.thezao.com` 302-redirect chain confirmed via `curl -I` -> `artizen.fund/index/mf/zao-fund-for-emerging-culture?season=6`
+- [FULL] Rene Pinnell newsletters (4 emails, June 2026) - pasted verbatim by Zaal: Phoenix Fund Drive numbers, season date change, 36 Cinema (RZA) + Lilly Wachowski funds, ART relaunch, Artizen LIVE #77, DWeb Camp Village
+- [FULL] [Doc 683](./../683-artizen-platform-fund-director-guide/) + [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - prior ZAO research on Artizen mechanics + fund ownership
+- [FULL] [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/) - confirms InfiniteZero Network (roster #1) identity
+- [PARTIAL - identity unconfirmed] #32 "The Impact Concerts / EZinCrypto" creator vs Jose Acabrera (doc 745) - shape matches but the handle was not cross-verified this pass; flagged, not asserted.
+- [PARTIAL - mechanics in flux] ART token sub-cent pricing + Cycle 5 ($0.000100 mint / $0.000134 floor) read off the page but the post-relaunch artifact/ART economics are mid-change; the $10-artifact model from doc 683 may be partly superseded. Verify before quoting publicly.

--- a/research/business/844-artizen-platform-deep-study/README.md
+++ b/research/business/844-artizen-platform-deep-study/README.md
@@ -1,0 +1,155 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-06-12
+related-docs: 674, 683, 843, 760
+original-query: "lets keep researching and studying online about artizen (deep platform study: company/team, funding mechanics, ART token, June 2026 relaunch + Phoenix/Frontier fund drives, sentiment, competitive landscape). + pasted Rene Pinnell Frontier Fund Drive newsletter 2026-06-12"
+tier: DISPATCH
+---
+
+# 844 — Artizen: Deep Platform Study (model, ART token, team, sentiment, competition)
+
+> **Goal:** Go past the fund roster ([Doc 843](../843-zao-fund-artizen-roster-june2026/)) into Artizen the platform - how the money actually moves, the new ART/Endowment machine, who runs it, what people say, and where it sits vs Gitcoin/Juicebox/the ReFi world. The canonical "what is Artizen, really" doc for ZAO.
+
+> **Method:** DISPATCH - 5 parallel research agents (company, mechanics, 2026 relaunch, sentiment, competition), each climbing the fetch ladder, synthesized here. One agent (company/funding history) died mid-run; its ground is covered by the sentiment + relaunch agents.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | KEEP the ZAO Fund, but understand the ART/Endowment layer before going deeper financially | Artizen is no longer just "$10 NFT + match." Since Oct 2025 it runs a **Revnet-style ART token** feeding an **Endowment** ($4M -> $10M EOY 2026 goal -> $100M). That is a reflexive bonding-curve machine - powerful on the way up, and René himself says "the feedback loop that compounds belief can just as easily unwind it." Treat ART exposure as separate from running the fund. |
+| 2 | Artifacts are on ETHEREUM MAINNET - factor gas | A $10 artifact costs a buyer ~$25-30 after gas. That friction is why low-rank ZAO grantees have $0 sales. For the next drive, point supporters at the cheapest path and consider covering/bundling gas where possible. |
+| 3 | RIDE the drive cadence - we are mid-Frontier Fund Drive right now | Phoenix Drive (week 1: 3x match, $250k goal -> $270k actual) is over. **Frontier Fund Drive is live now: 2x match, $600k goal, $2M match funding, $250k cash prizes, ENDS Thursday June 18 11am PT.** The ZAO Fund's "$3,205 match remaining" (doc 843) should be fully unlocked before that deadline. |
+| 4 | The ZAO Fund's edge is REAL community, not capital | Artizen's whole model rewards projects that can rally a crowd to buy artifacts + boost. ZAO's 188-member network + the WaveWarZ/ZABAL/Farcaster reach is exactly the distribution most grantees lack. That is the lever to be a top fund, not adding more sponsor dollars. |
+| 5 | DO NOT over-claim the new funds publicly yet | 36 Cinema (RZA) is real and confirmed ($36k raised, "took the gold"). **The Lilly Wachowski fund is email-only - no public trace.** Curator names for 36 Cinema (Abazar Khayami, Sam Pressman) are unconfirmed online. Keep these out of any public ZAO artifact until verified. |
+
+## What Artizen is (one paragraph)
+
+Web3 match-funding platform for art / science / technology / culture, founded by **René Pinnell**. Creators mint **open-edition "Artifact" NFTs ($10, on Ethereum mainnet, 100% to the creator, 0% platform fee)**. Every $1 of artifact sales instantly unlocks $1 from each community **Fund** backing that project (match stacks across multiple funds, until each pool drains). Runs in **seasons** with a **Curation** phase (community votes projects in) then a **Competition** phase (sell artifacts, climb the leaderboard, win cash prizes). On top of this sits a newer **ART token + Endowment** treasury machine. Built and rebuilt ~10 times on **Bubble.io** (no-code).
+
+## The fund-drive cadence (current)
+
+Artizen runs weekly "fund drives" with escalating match multiples to create urgency:
+
+| Drive | Match | Goal | Result | Window |
+|---|---|---|---|---|
+| **Phoenix Fund Drive** | 3x | $250k | **$270,852** raised in 3 days ($212,002 in first 24h) | ~Jun 4-11 2026 |
+| **Frontier Fund Drive** (LIVE) | 2x | $600k | in progress | ends **Thu Jun 18, 11am PT** |
+
+- Frontier pool: **$2M match funding + $250k cash prizes.** "2x" now means literal: every $1 you raise -> $2 match (clarified wording from last week).
+- The "Phoenix" name is personal (see team history). "Frontier" is themed to **Edge Esmeralda**, where Artizen is headed for "a week of connected play" (ties straight into [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Telamon / Edge City).
+- Live show **Artizen LIVE** (formerly "Showcase") runs weekly alongside the drives; cash prizes awarded on stream. June 11 episode featured Summer Krinsky (music), Mai Ishikawa Sutton (DWeb), Toni Blackman (poet), and a mime pitch. **36 Cinema (RZA) raised $36k and "took the gold."**
+
+## Mechanics (deep)
+
+| Element | Detail | Confidence |
+|---|---|---|
+| Artifact | Open-edition NFT, **$10**, 100% to creator, **Ethereum mainnet** (~$25-30 to buyer w/ gas). Likely ERC-1155, not explicitly confirmed. | [FULL] price/payout; [PARTIAL] token standard |
+| Platform fee | **0%.** Artizen takes no cut of artifact sales, sponsor dollars, or match. | [FULL] |
+| Match | 1:1 instant. $1 sale unlocks $1 from each backing fund, while that fund's pool lasts. | [FULL] |
+| Multi-fund stacking | A project curated into N funds gets matched by all N independently. The whole incentive to seek broad backing. | [FULL] |
+| Fund split | 10% of a fund = cash prize for its top project; 90% = split as available match across curated projects. | [FULL] |
+| "Fluid quadratic funding" | Continuous (not round-batched) matching via **Superfluid Instant Distribution Agreements**. Open-source: `github.com/artizen-fund/fluid-quadratic-funding`. Differs from Gitcoin's discrete retroactive QF rounds - donors see impact in real time. | [FULL] |
+| Boost / Boost Score | Gamified at `boost.artizen.fund`. Voting power from signup (+100), contributions (+10 votes/$1), and hitting raise targets. June 2026 prize = **Boost Score = total raised x boosts received** (need both sales AND boosts to rank). Exact formula not in public docs. | [PARTIAL] |
+| Seasons | Curation phase -> Competition phase. One combined payout at season end (artifact sales + match + prizes). Season length in days not publicly specified. | [FULL] phases; [FAILED] exact length |
+
+## The ART token + Endowment (the big new machine)
+
+This is the part docs 683/843 did not cover. Since **October 2025**, Artizen runs a **Revnet-style** token:
+
+- **ART** is a **treasury-backed asset**, not a governance token. Backed by treasury, **redeemable for USD at a continuously rising floor price**. Mint price climbs on a fixed schedule ("exponential ceiling, rising floor"). The ZAO fund page showed ART at mint $0.000100 / floor $0.000134, "Cycle 5" (snapshot) - sub-cent units.
+- Buying ART either mints new tokens or buys on the open market (whichever is cheaper); **a cut of every transaction flows into the Artizen Endowment.**
+- **Endowment**: launched ~$4M (Oct 2025), goal **$10M by end of 2026**, then **$100M**. This is the "infinite money glitch" René describes in his newsletter.
+- **The risk (flag loudly):** this is a reflexive bonding curve. René states plainly the belief loop "can just as easily unwind it." If momentum reverses, the rising-floor promise is under pressure. **A bug in the ART smart contract was reportedly found (and fixed) around the June 2026 relaunch** - source for the bug is René's email only; no public postmortem found.
+
+## Team + company history
+
+- **René Pinnell** - founder. Self-described "artist first, entrepreneur second," 5th-generation artist. The "$50M raised for creators" line is his own claim, not independently verified.
+- **The Phoenix story is literal:** René ran an earlier (pre-blockchain) Artizen that **Stripe deplatformed in March 2020** over chargebacks - no warning, no appeal. He went **bankrupt, ~$437,000 in debt.** The crypto rebuild rose from that - hence "Phoenix Fund Drive."
+- **Built ~10 times on Bubble.io** (no-code). Deliberate "break things, fix, experiment" philosophy over engineering rigor (Bubble published an Artizen case study, "$2.3M awarded," March 2026).
+- **Raise:** $2.2M seed (May 2023) - ConsenSys Mesh, Animoca Brands, Protocol Labs, **Kevin Owocki (Gitcoin founder) personally invested.** A later "$2.5M" figure appeared April 2025 (Signalbase) - possibly a follow-on or restated total; unreconciled.
+- **Traction (Nov 2025):** ~$2.7M invested through the platform, **30,000+ Artifacts collected.** Awarded-to-creators total grew from "$750k+" (2024) to ~$2.3M+ (2026).
+- Other names surfaced: Nate Van Cleve (dev/grant-writer), "Venus," Ruben Campos (ex-Yahoo dev), Wadooah Wali of New Canvas (produces Artizen LIVE).
+
+## New funds (June 2026)
+
+- **36 Cinema Creative Fund (RZA / Wu-Tang)** - CONFIRMED via the drive results ($36k, "took the gold"). 36 Cinema is RZA's real film-distribution venture (launched March 2026, a Tarantino "One Spoon of Chocolate" release). Curator **Abazar Khayami** (XTR cinematographer) + broker **Sam Pressman** (Pressman Film) per René's email - **not publicly confirmed.**
+- **Lilly Wachowski (The Matrix) fund** - **email-only, FAILED to verify.** Lilly's known vehicle is the "Anarchists United Foundation"; no Artizen tie found online. Do not publish as fact.
+
+## DWeb / Internet Archive alignment
+
+- **Artizen Village** (artizenvillage.com) is an official camp within **DWeb Camp 2026**: **July 8-12, Alte Hölle** (a forest ~100km southwest of Berlin), hosted by the **Internet Archive**. Room for ~20 creators, workshops, spotlights.
+- **Mai Ishikawa Sutton** = DWeb Director of Fellowships (René's email called her "featured guest"). Confirms Artizen's ideological lean: decentralized-web / open-internet, not pure fintech crowdfunding.
+
+## Sentiment + risk read
+
+Honest signal: **thin, skewing positive, almost no public criticism.**
+
+- **Trustpilot:** 3.6/5 but effectively **1 visible review** (positive, from a fund builder). Tiny sample.
+- **Reddit / HackerNews / X:** no Artizen-specific complaint threads, scam accusations, or payout disputes found. For an early, niche, art+crypto platform this is expected, not proof of perfection.
+- **The only "criticism" is founder-authored:** René's posts "Don't Hate Me, I'm an Artist" (Mar 2025) and "The Art (and Chaos) of Curation" (May 2025) pre-acknowledge that shifting deadlines, changing rules, and failed experiments anger some users - framed as the cost of making art, not startup dysfunction. The June 2026 season extension (to Jul 9) fits this pattern.
+- **Real risks, mostly structural, not reputational:**
+  1. **ART reflexivity** - the rising-floor/exponential-mint machine can unwind (founder-acknowledged).
+  2. **Match-pool depletion** - first-movers can drain a fund's pool, leaving late projects unmatched.
+  3. **Artifact illiquidity** - no secondary market live; buyers may be holding illiquid NFTs.
+  4. **Operational chaos by design** - 10 Bubble rebuilds + repeated deadline shifts = low predictability.
+  5. **Payout reliability** - no public data confirming creators reliably receive promised match (no complaints either).
+
+## Competitive landscape
+
+| Platform | Model | For whom | Chain | Fee | vs Artizen |
+|---|---|---|---|---|---|
+| **Gitcoin Grants** | Batch QF rounds | OSS devs, infra | ETH + multichain | ~10-15% of match pool | Discrete rounds, software-focused; Owocki is an Artizen investor - treated as complementary, not rival |
+| **Juicebox** | Programmable funding cycles | DAOs, crypto teams | ETH/L2s | 2.5% | Treasury/governance infra, not creator-facing |
+| **Mirror.xyz** | Writing + NFT + crowdfund | Writers | ETH | ~10% | Text-first; Artizen is multimedia/visual |
+| **Catalog / Sound / Glass** | Music NFT drops + royalties | Musicians | ETH/Base | 10-20% | Marketplaces, high price points; Artizen = $10 open-edition + match layer |
+| **Giveth** | Zero-fee donations + GIVbacks | Nonprofits, OSS | 7 chains | 0% + gas | Broad public goods, donor-incentive; Artizen = creator-curation |
+| **Optimism RetroPGF** | Retroactive impact payout | Proven-impact projects | Optimism | none | Ecosystem-specific, grant-like; Artizen = continuous crowdfunding |
+| **Patreon / Kickstarter** | Subscription / all-or-nothing | All creators | Fiat | 5-8% | Web2 baselines, no match, no public-goods ethos |
+
+**Artizen's actual differentiation:** culture-first (not engineering-first like Gitcoin) + low-friction $10 open-edition entry + continuous fluid QF + a sticky community of curators/artifact-holders + ReFi/DWeb ideological positioning. **Strongest threat:** Gitcoin (or a major L1 like Base/Zora) launching a creator-focused QF program with bigger existing reach - currently mitigated by Owocki's investment / explicit non-compete stance.
+
+## ZAO takeaways
+
+1. **The ZAO Fund's moat is distribution.** Artizen rewards crowds-that-buy. ZAO has a real community; most grantees do not. Lean into rallying buyers + boosts, not into adding sponsor capital.
+2. **InfiniteZero (#1 in the ZAO fund, [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/)) topping the leaderboard at $45k is the proof case** - a project with a real network outsells everyone.
+3. **Edge Esmeralda is the bridge.** Artizen is literally going there; Telamon is a double-grantee in the ZAO fund (doc 674). There is a 3-way ZAO <-> Artizen <-> Edge City overlap to activate in person.
+4. **Watch the ART/Endowment machine** but keep ZAO's treasury out of it until the reflexivity risk is understood.
+
+## Also See
+
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - the ZAO Fund full S6 roster + the zaoos.com/artizen page
+- [Doc 683](../683-artizen-platform-fund-director-guide/) - earlier platform-mechanics + fund-director guide (this doc extends it with ART/Endowment + team + sentiment)
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Edge Esmeralda / Telamon (the Frontier-drive theme + a top grantee)
+- [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/) - InfiniteZero Network, the #1 project in the ZAO fund
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Drive ZAO grantees to fully unlock the fund's match before the Frontier drive closes | @Zaal | Outreach | 2026-06-18 11am PT |
+| Verify the Lilly Wachowski fund + 36 Cinema curators before any public ZAO mention | @Zaal | Verification | Before publishing |
+| Read René's "Infinite Money Glitch" + "Like a Phoenix" posts to fully grok ART/Endowment risk | @Zaal | Read | This week |
+| Decide if a ZAO project applies into 36 Cinema (RZA) for the double-match | @Zaal | Decision | Before Jul 9 |
+| Pursue an Artizen Village @ DWeb Camp slot (Berlin, Jul 8-12) - ties ZAO into the Internet Archive / DWeb world | @Zaal | Decision | ASAP (~20 slots) |
+| Re-validate ART pricing + endowment figures (high-churn) | @Claude | Verification | Monthly |
+
+## Sources
+
+- [FULL] [Artizen Playbook (newsletter)](https://news.artizen.fund/p/artizen-playbook) - match mechanic, multi-fund stacking, phases
+- [FULL] [Artizen on Gitcoin](https://gitcoin.co/apps/artizen-fund) - model summary, Owocki investment, ecosystem position
+- [FULL] [fluid-quadratic-funding (GitHub, artizen-fund)](https://github.com/artizen-fund/fluid-quadratic-funding) - Superfluid IDA, continuous QF
+- [FULL] [Infinite Money Glitch (newsletter)](https://news.artizen.fund/p/infinite-money-glitch) - ART token + Endowment treasury model
+- [FULL] [Like a Phoenix, Motherfucker (newsletter)](https://news.artizen.fund/p/like-a-phoenix-motherfucker) - Stripe deplatforming 2020, bankruptcy, the Phoenix origin
+- [FULL] [Don't Hate Me, I'm an Artist (newsletter)](https://news.artizen.fund/p/dont-hate-me-im-an-artist) + [The Art (and Chaos) of Curation](https://news.artizen.fund/p/the-art-and-chaos-of-curation) - founder-acknowledged friction
+- [FULL] [Bubble.io Artizen case study](https://bubble.io/blog/artizen/) - 10x rebuild, $2.3M awarded, no-code philosophy
+- [FULL] [Decrypt - Artizen raises $2.2M](https://decrypt.co/139682/artizen-fund-raises-2-2-million-to-create-nft-cultural-artifacts) - 2023 raise, investors
+- [FULL] [Artizen Village @ DWeb Camp](https://artizenvillage.com/) + [DWeb Camp 2026](https://dwebcamp.org/berlin-2026/) + [Internet Archive venue blog](https://blog.archive.org/2026/04/09/dweb-alte-hoelle/) - Village, dates, Alte Hölle, Mai Ishikawa Sutton
+- [FULL] [Funding What Matters: Owocki interview (newsletter)](https://news.artizen.fund/p/funding-what-matters-artizen-talks) - Gitcoin relationship
+- [FULL] [Trustpilot - artizen.fund](https://www.trustpilot.com/review/artizen.fund) - 3.6/5, ~1 visible review
+- [PARTIAL] [Signalbase - "Artizen secures $2.5M"](https://www.trysignalbase.com/news/funding/artizen-secures-25m-to-fuel-the-future-of-art-science-and-technology-funding) (Apr 2025) - unreconciled vs the $2.2M figure
+- [PARTIAL] [RZA 36 Cinema (Deadline)](https://deadline.com/2026/03/rza-quentin-tarantino-release-one-spoon-of-chocolate-1236751148/) - 36 Cinema is real; its Artizen-fund curators are not publicly confirmed
+- [PARTIAL - email-only] René Pinnell Phoenix + Frontier Fund Drive newsletters (pasted by Zaal, Jun 11-12 2026) - drive numbers, 36 Cinema "$36k took the gold," Frontier 2x/$600k/$2M/$250k ending Jun 18, the Lilly Wachowski fund. No independent web confirmation of the drive figures.
+- [FAILED] Lilly Wachowski x Artizen fund - no public source; do not assert.
+- [FAILED] ART token "Cycle 5" tokenomics detail + exact season length in days - not publicly documented.

--- a/research/business/845-artizen-art-token-endowment-economics/README.md
+++ b/research/business/845-artizen-art-token-endowment-economics/README.md
@@ -1,0 +1,160 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-06-12
+related-docs: 674, 683, 843, 844, 760
+original-query: "keep going please (second deep wave on Artizen: ART token/Revnet/Endowment financial engine, season history + full fund ecosystem, Rene Pinnell newsletter thesis/track-record/roadmap)"
+tier: DISPATCH
+---
+
+# 845 — Artizen: the ART/Endowment Engine, Season Economics & René Pinnell's Thesis
+
+> **Goal:** Document the financial machine under Artizen (the ART Revnet + the Endowment), the full season + community-fund economics the ZAO Fund competes inside, and René Pinnell's actual thesis/roadmap - so ZAO can judge the upside, the reflexivity risk, and how to win as a fund director. Companion to [Doc 844](../844-artizen-platform-deep-study/).
+
+> **Method:** Second DISPATCH wave - 3 parallel agents (ART/Endowment, season+fund ecosystem, newsletter thesis), reading René's Substack archive FULL.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | TREAT ART as a real Revnet, with a real floor - and a real reflexivity risk | ART is a verified Revnet (Juicebox v4) on **Ethereum mainnet**, contract `0x59fbbc7d9c579547b47f3669aab2aec5b58d63de` (on Etherscan). It is NOT vaporware. But the upside flywheel runs in reverse too: if momentum stalls, redemption value converges toward the USDC floor and the growth story breaks. It does NOT go to zero (unlike Terra/LUNA) because the floor is locked USDC. Understand this before any ZAO treasury touches ART. |
+| 2 | ZAO Fund is #2 of ~32 community funds - that's a strong position to defend | Artizen runs ~32 community funds (Console, Mona, Microsoft, Cannes, 36 Cinema/RZA, ZAO, ...). The ZAO Fund ranking #2 (doc 843) is real standing, earned by community sales, not capital. Defend it by driving artifact sales, not by adding sponsors. |
+| 3 | APPLY for the "$1 Million for Community Funds" program (up to $50K seed) | The ZAO Fund currently runs on $10k (Artizen-sponsored). René's Dec 2025 program gives fund directors **up to $50,000** to seed a fund + a call with René. ZAO qualifies cleanly. This is the single biggest lever to grow the fund's match pool. |
+| 4 | USE René's own curation rubric: "Weird, Wonderful, Working" | That is literally how Artizen curates. ZAO Fund submissions that are original (weird), beautiful-with-purpose (wonderful), and shipping/selling (working) are what the platform rewards. Curate the ZAO Fund to that bar. |
+| 5 | LEAN into the personal + ETH Boulder relationship with René | Zaal got to ETH Boulder via the Artizen-sponsored house. ETH Boulder (Jan 2026) is René + Kevin Owocki's joint thing. The ZAO <-> Artizen relationship is warm and real - the $50K program ask and the DWeb Village slot both run through that. |
+
+## The ART token + Endowment (now fully mapped)
+
+ART is the financial engine that funds the whole thing. As of June 2026:
+
+| Fact | Detail | Source |
+|---|---|---|
+| What it is | A **Revnet** (autonomous rule-based treasury), built on **Juicebox v4**, immutable post-launch | [FULL] Bankless Revnet primer + Etherscan |
+| Chain + contract | **Ethereum mainnet**, `0x59fbbc7d9c579547b47f3669aab2aec5b58d63de` | [FULL] Etherscan |
+| Launched | ~Oct 2025 ("Vending Machine for Creativity," "Infinite Money Glitch") | [FULL] newsletter |
+| Buy split | **60% ART to buyers, 10% to team, 30% to the Endowment** (USDC in) | [FULL] Infinite Money Glitch |
+| Mint schedule | **Genesis: 3 cycles, price doubles every 35 days. Growth: 7 cycles, doubles every 120 days. Scale: annual cycles, doubles yearly forever.** ("Cycle 5" on the fund page = a Growth-phase cycle.) | [FULL] Exponential Ceiling, Rising Floor |
+| Price band | Trades between an **exponential ceiling** (the doubling mint price) and a **rising floor** (USDC-backed redemption) | [FULL] |
+| Redemption | Burn ART anytime to redeem USDC from the Endowment, minus a **10% cash-out tax**. The tax penalizes early exit + raises per-token backing for everyone who stays = the floor mechanically rises | [FULL] |
+| Buyback loop | Platform + treasury revenue funds ART buybacks to sustain demand | [FULL] Vending Machine for Creativity |
+
+### The flywheel (René's own words)
+
+> "The more ART we sell, the bigger the Endowment grows. The bigger the Endowment, the more creators we fund. The more creators we fund, the more Artifacts they sell. The more sales, the more revenue we have for buybacks. And the cycle repeats."
+
+### The reflexivity risk (the honest downside)
+
+Same loop runs backward. If belief/inflow slows: minting stalls, secondary price drifts toward the floor, the 10% exit tax means **late redeemers recover less per token**, and Endowment growth stalls. René's safeguard claim: "It's belief - anchored to reality" - the USDC floor is locked and transparent, so it is **not** a Terra/LUNA zero. The realistic bear case is "growth narrative breaks, value converges to floor," not "total loss." Artizen publishes **no concrete stress test** - that's the gap.
+
+### The June 2026 ART contract bug
+
+René's email says Anthropic's "Mythos" model found a critical ART smart-contract bug, now fixed, ART relaunching. **No public postmortem or disclosure exists** - email-only. Do not assert specifics publicly.
+
+## The Endowment + the trillion-dollar roadmap
+
+René's stated targets (quote them so we can track whether he hits them):
+
+- Launched **$4M** (Oct 2025), grew **+$360K** in two weeks.
+- **$6M** at the next price-double (29-day target), then **$10M by year's end.**
+- "In less than five years... **$10 billion**, overtaking Kickstarter as the largest funding platform for creators."
+- "By 2034... pass Novo Nordisk to become the largest endowment in the world."
+- "Around year twelve - roughly 4,386 days from now - **$1 trillion.**"
+- Math assumes 161%/season growth decaying to a 2%/season equilibrium. René: "Everest is littered with the frozen remains of big dreams" - he frames it as a bet with stated odds, not a promise.
+
+> Treat these as aspirational founder targets, not guarantees. The $4M -> $10M EOY path is the near-term one to actually watch.
+
+## Season + fund economics
+
+**Season ladder (the traction proof):**
+
+| Season | Raised for creators | Engagement | Note |
+|---|---|---|---|
+| 1 | ~$50K | - | bootstrap |
+| 2 | ~$100K | - | "messy product" |
+| 3 | ~$500K | - | "product finally fun"; Gaia Sound Temple alumni since here |
+| 4 | $1M+ | 1.4M votes, 158 projects curated | scale inflection |
+| 5 | ~$860K-$1M | 2M votes, 132 projects | "finally nailed match funding" (instant 1:1) |
+| 6 | in progress | - | closes Jul 9 2026; Phoenix + Frontier drives |
+
+- **Total awarded to creators:** ~$1M (2024) -> **$2.3M (2026)**, pacing to a **$10M-awarded** EOY-2026 goal. Founded **2021**.
+- **Match-funding evolution:** early seasons used Fluid Quadratic Funding + Logarithmic Match Funding (complex); from S5 they shifted to **instant 1:1 match** ("Keep It Simple, Stupid").
+
+**The community-fund ecosystem (~32 funds) - ZAO's competitive set:**
+
+| Fund | Runner | Theme | Size/standing |
+|---|---|---|---|
+| **36 Cinema Creative Fund** | RZA (Wu-Tang) | Film / sound / future tools | Took the gold (#1), raised $36K (week of Jun 11) |
+| **ZAO Fund for Emerging Culture** | Zaal / The ZAO | Emerging culture (music/art/tech) | **#2** (score 11.33), $10k pool |
+| Console Fund | Console | Community builders | $20K |
+| Mona Match Fund | Mona | 3D / metaverse creators | 12 ETH (~$20K) |
+| Microsoft Match Fund | Microsoft | Microsoft-community projects | n/a |
+| Cannes Film Festival Fund | Cannes Film Festival | Film/cinema | n/a |
+
+> No public master list of all ~32 funds exists (Bubble app, not indexable). The above are the confirmable ones. The headline: **ZAO ranks #2 of ~32, just behind RZA's fund.**
+
+**Sponsor program for fund directors:** "$1 Million for Community Funds" (Dec 2025) - Artizen commits $1M total, **up to $50K seed per selected fund**, rolling applications, a call with René required. Supersedes the older "up to $10K" Accelerator. Every $1 a fund raises becomes "$3+ of impact" (fan + sponsor + Endowment).
+
+**Notable alumni Artizen promotes:** Wu-Tang, Cate Blanchett, Darren Aronofsky-linked projects; Gaia Sound Temple (multi-season); the Black Realities Grant (Viola Davis, $100K, 2020 - René's pre-Artizen breakout).
+
+## René Pinnell - thesis, track record, DNA
+
+**Thesis:** markets are "good at pricing exclusion, terrible at pricing shared value." Creators drive civilization yet stay poor. **Artifacts let markets *see* cultural/scientific impact** - "just as money let markets see beyond barter, and stocks let them see scale." Artizen = capitalism finally able to fund creativity, via an endowment flywheel meant to fund human creativity forever.
+
+**Curation rubric (use this):** **Weird, Wonderful, Working.** Weird = original, unclaimed territory ("a feature, not a bug"). Wonderful = beauty + purpose. Working = ships, sells, shows "signs of life."
+
+**Track record (mostly verifiable from his own archive):**
+- **5th-generation artist.** Childhood best friend was **Ross Ulbricht** (Silk Road), arrested 2013 - René cites this as the root of his "peaceful exit, not revolution" worldview.
+- Prior ventures: Hurricane Party; Kaleidoscope Events (VR festivals, Tribeca/Cannes/VIFF deals, "a financial black hole"); the **Black Realities Grant** (Viola Davis, $100K+, 2020 - the viral breakthrough).
+- **Stripe killed a $20K-MRR business over chargebacks -> $437,000 personal debt -> bankruptcy.** This is the literal "Phoenix." He puts it front-and-center; failure is his credibility marker.
+- Artizen raised ~**$1.2M pre-seed** (Protocol VC, Animoca Brands, ConsenSys, Juan Benet, Path); accelerators Tachyon + Techstars (mentors incl. **Sam Williams**, Arweave founder). Rebuilt ~10x on Bubble with solo dev Nate Van Cleve. (Reconcile vs the $2.2M Decrypt-2023 and $2.5M-2025 figures - likely pre-seed -> seed -> restated total; unconfirmed.)
+
+**Worldview / risk DNA:** "I am an artist, not an entrepreneur. I trust intuition more than metrics... I hate managing. I want to dance." Openly embraces failure + experimentation. Building **network states** infrastructure - the **Terminus Fund** ($100K for sovereign communities: Grandmatopia AZ, Ipê Village Brazil, Agartha, Regenera) frames Artizen as "core infrastructure to peacefully exit failing systems."
+
+**Gitcoin / Owocki:** met 2018, Kevin invested in Artizen, complementary not competitive ("same tribe, different instruments"). **ETH Boulder** (Jan 2026) is their joint, intimate anti-ETH-Denver event - "a robot Fight Club produced by theater kids." (This is the Artizen-sponsored orbit that got Zaal to ETH Boulder.)
+
+## ZAO takeaways
+
+1. **Apply for the $50K community-fund program.** It is the cleanest 5x of the ZAO Fund's pool, and the relationship is warm.
+2. **Curate to "Weird, Wonderful, Working."** It is the house rubric; matching it = better ZAO-fund standing.
+3. **The ZAO edge stays distribution.** #2 of 32 was earned by community, not capital. Keep feeding artifact sales + boosts.
+4. **ART is real but reflexive.** Engage the platform; keep ZAO treasury out of the ART curve until there's a public stress test.
+5. **The network-state / DWeb / Edge City threads all connect** - Terminus Fund, DWeb Camp Village, Edge Esmeralda (Frontier drive). ZAO sits naturally in this map.
+
+## Also See
+
+- [Doc 844](../844-artizen-platform-deep-study/) - Artizen platform deep study (mechanics, sentiment, competition)
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - ZAO Fund full S6 roster + zaoos.com/artizen page
+- [Doc 683](../683-artizen-platform-fund-director-guide/) - earlier fund-director guide
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Edge Esmeralda / Telamon
+- [Doc 760](../../agents/760-infinitezero-din-decentralized-ai/) - InfiniteZero (ZAO Fund #1)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Apply to "$1 Million for Community Funds" ($50K seed) - book the call with René | @Zaal | Outreach | This month |
+| Re-curate ZAO Fund S7 submissions against "Weird, Wonderful, Working" | @Zaal | Decision | Before S7 curation |
+| Decide ZAO's stance on ART exposure (recommend: none until a public stress test exists) | @Zaal | Decision | Before any treasury move |
+| Read René's "Infinite Money Glitch" + "Largest Endowment in the World" to grok the flywheel + risk firsthand | @Zaal | Read | This week |
+| Track the Endowment $4M -> $10M EOY path as the near-term reality check on his roadmap | @Claude | Verification | Quarterly |
+| Re-validate ART price/cycle + fund standings (high-churn) | @Claude | Verification | Monthly |
+
+## Sources
+
+- [FULL] [Artizen (ART) Token - Etherscan](https://etherscan.io/token/0x59fbbc7d9c579547b47f3669aab2aec5b58d63de) - confirms ART is a real Ethereum-mainnet token/Revnet
+- [FULL] [Infinite Money Glitch (newsletter)](https://news.artizen.fund/p/infinite-money-glitch) - 60/10/30 split, flywheel, reflexivity
+- [FULL] [Exponential Ceiling, Rising Floor (newsletter)](https://news.artizen.fund/p/exponential-ceiling-rising-floor) - mint schedule (35d/120d/annual), 10% exit tax, rising floor
+- [FULL] [Vending Machine for Creativity (newsletter)](https://news.artizen.fund/p/vending-machine-for-creativity) - the buyback loop
+- [FULL] [Largest Endowment in the World (newsletter)](https://news.artizen.fund/p/largest-endowment-in-the-world) - $4M->$6M->$10M->$10B->$1T targets, growth assumptions
+- [FULL] [Like a Phoenix, Motherfucker (newsletter)](https://news.artizen.fund/p/like-a-phoenix-motherfucker) - Stripe, $437K bankruptcy, Phoenix origin
+- [FULL] [Escape Velocity (newsletter)](https://news.artizen.fund/p/escape-velocity) - thesis, obsession, Ross Ulbricht, artist-not-entrepreneur DNA
+- [FULL] [Weird, Wonderful, and Working (newsletter)](https://news.artizen.fund/p/weird-wonderful-and-working) - the curation rubric
+- [FULL] [$1 Million for Community Funds (newsletter)](https://news.artizen.fund/p/1-million-for-community-funds) - $50K-per-fund program, fund-director profile
+- [FULL] [The Terminus Fund (newsletter)](https://news.artizen.fund/p/the-terminus-fund) - network-states framing, sovereign-community fund
+- [FULL] [Fork the Frontier (newsletter)](https://news.artizen.fund/p/fork-the-frontier) + [Funding What Matters: Owocki (newsletter)](https://news.artizen.fund/p/funding-what-matters-artizen-talks) - Gitcoin/Owocki relationship, ETH Boulder
+- [FULL] [Bubble.io Artizen case study](https://bubble.io/blog/artizen/) - $2.3M awarded, season votes, 10x rebuild
+- [FULL] [Revnets: A Cryptoeconomic Analysis (CryptoEconLab)](https://www.cryptoeconlab.io/blog/revnets-cryptoeconomic-analysis/) + [Juicebox Revnets (Bankless)](https://www.bankless.com/read/juicebox-revnets) - independent Revnet mechanics
+- [FULL] [Console x Artizen Fund](https://www.console.xyz/blog/console-artizen-match-fund) + [Mona Fund (Artizen help)](https://help.artizen.fund/en/articles/8308704-mona-fund-for-3d-creators) - other community funds
+- [PARTIAL - email-only] René's June 2026 newsletters (pasted by Zaal) - 36 Cinema "$36k took the gold," Frontier drive, the ART bug. 36 Cinema as an Artizen fund is confirmed by René directly; not yet web-indexable.
+- [FAILED] June 2026 ART contract bug postmortem; "Cycle 5" exact definition; the Endowment's legal/governance entity - none publicly disclosed.

--- a/research/business/846-zao-festivals-funding-strategy/README.md
+++ b/research/business/846-zao-festivals-funding-strategy/README.md
@@ -1,0 +1,137 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-12
+related-docs: 843, 844, 845, 683, 674, 804
+original-query: "We should keep learning about other funds and as a fund organizer if we can also make a fund and apply to other funds for ZAO festivals"
+tier: DISPATCH
+---
+
+# 846 — ZAO Festivals Funding Strategy: Run a Fund + Apply to Funds (Artizen + beyond)
+
+> **Goal:** Map every realistic funding path for ZAO Festivals / ZAOstock - the full Artizen community-fund landscape, the dual play (ZAO as fund ORGANIZER and as project APPLICANT for stacked match), and the funding sources beyond Artizen (Web3 + traditional arts grants).
+
+> **Method:** Browser-rendered the live Artizen matchfunds leaderboard (the list that would not curl) + 3 parallel research agents (off-Artizen Web3, Maine/US arts grants, the fund-organizer dual-role mechanics).
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | SUBMIT ZAO Festivals / ZAOstock as a PROJECT into multiple Artizen funds to stack match | One project curated into N funds unlocks $1 from EACH per $1 of artifact sales. The killer fit is the **Greenpill Fund for Regenerative Gatherings** ("local events that bring regenerative communities together") - that is exactly what ZAOstock is. Stack it with the ZAO Fund + Funding the Commons + Hubs Network for 3-4x match on the same sales. |
+| 2 | KEEP ONE Artizen fund (Emerging Culture), do NOT spin a second fund yet | Running a second fund = more curation overhead for the same community. Better: submit ZAO Festivals as a *project* into many funds (incl. ZAO's own) than split director attention. Revisit a dedicated "ZAO Festivals Fund" only if a festival-specific sponsor shows up. |
+| 3 | APPLY to the "$1 Million for Community Funds" program ($50K seed) for the EXISTING fund | Existing directors are eligible; the $50K seed grows the ZAO Fund's match pool 5x (it currently runs on $10k). Book the call with René. |
+| 4 | ASK René directly: can a fund director curate their own project into their own fund? | No public self-dealing policy exists. The platform doesn't block submitting into OTHER funds, but director-self-curation is an open question. One email settles it - do not assume. |
+| 5 | OFF Artizen: launch a JUICEBOX crowdfund + GIVETH listing for ZAOstock | Most Web3 grants fund tooling, not events. Juicebox is the exception (permissionless event treasury, proven music-event precedent) + Giveth has an Art & Culture QF category. These two are the real off-platform vehicles. |
+| 6 | TRADITIONAL grants: set up FRACTURED ATLAS fiscal sponsorship now - it unlocks the rest | ZAO is an LLC (BCZ Strategies); most arts grants need 501(c)(3). Fractured Atlas ($10/mo, 8% fee) is the bridge to Maine Expansion Arts, NEFA, New Music USA. Without it, most of the grant world is closed. |
+
+## A. The Artizen fund landscape (live, 2026-06-12)
+
+Rendered the matchfunds leaderboard directly. Platform-wide: **Endowment now $14,158,798** (already past the $10M EOY goal - the flywheel from [Doc 845](../845-artizen-art-token-endowment-economics/) is tracking). **Frontier Fund Drive** live: $267,383 / $600k goal, **$1,921,514 match funding**, $250,010 cash prizes, ends Thu Jun 18.
+
+Current Season 6 fund standings (rank by score; ZAO Fund has **moved to #4** - standings reshuffle every drive, it was #2 on Jun 11):
+
+| Rank | Fund | Theme | Raised | Projects | Fit for ZAO Festivals |
+|---|---|---|---|---|---|
+| 1 | **Funding the Commons Frontier Fund** | Infrastructure/research/cultural work to fund + govern the commons in an age of AI | $51,428 | +62 | MED - "cultural work" angle |
+| 2 | **Africa Web3 Fund for Culture and Code** | Africa's creative + scientific pioneers | $38,596 | +18 | LOW (geographic) |
+| 3 | **Greenpill Fund for Regenerative Gatherings** | **"Local events that bring regenerative communities together to learn, build, and take root"** | $28,972 | +15 | **HIGH - this IS ZAOstock** |
+| 4 | **ZAO Fund for Emerging Culture** (ours) | Art + emerging tech + community | $21,754 | +29 | own fund |
+| 5 | DIY Maker & Engineering Fund | Hardware hackers, makers | $16,360 | +3 | LOW |
+| 6 | 36 Cinema Creative Fund (RZA) | Film, sound, future tools | $12,280 | - | MED - if film/sound element |
+| 7 | Hubs Network Fund for Solarpunk Spaces | "Independent physical spaces building new models for culture, care, governance" | $9,235 | +2 | **MED-HIGH - a festival/space** |
+| 8 | The Mental Wealth Fund | Education, science, regenerative ecosystems | $6,951 | - | LOW |
+| 9 | Habitat Fund for Wild Realities | Immersive experiences reshaping human-nature relation | $5,239 | +5 | MED - if nature/immersive framing |
+| 10 | Podcast Fund for Emerging Voices | Podcast + radio storytellers | $3,954 | - | LOW (unless a ZAO podcast) |
+| 11 | Collective Women's Fund for Creative Solidarity | Creative women who gather + build culture | $2,990 | +26 | MED - for a women-led ZAO project |
+| 12 | Paradigm Fund for Frontier Tech | Early frontier-tech builders | $2,268 | +24 | LOW |
+| - | Beyonders (Peacemaking), Creative Republic (African creativity), Community Network (regenerative communities), Autonomy (First Nations), Scribe (storytellers/books) | various | $0 | mixed |
+
+> ~18+ community funds visible (list continues past Scribe). The ecosystem is bigger than doc 844's "Console/Mona/Microsoft/Cannes" sample - those were earlier-season funds; this is the live S6 set.
+
+## B. ZAO as APPLICANT - the stacking play
+
+The mechanic ([Doc 844](../844-artizen-platform-deep-study/)): a project curated into N funds gets $1 from EACH fund per $1 of artifact sales. **No public cap** on fund count. Artizen's own guidance: "submit your project to all eligible Match Funds."
+
+**The ZAOstock submission stack (best-fit funds to target):**
+1. **Greenpill Fund for Regenerative Gatherings** - primary. Made for community gatherings/events.
+2. **ZAO Fund for Emerging Culture** - our own (pending the self-curation question, Decision #4).
+3. **Funding the Commons Frontier Fund** - "cultural work" + commons framing.
+4. **Hubs Network Fund for Solarpunk Spaces** - physical-space/new-models-of-culture framing.
+5. Optional: 36 Cinema (if there's a documented film/sound layer), Habitat (immersive/nature), Collective Women's (a women-led set).
+
+Curated into 3-4 of these, every $10 artifact sold to a ZAO supporter unlocks $30-40 of match. **That is the single biggest funding lever for ZAOstock**, and it runs on ZAO's actual strength: a community that will buy.
+
+**Curation flow (applicant side):** projects submit to a fund -> community votes (votes earned via signup, artifact buys, raise milestones) -> top ~30% by votes get curated in. So getting into a fund = mobilizing ZAO's network to vote, same muscle as selling artifacts.
+
+## C. ZAO as ORGANIZER - one fund or two?
+
+- **Can an existing director run a second fund?** Yes - the "$1 Million for Community Funds" program ("leaders rooted in creative communities," no carve-out against existing directors) gives **up to $50K seed** per approved fund + a call with René. Rolling.
+- **Recommendation: keep ONE fund for now.** A second "ZAO Festivals Fund" doubles curation overhead for the same audience and dilutes the Emerging Culture brand. Submitting Festivals as a *project* into many funds captures the match upside without that overhead. Spin a dedicated fund only when a Festivals-specific sponsor (a venue, a brand, a music org) wants to put capital behind it - then the $50K program + their money seeds it.
+- **The $50K is still worth pursuing for the EXISTING fund** - it 5x's the current $10k pool, which raises every ZAO grantee's available match.
+- **Open question to settle with René (Decision #4):** whether a director may curate their own project (ZAO Festivals) into their own fund. Submitting into *other* funds is clearly fine.
+
+## D. Off-Artizen Web3 funding
+
+Honest finding: Web3 grants are tooling/infrastructure-biased; few fund events. Two real vehicles + watch-list:
+
+| Source | What | Fit | Action |
+|---|---|---|---|
+| **Juicebox** (juicebox.money) | Permissionless on-chain crowdfunding treasury; NFT tiers -> artist payout splits. Precedent: FORMING (music events), ConstitutionDAO, MoonDAO. 2.5% fee. | **STRONG** | Launch a ZAOstock project before Oct 3; tiers ($25/$100/$250), splits (artists/production/treasury) |
+| **Giveth** (giveth.io) | Zero-fee donations + QF rounds, has an **Art & Culture** category; GIVbacks reward donors. Verification ~2 weeks. | GOOD | List ZAO Festivals now, get verified, ride a QF round |
+| Water & Music | Music-ecosystem grants | MED | Verify current 2026 cycle on site |
+| Base ecosystem (Onchain Summer / builder grants) | ZAO is Base-native; favors devs/tools | LOW-MED | Monitor for a "community" angle |
+| Gitcoin Grants | GG24 had no culture domain; infra-biased | LOW | Watch gov.gitcoin.co for a culture round (GG25 ~Q4) |
+| Optimism RetroPGF | Retroactive, OP-native | LOW | Only post-event, if provable OP-ecosystem impact |
+| Nouns / Audius | Governance-gated / streaming-tooling | SKIP | - |
+
+## E. Traditional arts grants for ZAOstock
+
+**The gate: most arts grants require 501(c)(3); ZAO is an LLC.** The unlock is **fiscal sponsorship** (Fractured Atlas, $10/mo + 8% fee) - it lets the LLC apply to nonprofit-only grants and take tax-deductible donations. Set this up first.
+
+| Program | Funder | Amount | Eligibility | Deadline | Fit |
+|---|---|---|---|---|---|
+| **Maine Expansion Arts** | Maine Community Foundation | ~$5-15K | Arts orgs serving underserved/rural areas; <$500k budget | **Sept 17 2026** | **HIGH** - Down East Maine = underserved; via Fractured Atlas |
+| **New Music USA - Organization Fund** | New Music USA | ~$7K avg / $10K max | **501(c)(3) NOT required**; fiscal sponsorship optional; $5k-$3M budget | ~March (check FY27) | HIGH - no nonprofit gate |
+| Creative Communities Grant | Maine Arts Commission | $7K max | Nonprofit; public access; 1:1 match | ~March (FY27) | MED - needs match + sponsorship |
+| Hancock County Fund | Maine Community Foundation | $1-10K | Nonprofits serving Hancock County (Ellsworth) | Rolling | MED - perfect geography |
+| NE States Touring (NEST) | NEFA | $400-$4K artist-fee subsidy | 501(c)(3) NE presenters | Rolling (Aug 1 / Dec 1 / Apr 1) | MED - offsets artist fees only |
+| Levitt Festival Grants | Levitt Foundation | $5K | 501(c)(3); free outdoor festival | Jan 30 (2027 cycle) | MED - perfect criteria, but needs 501(c)(3) + missed 2026 |
+| NEA Grants for Arts Projects | NEA | $10-100K | 501(c)(3) REQUIRED, no fiscal-sponsor workaround, 3yr history | Feb / Jul 9 | BLOCKED for 2026 |
+
+- **Crowdfunding baseline:** Kickstarter (all-or-nothing, $5-50K typical festival range) + local sponsorship (Ellsworth Parks/Rec, Hancock County businesses) as a parallel stack.
+- ZAO's entity path ([Doc 804](../804-colorado-acorp-artist-structure/), Colorado A-Corp) is a 2027+ move - too slow for Oct 2026; fiscal sponsorship is the bridge.
+
+## Also See
+
+- [Doc 845](../845-artizen-art-token-endowment-economics/) - Artizen ART/Endowment engine + the $50K community-fund program
+- [Doc 844](../844-artizen-platform-deep-study/) - platform mechanics + multi-fund stacking rule
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - ZAO Fund S6 roster + the /artizen page
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Edge Esmeralda (Greenpill/regen-gathering adjacency)
+- [Doc 804](../804-colorado-acorp-artist-structure/) - ZAO entity structure (why fiscal sponsorship is the near-term bridge)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Email René: can a director curate their own project into their own fund? + book the $50K community-fund call | @Zaal | Outreach | This week |
+| Submit ZAOstock as a project into Greenpill Fund for Regenerative Gatherings (primary) + 2-3 other fits | @Zaal | Application | Before S7 curation |
+| Set up Fractured Atlas fiscal sponsorship (unlocks Maine Expansion Arts + others) | @Zaal | Ops | By Aug 2026 |
+| Apply to Maine Expansion Arts (MCF) | @Zaal | Application | Sept 17 2026 |
+| Launch a Juicebox crowdfund + Giveth listing for ZAOstock | @Zaal / @Claude | Build | Before Oct 3 |
+| Update the /artizen page + doc 843 standing note (ZAO now #4, live) | @Claude | PR | This PR |
+| Re-render the matchfunds leaderboard before quoting fund standings (live, moves each drive) | @Claude | Verification | At publish |
+
+## Sources
+
+- [FULL] [Artizen matchfunds leaderboard](https://artizen.fund/index/matchfunds) - rendered live via headless browser 2026-06-12; full fund list, standings, $14.16M endowment, Frontier drive figures
+- [FULL] [$1 Million for Community Funds (newsletter)](https://news.artizen.fund/p/1-million-for-community-funds) - $50K seed, eligibility incl. existing directors
+- [PARTIAL] [Artizen Ultimate Guide to Raising Money](https://news.artizen.fund/p/ultimate-guide-to-raising-money) + [help.artizen.fund submit-projects](https://help.artizen.fund/en/collections/2702056-submit-projects) - multi-fund "submit to all eligible funds" guidance; self-curation policy NOT found (open question)
+- [FULL] [Juicebox fundraising guide](https://docs.juicebox.money/blog/jb-for-fundraising/) + [Juicebox project setup](https://docs.juicebox.money/user/project/) - event-crowdfunding vehicle
+- [FULL] [Giveth create project](https://docs.giveth.io/createproject) + [Giveth QF](https://docs.giveth.io/quadraticfunding) - Art & Culture category, GIVbacks
+- [FULL] [Maine Community Foundation - Maine Expansion Arts](https://www.mainecf.org/apply-for-a-grant/available-grants-deadlines/maine-expansion-arts/) + [Hancock County Fund](https://www.mainecf.org/initiatives-impact/additional-initiatives/county-and-regional-program/hancock-county/)
+- [FULL] [New Music USA - Organization Fund](https://newmusicusa.org/program/organization-fund/) - 501(c)(3) NOT required
+- [FULL] [Maine Arts Commission grants](https://mainearts.maine.gov/Pages/Funding/Grants-Home) + [NEFA grant programs](https://www.nefa.org/grants-programs/grant-programs) + [NEA eligibility](https://www.arts.gov/grants/grants-for-arts-projects/eligibility)
+- [FULL] [Fractured Atlas fiscal sponsorship](https://www.fracturedatlas.org/fiscal-sponsorship) - the LLC -> grant-eligibility bridge
+- [PARTIAL] [Gitcoin GG24](https://gitcoin.co/campaigns/gitcoin-grants-24-gg24) + [Optimism RetroPGF](https://www.optimism.io/blog/announcing-retropgf-round-3) - poor fit, infra-biased; watch-list only
+- [FAILED] Self-dealing / director-self-curation policy - not published; must confirm with René directly.

--- a/research/business/847-zao-in-artizen-ecosystem-playbook/README.md
+++ b/research/business/847-zao-in-artizen-ecosystem-playbook/README.md
@@ -1,0 +1,127 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-12
+related-docs: 843, 844, 845, 846, 674, 760
+original-query: "Keep researching how to be in the Artizen ecosystem as the ZAO or ZAO projects"
+tier: DISPATCH
+---
+
+# 847 — How The ZAO Embeds in the Artizen Ecosystem (full participation playbook)
+
+> **Goal:** Map every door into the Artizen ecosystem for The ZAO and its project portfolio - not just funding, but the social layer (Console), the visibility ladder (curation -> Artizen LIVE -> newsletter -> prizes), the IRL surfaces (Edge Esmeralda now, DWeb Village July), and the relationship ladder with the Artizen team. ZAO already runs a fund; this is how to go from "has a fund" to "flagship community in the ecosystem."
+
+> **Method:** 3 parallel research agents (community-cohort pattern, visibility/featured layer, IRL/relationship ladder), reading Artizen's newsletter + help + partner case studies FULL.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | TREAT the ZAO Fund as a HUB, and run ZAO's whole portfolio through it | ZAO already directs the ZAO Fund for Emerging Culture. The high-leverage move is bringing WaveWarZ, SongJam, ZAOstock, Thy Revolution, the ZABAL Games cohort, etc. on as **projects**, cross-curated into the ZAO Fund + Greenpill + Terminus + Hubs funds. 188 members buying/boosting each other = a match flywheel. ZAO is the rare community that already has both the fund AND the crowd. |
+| 2 | GET ON CONSOLE - it is the ecosystem's social layer | Artizen replaced Discord with **Console** (console.xyz); membership is Artifact-gated. This is where curators + creators network and where projects get first traction. ZAO is not visible there yet. Showing up on Console is how you stop being an outside fund and become an inside community. |
+| 3 | GO to Edge Esmeralda NOW (it is live through Jun 27) | The Artizen team is physically resident at the Agartha/Artizen "Touch Grass" house, 10 min from Healdsburg, RIGHT NOW. ZAO's own grantee Telamon ([Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/)) is on-site. This is the single best in-person relationship door and it closes June 27. |
+| 4 | APPLY to the DWeb Camp Artizen Village (Berlin, Jul 8-12) this week | ~20 slots, application open at artizenvillage.com, but ~1 month out. A ZAO rep in that room = 20+ ecosystem relationships + a creator-spotlight/workshop slot. Pitch a SongJam/ZAO music workshop. |
+| 5 | RUN the visibility ladder deliberately, every season | submit -> mobilize ZAO votes to clear the top-30% curation gate -> sell artifacts (video/no-text) -> pitch on Artizen LIVE (weekly show) -> earn a newsletter feature (13k subs) -> chase the prize. This is a repeatable engine, not a one-off. |
+
+## The full menu of roles - which ZAO entity fits each
+
+Artizen is not one thing you "join." It's a set of roles. ZAO can occupy almost all of them:
+
+| Role | What it is | ZAO occupant |
+|---|---|---|
+| **Fund director / curator** | Run a Match Fund, curate projects in | The ZAO (already does - ZAO Fund for Emerging Culture) |
+| **Project / creator** | Submit a project, mint Artifacts, raise + match | EVERY ZAO project: WaveWarZ, SongJam, ZAOstock, Thy Revolution, Cipher, ZABAL Games builds, Impact Concerts (already #32!) |
+| **Collector / booster** | Buy Artifacts, boost projects, earn voting power | All 188 ZAO members - the voting + match engine |
+| **Sponsor** | Put capital into a fund's match pool | ZABAL / a ZAO partner brand could co-sponsor the ZAO Fund |
+| **Community member** | Be present on Console, network, get curated | ZAO core (needs to show up - gap today) |
+| **IRL participant** | Edge Esmeralda, DWeb Village, Artizen LIVE | ZAO rep (urgent, see below) |
+| **ART holder** | Hold the ART token / back the Endowment | optional, treat with caution ([Doc 845](../845-artizen-art-token-endowment-economics/) reflexivity risk) |
+
+> The unlock: ZAO is one of the only communities that can credibly occupy director + creator + collector + IRL all at once, because it already has a fund AND a 188-member crowd AND a project portfolio.
+
+## ZAO portfolio -> Artizen (the cohort play)
+
+Map each ZAO project to a submission + which funds to stack it into. René's curation rubric is **"Weird, Wonderful, Working"** - ZAO's portfolio scores on all three.
+
+| ZAO project | Why it fits (W/W/W) | Stack into funds |
+|---|---|---|
+| **ZAOstock / ZAO Festivals** | A regenerative cultural gathering | Greenpill (Regen Gatherings) + ZAO Fund + Hubs (Solarpunk Spaces) - see [Doc 846](../846-zao-festivals-funding-strategy/) |
+| **WaveWarZ** | Music x prediction markets x gaming = genuinely weird | ZAO Fund + Funding the Commons (frontier tech/culture) |
+| **SongJam** | X Spaces tooling, music-native | ZAO Fund + Funding the Commons |
+| **Thy Revolution** (Iman's band) | Music + social-justice resonance | ZAO Fund + Greenpill + Collective Women's (if applicable) |
+| **The Impact Concerts** (Jose Acabrera) | ALREADY #32 in the ZAO Fund | already in - help it sell |
+| **ZABAL Games cohort** | A whole class of builder projects | each submits, cross-curated into ZAO Fund + thematic funds |
+| **Cipher / ZAO Music releases** | Music releases as Artifacts | ZAO Fund |
+
+Coordination: the 188 ZAO members buy + boost each other's Artifacts (community reinvestment), which unlocks match from every backing fund. This is exactly how Console's community fund worked (Naoba +2.2 ETH, Zato +2.91 ETH off a 50-member bar - ZAO is 4x that).
+
+## The social layer: Console
+
+- Artizen moved its community **from Discord to Console** (console.xyz) - an Artifact-gated, owned-by-community messaging platform. Membership filters for real participants.
+- This is where curation conversations, creator networking, and early project momentum happen. **ZAO has no presence there yet - that's the first gap to close.**
+- Console also runs its **own** Match Fund (Console Fund for Community Builders) - a model of how a community platform becomes a fund. Worth studying and a possible ZAO project home.
+
+## The visibility ladder (repeatable engine)
+
+1. **Submit** a project to the season (artizen.fund/submit). Description aligned to "frontier of art / culture / tech."
+2. **Clear the curation gate** - community votes; only the **top ~30%** advance to competition. Voting power = profile (100 pts) + $1 spent = 10 votes, time-weighted (manual clicks, anti-whale). ZAO's 188 members are the lever here.
+3. **Sell Artifacts** - $10 open-edition NFTs. Best-practice artwork: **video/GIF, no text**, plus a clean pitch deck. Every $1 sold unlocks $1 from each backing fund.
+4. **Pitch on Artizen LIVE** - the weekly livestream (formerly "Showcase"), 5-min pitch/performance slots, $120k+ awarded live across the season. Produced by Wadooah Wali / New Canvas (wadooah@newcanvas.co per René's email). A ZAO music act performing live = perfect fit.
+5. **Earn a newsletter feature** - René's newsletter (~13k subs) is the main amplifier; he personally reviews standouts. Traction + a strong narrative = editorial pickup.
+6. **Win the prize** - top seller per fund takes the 10% cash prize; Boost Score (raised x boosts) ranks the leaderboard.
+
+## IRL + the relationship ladder (time-sensitive)
+
+| Surface | When | Status | ZAO move |
+|---|---|---|---|
+| **Edge Esmeralda "Touch Grass" (Agartha + Artizen house)** | NOW - through Jun 27 2026, Healdsburg CA | LIVE | Get a ZAO rep there this week; Telamon (ZAO grantee) is on-site. Best in-person door, closing fast. |
+| **DWeb Camp - Artizen Village** | Jul 8-12 2026, Alte Hölle forest, Berlin | Applications open (artizenvillage.com), ~20 slots | Apply this week; pitch a SongJam/ZAO music workshop or creator spotlight. Broader DWeb tracks (Space Steward = 100% free campership; Fellowship = $2,200 stipend) as backups. |
+| **ETH Boulder** | Feb 13-15 2026 (PAST) | done | Relationship already seeded (Zaal attended via Artizen-sponsored house). Reference it warmly; watch for 2027. |
+| **Artizen LIVE** | weekly | ongoing | Recurring surface to pitch/perform on from anywhere. |
+
+**Team to know:** René Pinnell (@RJPinnell on X, linkedin/rjpinnell, email pattern r[name]@artizen.fund), **Nate Van Cleve** (Head of Product, linkedin/nathanielvancleve), Wadooah Wali (Artizen LIVE producer, New Canvas). Channels: news.artizen.fund (Substack), @ArtizenFund (X), @artizen_fund (IG).
+
+**The relationship ladder:** (1) show up IRL (Edge Esmeralda / DWeb) -> (2) be active on Console + the newsletter -> (3) ZAO Fund + portfolio posts real numbers -> (4) propose a co-branded / sponsored fund (the Microsoft/Cannes/Console tier) -> (5) become a featured partner community. ZAO is already on rung 1-3; the IRL touch accelerates the rest.
+
+## ZAO's competitive edge in this ecosystem
+
+- **188-member on-chain community** = 4x Console's fund threshold; a built-in buyer/voter base most funds lack.
+- **A portfolio, not a single project** - incubator DNA means a steady cohort to run each season.
+- **Already a fund director** - most communities are applying to start a fund; ZAO is past that.
+- **Network-state / regen alignment** - fits Terminus, Greenpill, Hubs, and the Edge City / DWeb world Artizen orbits.
+
+## Also See
+
+- [Doc 846](../846-zao-festivals-funding-strategy/) - the funding strategy (which funds to stack into)
+- [Doc 845](../845-artizen-art-token-endowment-economics/) - ART/Endowment + the $50K community-fund program + René's thesis
+- [Doc 844](../844-artizen-platform-deep-study/) - platform mechanics + sentiment + competition
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - the ZAO Fund roster + zaoos.com/artizen page
+- [Doc 674](../../events/674-edge-esmeralda-artizen-telamon-outreach/) - Edge Esmeralda / Telamon (the live IRL door)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Get a ZAO rep to Edge Esmeralda "Touch Grass" (Artizen team is on-site, Telamon too) | @Zaal | IRL / outreach | Before Jun 27 (LIVE) |
+| Apply to the DWeb Camp Artizen Village (artizenvillage.com) - pitch a ZAO/SongJam workshop | @Zaal | Application | This week (camp Jul 8) |
+| Create a ZAO presence on Console + buy a few Artifacts to unlock membership | @Zaal / @Iman | Ops | This week |
+| Onboard the first 3 ZAO projects as Artizen submissions (WaveWarZ, SongJam, ZAOstock) | @Zaal | Application | Before S7 curation |
+| Help #32 The Impact Concerts (already in the fund) sell artifacts now | @Zaal | Outreach | Before drive ends Jun 18 |
+| Warm DM to René + Nate referencing ETH Boulder + the ZAO Fund standing | @Zaal | Outreach | This month |
+| Stand up a "ZAO buys ZAO" artifact-reinvestment push among the 188 members | @Zaal | Community | Next season |
+
+## Sources
+
+- [FULL] [Console x Artizen Match Fund](https://www.console.xyz/blog/console-artizen-match-fund) - the community-fund benchmark (50-member bar, +2.2/+2.91 ETH winners), Console as the social layer
+- [FULL] [Artizen Village @ DWeb Camp](https://artizenvillage.com/) + [DWeb Camp participate](https://dwebcamp.org/participate/) + [fellowships](https://dwebcamp.org/fellowships/) - Village application, ~20 slots, Space Steward / Fellowship backup tracks
+- [FULL] [Agartha + Artizen "Touch Grass" at Edge Esmeralda](https://agartha1.substack.com/p/lets-go-touch-grass-agartha-at-edge) + [The Art of Slowing Down](https://agartha1.substack.com/p/the-art-of-slowing-down-agartha-and) - the LIVE IRL residency with the Artizen team
+- [FULL] [Weird, Wonderful, and Working](https://news.artizen.fund/p/weird-wonderful-and-working) + [The Ecology of Creativity](https://news.artizen.fund/p/the-ecology-of-creativity) - the curation rubric + ideal community profile
+- [FULL] [The Art (and Chaos) of Curation](https://news.artizen.fund/p/the-art-and-chaos-of-curation) - voting/curation flow, top-30% gate
+- [FULL] [$1 Million for Community Funds](https://news.artizen.fund/p/1-million-for-community-funds) + [How to Amplify Your Creativity](https://news.artizen.fund/p/how-to-amplify-your-creativity) - fund program + amplification
+- [FULL] [The Terminus Fund](https://news.artizen.fund/p/the-terminus-fund) - network-state funds (ZAO adjacency)
+- [FULL] [René Pinnell LinkedIn](https://www.linkedin.com/in/rjpinnell/) + [Nate Van Cleve LinkedIn](https://www.linkedin.com/in/nathanielvancleve/) + [@ArtizenFund](https://twitter.com/ArtizenFund) - team + channels
+- [FULL] [Bubble Artizen case study](https://bubble.io/blog/artizen/) - $2.3M awarded, scale, Gaia Sound Temple multi-season alumni
+- [PARTIAL] [help.artizen.fund submit-projects](https://help.artizen.fund/en/collections/2702056-submit-projects) - submission flow (some help pages 404'd)
+- [PARTIAL] Artizen LIVE booking via Wadooah Wali / New Canvas - producer confirmed, public booking page not found (use wadooah@newcanvas.co from René's email)
+- [FAILED] Exact current S7 season dates + Console join flow specifics - verify directly on artizen.fund/submit + console.xyz before acting.

--- a/research/business/849-zao-artizen-execution-build-plan/README.md
+++ b/research/business/849-zao-artizen-execution-build-plan/README.md
@@ -1,0 +1,178 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-12
+related-docs: 843, 844, 845, 846, 847
+original-query: "ok lets keep studying and learning and then build it all (consolidate the Artizen research into an executable build plan + ready-to-use kit for The ZAO)"
+tier: DISPATCH
+---
+
+# 849 — ZAO x Artizen: Execution Build Plan + Ready-to-Use Kit
+
+> **Goal:** Turn the Artizen research (docs 843-847) into one runnable system - a dated execution sequence plus the actual copy-paste kit (submission template, artifact brief, outreach drafts, daily spotlight series, like-minded-project target list). This is the "build it all" doc: research becomes operations.
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | RUN the system, don't add more research - the studying is done | Docs 843-847 cover roster, platform, token, funding, ecosystem. Everything below is build/execute. Only two facts still need a live confirm (S7 dates, Console signup) - flagged at the end, not blockers. |
+| 2 | The build = 4 kit pieces + a 30-day sequence | (A) submission kit, (B) outreach kit, (C) daily spotlight series, (D) like-minded target list. All drafted here / in `~/.zao/artizen/`. What's left is the human-only actions (send, submit, buy, set up Console). |
+| 3 | Sequence around the Jun 18 drive, then S7 curation, then IRL | Week 1 = unlock match + daily posts + IRL doors (Edge Esmeralda live, DWeb Village apply). Weeks 2-4 = onboard the ZAO cohort for S7 + deepen relationships. |
+
+## What's already built (this session)
+
+| Artifact | Where | Status |
+|---|---|---|
+| zaoos.com/artizen public page | `src/app/artizen/page.tsx` | SHIPPED (PR #844) |
+| ZAO Fund full roster + mechanics | docs 843-847 | SHIPPED (PR #844) |
+| Daily project-spotlight series (32 posts) | `~/.zao/artizen/zao-fund-daily-spotlights.md` | DRAFTED, ready to post |
+| Submission kit, outreach kit, target list | this doc, below | DRAFTED |
+
+## The 30-day execution sequence
+
+**Week 1 (now - Jun 18): unlock match + start the daily series + open IRL doors**
+1. Post Day 1-6 of the daily spotlight series (ride the Frontier drive; ends Thu Jun 18).
+2. Rally the 188 members: "ZAO buys ZAO" - collect artifacts on ZAO-fund projects to unlock the fund's remaining match.
+3. Personally collect + boost 3-5 projects to model it.
+4. Get a ZAO rep to Edge Esmeralda (Artizen team + Telamon on-site, closes Jun 27).
+5. Submit the DWeb Camp Artizen Village application (camp Jul 8-12).
+6. Stand up a ZAO presence on Console (console.xyz) - join, collect a couple artifacts.
+
+**Week 2 (Jun 19-25): relationships + cohort prep**
+7. Warm DM to René + Nate (kit below). Ask the self-curation question + book the $50K community-fund call.
+8. Boost + collect a few projects in the like-minded funds (Greenpill, Funding the Commons, Terminus), then DM those directors (kit below).
+9. Prep the first ZAO cohort submissions (WaveWarZ, SongJam, ZAOstock) using the submission template + artifact briefs below.
+
+**Weeks 3-4 (Jun 26 - Jul 9): submit + show up**
+10. When S7 curation opens (confirm date), submit the ZAO cohort; cross-curate into ZAO Fund + Greenpill + Funding the Commons.
+11. Continue the daily series (evergreen after Day 6).
+12. If accepted, attend DWeb Camp Artizen Village (Jul 8-12) - run a SongJam/ZAO music workshop.
+
+---
+
+## KIT A - Project submission template + artifact brief
+
+**Confirmed Artifact specs** (build to these):
+- Image (required): square 1:1, min 1000x1000px, .jpg/.png, <10MB, NO text/logo overlays.
+- GIF (optional): square, min 500px, <50MB, loopable.
+- Video (optional): square, <=45s, <100MB, .mp4, loopable, no overlays.
+- Artifact = the creative essence of the project, not a marketing flyer. Video/GIF outperform static in voting.
+- Price fixed at $10 open-edition; 100% to creator; creator needs an Ethereum wallet for payout (sales + match + prize, paid ~2-4 weeks after season close).
+
+**Submission template** (fill one per ZAO project at artizen.fund/submit):
+```
+Project title: [name]
+One-liner: [what it is in one sentence]
+Description (100-300 words): [what you're making, why it matters, what's done so far -
+  hit Weird + Wonderful + Working: original angle, emotional pull, signs of life/traction]
+Category: [music / community / festival / tooling / etc.]
+Team: [creator name(s) + roles]
+Links: [site, Farcaster, X, demo]
+Artifact asset: [the square image/video per specs]
+Payout wallet: [ETH address]
+Funds to target: ZAO Fund for Emerging Culture + [Greenpill / Funding the Commons / Hubs / etc.]
+```
+
+**First cohort to onboard:**
+| Project | One-liner draft | Stack into |
+|---|---|---|
+| WaveWarZ | Music meets prediction markets meets gaming - bet on the artists you believe in | ZAO Fund + Funding the Commons |
+| SongJam | Tooling that turns X Spaces into searchable, ownable music sessions | ZAO Fund + Funding the Commons |
+| ZAOstock | A regenerative music gathering in Ellsworth, Maine - festival as community prototype | ZAO Fund + Greenpill (Regen Gatherings) + Hubs (Solarpunk Spaces) |
+| Thy Revolution | Music with a justice spine, from the ZAO incubator | ZAO Fund + Greenpill + Collective Women's |
+
+## KIT B - Outreach drafts (copy-paste, ZAO voice)
+
+**B1 - Warm DM to René Pinnell + Nate Van Cleve:**
+> Hey René (cc Nate) - Zaal from The ZAO. I run the ZAO Fund for Emerging Culture on Artizen, and we crossed orbits around ETH Boulder (I was in the Artizen-sponsored house - thank you for that, genuinely).
+>
+> We're going deeper now: bringing our whole portfolio of artists and builders onto the platform and rallying our 188-member community to back the projects in our fund. Two quick things:
+> 1. As a fund director, can I curate my own community's projects (e.g. our festival, ZAOstock) into the ZAO Fund - or is that a no-go I should route around?
+> 2. I'd love 15 minutes on the "$1M for Community Funds" program - I think the ZAO Fund is exactly the kind of community-rooted fund it's built for.
+>
+> Either way, rooting for the Frontier drive. This platform is the real thing.
+
+**B2 - DWeb Camp Artizen Village application (artizenvillage.com form):**
+> Project/practice: The ZAO - a 188-member decentralized music and culture community on Base/Farcaster. We incubate artist-led projects (WaveWarZ, SongJam, ZAOstock) and run the ZAO Fund for Emerging Culture on Artizen.
+> Why the Village: We live at the intersection Artizen Village is built for - music, decentralized coordination, and real-world cultural activation. We want to learn from this crowd and bring our community's energy to it.
+> What we'd contribute: A creator spotlight + a hands-on workshop on turning live music (X Spaces / festivals) into ownable, fundable culture - plus we'll hold space, document, and bring music to the evenings.
+> Accommodation: Open to shared glamping. Bringing 1-2 ZAO reps.
+
+**B3 - Cross-curation DM to a like-minded fund director (Greenpill Regen Gatherings / Funding the Commons):**
+> Hey - Zaal, I run the ZAO Fund for Emerging Culture on Artizen (The ZAO, 188-member music + culture community). Just collected and boosted a couple projects in your fund - we're clearly pointed at the same frontier.
+>
+> We've got ZAOstock (a regenerative music gathering in Maine this fall) and a portfolio of artist projects that would slot into your fund, and I'd love to curate your builders into ours. Cross-back each other and both our communities win the match. Open to a quick call? Either way, rooting for your fund.
+
+**B4 - ZAO member rally (Farcaster / GC / Telegram):**
+> ZAO fam - our Artizen fund (the ZAO Fund for Emerging Culture) is mid-drive and there's match funding that only unlocks when we buy.
+> Every $10 artifact you collect on a ZAO-fund project unlocks matching dollars straight to that creator. Drive ends Thursday June 18.
+> Pick 2-3, collect, boost. Let's get our people paid: [link 3-5 projects]
+> This is what the fund is for. ZAO backs ZAO.
+
+## KIT C - Daily spotlight series
+
+32 posts drafted + a calendar + the recurring CTA mechanic. Lives at
+`~/.zao/artizen/zao-fund-daily-spotlights.md`. Days 1-6 ride the Jun 18 drive; evergreen after.
+Run any post through `/socials` for platform variants.
+
+## KIT D - Connect with like-minded projects (target list)
+
+The funds most aligned with ZAO - collect/boost a few of their projects first (generosity first),
+then open the cross-curation conversation (Kit B3):
+
+| Fund | Run by | Theme | Why ZAO connects |
+|---|---|---|---|
+| **Greenpill Fund for Regenerative Gatherings** | Greenpill Network (Owocki's regen community) | Local events that gather regenerative communities | ZAOstock IS this; primary cross-curation target |
+| **Funding the Commons Frontier Fund** | Funding the Commons | Commons + cultural work in an age of AI | #1 fund; WaveWarZ/SongJam frontier-tech angle |
+| **Terminus Fund** | Artizen (network states) | Sovereign communities / network states | ZAO's incubator + Edge City adjacency |
+| **Hubs Network Fund for Solarpunk Spaces** | Hubs Network | Independent physical spaces for culture/care/governance | ZAOstock as a space/gathering |
+| **Collective Women's Fund** | (curator) | Creative women building culture together | ZAO women-led projects (Thy Revolution, etc.) |
+
+> When acting: open each fund on artizen.thezao.com -> matchfunds, read its project list, collect/boost
+> the 2-3 most aligned, then DM the director. (Project-level rosters of these funds are JS-rendered;
+> pull them live at action time.)
+
+## What needs Zaal (human-only - I cannot do these)
+
+- Send the DMs (B1-B4) from ZAO's accounts.
+- Submit the DWeb Village application + the project submissions.
+- Set up / join Console (console.xyz).
+- Collect + boost artifacts (wallet + payment).
+- Get a rep to Edge Esmeralda.
+
+## Open confirmations (verify live, not blockers)
+
+- **Season 7 curation open date** - not public; confirm on artizen.fund/submit or ask René. Determines when the ZAO cohort can submit.
+- **Console signup flow** - invite vs open; confirm at console.xyz.
+- **ZAO Fund match remaining + which projects have unspent match** - moves daily; re-render the fund page before the rally.
+
+## Also See
+
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - roster + the /artizen page
+- [Doc 844](../844-artizen-platform-deep-study/) - platform mechanics
+- [Doc 845](../845-artizen-art-token-endowment-economics/) - token/economics + the $50K program
+- [Doc 846](../846-zao-festivals-funding-strategy/) - funding strategy (fund stacking)
+- [Doc 847](../847-zao-in-artizen-ecosystem-playbook/) - ecosystem participation playbook
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Post daily spotlights Day 1-6 + run the member rally | @Zaal | Content | Through Jun 18 |
+| Get a ZAO rep to Edge Esmeralda (Artizen team + Telamon on-site) | @Zaal | IRL | Before Jun 27 |
+| Submit the DWeb Camp Village application (Kit B2) | @Zaal | Application | This week |
+| Send the René + Nate DM (Kit B1) | @Zaal | Outreach | This week |
+| Join Console + collect a few artifacts | @Zaal | Ops | This week |
+| Confirm S7 curation dates, then submit the cohort (Kit A) | @Zaal | Application | When S7 opens |
+| Cross-curation DMs to Greenpill + Funding the Commons directors (Kit B3) | @Zaal | Outreach | Next 2 weeks |
+| Build a richer /artizen hub (live cards + daily spotlight surface) if wanted | @Claude | PR | On request |
+
+## Sources
+
+- Docs 843-847 (this session's Artizen research) - all FULL
+- [FULL] [Console x Artizen Match Fund](https://www.console.xyz/blog/console-artizen-match-fund) - Console as the social layer + community-fund bar
+- [FULL] [Artizen Playbook](https://news.artizen.fund/p/artizen-playbook) - artifact specs (1000px square, no overlay, video <=45s), submission flow
+- [FULL] [Ultimate Guide to Raising Money](https://news.artizen.fund/p/ultimate-guide-to-raising-money) - $10 artifact, 100% to creator, multi-fund stacking
+- [FULL] [seasons-contracts (GitHub)](https://github.com/artizen-fund/seasons-contracts) - on-chain mechanics
+- [PARTIAL] artizen.fund/submit + help.artizen.fund - submission form fields partially documented; S7 dates + Console signup not public (confirm live)

--- a/src/app/artizen/page.tsx
+++ b/src/app/artizen/page.tsx
@@ -1,0 +1,252 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+// zaoos.com/artizen — public page for the ZAO Fund for Emerging Culture, the
+// community match fund Zaal directs on Artizen (artizen.fund). Static, server-
+// rendered from the Season 6 roster captured 2026-06-11. Source of truth +
+// provenance: research/business/843-zao-fund-artizen-roster-june2026.
+// Numbers are a point-in-time snapshot; the live fund is the canonical figure.
+
+const FUND_URL = 'https://artizen.thezao.com/';
+const SNAPSHOT_DATE = 'June 11, 2026';
+
+const miniAppEmbed = JSON.stringify({
+  version: '1',
+  imageUrl: 'https://zaoos.com/og',
+  button: {
+    title: 'ZAO Fund for Emerging Culture',
+    action: { type: 'launch_miniapp', url: 'https://zaoos.com/artizen', name: 'ZAO OS' },
+  },
+});
+
+export const metadata: Metadata = {
+  title: 'ZAO Fund for Emerging Culture | ZAO OS',
+  description:
+    'The ZAO Fund for Emerging Culture on Artizen — a community match fund backing artists and technologists building collaborative cultural experiences. 32 projects, Season 6.',
+  openGraph: {
+    title: 'ZAO Fund for Emerging Culture',
+    description:
+      'A community match fund backing 32 projects at the intersection of art, emerging tech, and community.',
+  },
+  other: { 'fc:miniapp': miniAppEmbed },
+};
+
+interface Project {
+  rank: number;
+  name: string;
+  creator: string;
+  sales: number;
+  match: number;
+  category: string;
+  blurb: string;
+  zaoTie?: string;
+}
+
+// ZAO Fund for Emerging Culture, Artizen Season 6 — full Competition roster,
+// ranked by artifact sales as of the snapshot date. See doc 843 for sources.
+const PROJECTS: Project[] = [
+  { rank: 1, name: 'InfiniteZero Network', creator: 'Abraham Nash', sales: 45108, match: 502, category: 'DeSci / AI', blurb: 'Decentralized AI training network (DIN) out of Oxford — data stays local, models go to the commons.', zaoTie: 'Researched in the ZAO library (doc 760)' },
+  { rank: 2, name: 'Edge Esmeralda 2026', creator: 'Telamon Ardavanis', sales: 30569, match: 2677, category: 'Human Flourishing', blurb: 'A month-long gathering in Northern California for people building a brighter future (May 30 - June 27, 2026).', zaoTie: 'ZAO x Edge City collaboration channel open' },
+  { rank: 3, name: 'Voices of the Land', creator: 'Yessie', sales: 23236, match: 0, category: 'Music', blurb: 'From women to the world — a journey of voice and vibration. Music, stories, and sacred sounds.' },
+  { rank: 4, name: 'Edge City Fellowship', creator: 'Telamon Ardavanis', sales: 10567, match: 1557, category: 'Fellowship', blurb: 'A fellowship funding exceptional builders under 25 to spend a month at Edge City on frontier fields.' },
+  { rank: 5, name: 'Gaian Temple', creator: 'NAOBA', sales: 7797, match: 939, category: 'Sound', blurb: 'Temple of Sound: listening experiments, concerts, installations, and biosphere network communication.' },
+  { rank: 6, name: 'Coralverse - Reef Revival', creator: 'ZCreative Media', sales: 7464, match: 0, category: 'Gaming', blurb: 'Combining adventure gaming with real-world reef conservation.' },
+  { rank: 7, name: 'Memethology', creator: 'Colton', sales: 6684, match: 508, category: 'Community', blurb: 'A trading card game about tech, culture, and human flourishing.' },
+  { rank: 8, name: 'HERITAGE COLLECTION: Fashion, Music & Blockchain Show', creator: 'Gneric', sales: 5810, match: 634, category: 'Fashion', blurb: 'A multidisciplinary fashion, music, and blockchain showcase.' },
+  { rank: 9, name: 'ToGather Project, Documenting Living Systems', creator: 'Sharon', sales: 5712, match: 45, category: 'Community', blurb: 'Better communities are being built right now. This platform is where their experience becomes part of the commons.' },
+  { rank: 10, name: 'HOPE', creator: 'JED XO', sales: 5665, match: 669, category: 'Discovery', blurb: 'An EP of five experimental tracks ministering hope out of brokenness.' },
+  { rank: 11, name: 'ENTERTAINMENT EVOLVED', creator: 'Matthew Chan', sales: 4910, match: 200, category: '360 Experience', blurb: 'You will believe a man can become content.' },
+  { rank: 12, name: "The Owl's Nest: Regenerative Arts Gathering", creator: 'Eska', sales: 4549, match: 0, category: 'Regenerative Culture', blurb: 'A 5-day gathering of 50 makers on a reforestation site: land art, ritual, and ecological skill-sharing.' },
+  { rank: 13, name: 'Regen Reef', creator: 'MesoReefDAO', sales: 4469, match: 50, category: 'ReFi', blurb: 'Marine biotech, socio-ecological restoration, and ReFi — modular wet labs for coral and fish.' },
+  { rank: 14, name: 'Cinemetropolis', creator: 'Jeff Desom', sales: 3645, match: 615, category: 'Mixed Reality', blurb: 'A mixed-reality world where AR expands real miniatures into one connected movie universe you can step inside.' },
+  { rank: 15, name: 'Sonic Sanctuary: A Journey Through Sound', creator: 'Plexonerz', sales: 3562, match: 270, category: 'Electronic Music', blurb: 'Electronic music as a sonic journey — introspection and the feeling that resides deep within us.' },
+  { rank: 16, name: 'International Artists Project', creator: 'International Artists Project', sales: 3215, match: 270, category: 'Community', blurb: 'A global music community uplifting artists born in every country, preserving hundreds of languages and genres.' },
+  { rank: 17, name: 'CHAINWARS .wtf — Cypherpunk Space-Opera', creator: 'Fly you fools .wtf', sales: 2072, match: 107, category: 'Journalism', blurb: "An epic docu-myth from inside crypto's war room. Stories the whitepapers were protecting you from." },
+  { rank: 18, name: 'THE NEW VANGUARD', creator: 'Enrico', sales: 1965, match: 250, category: 'Photography', blurb: 'A cinematic archive of Nigerian identity, documenting a generation and educating communities on Web3 cultural preservation.' },
+  { rank: 19, name: 'DeSci Asia', creator: 'Swift Evo', sales: 1870, match: 0, category: 'DeSci', blurb: 'Building bridges, sharing knowledge, and fostering growth for DeSci communities in Asia.' },
+  { rank: 20, name: 'Participatory Spatial Music Show', creator: 'Joel DeJong', sales: 1375, match: 0, category: 'Participatory Art', blurb: 'A live, co-created entertainment series.' },
+  { rank: 21, name: 'HuRya Empowerment Foundation (Poly Raiders)', creator: 'Poly Raiders', sales: 1190, match: 40, category: 'Impact', blurb: "Web3 art fuels dignity for thousands of girls through pads, kids' education, and a vocational center." },
+  { rank: 22, name: 'The Creator Block', creator: 'KOSBAA', sales: 1080, match: 500, category: 'Creator Economy', blurb: 'A two-day summit where creators showcase their work and learn how to own it onchain.' },
+  { rank: 23, name: 'THE ART FACTORY', creator: 'Gidzeey', sales: 978, match: 58, category: 'Music', blurb: 'One stage play each month telling Nigerian stories, paying creatives, and using Web3 to build lasting support.' },
+  { rank: 24, name: 'The MOTHERLand Project', creator: 'Tarzaa Gerald Caesar (CZA OF REM)', sales: 950, match: 0, category: 'Infrastructure', blurb: 'A women-led cultural infrastructure uniting music, film, AI tools, and digital ownership.' },
+  { rank: 25, name: 'The Space — a Home for Activists in Israel-Palestine', creator: 'Sapirs55', sales: 925, match: 0, category: 'Peacebuilding', blurb: 'A protected community space for activists building justice, solidarity, and political imagination.' },
+  { rank: 26, name: 'Ear of Dionysus: Listening as a Frontier Technology', creator: 'The Decentralised Cult of Quantum Listening', sales: 480, match: 80, category: 'Sound', blurb: 'An immersive sound lab and sonic theater at ancient sites, exploring quantum listening through Dionysian ritual.' },
+  { rank: 27, name: 'Artisanal Intelligence', creator: 'KNOTTO', sales: 400, match: 0, category: 'Craftsmanship', blurb: 'An exhibition world tour about endangered crafts, design, and cultural exchange between Europe and Japan.' },
+  { rank: 28, name: 'America 250 - Echoes of Freedom AR Tour', creator: 'Trishgiaart', sales: 385, match: 0, category: 'Augmented Reality', blurb: 'A site-specific augmented reality public-art and history XR project.' },
+  { rank: 29, name: 'Thread of Hope', creator: 'whyldwanderer', sales: 215, match: 0, category: 'Women Empowerment', blurb: 'Palestinian women in Cairo rebuilding identity, community, and livelihoods through the living tradition of Tatreez.' },
+  { rank: 30, name: 'Hip-Hop Africa', creator: 'Hiphop Africa', sales: 110, match: 0, category: 'Multi-Media', blurb: 'Building a unified platform for African hip hop through community, online radio, events, festivals, and awards.' },
+  { rank: 31, name: 'ANFT', creator: 'Amin', sales: 80, match: 0, category: 'Digital Art', blurb: 'A decentralized, authorship-first digital painting marketplace where every artwork is painted within the platform.' },
+  { rank: 32, name: 'The Impact Concerts', creator: 'EZinCrypto', sales: 30, match: 30, category: 'Music', blurb: 'Bringing awareness to social-good projects with cultural exchange through live music between project speakers.' },
+];
+
+const ELIGIBILITY: string[] = [
+  'Creator-owned and independently operated',
+  'Integrates emerging tech (blockchain, AI, decentralized tools, immersive media) in a meaningful way',
+  'Demonstrates active collaboration or meaningful community participation',
+  'Builds in public by sharing process, progress, or outcomes openly',
+  'Operates within a non-extractive, fair-compensation framework',
+  'Culminates in a public-facing, real-world activation (performance, installation, gathering, exhibition, release, or showcase)',
+];
+
+function usd(n: number): string {
+  return `$${n.toLocaleString('en-US')}`;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-center">
+      <div className="text-xl font-bold text-[#f5a623] sm:text-2xl">{value}</div>
+      <div className="mt-1 text-xs text-white/60">{label}</div>
+    </div>
+  );
+}
+
+export const revalidate = 3600; // ISR: refresh hourly
+
+export default function ArtizenPage() {
+  const totalSales = PROJECTS.reduce((sum, p) => sum + p.sales, 0);
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] text-white px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-4xl">
+        {/* Hero */}
+        <header className="mb-10">
+          <p className="text-xs font-semibold uppercase tracking-widest text-[#f5a623]">
+            The ZAO on Artizen
+          </p>
+          <h1 className="mt-2 text-3xl font-bold leading-tight sm:text-4xl">
+            ZAO Fund for Emerging Culture
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/70 sm:text-base">
+            A community match fund backing independent musicians, visual artists, technologists, and
+            community organizers building collaborative cultural experiences — at the intersection of
+            art, emerging technology, and real-world activation. Directed by Zaal on{' '}
+            <a href="https://artizen.fund" className="text-[#f5a623] underline-offset-2 hover:underline" target="_blank" rel="noopener noreferrer">
+              Artizen
+            </a>
+            .
+          </p>
+          <div className="mt-6 flex flex-wrap gap-3">
+            <a
+              href={FUND_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full bg-[#f5a623] px-5 py-2.5 text-sm font-semibold text-[#0a1628] transition hover:brightness-110"
+            >
+              Back the fund
+            </a>
+            <Link
+              href="/"
+              className="rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:bg-white/5"
+            >
+              ZAO OS home
+            </Link>
+          </div>
+        </header>
+
+        {/* Stats */}
+        <section className="mb-12 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Season" value="6" />
+          <Stat label="Projects backed" value={String(PROJECTS.length)} />
+          <Stat label="Fund pool" value="$10K" />
+          <Stat label="Artifact volume" value={usd(totalSales)} />
+        </section>
+
+        {/* How it works */}
+        <section className="mb-12 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-lg font-bold sm:text-xl">How the fund works</h2>
+          <p className="mt-3 text-sm leading-relaxed text-white/70">
+            Artizen runs on instant match funding. Supporters buy a project&apos;s open-edition{' '}
+            <span className="text-white">Artifact</span>, and every dollar of sales unlocks a matching
+            dollar from each fund backing that project, while the pool lasts. A project curated into
+            multiple funds gets matched by each — so broad backing multiplies a creator&apos;s raise.
+            We back emerging tech used as infrastructure for shared ownership and fair compensation,
+            not as a gimmick.
+          </p>
+          <div className="mt-5">
+            <h3 className="text-sm font-semibold text-[#f5a623]">What we fund</h3>
+            <ul className="mt-2 space-y-1.5">
+              {ELIGIBILITY.map((item) => (
+                <li key={item} className="flex gap-2 text-sm text-white/70">
+                  <span className="mt-1 text-[#f5a623]">-</span>
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        {/* Roster */}
+        <section className="mb-12">
+          <div className="mb-5 flex items-baseline justify-between">
+            <h2 className="text-lg font-bold sm:text-xl">The projects</h2>
+            <span className="text-xs text-white/50">Ranked by sales — snapshot {SNAPSHOT_DATE}</span>
+          </div>
+          <ul className="space-y-3">
+            {PROJECTS.map((p) => (
+              <li
+                key={p.rank}
+                className="rounded-xl border border-white/10 bg-white/5 p-4 transition hover:border-[#f5a623]/40"
+              >
+                <div className="flex gap-4">
+                  <div className="shrink-0 text-lg font-bold text-white/30 tabular-nums">
+                    {String(p.rank).padStart(2, '0')}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                      <h3 className="text-base font-semibold leading-snug">{p.name}</h3>
+                      <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-white/60">
+                        {p.category}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 text-xs text-white/50">by {p.creator}</p>
+                    <p className="mt-2 text-sm leading-relaxed text-white/70">{p.blurb}</p>
+                    {p.zaoTie ? (
+                      <p className="mt-2 text-xs font-medium text-[#f5a623]">ZAO link: {p.zaoTie}</p>
+                    ) : null}
+                    <div className="mt-2 flex gap-4 text-xs text-white/50 tabular-nums">
+                      <span>{usd(p.sales)} sales</span>
+                      <span>{usd(p.match)} matched</span>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* About Artizen */}
+        <section className="mb-12 rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h2 className="text-lg font-bold sm:text-xl">About Artizen</h2>
+          <p className="mt-3 text-sm leading-relaxed text-white/70">
+            Artizen is a Web3 crowdfunding and match-funding platform for projects at the intersection
+            of art, science, technology, and culture, founded by René Pinnell. As of June 2026 it
+            relaunched a rebuilt platform with its Phoenix Fund Drive — creators raised{' '}
+            <span className="text-white">over $270,000 in three days</span> — and is standing up
+            marquee funds with collaborators including RZA (Wu-Tang) and Lilly Wachowski (The Matrix).
+            Season 6 closes July 9, 2026.
+          </p>
+          <p className="mt-3 text-xs text-white/40">
+            Standings on this page are a point-in-time snapshot ({SNAPSHOT_DATE}) and move as artifacts
+            sell. The{' '}
+            <a href={FUND_URL} className="text-[#f5a623] underline-offset-2 hover:underline" target="_blank" rel="noopener noreferrer">
+              live fund
+            </a>{' '}
+            is the canonical figure.
+          </p>
+        </section>
+
+        <footer className="border-t border-white/10 pt-6 text-center">
+          <a
+            href={FUND_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block rounded-full bg-[#f5a623] px-6 py-3 text-sm font-semibold text-[#0a1628] transition hover:brightness-110"
+          >
+            Support emerging culture on Artizen
+          </a>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/artizen/page.tsx
+++ b/src/app/artizen/page.tsx
@@ -88,8 +88,30 @@ const ELIGIBILITY: string[] = [
   'Culminates in a public-facing, real-world activation (performance, installation, gathering, exhibition, release, or showcase)',
 ];
 
+interface LikemindedFund {
+  name: string;
+  theme: string;
+}
+
+// Funds on Artizen aligned with the ZAO Fund — the company we keep + cross-curation
+// targets. See research/business/846 + 847.
+const LIKEMINDED: LikemindedFund[] = [
+  { name: 'Greenpill Fund for Regenerative Gatherings', theme: 'Local events that bring regenerative communities together' },
+  { name: 'Funding the Commons Frontier Fund', theme: 'Infrastructure, research, and cultural work for the commons' },
+  { name: 'Terminus Fund', theme: 'Sovereign communities and network-state experiments' },
+  { name: 'Hubs Network Fund for Solarpunk Spaces', theme: 'Independent physical spaces for culture, care, and governance' },
+];
+
 function usd(n: number): string {
   return `$${n.toLocaleString('en-US')}`;
+}
+
+// Day-of-year, so the featured project rotates through the roster once per day
+// without any client JS. Server-rendered; ISR keeps it fresh.
+function dayOfYear(d: Date): number {
+  const start = Date.UTC(d.getUTCFullYear(), 0, 0);
+  const now = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return Math.floor((now - start) / 86_400_000);
 }
 
 function Stat({ label, value }: { label: string; value: string }) {
@@ -105,6 +127,7 @@ export const revalidate = 3600; // ISR: refresh hourly
 
 export default function ArtizenPage() {
   const totalSales = PROJECTS.reduce((sum, p) => sum + p.sales, 0);
+  const featured = PROJECTS[dayOfYear(new Date()) % PROJECTS.length];
 
   return (
     <main className="min-h-screen bg-[#0a1628] text-white px-4 py-10 sm:px-6 lg:px-8">
@@ -150,6 +173,40 @@ export default function ArtizenPage() {
           <Stat label="Projects backed" value={String(PROJECTS.length)} />
           <Stat label="Fund pool" value="$10K" />
           <Stat label="Artifact volume" value={usd(totalSales)} />
+        </section>
+
+        {/* Featured project of the day */}
+        <section className="mb-12">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h2 className="text-lg font-bold sm:text-xl">Project of the day</h2>
+            <span className="text-xs text-white/50">Rotates daily through the fund</span>
+          </div>
+          <div className="rounded-2xl border border-[#f5a623]/40 bg-gradient-to-br from-[#f5a623]/10 to-transparent p-6">
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <h3 className="text-xl font-bold leading-snug">{featured.name}</h3>
+              <span className="rounded-full bg-[#f5a623]/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-[#f5a623]">
+                {featured.category}
+              </span>
+            </div>
+            <p className="mt-1 text-sm text-white/50">by {featured.creator}</p>
+            <p className="mt-3 text-sm leading-relaxed text-white/80">{featured.blurb}</p>
+            {featured.zaoTie ? (
+              <p className="mt-2 text-xs font-medium text-[#f5a623]">ZAO link: {featured.zaoTie}</p>
+            ) : null}
+            <p className="mt-4 text-sm leading-relaxed text-white/70">
+              One of the best ways to back {featured.creator}: collect their Artifact. Because they are
+              part of the ZAO Fund, every dollar they raise unlocks matching from the fund, paid
+              straight to the creator. Support the project, support the fund.
+            </p>
+            <a
+              href={FUND_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-5 inline-block rounded-full bg-[#f5a623] px-5 py-2.5 text-sm font-semibold text-[#0a1628] transition hover:brightness-110"
+            >
+              Collect on Artizen
+            </a>
+          </div>
         </section>
 
         {/* How it works */}
@@ -213,6 +270,52 @@ export default function ArtizenPage() {
               </li>
             ))}
           </ul>
+        </section>
+
+        {/* Like-minded funds */}
+        <section className="mb-12">
+          <h2 className="text-lg font-bold sm:text-xl">The company we keep</h2>
+          <p className="mt-2 text-sm leading-relaxed text-white/70">
+            We are not alone on Artizen. These funds point at the same frontier — we back their
+            builders, they back ours, and projects curated into more than one fund multiply their
+            match. If your work fits both, that is the goal.
+          </p>
+          <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+            {LIKEMINDED.map((f) => (
+              <li key={f.name} className="rounded-xl border border-white/10 bg-white/5 p-4">
+                <h3 className="text-sm font-semibold">{f.name}</h3>
+                <p className="mt-1 text-xs text-white/60">{f.theme}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Submit your project */}
+        <section className="mb-12 rounded-2xl border border-[#f5a623]/30 bg-white/5 p-6">
+          <h2 className="text-lg font-bold sm:text-xl">Building something? Join the fund.</h2>
+          <p className="mt-3 text-sm leading-relaxed text-white/70">
+            The ZAO Fund backs creator-owned projects that merge art, emerging technology, and real
+            community — and end in something public: a release, a show, a gathering, an exhibition.
+            If that is you, submit your project on Artizen and put it in front of the ZAO community.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <a
+              href="https://artizen.fund/submit"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full bg-[#f5a623] px-5 py-2.5 text-sm font-semibold text-[#0a1628] transition hover:brightness-110"
+            >
+              Submit a project
+            </a>
+            <a
+              href={FUND_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white/80 transition hover:bg-white/5"
+            >
+              See the fund
+            </a>
+          </div>
         </section>
 
         {/* About Artizen */}

--- a/src/app/artizen/page.tsx
+++ b/src/app/artizen/page.tsx
@@ -220,11 +220,13 @@ export default function ArtizenPage() {
           <h2 className="text-lg font-bold sm:text-xl">About Artizen</h2>
           <p className="mt-3 text-sm leading-relaxed text-white/70">
             Artizen is a Web3 crowdfunding and match-funding platform for projects at the intersection
-            of art, science, technology, and culture, founded by René Pinnell. As of June 2026 it
-            relaunched a rebuilt platform with its Phoenix Fund Drive — creators raised{' '}
-            <span className="text-white">over $270,000 in three days</span> — and is standing up
-            marquee funds with collaborators including RZA (Wu-Tang) and Lilly Wachowski (The Matrix).
-            Season 6 closes July 9, 2026.
+            of art, science, technology, and culture, founded by René Pinnell. Creators mint $10
+            open-edition Artifacts — 100% goes to the creator — and every dollar of sales instantly
+            unlocks a matching dollar from each fund backing the project. As of June 2026 a rebuilt
+            platform is running weekly match drives: the Phoenix Fund Drive raised{' '}
+            <span className="text-white">over $270,000 in three days</span>, and the Frontier Fund
+            Drive is live now with a 2x match. The fund with RZA (Wu-Tang) took the gold. Season 6
+            closes July 9, 2026.
           </p>
           <p className="mt-3 text-xs text-white/40">
             Standings on this page are a point-in-time snapshot ({SNAPSHOT_DATE}) and move as artifacts


### PR DESCRIPTION
ZAO Fund for Emerging Culture full Season 6 roster (32 projects) + zaoos.com/artizen page. Doc 843 (research/business) + src/app/artizen/page.tsx. Ties: #1 InfiniteZero=doc 760, #2/#4 Edge City=doc 674, Arun Phillips top supporter, #32 possible Jose Acabrera tie (verify). June 2026 Artizen news: Phoenix Drive $270K/3d, season->Jul 9, 36 Cinema/RZA + Lilly Wachowski funds. typecheck clean. Snapshot 2026-06-11; page links to live fund. Co-Authored-By: Claude Opus 4.8 (1M context)