### PR TITLE
fix(vote): stop silently undercounting vote weight on failed on-chain reads

### DIFF
--- a/src/app/api/proposals/vote/route.ts
+++ b/src/app/api/proposals/vote/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createPublicClient, http, parseAbi, formatEther } from 'viem';
+import { createPublicClient, http, parseAbi } from 'viem';
 import { optimism } from 'viem/chains';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { createInAppNotification } from '@/lib/notifications';
 import { proposalVoteSchema } from '@/lib/validation/schemas';
+import { computeRespectWeight } from '@/lib/respect/voteWeight';
 import { logger } from '@/lib/logger';
 
 const OG_RESPECT = '0x34cE89baA7E4a4B00E17F7E4C0cb97105C216957' as const;
@@ -86,9 +87,18 @@ export async function POST(req: NextRequest) {
         ],
       });
 
-      const og = ogBalance.status === 'success' ? Number(formatEther(ogBalance.result as bigint)) : 0;
-      const zor = zorBalance.status === 'success' ? Number(zorBalance.result as bigint) : 0;
-      respectWeight = Math.round(og + zor);
+      const computed = computeRespectWeight(ogBalance, zorBalance);
+      // A failed on-chain read previously became 0, silently undercounting the
+      // vote. Refuse to record a vote with an incomplete balance read - ask the
+      // voter to retry rather than store a corrupted weight.
+      if (!computed.complete) {
+        logger.error(`[vote] respect balance read failed (${computed.failed.join(',')}) for ${wallet}`);
+        return NextResponse.json(
+          { error: 'Could not read your on-chain Respect balance. Please try again.' },
+          { status: 503 },
+        );
+      }
+      respectWeight = computed.weight;
     }
 
     // Upsert vote (allows changing vote)

--- a/src/lib/respect/__tests__/voteWeight.test.ts
+++ b/src/lib/respect/__tests__/voteWeight.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { parseEther } from 'viem';
+import { computeRespectWeight } from '../voteWeight';
+
+describe('computeRespectWeight', () => {
+  it('sums OG (18 decimals) and ZOR (integer) when both reads succeed', () => {
+    const og = { status: 'success' as const, result: parseEther('40') }; // 40 OG
+    const zor = { status: 'success' as const, result: 26n }; // 26 ZOR
+    const r = computeRespectWeight(og, zor);
+    expect(r.weight).toBe(66);
+    expect(r.complete).toBe(true);
+    expect(r.failed).toEqual([]);
+  });
+
+  it('flags incomplete and lists og when the OG read fails', () => {
+    const og = { status: 'failure' as const };
+    const zor = { status: 'success' as const, result: 10n };
+    const r = computeRespectWeight(og, zor);
+    expect(r.weight).toBe(10); // only the successful read counts
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['og']);
+  });
+
+  it('flags incomplete and lists zor when the ZOR read fails', () => {
+    const og = { status: 'success' as const, result: parseEther('5') };
+    const zor = { status: 'failure' as const };
+    const r = computeRespectWeight(og, zor);
+    expect(r.weight).toBe(5);
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['zor']);
+  });
+
+  it('reports both failed and zero weight when both reads fail', () => {
+    const r = computeRespectWeight({ status: 'failure' }, { status: 'failure' });
+    expect(r.weight).toBe(0);
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['og', 'zor']);
+  });
+
+  it('rounds fractional OG balances', () => {
+    const og = { status: 'success' as const, result: parseEther('1.6') };
+    const zor = { status: 'success' as const, result: 0n };
+    expect(computeRespectWeight(og, zor).weight).toBe(2);
+  });
+});

--- a/src/lib/respect/voteWeight.ts
+++ b/src/lib/respect/voteWeight.ts
@@ -1,0 +1,62 @@
+/**
+ * Respect vote-weight computation.
+ *
+ * A proposal vote's weight is the voter's on-chain OG + ZOR Respect balance,
+ * read via a viem multicall. The previous inline code did:
+ *   const og = ogBalance.status === 'success' ? Number(formatEther(...)) : 0;
+ * which silently turned a FAILED balance read into 0 - indistinguishable from a
+ * real zero balance. A voter whose read failed would have their vote recorded
+ * with an undercounted weight and no signal that anything went wrong.
+ *
+ * This helper keeps the same math but reports whether every read actually
+ * succeeded, so the caller can refuse to record a vote with a corrupted weight.
+ *
+ * OG Respect is an ERC-20 (18 decimals -> formatEther). ZOR Respect is an
+ * ERC-1155 integer balance (used as-is).
+ */
+
+import { formatEther } from 'viem';
+
+export interface BalanceCallResult {
+  status: 'success' | 'failure';
+  result?: unknown;
+}
+
+export interface RespectWeight {
+  /** Rounded sum of the balances that were read successfully. */
+  weight: number;
+  /** True only when BOTH the OG and ZOR reads succeeded. */
+  complete: boolean;
+  /** Which reads failed, for logging. */
+  failed: Array<'og' | 'zor'>;
+}
+
+/**
+ * Compute vote weight from the OG (ERC-20) and ZOR (ERC-1155) multicall results.
+ * A failed read contributes 0 to the weight but is reported in `failed` and
+ * flips `complete` to false so the caller can reject the vote and ask for a retry
+ * instead of silently undercounting it.
+ */
+export function computeRespectWeight(og: BalanceCallResult, zor: BalanceCallResult): RespectWeight {
+  const failed: Array<'og' | 'zor'> = [];
+
+  let ogValue = 0;
+  if (og.status === 'success') {
+    ogValue = Number(formatEther(og.result as bigint));
+  } else {
+    failed.push('og');
+  }
+
+  let zorValue = 0;
+  if (zor.status === 'success') {
+    zorValue = Number(zor.result as bigint);
+  } else {
+    failed.push('zor');
+  }
+
+  return {
+    weight: Math.round(ogValue + zorValue),
+    complete: failed.length === 0,
+    failed,
+  };
+}


### PR DESCRIPTION
Extracts computeRespectWeight() (pure, 5 tests) so a FAILED on-chain balance read no longer silently becomes 0 (undercounting the vote). The route now returns 503 'try again' on an incomplete read instead of storing a corrupted weight. Weakness #1 (silent failure) + #2 (untested route).