### PR TITLE
overview: live fleet status in one place (+ refresh stale data)

### DIFF
--- a/src/app/(auth)/overview/OverviewPanel.tsx
+++ b/src/app/(auth)/overview/OverviewPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import {
   repoMap,
   botFleet,
@@ -8,9 +8,36 @@ import {
   tooling,
   toolingNote,
   improvements,
+  type BotRow,
   type BotStatus,
   type Priority,
 } from './data';
+
+interface LiveBot {
+  bot: string;
+  status: 'up' | 'degraded' | 'down';
+  online: boolean;
+  ageSeconds: number;
+  meta?: Record<string, unknown>;
+}
+
+interface FleetStatus {
+  configured: boolean;
+  fetchedAt: string;
+  bots: LiveBot[];
+  error?: string;
+}
+
+function normalizeId(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function formatAge(seconds: number): string {
+  if (seconds < 90) return `${Math.round(seconds)}s ago`;
+  if (seconds < 5400) return `${Math.round(seconds / 60)}m ago`;
+  if (seconds < 129_600) return `${Math.round(seconds / 3600)}h ago`;
+  return `${Math.round(seconds / 86_400)}d ago`;
+}
 
 type Tab = 'repo' | 'bots' | 'tooling' | 'fixes';
 
@@ -113,7 +140,64 @@ function RepoMap() {
   );
 }
 
+function LiveDot({ online }: { online: boolean }) {
+  return (
+    <span
+      className={`inline-block h-2 w-2 shrink-0 rounded-full ${
+        online ? 'bg-green-400 shadow-[0_0_6px] shadow-green-400/60' : 'bg-red-400'
+      }`}
+      aria-hidden
+    />
+  );
+}
+
+function LiveHeader({ status, loading }: { status: FleetStatus | null; loading: boolean }) {
+  if (loading) return <span className="text-[11px] text-white/40">checking live status…</span>;
+  if (!status) return null;
+  if (!status.configured)
+    return (
+      <span className="text-[11px] text-white/40">
+        live status not wired — set <code>COWORK_API_URL</code> + <code>COWORK_BOT_TOKEN</code>
+      </span>
+    );
+  if (status.error)
+    return <span className="text-[11px] text-red-400/80">live: {status.error}</span>;
+  const onlineCount = status.bots.filter((b) => b.online).length;
+  return (
+    <span className="text-[11px] text-white/40">
+      live · {onlineCount}/{status.bots.length} online · updated{' '}
+      {new Date(status.fetchedAt).toLocaleTimeString()}
+    </span>
+  );
+}
+
 function Bots() {
+  const [live, setLive] = useState<FleetStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/bots/status')
+      .then((r) => r.json() as Promise<FleetStatus>)
+      .then((d) => {
+        if (!cancelled) setLive(d);
+      })
+      .catch(() => {
+        if (!cancelled) setLive({ configured: false, fetchedAt: '', bots: [] });
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const liveById = new Map<string, LiveBot>();
+  for (const b of live?.bots ?? []) liveById.set(normalizeId(b.bot), b);
+  const liveFor = (row: BotRow): LiveBot | undefined =>
+    row.coworkId ? liveById.get(normalizeId(row.coworkId)) : undefined;
+
   return (
     <div className="space-y-5">
       <section>
@@ -137,22 +221,38 @@ function Bots() {
       </section>
 
       <section>
-        <h2 className="mb-2 text-sm font-semibold text-[#f5a623]">Fleet</h2>
+        <div className="mb-2 flex items-baseline justify-between gap-3">
+          <h2 className="text-sm font-semibold text-[#f5a623]">Fleet</h2>
+          <LiveHeader status={live} loading={loading} />
+        </div>
         <Card>
           <ul className="divide-y divide-white/5">
-            {botFleet.map((b) => (
-              <li key={b.name} className="flex items-start justify-between gap-3 py-2.5 first:pt-0 last:pb-0">
-                <div className="min-w-0">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium">{b.name}</span>
-                    <code className="text-xs text-white/40">{b.handle}</code>
+            {botFleet.map((b) => {
+              const l = liveFor(b);
+              const task = l?.meta?.current_task;
+              const uptime = l?.meta?.uptime;
+              return (
+                <li key={b.name} className="flex items-start justify-between gap-3 py-2.5 first:pt-0 last:pb-0">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {l && <LiveDot online={l.online} />}
+                      <span className="text-sm font-medium">{b.name}</span>
+                      <code className="text-xs text-white/40">{b.handle}</code>
+                    </div>
+                    <p className="mt-0.5 text-xs text-white/60">{b.board}</p>
+                    {l && (
+                      <p className="mt-0.5 text-[11px] text-white/50">
+                        {l.online ? 'online' : 'offline'} · seen {formatAge(l.ageSeconds)}
+                        {typeof uptime === 'string' || typeof uptime === 'number' ? ` · up ${uptime}` : ''}
+                        {typeof task === 'string' && task ? ` · ${task}` : ''}
+                      </p>
+                    )}
+                    <code className="text-[11px] text-white/30">{b.source}</code>
                   </div>
-                  <p className="mt-0.5 text-xs text-white/60">{b.board}</p>
-                  <code className="text-[11px] text-white/30">{b.source}</code>
-                </div>
-                <Badge label={b.status} className={BOT_STATUS_STYLE[b.status]} />
-              </li>
-            ))}
+                  <Badge label={b.status} className={BOT_STATUS_STYLE[b.status]} />
+                </li>
+              );
+            })}
           </ul>
         </Card>
       </section>

--- a/src/app/(auth)/overview/data.ts
+++ b/src/app/(auth)/overview/data.ts
@@ -1,7 +1,9 @@
 // Structured content for the /overview project dashboard.
 // Hand-maintained snapshot — update as the repo evolves. Sources: CLAUDE.md
 // Project Map, bot/REGISTRY.md, the .claude/skills catalog, and the bot audit.
-// Last refreshed: 2026-06-08.
+// The Bots tab overlays LIVE status from the cowork board (GET /api/bots/status)
+// on top of these rows, matched by `coworkId`.
+// Last refreshed: 2026-06-18.
 
 export interface RepoArea {
   area: string;
@@ -69,15 +71,15 @@ export interface BotRow {
   source: string;
   status: BotStatus;
   board: string;
+  /** Identity on the cowork heartbeat board, for overlaying live status. */
+  coworkId?: string;
 }
 
 export const botFleet: BotRow[] = [
-  { name: 'ZOE', handle: '@zaoclaw_bot', source: 'bot/src/zoe/', status: 'live', board: 'On board — full ask / run_task / lifecycle' },
-  { name: 'ZAO Devz', handle: '@zaodevz_bot', source: 'bot/src/devz/', status: 'live', board: 'On board — lifecycle' },
-  { name: 'Hermes', handle: '@zoe_hermes_bot', source: 'bot/src/hermes/ (in zao-devz-stack)', status: 'pending', board: 'Wired — needs token + Vercel redeploy' },
-  { name: 'ZAOstock', handle: '@ZAOstockTeamBot', source: 'bot/src/index.ts', status: 'live', board: 'On board — lifecycle (graduating)' },
-  { name: 'Magnetiq', handle: '@zao_magnetiq_bot', source: 'bot/src/teams/', status: 'decommissioned', board: 'Off — doc 601, fold into ZOE' },
-  { name: 'AttaBotty', handle: '@z_attabotty_bot', source: 'bot/src/teams/', status: 'decommissioned', board: 'Off — doc 601, fold into ZOE' },
+  { name: 'ZOE', handle: '@zaoclaw_bot', source: 'bot/src/zoe/', status: 'live', board: 'On board — full ask / run_task / lifecycle', coworkId: 'zoe' },
+  { name: 'ZAO Devz', handle: '@zaodevz_bot', source: 'bot/src/devz/', status: 'live', board: 'On board — lifecycle', coworkId: 'zao-devz' },
+  { name: 'Hermes', handle: '@zoe_hermes_bot', source: 'bot/src/hermes/ (in zao-devz-stack)', status: 'pending', board: 'Wired — needs token + Vercel redeploy', coworkId: 'hermes' },
+  { name: 'ZAOstock', handle: '@ZAOstockTeamBot', source: 'bot/src/index.ts', status: 'live', board: 'On board — lifecycle (graduating). Digests/alerts now DM Zaal, not the group', coworkId: 'zaostock' },
   { name: 'Bonfire', handle: '@zabal_bonfire', source: 'bonfires.ai', status: 'external', board: 'Off-VPS (Bonfires platform)' },
   { name: 'DeepMeeting', handle: '@zdeepmeeting_bot', source: 'bonfires.ai', status: 'external', board: 'Off-VPS — group routing broken' },
   { name: 'farscout', handle: 'Discord (DM + slash cmds)', source: 'github.com/bettercallzaal/farscout (cowork VPS 187.77.3.104)', status: 'live', board: 'Farcaster research scout — grounds findings in real sources, writes to ZABAL Bonfire (ZOE recalls via delve)' },
@@ -188,13 +190,6 @@ export const improvements: Improvement[] = [
     detail:
       'Hermes heartbeat code is wired (separate identity) but its token isn’t in the cowork COWORK_BOT_TOKENS env. Add hermes= token + redeploy + restart zao-devz-stack. Blocked on the Vercel daily-deploy cap.',
     effort: '~10min',
-  },
-  {
-    priority: 'P2',
-    title: 'Decommissioned code lingering',
-    detail:
-      'Magnetiq/AttaBotty (bot/src/teams/) is decommissioned per doc 601 but still in the tree. Archive or delete. (FISHBOWLZ has been removed from ZAOOS — it now lives standalone at fishbowlz.com.)',
-    effort: '1–2h',
   },
   {
     priority: 'P2',

--- a/src/app/api/bots/status/route.ts
+++ b/src/app/api/bots/status/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { getSessionData } from '@/lib/auth/session';
+
+// Live fleet status, proxied from the cowork control-plane board
+// (GET /api/v1/bots on the cowork-zaodevz app). Heartbeats live in that app's
+// Supabase, not ours, so this route is a thin server-side proxy: it injects the
+// bot bearer token (server-only) and normalizes the response for the /overview
+// Bots tab. Admin-gated — this is ops data.
+//
+// Config (Vercel env, server-only):
+//   COWORK_API_URL   e.g. https://www.thezao.xyz
+//   COWORK_BOT_TOKEN a bot bearer token with read access to /api/v1/bots
+// If either is missing, returns { configured: false } so the UI can show a
+// "not wired up" hint instead of erroring.
+
+export const dynamic = 'force-dynamic';
+
+interface CoworkBot {
+  bot: string;
+  status: 'up' | 'degraded' | 'down';
+  ts: string;
+  online: boolean;
+  ageSeconds: number;
+  meta?: Record<string, unknown>;
+}
+
+interface FleetStatusResponse {
+  configured: boolean;
+  fetchedAt: string;
+  bots: CoworkBot[];
+  error?: string;
+}
+
+export async function GET(): Promise<NextResponse<FleetStatusResponse>> {
+  const session = await getSessionData();
+  if (!session?.isAdmin) {
+    return NextResponse.json(
+      { configured: false, fetchedAt: new Date().toISOString(), bots: [], error: 'unauthorized' },
+      { status: 401 },
+    );
+  }
+
+  const base = process.env.COWORK_API_URL;
+  const token = process.env.COWORK_BOT_TOKEN;
+  if (!base || !token) {
+    return NextResponse.json({
+      configured: false,
+      fetchedAt: new Date().toISOString(),
+      bots: [],
+    });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 6000);
+    const res = await fetch(`${base.replace(/\/$/, '')}/api/v1/bots`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    }).finally(() => clearTimeout(timeout));
+
+    if (!res.ok) {
+      return NextResponse.json(
+        {
+          configured: true,
+          fetchedAt: new Date().toISOString(),
+          bots: [],
+          error: `cowork board returned ${res.status}`,
+        },
+        { status: 502 },
+      );
+    }
+
+    const data = (await res.json()) as { bots?: CoworkBot[] };
+    return NextResponse.json({
+      configured: true,
+      fetchedAt: new Date().toISOString(),
+      bots: Array.isArray(data.bots) ? data.bots : [],
+    });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown error';
+    console.error('[api/bots/status] cowork fetch failed:', message);
+    return NextResponse.json(
+      {
+        configured: true,
+        fetchedAt: new Date().toISOString(),
+        bots: [],
+        error: 'could not reach the cowork board',
+      },
+      { status: 502 },
+    );
+  }
+}


### PR DESCRIPTION
Answers "can I see this all in one place?" — the `/overview` page (admin-gated) already aggregates the repo map, bot fleet, tooling, and improvements, but the Bots tab was a **static, hand-maintained snapshot** (last refreshed 2026-06-08, and stale — it still listed the team bots that were just deleted). This makes it **live** and refreshes it.

## What you get
- **Live fleet status, in ZAOOS.** The Bots tab now overlays real heartbeat data from the cowork board: a green/red **online dot**, **last-seen age**, and **uptime + current task** (from heartbeat `meta`), matched to each row by `coworkId`. A header line shows `live · N/M online · updated <time>`.
- **No more SSH/SQL to answer "are the boys alive + how busy."** It's on the page you already use.

## How it's wired (safely)
- New **admin-gated** route `GET /api/bots/status` — a thin server-side proxy to cowork's existing `GET /api/v1/bots`. The bot bearer token is injected server-side and **never reaches the browser**. Session-checked (401 if not admin), 6s timeout, try/catch, sanitized errors.
- The heartbeat tables live in the **cowork-zaodevz** Supabase, not ours — so this proxies rather than duplicating. Set `COWORK_API_URL` + `COWORK_BOT_TOKEN` (server-only) in Vercel to light it up; until then the route returns `{ configured: false }` and the panel shows the static fleet with a clear "not wired" hint (no errors).

## Data refresh
- Dropped the deleted **Magnetiq/AttaBotty** rows.
- Noted **ZAOstock now DMs Zaal** (from the last PR), not the group.
- Removed the now-resolved "decommissioned code lingering" improvement; bumped the date.

## Verify
- App typecheck clean (`tsc --noEmit`, exit 0). Token never exposed (server-only env). Graceful when unconfigured.
- Couldn't end-to-end test the *live* fetch from here (no cowork token/URL in this env, and it's a different app) — the unconfigured + error paths are handled defensively; the live path will exercise once the two env vars are set in Vercel.

⚙️ One config step to go live: add `COWORK_API_URL` and a read-capable `COWORK_BOT_TOKEN` to the ZAOOS Vercel env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKmv8E6c8yBGJPwEs9vNA3

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKmv8E6c8yBGJPwEs9vNA3)_