### PR TITLE
fix(build): unbreak Vercel build - infer readdir Dirent type in estate fs-utils

### DIFF
--- a/tools/estate-control-plane/fs-utils.ts
+++ b/tools/estate-control-plane/fs-utils.ts
@@ -9,12 +9,11 @@ export async function walk(
   predicate: (relPath: string, name: string) => boolean,
   base = root,
 ): Promise<string[]> {
-  let entries: Awaited<ReturnType<typeof readdir>>;
-  try {
-    entries = await readdir(root, { withFileTypes: true });
-  } catch {
-    return []; // missing dir -> empty, not a throw (a check decides if that's a finding)
-  }
+  // Infer the Dirent type from the call rather than hand-writing it — the
+  // `Awaited<ReturnType<typeof readdir>>` form breaks across @types/node versions
+  // (the Buffer/NonSharedBuffer overload split). Missing dir -> empty, not a throw.
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => null);
+  if (entries === null) return [];
   const out: string[] = [];
   for (const e of entries) {
     if (e.isDirectory()) {


### PR DESCRIPTION
## Problem
Production build on main is RED. The TypeScript step fails:
```
./tools/estate-control-plane/fs-utils.ts:14
Type 'Dirent<string>[]' is not assignable to type 'Dirent<NonSharedBuffer>[]'
```
The `let entries: Awaited<ReturnType<typeof readdir>>` annotation is version-fragile. Vercel runs `npm install` (not `npm ci`), so it resolved a newer `@types/node` where readdir's overload return types split Buffer/NonSharedBuffer - the hand-written type no longer matched the `{withFileTypes:true}` result. Local @types/node 20.19.37 did not hit it (why local typecheck was green).

## Fix
Infer the Dirent type from the call instead of hand-writing it:
```ts
const entries = await readdir(root, { withFileTypes: true }).catch(() => null);
if (entries === null) return [];
```
No hand-written type = nothing to mismatch across @types/node versions. Behavior identical (missing dir -> empty array).

The two 'module not found' lines in the build log (@stream-io/audio-filters-web, @vectorize-io/hindsight-client) are non-fatal warnings for optional dynamic imports - left as-is.

## Verification
- `npm run typecheck` (tsc --noEmit): clean
- Only this one file used the fragile pattern; the other two readdir(withFileTypes) call sites already use inference.

## Follow-up (not in this PR)
Vercel building with `npm install` instead of `npm ci` makes builds non-reproducible (the install log shows packages changing). Worth pinning to `npm ci` so the lockfile is authoritative.

Co-Authored-By: Claude Opus 4.8 (1M context)