### PR TITLE
bot: test migration (55→269 in CI) + devz dispatch hardening

### DIFF
--- a/bot/src/__tests__/group.test.ts
+++ b/bot/src/__tests__/group.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getZaalDmId } from '../group';
+
+// First unit coverage for the ZAOstock bot. getZaalDmId is the linchpin of the
+// "DM Zaal instead of pinging the group" reroute (doc 869 / PR #881): if it
+// returns null, proactive pings are dropped rather than sent to the group.
+describe('getZaalDmId', () => {
+  afterEach(() => {
+    delete process.env.ZAAL_TELEGRAM_ID;
+  });
+
+  it('returns the numeric id when ZAAL_TELEGRAM_ID is a valid number', () => {
+    process.env.ZAAL_TELEGRAM_ID = '12345678';
+    expect(getZaalDmId()).toBe(12345678);
+  });
+
+  it('returns null when unset (ping is dropped, never sent to the group)', () => {
+    delete process.env.ZAAL_TELEGRAM_ID;
+    expect(getZaalDmId()).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    process.env.ZAAL_TELEGRAM_ID = '';
+    expect(getZaalDmId()).toBeNull();
+  });
+
+  it('returns null for a non-numeric value', () => {
+    process.env.ZAAL_TELEGRAM_ID = 'not-a-number';
+    expect(getZaalDmId()).toBeNull();
+  });
+
+  it('returns null for 0 (not a real chat id)', () => {
+    process.env.ZAAL_TELEGRAM_ID = '0';
+    expect(getZaalDmId()).toBeNull();
+  });
+
+  it('handles negative ids (Telegram group/channel ids can be negative)', () => {
+    process.env.ZAAL_TELEGRAM_ID = '-1001234567890';
+    expect(getZaalDmId()).toBe(-1001234567890);
+  });
+});

--- a/bot/src/devz/__tests__/dispatch-auth.test.ts
+++ b/bot/src/devz/__tests__/dispatch-auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { safeEqual, isValidDocPath } from '../dispatch-auth';
+
+// First unit coverage for the ZAO Devz module (doc 869: was zero tests).
+describe('safeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(safeEqual('s3cret-token', 's3cret-token')).toBe(true);
+  });
+
+  it('returns false for different strings of the same length', () => {
+    expect(safeEqual('aaaaaa', 'aaaaab')).toBe(false);
+  });
+
+  it('returns false for different-length strings (no throw)', () => {
+    expect(safeEqual('short', 'a-much-longer-secret')).toBe(false);
+  });
+
+  it('returns false when one side is empty', () => {
+    expect(safeEqual('', 'secret')).toBe(false);
+    expect(safeEqual('secret', '')).toBe(false);
+  });
+
+  it('treats empty/empty as equal', () => {
+    expect(safeEqual('', '')).toBe(true);
+  });
+});
+
+describe('isValidDocPath', () => {
+  it('accepts a normal research doc path', () => {
+    expect(isValidDocPath('research/agents/869-bot-fleet-audit-2026-06/README.md')).toBe(true);
+  });
+
+  it('accepts a top-level .md file', () => {
+    expect(isValidDocPath('README.md')).toBe(true);
+  });
+
+  it('rejects empty input', () => {
+    expect(isValidDocPath('')).toBe(false);
+  });
+
+  it('rejects path traversal', () => {
+    expect(isValidDocPath('../../../etc/passwd.md')).toBe(false);
+    expect(isValidDocPath('research/../../secret.md')).toBe(false);
+  });
+
+  it('rejects non-.md files', () => {
+    expect(isValidDocPath('research/notes.txt')).toBe(false);
+    expect(isValidDocPath('src/app/api/route.ts')).toBe(false);
+  });
+
+  it('rejects absolute paths and leading separators', () => {
+    expect(isValidDocPath('/etc/passwd.md')).toBe(false);
+  });
+
+  it('rejects paths with shell-ish characters', () => {
+    expect(isValidDocPath('research/x;rm -rf.md')).toBe(false);
+    expect(isValidDocPath('research/$(whoami).md')).toBe(false);
+  });
+});

--- a/bot/src/devz/dispatch-auth.ts
+++ b/bot/src/devz/dispatch-auth.ts
@@ -1,0 +1,29 @@
+// Auth + input validation for the loopback /hermes-dispatch HTTP listener
+// (bot/src/devz/index.ts). Extracted as pure functions so they're unit-testable
+// without booting the devz process. doc 869 follow-up (P3 defense-in-depth).
+
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Constant-time string comparison for the dispatch secret. A plain `!==`
+ * short-circuits on the first differing byte, leaking timing about how much of
+ * the secret was correct. Loopback-only + low severity, but cheap to do right.
+ * The length check leaks length only, which is acceptable here.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Validate a research-doc path supplied to /hermes-dispatch: must be a
+ * relative `.md` path, no traversal. Guards the doc the Hermes pipeline is
+ * pointed at.
+ */
+export function isValidDocPath(doc: string): boolean {
+  if (!doc) return false;
+  if (doc.includes('..')) return false;
+  return /^[a-z0-9][a-z0-9/_.-]*\.md$/i.test(doc);
+}

--- a/bot/src/devz/index.ts
+++ b/bot/src/devz/index.ts
@@ -25,6 +25,7 @@ import { existsSync } from 'node:fs';
 import { spawn } from 'node:child_process';
 import * as http from 'node:http';
 import { startHeartbeat, startHeartbeatAs } from '../lib/cowork';
+import { safeEqual, isValidDocPath } from './dispatch-auth';
 
 const devzToken = process.env.ZAO_DEVZ_BOT_TOKEN;
 const hermesToken = process.env.HERMES_BOT_TOKEN;
@@ -407,7 +408,7 @@ function startHermesHttpListener(): void {
         res.end(JSON.stringify({ error: 'not found' }));
         return;
       }
-      if ((req.headers['x-hermes-secret'] ?? '') !== secret) {
+      if (!safeEqual(String(req.headers['x-hermes-secret'] ?? ''), secret)) {
         res.writeHead(401, { 'content-type': 'application/json' });
         res.end(JSON.stringify({ error: 'unauthorized' }));
         return;
@@ -432,7 +433,7 @@ function startHermesHttpListener(): void {
         const title = (parsed.title ?? '').trim().slice(0, 120);
         const intent = (parsed.intent ?? 'review').trim();
         const extra = (parsed.extra ?? '').trim().slice(0, 600);
-        if (!doc || !/^[a-z0-9][a-z0-9/_.-]*\.md$/i.test(doc) || doc.includes('..')) {
+        if (!isValidDocPath(doc)) {
           res.writeHead(400, { 'content-type': 'application/json' });
           res.end(JSON.stringify({ error: 'invalid doc path' }));
           return;

--- a/bot/src/zoe/__tests__/agents.test.ts
+++ b/bot/src/zoe/__tests__/agents.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { decayWeight, scopeKey, HALF_LIFE_DAYS } from '../agents/decay.ts';

--- a/bot/src/zoe/__tests__/approvals.test.ts
+++ b/bot/src/zoe/__tests__/approvals.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/bonfire-queue.test.ts
+++ b/bot/src/zoe/__tests__/bonfire-queue.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/commands.test.ts
+++ b/bot/src/zoe/__tests__/commands.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { isZoeCommand, NOTE_PREFIX, PLAN_PREFIX } from '../commands.ts';

--- a/bot/src/zoe/__tests__/crm.test.ts
+++ b/bot/src/zoe/__tests__/crm.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { runCrmOps, summarizeCrmResults } from '../crm.ts';

--- a/bot/src/zoe/__tests__/decompose.test.ts
+++ b/bot/src/zoe/__tests__/decompose.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { shouldDecompose, renderPlanForApproval } from '../decompose.ts';

--- a/bot/src/zoe/__tests__/dispatch.test.ts
+++ b/bot/src/zoe/__tests__/dispatch.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/learn.test.ts
+++ b/bot/src/zoe/__tests__/learn.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { summarizeRuns, renderLearnProposals, capLearnings } from '../learn.ts';

--- a/bot/src/zoe/__tests__/pii.test.ts
+++ b/bot/src/zoe/__tests__/pii.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { scanPii, containsPii, redactPii, EMAIL_ALLOWLIST } from '../pii.ts';

--- a/bot/src/zoe/__tests__/proactive.test.ts
+++ b/bot/src/zoe/__tests__/proactive.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/reflexion.test.ts
+++ b/bot/src/zoe/__tests__/reflexion.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/relay.test.ts
+++ b/bot/src/zoe/__tests__/relay.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { resolveRelayChatId } from '../relay.ts';

--- a/bot/src/zoe/__tests__/sidequests.test.ts
+++ b/bot/src/zoe/__tests__/sidequests.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';

--- a/bot/src/zoe/__tests__/thread-memory.test.ts
+++ b/bot/src/zoe/__tests__/thread-memory.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { buildThreadEpisodeBody, emitThreadTransition } from '../thread-memory.ts';

--- a/bot/src/zoe/__tests__/thread-ops.test.ts
+++ b/bot/src/zoe/__tests__/thread-ops.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { resolveDueAt, summarizeThreadOps, type ThreadOpsSummary } from '../thread-ops.ts';

--- a/bot/src/zoe/__tests__/threads.test.ts
+++ b/bot/src/zoe/__tests__/threads.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/src/zoe/__tests__/workers.test.ts
+++ b/bot/src/zoe/__tests__/workers.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { revisionBudget } from '../workers.ts';

--- a/bot/src/zoe/critics/__tests__/types.test.ts
+++ b/bot/src/zoe/critics/__tests__/types.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import {

--- a/bot/vitest.config.ts
+++ b/bot/vitest.config.ts
@@ -1,40 +1,15 @@
-import { configDefaults, defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
 // Bot is a standalone package (no npm workspace), so it needs its own vitest
 // runner. Node environment — these are server/bot unit tests, no DOM.
 //
-// NOTE: 18 older suites under src/zoe/__tests__ use Node's built-in `node:test`
-// runner (`import { test } from 'node:test'`) instead of vitest, so vitest
-// can't collect them ("No test suite found"). They're excluded below and still
-// run via `node --test`. Standardizing them on vitest (per .claude/rules/
-// tests.md) is a separate follow-up; new tests should be vitest-style and will
-// be picked up automatically.
-const LEGACY_NODE_TEST_FILES = [
-  'src/zoe/__tests__/pii.test.ts',
-  'src/zoe/__tests__/proactive.test.ts',
-  'src/zoe/__tests__/thread-memory.test.ts',
-  'src/zoe/__tests__/thread-ops.test.ts',
-  'src/zoe/__tests__/threads.test.ts',
-  'src/zoe/critics/__tests__/types.test.ts',
-  'src/zoe/__tests__/approvals.test.ts',
-  'src/zoe/__tests__/bonfire-queue.test.ts',
-  'src/zoe/__tests__/commands.test.ts',
-  'src/zoe/__tests__/crm.test.ts',
-  'src/zoe/__tests__/decompose.test.ts',
-  'src/zoe/__tests__/dispatch.test.ts',
-  'src/zoe/__tests__/learn.test.ts',
-  'src/zoe/__tests__/reflexion.test.ts',
-  'src/zoe/__tests__/relay.test.ts',
-  'src/zoe/__tests__/sidequests.test.ts',
-  'src/zoe/__tests__/workers.test.ts',
-  'src/zoe/__tests__/agents.test.ts',
-];
-
+// Suites that historically used Node's built-in `node:test` runner were
+// migrated to import `test` from vitest (they keep using `node:assert/strict`,
+// which works fine inside vitest), so vitest now collects the whole suite.
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
     include: ['src/**/*.test.ts'],
-    exclude: [...configDefaults.exclude, ...LEGACY_NODE_TEST_FILES],
   },
 });


### PR DESCRIPTION
Two related bot-quality commits from the "do it all + audit" pass on the doc 869 follow-ups.

## 1. Migrate 18 legacy `node:test` suites to vitest (`67fff6a`)
The bot had a split test convention: 5 vitest suites ran in CI, but 18 older suites used Node's built-in `node:test` runner and were **excluded** from `vitest.config.ts` — so they never ran in CI (~196 assertions of dead-weight coverage).
- Each file now imports `test` from `'vitest'` instead of `'node:test'`. They keep `node:assert/strict` (works inside vitest) — a **one-line import swap per file, no assertion rewrites**, low risk.
- Removed the `LEGACY_NODE_TEST_FILES` exclude list.
- Added the ZAOstock bot's first unit test (`getZaalDmId`).

## 2. Harden the ZAO Devz `/hermes-dispatch` listener (`5eb0262`)
doc 869 P3 (defense-in-depth). Extracted the loopback listener's auth + input validation into pure, tested functions (`bot/src/devz/dispatch-auth.ts`):
- **`safeEqual`** — constant-time secret comparison (`crypto.timingSafeEqual`), replacing a timing-leaky `!==`.
- **`isValidDocPath`** — the relative-`.md`/no-traversal guard, extracted and tested (incl. path-traversal + shell-character rejection).
- Gives the ZAO Devz module its **first unit tests** (was zero).

## Result
**25 files / 269 tests pass** (was 5 files / 55 in CI). Bot typecheck clean. App untouched (bot-only).

A code-review pass over the full diff (correctness / removed-behavior / cross-file / conventions angles) surfaced **no correctness findings**. Pairs with the `bot-test` CI job from #881 — once that job lands, all 269 run on every PR.

### Deliberately *not* done (would risk regressions / need a decision)
- **ZAOstock 4-char auth** — login validation lives in cowork-zaodevz, not this repo; codes are already scrypt-hashed (real fix = rate-limit there).
- **OpenClaw agent dashboard** (`src/components/admin/agents/constants.ts`) — the whole `AGENTS` array is the decommissioned squad; removing one entry is a half-measure, removing the dashboard is a product call.
- **Structured logging** (~167 `console.*`) — broad refactor, deferred.
- Migrated suites still use `node:assert` not vitest `expect` — deliberate (avoids an 18-file assertion rewrite); convertible later file-by-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FKmv8E6c8yBGJPwEs9vNA3