### PR TITLE
fix(api): BigInt-serialize the ADDRESS path of fc-identity/check (incomplete #927)

### DIFF
--- a/src/app/api/fc-identity/check/__tests__/check-route.test.ts
+++ b/src/app/api/fc-identity/check/__tests__/check-route.test.ts
@@ -32,12 +32,13 @@ describe('GET /api/fc-identity/check', () => {
   });
 
   it('checks eligibility by address', async () => {
-    mockCheckGating.mockResolvedValue({ eligible: true, score: '5' });
+    mockCheckGating.mockResolvedValue({ eligible: true, score: 5n, fid: 100 });
     const res = await GET(req(`?address=${VALID_ADDR}&minScore=3`));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.type).toBe('address');
     expect(body.eligible).toBe(true);
+    expect(body.score).toBe('5');
     expect(mockCheckGating).toHaveBeenCalledWith(VALID_ADDR, 3);
   });
 

--- a/src/app/api/fc-identity/check/route.ts
+++ b/src/app/api/fc-identity/check/route.ts
@@ -35,6 +35,8 @@ export async function GET(req: NextRequest) {
         type: 'address',
         address,
         ...result,
+        // result.score is a bigint; override the spread with a serializable value
+        score: result.score !== null ? result.score.toString() : null,
       });
     }
 


### PR DESCRIPTION
**#927 only half-fixed the bug.** It serialized the fid path but the **address path** still does `NextResponse.json({ ...result })` where `result.score` from `checkGatingEligibility` is a `bigint` - same 502. The #927 test masked it by mocking `score` as a *string*; lesson: mock with realistic types.

This fixes the address path (override the spread score with `.toString()`) and changes the test mock to a real bigint (`5n`) so it actually exercises the path. typecheck green, 4 tests pass.

Found by following the BigInt-in-JSON lead from #927.