### PR TITLE
fix(respect-sync): do not write 0 balance on failed on-chain read

### DIFF
--- a/src/app/api/respect/sync/route.ts
+++ b/src/app/api/respect/sync/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from 'next/server';
-import { createPublicClient, http, parseAbi, formatEther } from 'viem';
+import { createPublicClient, http, parseAbi } from 'viem';
 import { optimism } from 'viem/chains';
 import { getSessionData } from '@/lib/auth/session';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { communityConfig } from '@/../community.config';
+import { readMemberBalances } from '@/lib/respect/onchainBalances';
 import { logger } from '@/lib/logger';
 
 const { ogContract: OG_RESPECT, zorContract: ZOR_RESPECT, zorTokenId: ZOR_TOKEN_ID } =
@@ -79,41 +80,47 @@ export async function POST() {
     // 3. Update each member's onchain_og and onchain_zor in Supabase
     let syncedCount = 0;
     const errors: string[] = [];
+    const skipped: string[] = [];
 
-    const updates = walletsToSync.map((member, idx) => {
-      const ogResult = results[idx * 2];
-      const zorResult = results[idx * 2 + 1];
+    const updates = walletsToSync
+      .map((member, idx) => {
+        const balances = readMemberBalances(results[idx * 2], results[idx * 2 + 1]);
 
-      const ogRaw = ogResult.status === 'success' ? (ogResult.result as bigint) : BigInt(0);
-      const zorRaw = zorResult.status === 'success' ? (zorResult.result as bigint) : BigInt(0);
+        // A failed on-chain read must NOT be written as 0 - that would silently
+        // wipe the member's cached Respect. Skip them so their value is kept.
+        if (!balances.complete) {
+          skipped.push(`${member.name} (${balances.failed.join(',')} read failed)`);
+          return null;
+        }
 
-      // OG is ERC-20 with 18 decimals, ZOR is ERC-1155 (whole tokens)
-      // Store full precision — rounding happens at display layer only
-      const onchainOg = Number(formatEther(ogRaw));
-      const onchainZor = Number(zorRaw);
-
-      return supabaseAdmin
-        .from('respect_members')
-        .update({
-          onchain_og: onchainOg,
-          onchain_zor: onchainZor,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', member.id)
-        .then(({ error: updateErr }) => {
-          if (updateErr) {
-            errors.push(`${member.name}: ${updateErr.message}`);
-          } else {
-            syncedCount++;
-          }
-        });
-    });
+        return supabaseAdmin
+          .from('respect_members')
+          .update({
+            onchain_og: balances.onchainOg,
+            onchain_zor: balances.onchainZor,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', member.id)
+          .then(({ error: updateErr }) => {
+            if (updateErr) {
+              errors.push(`${member.name}: ${updateErr.message}`);
+            } else {
+              syncedCount++;
+            }
+          });
+      })
+      .filter((u): u is NonNullable<typeof u> => u !== null);
 
     await Promise.allSettled(updates);
+
+    if (skipped.length > 0) {
+      logger.warn(`[respect-sync] skipped ${skipped.length} members with failed balance reads`);
+    }
 
     return NextResponse.json({
       synced: syncedCount,
       total: walletsToSync.length,
+      skipped: skipped.length > 0 ? skipped : undefined,
       errors: errors.length > 0 ? errors : undefined,
     });
   } catch (err) {

--- a/src/lib/respect/__tests__/onchainBalances.test.ts
+++ b/src/lib/respect/__tests__/onchainBalances.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { parseEther } from 'viem';
+import { readMemberBalances } from '../onchainBalances';
+
+describe('readMemberBalances', () => {
+  it('reads OG (18 decimals) and ZOR (integer) when both succeed', () => {
+    const r = readMemberBalances(
+      { status: 'success', result: parseEther('123.5') },
+      { status: 'success', result: 7n },
+    );
+    expect(r.complete).toBe(true);
+    expect(r.onchainOg).toBeCloseTo(123.5, 6);
+    expect(r.onchainZor).toBe(7);
+    expect(r.failed).toEqual([]);
+  });
+
+  it('treats a real zero balance as complete (both reads succeeded)', () => {
+    const r = readMemberBalances(
+      { status: 'success', result: 0n },
+      { status: 'success', result: 0n },
+    );
+    expect(r.complete).toBe(true);
+    expect(r.onchainOg).toBe(0);
+    expect(r.onchainZor).toBe(0);
+  });
+
+  it('flags incomplete when the OG read fails (so the caller skips the write)', () => {
+    const r = readMemberBalances({ status: 'failure' }, { status: 'success', result: 3n });
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['og']);
+  });
+
+  it('flags incomplete when the ZOR read fails', () => {
+    const r = readMemberBalances({ status: 'success', result: parseEther('1') }, { status: 'failure' });
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['zor']);
+  });
+
+  it('flags both failed', () => {
+    const r = readMemberBalances({ status: 'failure' }, { status: 'failure' });
+    expect(r.complete).toBe(false);
+    expect(r.failed).toEqual(['og', 'zor']);
+  });
+});

--- a/src/lib/respect/onchainBalances.ts
+++ b/src/lib/respect/onchainBalances.ts
@@ -1,0 +1,55 @@
+/**
+ * On-chain Respect balance interpretation for the member sync.
+ *
+ * The respect sync reads each member's OG (ERC-20) and ZOR (ERC-1155) balance
+ * via a viem multicall and writes the result to respect_members. The previous
+ * inline code did:
+ *   const ogRaw = ogResult.status === 'success' ? ... : BigInt(0);
+ * so a FAILED read became 0 and was WRITTEN to the DB - silently zeroing a
+ * member's cached Respect on any transient RPC failure, corrupting the
+ * leaderboard and governance weights.
+ *
+ * This helper keeps the same decimals (OG via formatEther, ZOR integer) but
+ * reports whether both reads succeeded, so the caller can SKIP writing a
+ * member whose read failed (preserving their existing value) instead of
+ * overwriting it with 0.
+ */
+
+import { formatEther } from 'viem';
+import type { BalanceCallResult } from './voteWeight';
+
+export interface MemberBalances {
+  /** True only when BOTH the OG and ZOR reads succeeded. */
+  complete: boolean;
+  /** OG balance (ERC-20, 18 decimals). 0 if its read failed. */
+  onchainOg: number;
+  /** ZOR balance (ERC-1155 integer). 0 if its read failed. */
+  onchainZor: number;
+  /** Which reads failed, for logging. */
+  failed: Array<'og' | 'zor'>;
+}
+
+/**
+ * Interpret a member's OG + ZOR multicall results. When `complete` is false the
+ * caller MUST NOT write the (partial) values - skip the member so their existing
+ * cached balance is preserved.
+ */
+export function readMemberBalances(og: BalanceCallResult, zor: BalanceCallResult): MemberBalances {
+  const failed: Array<'og' | 'zor'> = [];
+
+  let onchainOg = 0;
+  if (og.status === 'success') {
+    onchainOg = Number(formatEther(og.result as bigint));
+  } else {
+    failed.push('og');
+  }
+
+  let onchainZor = 0;
+  if (zor.status === 'success') {
+    onchainZor = Number(zor.result as bigint);
+  } else {
+    failed.push('zor');
+  }
+
+  return { complete: failed.length === 0, onchainOg, onchainZor, failed };
+}


### PR DESCRIPTION
## Problem (weakness #1 - silent failure, write path)
The respect sync defaulted a FAILED multicall read to BigInt(0) and then WROTE it to respect_members. A transient Optimism RPC failure during sync would silently overwrite a member's cached OG/ZOR balance with 0 - wiping their Respect and corrupting the leaderboard + governance weights. A real zero balance and a failed read were indistinguishable.

## Fix
- New src/lib/respect/onchainBalances.ts readMemberBalances(og, zor): same decimals (OG formatEther, ZOR integer) but returns { complete, onchainOg, onchainZor, failed }.
- The sync now SKIPS members whose read was incomplete (keeps their existing value) and returns them in a 'skipped' list, instead of writing 0. Real zeros (both reads succeed) still sync.

## Tests
5 vitest cases (both-succeed, real-zero, og-fail, zor-fail, both-fail). Pure helper, node env. Typecheck clean. Companion to the vote-weight fix (#897) - same bug class, write path. Loop iteration 10.