### PR TITLE
fix(wavewarz): derive spotlight tier order from SPOTLIGHT_TIERS (+ tests)

### DIFF
--- a/src/lib/wavewarz/__tests__/proposals.test.ts
+++ b/src/lib/wavewarz/__tests__/proposals.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { getNewSpotlightTier } from '../proposals';
+
+// SPOTLIGHT_TIERS thresholds: rising_star >= 3, veteran >= 10, legend >= 25.
+describe('getNewSpotlightTier', () => {
+  it('returns null below the lowest threshold', () => {
+    expect(getNewSpotlightTier(0, null)).toBeNull();
+    expect(getNewSpotlightTier(2, null)).toBeNull();
+  });
+
+  it('promotes a new artist to the highest tier they qualify for', () => {
+    expect(getNewSpotlightTier(3, null)).toBe('rising_star');
+    expect(getNewSpotlightTier(9, null)).toBe('rising_star');
+    expect(getNewSpotlightTier(10, null)).toBe('veteran');
+    expect(getNewSpotlightTier(24, null)).toBe('veteran');
+    expect(getNewSpotlightTier(25, null)).toBe('legend');
+    expect(getNewSpotlightTier(1000, null)).toBe('legend');
+  });
+
+  it('promotes up one tier at a time as wins grow', () => {
+    expect(getNewSpotlightTier(10, 'rising_star')).toBe('veteran');
+    expect(getNewSpotlightTier(25, 'veteran')).toBe('legend');
+  });
+
+  it('can skip a tier when wins jump past two thresholds', () => {
+    expect(getNewSpotlightTier(30, 'rising_star')).toBe('legend');
+    expect(getNewSpotlightTier(100, null)).toBe('legend');
+  });
+
+  it('does not re-promote to the current tier or below', () => {
+    expect(getNewSpotlightTier(9, 'rising_star')).toBeNull();
+    expect(getNewSpotlightTier(20, 'veteran')).toBeNull();
+    expect(getNewSpotlightTier(1000, 'legend')).toBeNull();
+  });
+
+  it('never demotes when wins drop below the current tier', () => {
+    expect(getNewSpotlightTier(2, 'rising_star')).toBeNull();
+    expect(getNewSpotlightTier(0, 'legend')).toBeNull();
+  });
+
+  it('treats an unknown current tier as no tier (promotes from scratch)', () => {
+    expect(getNewSpotlightTier(10, 'nonexistent')).toBe('veteran');
+  });
+});

--- a/src/lib/wavewarz/proposals.ts
+++ b/src/lib/wavewarz/proposals.ts
@@ -135,9 +135,19 @@ export async function createSessionReminderProposal(authorId: string) {
   });
 }
 
+/**
+ * Decide whether an artist's win count promotes them to a NEW (higher) spotlight
+ * tier. Returns the highest tier they now qualify for that is strictly above
+ * their current tier, or null if no promotion (already at/above it, or below the
+ * lowest threshold). Never demotes.
+ *
+ * Tier ordering is derived from SPOTLIGHT_TIERS directly (single source of
+ * truth) so reordering or renaming a tier there cannot silently break this.
+ */
 export function getNewSpotlightTier(wins: number, currentTier: string | null): SpotlightTier | null {
-  const tierOrder: SpotlightTier[] = ['rising_star', 'veteran', 'legend'];
-  const currentIdx = currentTier ? tierOrder.indexOf(currentTier as SpotlightTier) : -1;
+  const currentIdx = currentTier
+    ? SPOTLIGHT_TIERS.findIndex((t) => t.tier === currentTier)
+    : -1;
 
   for (let i = SPOTLIGHT_TIERS.length - 1; i >= 0; i--) {
     const t = SPOTLIGHT_TIERS[i];


### PR DESCRIPTION
getNewSpotlightTier() (which gates WaveWarZ spotlight proposals from battle wins) hardcoded a parallel tierOrder array and compared its index against the SPOTLIGHT_TIERS index. They match today, but reordering/renaming a tier in SPOTLIGHT_TIERS would silently break tier promotions. Now derives the current-tier index from SPOTLIGHT_TIERS directly (single source of truth). Behavior unchanged.

Plus the missing test coverage (the function was untested): 7 vitest cases - thresholds, highest-qualifying-tier, skip-tier jumps, no re-promotion to current/below, never-demote, unknown-tier. Typecheck clean. Off clean main. Loop iteration 13 (non-scraping: governance correctness + test coverage).