### PR TITLE
fix(api): BigInt-serialize fc-identity score (real bug) + fc-identity & discord tests

### DIFF
--- a/src/app/api/discord/intros/__tests__/intros-route.test.ts
+++ b/src/app/api/discord/intros/__tests__/intros-route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockFrom } = vi.hoisted(() => ({ mockFrom: vi.fn() }));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+import { GET } from '@/app/api/discord/intros/route';
+
+function singleChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'order', 'limit']) chain[m] = vi.fn().mockReturnValue(chain);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+function listChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  chain.then = vi.fn((resolve: (v: unknown) => void) => resolve(result));
+  return chain;
+}
+const req = (q = '') => new NextRequest(`http://localhost:3000/api/discord/intros${q}`);
+const intro = { discord_id: '123', discord_username: 'bob', intro_text: 'hi', posted_at: '2026-01-01' };
+
+describe('GET /api/discord/intros', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('400 on a non-numeric discord_id', async () => {
+    const res = await GET(req('?discord_id=not-a-snowflake'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid query parameters');
+  });
+
+  it('400 when neither discord_id nor all is provided', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Provide discord_id or all=true');
+  });
+
+  it('returns a single intro by discord_id', async () => {
+    mockFrom.mockReturnValue(singleChain({ data: intro, error: null }));
+    const res = await GET(req('?discord_id=123'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).intro.discordId).toBe('123');
+  });
+
+  it('returns null intro when none found', async () => {
+    mockFrom.mockReturnValue(singleChain({ data: null, error: null }));
+    const res = await GET(req('?discord_id=999'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).intro).toBeNull();
+  });
+
+  it('returns all intros with all=true', async () => {
+    mockFrom.mockReturnValue(listChain({ data: [intro], error: null }));
+    const res = await GET(req('?all=true'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total).toBe(1);
+    expect(body.intros[0].discordUsername).toBe('bob');
+  });
+});

--- a/src/app/api/fc-identity/check/__tests__/check-route.test.ts
+++ b/src/app/api/fc-identity/check/__tests__/check-route.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockCheckGating, mockScoreByFid } = vi.hoisted(() => ({
+  mockCheckGating: vi.fn(),
+  mockScoreByFid: vi.fn(),
+}));
+
+vi.mock('@/lib/fc-identity', () => ({
+  checkGatingEligibility: (...a: unknown[]) => mockCheckGating(...a),
+  getFcQualityScoreByFid: (...a: unknown[]) => mockScoreByFid(...a),
+}));
+
+import { GET } from '@/app/api/fc-identity/check/route';
+
+const VALID_ADDR = '0x1234567890abcdef1234567890abcdef12345678';
+const req = (q = '') => new NextRequest(`http://localhost:3000/api/fc-identity/check${q}`);
+
+describe('GET /api/fc-identity/check', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('400 when neither address nor fid is provided', async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('address or fid required');
+  });
+
+  it('400 on a malformed address', async () => {
+    const res = await GET(req('?address=0xnothex'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('invalid address');
+  });
+
+  it('checks eligibility by address', async () => {
+    mockCheckGating.mockResolvedValue({ eligible: true, score: '5' });
+    const res = await GET(req(`?address=${VALID_ADDR}&minScore=3`));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.type).toBe('address');
+    expect(body.eligible).toBe(true);
+    expect(mockCheckGating).toHaveBeenCalledWith(VALID_ADDR, 3);
+  });
+
+  it('checks eligibility by fid', async () => {
+    mockScoreByFid.mockResolvedValue(10n);
+    const res = await GET(req('?fid=42&minScore=5'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.type).toBe('fid');
+    expect(body.fid).toBe(42);
+    expect(body.score).toBe('10');
+    expect(body.eligible).toBe(true);
+  });
+});

--- a/src/app/api/fc-identity/check/route.ts
+++ b/src/app/api/fc-identity/check/route.ts
@@ -44,7 +44,8 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({
         type: 'fid',
         fid,
-        score,
+        // score is a bigint; JSON.stringify cannot serialize BigInt, so stringify it
+        score: score !== null ? score.toString() : null,
         eligible: score !== null ? score >= BigInt(minScore) : true,
       });
     }


### PR DESCRIPTION
**Found a real production bug while writing tests.** GET /api/fc-identity/check?fid=... put the quality score (a `bigint`) straight into `NextResponse.json`. `JSON.stringify` throws on BigInt, the route's try/catch swallowed it, and **every fid query with a non-null score returned 502**. Fixed by serializing the score to a string.

Tests added (9, all pass under node 22):
- **fc-identity/check** (4): 400 no-params, 400 malformed address, by-address eligibility, by-fid (asserts the now-serialized score)
- **discord/intros** (5): 400 bad discord_id, 400 no-params, single intro, null intro, all=true

This is the loop doing its job - test-coverage work surfaced an actual swallowed-500 bug. typecheck green.