### PR TITLE
Docs cleanup: count drift + estate map (844) + CLAUDE.md standard (843)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,16 +39,15 @@ npx biome check src/lib/agents        # lint specific module
 ## Project Structure
 
 ```
-src/app/api/         # 301 route handlers: /api/[feature]/[action]/route.ts
-src/components/      # 279 components organized by feature
-src/hooks/           # 19 custom hooks (useAuth, useChat, useRadio, etc.)
-src/lib/             # Utilities by domain (auth, db, farcaster, music, publish, agents)
+src/app/api/         # 302 route handlers across 55 domains: /api/[feature]/[action]/route.ts
+src/components/      # 295 components organized by feature
+src/hooks/           # 18 custom hooks (useAuth, useChat, useRadio, etc.)
+src/lib/             # Utilities across 42 domains (auth, db, farcaster, music, publish, agents)
 src/providers/       # React providers (audio player, contexts)
 src/types/           # TypeScript type definitions
-community.config.ts  # Branding, channels, contracts, nav - THE fork point
-research/            # 240+ research docs
+community.config.ts  # Branding, channels, contract addresses, nav - THE fork point
+research/            # ~820 active research docs (counts verified 2026-06-11, Doc 836)
 scripts/             # SQL migrations, wallet generation, webhooks
-contracts/           # Solidity (staking, bounty board)
 ```
 
 ## Code Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The pattern: **Monorepo as Lab.**
 - Sharing model: clone, no deps. Each graduate stands alone.
 - Research stays in ZAOOS forever - it's the institutional memory across every product.
 
-**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (graduating Wed), agent stack (ZOE, Hermes), music player components, 540+ research docs. 301 API routes, 279 components, 19 hooks.
+**Today the lab includes:** the original Farcaster client for The ZAO, the ZAOstock dashboard + Telegram bot (spinning out to its own repo), agent stack (ZOE, Hermes), music player components, ~820 active research docs. 302 API routes, 295 components, 18 hooks. (Counts verified 2026-06-11 - see [Doc 836](research/infrastructure/836-zaoos-repo-estate-census/).)
 
 **Stack:** Next.js 16, React 19, Supabase (RLS), Neynar, XMTP, Stream.io, Wagmi/Viem, Tailwind v4, iron-session.
 
@@ -25,17 +25,16 @@ The pattern: **Monorepo as Lab.**
 
 | Directory | What | When to Read |
 |-----------|------|-------------|
-| `src/app/api/` | 301 route handlers across 54 domains | Working on backend |
-| `src/components/` | 279 components by feature | Working on UI |
-| `src/hooks/` | 19 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
-| `src/lib/` | Utils by domain: auth, db, farcaster, music, publish, agents | Working on business logic |
+| `src/app/api/` | 302 route handlers across 55 domains | Working on backend |
+| `src/components/` | 295 components by feature | Working on UI |
+| `src/hooks/` | 18 custom hooks (useAuth, useChat, useRadio, etc.) | Working on state |
+| `src/lib/` | Utils across 42 domains: auth, db, farcaster, music, publish, agents | Working on business logic |
 | `src/lib/agents/` | VAULT/BANKER/DEALER autonomous trading bots | Working on agents |
 | `src/lib/publish/` | Cross-platform posting (Farcaster, X, Bluesky) | Working on distribution |
 | `src/providers/` | Audio player, contexts | Working on player |
-| `community.config.ts` | All branding, channels, admin FIDs, contracts, nav | Forking or configuring |
-| `research/` | 240+ research docs (see research/README.md) | Use grep, not bulk reads |
+| `community.config.ts` | All branding, channels, admin FIDs, contract addresses, nav | Forking or configuring |
+| `research/` | ~820 active research docs (see research/README.md) | Use grep, not bulk reads |
 | `scripts/` | SQL migrations, wallet generation, webhook setup | DB or infra work |
-| `contracts/` | Solidity (staking, bounty board) | Smart contract work |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The pattern: **Monorepo as Lab.**
 | Agent stack (ZOE, Hermes, others) | In R&D until one is solid + worth its own brand |
 | Music player components (Sonata-pattern, etc) | In R&D |
 | Live audio: ZAO Spaces (Stream.io + 100ms) + Juke integration ([/spaces](https://zaoos.com/spaces), [/live](https://zaoos.com/live), [/juke-status](https://zaoos.com/juke-status)) | In production - 3 providers from one Go-Live button, public Juke dashboard for partner |
-| Research library (540+ docs across 13 topic areas) | Always stays here |
+| Research library (~820 active docs across 14 topic areas) | Always stays here |
 
 ### What&rsquo;s already graduated
 
@@ -646,16 +646,16 @@ Compose once in ZAO OS, publish to multiple platforms simultaneously. Farcaster 
 src/
 ├── app/                  # Next.js App Router
 │   ├── (auth)/           # Protected routes (chat, messages, governance, fractals, social, admin, etc.)
-│   ├── api/              # 121 route handlers: /api/[feature]/[action]/route.ts
+│   ├── api/              # 302 route handlers across 55 domains: /api/[feature]/[action]/route.ts
 │   └── page.tsx          # Landing / login
 ├── components/           # React components by feature (chat, messages, music, admin, social, etc.)
-├── hooks/                # 16+ custom hooks (useAuth, useChat, useRadio, usePlayerQueue, useNowPlaying, useListeningRoom, useENS, etc.)
+├── hooks/                # 18 custom hooks (useAuth, useChat, useRadio, usePlayerQueue, useNowPlaying, useListeningRoom, useENS, etc.)
 ├── contexts/             # React contexts (XMTPContext, QueueContext)
 ├── providers/            # Provider wrappers (8 audio providers, PostHog)
 ├── lib/                  # Utilities by domain (auth, db, farcaster, gates, music, xmtp, hats, publish, moderation, etc.)
 └── types/                # TypeScript type definitions
 community.config.ts       # All community config — fork-friendly
-research/                 # 155+ research docs (see research/README.md)
+research/                 # ~820 active research docs (see research/README.md)
 scripts/                  # DB setup, wallet generation, webhook registration, data import
 docs/                     # Internal plans, QA checklists, architecture decisions
 ```
@@ -664,7 +664,7 @@ docs/                     # Internal plans, QA checklists, architecture decision
 
 ## Research Library
 
-**155+ research documents** covering every aspect of building a decentralized music platform — protocol, identity, music, AI agents, governance, revenue, cross-platform publishing, on-chain distribution, Arweave, NFTs, reputation, security, and developer tooling.
+**~820 active research documents** (plus 77 superseded in `_archive/`) covering every aspect of building a decentralized music platform — protocol, identity, music, AI agents, governance, revenue, cross-platform publishing, on-chain distribution, Arweave, NFTs, reputation, security, and developer tooling.
 
 Start with:
 - [research/50 — The ZAO Complete Guide](./research/50-the-zao-complete-guide/) — canonical ecosystem reference

--- a/research/README.md
+++ b/research/README.md
@@ -1,6 +1,6 @@
 # ZAO OS Research Library
 
-> **771+ active research documents** across 13 topic folders (77 superseded docs in `_archive/`, plus 9 daily inspiration logs) covering the full ZAO ecosystem — a decentralized social media platform for music, plus festivals, agents, governance, and the ZABAL economy.
+> **~820 active research documents** across 14 topic folders (77 superseded docs in `_archive/`, plus 9 daily inspiration logs) covering the full ZAO ecosystem — a decentralized social media platform for music, plus festivals, agents, governance, and the ZABAL economy. Counts verified 2026-06-11 ([Doc 836](./infrastructure/836-zaoos-repo-estate-census/)).
 
 ---
 
@@ -8,19 +8,19 @@
 
 | Topic | Docs | Description |
 |-------|------|-------------|
-| [Dev Workflows](./dev-workflows/) | 156 | Skills, Claude Code, testing, autoresearch, git, worktrees, MCP servers |
-| [Agents](./agents/) | 142 | OpenClaw, ZOE, Hermes, frameworks, memory, orchestration, self-optimization, agent identity/registration |
+| [Dev Workflows](./dev-workflows/) | 167 | Skills, Claude Code, testing, autoresearch, git, worktrees, MCP servers |
+| [Agents](./agents/) | 152 | OpenClaw, ZOE, Hermes, frameworks, memory, orchestration, self-optimization, agent identity/registration |
 | [Music](./music/) | 85 | Player, NFTs, distribution, Arweave, audio APIs, FISHBOWLZ, AI generation, ElevenLabs, metadata/ISRC, games/interactive media |
-| [Business](./business/) | 78 | Revenue, payments, token economics, strategy, marketplace, brand kits, partnerships |
-| [Events](./events/) | 77 | Bootcamps, ZAOstock, ZABAL Games, meeting/call recaps, ship logs, big wins, status snapshots |
-| [Infrastructure](./infrastructure/) | 54 | Next.js 16, Supabase, streaming, mobile, notifications, admin, 3D portal hub, repo+estate census (836) |
-| [Community](./community/) | 44 | ZAO guide, whitepaper, onboarding, member profiles, task forces, people/brands |
+| [Business](./business/) | 81 | Revenue, payments, token economics, strategy, marketplace, brand kits, partnerships |
+| [Events](./events/) | 94 | Bootcamps, ZAOstock, ZABAL Games, meeting/call recaps, ship logs, big wins, status snapshots |
+| [Infrastructure](./infrastructure/) | 59 | Next.js 16, Supabase, streaming, mobile, notifications, admin, 3D portal hub, repo+estate census (836), estate map (844) |
+| [Community](./community/) | 45 | ZAO guide, whitepaper, onboarding, member profiles, task forces, people/brands |
 | [Farcaster](./farcaster/) | 42 | Protocol, Mini Apps, XMTP, ecosystem, social graph, agentic bootcamp |
-| [Governance](./governance/) | 41 | Respect, ORDAO, Hats, ZOUNZ, fractals, Snapshot, BuilderOSS |
+| [Governance](./governance/) | 43 | Respect, ORDAO, Hats, ZOUNZ, fractals, Snapshot, BuilderOSS |
 | [Identity](./identity/) | 25 | ZIDs, ENS/Basenames, reputation scoring, knowledge graph, Privy auth/wallets |
 | [Cross-Platform](./cross-platform/) | 15 | Bluesky, Lens, Nostr, Mastodon, Reddit, X, Twitch, Meta |
 | [Inspiration](./inspiration/) | 9 | Daily "steal like an artist" research — apps analyzed per session, gap analysis |
-| [Security](./security/) | 7 | Audits, API verification, testing |
+| [Security](./security/) | 8 | Audits, API verification, testing |
 | [WaveWarZ](./wavewarz/) | 6 | Prediction markets, artist pipeline, Solana PDAs |
 | [Archive](./_archive/) | 77 | Superseded docs (preserved for history) |
 
@@ -137,8 +137,8 @@
 
 ## Research Stats
 
-- **Active documents:** 771 across 13 topic folders (+9 daily inspiration logs; all docs filed in topic folders)
-- **Highest doc number:** 802
+- **Active documents:** ~820 across 14 topic folders (+9 daily inspiration logs; all docs filed in topic folders)
+- **Highest doc number:** 841
 - **Archived (superseded/merged):** 77 (in `_archive/`)
 - **Time span:** January — June 2026
 - **Topic folders:** dev-workflows, agents, music, events, business, infrastructure, community, farcaster, governance, identity, cross-platform, security, wavewarz

--- a/research/dev-workflows/843-claude-md-alignment-standard/README.md
+++ b/research/dev-workflows/843-claude-md-alignment-standard/README.md
@@ -1,0 +1,89 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-06-11
+related-docs: 844, 836
+original-query: "Align CLAUDE.md files across all ZAO repos - one standard, consistent agent context everywhere."
+tier: STANDARD
+---
+
+# Doc 843 - CLAUDE.md Alignment Standard
+
+> **Goal:** One standard for every ZAO repo's `CLAUDE.md` so any AI coding agent (Claude Code, Cursor, etc) gets consistent, accurate context across the estate. Defines the two-layer model, the required sections, and a copy-paste [TEMPLATE.md](./TEMPLATE.md).
+
+## The two-layer model
+
+ZAO context lives in two layers. Do NOT duplicate layer 1 into layer 2 - that's
+how drift starts.
+
+| Layer | File | Holds | Scope |
+|-------|------|-------|-------|
+| 1. Global | `~/.claude/CLAUDE.md` | No-emoji / no-em-dash rules, **brand glossary** (WaveWarZ, COC Concertz, The ZAO, etc), graphify/socials skills | Every project, every machine |
+| 2. Per-repo | `<repo>/CLAUDE.md` | What this repo is, stack, project map, security, boundaries, key files | One repo |
+
+Layer 2 **references** layer 1 ("brand spellings: see global `~/.claude/CLAUDE.md`")
+rather than copying it. The brand glossary has exactly one home.
+
+## Required sections (every repo CLAUDE.md)
+
+1. **What this is** - one paragraph. For ZAOOS-graduated repos, state the
+   graduation lineage ("graduated from ZAOOS 2026-05-06").
+2. **Stack** - one line, real versions.
+3. **Project Map** - directory table with **live counts** (verify before
+   writing; stale counts are the #1 drift, see Doc 841). Add a "verified YYYY-MM-DD"
+   stamp.
+4. **Security (Non-Negotiable)** - never-expose secrets, no `dangerouslySetInnerHTML`,
+   Zod on input, RLS. Copy the ZAOOS block; trim to what the repo actually uses.
+5. **Boundaries** - Always do / Ask first / Never do. Mirror from `AGENTS.md` if
+   the repo has one (AGENTS.md is source of truth; CLAUDE.md mirrors it).
+6. **Key Files** - the 5-10 files an agent must know.
+7. **Estate pointer** - link to [Doc 844](../../infrastructure/844-zao-estate-map/)
+   so any agent can see where this repo sits in the ecosystem.
+
+## Rules
+
+- **Counts must be verified, not guessed.** Run the count, stamp the date. Doc 841
+  found 6 separate stale counts in ZAOOS docs (301 vs 302 routes, 279 vs 295
+  components, etc). A wrong count erodes agent trust in the whole file.
+- **No phantom paths.** Don't list a directory that doesn't exist (ZAOOS CLAUDE.md
+  claimed a `contracts/` dir for months - it never existed).
+- **AGENTS.md is source of truth where both exist.** CLAUDE.md mirrors it. If they
+  drift, fix AGENTS.md first, then sync CLAUDE.md.
+- **One glossary.** Brand spellings live in global `~/.claude/CLAUDE.md` only.
+
+## Which repos need this (2026-06-11)
+
+| Repo | Has CLAUDE.md | Action |
+|------|---------------|--------|
+| ZAOOS | yes | aligned 2026-06-11 (this PR) |
+| ZAOcowork | yes | review against standard |
+| ZAOcowork/research-dispatch | yes | review against standard |
+| ZAOscout | no | add (graduated, keyless-fetch toolkit) |
+| bcz-yapz | unknown (remote) | add on next touch |
+| zpoidh | unknown (remote) | add on next touch |
+| zlank | unknown (remote) | add on next touch |
+| ZAOVideoEditor | unknown (remote) | add on next touch |
+| CoCConcertZ | unknown (remote) | add on next touch |
+
+Adopt opportunistically: when you next open a repo, drop in [TEMPLATE.md](./TEMPLATE.md)
+and fill it. No need for a big-bang pass across all repos.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Align ZAOcowork CLAUDE.md to the standard | @Zaal | PR (that repo) | Next touch |
+| Add CLAUDE.md to ZAOscout from TEMPLATE | @Zaal | PR (that repo) | Next touch |
+| Drop TEMPLATE into each graduated repo as opened | @Zaal | PRs | Opportunistic |
+
+## Also See
+
+- [Doc 844](../../infrastructure/844-zao-estate-map/) - the estate map (which repos exist)
+- [Doc 841](../../security/841-zaoos-over-audit-2026-06/) - found the doc drift this standardizes against
+- [TEMPLATE.md](./TEMPLATE.md) - copy-paste starting point
+
+## Sources
+
+- [FULL] ZAOOS CLAUDE.md / AGENTS.md alignment, this PR, 2026-06-11
+- [FULL] Local repo CLAUDE.md survey, 2026-06-11

--- a/research/dev-workflows/843-claude-md-alignment-standard/TEMPLATE.md
+++ b/research/dev-workflows/843-claude-md-alignment-standard/TEMPLATE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md - <REPO NAME>
+
+> Copy this into a ZAO repo's root as `CLAUDE.md`, fill the angle-bracket slots,
+> delete this quote block. Standard: research/dev-workflows/843 in ZAOOS.
+
+## What this is
+
+<One paragraph: what this repo does, who it serves. If it graduated from ZAOOS,
+say so: "Graduated from ZAOOS <date>; clone-no-deps, stands alone.">
+
+**Stack:** <e.g. Next.js 16, React 19, Supabase (RLS), Tailwind v4>
+
+> Brand spellings (WaveWarZ, COC Concertz, The ZAO, ZABAL, etc): see global
+> `~/.claude/CLAUDE.md`. Do not re-copy the glossary here.
+
+## Project Map
+
+> Counts verified <YYYY-MM-DD>. Re-verify before editing - stale counts erode trust.
+
+| Directory | What | When to Read |
+|-----------|------|-------------|
+| `<dir>/` | <purpose> (<N> files) | <when> |
+
+## Security (Non-Negotiable)
+
+- **NEVER** expose server-only secrets (`<SERVICE_ROLE_KEY>`, `<API_KEY>`, `<SESSION_SECRET>`) to the browser
+- **NEVER** use `dangerouslySetInnerHTML`
+- All user input: validate with Zod `safeParse` before processing
+- <DB> RLS on all tables; service role = server-side only
+
+## Boundaries
+
+> If this repo has an AGENTS.md, it is the source of truth - mirror it here.
+
+**Always do:** <validate input, check session, use the `@/` alias, mobile-first>
+**Ask first:** <DB migrations, new deps, env-var changes, config changes>
+**Never do:** <commit secrets/.env, skip Zod, push directly to main>
+
+## Key Files
+
+- `<path>` - <what>
+- `<path>` - <what>
+
+## Where this sits in the estate
+
+Part of the ZAO ecosystem - see the estate map:
+`research/infrastructure/844-zao-estate-map/` in ZAOOS.

--- a/research/infrastructure/844-zao-estate-map/README.md
+++ b/research/infrastructure/844-zao-estate-map/README.md
@@ -1,0 +1,117 @@
+---
+topic: infrastructure
+type: guide
+status: research-complete
+last-validated: 2026-06-11
+related-docs: 836, 841, 843
+original-query: "Align documentation across the ZAO estate - build a canonical map of every live project, repo, and DB so the next 'what do we even have' question doesn't cost another census."
+tier: STANDARD
+---
+
+# Doc 844 - ZAO Estate Map
+
+> **Goal:** The single canonical inventory of every live ZAO surface - project, repo, domain, database, status. Built from the 2026-06-11 census ([Doc 836](../836-zaoos-repo-estate-census/)). When something graduates, is born, or dies, update THIS doc.
+
+## Why this exists
+
+The estate sprawls across 86 Vercel projects, 4 Supabase projects (under Zaal's
+account), and a dozen+ git repos. Before this doc there was no map - answering
+"what's live" cost a token-census. This is the connective tissue every other doc
+references. Pair it with [Doc 843](../../dev-workflows/843-claude-md-alignment-standard/)
+(CLAUDE.md standard) so each repo's local context stays consistent with the map.
+
+## Live surfaces (32 Vercel projects deployed in last 90 days)
+
+### Core ZAO products
+| Project | Repo | What | DB |
+|---------|------|------|-----|
+| zaoos | bettercallzaal/ZAOOS | The lab - gated Farcaster client + monorepo | Supabase ZAOOS |
+| zaonexus | bettercallzaal/ZAONEXUS | ZAO link hub (141 canonical links) | static/JSON |
+| zaofractal | (v0) | Fractal governance surface | - |
+| zuke | (no repo linked) | Juke audio partner surface | - |
+| co-c-concert-z | bettercallzaal/CoCConcertZ | COC Concertz (graduated) | own |
+| fishbowlz | bettercallzaal/fishbowlz | FISHBOWLZ (paused, Juke partnership) | own |
+| wavewarzapp | bettercallzaal/wavewarzapp | WaveWarZ app | own |
+
+### Graduated / standalone products
+| Project | Repo | What |
+|---------|------|------|
+| bcz-yapz | bettercallzaal/bcz-yapz | BCZ YapZ (graduated 2026-05-06, bczyapz.com) |
+| zpoidh | bettercallzaal/zpoidh | POIDH bounty home |
+| zlank | bettercallzaal/zlank | Zlank OSS+managed service |
+| zaostock | bettercallzaal/zaostock | ZAOstock festival (spinning out of ZAOOS) |
+| zao-video-editor | bettercallzaal/ZAOVideoEditor | Livestream-to-clips editor (local FastAPI+React) |
+| (local) | bettercallzaal/ZAOscout | Keyless social-fetch toolkit (graduated 2026-06-10) |
+
+### Client / personal
+| Project | Repo | What |
+|---------|------|------|
+| riverside-group-demo | bettercallzaal/riverside-group-demo | Riverside Group (Cameron) client work |
+| bettercallzaalwebsite | bettercallzaal/bettercallzaalwebsite | BCZ personal site |
+| zaal-donate-button | bettercallzaal/Zaal-s-Birthday | Donation widget |
+| imanprojects | bettercallzaal/imanprojects | Iman's project surface |
+
+### Experiments / snaps / scratch (keep-or-prune as they age)
+duodo-snap, nouns-snap, zabalsnap1, ltaesnap (Farcaster snaps), crownvics,
+aurdour, farmdrop, textsplitter, b-zbuild-2, zabalart, plus 6 `v0-*` scratch
+deploys (v-worker-63, v0-thirdweb-emebed, za-ocowork, v0-mint-widget-for-zao,
+v0-zoundz-mini-app-design, v0-bidding-war-z).
+
+## Databases (Supabase, Zaal's account)
+
+| Project | Status | Used by |
+|---------|--------|---------|
+| ZAOOS | ACTIVE | the monorepo |
+| ZAO STOCK | ACTIVE | ZAOstock spinout |
+| zaalp99's Project | INACTIVE | (paused - deletable) |
+| supabase-chestnut-pebble | INACTIVE | (paused - deletable) |
+
+Note: the cowork tracker DB (`etwvzrmlxeobinrlytza`) lives under **Iman's**
+account, not Zaal's - it is not in the list above.
+
+## Dead (the kill-list)
+
+54 dead Vercel projects (no deploy in 90+ days) - full list + delete URLs in
+[Doc 836](../836-zaoos-repo-estate-census/) section 7. Headline: 12 old NEXUS
+iterations + ~5 duplicate projects lead the cleanup.
+
+## Graduation ledger (the lab rule)
+
+Per the Monorepo-as-Lab model, a thing graduates -> own repo, own DB, own
+domain, and **code is deleted from ZAOOS**. Confirmed graduates: COC Concertz,
+BCZ YapZ, ZAOscout, ZAOVideoEditor. In progress: ZAOstock. **Open hygiene debt**
+(from [Doc 841](../../security/841-zaoos-over-audit-2026-06/)): decommissioned
+Magnetiq/AttaBotty code, half-built Arweave mint, and duplicate miniapp auth
+routes still linger in ZAOOS and should be deleted or finished.
+
+## Recommendations (ecosystem-level)
+
+1. **Treat this doc as a registry, not prose** - update on every graduate/birth/
+   death. Re-run `scripts/estate-audit/audit.sh` quarterly and reconcile.
+2. **Prune the 54 dead Vercel projects** - clutter, and each is an attack/confusion
+   surface. Start with the 12 NEXUS dupes.
+3. **Adopt the CLAUDE.md standard** ([Doc 843](../../dev-workflows/843-claude-md-alignment-standard/))
+   in every graduated repo so agent context is consistent estate-wide.
+4. **One brand-glossary source of truth** - the glossary lives in the global
+   `~/.claude/CLAUDE.md`; graduated repos should reference it, not re-copy (drift risk).
+5. **Finish the graduation deletes** - close the lab-rule hygiene debt above.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Keep this map current on every graduate/birth/death | @Zaal | Doc | Ongoing |
+| Quarterly re-run of estate-audit + reconcile | @Zaal | Manual | Quarterly |
+| Delete decommissioned/graduated code still in ZAOOS | @Zaal | PR | Next cleanup |
+| Roll CLAUDE.md standard into graduated repos | @Zaal | PRs | Backlog |
+
+## Also See
+
+- [Doc 836](../836-zaoos-repo-estate-census/) - the census this is built from
+- [Doc 843](../../dev-workflows/843-claude-md-alignment-standard/) - CLAUDE.md standard
+- [Doc 841](../../security/841-zaoos-over-audit-2026-06/) - over-audit (graduation hygiene debt)
+
+## Sources
+
+- [FULL] Vercel + Supabase census 2026-06-11 (`~/.zao/private/*-estate-*.json`), Doc 836
+- [FULL] Local repo survey + git remotes, 2026-06-11


### PR DESCRIPTION
Aligns documentation across the estate. Three parts:

## Tier 1 - drift fixes (all counts verified live 2026-06-11)
CLAUDE.md, AGENTS.md, README.md, research/README.md were all stale:
- routes 301 -> 302 (55 domains), components 279 -> 295, hooks 19 -> 18
- research docs 540+/771+/155+ -> ~820 active (14 topic folders)
- removed the phantom contracts/ dir reference (it never existed - flagged by audit doc 841)
- corrected per-category counts in research/README

## Tier 2 - new connective docs
- **Doc 844 (ZAO Estate Map)**: the canonical inventory - every live (32), graduated, and dead Vercel project + the 4 Supabase DBs, mapped to repos. Built from census 836. The 'what do we even have' source of truth.
- **Doc 843 (CLAUDE.md Alignment Standard)** + TEMPLATE.md: two-layer model (global glossary vs per-repo context), required sections, and a copy-paste template for graduated repos.

## Why
Doc 841's audit found 6+ separate stale counts and a phantom directory across the docs. This fixes them at the source and adds the standard so it doesn't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)