### PR TITLE
test(security): timingSafeEqual tests (10 cases)

### DIFF
--- a/src/lib/security/__tests__/timingSafeEqual.test.ts
+++ b/src/lib/security/__tests__/timingSafeEqual.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { timingSafeEqual } from '@/lib/security/timingSafeEqual';
+
+describe('timingSafeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(timingSafeEqual('secret-token', 'secret-token')).toBe(true);
+  });
+
+  it('returns true for two empty strings', () => {
+    expect(timingSafeEqual('', '')).toBe(true);
+  });
+
+  it('returns false for different strings of equal length', () => {
+    expect(timingSafeEqual('aaaa', 'aaab')).toBe(false);
+  });
+
+  it('returns false when only the first byte differs', () => {
+    expect(timingSafeEqual('Xbcd', 'abcd')).toBe(false);
+  });
+
+  it('returns false when only the last byte differs', () => {
+    expect(timingSafeEqual('abcd', 'abcX')).toBe(false);
+  });
+
+  it('returns false for different lengths (shorter vs longer)', () => {
+    expect(timingSafeEqual('abc', 'abcd')).toBe(false);
+    expect(timingSafeEqual('abcd', 'abc')).toBe(false);
+  });
+
+  it('returns false when one side is empty', () => {
+    expect(timingSafeEqual('', 'a')).toBe(false);
+    expect(timingSafeEqual('a', '')).toBe(false);
+  });
+
+  it('distinguishes the Bearer-prefixed form from the bare secret', () => {
+    const secret = 's3cr3t';
+    expect(timingSafeEqual('Bearer s3cr3t', `Bearer ${secret}`)).toBe(true);
+    expect(timingSafeEqual('s3cr3t', `Bearer ${secret}`)).toBe(false);
+  });
+
+  it('handles unicode / multi-byte chars by code unit', () => {
+    expect(timingSafeEqual('café', 'café')).toBe(true);
+    expect(timingSafeEqual('café', 'cafe')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(timingSafeEqual('Secret', 'secret')).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds 10 tests for `timingSafeEqual` - the constant-time comparison that authenticates the 100ms webhook secret. A security-critical pure function with zero prior coverage. Covers identical/empty strings, first/last-byte diffs, length mismatches, Bearer-prefix vs bare-secret, unicode, case-sensitivity. All pass under node 22.