### PR TITLE
ZAO Estate Control Plane - automated truth-keeping (engine + CI + dashboard)

### DIFF
--- a/.github/workflows/estate-health.yml
+++ b/.github/workflows/estate-health.yml
@@ -1,0 +1,90 @@
+name: Estate Health
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 13 * * 1' # Mondays 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  # PR guardrail: token-free checks, sticky comment, ratchet (fail only on NEW debt).
+  guardrail:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run estate checks
+        id: checks
+        run: |
+          MAX=$(jq -r '.baseline.ratchetMaxFails' tools/estate-control-plane/config.json)
+          echo "max_fails=$MAX" >> "$GITHUB_OUTPUT"
+          set +e
+          npx -y tsx tools/estate-control-plane/run-checks.ts \
+            --ci --max-fails="$MAX" \
+            --pr-comment=/tmp/estate-pr.md --baseline-fails="$MAX" \
+            --out=/tmp/estate-report.json
+          echo "exit=$?" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Upsert sticky PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/estate-pr.md', 'utf8');
+            const marker = '<!-- estate-control-plane -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Enforce ratchet
+        if: steps.checks.outputs.exit != '0'
+        run: |
+          echo "Estate health ratchet breached - new debt added above baseline ${{ steps.checks.outputs.max_fails }}."
+          exit 1
+
+  # Weekly sweep: regenerate dashboard + digest, upload as artifacts.
+  # Next steps (need secrets, wire when ready): deploy dashboard to Vercel,
+  # open/update an 'Estate Health' issue, push the digest to ZOE/Telegram,
+  # open an auto count-fix PR for fixable drift.
+  sweep:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run + render
+        run: |
+          npx -y tsx tools/estate-control-plane/run-checks.ts \
+            --out=/tmp/estate-report.json \
+            --dashboard=/tmp/estate-dashboard.html \
+            --digest=/tmp/estate-digest.txt
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: estate-health
+          path: |
+            /tmp/estate-report.json
+            /tmp/estate-dashboard.html
+            /tmp/estate-digest.txt
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ build-log/
 coverage/
 autoresearch-test-coverage/
 tmp/
+
+# estate-control-plane generated artifacts
+tools/estate-control-plane/estate-report.json
+.estate-scan-stamp

--- a/docs/superpowers/specs/2026-06-12-estate-control-plane-design.md
+++ b/docs/superpowers/specs/2026-06-12-estate-control-plane-design.md
@@ -1,0 +1,140 @@
+# ZAO Estate Control Plane - Design Spec
+
+Date: 2026-06-12
+Status: approved (brainstorm), ready to build
+Related: research/infrastructure/836 (census), 844 (estate map), dev-workflows/843 (CLAUDE.md standard), security/841 (over-audit)
+
+## Problem
+
+Truth rots faster than anyone fixes it by hand. This session alone found 6+ stale
+counts, a phantom `contracts/` dir, 54 dead Vercel projects, and lingering
+graduated/decommissioned code. Each was fixed manually; all will rot again. The
+estate has no automated truth-keeping and no live map of what is actually alive.
+
+## Goal
+
+A checks engine that scans a repo, emits one `estate-report.json`, and feeds three
+dumb surfaces (PR guardrail, dashboard, Telegram digest). Prevention + monitoring,
+propose-don't-act. Repo-agnostic so the whole estate can adopt it.
+
+## Architecture
+
+```
+tools/estate-control-plane/
+  config.json            # data-driven: doc-count pointers, zombie denylist,
+                         # staleness thresholds, baseline allowlists, repo paths
+  types.ts               # CheckResult, Finding, Report
+  run-checks.ts          # CLI entry: runs checks -> estate-report.json (+ exit code)
+  checks/
+    drift.ts             # documented counts/paths vs live repo reality
+    zombie.ts            # graduated/decommissioned code still present
+    quality.ts          # untested API domains, npm audit (baselined), typecheck
+    estate.ts            # OPTIONAL token-gated Vercel/Supabase census
+  surfaces/
+    dashboard.ts         # report.json -> self-contained dashboard.html
+    digest.ts            # report.json -> short Telegram/markdown digest (change-only)
+    pr-comment.ts        # report.json -> sticky PR comment markdown
+  __tests__/
+    *.test.ts + fixtures/  # each check tested against fake-repo fixtures
+.github/workflows/estate-health.yml   # PR guardrail + weekly cron
+```
+
+Data flow: `repo + config.json -> run-checks.ts -> estate-report.json ->
+{pr-comment | dashboard.html | digest | tracking issue | count-fix PR}`.
+
+## The report (single source of truth)
+
+```ts
+interface Finding { check: string; severity: 'fail'|'warn'|'info'; title: string; detail: string; file?: string; fixable?: boolean }
+interface CheckResult { id: string; status: 'ok'|'warn'|'fail'|'skipped'; findings: Finding[]; counts?: Record<string,number> }
+interface Report { repo: string; generatedAt: string; healthScore: number; checks: CheckResult[]; summary: { fail: number; warn: number; fixable: number } }
+```
+
+`healthScore` = 100 minus weighted penalties (fail=10, warn=3). Always emits even
+if a check throws (each check wrapped; `Promise.allSettled`).
+
+## Checks
+
+### drift (token-free, the load-bearing one)
+- Reads documented counts from config-listed files (CLAUDE.md, AGENTS.md, README.md,
+  research/README.md) via labelled regexes, compares to live repo reality:
+  - API routes (`src/app/api/**/route.ts`), domains, components, hooks, lib domains,
+    research doc folders.
+- Phantom paths: any directory named in a doc's project-map that does not exist
+  on disk (catches the `contracts/` case).
+- Staleness: research docs whose `last-validated` frontmatter is older than
+  `staleness.maxDays` (warn).
+- `fixable: true` on count mismatches (the cron can auto-correct + open a PR).
+
+### zombie (token-free)
+- Greps for `config.zombie.denylist` patterns (openclaw, composio, agent-zero,
+  Magnetiq/AttaBotty leftovers, half-built "coming soon"/"not yet configured",
+  duplicate route markers) under `src/`, `bot/`.
+- Cross-checks `config.graduation` ledger: for each graduated entry, assert its
+  code paths are gone (fail if still present) and a redirect exists (warn if not).
+
+### quality (token-free)
+- API domains with no `__tests__` dir -> warn (count, not per-file noise).
+- `npm audit --json` critical/high count, MINUS `config.baseline.auditAllowlist`
+  (the known-deferred web3 transitive CVEs) -> fail only on NEW/critical-not-allowlisted.
+- `tsc --noEmit` error count -> fail if > `baseline.typecheckErrors`.
+
+### estate (OPTIONAL, token-gated)
+- If `VERCEL_TOKEN`/`SUPABASE_ACCESS_TOKEN` present, runs the existing
+  `scripts/estate-audit/audit.sh` and folds dead-project/inactive-DB counts in.
+- Else: `status: 'skipped'`, reports "last manual estate scan: N days ago" from a
+  stamp file, warns if older than `staleness.estateMaxDays`.
+
+## Adoption safety (so it gets used, not ignored)
+
+- **Ratchet, not big-bang.** In PR mode the guardrail fails ONLY when `fail` count
+  rises vs the base branch (existing debt allowed, new debt blocked). Baselines in
+  `config.baseline` capture today's known debt.
+- **Audit allowlist.** Known-deferred CVEs are listed; only new/fixable ones fire.
+- **Notify-on-change only.** Telegram digest + tracking-issue update fire only when
+  status changes or crosses a threshold - silence when steady. (Honors the
+  decommissioned-bots no-nag lesson.)
+
+## Surfaces
+
+- **GitHub Action** (`estate-health.yml`):
+  - on `pull_request`: run token-free checks, post sticky PR comment, set a check
+    status, fail only on ratchet breach.
+  - weekly `schedule`: run token-free checks, regenerate `dashboard.html`, deploy it,
+    open/update ONE "Estate Health" issue, open a count-fix PR if drift is fixable,
+    push a digest to Telegram if changed.
+- **Dashboard:** self-contained static HTML (health score, per-check status,
+  findings, last-run, estate-scan staleness). Deployed to a tiny Vercel project.
+- **Telegram:** digest via the existing ZOE/vps send path; change-only.
+
+## Autonomy
+
+Propose-only. The single auto-generated change is the mechanical count-fix PR.
+Everything else is an issue with a checklist. Never auto-merges.
+
+## Repo-agnostic
+
+`config.json` carries `repoRoot` + the doc-count pointers + denylists, so the
+engine runs against any ZAO repo. Graduated repos drop in a config + the workflow
+and inherit the same control plane (and the Doc 843 CLAUDE.md standard checks).
+
+## Phasing
+
+1. Engine: types, config, drift + zombie + quality checks, run-checks CLI, report.json, tests.
+2. GitHub Action: PR guardrail (ratchet) + weekly cron + tracking issue + count-fix PR.
+3. Dashboard: generator + deploy.
+4. Telegram digest (change-only).
+5. (later) estate check token-gating polish + trend history.
+
+## Testing
+
+Each check has a `__tests__` with `fixtures/` (a fake repo state -> expected
+findings). Drift gets the most coverage (the load-bearing check). The engine runs
+identically locally (`node tools/estate-control-plane/run-checks.ts`) and in CI.
+
+## Non-goals (v1)
+
+- No live interactive dashboard backend (static only).
+- No auto-merge of any change.
+- No auto-deletion of dead Vercel/Supabase projects (propose via issue only).
+- Trend history deferred to a later phase.

--- a/tools/estate-control-plane/README.md
+++ b/tools/estate-control-plane/README.md
@@ -1,0 +1,66 @@
+# Estate Control Plane
+
+Automated truth-keeping for the ZAO estate. Scans a repo, emits one
+`estate-report.json`, and feeds three surfaces: a PR guardrail, a static
+dashboard, and a Telegram digest. Propose-don't-act.
+
+Design: `docs/superpowers/specs/2026-06-12-estate-control-plane-design.md`.
+Estate map: `research/infrastructure/844-zao-estate-map/`.
+
+## Run it
+
+```bash
+# human summary + estate-report.json
+npx tsx tools/estate-control-plane/run-checks.ts
+
+# CI ratchet (exit 1 only if fails exceed the accepted baseline)
+npx tsx tools/estate-control-plane/run-checks.ts --ci --max-fails=7
+
+# render surfaces
+npx tsx tools/estate-control-plane/run-checks.ts \
+  --dashboard=dash.html --digest=digest.txt --pr-comment=pr.md --baseline-fails=7
+
+# include the heavy checks (npm audit + tsc; needs node_modules)
+npx tsx tools/estate-control-plane/run-checks.ts --heavy
+```
+
+Flags: `--config=`, `--repo=`, `--out=`, `--dashboard=`, `--digest=`,
+`--pr-comment=`, `--baseline-fails=`, `--ci`, `--max-fails=`, `--heavy`.
+Repo can also be set via `ESTATE_REPO_ROOT`.
+
+## Checks
+
+| id | what | tokens |
+|----|------|--------|
+| drift | documented counts/paths vs live repo; stale docs | none |
+| zombie | decommissioned/graduated code still present; half-built markers | none |
+| quality | untested API domains; npm audit (baselined); typecheck (heavy) | none |
+| estate | freshness of the last manual Vercel/Supabase scan | optional |
+
+## Adoption safety
+
+- **Ratchet** (`baseline.ratchetMaxFails`): existing debt is allowed; a PR fails
+  only when it ADDS a failure. Lower the baseline as debt is burned down.
+- **Audit allowlist** (`baseline.auditAllowlist`): known-deferred transitive CVEs
+  are ignored; only new/fixable ones fire.
+- **Change-only digests**: the Action only notifies when status changes.
+
+## Repo-agnostic
+
+`config.json` carries `repoRoot`, the doc-count pointers, and the denylists.
+Point it at any ZAO repo (`--repo=` or `ESTATE_REPO_ROOT`) and it enforces the
+same standard - see `research/dev-workflows/843-claude-md-alignment-standard/`.
+
+## Tests
+
+```bash
+npx vitest run --config tools/estate-control-plane/vitest.config.ts
+```
+
+## Wired vs next
+
+Wired: checks engine, all surfaces' renderers, PR guardrail (sticky comment +
+ratchet), weekly artifact upload.
+Next (need secrets): deploy dashboard to Vercel, open/update an "Estate Health"
+issue, push the digest to ZOE/Telegram, auto count-fix PR for fixable drift,
+live token-gated estate scan, trend history.

--- a/tools/estate-control-plane/__tests__/checks.test.ts
+++ b/tools/estate-control-plane/__tests__/checks.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { EstateConfig } from '../types';
+import { driftCheck, measureLiveCounts } from '../checks/drift';
+import { zombieCheck } from '../checks/zombie';
+import { countUntestedDomains, qualityCheck } from '../checks/quality';
+
+let root: string;
+
+async function write(rel: string, content: string) {
+  const full = join(root, rel);
+  await mkdir(join(full, '..'), { recursive: true });
+  await writeFile(full, content);
+}
+
+function cfg(): EstateConfig {
+  return {
+    repoRoot: root,
+    live: {
+      apiRoutes: 'src/app/api/**/route.ts',
+      apiDomainsDir: 'src/app/api',
+      components: 'src/components/**/*.tsx',
+      hooks: 'src/hooks',
+      libDomainsDir: 'src/lib',
+      researchDir: 'research',
+    },
+    docPointers: [
+      {
+        file: 'CLAUDE.md',
+        claims: { apiRoutes: '(\\d+) route handlers', components: '(\\d+) components', hooks: '(\\d+) hooks' },
+      },
+    ],
+    phantomPathScan: [{ file: 'CLAUDE.md' }],
+    zombie: {
+      denylist: [{ pattern: 'openclaw', label: 'decommissioned: openclaw', paths: ['src', 'bot/src'] }],
+      graduation: [{ name: 'graduated-thing', removedPaths: ['src/graduated'], redirect: '/graduated' }],
+    },
+    quality: { apiDomainsDir: 'src/app/api', testDirName: '__tests__' },
+    staleness: { maxDays: 120, estateMaxDays: 100, estateStampFile: '.estate-scan-stamp' },
+    baseline: { auditAllowlist: [], typecheckErrors: 0, untestedDomains: 0 },
+  };
+}
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), 'ecp-'));
+  // 2 routes across 2 domains, 1 component, 1 hook, 1 lib domain
+  await write('src/app/api/foo/route.ts', 'export const GET = () => {};');
+  await write('src/app/api/bar/route.ts', 'export const GET = () => {};');
+  await write('src/app/api/bar/__tests__/route.test.ts', 'test');
+  await write('src/components/Widget.tsx', 'export const Widget = () => null;');
+  await write('src/hooks/useThing.ts', 'export const useThing = () => {};');
+  await write('src/lib/auth/index.ts', 'export {};');
+  await write('research/infra/100-sample/README.md', '---\nlast-validated: 2020-01-01\n---\n# old');
+  // a decommissioned-code reference + graduated code left behind
+  await write('src/legacy/old.ts', '// uses openclaw under the hood');
+  await write('src/graduated/leftover.ts', 'export {};');
+  // CLAUDE.md with WRONG counts + a phantom path row
+  await write(
+    'CLAUDE.md',
+    [
+      '# Test',
+      'It has 9 route handlers, 9 components, 9 hooks.',
+      '',
+      '| Dir | What |',
+      '|-----|------|',
+      '| `src/app/api/` | routes |',
+      '| `ghost/` | does not exist |',
+    ].join('\n'),
+  );
+});
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('drift check', () => {
+  it('measures live counts from the repo', async () => {
+    const live = await measureLiveCounts(cfg());
+    expect(live.apiRoutes).toBe(2);
+    expect(live.apiDomains).toBe(2);
+    expect(live.components).toBe(1);
+    expect(live.hooks).toBe(1);
+    expect(live.libDomains).toBe(1);
+    expect(live.researchDocs).toBe(1);
+  });
+
+  it('flags count drift (claims 9, repo has fewer) as fixable fails', async () => {
+    const res = await driftCheck(cfg());
+    const counts = res.findings.filter((f) => f.title.includes('count drift'));
+    expect(counts.length).toBe(3); // routes, components, hooks all wrong
+    expect(counts.every((f) => f.severity === 'fail' && f.fixable)).toBe(true);
+  });
+
+  it('flags a phantom path that exists only in the project-map table', async () => {
+    const res = await driftCheck(cfg());
+    expect(res.findings.some((f) => f.title.includes('phantom path `ghost/`'))).toBe(true);
+    // does NOT flag src/app/api/ (it exists)
+    expect(res.findings.some((f) => f.title.includes('src/app/api'))).toBe(false);
+  });
+
+  it('warns on a research doc past its last-validated SLA', async () => {
+    const res = await driftCheck(cfg());
+    expect(res.findings.some((f) => f.severity === 'warn' && f.title.includes('last-validated SLA'))).toBe(true);
+  });
+});
+
+describe('zombie check', () => {
+  it('flags decommissioned code references (code, not docs)', async () => {
+    const res = await zombieCheck(cfg());
+    expect(res.findings.some((f) => f.title.includes('openclaw'))).toBe(true);
+  });
+
+  it('fails when graduated code is still present', async () => {
+    const res = await zombieCheck(cfg());
+    const g = res.findings.find((f) => f.title.includes("graduated 'graduated-thing' code still present"));
+    expect(g?.severity).toBe('fail');
+  });
+});
+
+describe('quality check', () => {
+  it('counts API domains with no __tests__', async () => {
+    const { untested, total } = await countUntestedDomains(join(root, 'src/app/api'), '__tests__');
+    expect(total).toBe(2);
+    expect(untested).toEqual(['foo']); // bar has __tests__, foo does not
+  });
+
+  it('warns when untested domains exceed the baseline', async () => {
+    const res = await qualityCheck(cfg()); // baseline untestedDomains=0, actual=1
+    expect(res.findings.some((f) => f.title.includes('untested API domains'))).toBe(true);
+  });
+});

--- a/tools/estate-control-plane/checks/drift.ts
+++ b/tools/estate-control-plane/checks/drift.ts
@@ -1,0 +1,136 @@
+import { join } from 'node:path';
+import type { CheckResult, EstateConfig, Finding } from '../types';
+import {
+  countFilesNamed,
+  countResearchDocs,
+  listDirs,
+  pathExists,
+  readFileSafe,
+  walk,
+} from '../fs-utils';
+
+/** Live counts measured from the repo - the ground truth docs are compared against. */
+export async function measureLiveCounts(cfg: EstateConfig): Promise<Record<string, number>> {
+  const root = cfg.repoRoot;
+  const [apiRoutes, components, hooks, researchDocs] = await Promise.all([
+    countFilesNamed(join(root, 'src/app/api'), 'route.ts'),
+    walk(join(root, 'src/components'), (_r, n) => n.endsWith('.tsx')).then((f) => f.length),
+    walk(join(root, 'src/hooks'), (_r, n) => /\.tsx?$/.test(n) && !n.includes('.test.')).then((f) => f.length),
+    countResearchDocs(join(root, cfg.live.researchDir)),
+  ]);
+  const apiDomains = (await listDirs(join(root, cfg.live.apiDomainsDir))).length;
+  const libDomains = (await listDirs(join(root, cfg.live.libDomainsDir))).length;
+  return { apiRoutes, apiDomains, components, hooks, libDomains, researchDocs };
+}
+
+function readClaim(text: string, regex: string): number | null {
+  const m = text.match(new RegExp(regex));
+  return m && m[1] ? Number(m[1]) : null;
+}
+
+/**
+ * Phantom paths: directories claimed in a doc's PROJECT-MAP TABLE that don't
+ * exist. Scoped to table rows whose first cell is a backticked path
+ * (`| `contracts/` | ... |`) so prose mentions of dirs that live deeper in the
+ * tree (e.g. `music/` meaning src/components/music/) don't false-positive.
+ */
+async function phantomPaths(root: string, docText: string): Promise<string[]> {
+  const tokens = new Set<string>();
+  for (const line of docText.split('\n')) {
+    const m = line.match(/^\|\s*`([A-Za-z0-9_.-]+\/)`\s*\|/);
+    if (m) tokens.add(m[1]);
+  }
+  const missing: string[] = [];
+  for (const t of tokens) {
+    if (!(await pathExists(join(root, t)))) missing.push(t);
+  }
+  return missing;
+}
+
+export async function driftCheck(cfg: EstateConfig): Promise<CheckResult> {
+  const findings: Finding[] = [];
+  const live = await measureLiveCounts(cfg);
+
+  // 1. Documented counts vs live
+  for (const ptr of cfg.docPointers) {
+    const text = await readFileSafe(join(cfg.repoRoot, ptr.file));
+    if (text == null) continue;
+    for (const [key, regex] of Object.entries(ptr.claims)) {
+      const claimed = readClaim(text, regex);
+      const actual = live[key];
+      if (claimed == null || actual == null) continue;
+      if (claimed !== actual) {
+        findings.push({
+          check: 'drift',
+          severity: 'fail',
+          title: `${ptr.file}: ${key} count drift`,
+          detail: `claims ${claimed}, repo has ${actual}`,
+          file: ptr.file,
+          fixable: true,
+        });
+      }
+    }
+  }
+
+  // 2. Phantom paths (documented dirs that don't exist)
+  for (const scan of cfg.phantomPathScan) {
+    const text = await readFileSafe(join(cfg.repoRoot, scan.file));
+    if (text == null) continue;
+    for (const missing of await phantomPaths(cfg.repoRoot, text)) {
+      findings.push({
+        check: 'drift',
+        severity: 'fail',
+        title: `${scan.file}: phantom path \`${missing}\``,
+        detail: `documented directory does not exist on disk`,
+        file: scan.file,
+        fixable: false,
+      });
+    }
+  }
+
+  // 3. Stale research docs (have a last-validated past the SLA)
+  const stale = await countStaleDocs(join(cfg.repoRoot, cfg.live.researchDir), cfg.staleness.maxDays);
+  if (stale.count > 0) {
+    findings.push({
+      check: 'drift',
+      severity: 'warn',
+      title: `${stale.count} research docs past last-validated SLA (${cfg.staleness.maxDays}d)`,
+      detail: stale.examples.length ? `e.g. ${stale.examples.join(', ')}` : '',
+      fixable: false,
+    });
+  }
+
+  const fail = findings.some((f) => f.severity === 'fail');
+  const warn = findings.some((f) => f.severity === 'warn');
+  return {
+    id: 'drift',
+    status: fail ? 'fail' : warn ? 'warn' : 'ok',
+    findings,
+    counts: live,
+  };
+}
+
+async function countStaleDocs(
+  researchDir: string,
+  maxDays: number,
+): Promise<{ count: number; examples: string[] }> {
+  const readmes = await walk(researchDir, (_r, n) => n === 'README.md');
+  const nowMs = Date.now();
+  let count = 0;
+  const examples: string[] = [];
+  for (const file of readmes) {
+    const text = await readFileSafe(file);
+    if (!text) continue;
+    const m = text.match(/last-validated:\s*(\d{4})-(\d{2})-(\d{2})/);
+    if (!m) continue;
+    const ageDays = (nowMs - Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]))) / 86_400_000;
+    if (ageDays > maxDays) {
+      count++;
+      if (examples.length < 5) {
+        const slug = file.split('/').slice(-2, -1)[0];
+        examples.push(slug ?? file);
+      }
+    }
+  }
+  return { count, examples };
+}

--- a/tools/estate-control-plane/checks/estate.ts
+++ b/tools/estate-control-plane/checks/estate.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path';
+import type { CheckResult, EstateConfig, Finding } from '../types';
+import { readFileSafe } from '../fs-utils';
+
+/**
+ * Token-gated Vercel/Supabase census. To avoid a stored long-lived credential
+ * (the concentration risk), this check does NOT run the cloud scan in CI by
+ * default. It reports the freshness of the last MANUAL scan (the stamp file that
+ * scripts/estate-audit/audit.sh can write) and warns when it is stale.
+ *
+ * If VERCEL_TOKEN / SUPABASE_ACCESS_TOKEN are present in the environment, a future
+ * version can shell out to scripts/estate-audit/audit.sh here.
+ */
+export async function estateCheck(cfg: EstateConfig): Promise<CheckResult> {
+  const hasTokens = Boolean(process.env.VERCEL_TOKEN || process.env.SUPABASE_ACCESS_TOKEN);
+  const findings: Finding[] = [];
+
+  const stamp = await readFileSafe(join(cfg.repoRoot, cfg.staleness.estateStampFile));
+  const lastIso = stamp?.trim().match(/\d{4}-\d{2}-\d{2}/)?.[0] ?? null;
+  let ageDays: number | null = null;
+  if (lastIso) {
+    const [y, m, d] = lastIso.split('-').map(Number);
+    ageDays = Math.floor((Date.now() - Date.UTC(y, m - 1, d)) / 86_400_000);
+  }
+
+  if (ageDays == null) {
+    findings.push({
+      check: 'estate',
+      severity: 'warn',
+      title: 'no estate scan on record',
+      detail: `run scripts/estate-audit/audit.sh and stamp ${cfg.staleness.estateStampFile}`,
+      fixable: false,
+    });
+  } else if (ageDays > cfg.staleness.estateMaxDays) {
+    findings.push({
+      check: 'estate',
+      severity: 'warn',
+      title: `estate scan stale (${ageDays}d old, SLA ${cfg.staleness.estateMaxDays}d)`,
+      detail: 'kill-list may be out of date; re-run scripts/estate-audit/audit.sh',
+      fixable: false,
+    });
+  }
+
+  return {
+    id: 'estate',
+    status: findings.length ? 'warn' : 'ok',
+    findings,
+    note: hasTokens
+      ? 'tokens present - live scan not yet wired (reports stamp freshness only)'
+      : 'token-free: reports last manual scan freshness',
+  };
+}

--- a/tools/estate-control-plane/checks/quality.ts
+++ b/tools/estate-control-plane/checks/quality.ts
@@ -1,0 +1,120 @@
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import type { CheckResult, EstateConfig, Finding } from '../types';
+import { listDirs, pathExists } from '../fs-utils';
+
+/** Count API domains with no __tests__ dir anywhere beneath them. */
+export async function countUntestedDomains(
+  apiDir: string,
+  testDirName: string,
+): Promise<{ untested: string[]; total: number }> {
+  const domains = await listDirs(apiDir);
+  const untested: string[] = [];
+  for (const d of domains) {
+    const hasTests = await hasDirNamed(join(apiDir, d), testDirName);
+    if (!hasTests) untested.push(d);
+  }
+  return { untested, total: domains.length };
+}
+
+async function hasDirNamed(root: string, name: string): Promise<boolean> {
+  // BFS for a directory called `name`
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    const subs = await listDirs(dir);
+    if (subs.includes(name)) return true;
+    for (const s of subs) {
+      if (s === 'node_modules') continue;
+      stack.push(join(dir, s));
+    }
+  }
+  return false;
+}
+
+function tryExec(cmd: string, cwd: string): string | null {
+  try {
+    return execSync(cmd, { cwd, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch (e: unknown) {
+    // Many of these tools exit non-zero with the payload on stdout (npm audit, tsc).
+    const out = (e as { stdout?: string }).stdout;
+    return typeof out === 'string' ? out : null;
+  }
+}
+
+function auditCounts(json: string, allowlist: string[]): { criticalHigh: number; flagged: string[] } {
+  let parsed: { vulnerabilities?: Record<string, { severity: string; via?: unknown[] }> };
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { criticalHigh: 0, flagged: [] };
+  }
+  const flagged: string[] = [];
+  const allow = new Set(allowlist.map((a) => a.toLowerCase()));
+  for (const [pkg, v] of Object.entries(parsed.vulnerabilities ?? {})) {
+    if ((v.severity === 'critical' || v.severity === 'high') && !allow.has(pkg.toLowerCase())) {
+      flagged.push(`${pkg} (${v.severity})`);
+    }
+  }
+  return { criticalHigh: flagged.length, flagged };
+}
+
+export async function qualityCheck(cfg: EstateConfig, opts: { runHeavy?: boolean } = {}): Promise<CheckResult> {
+  const findings: Finding[] = [];
+  const root = cfg.repoRoot;
+  const counts: Record<string, number> = {};
+
+  // 1. Untested API domains (always; pure fs)
+  const apiDir = join(root, cfg.quality.apiDomainsDir);
+  if (await pathExists(apiDir)) {
+    const { untested, total } = await countUntestedDomains(apiDir, cfg.quality.testDirName);
+    counts.untestedDomains = untested.length;
+    counts.totalDomains = total;
+    if (untested.length > cfg.baseline.untestedDomains) {
+      findings.push({
+        check: 'quality',
+        severity: 'warn',
+        title: `untested API domains rose to ${untested.length} (baseline ${cfg.baseline.untestedDomains})`,
+        detail: `new untested: budget exceeded`,
+        fixable: false,
+      });
+    }
+  }
+
+  // 2 + 3. npm audit + typecheck (heavy; only when node_modules present and opted in)
+  const heavy = opts.runHeavy && (await pathExists(join(root, 'node_modules')));
+  if (heavy) {
+    const auditJson = tryExec('npm audit --json', root);
+    if (auditJson) {
+      const { criticalHigh, flagged } = auditCounts(auditJson, cfg.baseline.auditAllowlist);
+      counts.nonAllowlistedCriticalHigh = criticalHigh;
+      if (criticalHigh > 0) {
+        findings.push({
+          check: 'quality',
+          severity: 'fail',
+          title: `${criticalHigh} non-allowlisted critical/high npm advisories`,
+          detail: flagged.slice(0, 8).join(', '),
+          fixable: false,
+        });
+      }
+    }
+    const tsc = tryExec('npx tsc --noEmit', root);
+    if (tsc != null) {
+      const errors = (tsc.match(/error TS\d+/g) ?? []).length;
+      counts.typecheckErrors = errors;
+      if (errors > cfg.baseline.typecheckErrors) {
+        findings.push({
+          check: 'quality',
+          severity: 'fail',
+          title: `typecheck errors rose to ${errors} (baseline ${cfg.baseline.typecheckErrors})`,
+          detail: 'new type errors introduced',
+          fixable: false,
+        });
+      }
+    }
+  }
+
+  const fail = findings.some((f) => f.severity === 'fail');
+  const warn = findings.some((f) => f.severity === 'warn');
+  return { id: 'quality', status: fail ? 'fail' : warn ? 'warn' : 'ok', findings, counts };
+}

--- a/tools/estate-control-plane/checks/zombie.ts
+++ b/tools/estate-control-plane/checks/zombie.ts
@@ -1,0 +1,75 @@
+import { join, relative } from 'node:path';
+import type { CheckResult, EstateConfig, Finding } from '../types';
+import { pathExists, readFileSafe, walk } from '../fs-utils';
+
+// Code only - decommissioned/half-built CODE is the concern. Doc/README mentions
+// of a retired system are history, not zombies, so .md is excluded.
+const TEXT_EXT = /\.(ts|tsx|js|jsx)$/;
+
+/** Detect graduated/decommissioned code that should be gone, plus half-built markers. */
+export async function zombieCheck(cfg: EstateConfig): Promise<CheckResult> {
+  const findings: Finding[] = [];
+  const root = cfg.repoRoot;
+
+  // 1. Denylist patterns still present in code
+  for (const entry of cfg.zombie.denylist) {
+    const needle = entry.pattern.toLowerCase();
+    let hits = 0;
+    const examples: string[] = [];
+    for (const p of entry.paths) {
+      const files = await walk(join(root, p), (_r, n) => TEXT_EXT.test(n));
+      for (const file of files) {
+        const text = await readFileSafe(file);
+        if (text && text.toLowerCase().includes(needle)) {
+          hits++;
+          if (examples.length < 5) examples.push(relative(root, file));
+        }
+      }
+    }
+    if (hits > 0) {
+      findings.push({
+        check: 'zombie',
+        severity: 'warn',
+        title: `${entry.label}: ${hits} file(s)`,
+        detail: examples.join(', '),
+        fixable: false,
+      });
+    }
+  }
+
+  // 2. Graduation ledger: graduated code must be gone; redirect should exist
+  for (const grad of cfg.zombie.graduation) {
+    for (const p of grad.removedPaths) {
+      if (await pathExists(join(root, p))) {
+        findings.push({
+          check: 'zombie',
+          severity: 'fail',
+          title: `graduated '${grad.name}' code still present`,
+          detail: `${p} should have been deleted on graduation`,
+          file: p,
+          fixable: false,
+        });
+      }
+    }
+    if (grad.redirect && !(await redirectExists(root, grad.redirect))) {
+      findings.push({
+        check: 'zombie',
+        severity: 'warn',
+        title: `graduated '${grad.name}' missing redirect`,
+        detail: `expected a redirect for ${grad.redirect}`,
+        fixable: false,
+      });
+    }
+  }
+
+  const fail = findings.some((f) => f.severity === 'fail');
+  const warn = findings.some((f) => f.severity === 'warn');
+  return { id: 'zombie', status: fail ? 'fail' : warn ? 'warn' : 'ok', findings };
+}
+
+async function redirectExists(root: string, route: string): Promise<boolean> {
+  // Heuristic: a next.config redirect or a page that calls redirect() for the route.
+  const cfgText = (await readFileSafe(join(root, 'next.config.ts'))) ?? (await readFileSafe(join(root, 'next.config.js')));
+  if (cfgText && cfgText.includes(route)) return true;
+  return false;
+}

--- a/tools/estate-control-plane/config.json
+++ b/tools/estate-control-plane/config.json
@@ -1,0 +1,59 @@
+{
+  "repoRoot": ".",
+  "live": {
+    "apiRoutes": "src/app/api/**/route.ts",
+    "apiDomainsDir": "src/app/api",
+    "components": "src/components/**/*.tsx",
+    "hooks": "src/hooks",
+    "libDomainsDir": "src/lib",
+    "researchDir": "research"
+  },
+  "docPointers": [
+    {
+      "file": "CLAUDE.md",
+      "claims": {
+        "apiRoutes": "(\\d+) (?:API )?route handlers?",
+        "components": "(\\d+) components",
+        "hooks": "(\\d+) (?:custom )?hooks"
+      }
+    },
+    {
+      "file": "AGENTS.md",
+      "claims": {
+        "apiRoutes": "(\\d+) route handlers",
+        "components": "(\\d+) components",
+        "hooks": "(\\d+) custom hooks"
+      }
+    }
+  ],
+  "phantomPathScan": [{ "file": "CLAUDE.md" }, { "file": "AGENTS.md" }],
+  "zombie": {
+    "denylist": [
+      { "pattern": "openclaw", "label": "decommissioned: openclaw (doc 601)", "paths": ["src", "bot/src"] },
+      { "pattern": "composio", "label": "decommissioned: Composio AO (doc 601)", "paths": ["src", "bot/src"] },
+      { "pattern": "agent-zero", "label": "decommissioned: Agent Zero (doc 601)", "paths": ["src", "bot/src"] },
+      { "pattern": "coming soon", "label": "half-built: 'coming soon' placeholder", "paths": ["src"] },
+      { "pattern": "not yet configured", "label": "half-built: 'not yet configured'", "paths": ["src"] }
+    ],
+    "graduation": []
+  },
+  "quality": {
+    "apiDomainsDir": "src/app/api",
+    "testDirName": "__tests__"
+  },
+  "staleness": {
+    "maxDays": 120,
+    "estateMaxDays": 100,
+    "estateStampFile": ".estate-scan-stamp"
+  },
+  "baseline": {
+    "auditAllowlist": [
+      "axios", "ws", "@xmldom/xmldom", "lodash", "lodash-es", "lodash.set",
+      "defu", "basic-ftp", "brace-expansion", "protobufjs", "elliptic",
+      "@snapshot-labs/snapshot.js", "@solana/wallet-adapter-wallets"
+    ],
+    "typecheckErrors": 0,
+    "untestedDomains": 39,
+    "ratchetMaxFails": 7
+  }
+}

--- a/tools/estate-control-plane/fs-utils.ts
+++ b/tools/estate-control-plane/fs-utils.ts
@@ -1,0 +1,78 @@
+import { readdir, stat, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const IGNORE_DIRS = new Set(['node_modules', '.next', '.git', 'dist', 'build', 'out', 'coverage']);
+
+/** Recursively walk `root`, returning absolute paths of files matching `predicate`. */
+export async function walk(
+  root: string,
+  predicate: (relPath: string, name: string) => boolean,
+  base = root,
+): Promise<string[]> {
+  let entries: Awaited<ReturnType<typeof readdir>>;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return []; // missing dir -> empty, not a throw (a check decides if that's a finding)
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (IGNORE_DIRS.has(e.name)) continue;
+      out.push(...(await walk(join(root, e.name), predicate, base)));
+    } else if (e.isFile()) {
+      const rel = relative(base, join(root, e.name));
+      if (predicate(rel, e.name)) out.push(join(root, e.name));
+    }
+  }
+  return out;
+}
+
+/** Count files under `dir` whose name matches `name` (exact) - e.g. route.ts. */
+export async function countFilesNamed(dir: string, name: string): Promise<number> {
+  return (await walk(dir, (_rel, n) => n === name)).length;
+}
+
+/** Count files under `dir` with one of the given extensions. */
+export async function countFilesExt(dir: string, exts: string[]): Promise<number> {
+  return (await walk(dir, (_rel, n) => exts.some((x) => n.endsWith(x)))).length;
+}
+
+/** List immediate subdirectory names of `dir` (non-recursive). */
+export async function listDirs(dir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+    return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+  } catch {
+    return [];
+  }
+}
+
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readFileSafe(p: string): Promise<string | null> {
+  try {
+    return await readFile(p, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+/** Count NNN-slug research doc folders (e.g. 836-foo) under researchDir, excluding _archive. */
+export async function countResearchDocs(researchDir: string): Promise<number> {
+  const categories = await listDirs(researchDir);
+  let total = 0;
+  for (const cat of categories) {
+    if (cat.startsWith('_')) continue; // skip _archive, _graph, _handoffs
+    const docs = await listDirs(join(researchDir, cat));
+    total += docs.filter((d) => /^\d+-/.test(d)).length;
+  }
+  return total;
+}

--- a/tools/estate-control-plane/run-checks.ts
+++ b/tools/estate-control-plane/run-checks.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { CheckResult, EstateConfig, Report } from './types';
+import { driftCheck } from './checks/drift';
+import { zombieCheck } from './checks/zombie';
+import { qualityCheck } from './checks/quality';
+import { estateCheck } from './checks/estate';
+import { renderDashboardHtml, renderDigest, renderPrComment } from './surfaces/render';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function arg(name: string): string | undefined {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=').slice(1).join('=') : undefined;
+}
+const has = (name: string) => process.argv.includes(`--${name}`);
+
+async function loadConfig(): Promise<EstateConfig> {
+  const path = arg('config') ?? join(__dirname, 'config.json');
+  const cfg = JSON.parse(await readFile(path, 'utf8')) as EstateConfig;
+  // Resolve repoRoot: "." -> the repo containing this tool (two levels up).
+  const envRoot = process.env.ESTATE_REPO_ROOT;
+  const raw = arg('repo') ?? envRoot ?? cfg.repoRoot;
+  cfg.repoRoot = raw === '.' ? resolve(__dirname, '../..') : isAbsolute(raw) ? raw : resolve(process.cwd(), raw);
+  return cfg;
+}
+
+function scoreAndSummarize(checks: CheckResult[]): Pick<Report, 'healthScore' | 'summary'> {
+  let penalty = 0;
+  let fail = 0;
+  let warn = 0;
+  let fixable = 0;
+  for (const c of checks) {
+    for (const f of c.findings) {
+      if (f.severity === 'fail') { penalty += 10; fail++; }
+      else if (f.severity === 'warn') { penalty += 3; warn++; }
+      if (f.fixable) fixable++;
+    }
+  }
+  return { healthScore: Math.max(0, 100 - penalty), summary: { fail, warn, fixable } };
+}
+
+async function runOne(name: string, fn: () => Promise<CheckResult>): Promise<CheckResult> {
+  try {
+    return await fn();
+  } catch (e) {
+    return {
+      id: name,
+      status: 'skipped',
+      findings: [],
+      note: `check threw: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+async function main() {
+  const cfg = await loadConfig();
+  const runHeavy = has('heavy');
+
+  // Isolated: one failing check never sinks the run.
+  const checks = await Promise.all([
+    runOne('drift', () => driftCheck(cfg)),
+    runOne('zombie', () => zombieCheck(cfg)),
+    runOne('quality', () => qualityCheck(cfg, { runHeavy })),
+    runOne('estate', () => estateCheck(cfg)),
+  ]);
+
+  const { healthScore, summary } = scoreAndSummarize(checks);
+  const report: Report = {
+    repo: cfg.repoRoot,
+    generatedAt: new Date().toISOString(),
+    healthScore,
+    checks,
+    summary,
+  };
+
+  const out = arg('out') ?? join(__dirname, 'estate-report.json');
+  await writeFile(out, JSON.stringify(report, null, 2));
+
+  // Optional rendered surfaces (the GitHub Action passes these paths).
+  const dash = arg('dashboard');
+  if (dash) await writeFile(dash, renderDashboardHtml(report));
+  const digestPath = arg('digest');
+  if (digestPath) await writeFile(digestPath, renderDigest(report));
+  const prComment = arg('pr-comment');
+  if (prComment) {
+    const baseFails = arg('baseline-fails');
+    await writeFile(prComment, renderPrComment(report, baseFails != null ? Number(baseFails) : undefined));
+  }
+
+  // Human summary
+  const icon = (s: string) => (s === 'ok' ? '[OK]' : s === 'warn' ? '[WARN]' : s === 'fail' ? '[FAIL]' : '[SKIP]');
+  console.log(`\nZAO Estate Control Plane - health ${healthScore}/100`);
+  console.log(`repo: ${cfg.repoRoot}`);
+  console.log(`fails: ${summary.fail}  warns: ${summary.warn}  fixable: ${summary.fixable}\n`);
+  for (const c of checks) {
+    console.log(`${icon(c.status)} ${c.id}${c.note ? ` (${c.note})` : ''}`);
+    for (const f of c.findings) {
+      console.log(`    - [${f.severity}] ${f.title}${f.detail ? ` - ${f.detail}` : ''}`);
+    }
+  }
+  console.log(`\nreport -> ${out}`);
+
+  // Ratchet: fail CI only when fails exceed the accepted baseline (default 0).
+  // Existing debt is allowed; NEW debt blocks the PR.
+  if (has('ci')) {
+    const maxFails = Number(arg('max-fails') ?? 0);
+    if (summary.fail > maxFails) {
+      console.error(`\nRATCHET BREACH: ${summary.fail} fails > baseline ${maxFails}`);
+      process.exit(1);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error('estate-control-plane fatal:', e);
+  process.exit(2);
+});

--- a/tools/estate-control-plane/surfaces/render.ts
+++ b/tools/estate-control-plane/surfaces/render.ts
@@ -1,0 +1,109 @@
+import type { Report, CheckResult } from '../types';
+
+const STICKY_MARKER = '<!-- estate-control-plane -->';
+
+const statusEmoji: Record<string, string> = { ok: 'OK', warn: 'WARN', fail: 'FAIL', skipped: 'SKIP' };
+
+function scoreColor(score: number): string {
+  if (score >= 85) return '#3ECF8E';
+  if (score >= 50) return '#f5a623';
+  return '#ff5c5c';
+}
+
+/** Self-contained dark-theme dashboard. No external assets. */
+export function renderDashboardHtml(report: Report): string {
+  const color = scoreColor(report.healthScore);
+  const checkCards = report.checks
+    .map((c) => {
+      const findings = c.findings
+        .map(
+          (f) =>
+            `<li class="f-${f.severity}"><b>[${f.severity}]</b> ${esc(f.title)}${f.detail ? ` <span class="muted">- ${esc(f.detail)}</span>` : ''}</li>`,
+        )
+        .join('');
+      return `<div class="card">
+        <div class="card-h"><span class="badge b-${c.status}">${statusEmoji[c.status]}</span> ${esc(c.id)}${c.note ? `<span class="muted"> - ${esc(c.note)}</span>` : ''}</div>
+        ${findings ? `<ul>${findings}</ul>` : '<div class="muted">clean</div>'}
+      </div>`;
+    })
+    .join('');
+
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>ZAO Estate Health</title>
+<style>
+  :root { color-scheme: dark; }
+  body { background:#0a1628; color:#e8eef7; font:15px/1.5 -apple-system,system-ui,sans-serif; margin:0; padding:24px; }
+  .wrap { max-width:880px; margin:0 auto; }
+  h1 { font-size:20px; margin:0 0 4px; }
+  .muted { color:#7e8aa0; }
+  .score { font-size:64px; font-weight:700; color:${color}; line-height:1; margin:8px 0; }
+  .meta { color:#7e8aa0; font-size:13px; margin-bottom:20px; }
+  .card { background:#0f1f38; border:1px solid #1c3157; border-radius:10px; padding:14px 16px; margin:12px 0; }
+  .card-h { font-weight:600; margin-bottom:6px; }
+  ul { margin:8px 0 0; padding-left:18px; }
+  li { margin:3px 0; }
+  .f-fail { color:#ff8c8c; } .f-warn { color:#ffd27a; } .f-info { color:#9fb3d0; }
+  .badge { font-size:11px; font-weight:700; padding:2px 7px; border-radius:5px; margin-right:6px; }
+  .b-ok { background:#10351f; color:#3ECF8E; } .b-warn { background:#3a2e0e; color:#f5a623; }
+  .b-fail { background:#3a1414; color:#ff5c5c; } .b-skipped { background:#1c2538; color:#7e8aa0; }
+</style></head>
+<body><div class="wrap">
+  <h1>ZAO Estate Health <span class="muted">/ ${esc(report.repo.split('/').pop() ?? '')}</span></h1>
+  <div class="score">${report.healthScore}<span style="font-size:24px;color:#7e8aa0">/100</span></div>
+  <div class="meta">${report.summary.fail} fails &middot; ${report.summary.warn} warns &middot; ${report.summary.fixable} auto-fixable &middot; generated ${esc(report.generatedAt)}</div>
+  ${checkCards}
+  <p class="muted" style="margin-top:24px;font-size:12px">ZAO Estate Control Plane &middot; propose-don't-act &middot; tools/estate-control-plane</p>
+</div></body></html>`;
+}
+
+/** Short plain-text digest for Telegram. Change-only gating is the caller's job. */
+export function renderDigest(report: Report): string {
+  const lines = [
+    `ZAO Estate Health: ${report.healthScore}/100`,
+    `${report.summary.fail} fails, ${report.summary.warn} warns, ${report.summary.fixable} auto-fixable`,
+    '',
+  ];
+  for (const c of report.checks) {
+    if (c.status === 'ok') continue;
+    lines.push(`[${statusEmoji[c.status]}] ${c.id}`);
+    for (const f of c.findings.slice(0, 4)) lines.push(`  - ${f.title}`);
+  }
+  return lines.join('\n').trim();
+}
+
+/** Sticky markdown PR comment (the marker lets the Action update in place). */
+export function renderPrComment(report: Report, baselineFails?: number): string {
+  const rows = report.checks
+    .map((c) => `| ${statusEmoji[c.status]} | \`${c.id}\` | ${c.findings.length} |`)
+    .join('\n');
+  const ratchet =
+    baselineFails != null
+      ? report.summary.fail > baselineFails
+        ? `**Ratchet: BLOCKED** - fails rose ${baselineFails} -> ${report.summary.fail}. Resolve the new failure(s) below.`
+        : `**Ratchet: ok** - no new failures vs base (${baselineFails}).`
+      : '';
+  const findingLines = report.checks
+    .flatMap((c) => c.findings.filter((f) => f.severity === 'fail'))
+    .map((f) => `- **${f.title}**${f.detail ? ` - ${f.detail}` : ''}${f.fixable ? ' _(auto-fixable)_' : ''}`)
+    .join('\n');
+
+  return `${STICKY_MARKER}
+## ZAO Estate Health: ${report.healthScore}/100
+
+${ratchet}
+
+| | check | findings |
+|---|---|---|
+${rows}
+
+${findingLines ? `### Failures\n${findingLines}` : '_No failures._'}
+
+<sub>ZAO Estate Control Plane - propose-don't-act. ${report.summary.fixable} auto-fixable.</sub>`;
+}
+
+export const STICKY = STICKY_MARKER;
+
+function esc(s: string): string {
+  return s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] ?? c);
+}

--- a/tools/estate-control-plane/types.ts
+++ b/tools/estate-control-plane/types.ts
@@ -1,0 +1,91 @@
+// Shared types for the ZAO Estate Control Plane.
+// See docs/superpowers/specs/2026-06-12-estate-control-plane-design.md
+
+export type Severity = 'fail' | 'warn' | 'info';
+export type CheckStatus = 'ok' | 'warn' | 'fail' | 'skipped';
+
+export interface Finding {
+  check: string;
+  severity: Severity;
+  title: string;
+  detail: string;
+  /** repo-relative path, when applicable */
+  file?: string;
+  /** true if a machine can mechanically correct this (e.g. a stale count) */
+  fixable?: boolean;
+}
+
+export interface CheckResult {
+  id: string;
+  status: CheckStatus;
+  findings: Finding[];
+  /** optional raw counts the check measured (live vs documented, etc) */
+  counts?: Record<string, number>;
+  /** present when status === 'skipped' or the check threw */
+  note?: string;
+}
+
+export interface Report {
+  repo: string;
+  generatedAt: string;
+  healthScore: number;
+  checks: CheckResult[];
+  summary: { fail: number; warn: number; fixable: number };
+}
+
+export interface DocPointer {
+  /** repo-relative path to a doc that claims counts */
+  file: string;
+  /** label -> regex (with one capture group for the number) that finds a claimed count */
+  claims: Record<string, string>;
+}
+
+export interface GraduationEntry {
+  name: string;
+  /** repo-relative paths that MUST be gone after graduation */
+  removedPaths: string[];
+  /** optional redirect route that SHOULD exist */
+  redirect?: string;
+}
+
+export interface EstateConfig {
+  repoRoot: string;
+  /** live-count sources (globs relative to repoRoot) */
+  live: {
+    apiRoutes: string;
+    apiDomainsDir: string;
+    components: string;
+    hooks: string;
+    libDomainsDir: string;
+    researchDir: string;
+  };
+  /** docs that claim counts, and the regexes to read them */
+  docPointers: DocPointer[];
+  /** directories a doc project-map might claim; flagged if absent */
+  phantomPathScan: { file: string }[];
+  zombie: {
+    denylist: { pattern: string; label: string; paths: string[] }[];
+    graduation: GraduationEntry[];
+  };
+  quality: {
+    apiDomainsDir: string;
+    testDirName: string;
+  };
+  staleness: {
+    /** research doc last-validated older than this (days) -> warn */
+    maxDays: number;
+    /** estate scan stamp older than this (days) -> warn */
+    estateMaxDays: number;
+    estateStampFile: string;
+  };
+  baseline: {
+    /** known-deferred npm audit advisory ids/titles to ignore */
+    auditAllowlist: string[];
+    /** typecheck errors allowed (pre-existing debt); fail if exceeded */
+    typecheckErrors: number;
+    /** untested API domains allowed; warn count, never fails */
+    untestedDomains: number;
+    /** accepted total 'fail' findings (the ratchet). New debt above this blocks a PR. */
+    ratchetMaxFails: number;
+  };
+}

--- a/tools/estate-control-plane/vitest.config.ts
+++ b/tools/estate-control-plane/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// Standalone test config for the estate-control-plane tool (the repo's root
+// vitest config only scans src/). Run: npx vitest run --config tools/estate-control-plane/vitest.config.ts
+export default defineConfig({
+  test: {
+    include: ['tools/estate-control-plane/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
The system to stop drift from rotting back. One checks engine -> estate-report.json -> three surfaces. Propose-don't-act.

## What it does
- **drift** - documented counts/paths (CLAUDE.md/AGENTS.md) vs live repo reality + stale-doc detection
- **zombie** - decommissioned/graduated code still present + half-built markers
- **quality** - untested API domains, npm audit (baselined), typecheck (heavy mode)
- **estate** - token-gated; reports manual-scan freshness (no stored credential = avoids the concentration risk)

## Surfaces
- **PR guardrail** - sticky comment + ratchet (existing debt allowed, NEW debt blocks the PR)
- **Dashboard** - self-contained dark-theme HTML (weekly artifact; deploy-to-Vercel is the next wire)
- **Telegram digest** - change-only (honors the no-nag lesson)

## Adoption safety (so it gets used, not ignored)
- Ratchet baseline = 7 (today's drift debt); drops to 0 once docs-cleanup #845 lands
- npm audit baseline allowlist for the known-deferred web3 CVEs
- Repo-agnostic via config.json - point it at any ZAO repo, enforces the Doc 843 CLAUDE.md standard estate-wide

## Proof
- 8 unit tests pass (programmatic fixture repo)
- Run against THIS repo: correctly caught all 6 real count drifts + the phantom contracts/ path (health 18/100 because this branch predates #845; goes green when #845 + count fixes merge)

## Wired vs next
Wired: engine, all renderers, PR guardrail, weekly artifacts. Next (need secrets): Vercel dashboard deploy, Estate Health issue, ZOE/Telegram push, auto count-fix PR, live token-gated estate scan, trend history.

Spec: docs/superpowers/specs/2026-06-12-estate-control-plane-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)