### PR TITLE
doc 855: GCvlcnti bonfire admin relationship log (STANDARD)

### DIFF
--- a/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
+++ b/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
@@ -118,8 +118,45 @@ The deepmeeting **content store is now zdeepmeeting, not ZAOOS.** This doc remai
 the ZAOOS-side relationship + governance record (research stays in ZAOOS per the
 monorepo-as-lab model).
 
+## Follow-up study (2026-06-14): Brazil DD + graph pollution audit
+
+### Brazil network - the people are real, the BNDES path is not
+
+Verified his named contacts via web research:
+- **Sentinela Web3 + Juscelino** - CONFIRMED. Real registered company (CNPJ
+  55.414.034/0001-14), Juscelino listed as partner. Caveat: site currently
+  suspended ("Conta Interrompida").
+- **Upland BR + Mucida** - CONFIRMED. Lucas Mucida is the official Brazilian
+  Upland moderator (t.me/uplandbr). Reach modest (~5k TikTok).
+- **CastaCrypto (Castaneda)** - CONFIRMED. Rafael Castaneda, real mid-tier crypto
+  influencer (~70k IG, co-founder of a stablecoin/payments co).
+- **Brazil Web3 scene** - real + sizable (#9 globally for crypto devs, ~24M holders).
+- **BNDES grant claim - the red flag.** He overstated scale (~314M BRL/day actual,
+  not 1B) and BNDES categorically does not fund small foreign crypto-arts projects
+  (foreign-ownership barrier, no crypto/arts mandate). The funding story is not
+  credible; the people are. **Lean on the network, ignore the BNDES pitch.**
+
+### Graph pollution audit (DeepMeeting slice)
+
+From the 1,381-entry backlog: GCvlcnti's framework vocabulary outweighs canonical
+ZAO terms **~4:1 (381 vs 95)**, across 291 ingest/commit triggers, 125
+confidence-1.0 claims, and **20 record self-corrections** (the bot absorbed bad
+data then walked it back). This is the DeepMeeting slice, not the whole ZABAL
+graph - true blast radius needs the live `/delve` recall script. Fairness note:
+he later clarified he was distinguishing working-memory from stored facts and told
+the bot "not to store" some items - so it was not pure carelessness; but the 4:1
+ratio still confirms the shard-isolation rule is warranted. Detail: doc 798.
+
+### Co-resident bot leakage
+
+Mira (mira.tg) sitting in the group is an active cross-chat leak vector for the
+ZABAL graph - he is, ironically, the one championing it. Full assessment + the
+remove-Mira action: doc 856. The TON/Telegram strategic question it raised: doc 857.
+
 ## Also See
 
+- [Doc 856](../../security/856-mira-cross-chat-graph-leakage/) - Mira graph leakage + remove action
+- [Doc 857](../../infrastructure/857-ton-telegram-native-strategy/) - TON/Telegram SKIP/WAIT decision
 - [Doc 799](../../agents/799-deepmeeting-agent-shard-architecture/) - the gated DeepMeeting shard bot (this contact = admin)
 - [Doc 798](../../agents/798-bonfire-graph-quality-audit/) - where his vocabulary polluted the main graph
 - [Doc 781](../../agents/781-zabal-bonfire-contribution-architecture/) - shared-graph + soft-barrier contribution model

--- a/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
+++ b/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
@@ -101,15 +101,22 @@ tier: STANDARD
   spent real time confused. The fix is structural (one pinned list, Iman
   co-carrying), not more explaining.
 
-## "zabal deepmeeting" group logging - NOT yet captured
+## "zabal deepmeeting" group logging - DONE, moved to its own repo
 
-Zaal also asked to "start logging all the stuff from zabal deepmeeting." That is
-a separate Telegram **group** with resources/tools/screenshots - distinct from
-these DMs. It is **not in scope of this doc** because the group content was not
-provided. To log it: export the group (Telegram desktop -> Export chat history ->
-JSON), drop the export at `~/.zao/private/gcal-... -> ~/.zao/private/tg-zabal-deepmeeting-YYYYMMDD.json`
-(per PII rule, off-repo), then run it through the same FULL/PARTIAL classify +
-graph-ingest. Tracked in Next Actions.
+Updated 2026-06-14: the DeepMeeting **group** ([DeepMeeting][@Zaabal], created
+21 May 2026, 20 members) was exported and now has its own public home:
+**github.com/bettercallzaal/zdeepmeeting**.
+
+- Backlog: 1,381 entries through 2026-06-14 redacted into `transcript/`
+  (emails/phones stripped; DvlsMojo 795, ZABAL Bonfire Bot 267, Zaal 112).
+- 51 non-Telegram shared links indexed in `links/`.
+- Raw export stays off-repo at `~/.zao/private/zdeepmeeting-raw-20260614/` (PII).
+- `CONTEXT.md` in that repo carries the relationship + the ZAO DeepMeeting bot
+  plan (extraction done; live Q&A-proxy gated by doc 799, guardrails deferred).
+
+The deepmeeting **content store is now zdeepmeeting, not ZAOOS.** This doc remains
+the ZAOOS-side relationship + governance record (research stays in ZAOOS per the
+monorepo-as-lab model).
 
 ## Also See
 

--- a/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
+++ b/research/community/855-gcvlcnti-bonfire-admin-relationship-log/README.md
@@ -1,0 +1,139 @@
+---
+topic: community
+type: relationship-log
+status: research-complete
+last-validated: 2026-06-14
+related-docs: "781, 798, 799, 665, 669"
+original-query: "log my DMs with my Bonfire admin @GCvlcnti, then clean up communication with him; start logging all the zabal deepmeeting stuff"
+tier: STANDARD
+---
+
+# 855 - GCvlcnti (Bonfire admin) - DM relationship log + comms reset
+
+> **Goal:** capture the full DM relationship with @GCvlcnti (Zaal's designated
+> ZABAL Bonfire graph admin, doc 799), inventory the threads he has raised,
+> record Zaal's stated positions, separate verified signal from unverified
+> claims, and define a clean communication protocol going forward. The DM
+> stream is high-volume, low-structure - this doc is the structured index.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | KEEP GCvlcnti as ZABAL Bonfire graph admin, scoped to a shard, NOT the main graph | His solo graph-fill is real volume; doc 798 already flagged his vocabulary polluting the main graph (TreeUnix fabrication). Shard isolation per doc 799. |
+| 2 | RESET comms to a single pinned "important list" in one place; stop free-form DM sprawl | Zaal said it directly: "too much info here in text", "pick one thing and do it to completion", "unbelievably confused by what you're doing". A static edited message kills the visual pollution. |
+| 3 | TRUST his macro/industry reads; VERIFY his specifics before they hit the graph | Both big claims this session (Mira, Manus->Meta) checked out. His detail-level claims (TreeUnix, $KNOWS economics) have been wrong/fabricated before. Read = signal, specifics = verify. |
+| 4 | His personalized bot is the doc-799 DeepMeeting shard - already gated, do NOT spin a second bot | CLAUDE.md "no new bots without doc". 799 is the gate; this convo is its upstream raw material. |
+| 5 | Iman to make first contact to co-carry the relationship | Zaal already told Iman to message him. Offloads the high-touch comms load. |
+
+## Who he is
+
+- **Handle:** @GCvlcnti (alias **DvlsMojo**). Email on file (redacted, off-repo).
+- **Age / location:** 42, Brazil (Recife region).
+- **Background:** Business Administration faculty ("Faculdade de Administracao
+  de Empresas"). Self-deprecating - "never wrote a contract", "ocean of
+  knowledge, deep as a puddle". Cancer survivor; had hardware loss + crypto
+  FOMO losses circa 2020-21.
+- **Self-definition:** **networker** - connects people / projects / flows so
+  they meet. Pattern repeats his whole life: Counter-Strike clan -> Telegram
+  groups -> `$BITCOIN RECIFE$` Facebook group (2017, still has high-value
+  members: doctors, PhDs, a financial manager, an awarded ex-Facebook marketing
+  expert, streamers with audience).
+- **Claimed Brazil network (UNVERIFIED, high-value-if-true):** a contact at
+  **BNDES** (Brazil's federal development bank, deploys ~1B BRL/day) who can
+  reportedly reach the sitting president. Grant access requires a formal
+  Portuguese-language project with metrics. He cannot execute it solo.
+- **Posture:** nervous on live voice ("Blank Thoughts" when live), prefers
+  async text + images. Sends screenshots constantly; learns visually.
+
+## Threads he raised (inventory)
+
+| Thread | What it is | Status / action |
+|--------|-----------|-----------------|
+| **Mira / mira.tg** | First consumer AI agent native to Telegram; builds shared chat memory. Direct parallel to Bonfires-on-Telegram. VERIFIED real. | Competitive watch - see Findings. |
+| **Socratox graph** | Another Bonfires graph he found in a Brazilian AI/DeSci public ecosystem. | Note; he says ZABAL branding is "missing" from that ecosystem. |
+| **TON ecosystem** | TON.org / t.me - suggests it as the rail for business, partnerships, grants, community-building at world scale. | Park - not a near-term ZAO surface. |
+| **Telegram shared folders = public addresses** | Sharing a TG folder yields a public link; `t.me/username` behaves like an https page; chat export = html+css+js+json like a webpage. | True mechanic. Useful for graph-ingest of TG content. Zaal "didn't know that". |
+| **Referral system everywhere** | Wants every ZAO project/app to carry a referral/attribution layer so his sharing is counted, evaluated, rewarded (not only money). | His core personal ask. See comms draft. |
+| **godfather miniapp** | Config surface for Bonfire bots; he believes the consumer-side config (buttons on godfather + bonfire dashboard) differs from the owner/dev view Carlos sees. | He will investigate bot-config buttons himself. |
+| **His named protocols** | "deepmeeting" (DM-as-memory-DB pattern), "TheBlockMeeting" (fractal Circles-in-Circles networking protocol), "Blank Token"/"pomposo" HTML jokes, an old "Wiki Project.html". | Naming/mnemonic patterns, not shipped products. Do not over-weight. |
+| **t.me/BotNews** | Telegram's bot-platform news channel. | Reference. |
+
+## Zaal's stated positions this session (for the record)
+
+- Added him as viewer to `zabal.app.bonfires.ai`; graph access confirmed ("i connected").
+- Will build him a bot on the ZABAL knowledge graph - coded for him to talk to,
+  bring into chats, keep his context. (= doc 799 DeepMeeting shard, already gated.)
+- Offered a light title: "ZABAL Bonfire graph lead" / "data lead".
+- Pushed back, verbatim: "you get v stuck in a lot of different things", "pick
+  one thing and do it to completion", "I'm unbelievably confused by what you are
+  doing", "it's just not something I can work with right now", "I am busy most
+  of my day so my rnd time is all coding".
+- On ZABAL Games: it is intentionally NOT a 3-day hackathon (his critique). Zaal:
+  "the 3 day ones never actually go and do anything - dead repo as soon as the
+  event is over"; ZAO targets non-technical vibe-coders, AI fills you in by
+  month 2. (His prize-structure / compensation question went unanswered.)
+- Disagreed with his semantic-markup / `.md`-linking-everything thesis (deferred
+  as "a long convo").
+- Does not know how `$KNOWS` token economics work; "not too stressed", trusts
+  "Carlos is goated dev" (met Carlos in person at ETH Boulder).
+
+## Findings
+
+- **Mira is a real, funded competitor to the Bonfires-on-Telegram thesis.**
+  Mira (mira.tg) is positioned as "the first consumer AI agent inside Telegram",
+  turning chats into an execution layer with cross-chat shared memory + retrieval
+  - the exact shape of what ZABAL Bonfire wants to be on Telegram. GCvlcnti
+  surfacing it is genuine competitive intel, not noise. (Sources below.)
+- **His Manus->Meta read was correct.** Meta acquired Manus (~$2B+, Dec 2025) and
+  Manus's new Agents mode launched on **Telegram first** despite Meta owning
+  WhatsApp. His broader narrative - the AI-agent center of gravity moving to
+  Telegram, WhatsApp trailing - is supported by the reporting. His macro
+  pattern-reading is a real asset.
+- **His detail-level claims remain a bad-data risk.** Doc 798 Finding 1 already
+  caught his "TreeUnix Protocol" vocabulary fabricating into the main graph. The
+  rule that falls out: his industry *reads* are signal; his project-specific
+  *specifics* (protocol names, token mechanics, who-owns-what details) must be
+  verified before they enter the shared graph. This is exactly why doc 799
+  isolates him to a shard.
+- **Relationship load is the real cost, not the tech.** The DM stream is
+  high-affect, low-structure, multilingual, AI-"corrected" mid-thread. Zaal
+  spent real time confused. The fix is structural (one pinned list, Iman
+  co-carrying), not more explaining.
+
+## "zabal deepmeeting" group logging - NOT yet captured
+
+Zaal also asked to "start logging all the stuff from zabal deepmeeting." That is
+a separate Telegram **group** with resources/tools/screenshots - distinct from
+these DMs. It is **not in scope of this doc** because the group content was not
+provided. To log it: export the group (Telegram desktop -> Export chat history ->
+JSON), drop the export at `~/.zao/private/gcal-... -> ~/.zao/private/tg-zabal-deepmeeting-YYYYMMDD.json`
+(per PII rule, off-repo), then run it through the same FULL/PARTIAL classify +
+graph-ingest. Tracked in Next Actions.
+
+## Also See
+
+- [Doc 799](../../agents/799-deepmeeting-agent-shard-architecture/) - the gated DeepMeeting shard bot (this contact = admin)
+- [Doc 798](../../agents/798-bonfire-graph-quality-audit/) - where his vocabulary polluted the main graph
+- [Doc 781](../../agents/781-zabal-bonfire-contribution-architecture/) - shared-graph + soft-barrier contribution model
+- [Doc 669](../../agents/669-bonfires-everything-we-know/) - Bonfires reference
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Send the comms-reset message (below) - ask for ONE pinned "important list", set role expectation | @Zaal | DM | Next reply |
+| Iman makes first contact to co-carry the relationship | @Iman | DM | This week |
+| Export "zabal deepmeeting" TG group -> ~/.zao/private/ -> ingest to shard graph | @Zaal | Bot task | When at desk |
+| Confirm doc-799 shard bot greenlight before any bot is created (still gated) | @Zaal | Decision | Before bot build |
+| Add Mira (mira.tg) to competitive watch for the Bonfire-on-Telegram thesis | @Zaal | Note | Next Bonfire review |
+| Keep his specifics OUT of the main graph; shard-only until verified | @Zaal | Standing rule | Ongoing |
+
+## Sources
+
+- [Mira - mira.tg homepage](https://mira.tg/) [FULL - search-surfaced description: "first consumer AI agent inside Telegram", chat-as-execution-layer, shared memory]
+- [Mira wiki](https://wiki.mira.tg/) [PARTIAL - title/positioning only, not deep-fetched]
+- [How Telegram's AI Agent Ecosystem And Mira Are Changing Collaborative Workflows - Dataconomy, 2026-05-20](https://dataconomy.com/2026/05/20/telegrams-ai-agent-ecosystem-mira/) [FULL - via search]
+- [Manus new "Agents" mode arrives on Telegram first despite Meta owning WhatsApp - the-decoder](https://the-decoder.com/manus-new-agents-mode-arrives-on-telegram-first-despite-meta-owning-whatsapp/) [FULL - via search, corroborates his macro read]
+- [Meta-owned Manus launches AI agents on Telegram - Silicon Republic](https://www.siliconrepublic.com/machines/manus-ai-agents-meta-china-telegram-whatsapp) [FULL - via search; ~$2B+ deal Dec 2025]
+- Primary source: Zaal <-> @GCvlcnti Telegram DM stream, captured 2026-06-14 [FULL - the convo itself]

--- a/research/events/853-zaostock-launch-backlog/README.md
+++ b/research/events/853-zaostock-launch-backlog/README.md
@@ -1,0 +1,109 @@
+---
+topic: events
+type: decision
+status: research-complete
+last-validated: 2026-06-13
+superseded-by:
+related-docs: 224, 364, 369, 839
+original-query: "whats next to do on the zao-stock event site - prioritized backlog of remaining work to make it launch-ready for the Oct 3 Ellsworth event (musician submission flow, volunteer signup, RSVP, lineup, schedule, content gaps)"
+tier: STANDARD
+---
+
+# 853 - ZAOstock Event Site: Launch-Ready Backlog
+
+> **Goal:** Prioritized backlog to take the public ZAOstock site from "brand-correct skeleton" to launch-ready for October 3, 2026 (Franklin Street Parklet, Ellsworth Maine). Grounded in the actual current state of the `bettercallzaal/zao-stock` repo after the Fellenz brand cleanup (PR #1).
+
+## Key Decisions (read first)
+
+| # | Decision | Why |
+|---|----------|-----|
+| D1 | **RESOLVE the two-surface fork before building anything else.** There are two live public surfaces: the standalone `zao-stock` repo (minimal, just brand-cleaned) and `zaoos.com/stock` inside the main ZAO OS app (already has team dashboard, RSVP, countdown, partners per MASTER-PLAN). Pick ONE canonical public site; make the other redirect or retire. | Building the backlog twice is waste. Two public URLs for one event splits SEO, RSVP data, and confuses the Ellsworth audience. This is the gating decision - everything below depends on it. |
+| D2 | If the standalone repo stays canonical: **port the existing `SubmitForm` + `/api/library/submit` pattern** from the main app (Farcaster-auth-gated, zod-validated, Supabase-backed, moderated) for the musician intake. Do NOT hand-roll a new form. | A battle-tested intake pattern already exists at `src/components/library/SubmitForm.tsx`. Reuse beats reinvention. |
+| D3 | **Ship the passive `/submit` intake, not outreach.** Musician path = a passive submission form. No outreach campaigns, no target lists (standing rule). | Active musician outreach is months away; the site's job is to catch inbound, not push. |
+| D4 | **Lineup is the highest-value content gap.** Repo shows 5 names (Hurric4n3ike, DJANGO UU, CLEJAN, ATTABOTTY, Mr. Darius) all marked "TBA"; MASTER-PLAN calls for 10 artists noon-6pm. Fill confirmed slots, mark the rest "more TBA". | The lineup is what a music audience comes to see. Half-empty + "TBA" reads as unfinished. |
+| D5 | **Wire the dead RSVP + Farcaster buttons or remove them.** `stock/page.tsx` has a non-functional "Sign in with Farcaster & RSVP" button. A button that does nothing is worse than no button. | Either make it real or cut it until it is. |
+
+## Current State (ground truth, post-PR #1)
+
+Repo: `bettercallzaal/zao-stock`, Next.js 16 + React 19 + Tailwind, build now green.
+
+Routes that exist (all static):
+- `/` - hero, now "ZAO Festivals presents ZAOstock / by The ZAO", Oct 3 + Ellsworth, two CTA cards (musicians / volunteers) pointing at `mailto:info@thezao.com` with `TODO: confirm submission link`.
+- `/stock` - event detail: date/location/capacity/ticket cards, dead RSVP button, 5-name lineup, "Schedule (TBD)", "Community Feed" placeholder.
+- `/talks` - Schelling Point roundtables (2 entries), Archive placeholder.
+- `/past` - ZAO-PALOOZA + ZAO-CHELLA stats, "Help us gather media" mailto.
+
+What is missing or fake:
+- No real submission flow (mailto placeholder only).
+- No volunteer signup flow (mailto placeholder only).
+- RSVP button has no handler.
+- Schedule is "TBD"; Community Feed is "coming soon"; lineup details are "TBA".
+- No navigation between pages (no header/nav component - homepage does not link to `/stock`, `/talks`, `/past`).
+- No OG image / share preview; `farcaster.json` accountAssociation signature is empty.
+- Ticket shows "$10"; donate/sponsor path absent.
+
+## Findings (prioritized backlog)
+
+### P0 - Gating (do before anything)
+| Item | Detail |
+|------|--------|
+| Resolve two-surface fork (D1) | Decide canonical public site: standalone `zao-stock` repo vs `zaoos.com/stock`. The main-app page already has RSVP + team dashboard + countdown + partners. If `zaoos.com/stock` wins, the standalone repo becomes a redirect and most of this backlog moves there. |
+
+### P1 - Core launch (musician + helper entry, the brief)
+| Item | Detail |
+|------|--------|
+| Musician submission flow | Replace homepage `mailto` with a real `/submit` page. Port `SubmitForm` + `/api/library/submit` pattern. Fields: act name, links (Farcaster/music), short bio, building-with-tech note. Honor Sep 3 deliverable cutoff messaging. |
+| Volunteer signup flow | Same pattern, lighter form: name, contact, what they can help with (ops/design/music/livestream). Routes to info@thezao.com inbox or Supabase table. |
+| Add site navigation | Header linking `/` `/stock` `/talks` `/past` (+ `/submit`). Homepage is currently a dead end. |
+| Fill the lineup (D4) | Confirm which of the 5 are locked; target 10 per MASTER-PLAN; mark unconfirmed as "more artists TBA". Confirmed-only on the public grid (standing rule). |
+| Wire or cut RSVP (D5) | Either implement Farcaster sign-in RSVP (Neynar) or remove the button until backend exists. |
+
+### P2 - Content completeness
+| Item | Detail |
+|------|--------|
+| Schedule / run-of-show | MASTER-PLAN has `planning/run-of-show.md` (10 artists, DJ transitions, livestream, noon-6pm + Black Moon after-party). Publish a public-safe version. |
+| Event context | Add "Part of the 9th Annual Art of Ellsworth / Maine Craft Weekend", gateway to Acadia. Lead with music, zero web3 jargon (Ellsworth audience framing). |
+| Partners / sponsors grid | Confirmed partners only. Add a sponsor CTA (tax-deductible via Fractured Atlas 501(c)(3) - use approved fiscal-sponsor phrasing). |
+| Donate path | Two paths only: PayPal (fiat) + Giveth (crypto). |
+| Past festivals polish | Galleries are "Coming Soon"; wire real media or drop the buttons. |
+
+### P3 - Polish / distribution
+| Item | Detail |
+|------|--------|
+| OG image + share preview | Needed for Farcaster/social shares. No OG currently. |
+| Farcaster Mini App / frame | `farcaster.json` exists but signature is empty; decide if this ships as a Mini App. Livestream group (Mickey/Rev lead) + COC Concertz partnership framing if surfaced. |
+| Countdown timer | MASTER-PLAN lists a countdown on `zaoos.com/stock`; port if standalone wins. |
+| Remove section emojis | Per house style, strip remaining 🎵 / 💬 / 🎸 from `/stock` sections (left out of brand PR scope). |
+
+## Reusable assets already in the ecosystem
+
+- `src/components/library/SubmitForm.tsx` - Farcaster-gated submission UI (zod tags, optimistic feedback). Copy for musician/volunteer intake.
+- `src/app/api/library/submit/route.ts` - POST handler: session auth, fid gate, zod validation, Supabase insert, moderation. Template for the intake backend.
+- `ZAO-STOCK/MASTER-PLAN.md` + `planning/*` - the full event plan (run-of-show, venue, budget, staffing, contingency). The public site should surface the public-safe slices of these.
+- `zaoos.com/stock` + `zaoos.com/stock/team` - existing built-out festival page + team dashboard (the D1 fork candidate).
+
+## Also See
+
+- [Doc 224 - ZAO Stock multi-year vision](../../_archive/224-zao-stock-multi-year-vision/) (archived)
+- [Doc 364 - ZAO Festivals deep research](../364-zao-festivals-deep-research/) (Ellsworth context, sponsor framework, Fractured Atlas wording)
+- [Doc 369 - DreamEvent gap analysis](../369-dreamevent-framework-gap-analysis/)
+- [Doc 839 - Fellenz brand + org strategy](../839-fellenz-brand-org-strategy/) (the critique that drove PR #1)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Decide canonical public site: standalone `zao-stock` vs `zaoos.com/stock` (D1) | @Zaal | Decision | Before further site work |
+| If standalone canonical: build `/submit` from SubmitForm pattern (D2) | @Zaal | PR | Next sprint |
+| Add site nav + fill confirmed lineup slots | @Zaal | PR | Before public push |
+| Wire or remove dead RSVP button | @Zaal | PR | Next sprint |
+| Confirm musician submission link to replace `TODO` in `page.tsx` | @Zaal | PR | After D1 |
+| Publish public-safe schedule + Art of Ellsworth context | @Team | PR | After lineup locked |
+
+## Sources
+
+- [FULL] `bettercallzaal/zao-stock` repo - full audit of all routes/components, post-PR #1 (cloned + read every user-facing file this session).
+- [FULL] `ZAO OS V1/ZAO-STOCK/MASTER-PLAN.md` - event master plan (venue, teams, pitch, run-of-show index, live page URLs).
+- [FULL] `ZAO OS V1/src/components/library/SubmitForm.tsx` - reusable submission form pattern.
+- [FULL] `ZAO OS V1/src/app/api/library/submit/route.ts` - submission backend pattern.
+- Note: this is an internal product backlog grounded in primary repo sources; no external community source applies. All citations are first-read of working-tree files (FULL), not snippets.

--- a/research/infrastructure/857-ton-telegram-native-strategy/README.md
+++ b/research/infrastructure/857-ton-telegram-native-strategy/README.md
@@ -1,0 +1,86 @@
+---
+topic: infrastructure
+type: decision
+status: research-complete
+last-validated: 2026-06-14
+related-docs: "855, 856, 601"
+original-query: "Should ZAO build a Telegram-native surface, and is TON worth it? Triggered by the AI-agent shift to Telegram (Mira, Manus) that GCvlcnti surfaced."
+tier: STANDARD
+---
+
+# 857 - TON / Telegram-native strategy for ZAO
+
+> **Goal:** decide whether ZAO should build a Telegram-native surface (mini app,
+> TON rail, public bonfire bot) given the verified shift of consumer AI agents
+> to Telegram, or stay focused on Farcaster + Base.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **SKIP a Telegram mini app / TON build now. WAIT 12-18 months.** | Telegram mini apps are optimized for gaming / DeFi / memecoins; zero successful artist-community examples; retention is structurally broken (Hamster Kombat lost 96% of users in 18 months). Wrong surface for a 188-member high-intent artist network. |
+| 2 | **DO the one low-effort move: put ZOE on Telegram as a bot** (no mini app) | Gives Telegram distribution of the concierge without the gaming/monetization/mini-app build. ZOE already exists. |
+| 3 | **Treat Mira as a WATCH (competitor), not a model to copy** | GCvlcnti wants Bonfire to copy Mira. Mira is impressive (2M users, 900+ integrations) but its cross-chat-memory model is a security liability for a private graph (doc 856). Learn from its UX, do not adopt its data model. |
+| 4 | **Do NOT chase TON grants** | Real money exists (Memelandia $5M, Accelerator $2.5M) but requires a working Telegram product with traction ZAO does not have, and the meme/gaming focus does not fit. Funding without product clarity = wasted effort. |
+| 5 | Revisit when ZAO hits 500+ active Farcaster members OR a real artist use-case appears on Telegram OR ZAOstock spins out with spare bandwidth | Clear re-entry triggers, not a permanent no. |
+
+## What the research found (June 2026)
+
+### TON ecosystem - real but mismatched
+- Grants are real + accessible to foreign teams: TON Champion Grants, **Memelandia
+  ($5M fund, $500K/project)**, **TON Accelerator ($2.5M)**, STON.fi (up to $10K).
+  But Memelandia requires 25k+ mini-app users + $1M+ volume; all require a working
+  product with traction.
+- Ecosystem health: ~10,938 active devs (June 2025), 34k+ contracts, 800M Telegram
+  users addressable. Real, but 2026 growth figures unpublished.
+
+### Telegram mini apps - adoption is easy, retention is broken
+- Mega-apps exist: MAJOR (70M), Blum (43M MAU), X Empire (36M), Catizen (34M),
+  Notcoin (35M+).
+- **Retention is the killer:** Hamster Kombat went from a ~155M peak to losing
+  **96% of users + 95% of token value in 18 months.** Tap-to-earn bleeds out.
+- Monetization via Telegram Stars nets creators ~$0.013/Star after a 30% cut;
+  32% total fees on mobile. Token launches != sustainable revenue.
+- **No successful artist-collective or community-DAO mini app exists.** The space
+  is transactional (games, DeFi, memecoins).
+
+### The AI-agent wave - real, but saturated + commoditized
+- **Mira:** launched Feb 2026, 2M+ users, 500k MAU, 50k+ groups, 900+ integrations,
+  model-routing across OpenAI/Anthropic/Minimax/ByteDance, Private Mode via Cocoon
+  (decentralized GPU on TON). Genuinely strong.
+- **Manus:** Meta's ~$2B+ acquisition (Dec 2025) launched Agents on Telegram Feb
+  16 2026 - **but China's NDRC BLOCKED the acquisition in April 2026; status is
+  now in legal limbo.** (GCvlcnti's "Manus bought by Meta" was correct when said,
+  now uncertain.)
+- 120+ agentic AI tools competing. Launching an AI agent gives **no defensibility**.
+
+## Why this matters for ZAO specifically
+
+ZAO's edge is a small (188), high-intent, artist-first community on Farcaster +
+Base, with ZABAL Games live and ZAOstock spinning out. Telegram mini apps reward
+casual churn and viral spikes - the opposite of ZAO's retention profile. The
+bandwidth is better spent deepening Farcaster and shipping ZAOstock. The AI-agent
+shift to Telegram is real and worth tracking (GCvlcnti's macro read holds), but
+"real trend" does not equal "ZAO should build there now."
+
+## Also See
+
+- [Doc 856](../../security/856-mira-cross-chat-graph-leakage/) - Mira as a security liability (the other half of the Mira story)
+- [Doc 855](../../community/855-gcvlcnti-bonfire-admin-relationship-log/) - where this question originated
+- [Doc 601](../../agents/601-agent-stack-cleanup-decision/) - the "no new surfaces" discipline this respects
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Decide ZOE-on-Telegram (low-effort distribution) yes/no | @Zaal | Decision | Next sprint |
+| Keep Mira/Telegram-agent space on a quarterly watch | @Zaal | Note | Q3 2026 |
+| Re-evaluate TON/Telegram when 500+ Farcaster members OR ZAOstock spun out | @Zaal | Trigger | When hit |
+
+## Sources
+
+- [TON Grants](https://ton.org/en/grants) [FULL]
+- [Top Telegram Mini Apps on TON - BingX](https://bingx.com/en/learn/article/top-telegram-mini-apps-on-ton-network-ecosystem) [FULL]
+- [Telegram Stars monetization - TeleStars](https://telestars.io/blog/telegram-stars) [FULL]
+- [China blocks Meta from buying Manus - Euronews, 2026-04-27](https://www.euronews.com/next/2026/04/27/china-blocks-meta-from-buying-ai-startup-manus) [FULL]
+- [Mira - mira.tg](https://mira.tg/) [FULL]

--- a/research/security/856-mira-cross-chat-graph-leakage/README.md
+++ b/research/security/856-mira-cross-chat-graph-leakage/README.md
@@ -18,7 +18,7 @@ tier: STANDARD
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| 1 | REMOVE Mira (`@mira`) from the DeepMeeting group now | Mira is designed to learn from every chat it joins and stores cross-chat memory on its own servers, outside ZAO control. It has been ingesting the ZABAL bot's system prompt, graph architecture, and Zaal's strategy since it joined. |
+| 1 | Keep Mira (`@mira`) OUT of the private graph-coordination group, but USE it elsewhere (content, explainer videos, translation, GCvlcnti's Brazil outreach) | Mira learns from every chat it joins and stores cross-chat memory on its own servers, outside ZAO control - bad for private graph internals. But it's a capable tool; the fix is a safe lane, not a ban. Use it for public/content/personal work, not where the ZABAL bot's architecture + strategy live. |
 | 2 | Ask GCvlcnti to disable Mira's daily summaries + audit what it has stored | Daily recaps have run since ~2026-06-02; the already-ingested data lives on mira.tg servers. Reduce ongoing capture. |
 | 3 | ADOPT a standing rule: no third-party bot/agent added to any ZAO coordination group without Zaal's explicit approval | The leak happened because bots were added freely. Gate it. |
 | 4 | CLARIFY Socrat0x / kEngram status with GCvlcnti - collaborator or sovereign external graph | Socrat0x is GCvlcnti's own separate ~36,000-node graph actively querying the ZABAL bot. Not leakage (separate system) but it is modeling ZAO structure. Decide the boundary. |

--- a/research/security/856-mira-cross-chat-graph-leakage/README.md
+++ b/research/security/856-mira-cross-chat-graph-leakage/README.md
@@ -1,0 +1,92 @@
+---
+topic: security
+type: threat-landscape
+status: research-complete
+last-validated: 2026-06-14
+related-docs: "855, 799, 798, 781, 669"
+original-query: "investigate the bots co-resident in the DeepMeeting group (Mira, Socratox, Sanctuary, Suma) - are they reading/federating with ZAO's knowledge graph?"
+tier: STANDARD
+---
+
+# 856 - Mira cross-chat leakage of the ZABAL knowledge graph
+
+> **Goal:** assess whether the third-party AI agents sharing the DeepMeeting
+> Telegram group with ZAO's ZABAL Bonfire Bot are ingesting or leaking ZAO's
+> private knowledge-graph context, and what to do about it.
+
+## Key Decisions
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | REMOVE Mira (`@mira`) from the DeepMeeting group now | Mira is designed to learn from every chat it joins and stores cross-chat memory on its own servers, outside ZAO control. It has been ingesting the ZABAL bot's system prompt, graph architecture, and Zaal's strategy since it joined. |
+| 2 | Ask GCvlcnti to disable Mira's daily summaries + audit what it has stored | Daily recaps have run since ~2026-06-02; the already-ingested data lives on mira.tg servers. Reduce ongoing capture. |
+| 3 | ADOPT a standing rule: no third-party bot/agent added to any ZAO coordination group without Zaal's explicit approval | The leak happened because bots were added freely. Gate it. |
+| 4 | CLARIFY Socrat0x / kEngram status with GCvlcnti - collaborator or sovereign external graph | Socrat0x is GCvlcnti's own separate ~36,000-node graph actively querying the ZABAL bot. Not leakage (separate system) but it is modeling ZAO structure. Decide the boundary. |
+| 5 | Mira itself = WATCH not adopt (covered in doc 857) | It is a real, capable product GCvlcnti is championing - but its data model is incompatible with private graph work. |
+
+## The finding
+
+The DeepMeeting group (`[DeepMeeting][@Zaabal]`, 20 members) runs ZAO's
+`@zabal_bonfire_bot` alongside several other agents. Investigation of the
+1,381-entry backlog + web research on each:
+
+| Agent | What it is | Risk to ZAO graph |
+|-------|-----------|-------------------|
+| **`@zabal_bonfire_bot`** | ZAO's own graph agent (ElizaOS v1.7, 12 constraints, explicit ingest-only discipline) | None - owned, gated. Only ingests on explicit "ingest"/"commit". |
+| **Mira** (`@mira`, mira.tg) | Telegram-native AI agent; 500k MAU, 50k+ groups. **Learns from all conversations across personal + group chats, builds a cross-chat shared-memory layer, stores embeddings + daily summaries on its own servers.** | **HIGH - uncontrolled ingestion.** Captures ZABAL bot system prompt, graph architecture, Zaal identity/strategy; can surface that context in other groups its users belong to. |
+| **Socrat0x** | GCvlcnti's own separate ~36,000-node "kEngram" graph; actively queries `@zabal_bonfire_bot`. | MEDIUM - not leakage (separate system) but a competing graph actively modeling ZAO structure. Boundary unclear. |
+| **`@sanctuary_bonfire_bot`** | Another bonfire instance; non-responsive in the group. | LOW - dormant here. |
+| **Suma AI** (`@SumaAI_Bot`) | Present, role unclear. | LOW - no observed ingestion. |
+
+### Why Mira is the real problem
+
+- **By design it learns cross-chat.** Mira's own positioning: "learns from real
+  conversations across personal and group chats" with a shared memory layer and
+  semantic retrieval. That is the opposite of a gated graph.
+- **Storage is off-ZAO.** Embeddings + summaries live on mira.tg infrastructure.
+  Zaal cannot delete or audit them directly.
+- **Cross-group surfacing.** Mira's memory is shared per user; ZAO context can
+  appear in other groups a member is in.
+- **Telegram API does NOT save you here.** Bots can't read other bots' messages,
+  but Mira records all *human* messages and any human relay of bot output - which
+  in this group includes the ZABAL bot's architecture, repeatedly pasted/quoted.
+
+### What is NOT a leak
+
+- Bonfire-to-bonfire: separate bonfires (ZABAL vs Sanctuary) are isolated
+  instances; no documented cross-graph federation on bonfires.ai. Low risk.
+- Socrat0x querying the ZABAL bot returns only what the bot chooses to answer -
+  it's external observation, not exfiltration. Still worth a boundary conversation.
+
+## The irony worth noting
+
+GCvlcnti is the one championing Mira ("use mira", "it's years ahead", "what
+bonfires should copy") - i.e. he is advocating for the exact agent that is
+siphoning the graph he helps maintain. He is not acting in bad faith; he sees
+Mira as the product model. The fix is hygiene, not blame: keep Mira out of
+private coordination spaces, study it separately as a competitor (doc 857).
+
+## Also See
+
+- [Doc 855](../../community/855-gcvlcnti-bonfire-admin-relationship-log/) - the relationship + comms context
+- [Doc 857](../../infrastructure/857-ton-telegram-native-strategy/) - Mira/TON as a competitive/strategic question (separate from the security one)
+- [Doc 799](../../agents/799-deepmeeting-agent-shard-architecture/) - DeepMeeting shard (the gate)
+- `.claude/rules/pii-hygiene.md` + `secret-hygiene.md` - extend with the bot-boundary checklist below
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Remove Mira from the DeepMeeting group | @Zaal | Telegram action | Today |
+| Ask GCvlcnti to disable Mira daily summaries | @Zaal | DM | Today |
+| Add "no third-party bots without approval" to ZAO group norms | @Zaal | Rule | This week |
+| Pre-bot checklist (learns cross-chat? where stored? can Zaal delete? audit log?) -> pii-hygiene.md | @Zaal | PR | Next |
+| Clarify Socrat0x/kEngram boundary with GCvlcnti | @Zaal | DM | This week |
+
+## Sources
+
+- [Mira - mira.tg](https://mira.tg/) [FULL]
+- [Mira AI agent launches inside Telegram group chats - ITBrief](https://itbrief.co.uk/story/mira-ai-agent-launches-inside-telegram-group-chats) [FULL]
+- [Telegram's AI Agent Ecosystem And Mira - Dataconomy, 2026-05-20](https://dataconomy.com/2026/05/20/telegrams-ai-agent-ecosystem-mira/) [FULL]
+- [Bonfires Technical Documentation](https://publish.obsidian.md/bonfires/files/Technical/Bonfires) [PARTIAL - platform isolation model not fully documented]
+- Primary: DeepMeeting backlog (1,381 entries), 2026-06-14, zdeepmeeting repo [FULL]


### PR DESCRIPTION
## Summary
Logs the full DM relationship with @GCvlcnti (Zaal's ZABAL Bonfire graph admin, doc 799). Inventories the threads he raised, records Zaal's positions, separates verified signal from unverified claims, and sets a clean comms protocol.

## Key findings
- His macro reads check out: Mira (mira.tg, real Telegram-native AI agent competitor) and Manus->Meta ($2B Dec 2025, Telegram-first) both verified true.
- His detail-level claims remain a bad-data risk (doc 798 caught TreeUnix pollution). Rule: macro reads = signal, specifics = verify, shard-only.
- Comms reset: one pinned 'important list', Iman co-carries, pick one thing.

## Tier
STANDARD

## Sources
2 verified web (Mira, Manus/Meta reporting) + the primary DM stream.

## Next Actions
See doc Next Actions table - includes exporting the 'zabal deepmeeting' TG group to ingest separately.