### PR TITLE
feat(scrape): BetterCallZaal unified profile aggregator

### DIFF
--- a/src/lib/scrape/__tests__/bcz-profile.test.ts
+++ b/src/lib/scrape/__tests__/bcz-profile.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { scrapeBettercallzaalProfile } from '../bcz-profile';
+import type { BczSite } from '../bcz-site';
+import type { XTimeline } from '../x-timeline';
+import type { BczHistory } from '../bcz-history';
+
+const fakeSite: BczSite = { title: 'BCZ', description: null, links: [], socials: [], projects: [] };
+const fakeTimeline: XTimeline = { handle: 'bettercallzaal', total: 1, tweets: [] };
+const fakeHistory: BczHistory = { fid: 8513, total: 2, casts: [], truncated: false };
+
+describe('scrapeBettercallzaalProfile', () => {
+  it('aggregates all three sources when they succeed', async () => {
+    const profile = await scrapeBettercallzaalProfile({
+      neynarApiKey: 'key',
+      siteScraper: async () => fakeSite,
+      timelineScraper: async () => fakeTimeline,
+      farcasterScraper: async () => fakeHistory,
+    });
+    expect(profile.handle).toBe('bettercallzaal');
+    expect(profile.site?.title).toBe('BCZ');
+    expect(profile.xTimeline?.total).toBe(1);
+    expect(profile.farcaster?.fid).toBe(8513);
+    expect(profile.errors).toEqual([]);
+  });
+
+  it('records a failed source without sinking the others', async () => {
+    const profile = await scrapeBettercallzaalProfile({
+      neynarApiKey: 'key',
+      siteScraper: async () => fakeSite,
+      timelineScraper: async () => {
+        throw new Error('timeline 503');
+      },
+      farcasterScraper: async () => fakeHistory,
+    });
+    expect(profile.site).not.toBeNull();
+    expect(profile.farcaster).not.toBeNull();
+    expect(profile.xTimeline).toBeNull();
+    expect(profile.errors).toEqual([{ source: 'x-timeline', error: 'timeline 503' }]);
+  });
+
+  it('collects multiple failures', async () => {
+    const profile = await scrapeBettercallzaalProfile({
+      neynarApiKey: 'key',
+      siteScraper: async () => {
+        throw new Error('site down');
+      },
+      timelineScraper: async () => {
+        throw new Error('tl down');
+      },
+      farcasterScraper: async () => fakeHistory,
+    });
+    expect(profile.errors.map((e) => e.source).sort()).toEqual(['site', 'x-timeline']);
+    expect(profile.farcaster).not.toBeNull();
+  });
+
+  it('skips Farcaster (null, no error) when no Neynar key is given', async () => {
+    let farcasterCalled = false;
+    const profile = await scrapeBettercallzaalProfile({
+      siteScraper: async () => fakeSite,
+      timelineScraper: async () => fakeTimeline,
+      farcasterScraper: async () => {
+        farcasterCalled = true;
+        return fakeHistory;
+      },
+    });
+    expect(farcasterCalled).toBe(false);
+    expect(profile.farcaster).toBeNull();
+    expect(profile.errors).toEqual([]);
+  });
+
+  it('passes the handle through to the sub-scrapers, stripping @', async () => {
+    let seenHandle = '';
+    await scrapeBettercallzaalProfile({
+      handle: '@someone',
+      siteScraper: async () => fakeSite,
+      timelineScraper: async (h) => {
+        seenHandle = h;
+        return fakeTimeline;
+      },
+    });
+    expect(seenHandle).toBe('someone');
+  });
+});

--- a/src/lib/scrape/bcz-profile.ts
+++ b/src/lib/scrape/bcz-profile.ts
@@ -1,0 +1,78 @@
+/**
+ * BetterCallZaal unified profile aggregator.
+ *
+ * Composes the three BCZ scrapers - site (bcz-site), X timeline (x-timeline),
+ * and Farcaster history (bcz-history) - into one call. Uses Promise.allSettled
+ * so a single failing source does NOT sink the others, and every failure is
+ * recorded in `errors` rather than silently dropped.
+ *
+ * The three sub-scrapers are injectable so the composition (partial-failure
+ * handling, error collection) can be unit tested without network.
+ */
+
+import { scrapeBczSite, type BczSite } from './bcz-site';
+import { scrapeXUserTimeline, type XTimeline } from './x-timeline';
+import { scrapeFarcasterHistoryByUsername, type BczHistory } from './bcz-history';
+
+const DEFAULT_HANDLE = 'bettercallzaal';
+
+export interface BczProfile {
+  handle: string;
+  site: BczSite | null;
+  xTimeline: XTimeline | null;
+  farcaster: BczHistory | null;
+  /** Sources that failed, with the reason. Empty when all succeeded. */
+  errors: Array<{ source: 'site' | 'x-timeline' | 'farcaster'; error: string }>;
+}
+
+export interface BczProfileOptions {
+  handle?: string;
+  /** Neynar API key - required for the Farcaster source; omit to skip it. */
+  neynarApiKey?: string;
+  maxFarcasterPages?: number;
+  // Injectable sub-scrapers (tests pass fakes; default to the real ones).
+  siteScraper?: () => Promise<BczSite>;
+  timelineScraper?: (handle: string) => Promise<XTimeline>;
+  farcasterScraper?: (handle: string, apiKey: string) => Promise<BczHistory>;
+}
+
+function errMessage(e: unknown): string {
+  return e instanceof Error ? e.message : 'unknown error';
+}
+
+/**
+ * Scrape every BetterCallZaal surface in parallel. Never throws - a failed
+ * source yields null plus an entry in `errors`. The Farcaster source is skipped
+ * (null, no error) when no Neynar key is available.
+ */
+export async function scrapeBettercallzaalProfile(opts: BczProfileOptions = {}): Promise<BczProfile> {
+  const handle = (opts.handle ?? DEFAULT_HANDLE).trim().replace(/^@/, '');
+  const site = opts.siteScraper ?? (() => scrapeBczSite());
+  const timeline = opts.timelineScraper ?? ((h: string) => scrapeXUserTimeline(h));
+  const farcaster =
+    opts.farcasterScraper ??
+    ((h: string, key: string) => scrapeFarcasterHistoryByUsername(h, { apiKey: key, maxPages: opts.maxFarcasterPages }));
+
+  const apiKey = opts.neynarApiKey;
+  const errors: BczProfile['errors'] = [];
+
+  const [siteRes, timelineRes, farcasterRes] = await Promise.allSettled([
+    site(),
+    timeline(handle),
+    apiKey ? farcaster(handle, apiKey) : Promise.resolve(null),
+  ]);
+
+  let siteData: BczSite | null = null;
+  if (siteRes.status === 'fulfilled') siteData = siteRes.value;
+  else errors.push({ source: 'site', error: errMessage(siteRes.reason) });
+
+  let timelineData: XTimeline | null = null;
+  if (timelineRes.status === 'fulfilled') timelineData = timelineRes.value;
+  else errors.push({ source: 'x-timeline', error: errMessage(timelineRes.reason) });
+
+  let farcasterData: BczHistory | null = null;
+  if (farcasterRes.status === 'fulfilled') farcasterData = farcasterRes.value;
+  else errors.push({ source: 'farcaster', error: errMessage(farcasterRes.reason) });
+
+  return { handle, site: siteData, xTimeline: timelineData, farcaster: farcasterData, errors };
+}

--- a/src/lib/scrape/index.ts
+++ b/src/lib/scrape/index.ts
@@ -16,6 +16,7 @@ export * from './x-fetch';
 export * from './x-timeline';
 export * from './bcz-history';
 export * from './bcz-site';
+export * from './bcz-profile';
 export * from './wavewarz';
 export * from './wavewarz-battles';
 


### PR DESCRIPTION
scrapeBettercallzaalProfile() composes site + X timeline + Farcaster history via Promise.allSettled - a failed source yields null + an errors[] entry, never sinks the others or gets silently dropped. Injectable sub-scrapers, 5 tests. Loop iteration 14.