### PR TITLE
fix(api): Zod on unauthed fc-identity, discord/intros, bluesky/feed

### DIFF
--- a/src/app/api/bluesky/feed/route.ts
+++ b/src/app/api/bluesky/feed/route.ts
@@ -12,7 +12,10 @@ import { logger } from '@/lib/logger';
  */
 export async function GET(req: NextRequest) {
   try {
-    const cursor = req.nextUrl.searchParams.get('cursor') || undefined;
+    // External endpoint (Bluesky AppView). Validate defensively but do NOT 400 -
+    // clamp/ignore bad input so the feed keeps rendering. Ignore an over-long cursor.
+    const rawCursor = req.nextUrl.searchParams.get('cursor') || undefined;
+    const cursor = rawCursor && rawCursor.length <= 200 ? rawCursor : undefined;
     const limit = Math.min(
       parseInt(req.nextUrl.searchParams.get('limit') || '30', 10),
       100,

--- a/src/app/api/discord/intros/route.ts
+++ b/src/app/api/discord/intros/route.ts
@@ -1,6 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSupabaseAdmin } from '@/lib/db/supabase';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const introsQuerySchema = z.object({
+  discord_id: z.string().regex(/^\d{1,32}$/, 'invalid discord_id').nullish(),
+  all: z.string().nullish(),
+});
 
 /**
  * GET /api/discord/intros — Fetch Discord intro(s)
@@ -9,8 +15,15 @@ import { logger } from '@/lib/logger';
  *   ?all=true              — return all intros
  */
 export async function GET(req: NextRequest) {
-  const discordId = req.nextUrl.searchParams.get('discord_id');
-  const all = req.nextUrl.searchParams.get('all') === 'true';
+  const parsed = introsQuerySchema.safeParse({
+    discord_id: req.nextUrl.searchParams.get('discord_id'),
+    all: req.nextUrl.searchParams.get('all'),
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query parameters' }, { status: 400 });
+  }
+  const discordId = parsed.data.discord_id ?? null;
+  const all = parsed.data.all === 'true';
 
   if (!discordId && !all) {
     return NextResponse.json(

--- a/src/app/api/fc-identity/check/route.ts
+++ b/src/app/api/fc-identity/check/route.ts
@@ -1,15 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 import { checkGatingEligibility, getFcQualityScoreByFid } from '@/lib/fc-identity';
+
+const checkQuerySchema = z
+  .object({
+    address: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'invalid address').optional(),
+    fid: z.coerce.number().int().positive().optional(),
+    minScore: z.coerce.number().int().min(0).default(0),
+  })
+  .refine((d) => d.address !== undefined || d.fid !== undefined, {
+    message: 'address or fid required',
+  });
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
-  const address = searchParams.get('address');
-  const fid = searchParams.get('fid');
-  const minScore = parseInt(searchParams.get('minScore') ?? '0', 10);
-
-  if (!address && !fid) {
-    return NextResponse.json({ error: 'address or fid required' }, { status: 400 });
+  const parsed = checkQuerySchema.safeParse({
+    address: searchParams.get('address') ?? undefined,
+    fid: searchParams.get('fid') ?? undefined,
+    minScore: searchParams.get('minScore') ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'invalid query parameters' },
+      { status: 400 },
+    );
   }
+  const { address, fid, minScore } = parsed.data;
 
   try {
     // Check by ETH address
@@ -23,12 +39,11 @@ export async function GET(req: NextRequest) {
     }
 
     // Check by FID
-    if (fid) {
-      const fidNum = parseInt(fid, 10);
-      const score = await getFcQualityScoreByFid(fidNum);
+    if (fid !== undefined) {
+      const score = await getFcQualityScoreByFid(fid);
       return NextResponse.json({
         type: 'fid',
-        fid: fidNum,
+        fid,
         score,
         eligible: score !== null ? score >= BigInt(minScore) : true,
       });


### PR DESCRIPTION
Second batch of unauthed-route validation.

- **fc-identity/check** - validates address (0x-hex), fid (positive int), minScore; 400 on bad input.
- **discord/intros** - validates discord_id (numeric snowflake) + all flag; 400 on bad input.
- **bluesky/feed** - called by Bluesky's external AppView, so it **clamps** (ignores an over-long cursor) rather than 400ing - a 400 would break the live feed. Defensive without breaking the external contract.

Applies the new DOCTRINE's external-endpoint caution. typecheck green. Remaining unauthed routes: members/[username] family + the 2 signed webhooks (careful separate pass).