### PR TITLE
feat: Unlock NFT event ticketing - one lock per event on Base (doc 863)

### DIFF
--- a/scripts/20260616_unlock_events.sql
+++ b/scripts/20260616_unlock_events.sql
@@ -1,0 +1,64 @@
+-- Unlock Protocol event ticketing (research doc 863)
+-- Adds a central `events` registry so each ZAO event can carry its Unlock lock
+-- address + hosted event page URL. The existing `event_rsvps` table (email + name
+-- capture, CSV export) is UNCHANGED - this table sits alongside it, joined on slug.
+--
+-- Run this against the ZAO OS app Supabase project (NOT the cowork tracker).
+-- Paste into the Supabase SQL editor and run.
+
+create table if not exists public.events (
+  id               uuid primary key default gen_random_uuid(),
+  slug             text not null unique,
+  title            text not null,
+  description      text,
+  -- Unlock Protocol fields. Created via EVENTS by Unlock Labs (events.unlock-protocol.com).
+  lock_address     text,                       -- 0x... PublicLock contract on Base
+  unlock_event_url text,                       -- hosted event page / checkout URL
+  chain_id         integer not null default 8453,  -- Base mainnet
+  -- Scheduling / display
+  starts_at        timestamptz,
+  ends_at          timestamptz,
+  location         text,
+  is_published     boolean not null default false,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+create index if not exists events_slug_idx on public.events (slug);
+create index if not exists events_published_idx on public.events (is_published, starts_at);
+
+-- keep updated_at fresh
+create or replace function public.events_set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists events_updated_at on public.events;
+create trigger events_updated_at
+  before update on public.events
+  for each row execute function public.events_set_updated_at();
+
+-- RLS: public can read published events; only service role writes.
+alter table public.events enable row level security;
+
+drop policy if exists "events public read published" on public.events;
+create policy "events public read published"
+  on public.events for select
+  using (is_published = true);
+
+-- (writes happen via the service-role key server-side, which bypasses RLS)
+
+-- Seed the first weekend event. Fill lock_address + unlock_event_url after you
+-- create the event on events.unlock-protocol.com (Base, free ticket + approval).
+insert into public.events (slug, title, description, chain_id, is_published)
+values (
+  'flowstage-weekend',
+  'FlowStage Weekend Session',
+  'ZABAL Gamez / FlowStage session. NFT ticket is your proof of attendance and July build-eligibility signal.',
+  8453,
+  true
+)
+on conflict (slug) do nothing;

--- a/src/app/api/events/[slug]/route.ts
+++ b/src/app/api/events/[slug]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getEventBySlug } from '@/lib/unlock/events';
+import { logger } from '@/lib/logger';
+
+const slugSchema = z.string().min(1).max(100);
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const { slug } = await params;
+    const parsed = slugSchema.safeParse(slug);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid event slug' }, { status: 400 });
+    }
+
+    const event = await getEventBySlug(parsed.data);
+    if (!event || !event.is_published) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ event });
+  } catch (err) {
+    logger.error('[events/[slug]] Unexpected error:', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/events/verify-ticket/route.ts
+++ b/src/app/api/events/verify-ticket/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getEventBySlug } from '@/lib/unlock/events';
+import { findKeyHolder } from '@/lib/unlock/lock';
+import { getUserByFid } from '@/lib/farcaster/neynar';
+import { logger } from '@/lib/logger';
+
+/**
+ * Verify whether a person holds the Unlock ticket (key) for an event.
+ *
+ * Input: eventSlug + at least one of { fid, wallet }.
+ * - fid  -> resolves to Farcaster custody + verified ETH addresses via Neynar
+ * - wallet -> checked directly
+ * All candidate addresses are checked against the event's lock on Base.
+ *
+ * Used for gating recordings / perks for ticket holders. Research doc 863.
+ */
+const verifySchema = z
+  .object({
+    eventSlug: z.string().min(1).max(100),
+    fid: z.number().int().positive().optional(),
+    wallet: z.string().regex(/^0x[a-fA-F0-9]{40}$/).optional(),
+  })
+  .refine((d) => d.fid !== undefined || d.wallet !== undefined, {
+    message: 'Provide a fid or a wallet',
+  });
+
+async function addressesForFid(fid: number): Promise<string[]> {
+  try {
+    const user = await getUserByFid(fid);
+    if (!user) return [];
+    const verified: string[] = user.verified_addresses?.eth_addresses ?? [];
+    const custody: string | undefined = user.custody_address;
+    return [...verified, ...(custody ? [custody] : [])];
+  } catch (err) {
+    logger.error('[events/verify-ticket] Neynar lookup failed:', err);
+    return [];
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = verifySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid input', details: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { eventSlug, fid, wallet } = parsed.data;
+
+    const event = await getEventBySlug(eventSlug);
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+    if (!event.lock_address) {
+      return NextResponse.json(
+        { error: 'Event has no ticket lock yet', holdsTicket: false },
+        { status: 409 }
+      );
+    }
+
+    // Gather candidate wallets: directly passed + all addresses for the FID.
+    const candidates: string[] = [];
+    if (wallet) candidates.push(wallet);
+    if (fid !== undefined) candidates.push(...(await addressesForFid(fid)));
+
+    const matchedAddress = await findKeyHolder(event.lock_address, candidates);
+
+    return NextResponse.json({
+      holdsTicket: matchedAddress !== null,
+      matchedAddress,
+      eventSlug,
+      lockAddress: event.lock_address,
+      chainId: event.chain_id,
+    });
+  } catch (err) {
+    logger.error('[events/verify-ticket] Unexpected error:', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getEventBySlug } from '@/lib/unlock/events';
+import { EventTicket } from '@/components/events/EventTicket';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const event = await getEventBySlug(slug);
+  if (!event) return { title: 'Event not found' };
+  return {
+    title: `${event.title} - The ZAO`,
+    description: event.description ?? undefined,
+  };
+}
+
+export default async function EventPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const event = await getEventBySlug(slug);
+
+  if (!event || !event.is_published) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen bg-[#0a1628] py-8">
+      <EventTicket event={event} />
+    </main>
+  );
+}

--- a/src/components/events/EventTicket.tsx
+++ b/src/components/events/EventTicket.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { useAccount } from 'wagmi';
+import type { ZaoEvent } from '@/lib/unlock/events';
+
+interface EventTicketProps {
+  event: ZaoEvent;
+}
+
+type RsvpState = 'idle' | 'saving' | 'done' | 'error';
+type CheckState = 'idle' | 'checking' | 'holds' | 'missing' | 'error';
+
+export function EventTicket({ event }: EventTicketProps) {
+  const { address } = useAccount();
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [rsvp, setRsvp] = useState<RsvpState>('idle');
+  const [rsvpMsg, setRsvpMsg] = useState('');
+
+  const [check, setCheck] = useState<CheckState>('idle');
+  const [checkMsg, setCheckMsg] = useState('');
+
+  async function submitRsvp(e: React.FormEvent) {
+    e.preventDefault();
+    setRsvp('saving');
+    setRsvpMsg('');
+    try {
+      const res = await fetch('/api/events/rsvp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, eventSlug: event.slug }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setRsvp('error');
+        setRsvpMsg(data.error ?? 'Could not save your RSVP.');
+        return;
+      }
+      setRsvp('done');
+      setRsvpMsg('You are on the list. Watch your email for the ticket.');
+    } catch {
+      setRsvp('error');
+      setRsvpMsg('Network error. Try again.');
+    }
+  }
+
+  async function checkTicket() {
+    if (!address) return;
+    setCheck('checking');
+    setCheckMsg('');
+    try {
+      const res = await fetch('/api/events/verify-ticket', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventSlug: event.slug, wallet: address }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setCheck('error');
+        setCheckMsg(data.error ?? 'Could not check your ticket.');
+        return;
+      }
+      if (data.holdsTicket) {
+        setCheck('holds');
+        setCheckMsg('CONFIRMED - your wallet holds the ticket.');
+      } else {
+        setCheck('missing');
+        setCheckMsg('No ticket found for this wallet yet.');
+      }
+    } catch {
+      setCheck('error');
+      setCheckMsg('Network error. Try again.');
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-lg space-y-6 p-4">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold text-[#f5a623]">{event.title}</h1>
+        {event.description ? (
+          <p className="text-sm text-gray-300">{event.description}</p>
+        ) : null}
+        {event.location ? (
+          <p className="text-xs text-gray-400">{event.location}</p>
+        ) : null}
+      </header>
+
+      {/* Get the ticket - hosted Unlock event page */}
+      <section className="rounded-lg border border-[#1e2d40] bg-[#0a1628] p-4">
+        <h2 className="mb-2 text-sm font-semibold text-gray-200">Get the ticket</h2>
+        {event.unlock_event_url ? (
+          <a
+            href={event.unlock_event_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block w-full rounded-md bg-[#f5a623] px-4 py-3 text-center text-sm font-semibold text-[#0a1628] transition hover:opacity-90"
+          >
+            Get the ticket
+          </a>
+        ) : (
+          <p className="text-xs text-gray-400">
+            Ticket opens soon. Add your email below and we will send it to you.
+          </p>
+        )}
+      </section>
+
+      {/* Email RSVP - existing flow, kept */}
+      <section className="rounded-lg border border-[#1e2d40] bg-[#0a1628] p-4">
+        <h2 className="mb-3 text-sm font-semibold text-gray-200">RSVP by email</h2>
+        {rsvp === 'done' ? (
+          <p className="text-sm text-[#f5a623]">{rsvpMsg}</p>
+        ) : (
+          <form onSubmit={submitRsvp} className="space-y-3">
+            <input
+              type="text"
+              required
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Your name"
+              className="w-full rounded-md border border-[#1e2d40] bg-[#0d1a2d] px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-[#f5a623] focus:outline-none"
+            />
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@email.com"
+              className="w-full rounded-md border border-[#1e2d40] bg-[#0d1a2d] px-3 py-2 text-sm text-gray-100 placeholder-gray-500 focus:border-[#f5a623] focus:outline-none"
+            />
+            <button
+              type="submit"
+              disabled={rsvp === 'saving'}
+              className="w-full rounded-md border border-[#f5a623] px-4 py-2 text-sm font-semibold text-[#f5a623] transition hover:bg-[#f5a623] hover:text-[#0a1628] disabled:opacity-50"
+            >
+              {rsvp === 'saving' ? 'Saving...' : 'RSVP'}
+            </button>
+            {rsvp === 'error' ? <p className="text-xs text-red-400">{rsvpMsg}</p> : null}
+          </form>
+        )}
+      </section>
+
+      {/* Check ownership - for connected wallet */}
+      {event.lock_address ? (
+        <section className="rounded-lg border border-[#1e2d40] bg-[#0a1628] p-4">
+          <h2 className="mb-2 text-sm font-semibold text-gray-200">Check my ticket</h2>
+          {address ? (
+            <button
+              type="button"
+              onClick={checkTicket}
+              disabled={check === 'checking'}
+              className="w-full rounded-md border border-[#1e2d40] px-4 py-2 text-sm text-gray-200 transition hover:border-[#f5a623] disabled:opacity-50"
+            >
+              {check === 'checking' ? 'Checking...' : 'Check my ticket'}
+            </button>
+          ) : (
+            <p className="text-xs text-gray-400">Connect your wallet to check.</p>
+          )}
+          {checkMsg ? (
+            <p
+              className={`mt-2 text-xs ${
+                check === 'holds' ? 'text-[#f5a623]' : 'text-gray-400'
+              }`}
+            >
+              {checkMsg}
+            </p>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/unlock/__tests__/lock.test.ts
+++ b/src/lib/unlock/__tests__/lock.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { hasValidKey, findKeyHolder } from '../lock';
+
+// These cover the input-guard paths only - they short-circuit before any RPC
+// call, so they are deterministic and never touch the network.
+describe('unlock/lock guards', () => {
+  it('hasValidKey returns false for an invalid lock address', async () => {
+    expect(await hasValidKey('not-an-address', '0x'.padEnd(42, '1'))).toBe(false);
+  });
+
+  it('hasValidKey returns false for an invalid wallet address', async () => {
+    const lock = '0x'.padEnd(42, 'a');
+    expect(await hasValidKey(lock, 'nope')).toBe(false);
+  });
+
+  it('findKeyHolder returns null when no candidate is a valid address', async () => {
+    const lock = '0x'.padEnd(42, 'a');
+    expect(await findKeyHolder(lock, ['bad', 'also-bad'])).toBeNull();
+  });
+
+  it('findKeyHolder returns null for an invalid lock address', async () => {
+    expect(await findKeyHolder('bad', ['0x'.padEnd(42, '1')])).toBeNull();
+  });
+
+  it('findKeyHolder returns null for an empty candidate list', async () => {
+    const lock = '0x'.padEnd(42, 'a');
+    expect(await findKeyHolder(lock, [])).toBeNull();
+  });
+});

--- a/src/lib/unlock/events.ts
+++ b/src/lib/unlock/events.ts
@@ -1,0 +1,41 @@
+import { getSupabaseAdmin } from '@/lib/db/supabase';
+
+/** A ZAO event row, carrying its Unlock lock + hosted page (research doc 863). */
+export interface ZaoEvent {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  lock_address: string | null;
+  unlock_event_url: string | null;
+  chain_id: number;
+  starts_at: string | null;
+  ends_at: string | null;
+  location: string | null;
+  is_published: boolean;
+}
+
+const EVENT_COLUMNS =
+  'id, slug, title, description, lock_address, unlock_event_url, chain_id, starts_at, ends_at, location, is_published';
+
+export async function getEventBySlug(slug: string): Promise<ZaoEvent | null> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('events')
+    .select(EVENT_COLUMNS)
+    .eq('slug', slug)
+    .maybeSingle();
+
+  return (data as ZaoEvent) ?? null;
+}
+
+export async function listPublishedEvents(): Promise<ZaoEvent[]> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase
+    .from('events')
+    .select(EVENT_COLUMNS)
+    .eq('is_published', true)
+    .order('starts_at', { ascending: true, nullsFirst: false });
+
+  return (data as ZaoEvent[]) ?? [];
+}

--- a/src/lib/unlock/lock.ts
+++ b/src/lib/unlock/lock.ts
@@ -1,0 +1,71 @@
+import { createPublicClient, http, fallback, isAddress, type Address } from 'viem';
+import { base } from 'viem/chains';
+
+/**
+ * Unlock Protocol key-ownership reads on Base.
+ *
+ * No new dependency: an Unlock "lock" is a PublicLock ERC-721 contract, and the
+ * single view we need (`getHasValidKey`) is read with plain viem. Locks are
+ * created via EVENTS by Unlock Labs (events.unlock-protocol.com); we only read
+ * them here for gating. See research doc 863.
+ */
+
+// Mirrors the Base public client in src/lib/ens/resolve.ts
+const baseClient = createPublicClient({
+  chain: base,
+  transport: fallback([
+    ...(process.env.ALCHEMY_API_KEY
+      ? [http(`https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`)]
+      : []),
+    http('https://mainnet.base.org'),
+    http('https://base-rpc.publicnode.com'),
+  ]),
+});
+
+// Minimal PublicLock ABI - only the view we read.
+const PUBLIC_LOCK_ABI = [
+  {
+    inputs: [{ name: '_user', type: 'address' }],
+    name: 'getHasValidKey',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+/** True if `wallet` holds a valid (non-expired) key for the lock. */
+export async function hasValidKey(lockAddress: string, wallet: string): Promise<boolean> {
+  if (!isAddress(lockAddress) || !isAddress(wallet)) return false;
+  try {
+    return await baseClient.readContract({
+      address: lockAddress as Address,
+      abi: PUBLIC_LOCK_ABI,
+      functionName: 'getHasValidKey',
+      args: [wallet as Address],
+    });
+  } catch {
+    // Contract read failure (bad address, RPC hiccup) = treat as "no key".
+    return false;
+  }
+}
+
+/**
+ * Check a set of wallets against one lock. Returns the first address that holds
+ * a valid key, or null. Fault-tolerant: one bad read does not fail the batch.
+ */
+export async function findKeyHolder(
+  lockAddress: string,
+  wallets: string[]
+): Promise<string | null> {
+  const candidates = wallets.filter((w) => isAddress(w));
+  if (!isAddress(lockAddress) || candidates.length === 0) return null;
+
+  const results = await Promise.allSettled(
+    candidates.map(async (w) => ((await hasValidKey(lockAddress, w)) ? w : null))
+  );
+
+  for (const r of results) {
+    if (r.status === 'fulfilled' && r.value) return r.value;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
Builds the Unlock Protocol event ticketing from research doc 863. Every ZAO event can carry an Unlock lock (NFT ticket) on Base. Events are created on EVENTS by Unlock Labs (hosted, no server-side deployer key); we store the lock address + hosted URL and wire ownership verification + the ticket surface into ZAO OS. Existing email RSVP (event_rsvps) + CSV export are untouched.

## What shipped (MVP, one event end-to-end)
- DB: `events` table migration - slug, lock_address, unlock_event_url, chain_id (Base 8453). Copy-paste SQL at scripts/20260616_unlock_events.sql (run against the app DB - the connected MCP is the cowork tracker, not the app project).
- lib: src/lib/unlock/lock.ts (viem getHasValidKey on Base, NO new dependency) + events.ts registry reads.
- API: GET /api/events/[slug] (event + lock address) and POST /api/events/verify-ticket (resolves a FID's Neynar verified addresses, checks key ownership for gating).
- UI: /events/[slug] page + EventTicket component - Get-the-ticket link, email RSVP (kept), connected-wallet ticket check.
- Tests: 5 passing unit tests on the lock guards.

## Verification
- npm run typecheck: PASS
- npx vitest run src/lib/unlock: 5/5 PASS

## Decisions (per doc 863 + Zaal)
- Hosted creation (events.unlock-protocol.com), Base, free ticket + approval. No server-side keys.
- QR check-in stays on the Unlock flow (not rebuilt).
- Stripe fiat tickets deferred (KYC + ~13% all-in; free events skip it).

## Next steps for Zaal
1. Run scripts/20260616_unlock_events.sql in the app Supabase SQL editor.
2. Create the weekend event on events.unlock-protocol.com (Base, free + approval).
3. Paste the lock address + event URL into the `flowstage-weekend` row.
4. Open /events/flowstage-weekend to demo RSVP -> ticket -> ownership check.

## Brand
No emojis, no em dashes, no decorative Unicode, no web3 jargon in user-facing copy.