### PR TITLE
fix(api): username length validation on public members/[username] routes

### DIFF
--- a/src/app/api/members/[username]/friends/route.ts
+++ b/src/app/api/members/[username]/friends/route.ts
@@ -2,12 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { getBestFriends } from '@/lib/farcaster/neynar';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const usernameParamSchema = z.string().min(1).max(100);
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ username: string }> },
 ) {
   const { username } = await params;
+  const usernameCheck = usernameParamSchema.safeParse(username);
+  if (!usernameCheck.success) {
+    return NextResponse.json({ error: 'Invalid username' }, { status: 400 });
+  }
   try {
     const { data: user } = await supabaseAdmin
       .from('users')

--- a/src/app/api/members/[username]/popular/route.ts
+++ b/src/app/api/members/[username]/popular/route.ts
@@ -2,12 +2,19 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { getPopularCasts } from '@/lib/farcaster/neynar';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const usernameParamSchema = z.string().min(1).max(100);
 
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ username: string }> },
 ) {
   const { username } = await params;
+  const usernameCheck = usernameParamSchema.safeParse(username);
+  if (!usernameCheck.success) {
+    return NextResponse.json({ error: 'Invalid username' }, { status: 400 });
+  }
   try {
     const { data: user } = await supabaseAdmin
       .from('users')

--- a/src/app/api/members/[username]/route.ts
+++ b/src/app/api/members/[username]/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/db/supabase';
 import { resolveENSNames, getENSTextRecords, getENSAvatar, resolveBasenames } from '@/lib/ens/resolve';
 import { logger } from '@/lib/logger';
+import { z } from 'zod';
+
+const usernameParamSchema = z.string().min(1).max(100);
 
 /**
  * GET /api/members/[username] — Unified member profile
@@ -14,6 +17,10 @@ export async function GET(
 ) {
 
   const { username } = await params;
+  const usernameCheck = usernameParamSchema.safeParse(username);
+  if (!usernameCheck.success) {
+    return NextResponse.json({ error: 'Invalid username' }, { status: 400 });
+  }
   const lookup = decodeURIComponent(username).toLowerCase();
 
   try {


### PR DESCRIPTION
Third + final batch of the public GET-route validation pass. The 3 member-profile routes (members/[username], /friends, /popular) took the username path param into Supabase ilike with no bound. Queries are already parameterized (no injection risk), so this adds a length guard (1-100 chars, 400 on violation) against oversized/abusive input. typecheck green.

**Public unauthed GET routes now validated** (this + #918 + #921): music/artists, nexus/links, fc-identity/check, discord/intros, bluesky/feed (clamp), members/[username] x3. **Remaining:** the 2 signed webhooks (100ms/webhook, miniapp/webhook) - these verify external signatures; their validation needs a careful separate pass, flagged for review.