### PR TITLE
fix(lint): re-enable biome on src, scoped to changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so `biome --changed --since=origin/main` can diff
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -24,8 +27,15 @@ jobs:
 
       - run: npm ci
 
-      - name: Lint
-        run: npm run ci:lint
+      - run: git fetch origin main --depth=0 || git fetch origin main
+
+      # Biome lints ONLY files changed vs main (scoped re-enable). Until the
+      # pre-existing backlog is worked down, this is non-blocking: it reports
+      # issues on touched files without failing CI. Flip continue-on-error to
+      # false to make it enforcing. See research doc 887 / loop-zaoos-fixes.
+      - name: Lint (biome, changed files)
+        continue-on-error: true
+        run: npm run ci:lint:changed
 
       - name: Typecheck
         run: npm run typecheck

--- a/biome.json
+++ b/biome.json
@@ -38,13 +38,19 @@
   "files": {
     "ignoreUnknown": true,
     "includes": [
-      "src",
-      "scripts",
+      "src/**",
+      "scripts/**",
       "community.config.ts",
       "next.config.js",
       "tailwind.config.ts",
       "postcss.config.js",
       "vitest.config.ts"
     ]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "defaultBranch": "main",
+    "useIgnoreFile": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
-    "ci:lint": "biome ci ."
+    "ci:lint": "biome ci .",
+    "ci:lint:changed": "biome ci --changed --since=origin/main"
   },
   "dependencies": {
     "@100mslive/hms-video-store": "^0.13.2",


### PR DESCRIPTION
**Problem:** biome.json's `files.includes` used bare `src`/`scripts` instead of Biome-2.x globs, so biome linted only 2 of ~1035 files. The no-`any`/unused-vars/useConst rules were silently unenforced repo-wide. (The audit blamed `ignoreUnknown`; the real cause is the glob - verified.)

**Why both files change together:** fixing the glob alone makes `biome ci .` lint the whole tree and fail CI on the pre-existing backlog (115+ infos + errors). So enforcement is scoped to CHANGED files:
- `biome.json`: includes -> `src/**`, `scripts/**`; add `vcs` block (defaultBranch main)
- `package.json`: `ci:lint:changed = biome ci --changed --since=origin/main`
- `ci.yml`: `fetch-depth: 0` + fetch main; Lint step lints changed files only

**Safe to merge:** the new lint step is `continue-on-error: true` (non-blocking) - it surfaces issues on touched files without breaking CI while the backlog is worked down. **Flip `continue-on-error` to `false` to enforce.** Verified this PR's own changed files pass clean; typecheck untouched + green.

Note: biome lints whole files, so a PR touching a file with pre-existing issues will see them flagged - that's why it starts non-blocking.

Found via the ZAOOS weakness audit (loop). Implements the 'scope to changed files' decision.