### PR TITLE
feat(scrape): resolve Farcaster username to fid (+ ?farcasterUser=)

### DIFF
--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -6,6 +6,7 @@ import {
   scrapeContent,
   scrapeWaveWarzBattles,
   scrapeBczFarcasterHistory,
+  scrapeFarcasterHistoryByUsername,
 } from '@/lib/scrape';
 import { cacheScrape, type ScrapeCacheSource } from '@/lib/scrape/persist';
 import { scrapeArtistStats } from '@/lib/wavewarz/scraper';
@@ -18,6 +19,7 @@ import { scrapeArtistStats } from '@/lib/wavewarz/scraper';
  *   ?wavewarzArtist=<solana wallet>       -> artist battle stats
  *   ?wavewarzBattles=1[&maxPages=N]       -> battle history (paginated)
  *   ?farcasterFid=<fid>[&maxPages=N]      -> full Farcaster post history (Neynar)
+ *   ?farcasterUser=<username>[&maxPages=N] -> resolve username, then full history
  *
  * No arbitrary-host fetching: the X path only ever calls api.fxtwitter.com /
  * syndication for a parsed tweet id, and the others hit fixed known hosts.
@@ -28,12 +30,14 @@ const QuerySchema = z
     wavewarzArtist: z.string().min(1).optional(),
     wavewarzBattles: z.string().optional(),
     farcasterFid: z.coerce.number().int().positive().optional(),
+    farcasterUser: z.string().min(1).max(64).optional(),
     maxPages: z.coerce.number().int().positive().max(500).optional(),
     cache: z.string().optional(),
   })
   .refine(
-    (q) => Boolean(q.url || q.wavewarzArtist || q.wavewarzBattles || q.farcasterFid),
-    { message: 'one of url, wavewarzArtist, wavewarzBattles, farcasterFid is required' },
+    (q) =>
+      Boolean(q.url || q.wavewarzArtist || q.wavewarzBattles || q.farcasterFid || q.farcasterUser),
+    { message: 'one of url, wavewarzArtist, wavewarzBattles, farcasterFid, farcasterUser is required' },
   );
 
 export async function GET(req: NextRequest) {
@@ -96,6 +100,19 @@ export async function GET(req: NextRequest) {
       });
       const cached = await persist('farcaster', String(q.farcasterFid), history);
       return NextResponse.json({ source: 'farcaster', cached, ...history });
+    }
+
+    if (q.farcasterUser) {
+      const apiKey = process.env.NEYNAR_API_KEY;
+      if (!apiKey) {
+        return NextResponse.json({ error: 'NEYNAR_API_KEY not configured' }, { status: 500 });
+      }
+      const history = await scrapeFarcasterHistoryByUsername(q.farcasterUser, {
+        apiKey,
+        maxPages: q.maxPages,
+      });
+      const cached = await persist('farcaster', String(history.fid), history);
+      return NextResponse.json({ source: 'farcaster', cached, username: q.farcasterUser, ...history });
     }
 
     return NextResponse.json({ error: 'no target supplied' }, { status: 400 });

--- a/src/lib/scrape/__tests__/bcz-history.test.ts
+++ b/src/lib/scrape/__tests__/bcz-history.test.ts
@@ -3,10 +3,23 @@ import { describe, it, expect } from 'vitest';
 import {
   paginateCasts,
   scrapeBczFarcasterHistory,
+  resolveFarcasterFid,
+  scrapeFarcasterHistoryByUsername,
   BczScrapeError,
   type FetchCastPage,
   type CastPage,
 } from '../bcz-history';
+import type { FetchImpl } from '../x-fetch';
+
+/** Route a fake fetch by URL substring to a JSON/status response. */
+function routedFetch(routes: Array<{ match: string; status?: number; json?: unknown }>): FetchImpl {
+  return (async (url: string | URL | Request) => {
+    const href = typeof url === 'string' ? url : url.toString();
+    const r = routes.find((x) => href.includes(x.match));
+    if (!r) throw new Error(`no route for ${href}`);
+    return { ok: (r.status ?? 200) < 400, status: r.status ?? 200, json: async () => r.json } as Response;
+  }) as unknown as FetchImpl;
+}
 
 function rawCast(hash: string, text: string, likes = 0): unknown {
   return {
@@ -90,5 +103,51 @@ describe('scrapeBczFarcasterHistory', () => {
 
   it('throws when neither fetchPage nor apiKey is provided', async () => {
     await expect(scrapeBczFarcasterHistory(3)).rejects.toBeInstanceOf(BczScrapeError);
+  });
+});
+describe('resolveFarcasterFid', () => {
+  it('resolves a username to its fid', async () => {
+    const fetchImpl = routedFetch([{ match: 'by_username', json: { user: { fid: 8513 } } }]);
+    const fid = await resolveFarcasterFid('bettercallzaal', 'key', fetchImpl);
+    expect(fid).toBe(8513);
+  });
+
+  it('strips a leading @ from the handle', async () => {
+    let seen = '';
+    const fetchImpl = (async (url: string) => {
+      seen = url;
+      return { ok: true, status: 200, json: async () => ({ user: { fid: 1 } }) } as Response;
+    }) as unknown as FetchImpl;
+    await resolveFarcasterFid('@dwr', 'key', fetchImpl);
+    expect(seen).toContain('username=dwr');
+  });
+
+  it('returns null for a non-existent username (404)', async () => {
+    const fetchImpl = routedFetch([{ match: 'by_username', status: 404 }]);
+    expect(await resolveFarcasterFid('nope', 'key', fetchImpl)).toBeNull();
+  });
+
+  it('returns null for empty input', async () => {
+    const fetchImpl = routedFetch([]);
+    expect(await resolveFarcasterFid('  ', 'key', fetchImpl)).toBeNull();
+  });
+});
+
+describe('scrapeFarcasterHistoryByUsername', () => {
+  it('resolves then scrapes full history', async () => {
+    const fetchImpl = routedFetch([
+      { match: 'by_username', json: { user: { fid: 8513 } } },
+      { match: 'feed/user/casts', json: { casts: [rawCast('0xa', 'gm')], next: { cursor: null } } },
+    ]);
+    const history = await scrapeFarcasterHistoryByUsername('bettercallzaal', { apiKey: 'key', fetchImpl });
+    expect(history.fid).toBe(8513);
+    expect(history.total).toBe(1);
+  });
+
+  it('throws when the username cannot be resolved', async () => {
+    const fetchImpl = routedFetch([{ match: 'by_username', status: 404 }]);
+    await expect(
+      scrapeFarcasterHistoryByUsername('nope', { apiKey: 'key', fetchImpl }),
+    ).rejects.toBeInstanceOf(BczScrapeError);
   });
 });

--- a/src/lib/scrape/bcz-history.ts
+++ b/src/lib/scrape/bcz-history.ts
@@ -113,6 +113,36 @@ export async function paginateCasts(
 
 const NEYNAR_BASE = 'https://api.neynar.com/v2/farcaster';
 
+/**
+ * Resolve a Farcaster username (e.g. "bettercallzaal") to its fid via Neynar.
+ * Returns null when the username does not exist. Throws BczScrapeError on a
+ * transport/HTTP failure (after retry) so the caller can distinguish "no such
+ * user" from "lookup failed".
+ */
+export async function resolveFarcasterFid(
+  username: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | null> {
+  const handle = username.trim().replace(/^@/, '');
+  if (!handle) return null;
+  return withRetry(
+    async () => {
+      const res = await fetchImpl(
+        `${NEYNAR_BASE}/user/by_username?username=${encodeURIComponent(handle)}`,
+        { headers: { 'x-api-key': apiKey, Accept: 'application/json' }, signal: AbortSignal.timeout(10000) },
+      );
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        throw new BczScrapeError(`Neynar username lookup error ${res.status} for ${handle}`);
+      }
+      const data = (await res.json()) as { user?: { fid?: number } };
+      return typeof data.user?.fid === 'number' ? data.user.fid : null;
+    },
+    { shouldRetry: isRetryableHttpError },
+  );
+}
+
 /** Build a Neynar-backed page fetcher for a fid. Injectable fetch for tests. */
 export function neynarCastPageFetcher(
   fid: number,
@@ -160,4 +190,24 @@ export async function scrapeBczFarcasterHistory(
   }
   const { casts, truncated } = await paginateCasts(fetchPage, { maxPages: opts.maxPages });
   return { fid, total: casts.length, casts, truncated };
+}
+
+/**
+ * Resolve a Farcaster username to a fid and scrape its full post history in one
+ * call (e.g. scrapeFarcasterHistoryByUsername('bettercallzaal', { apiKey })).
+ * Throws BczScrapeError when the username cannot be resolved.
+ */
+export async function scrapeFarcasterHistoryByUsername(
+  username: string,
+  opts: { apiKey: string; fetchImpl?: typeof fetch; maxPages?: number },
+): Promise<BczHistory> {
+  const fid = await resolveFarcasterFid(username, opts.apiKey, opts.fetchImpl);
+  if (fid === null) {
+    throw new BczScrapeError(`Could not resolve Farcaster username: ${username}`);
+  }
+  return scrapeBczFarcasterHistory(fid, {
+    apiKey: opts.apiKey,
+    fetchImpl: opts.fetchImpl,
+    maxPages: opts.maxPages,
+  });
 }


### PR DESCRIPTION
Makes the BetterCallZaal Farcaster scraper usable without a hardcoded fid.

- resolveFarcasterFid('bettercallzaal', apiKey) via Neynar /user/by_username; 404 -> null (no such user), HTTP failure -> throws after retry.
- scrapeFarcasterHistoryByUsername() resolves then scrapes full history.
- /api/scrape ?farcasterUser=<handle> wired in.

6 new vitest cases; full scrape suite 57 tests pass. Typecheck clean. Off clean main (no stacking). Loop iteration 9.