### PR TITLE
zoe: knowledge extraction fan-out to Bonfire (doc 862)

### DIFF
--- a/bot/src/zoe/__tests__/extractors.test.ts
+++ b/bot/src/zoe/__tests__/extractors.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Isolate the seen-episodes store in a temp dir. ZOE_HOME is read at module
+// load, so this hoisted assignment must run before importing extractors.
+const TEST_HOME = vi.hoisted(() => {
+  const { join } = require('node:path');
+  const { tmpdir } = require('node:os');
+  const dir = join(tmpdir(), 'zoe-extract-test');
+  process.env.ZOE_HOME = dir;
+  return dir;
+});
+const SEEN_PATH = join(TEST_HOME, 'seen-episodes.json');
+
+const mocks = vi.hoisted(() => ({
+  callClaudeCli: vi.fn(),
+  remember: vi.fn(),
+  bonfireConfigured: vi.fn(() => true),
+}));
+
+vi.mock('../../hermes/claude-cli', () => ({
+  callClaudeCli: mocks.callClaudeCli,
+}));
+
+vi.mock('../recall', () => ({
+  remember: mocks.remember,
+  bonfireConfigured: mocks.bonfireConfigured,
+}));
+
+import {
+  fanOutKnowledgeExtractors,
+  parseCandidates,
+  containsPii,
+  bodyHash,
+  EXTRACT_MIN_LEN,
+} from '../extractors';
+
+function cliResult(text: string, isError = false) {
+  return {
+    text,
+    isError,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalCostUsd: 0,
+    model: 'haiku',
+    durationMs: 1,
+    numTurns: 1,
+    sessionId: 't',
+  };
+}
+
+const LONG = 'On 2026-06-16 Zaal decided to ship the extractor fan-out and met a new collaborator named Sam.';
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await fs.rm(SEEN_PATH, { force: true }); // fresh seen store each test
+  mocks.bonfireConfigured.mockReturnValue(true);
+  mocks.remember.mockResolvedValue({ ok: true });
+  mocks.callClaudeCli.mockResolvedValue(cliResult('[]'));
+});
+
+describe('bodyHash', () => {
+  it('is stable across whitespace and case', () => {
+    expect(bodyHash('Hello  World')).toBe(bodyHash('hello world'));
+  });
+  it('differs for different content', () => {
+    expect(bodyHash('a fact')).not.toBe(bodyHash('another fact'));
+  });
+});
+
+describe('containsPii', () => {
+  it('flags a non-allowlisted email', () => {
+    expect(containsPii('reach Bob at bob@randomcorp.com today')).toBe(true);
+  });
+  it('allows an allowlisted ZAO email', () => {
+    expect(containsPii('email zaal@thezao.com for the deck')).toBe(false);
+  });
+  it('flags a phone number', () => {
+    expect(containsPii('call +1 415 555 1234 tomorrow')).toBe(true);
+  });
+  it('passes clean prose', () => {
+    expect(containsPii('Zaal shipped the extractor on 2026-06-16')).toBe(false);
+  });
+});
+
+describe('parseCandidates', () => {
+  it('parses a clean JSON array', () => {
+    const out = parseCandidates('[{"body":"Zaal shipped extractors on 2026-06-16","confidence":0.9}]', 'decisions');
+    expect(out).toHaveLength(1);
+    expect(out[0].confidence).toBe(0.9);
+    expect(out[0].name).toMatch(/^extract:decisions:[0-9a-f]{12}$/);
+  });
+  it('pulls the array out of surrounding prose', () => {
+    const out = parseCandidates('Here you go: [{"body":"a fact stated clearly here","confidence":0.8}] done', 'people');
+    expect(out).toHaveLength(1);
+  });
+  it('returns [] on non-array JSON', () => {
+    expect(parseCandidates('{"body":"x","confidence":1}', 'people')).toEqual([]);
+  });
+  it('returns [] on garbage', () => {
+    expect(parseCandidates('not json at all', 'people')).toEqual([]);
+  });
+  it('drops items with wrong types or too-short bodies', () => {
+    const out = parseCandidates('[{"body":"short","confidence":0.9},{"body":123,"confidence":0.9},{"body":"a valid long body here","confidence":"hi"}]', 'projects');
+    expect(out).toEqual([]);
+  });
+});
+
+describe('fanOutKnowledgeExtractors', () => {
+  it('no-ops when Bonfire is unconfigured', async () => {
+    mocks.bonfireConfigured.mockReturnValue(false);
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp' });
+    expect(r).toEqual({ written: 0, skipped: 0 });
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+  });
+
+  it('no-ops on a short message', async () => {
+    const r = await fanOutKnowledgeExtractors('ok thanks', { cwd: '/tmp' });
+    expect(r).toEqual({ written: 0, skipped: 0 });
+    expect(mocks.callClaudeCli).not.toHaveBeenCalled();
+    expect(LONG.length).toBeGreaterThanOrEqual(EXTRACT_MIN_LEN);
+  });
+
+  it('writes a high-confidence candidate to the graph', async () => {
+    mocks.callClaudeCli
+      .mockResolvedValueOnce(cliResult('[{"body":"Sam is a new collaborator as of 2026-06-16","confidence":0.9}]'))
+      .mockResolvedValue(cliResult('[]'));
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp', today: '2026-06-16' });
+    expect(r.written).toBe(1);
+    expect(mocks.remember).toHaveBeenCalledTimes(1);
+    expect(mocks.remember).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceTag: 'zoe:extract' }),
+    );
+    const persisted = JSON.parse(await fs.readFile(SEEN_PATH, 'utf8')) as string[];
+    expect(persisted).toContain(bodyHash('Sam is a new collaborator as of 2026-06-16'));
+  });
+
+  it('filters out low-confidence candidates', async () => {
+    mocks.callClaudeCli
+      .mockResolvedValueOnce(cliResult('[{"body":"a weakly-supported guess here","confidence":0.4}]'))
+      .mockResolvedValue(cliResult('[]'));
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp' });
+    expect(r.written).toBe(0);
+    expect(r.skipped).toBe(1);
+    expect(mocks.remember).not.toHaveBeenCalled();
+  });
+
+  it('filters out candidates containing PII', async () => {
+    mocks.callClaudeCli
+      .mockResolvedValueOnce(cliResult('[{"body":"Reach the vendor at vendor@thirdparty.com per Zaal","confidence":0.95}]'))
+      .mockResolvedValue(cliResult('[]'));
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp' });
+    expect(r.written).toBe(0);
+    expect(r.skipped).toBe(1);
+    expect(mocks.remember).not.toHaveBeenCalled();
+  });
+
+  it('skips candidates already in the seen store (dedup)', async () => {
+    const body = 'Sam is a new collaborator as of 2026-06-16';
+    await fs.mkdir(TEST_HOME, { recursive: true });
+    await fs.writeFile(SEEN_PATH, JSON.stringify([bodyHash(body)]), 'utf8');
+    mocks.callClaudeCli
+      .mockResolvedValueOnce(cliResult(`[{"body":"${body}","confidence":0.9}]`))
+      .mockResolvedValue(cliResult('[]'));
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp' });
+    expect(r.written).toBe(0);
+    expect(r.skipped).toBe(1);
+    expect(mocks.remember).not.toHaveBeenCalled();
+  });
+
+  it('survives an extractor throwing (best-effort)', async () => {
+    mocks.callClaudeCli
+      .mockRejectedValueOnce(new Error('cli boom'))
+      .mockResolvedValue(cliResult('[]'));
+    const r = await fanOutKnowledgeExtractors(LONG, { cwd: '/tmp' });
+    expect(r.written).toBe(0);
+  });
+});

--- a/bot/src/zoe/extractors.ts
+++ b/bot/src/zoe/extractors.ts
@@ -1,0 +1,256 @@
+/**
+ * Knowledge extraction fan-out (doc 862).
+ *
+ * After a substantive Zaal turn, fan out 4 cheap Haiku readers that each comb
+ * the message for ONE category of fact (people / projects / decisions /
+ * commitments) and emit graph-ready episodes. Only high-confidence, de-duped,
+ * secret/PII-clean episodes are written to the ZABAL Bonfire via remember().
+ *
+ * Silent + fire-and-forget: never blocks the reply, never reports to Zaal,
+ * never throws. No-op if Bonfire is unconfigured.
+ *
+ * This is NOT a new bot or a new dispatch path. It is a background extraction
+ * layer that turns conversation into durable graph memory. See doc 862.
+ */
+import { createHash } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { callClaudeCli } from '../hermes/claude-cli';
+import { remember, bonfireConfigured } from './recall';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const SEEN_PATH = join(ZOE_HOME, 'seen-episodes.json');
+
+/** Minimum message length to bother extracting. Short acks carry no facts. */
+export const EXTRACT_MIN_LEN = 40;
+/** Only write episodes the extractor is at least this sure are literally stated. */
+const CONFIDENCE_MIN = 0.7;
+/** Cap the rolling dedup store so it never grows unbounded. */
+const SEEN_MAX = 2000;
+/** Per-extractor wall-clock cap. Extraction is span-tagging, not research. */
+const EXTRACT_TIMEOUT_MS = 60_000;
+/** Hard cost cap per extractor call. */
+const EXTRACT_BUDGET_USD = 0.05;
+
+interface ExtractorSpec {
+  key: 'people' | 'projects' | 'decisions' | 'commitments';
+  /** What this reader pulls. Injected into its system prompt. */
+  target: string;
+}
+
+const EXTRACTORS: ExtractorSpec[] = [
+  {
+    key: 'people',
+    target:
+      'new humans mentioned, their role, their affiliation, and their relationship to Zaal or the ZAO ecosystem',
+  },
+  {
+    key: 'projects',
+    target:
+      'products, repos, or initiatives named, with their status or purpose (only what is stated)',
+  },
+  {
+    key: 'decisions',
+    target: 'choices Zaal made or locked, together with the stated reason',
+  },
+  {
+    key: 'commitments',
+    target:
+      'things Zaal said he will do, follow-ups he owes, or due dates he set',
+  },
+];
+
+interface Candidate {
+  name: string;
+  body: string;
+  confidence: number;
+}
+
+/** PII the extractor must never put in a graph episode (third-party leakage). */
+const EMAIL_RE = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
+const PHONE_RE = /\+?\d{1,3}[\s.-]?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\b/;
+/** Public ZAO/BCZ emails that are allowed to appear (see pii-hygiene.md). */
+const EMAIL_ALLOW = [
+  'zaal@thezao.com',
+  'zaalp99@gmail.com',
+  'zaal@bettercallzaal.com',
+  'zoe-zao@agentmail.to',
+  'hello@thezao.com',
+  'support@thezao.com',
+  'info@thezao.com',
+];
+
+export function containsPii(body: string): boolean {
+  const m = body.match(EMAIL_RE);
+  if (m && !EMAIL_ALLOW.includes(m[0].toLowerCase())) return true;
+  if (PHONE_RE.test(body)) return true;
+  return false;
+}
+
+/** Stable 12-char content hash. Same fact -> same hash -> idempotent + dedup. */
+export function bodyHash(body: string): string {
+  return createHash('sha256')
+    .update(body.trim().toLowerCase().replace(/\s+/g, ' '))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+function buildSystemPrompt(spec: ExtractorSpec, today: string): string {
+  return [
+    `You read a message Zaal sent to his assistant and extract ${spec.target}.`,
+    '',
+    'Output ONLY a raw JSON array. No prose, no markdown, no code fences.',
+    'Each array item is an object:',
+    '  {"body": string, "confidence": number}',
+    '',
+    'Rules:',
+    '- Extract ONLY facts literally stated in the message. Never infer, guess, or invent.',
+    `- "body" is one self-contained sentence that stands alone: name the who/what, and anchor it with "as of ${today}". A reader with no other context must understand it.`,
+    '- "confidence" is 0 to 1: how certain you are the fact is literally stated.',
+    '- If the message states no such fact, output exactly [].',
+    '- No emojis. No em dashes. No marketing language.',
+    '- Do NOT include anyone\'s personal email, phone number, or home address.',
+    '',
+    'Output the JSON array and nothing else.',
+  ].join('\n');
+}
+
+/** Defensively pull the first JSON array out of a model response. */
+export function parseCandidates(text: string, key: string): Candidate[] {
+  const start = text.indexOf('[');
+  const end = text.lastIndexOf(']');
+  if (start === -1 || end === -1 || end <= start) return [];
+  let arr: unknown;
+  try {
+    arr = JSON.parse(text.slice(start, end + 1));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(arr)) return [];
+  const out: Candidate[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+    const body = (item as Record<string, unknown>).body;
+    const confidence = (item as Record<string, unknown>).confidence;
+    if (typeof body !== 'string' || typeof confidence !== 'number') continue;
+    const clean = body.trim();
+    if (clean.length < 12) continue;
+    out.push({
+      name: `extract:${key}:${bodyHash(clean)}`,
+      body: clean,
+      confidence,
+    });
+  }
+  return out;
+}
+
+async function loadSeen(): Promise<Set<string>> {
+  try {
+    const raw = await fs.readFile(SEEN_PATH, 'utf8');
+    const arr = JSON.parse(raw) as unknown;
+    return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+  } catch {
+    return new Set();
+  }
+}
+
+async function saveSeen(seen: Set<string>): Promise<void> {
+  // Keep the most recent SEEN_MAX hashes (insertion order = Set iteration order).
+  const arr = [...seen].slice(-SEEN_MAX);
+  try {
+    await fs.mkdir(ZOE_HOME, { recursive: true });
+    await fs.writeFile(SEEN_PATH, JSON.stringify(arr), 'utf8');
+  } catch (err) {
+    console.warn('[zoe/extractors] could not persist seen-episodes:', (err as Error).message);
+  }
+}
+
+async function runExtractor(
+  spec: ExtractorSpec,
+  message: string,
+  today: string,
+  cwd: string,
+): Promise<Candidate[]> {
+  const res = await callClaudeCli({
+    model: 'haiku',
+    prompt: message,
+    cwd,
+    appendSystemPrompt: buildSystemPrompt(spec, today),
+    permissionMode: 'default',
+    outputFormat: 'json',
+    bare: true,
+    timeoutMs: EXTRACT_TIMEOUT_MS,
+    maxBudgetUsd: EXTRACT_BUDGET_USD,
+  });
+  if (res.isError) return [];
+  return parseCandidates(res.text, spec.key);
+}
+
+export interface FanOutResult {
+  written: number;
+  skipped: number;
+}
+
+/**
+ * Fan out the 4 extractors over a Zaal message, write the clean high-confidence
+ * facts to the graph. Best-effort: never throws.
+ *
+ * Caller should gate on scope === 'private' && message.length >= EXTRACT_MIN_LEN
+ * before calling, but this function re-checks the length defensively.
+ */
+export async function fanOutKnowledgeExtractors(
+  message: string,
+  opts: { cwd: string; today?: string },
+): Promise<FanOutResult> {
+  if (!bonfireConfigured()) return { written: 0, skipped: 0 };
+  const trimmed = message.trim();
+  if (trimmed.length < EXTRACT_MIN_LEN) return { written: 0, skipped: 0 };
+
+  const today = opts.today ?? new Date().toISOString().slice(0, 10);
+
+  const settled = await Promise.allSettled(
+    EXTRACTORS.map((spec) => runExtractor(spec, trimmed, today, opts.cwd)),
+  );
+
+  const candidates: Candidate[] = [];
+  for (const s of settled) {
+    if (s.status === 'fulfilled') candidates.push(...s.value);
+  }
+
+  const seen = await loadSeen();
+  let written = 0;
+  let skipped = 0;
+
+  for (const c of candidates) {
+    if (c.confidence < CONFIDENCE_MIN) {
+      skipped++;
+      continue;
+    }
+    const hash = bodyHash(c.body);
+    if (seen.has(hash)) {
+      skipped++;
+      continue;
+    }
+    if (containsPii(c.body)) {
+      console.warn('[zoe/extractors] skipped episode with PII-shaped content');
+      skipped++;
+      continue;
+    }
+    // remember() runs its own secret scan and the actual POST.
+    const r = await remember({
+      body: c.body,
+      name: c.name,
+      sourceTag: 'zoe:extract',
+    });
+    if (r.ok) {
+      seen.add(hash);
+      written++;
+    } else {
+      skipped++;
+    }
+  }
+
+  if (written > 0) await saveSeen(seen);
+  return { written, skipped };
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -48,6 +48,7 @@ import { applyLearnProposal, type LearnProposal } from './learn';
 import { startScheduler } from './scheduler';
 import { disableNudges, enableNudges, nudgesEnabled } from './nudges';
 import { mirrorTurn, recall } from './recall';
+import { fanOutKnowledgeExtractors, EXTRACT_MIN_LEN } from './extractors';
 import {
   addAllowlistMember,
   getGroupConfig,
@@ -797,6 +798,20 @@ async function dispatchConcierge(
         }
       })
       .catch((e) => console.error('[zoe/index] bonfire mirror failed:', e));
+
+    // Knowledge extraction fan-out (doc 862): on substantive DMs, fan out 4
+    // Haiku readers that comb Zaal's message for people/projects/decisions/
+    // commitments and write graph-ready episodes. Silent, fire-and-forget,
+    // never blocks the reply. DMs only - group chatter does not seed Zaal's graph.
+    if (scope === 'private' && text.trim().length >= EXTRACT_MIN_LEN) {
+      fanOutKnowledgeExtractors(text, { cwd: repoDir })
+        .then((f) => {
+          if (f.written > 0) {
+            console.log(`[zoe/index] extract — ${f.written} episode(s), ${f.skipped} skipped`);
+          }
+        })
+        .catch((e) => console.error('[zoe/index] extract fan-out failed:', e));
+    }
 
     await pushRecent({ from: 'zoe', text: result.reply }, scope);
 


### PR DESCRIPTION
## Summary
Implements doc 862. After each substantive Zaal DM, ZOE fans out 4 cheap Haiku readers (people / projects / decisions / commitments) that extract literally-stated facts and write graph-ready episodes to the ZABAL Bonfire. Hooked after mirrorTurn() in index.ts, silent + fire-and-forget. Conversation becomes durable graph memory.

## Guardrails
- confidence >= 0.7 to write
- content-hash dedup via seen-episodes.json (idempotent; Graphiti node-merge handles near-dups)
- secret scan (via remember) + PII scan (non-allowlisted email/phone blocked)
- DMs only, length gate >= 40 chars
- never blocks the reply, never throws

## Tests
18 unit tests (parse / PII / dedup / fan-out success+error paths). All green. extractors.ts typechecks clean.

## Deploy
After merge: repoint VPS clone to main, git pull, restart via scripts/zoe-deploy.sh. Verify by DMing a rich intro and checking /delve returns the new extract:* episodes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>