### PR TITLE
feat(scrape): BetterCallZaal Farcaster full post-history scraper

### DIFF
--- a/src/lib/scrape/__tests__/bcz-history.test.ts
+++ b/src/lib/scrape/__tests__/bcz-history.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  paginateCasts,
+  scrapeBczFarcasterHistory,
+  BczScrapeError,
+  type FetchCastPage,
+  type CastPage,
+} from '../bcz-history';
+
+function rawCast(hash: string, text: string, likes = 0): unknown {
+  return {
+    hash,
+    text,
+    timestamp: '2026-06-17T00:00:00Z',
+    reactions: { likes_count: likes, recasts_count: 1 },
+    replies: { count: 2 },
+  };
+}
+
+/** A fake page fetcher backed by an in-memory list of pages. */
+function pagedFetcher(pages: CastPage[]): FetchCastPage {
+  let i = 0;
+  return async () => {
+    const page = pages[i] ?? { casts: [], nextCursor: null };
+    i += 1;
+    return page;
+  };
+}
+
+describe('paginateCasts', () => {
+  it('follows cursors across pages and normalizes casts', async () => {
+    const fetchPage = pagedFetcher([
+      { casts: [rawCast('0xa', 'first', 5)], nextCursor: 'c1' },
+      { casts: [rawCast('0xb', 'second')], nextCursor: 'c2' },
+      { casts: [rawCast('0xc', 'third')], nextCursor: null },
+    ]);
+    const { casts, truncated } = await paginateCasts(fetchPage);
+    expect(casts.map((c) => c.hash)).toEqual(['0xa', '0xb', '0xc']);
+    expect(casts[0].likes).toBe(5);
+    expect(casts[0].recasts).toBe(1);
+    expect(casts[0].replies).toBe(2);
+    expect(truncated).toBe(false);
+  });
+
+  it('dedupes casts that appear on multiple pages', async () => {
+    const fetchPage = pagedFetcher([
+      { casts: [rawCast('0xa', 'first'), rawCast('0xb', 'second')], nextCursor: 'c1' },
+      { casts: [rawCast('0xb', 'second-dup'), rawCast('0xc', 'third')], nextCursor: null },
+    ]);
+    const { casts } = await paginateCasts(fetchPage);
+    expect(casts.map((c) => c.hash)).toEqual(['0xa', '0xb', '0xc']);
+  });
+
+  it('marks truncated when maxPages is hit with a pending cursor', async () => {
+    const fetchPage = pagedFetcher([
+      { casts: [rawCast('0xa', 'a')], nextCursor: 'c1' },
+      { casts: [rawCast('0xb', 'b')], nextCursor: 'c2' },
+    ]);
+    const { casts, truncated } = await paginateCasts(fetchPage, { maxPages: 2 });
+    expect(casts).toHaveLength(2);
+    expect(truncated).toBe(true);
+  });
+
+  it('skips malformed casts without throwing', async () => {
+    const fetchPage = pagedFetcher([
+      { casts: [{ no_hash: true }, rawCast('0xa', 'good')], nextCursor: null },
+    ]);
+    const { casts } = await paginateCasts(fetchPage);
+    expect(casts.map((c) => c.hash)).toEqual(['0xa']);
+  });
+});
+
+describe('scrapeBczFarcasterHistory', () => {
+  it('returns full normalized history with a custom fetchPage', async () => {
+    const fetchPage = pagedFetcher([
+      { casts: [rawCast('0xa', 'one'), rawCast('0xb', 'two')], nextCursor: null },
+    ]);
+    const history = await scrapeBczFarcasterHistory(3, { fetchPage });
+    expect(history.fid).toBe(3);
+    expect(history.total).toBe(2);
+    expect(history.truncated).toBe(false);
+  });
+
+  it('throws on invalid fid', async () => {
+    await expect(scrapeBczFarcasterHistory(0, { fetchPage: pagedFetcher([]) })).rejects.toBeInstanceOf(
+      BczScrapeError,
+    );
+  });
+
+  it('throws when neither fetchPage nor apiKey is provided', async () => {
+    await expect(scrapeBczFarcasterHistory(3)).rejects.toBeInstanceOf(BczScrapeError);
+  });
+});

--- a/src/lib/scrape/bcz-history.ts
+++ b/src/lib/scrape/bcz-history.ts
@@ -1,0 +1,158 @@
+/**
+ * BetterCallZaal Farcaster post-history scraper.
+ *
+ * Neynar's `/feed/user/casts` (and the repo's getUserCasts) returns at most one
+ * page. To get the FULL post history you must follow the `next.cursor` until it
+ * is empty. This module provides a pure, testable cursor paginator plus a thin
+ * Neynar adapter, with Zod-validated, normalized output.
+ *
+ * The core `paginateCasts` takes an injectable page fetcher so it can be unit
+ * tested without network or an API key.
+ *
+ * Usage:
+ *   const history = await scrapeBczFarcasterHistory(fid, { apiKey });
+ *   console.log(history.total, history.casts[0].text);
+ */
+
+import { z } from 'zod';
+
+/** A single Farcaster cast in a Neynar feed page (subset we read). */
+const RawCastSchema = z
+  .object({
+    hash: z.string(),
+    text: z.string().optional(),
+    timestamp: z.string().optional(),
+    reactions: z
+      .object({ likes_count: z.number().optional(), recasts_count: z.number().optional() })
+      .partial()
+      .passthrough()
+      .optional(),
+    replies: z.object({ count: z.number().optional() }).partial().passthrough().optional(),
+  })
+  .passthrough();
+
+export interface NormalizedCast {
+  hash: string;
+  text: string;
+  timestamp: string | null;
+  likes: number;
+  recasts: number;
+  replies: number;
+}
+
+export interface CastPage {
+  casts: unknown[];
+  nextCursor: string | null;
+}
+
+export interface BczHistory {
+  fid: number;
+  total: number;
+  casts: NormalizedCast[];
+  /** True when pagination stopped at maxPages rather than exhausting history. */
+  truncated: boolean;
+}
+
+export class BczScrapeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BczScrapeError';
+  }
+}
+
+/** A function that fetches one page of casts given a cursor (null for the first page). */
+export type FetchCastPage = (cursor: string | null) => Promise<CastPage>;
+
+function normalizeCast(raw: unknown): NormalizedCast | null {
+  const parsed = RawCastSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  const c = parsed.data;
+  return {
+    hash: c.hash,
+    text: (c.text ?? '').trim(),
+    timestamp: c.timestamp ?? null,
+    likes: c.reactions?.likes_count ?? 0,
+    recasts: c.reactions?.recasts_count ?? 0,
+    replies: c.replies?.count ?? 0,
+  };
+}
+
+/**
+ * Follow cursors through every page, deduping by hash, until the cursor is empty
+ * or maxPages is reached. Pure - the page fetcher is injected.
+ */
+export async function paginateCasts(
+  fetchPage: FetchCastPage,
+  opts: { maxPages?: number } = {},
+): Promise<{ casts: NormalizedCast[]; truncated: boolean }> {
+  const maxPages = opts.maxPages ?? 50;
+  const seen = new Set<string>();
+  const casts: NormalizedCast[] = [];
+  let cursor: string | null = null;
+  let page = 0;
+
+  while (page < maxPages) {
+    const result: CastPage = await fetchPage(cursor);
+    for (const raw of result.casts) {
+      const n = normalizeCast(raw);
+      if (n && !seen.has(n.hash)) {
+        seen.add(n.hash);
+        casts.push(n);
+      }
+    }
+    page += 1;
+    if (!result.nextCursor) {
+      return { casts, truncated: false };
+    }
+    cursor = result.nextCursor;
+  }
+  // Hit the page cap with a cursor still pending.
+  return { casts, truncated: true };
+}
+
+const NEYNAR_BASE = 'https://api.neynar.com/v2/farcaster';
+
+/** Build a Neynar-backed page fetcher for a fid. Injectable fetch for tests. */
+export function neynarCastPageFetcher(
+  fid: number,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): FetchCastPage {
+  return async (cursor: string | null): Promise<CastPage> => {
+    const params = new URLSearchParams({ fid: String(fid), limit: '100' });
+    if (cursor) params.set('cursor', cursor);
+    const res = await fetchImpl(`${NEYNAR_BASE}/feed/user/casts?${params}`, {
+      headers: { 'x-api-key': apiKey, Accept: 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!res.ok) {
+      throw new BczScrapeError(`Neynar casts error ${res.status} for fid ${fid}`);
+    }
+    const data = (await res.json()) as { casts?: unknown[]; next?: { cursor?: string | null } };
+    return { casts: data.casts ?? [], nextCursor: data.next?.cursor ?? null };
+  };
+}
+
+/**
+ * Scrape the full Farcaster post history for a fid (BetterCallZaal by default
+ * resolves elsewhere). Pass a custom `fetchPage` in tests; otherwise provide an
+ * `apiKey` to use Neynar.
+ */
+export async function scrapeBczFarcasterHistory(
+  fid: number,
+  opts: { apiKey?: string; fetchImpl?: typeof fetch; fetchPage?: FetchCastPage; maxPages?: number } = {},
+): Promise<BczHistory> {
+  if (!Number.isInteger(fid) || fid <= 0) {
+    throw new BczScrapeError(`Invalid fid: ${fid}`);
+  }
+  const fetchPage =
+    opts.fetchPage ??
+    (opts.apiKey
+      ? neynarCastPageFetcher(fid, opts.apiKey, opts.fetchImpl)
+      : null);
+  if (!fetchPage) {
+    throw new BczScrapeError('scrapeBczFarcasterHistory requires either opts.fetchPage or opts.apiKey');
+  }
+  const { casts, truncated } = await paginateCasts(fetchPage, { maxPages: opts.maxPages });
+  return { fid, total: casts.length, casts, truncated };
+}


### PR DESCRIPTION
src/lib/scrape/bcz-history.ts: cursor-paginates Neynar /feed/user/casts past the 1-page getUserCasts limit for FULL history. Pure paginateCasts() with injectable page fetcher, dedupe-by-hash, Zod-validated normalized casts, truncated flag. 7 vitest cases pass. No new deps.