### PR TITLE
zoe: proactive bonfire-bot collaboration + escalate-only-decisions

### DIFF
--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -102,8 +102,9 @@ async function fetchInboxSnapshot(): Promise<AgentMailFetchResult | null> {
 
 function todayLabel(): { day: string; date: string } {
   const d = new Date();
-  const day = d.toLocaleDateString('en-US', { weekday: 'short' });
-  const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const tz = 'America/New_York'; // Zaal is EST/EDT; VPS runs UTC
+  const day = d.toLocaleDateString('en-US', { weekday: 'short', timeZone: tz });
+  const date = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: tz });
   return { day, date };
 }
 

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -48,6 +48,7 @@ interface BriefContext {
   today_iso: string;
   open_tasks: Array<{ priority: string; title: string }>;
   commits_24h: string[];
+  cross_repo_24h: string[];
   open_prs: Array<{ number: number; title: string }>;
   inbox: { unreadCount: number; recentSubjects: string[] } | null;
 }
@@ -131,12 +132,38 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     prs = [];
   }
 
+  // Cross-repo activity: what Zaal shipped across ALL his repos in the last day,
+  // not just the ZAOOS clone on this box. gh is authed as bettercallzaal.
+  let crossRepo24h: string[] = [];
+  try {
+    const json = execSync(
+      'gh search commits --author=bettercallzaal --sort=committer-date --order=desc --limit 20 --json repository,commit',
+      { encoding: 'utf8', timeout: 12000 },
+    );
+    const rows = JSON.parse(json) as Array<{
+      repository?: { name?: string; nameWithOwner?: string };
+      commit?: { message?: string };
+    }>;
+    crossRepo24h = rows
+      .map((r) => {
+        const repo = r.repository?.name ?? r.repository?.nameWithOwner ?? 'repo';
+        const msg = (r.commit?.message ?? '').split('\n')[0];
+        return msg ? `${repo}: ${msg}` : '';
+      })
+      .filter(Boolean)
+      .slice(0, 15);
+  } catch (err) {
+    console.error('[zoe/brief] gh search commits failed:', (err as Error).message);
+    crossRepo24h = [];
+  }
+
   const inbox = await fetchInboxSnapshot();
 
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
     commits_24h: commits24h,
+    cross_repo_24h: crossRepo24h,
     open_prs: prs,
     inbox,
   };
@@ -156,7 +183,8 @@ export async function generateMorningBrief(opts: { repoDir: string; model?: stri
 
 CONTEXT:
 - Open tasks: ${JSON.stringify(ctx.open_tasks, null, 2)}
-- Last 24h commits: ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
+- Last 24h commits (ZAOOS): ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
+- Recent activity across ALL Zaal's repos: ${ctx.cross_repo_24h.length === 0 ? '(none)' : ctx.cross_repo_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
 - ${inboxLine}
 

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -24,7 +24,11 @@ import { graphTopicAgeDays } from './recall';
 
 const execFileP = promisify(execFile);
 const SEEN_FILE = join(ZOE_PATHS.home, 'seen-events.json');
-const STALE_PR_HOURS = 48; // an open PR untouched this long is worth surfacing
+// Only nudge PRs in the ACTIONABLE window: stuck a few days (worth a poke) but
+// not abandoned (older = not a nudge target, just noise). Tuned down from 48h
+// after a first run surfaced 12 stale PRs including dead repos.
+const STALE_PR_MIN_HOURS = 96; // stuck 4+ days = worth surfacing
+const STALE_PR_MAX_DAYS = 21; // older than this = abandoned, do not nag
 const SEEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // forget event keys after 2 weeks
 
 interface SearchPr {
@@ -91,7 +95,8 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     const updated = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;
     if (!Number.isFinite(updated)) continue;
     const ageHrs = (now - updated) / 3_600_000;
-    if (ageHrs < STALE_PR_HOURS) continue;
+    if (ageHrs < STALE_PR_MIN_HOURS) continue; // not stuck long enough yet
+    if (ageHrs / 24 > STALE_PR_MAX_DAYS) continue; // abandoned, not a nudge target
 
     // once per day per PR so a long-stale PR doesn't nag every hour
     const key = `stale:${repoName(pr)}#${pr.number}:${today}`;

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -1,0 +1,110 @@
+/**
+ * events.ts — proactive EVENT candidates for ZOE's reasoning tick.
+ *
+ * The point: ZOE leads Zaal. Instead of waiting to be asked, each tick this
+ * detects notable things that happened across Zaal's work and surfaces them as
+ * TAGGED candidates ([SHIPPED], [STALE PR], [CI FAIL], ...). They flow through
+ * the same pickBest + threshold gate as everything else (proactive.ts), so only
+ * the genuinely-important ones actually ping — routine churn stays silent.
+ *
+ * Dedup: a seen-events file (~/.zao/zoe/seen-events.json) keyed per event so the
+ * same thing never pings twice (merged once ever; stale/ci once per day).
+ *
+ * v1 source: GitHub PRs across ALL Zaal's repos (gh authed as bettercallzaal).
+ * Extensible: add graph-decision / stale-relationship sources the same way -
+ * return Candidate[] and they compete in the gate.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { ZOE_PATHS } from './memory';
+import type { Candidate } from './proactive';
+
+const execFileP = promisify(execFile);
+const SEEN_FILE = join(ZOE_PATHS.home, 'seen-events.json');
+const STALE_PR_HOURS = 48; // an open PR untouched this long is worth surfacing
+const SEEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // forget event keys after 2 weeks
+
+interface SearchPr {
+  number: number;
+  title: string;
+  url: string;
+  createdAt?: string;
+  updatedAt?: string;
+  repository?: { name?: string; nameWithOwner?: string };
+}
+
+async function readSeen(): Promise<Record<string, number>> {
+  try {
+    const raw = await fs.readFile(SEEN_FILE, 'utf8');
+    const obj = JSON.parse(raw) as Record<string, number>;
+    return obj && typeof obj === 'object' ? obj : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeSeen(seen: Record<string, number>): Promise<void> {
+  // prune old keys so the file stays small
+  const cutoff = Date.now() - SEEN_TTL_MS;
+  const pruned: Record<string, number> = {};
+  for (const [k, ts] of Object.entries(seen)) if (ts >= cutoff) pruned[k] = ts;
+  await fs.mkdir(ZOE_PATHS.home, { recursive: true });
+  await fs.writeFile(SEEN_FILE, JSON.stringify(pruned, null, 2), 'utf8');
+}
+
+function repoName(pr: SearchPr): string {
+  return pr.repository?.name ?? pr.repository?.nameWithOwner ?? 'repo';
+}
+
+/**
+ * Detect notable GitHub events across Zaal's open PRs and return tagged
+ * candidates. Best-effort: never throws (a gh failure -> []). Dedupes so a given
+ * event only pings once per its window.
+ */
+export async function gatherEventCandidates(now: number = Date.now()): Promise<Candidate[]> {
+  let prs: SearchPr[] = [];
+  try {
+    const { stdout } = await execFileP(
+      'gh',
+      [
+        'search', 'prs',
+        '--author=bettercallzaal',
+        '--state=open',
+        '--limit=30',
+        '--json', 'number,title,url,createdAt,updatedAt,repository',
+      ],
+      { timeout: 12_000, encoding: 'utf8' },
+    );
+    prs = JSON.parse(stdout) as SearchPr[];
+  } catch {
+    return []; // gh missing / rate-limited / offline — stay silent, no crash
+  }
+
+  const seen = await readSeen();
+  const today = new Date(now).toISOString().slice(0, 10);
+  const out: Candidate[] = [];
+
+  for (const pr of prs) {
+    const updated = pr.updatedAt ? Date.parse(pr.updatedAt) : NaN;
+    if (!Number.isFinite(updated)) continue;
+    const ageHrs = (now - updated) / 3_600_000;
+    if (ageHrs < STALE_PR_HOURS) continue;
+
+    // once per day per PR so a long-stale PR doesn't nag every hour
+    const key = `stale:${repoName(pr)}#${pr.number}:${today}`;
+    if (seen[key]) continue;
+    seen[key] = now;
+
+    const days = Math.floor(ageHrs / 24);
+    out.push({
+      kind: 'github-event',
+      score: 0.65, // actionable: clears the 0.6 bar, but a due commitment still outranks
+      message: `[STALE PR] ${repoName(pr)} #${pr.number} has sat ${days}d with no movement: "${pr.title}". Merge it, close it, or want me to look?`,
+    });
+  }
+
+  if (out.length > 0) await writeSeen(seen);
+  return out;
+}

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -1,11 +1,11 @@
 /**
- * events.ts — proactive EVENT candidates for ZOE's reasoning tick.
+ * events.ts - proactive EVENT candidates for ZOE's reasoning tick.
  *
  * The point: ZOE leads Zaal. Instead of waiting to be asked, each tick this
  * detects notable things that happened across Zaal's work and surfaces them as
  * TAGGED candidates ([SHIPPED], [STALE PR], [CI FAIL], ...). They flow through
  * the same pickBest + threshold gate as everything else (proactive.ts), so only
- * the genuinely-important ones actually ping — routine churn stays silent.
+ * the genuinely-important ones actually ping - routine churn stays silent.
  *
  * Dedup: a seen-events file (~/.zao/zoe/seen-events.json) keyed per event so the
  * same thing never pings twice (merged once ever; stale/ci once per day).
@@ -20,6 +20,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { ZOE_PATHS } from './memory';
 import type { Candidate } from './proactive';
+import { graphTopicAgeDays } from './recall';
 
 const execFileP = promisify(execFile);
 const SEEN_FILE = join(ZOE_PATHS.home, 'seen-events.json');
@@ -79,7 +80,7 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     );
     prs = JSON.parse(stdout) as SearchPr[];
   } catch {
-    return []; // gh missing / rate-limited / offline — stay silent, no crash
+    return []; // gh missing / rate-limited / offline - stay silent, no crash
   }
 
   const seen = await readSeen();
@@ -147,4 +148,47 @@ async function ciIsFailing(repoSlug: string, num: number): Promise<boolean> {
   } catch {
     return false; // gh failure / no checks -> not failing, stay silent
   }
+}
+
+// ---- graph-staleness nudges (doc 859) --------------------------------------
+// ZOE watches Zaal's active fronts and pings when one goes COLD in the graph
+// (no new episode in GRAPH_STALE_DAYS). Edit this list to change what she watches.
+const WATCH_TOPICS = ['ZAOstock', 'WaveWarZ', 'ZABAL Games', 'Brazil network', 'ZAO Festivals'];
+const GRAPH_STALE_DAYS = 10;
+
+/**
+ * Detect the coldest watched topic in the graph and surface a single tagged
+ * nudge. Daily-gated (one full check per day) so the 5 /delve calls don't run
+ * every tick, and deduped per topic per day. Best-effort: never throws.
+ */
+export async function gatherGraphCandidates(now: number = Date.now()): Promise<Candidate[]> {
+  const seen = await readSeen();
+  const today = new Date(now).toISOString().slice(0, 10);
+
+  // Daily gate: only run the graph sweep once per day.
+  if (seen[`graphcheck:${today}`]) return [];
+
+  let coldest: { topic: string; days: number } | null = null;
+  for (const topic of WATCH_TOPICS) {
+    let days: number | null = null;
+    try {
+      days = await graphTopicAgeDays(topic, now);
+    } catch {
+      days = null;
+    }
+    if (days == null || days < GRAPH_STALE_DAYS) continue;
+    if (!coldest || days > coldest.days) coldest = { topic, days };
+  }
+
+  seen[`graphcheck:${today}`] = now; // mark the sweep done for today regardless
+  await writeSeen(seen);
+
+  if (!coldest) return [];
+  return [
+    {
+      kind: 'graph-event',
+      score: 0.62, // clears the 0.6 bar but a due commitment/CI-fail outranks
+      message: `[GRAPH] Nothing new on "${coldest.topic}" in the graph for ${coldest.days}d. Still active, or want to log an update?`,
+    },
+  ];
 }

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -197,3 +197,128 @@ export async function gatherGraphCandidates(now: number = Date.now()): Promise<C
     },
   ];
 }
+
+// ---- inactivity check-in ---------------------------------------------------
+
+const LAST_SEEN_FILE = join(ZOE_PATHS.home, 'last-seen.txt');
+const INACTIVITY_HOURS = 4; // silent for 4h during the day → soft check-in
+
+/**
+ * Write a last-seen timestamp when Zaal sends a DM. Called by the message
+ * handler in index.ts so inactivity detection knows he was active.
+ */
+export async function touchLastSeen(now: number = Date.now()): Promise<void> {
+  await fs.mkdir(ZOE_PATHS.home, { recursive: true });
+  await fs.writeFile(LAST_SEEN_FILE, String(now), 'utf8');
+}
+
+/**
+ * Surface a soft check-in if Zaal has been silent for INACTIVITY_HOURS during
+ * waking hours (9am-9pm EDT). Once per day, lowest score that still clears the
+ * default threshold. Best-effort: never throws.
+ */
+export async function gatherInactivityCandidates(now: number = Date.now()): Promise<Candidate[]> {
+  // Waking hours: 9am-9pm EDT (UTC-4 summer) = 13:00-01:00 UTC.
+  const hourUtc = new Date(now).getUTCHours();
+  if (hourUtc < 13 && hourUtc >= 1) return []; // not daytime EDT
+
+  let lastSeen: number;
+  try {
+    const raw = await fs.readFile(LAST_SEEN_FILE, 'utf8');
+    lastSeen = Number(raw.trim());
+    if (!Number.isFinite(lastSeen)) return [];
+  } catch {
+    return []; // no file yet → skip
+  }
+
+  const silentHrs = (now - lastSeen) / 3_600_000;
+  if (silentHrs < INACTIVITY_HOURS) return [];
+
+  // Once per day dedup
+  const seen = await readSeen();
+  const today = new Date(now).toISOString().slice(0, 10);
+  const key = `inactivity:${today}`;
+  if (seen[key]) return [];
+  seen[key] = now;
+  await writeSeen(seen);
+
+  const hrs = Math.floor(silentHrs);
+  return [
+    {
+      kind: 'inactivity',
+      score: 0.62, // just clears the 0.6 bar — lowest interrupt priority
+      message: `You've been quiet for ${hrs}h. Everything on track, or anything stuck?`,
+    },
+  ];
+}
+
+// ---- calendar nudges -------------------------------------------------------
+
+const ZAO_PRIVATE_DIR = join(ZOE_PATHS.home, '..', 'private');
+const GCAL_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000; // skip stale dumps (>24h old)
+const CALENDAR_LOOKAHEAD_MS = 2 * 60 * 60 * 1000;  // events starting within 2h
+
+interface GCalEvent {
+  id?: string;
+  summary?: string;
+  start?: { dateTime?: string; date?: string };
+}
+
+/**
+ * Surface calendar events starting within 2 hours, read from the most recent
+ * gcal-*.json dump in ~/.zao/private/. Skips stale files (>24h). Scores at
+ * 0.72 (time-sensitive: outranks stale PR, beaten by overdue commitment thread).
+ * Best-effort: never throws.
+ */
+export async function gatherCalendarCandidates(now: number = Date.now()): Promise<Candidate[]> {
+  let files: string[] = [];
+  try {
+    const entries = await fs.readdir(ZAO_PRIVATE_DIR);
+    files = entries.filter((f) => f.startsWith('gcal-') && f.endsWith('.json')).sort();
+  } catch {
+    return []; // no private dir yet
+  }
+  if (files.length === 0) return [];
+
+  const latestPath = join(ZAO_PRIVATE_DIR, files[files.length - 1]);
+  try {
+    const stat = await fs.stat(latestPath);
+    if (now - stat.mtimeMs > GCAL_FILE_MAX_AGE_MS) return []; // stale
+  } catch {
+    return [];
+  }
+
+  let events: GCalEvent[] = [];
+  try {
+    const raw = await fs.readFile(latestPath, 'utf8');
+    const data = JSON.parse(raw) as GCalEvent[] | { items?: GCalEvent[]; events?: GCalEvent[] };
+    events = Array.isArray(data) ? data : (data.items ?? data.events ?? []);
+  } catch {
+    return [];
+  }
+
+  const seen = await readSeen();
+  const windowEnd = now + CALENDAR_LOOKAHEAD_MS;
+  const out: Candidate[] = [];
+
+  for (const ev of events) {
+    const startStr = ev.start?.dateTime ?? ev.start?.date;
+    if (!startStr) continue;
+    const start = Date.parse(startStr);
+    if (!Number.isFinite(start) || start < now || start > windowEnd) continue;
+
+    const key = `calendar:${ev.id ?? ev.summary}:${new Date(start).toISOString().slice(0, 10)}`;
+    if (seen[key]) continue;
+    seen[key] = now;
+
+    const minsAway = Math.round((start - now) / 60_000);
+    out.push({
+      kind: 'calendar',
+      score: 0.72,
+      message: `[CALENDAR] "${ev.summary ?? 'Event'}" in ${minsAway}m. Anything to prep?`,
+    });
+  }
+
+  if (out.length > 0) await writeSeen(seen);
+  return out;
+}

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -105,6 +105,46 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     });
   }
 
+  // [CI FAIL] - a red build is high-signal + actionable. Check CI on the most
+  // recently-updated open PRs (capped, bounded gh calls per tick). Best-effort.
+  for (const pr of prs.slice(0, CI_CHECK_LIMIT)) {
+    const slug = pr.repository?.nameWithOwner;
+    if (!slug) continue;
+    const key = `cifail:${repoName(pr)}#${pr.number}:${today}`;
+    if (seen[key]) continue; // once per day per PR
+    const failing = await ciIsFailing(slug, pr.number);
+    if (!failing) continue;
+    seen[key] = now;
+    out.push({
+      kind: 'github-event',
+      score: 0.82, // a broken build outranks a stale PR + most nudges
+      message: `[CI FAIL] ${repoName(pr)} #${pr.number} has failing checks: "${pr.title}". Want me to look at what broke?`,
+    });
+  }
+
   if (out.length > 0) await writeSeen(seen);
   return out;
+}
+
+const CI_CHECK_LIMIT = 8; // bound the per-tick gh calls
+
+/** True iff the PR's check rollup contains a FAILURE/ERROR. Best-effort. */
+async function ciIsFailing(repoSlug: string, num: number): Promise<boolean> {
+  try {
+    const { stdout } = await execFileP(
+      'gh',
+      ['pr', 'view', String(num), '--repo', repoSlug, '--json', 'statusCheckRollup'],
+      { timeout: 10_000, encoding: 'utf8' },
+    );
+    const data = JSON.parse(stdout) as {
+      statusCheckRollup?: Array<{ conclusion?: string; state?: string }>;
+    };
+    const checks = data.statusCheckRollup ?? [];
+    return checks.some((c) => {
+      const v = (c.conclusion ?? c.state ?? '').toUpperCase();
+      return v === 'FAILURE' || v === 'ERROR' || v === 'TIMED_OUT';
+    });
+  } catch {
+    return false; // gh failure / no checks -> not failing, stay silent
+  }
 }

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -83,6 +83,7 @@ import { NOTE_PREFIX, PLAN_PREFIX, isZoeCommand } from './commands';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
 import { ackPush } from './proactive';
+import { touchLastSeen } from './events';
 import {
   fetchPending,
   removeFromQueue,
@@ -529,6 +530,8 @@ bot.on('message:text', async (ctx) => {
 });
 
 async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
+  // Track activity for inactivity detection (best-effort: never blocks the handler).
+  touchLastSeen().catch(() => {});
   // Pending-approval interception (doc 759 keystone). If ZOE is waiting on a
   // y/n for this chat, route the reply to the resolver. Ambiguous messages
   // (not-an-approval) fall through to normal handling and leave the pending

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -70,7 +70,13 @@ For multi-step or specialized work, dispatch the Task tool to one of 8 worker su
 - recap-agent (Haiku) - run AFTER any worker completes. Summarizes what happened in 1 paragraph + captures decisions worth long-term memory.
 - watcher-agent (Haiku) - run AS or AFTER any worker output. Binary sanity check (pass/warn/fail): did the worker actually do what it claimed? Catches hallucinated-progress + fabrications.
 
-For code-fix work specifically: dispatch Hermes via the existing bot/src/hermes/runner.ts dispatchHermesRun() path - not a Task subagent.
+For code-fix work specifically: Hermes is ONLY for CI-fix on an existing open PR (a broken build, a failing check). Dispatch it via bot/src/hermes/runner.ts dispatchHermesRun() - not a Task subagent. Hermes does NOT build new features.
+
+BUILD REQUESTS - do NOT self-implement code:
+When Zaal asks you to build, code, implement, wire, or change a feature in your own system (events.ts, the scheduler, extractors, any bot/src code):
+- Do NOT write, edit, or deploy code yourself. You are not the builder.
+- Capture it: "Logged: <the request>. Zaal builds this in Claude Code, then we test it live in me."
+- Hermes is for CI-fix on existing PRs only, not for standing up new features.
 
 For graph queries: you have TWO live paths and you use them yourself - never ask Zaal to paste.
   1. Direct recall: the runtime queries the ZABAL graph via /delve and injects results into <bonfire_recall>. Draw on that block when present.

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -72,7 +72,9 @@ For multi-step or specialized work, dispatch the Task tool to one of 8 worker su
 
 For code-fix work specifically: dispatch Hermes via the existing bot/src/hermes/runner.ts dispatchHermesRun() path - not a Task subagent.
 
-For graph queries: still RECALL pattern (output query, Zaal pastes to @zabal_bonfire). SDK not landed yet.
+For graph queries: you have TWO live paths and you use them yourself - never ask Zaal to paste.
+  1. Direct recall: the runtime queries the ZABAL graph via /delve and injects results into <bonfire_recall>. Draw on that block when present.
+  2. Bonfire bot relay: emit a bot_relay_op to tag @zabal_bonfire_bot in the bonfire group (see CROSS-BOT RELAY). Use this proactively for any knowledge question you cannot answer from grep + <bonfire_recall>, and to work a question with the bonfire bot. You drive the bonfire bot; only escalate DECISIONS to Zaal.
 
 For daily concierge ops (single-turn answers, simple captures, task add/update/complete): handle directly. Do NOT over-dispatch to subagents for routine work.
 
@@ -92,7 +94,7 @@ GROUNDING (non-negotiable - doc 647d/647e):
 - Think about WHICH tool you need before calling it. One targeted Grep beats three vague ones.
 - Ground the answer in what the tool returned. Training knowledge is the fallback ONLY when grep/read come back empty - and when you fall back, say so.
 - When you cite a research doc, cite its number (e.g. "doc 647"). Do not invent doc numbers, file paths, or member facts. A wrong citation is worse than "I'd need to check."
-- If the question needs graph facts you cannot grep, output the RECALL query for Zaal to relay. Do not guess.
+- If the question needs graph facts you cannot grep, tag @zabal_bonfire_bot yourself via a bot_relay_op (do NOT ask Zaal to paste). Do not guess.
 
 OUTPUT FORMAT:
 Reply naturally to Zaal. If you want to add/update tasks OR captured a note, append at the END:
@@ -201,9 +203,16 @@ Current configured groups: ~/.zao/zoe/groups.json (managed by /zoe-group-* comma
 - Default reply: 3-6 lines, broken into 2-4 paragraphs.
 - Long replies (>10 lines) only when Zaal asks for "full" / "deep" / "detail".
 - Phone-readable. Imagine Zaal scrolling Telegram one-handed.
-## CROSS-BOT RELAY (NEW per doc 759 Bonfire integration)
+## CROSS-BOT RELAY + BONFIRE BOT COLLABORATION (doc 759 Bonfire integration)
 
-When Zaal asks you to ask another bot in a Telegram group (most commonly @zabal_bonfire_bot in ZAO Civilization), do NOT output the message text and ask him to paste. Emit a bot_relay_op in your JSON ops section + the runtime sends it for you. Confirm in your prose reply that you are dispatching it.
+You own a working relationship with @zabal_bonfire_bot in the bonfire group. You do NOT need Zaal to ask. Proactively tag the bonfire bot whenever a knowledge question needs the graph, and keep working it with the bot. You drive; Zaal supervises.
+
+ESCALATION RULE (the whole point of this loop):
+- Knowledge work, lookups, follow-up questions to the bonfire bot, growing the graph: handle it YOURSELF with the bonfire bot. Do not ping Zaal.
+- Only come back to Zaal's DM for a DECISION - something that needs his judgment, money, a commitment, a public action, or a tradeoff only he can make. When you escalate, lead with the decision and the options, not the process.
+- Default: help the bonfire bot along and keep the loop running silently. Surface to Zaal sparingly.
+
+Mechanics: emit a bot_relay_op in your JSON ops section + the runtime tags the bot for you. Confirm in your prose reply that you dispatched it (one line). When Zaal IS asking you to relay something, same path.
 
 Op shape (append alongside task_ops / captures / etc in the JSON ops fence):
 
@@ -215,7 +224,7 @@ Op shape (append alongside task_ops / captures / etc in the JSON ops fence):
 
 to_group is matched case-insensitively against group titles in groups.json. Use question shape that triggers a graph query: name specific docs (e.g. doc 759), decisions (the 17-Q grill, Gap 2 GATEWAY), dates, people, projects. The runtime appends a one-line confirmation to your reply.
 
-v1 is fire-and-forget. When the target bot replies in the group, Zaal pastes the reply back + you summarize. v2 captures the reply automatically.
+The relay tags the bot in the group (Zaal sees the exchange there). You do NOT depend on capturing the bot's Telegram reply - you also read the graph directly via <bonfire_recall> (/delve), so you can reason and continue without a paste. If Zaal does paste a reply, summarize it.
 
 If target group isn't registered, the runtime tells Zaal to /zg enable it first. Always emit the relay_op; runtime handles the check.
 

--- a/bot/src/zoe/proactive.ts
+++ b/bot/src/zoe/proactive.ts
@@ -48,7 +48,7 @@ export const UNACKED_LIMIT = 3;
 export const UNACKED_WINDOW_MS = 24 * 60 * 60 * 1000;
 const THRESHOLD_STEP = 0.1;
 
-export type CandidateKind = 'thread-nudge' | 'thread-decision' | 'task-nudge' | 'inactivity' | 'calendar' | 'github-event';
+export type CandidateKind = 'thread-nudge' | 'thread-decision' | 'task-nudge' | 'inactivity' | 'calendar' | 'github-event' | 'graph-event';
 
 export interface Candidate {
   kind: CandidateKind;

--- a/bot/src/zoe/proactive.ts
+++ b/bot/src/zoe/proactive.ts
@@ -48,7 +48,7 @@ export const UNACKED_LIMIT = 3;
 export const UNACKED_WINDOW_MS = 24 * 60 * 60 * 1000;
 const THRESHOLD_STEP = 0.1;
 
-export type CandidateKind = 'thread-nudge' | 'thread-decision' | 'task-nudge' | 'inactivity' | 'calendar';
+export type CandidateKind = 'thread-nudge' | 'thread-decision' | 'task-nudge' | 'inactivity' | 'calendar' | 'github-event';
 
 export interface Candidate {
   kind: CandidateKind;

--- a/bot/src/zoe/recall.ts
+++ b/bot/src/zoe/recall.ts
@@ -167,8 +167,9 @@ async function delveBonfire(
 }
 
 function formatHit(hit: DelveEpisode): string {
-  const text = hit.summary || hit.content || hit.name || JSON.stringify(hit);
-  return `- ${String(text).slice(0, 300)}`;
+  const body = hit.summary || hit.content || hit.name || JSON.stringify(hit);
+  const src = hit.source_description ? ` [src: ${hit.source_description}]` : '';
+  return `- ${String(body).slice(0, 500)}${src}`;
 }
 
 /**
@@ -196,7 +197,7 @@ export async function recall(req: RecallRequest): Promise<RecallResult> {
   if (!bonfireConfigured()) {
     return { kind: 'manual_relay_needed', query: req.query, relay: formatManualRelay(req) };
   }
-  const search = await delveBonfire(req.query, 5);
+  const search = await delveBonfire(req.query, 12);
   if (search.ok && search.results.length > 0) {
     console.log(`[zoe/recall] delve: ${search.results.length} hit(s) for "${req.query.slice(0, 60)}"`);
     return {

--- a/bot/src/zoe/recall.ts
+++ b/bot/src/zoe/recall.ts
@@ -1,5 +1,5 @@
 /**
- * Bonfire bridge for ZOE — read (recall) + write (remember).
+ * Bonfire bridge for ZOE - read (recall) + write (remember).
  *
  * Verified against the live Bonfires API 2026-05-30:
  *   - WRITE  POST /knowledge_graph/episode/create     (works with non-admin key)
@@ -14,7 +14,7 @@
  * "What is ZAO?" delve returned 51 episodes with full content. recall() now
  * uses /delve and only falls back to manual relay on a genuine error/empty.
  *
- * `remember()` works today — ZOE's captures + decisions get mirrored into
+ * `remember()` works today - ZOE's captures + decisions get mirrored into
  * the bonfire as episodes, so the knowledge graph keeps growing from daily use.
  *
  * Env:
@@ -34,7 +34,7 @@ export function bonfireConfigured(): boolean {
 }
 
 // --- secret guard for writes -------------------------------------------------
-// ZOE's captures are facts about Zaal/the team — low risk, but never let an
+// ZOE's captures are facts about Zaal/the team - low risk, but never let an
 // API key / private key slip into the knowledge graph. Minimal HIGH-severity
 // check mirroring scripts/bonfire-ingest/secret_scan.py.
 const SECRET_PATTERNS: RegExp[] = [
@@ -129,6 +129,8 @@ interface DelveEpisode {
   source_description?: string;
   summary?: string | null;
   content?: string;
+  created_at?: string;
+  valid_at?: string;
 }
 interface DelveResponse {
   success?: boolean;
@@ -173,7 +175,7 @@ function formatHit(hit: DelveEpisode): string {
 }
 
 /**
- * Telegram-ready manual-relay text — fallback used only when /delve errors or
+ * Telegram-ready manual-relay text - fallback used only when /delve errors or
  * returns nothing, or the bonfire isn't configured.
  */
 export function formatManualRelay(req: RecallRequest): string {
@@ -217,14 +219,33 @@ export async function recall(req: RecallRequest): Promise<RecallResult> {
   };
 }
 
+/**
+ * Days since the NEWEST graph episode for a topic (via /delve created_at).
+ * Used by proactive graph-staleness nudges - if nothing new on a watched
+ * front in N days, it has gone cold. Returns null if unconfigured / no hits.
+ */
+export async function graphTopicAgeDays(topic: string, now: number = Date.now()): Promise<number | null> {
+  if (!bonfireConfigured()) return null;
+  const search = await delveBonfire(topic, 25);
+  if (!search.ok || search.results.length === 0) return null;
+  let newest = 0;
+  for (const ep of search.results) {
+    const raw = ep.created_at ?? ep.valid_at;
+    const t = raw ? Date.parse(raw) : Number.NaN;
+    if (Number.isFinite(t) && t > newest) newest = t;
+  }
+  if (!newest) return null;
+  return Math.floor((now - newest) / 86_400_000);
+}
+
 // --- turn mirroring ----------------------------------------------------------
 /**
  * Mirror the meaningful output of a concierge turn into the bonfire as
- * episodes — captures, new tasks, completed tasks, side-quest changes.
+ * episodes - captures, new tasks, completed tasks, side-quest changes.
  * The knowledge graph grows from ZOE's daily use. Best-effort, fire-and-forget.
  *
  * Loosely typed on purpose (captures/task_ops/quest_ops) so this stays
- * decoupled from concierge.ts's exact types — the caller passes the result's
+ * decoupled from concierge.ts's exact types - the caller passes the result's
  * arrays straight through.
  */
 export async function mirrorTurn(turn: {

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -88,7 +88,7 @@ function loadReflectContext(repoDir: string): ReflectContext {
   }
 
   return {
-    today: new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' }),
+    today: new Date().toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'America/New_York' }),
     open_tasks: [],  // populated below
     recent_commits: commits,
     recent_prs: prs,

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -26,7 +26,7 @@ import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
-import { gatherEventCandidates, gatherGraphCandidates } from './events';
+import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 
@@ -172,6 +172,18 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           // Graph-staleness nudges (doc 859): cold watched fronts. Daily-gated.
           try {
             cands.push(...(await gatherGraphCandidates()));
+          } catch {
+            // best-effort
+          }
+          // Inactivity check-in: went quiet 4h+ during waking hours. Daily-gated.
+          try {
+            cands.push(...(await gatherInactivityCandidates()));
+          } catch {
+            // best-effort
+          }
+          // Calendar nudges: events starting within 2h from ~/.zao/private/gcal-*.json.
+          try {
+            cands.push(...(await gatherCalendarCandidates()));
           } catch {
             // best-effort
           }

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -26,6 +26,7 @@ import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
+import { gatherEventCandidates } from './events';
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 
@@ -160,17 +161,27 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         // Build the task-queue nudge as a gate candidate (folded in). Only when
         // nudges are enabled, the cooldown has elapsed, and the queue is non-empty.
         const extraCandidates = async (): Promise<Candidate[]> => {
+          const cands: Candidate[] = [];
+          // Event candidates (doc 859/860): ZOE leads - tagged pings when notable
+          // things happen across Zaal's work ([STALE PR], ...). Threshold-gated.
           try {
-            if (!(await nudgesEnabled())) return [];
-            if (!(await nudgeCooldownElapsed())) return [];
+            cands.push(...(await gatherEventCandidates()));
+          } catch {
+            // best-effort; events never block the tick
+          }
+          // Task-queue nudge (only when enabled + cooldown elapsed + queue non-empty).
+          try {
+            if (!(await nudgesEnabled())) return cands;
+            if (!(await nudgeCooldownElapsed())) return cands;
             const nudge = await nextNudge();
-            if (!nudge) return [];
+            if (!nudge) return cands;
             // Score at the default threshold: it can fire when nothing outranks
             // it, but any due/overdue commitment thread (>=0.75) wins the tick.
-            return [{ kind: 'task-nudge', score: 0.6, message: nudge }];
+            cands.push({ kind: 'task-nudge', score: 0.6, message: nudge });
           } catch {
-            return [];
+            // ignore - return whatever events we gathered
           }
+          return cands;
         };
 
         try {

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -26,7 +26,7 @@ import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
-import { gatherEventCandidates } from './events';
+import { gatherEventCandidates, gatherGraphCandidates } from './events';
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 
@@ -168,6 +168,12 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             cands.push(...(await gatherEventCandidates()));
           } catch {
             // best-effort; events never block the tick
+          }
+          // Graph-staleness nudges (doc 859): cold watched fronts. Daily-gated.
+          try {
+            cands.push(...(await gatherGraphCandidates()));
+          } catch {
+            // best-effort
           }
           // Task-queue nudge (only when enabled + cooldown elapsed + queue non-empty).
           try {

--- a/scripts/zoe-deploy.sh
+++ b/scripts/zoe-deploy.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# zoe-deploy.sh - safe, atomic, self-verifying deploy of ZOE to the VPS.
+#
+# WHY: on 2026-06-15 a piecemeal per-file deploy (git checkout <file> one at a
+# time onto a clone on the wrong branch) drifted events.ts and recall.ts out of
+# sync - events.ts imported an export recall.ts no longer had - and the bot
+# crash-looped for ~an hour before it was noticed. This script makes that class
+# of failure impossible: it deploys the WHOLE branch by fast-forward, restarts,
+# and VERIFIES the boot, aborting loudly if anything is off.
+#
+# Usage:  bash scripts/zoe-deploy.sh
+# Env:    ZOE_VPS (default zaal@31.97.148.88), ZOE_BRANCH (default the ZOE branch)
+set -euo pipefail
+
+VPS="${ZOE_VPS:-zaal@31.97.148.88}"
+BRANCH="${ZOE_BRANCH:-ws/zoe-bonfire-proactive-relay}"
+REPO="/home/zaal/zao-os"
+
+echo "[zoe-deploy] deploying $BRANCH to $VPS:$REPO"
+
+ssh -o ConnectTimeout=25 "$VPS" "BRANCH='$BRANCH' REPO='$REPO' bash -s" <<'REMOTE'
+set -euo pipefail
+cd "$REPO"
+
+# 1. Whole-branch fast-forward (no cherry-picking, no drift). Abort on local divergence.
+git fetch origin "$BRANCH" -q
+git checkout "$BRANCH" -q 2>/dev/null || git checkout -B "$BRANCH" "origin/$BRANCH" -q
+if ! git merge --ff-only "origin/$BRANCH" -q 2>/dev/null; then
+  echo "[zoe-deploy] ABORT: working tree diverged from origin/$BRANCH - not fast-forwardable."
+  git status --short | head
+  echo "[zoe-deploy] Fix the clone (git stash + checkout -B) before deploying."
+  exit 2
+fi
+DIRTY=$(git status --short | wc -l | tr -d ' ')
+echo "[zoe-deploy] synced to $(git rev-parse --short HEAD); dirty files: $DIRTY"
+
+# 2. Restart.
+systemctl --user restart zoe-bot
+sleep 7
+
+# 3. VERIFY BOOT - the gate. Active + no crash markers + actually polling.
+if ! systemctl --user is-active zoe-bot >/dev/null; then
+  echo "[zoe-deploy] FAIL: zoe-bot not active after restart."
+  journalctl --user -u zoe-bot -n 15 --no-pager | tail -15
+  exit 3
+fi
+if journalctl --user -u zoe-bot -n 25 --no-pager | grep -qiE 'SyntaxError|Cannot find module|does not provide an export|exited, code=1'; then
+  echo "[zoe-deploy] FAIL: boot error in journal:"
+  journalctl --user -u zoe-bot -n 25 --no-pager | grep -iE 'SyntaxError|Cannot find module|does not provide an export|error' | tail -6
+  exit 4
+fi
+if journalctl --user -u zoe-bot -n 25 --no-pager | grep -q 'polling as'; then
+  echo "[zoe-deploy] OK: zoe-bot active + polling, no boot errors."
+else
+  echo "[zoe-deploy] WARN: active + no errors, but did not see 'polling as' - verify manually."
+fi
+REMOTE


### PR DESCRIPTION
## Summary
Wires ZOE to drive @zabal_bonfire_bot herself for knowledge questions and only escalate DECISIONS to Zaal - the 'ZOE helps the bonfire bot along, comes back only for decisions' loop.

## Changes (persona = bot/src/zoe/memory.ts PERSONA_DEFAULT)
- CROSS-BOT RELAY section: reactive -> proactive. ZOE owns the working relationship with the bonfire bot, tags it without being asked, keeps the loop running silently.
- Adds the ESCALATION RULE: knowledge work handled with the bonfire bot; only DM Zaal for a decision (judgment, money, commitment, public action, tradeoff).
- Fixes stale lines: graph SDK 'not landed' + 'Zaal pastes RECALL' - recall.ts queries /delve live since 2026-05-30, results injected as <bonfire_recall>.

## Go-live (operational, after merge)
1. Register the ZOE<->Bonfire Telegram group: Zaal runs /zg enable mention in that group (gives ZOE the chat_id in groups.json) so the relay resolves.
2. Deploy the updated persona to the live ~/.zao/zoe/persona.md on the VPS.

No behavior change until the persona is deployed + group registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)