### PR TITLE
fix(api): stop swallowing fire-and-forget failures (chat/send + music/submissions)

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest) {
 
     // Track member activity + save music links (fire and forget)
     touchActivity(session.fid);
-    extractAndSaveSongs(text, embedUrls, session.fid, 'chat').catch(() => {});
+    extractAndSaveSongs(text, embedUrls, session.fid, 'chat').catch((err) => logger.error('[chat/send] song extraction failed:', err));
 
     // Cross-post to additional channels (fire and forget)
     const additionalChannels = [...channels].filter((ch) => ch !== primaryChannel);

--- a/src/app/api/music/submissions/route.ts
+++ b/src/app/api/music/submissions/route.ts
@@ -187,7 +187,7 @@ export async function POST(req: NextRequest) {
       submittedByFid: session.fid,
       source: 'submission',
       tags: tags as string[] | undefined,
-    }).catch(() => {});
+    }).catch((err) => logger.error('[music/submissions] background upsert failed:', err));
 
     return NextResponse.json({ success: true, submission: result.data });
   } catch (error) {


### PR DESCRIPTION
Two API routes used `.catch(() => {})` on fire-and-forget async calls, silently dropping failures with zero trace:

- `src/app/api/chat/send/route.ts:72` - `extractAndSaveSongs(...)` (lost song extraction, no signal)
- `src/app/api/music/submissions/route.ts:190` - background song upsert (lost write, no signal)

Both violate the no-silent-failure rule. Both files already import `logger` and use `.catch((err) => logger.error(...))` for every other fire-and-forget call - this just makes these two consistent. Behavior-preserving (still fire-and-forget), now logs on failure.

Found via an in-progress ZAOOS weakness audit. First of several safe fixes; larger systemic items (132 unvalidated routes, biome lint disabled) queued for Zaal.