### PR TITLE
fix(api): add Zod validation to unauthed music/artists + nexus/links

### DIFF
--- a/src/app/api/music/artists/route.ts
+++ b/src/app/api/music/artists/route.ts
@@ -1,15 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const artistsQuerySchema = z.object({ artist: z.string().trim().min(1).max(120) });
 
 /**
  * GET /api/music/artists?artist=... — get aggregated data for an artist
  */
 export async function GET(req: NextRequest) {
-  const artist = req.nextUrl.searchParams.get('artist');
-  if (!artist || !artist.trim()) {
-    return NextResponse.json({ error: 'Missing artist parameter' }, { status: 400 });
+  const parsed = artistsQuerySchema.safeParse({ artist: req.nextUrl.searchParams.get('artist') ?? '' });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Missing or invalid artist parameter' }, { status: 400 });
   }
+  const artist = parsed.data.artist;
 
   try {
     // Query songs where artist matches (case-insensitive partial match)

--- a/src/app/api/nexus/links/route.ts
+++ b/src/app/api/nexus/links/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
+import { z } from 'zod';
+
+const nexusLinksQuerySchema = z.object({
+  portal_group: z.string().max(100).nullish(),
+  category: z.string().max(100).nullish(),
+  tag: z.string().max(100).nullish(),
+  featured: z.string().max(10).nullish(),
+});
 
 /**
  * Public API: GET /api/nexus/links
@@ -15,10 +23,16 @@ import { supabaseAdmin } from '@/lib/db/supabase';
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const portalGroup = searchParams.get('portal_group');
-    const category = searchParams.get('category');
-    const tag = searchParams.get('tag');
-    const featured = searchParams.get('featured');
+    const parsed = nexusLinksQuerySchema.safeParse({
+      portal_group: searchParams.get('portal_group'),
+      category: searchParams.get('category'),
+      tag: searchParams.get('tag'),
+      featured: searchParams.get('featured'),
+    });
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid query parameters' }, { status: 400 });
+    }
+    const { portal_group: portalGroup, category, tag, featured } = parsed.data;
 
     let query = supabaseAdmin
       .from('nexus_links')


### PR DESCRIPTION
First batch of the unauthed-route validation pass (audit found ~10 public routes taking input with no Zod). These two public GET routes read user-controlled query params straight into Supabase queries with zero validation. Added permissive Zod (length caps, optional filters) - rejects malformed/abusive input with 400, behavior-preserving for valid traffic. typecheck green. More routes in follow-up batches.