### PR TITLE
doc 852: @thezao.com email addresses on Workspace (STANDARD tier)

### DIFF
--- a/research/business/850-zao-festivals-fund-creation-manager-playbook/README.md
+++ b/research/business/850-zao-festivals-fund-creation-manager-playbook/README.md
@@ -1,0 +1,123 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-13
+related-docs: 843, 844, 845, 846, 847, 849
+original-query: "/zao-research more about artizen what we know and how we can bring the ZAO there most effectively both as a fund manager and create a fund for the ZAO festival initiatives so that others can join from there and we can join other funds too"
+tier: DISPATCH
+---
+
+# 850 — Creating + Running the ZAO Festivals Fund: the dual fund-manager playbook
+
+> **Goal:** A build-ready plan to (1) create a dedicated **ZAO Festivals Fund** on Artizen so other festival/event organizers join under it, (2) run it well as a manager, and (3) keep submitting ZAO's own festivals into other aligned funds for stacked match. Includes a ready-to-submit fund proposal.
+
+> **Evolves [Doc 846](../846-zao-festivals-funding-strategy/)** which recommended keeping ONE fund. Zaal's decision is to create the Festivals fund - and the research supports it: running two funds is allowed, the festival-fund model is proven (Greenpill), and there is clear white space (no music/artist-led festival fund exists yet).
+
+## Key Decisions
+
+| # | Decision | Why |
+|---|---|---|
+| 1 | CREATE the ZAO Festivals Fund as a second ZAO fund | Allowed (no rule against one org running multiple funds; 32 funds exist, stacking is the core design). Apply via the "$1M for Community Funds" program: proposal -> call with René -> up to $50K seed. Confirm the two-fund governance on the call. |
+| 2 | POSITION it as the music + artist-led real-world activation fund - the white space | Greenpill = regen/ecovillage gatherings; Terminus = sovereign communities/network states; Hubs/Third Place = permanent spaces. NONE own **music festivals, concerts, artist activations, touring**. That's ZAO's lane and nobody is in it. |
+| 3 | KEEP the ZAO Fund for Emerging Culture too - distinct missions, shared community | Emerging Culture = broad (any emerging-culture creator). Festivals = events/gatherings/activations only. A project can stack BOTH. Shared 188-member crowd powers both; not zero-sum. |
+| 4 | STACK ZAO's own festivals into other funds (Greenpill, Funding the Commons) | Proven live: Edge Esmeralda 2026 is curated into BOTH the ZAO Fund AND the Greenpill Regen Gatherings fund right now. ZAOstock should sit in ZAO Festivals Fund + Greenpill + Emerging Culture = 3x match on the same sales. |
+| 5 | SEED it with the $50K + a ZAO-treasury "Founding Sponsor" stake + event-brand sponsors | The $50K is a gift on approval. Grow the pool with sponsors (Restream, Magnetiq, labels, festival-infra brands). ZAO treasury can add as a sponsor. |
+
+## The proof: Greenpill Fund for Regenerative Gatherings (the model)
+
+Rendered live 2026-06-13 - this is exactly the shape a ZAO Festivals Fund takes:
+- 18 projects in Competition, 27 in Curation; ~$15k sales, ~$21k match unlocked.
+- Run by the **Greenpill Network** - a community that turned its chapters + ethos into a fund and filled it with its own people's gatherings.
+- Roster is mostly Greenpill chapter events + regen-ag/ecovillage gatherings: Greenpill Cape Town / London Ontario / NYC / Ukraine / Uganda / Kenya / Nigeria / Cote d'Ivoire, The Living Village, AgroforestDAO, Rifai Sicilia DAO, Vida Verde, etc.
+- **#1 in that fund = Edge Esmeralda 2026 (Telamon), $30,569 sales / $5,270 match** - and the SAME project is #2 in the ZAO Fund. That is multi-fund stacking working in the wild. It is the template.
+
+Takeaway: a community fund is "your community's gatherings, curated into one branded pool, cross-listed into adjacent funds." ZAO can do this for music/artist festivals.
+
+## How to create the fund (the mechanics)
+
+1. **Write a fund proposal**: mission, who it serves, eligibility, why ZAO's community matters (draft below).
+2. **Apply** via the "$1M for Community Funds" program (rolling, no deadline). As an existing director, take the **direct path**, not the 12-week Accelerator (that's for first-time fund leaders; $10K + cohort).
+3. **Call with René Pinnell** - he reviews + approves. Ask the two open questions (below) on this call.
+4. **On approval: up to $50,000 seed** match capital (a gift, no match requirement).
+5. **Grow the pool** with sponsors - 100% of sponsor dollars go to the fund (10% top-project prize, 90% split as match); Artizen takes 0%.
+
+## Ready-to-submit fund proposal (draft)
+
+> **Fund name:** ZAO Festivals Fund (working - alt: "ZAO Fund for Live Culture")
+>
+> **Mission:** Back the artists and organizers who gather people in the real world - music festivals, concerts, pop-up shows, residencies, and cultural activations - and help them fund it without losing ownership. Where Greenpill funds regenerative gatherings and Terminus funds sovereign communities, the ZAO Festivals Fund funds the music and the moment: artist-led, IRL, community-powered.
+>
+> **Eligibility:** Projects that produce a real-world gathering or live cultural activation (festival, concert, show, residency, tour, exhibition, or activation) with: creator/organizer ownership; meaningful community participation; build-in-public; fair compensation for artists; a public-facing culmination.
+>
+> **Who it serves:** Independent festival + event organizers, musicians, artist collectives, and ZAO-ecosystem projects (ZAOstock, Zaoville, COC Concertz, ZABAL Games activations, artist tours) - plus aligned outside organizers who want a fund that gets live culture.
+>
+> **Why ZAO:** A 4-year, 188-member music + culture community that already runs the ZAO Fund for Emerging Culture, incubates artist projects (WaveWarZ, SongJam), and is producing ZAOstock (Oct 2026, Ellsworth ME). We bring the crowd that buys + boosts.
+
+## Differentiation (so organizers join ours, not the others)
+
+| Existing fund | Owns | ZAO Festivals Fund difference |
+|---|---|---|
+| Greenpill Regen Gatherings | regen / ReFi / ecovillage gatherings | music + artist-led, not regen-first |
+| Terminus | sovereign communities / network states / pop-up cities | a festival/event, not a territory or government |
+| Hubs / Third Place | permanent physical spaces / coworking | a temporary gathering / live moment, not infra |
+| Console | digital community platforms | real-world activation, not a digital community tool |
+
+The pitch to an organizer: "Your festival is artist-first and IRL. This is the only fund built for exactly that, run by a community that throws festivals itself."
+
+## Director's levers + how others join
+
+**What the manager controls:** the fund's mission + eligibility, its public page/branding, recruiting sponsors to grow the pool, and curation judgment alongside the community vote. Prize split is automatic (10% top seller / 90% even). Artifact price is fixed ($10).
+
+**How another organizer joins your fund (creator flow):** they submit their project to the season at artizen.fund/submit; Artizen's curation matches it to funds whose eligibility it meets (the ZAO Festivals Fund), with director judgment in the loop; the community vote curates the top ~30% into competition. So to fill the fund: (a) define eligibility crisply, (b) recruit festival organizers to submit, (c) tell them to qualify for the ZAO Festivals Fund by fit, and (d) rally votes. There is no separate "apply to fund X" button - it's eligibility-match + curation.
+
+## The full ZAO play on Artizen (manager + creator + stacker)
+
+1. **Manager x2:** run ZAO Fund for Emerging Culture (broad) + ZAO Festivals Fund (events). Distinct missions, one community.
+2. **Recruiter:** fill the Festivals Fund with ZAO events + outside organizers; recruit music/event-brand sponsors.
+3. **Creator/stacker:** submit ZAO's own festivals (ZAOstock, Zaoville, COC) as projects, cross-curated into ZAO Festivals + Greenpill + Emerging Culture for 3x match.
+4. **Cross-backer:** collect/boost projects in aligned funds first, then propose cross-curation (doc 847/849 kit).
+
+## Seeding + sponsors for the Festivals Fund
+
+- **$50K** Artizen seed on approval.
+- **ZAO treasury** can be a "Founding Sponsor" (treated like any sponsor; confirm with René).
+- **Target sponsors:** Restream (streaming), Magnetiq (events/launch platform), music labels/guilds, festival-infra brands (ticketing, gear, merch), Web3 orgs wanting cultural credibility (Protocol Labs / ConsenSys ecosystem already fund Artizen).
+- First-season goal: 5-10 festival projects, $10-20K added match pool, ZAO + 2-3 sponsors.
+
+## Open questions for the René call
+
+1. Can one org/director run two funds (Emerging Culture + Festivals)? Any capacity/governance guideline? (No public rule found; low risk; confirm.)
+2. Can a fund director curate their own community's projects into their own fund? (Carried over from doc 849 - still unconfirmed.)
+3. Does the second fund get its own $50K seed, or is the program one-per-organization?
+
+## Also See
+
+- [Doc 846](../846-zao-festivals-funding-strategy/) - funding strategy (this doc evolves its one-fund stance)
+- [Doc 845](../845-artizen-art-token-endowment-economics/) - the $50K program + economics
+- [Doc 847](../847-zao-in-artizen-ecosystem-playbook/) - ecosystem participation
+- [Doc 849](../849-zao-artizen-execution-build-plan/) - the execution kit (outreach drafts)
+- [Doc 843](../843-zao-fund-artizen-roster-june2026/) - the existing ZAO Fund roster + /artizen page
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|---|---|---|---|
+| Finalize the ZAO Festivals Fund proposal (name + mission + eligibility above) | @Zaal | Decision | This week |
+| Book the René call; pitch the second fund + ask the 3 open questions | @Zaal | Outreach | This week |
+| Line up a ZAO-treasury Founding Sponsor stake + a shortlist of event-brand sponsors | @Zaal | Decision | Before the call |
+| On approval: set the fund page + recruit the first 5-10 festival projects (ZAOstock first) | @Zaal | Build | On approval |
+| Cross-curate ZAOstock into ZAO Festivals + Greenpill + Emerging Culture (3x match) | @Zaal | Application | S7 curation |
+| Add the ZAO Festivals Fund to the zaoos.com/artizen hub once live | @Claude | PR | On approval |
+
+## Sources
+
+- [FULL] [Greenpill Fund for Regenerative Gatherings](https://artizen.fund/index/mf/greenpill-fund-for-regenerative-gatherings?season=6) - rendered live 2026-06-13; full roster, Edge Esmeralda cross-curation proof, the festival-fund model
+- [FULL] [$1 Million for Community Funds](https://news.artizen.fund/p/1-million-for-community-funds) - create-a-fund path, $50K seed, eligibility
+- [FULL] [Artizen Accelerator for Community Funds](https://news.artizen.fund/p/artizen-accelerator-for-community) - the 12-week alt path + curriculum (attract submissions, recruit sponsors, scale)
+- [FULL] [The Art (and Chaos) of Curation](https://news.artizen.fund/p/the-art-and-chaos-of-curation) - curation flow, director vs community vote
+- [FULL] [The Terminus Fund](https://news.artizen.fund/p/the-terminus-fund) - sovereign-community fund (differentiation reference)
+- [FULL] [Console x Artizen Match Fund](https://www.console.xyz/blog/console-artizen-match-fund) - sponsor/co-fund model (~$20K), community-bar precedent
+- [PARTIAL] [Artizen Ultimate Guide to Raising Money](https://news.artizen.fund/p/ultimate-guide-to-raising-money) - multi-fund stacking math (404 on direct fetch; corroborated via search + the live Greenpill/ZAO Edge Esmeralda overlap)
+- [PARTIAL] [matchfunds directory](https://artizen.fund/index/matchfunds) - full fund list (Bubble app; rendered earlier in doc 846)
+- [FAILED] Exact director self-curation policy + two-fund governance + whether a 2nd fund gets its own $50K - not public; confirm with René.

--- a/research/infrastructure/852-thezao-email-addresses-workspace/README.md
+++ b/research/infrastructure/852-thezao-email-addresses-workspace/README.md
@@ -1,0 +1,102 @@
+---
+topic: infrastructure
+type: guide
+status: research-complete
+last-validated: 2026-06-13
+superseded-by:
+related-docs: 650, 804
+original-query: "What can we do with @thezao.com email addresses on Google Workspace - aliases, groups, catch-all routing, send-as, distribution lists - and what is possible without paying beyond the current plan. Practical guide for The ZAO: how to give brands/projects/roles their own @thezao.com addresses (submissions@, volunteer@, hello@, zaofestivals@, etc.) feeding into one mailbox, free."
+tier: STANDARD
+---
+
+# 852 — @thezao.com Email Addresses: What You Can Do for Free on Workspace
+
+> **Goal:** Give every ZAO brand, project, and role its own `@thezao.com` address - submissions@, volunteer@, hello@, zaofestivals@, etc. - all landing where you already read mail, paying nothing beyond the seat you already have.
+
+## Key Decisions (do this)
+
+| # | Decision | Why | Cost |
+|---|----------|-----|------|
+| 1 | **Use Google Workspace email aliases** for role/brand addresses on your one mailbox | Up to **30 aliases per user**, all land in the same inbox you already check | $0 extra |
+| 2 | **Use "Send mail as"** in Gmail so replies go out FROM the alias | A reply to a submissions@ email should come from submissions@, not your personal address | $0 |
+| 3 | **Use Google Groups** for any address that should reach MORE than one person or outlive one person (team@, festivals@) | Groups are free, unlimited, and need **no per-user license** | $0 |
+| 4 | **Set a catch-all** (Admin default routing) so any typo / unknown `@thezao.com` still lands in your main mailbox | Nothing gets bounced/lost | $0 |
+| 5 | **Do NOT use Cloudflare Email Routing on thezao.com** | It needs the domain's MX records, which Google Workspace already owns - the two cannot coexist on one domain | n/a |
+| 6 | If The ZAO gets nonprofit/entity status, **apply to Google for Nonprofits** for free Workspace | Removes the per-seat cost entirely | $0 (if approved) |
+
+Bottom line for the budget question: **aliases + Groups add zero dollars** on top of the seat you already pay for. You can hand out as many `@thezao.com` addresses as you need (30 aliases on your user + unlimited Groups) without paying more.
+
+## Findings
+
+### 1. Aliases - up to 30 per user, free, all plans
+A Workspace user can have up to **30 alternate addresses (aliases)** at no extra cost, on any plan. Mail to any alias drops into that user's one inbox. Add them in Admin console -> Directory -> Users -> (your user) -> "Add alternate emails (email alias)."
+
+Use aliases for **role addresses that one person handles**: `submissions@`, `volunteer@`, `hello@`, `zaofestivals@`, `press@`, `bookings@`. All feed your single mailbox; you filter/label by the to: address.
+
+Limit to know: an alias is for **one** user. If an address needs to reach multiple people, use a Group (below), not an alias.
+
+### 2. Send mail as - reply from the alias
+Gmail -> Settings -> Accounts -> "Send mail as" lets you send/reply FROM any alias. So a booking inquiry to `bookings@thezao.com` gets answered from `bookings@thezao.com`, keeping the brand consistent and your personal address private. Within Workspace you do not need a separate SMTP/password for an alias on the same account.
+
+### 3. Google Groups - free distribution lists + shared inboxes, no per-seat cost
+Google Groups is **included in Workspace at no additional license cost** - a Group is not a billed user. Create as many as you want. Two modes:
+- **Distribution list**: mail to `team@thezao.com` fans out to every member. Good for "reach the whole ZAOstock crew."
+- **Collaborative Inbox**: members claim/assign incoming threads (a shared support queue). Requires turning on **"Groups for Business"** in Admin console first.
+
+Use Groups for addresses that should **outlive any one person** or **reach several people**: `team@`, `festivals@`, `coc@` (if a partnership address is ever wanted), `support@`.
+
+Alias vs Group rule of thumb:
+- One person reads it, want it in your inbox -> **alias**.
+- Multiple people, or it should survive a handoff -> **Group**.
+
+### 4. Catch-all - never lose a misdirected email
+In Admin console you can set a **default routing rule** so any message to an unrecognized `@thezao.com` address (e.g. `bookings@` you never created, or a typo like `ifno@`) routes to your main mailbox instead of bouncing. Optional but cheap insurance.
+
+### 5. Cloudflare Email Routing - free, but NOT for thezao.com while it's on Workspace
+Cloudflare Email Routing gives **unlimited** custom addresses that forward to any inbox, **free on all plans**, with a catch-all. It sounds perfect - but it is **receive/forward only** (no mailbox, no native send) and, critically, it **requires control of the domain's MX records**. Google Workspace already owns thezao.com's MX. **You cannot run both on the same domain.** So Cloudflare is only the free answer for:
+- a domain that is NOT on Workspace, or
+- a separate/secondary domain you point at Cloudflare on purpose.
+
+For thezao.com today, the Workspace-native tools (aliases + Groups) are the right call.
+
+### 6. Plan + nonprofit note
+Workspace Business Starter runs about **$7/user/month** in 2026 (~$84/yr per seat); aliases and Groups do not add to that. If The ZAO formalizes as a nonprofit/entity (see the Colorado A-Corp track, doc 804), it can apply to **Google for Nonprofits**, which grants Workspace free - eliminating the seat cost. Gmail also caps sending at ~2,000 messages/day on Workspace, which matters only if an address is ever used for bulk blasts (use a real ESP for newsletters, not the mailbox).
+
+## How this maps to ZAO brands/roles
+
+| Address | Type | Lands where |
+|---------|------|-------------|
+| `info@thezao.com` | primary mailbox | your inbox (already set) |
+| `submissions@thezao.com` | alias | your inbox |
+| `volunteer@thezao.com` | alias | your inbox |
+| `zaofestivals@thezao.com` / `festivals@thezao.com` | alias (1 person) or Group (team) | inbox or group members |
+| `hello@thezao.com` / `press@` / `bookings@` | alias | your inbox |
+| `team@thezao.com` | Group | Zaal + Iman + crew |
+
+All free. The zao-stock site CTAs (doc-pending PR #1) currently point at `info@thezao.com` - once you want cleaner purpose addresses, add `submissions@` + `volunteer@` as aliases and swap the CTAs; both still land in info@.
+
+## Also See
+
+- [Doc 650](../../agents/650-cowork-zaodevz-imanagent/) - cowork/Iman infra context
+- [Doc 804](../../business/804-colorado-acorp/) - entity status (unlocks Google for Nonprofits)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Add `submissions@` + `volunteer@` + `hello@` as aliases on the info@ user | Zaal | Admin console | When ready |
+| Turn on "Send mail as" for the aliases you'll reply from | Zaal | Gmail settings | Same session |
+| Create a `team@thezao.com` Group for ZAOstock crew (Zaal + Iman) | Zaal | Admin console | Before ZAOstock ramp |
+| Set a catch-all default routing rule to info@ | Zaal | Admin console | Optional |
+| Swap zao-stock CTAs from info@ to submissions@/volunteer@ once aliases exist | Zaal | PR | After aliases |
+
+## Sources
+
+- [Add or delete an email alias - Google Workspace Help](https://knowledge.workspace.google.com/admin/users/add-or-delete-an-alternate-email-address-email-alias) `[FULL]` - 30 aliases/user, no extra cost
+- [What you get with Groups for Business - Google Workspace Admin Help](https://support.google.com/a/answer/10308022) `[FULL]` - Groups included, distribution lists
+- [Use a group as a Collaborative Inbox - Google Workspace](https://support.google.com/a/users/answer/167430) `[FULL]` - shared-inbox mode
+- [Cloudflare Email Routing addresses + catch-all - Cloudflare docs](https://developers.cloudflare.com/email-routing/setup/email-routing-addresses/) `[FULL]` - unlimited addresses, free, catch-all
+- [Cloudflare Email Routing vs Workspace comparison - inventivehq.com](https://inventivehq.com/blog/cloudflare-email-routing-vs-aws-ses-vs-azure-communication-services-vs-google-workspace) `[FULL]` - confirms Email Routing needs MX control, is inbound/forward-only (no mailbox, no sending), free; two providers cannot manage one domain's MX simultaneously
+- [Email Routing and Google Workspace - Cloudflare Community](https://community.cloudflare.com/t/email-routing-and-google-workspace/332394) `[FAILED - HTTP 403 to WebFetch; claim corroborated by the inventivehq source above]` - the MX-conflict point
+- [Gmail sending limits - Google Workspace Help](https://support.google.com/a/answer/166852) `[FULL]` - ~2,000/day send cap
+- [Compare pricing plans - Google Workspace](https://workspace.google.com/pricing) `[FULL]` - Business Starter ~$7/user/mo


### PR DESCRIPTION
## Summary
Practical guide to giving every ZAO brand/role its own @thezao.com address for free. Google Workspace aliases (up to 30/user) + Google Groups (free, no per-seat license) cover it at zero extra cost. Cloudflare Email Routing ruled out for thezao.com - it needs the MX records Workspace already owns; the two can't coexist on one domain.

## Tier
STANDARD - 7 sources (Google Workspace official x4, Cloudflare docs + comparison, pricing).

## Key answer for the budget question
Aliases + Groups add $0 on top of the existing seat. submissions@/volunteer@/hello@/team@ all free.

## Next Actions
See doc's Next Actions table: add aliases, enable Send-as, create team@ Group, optional catch-all, swap zao-stock CTAs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)