### PR TITLE
docs: ZOE morning briefing 2026-06-22

### DIFF
--- a/docs/daily/2026-06-22-briefing.md
+++ b/docs/daily/2026-06-22-briefing.md
@@ -57,3 +57,49 @@ Doc 882 revealed that ZAOscout — the renamed farscout — is fully assembled a
 ---
 
 *Sources: git log (last 24h), GitHub PRs, docs/daily/2026-06-21-tasks.md, doc 882, ZOE nightly processor*
+
+---
+
+## JOB BOARD — Top 3 Matches (June 22, 2026)
+
+> Roles matching: DevRel / community / AI automation / web3 / $35/hr+ remote
+
+1. **Remote Web3 DevRel — $125k–$300k/year** (CryptoJobsList)
+   Multiple positions open. Covers DevRel, events, community, growth. Dev.fun role explicitly needs someone who helps builders "move from shipping apps to launching products" — your profile fits cold. Token allocation included.
+   → [cryptojobslist.com/remote_devrel](https://cryptojobslist.com/remote_devrel)
+
+2. **Developer Advocate — Base / Blockstream / Affine** (Web3.career, 54 open)
+   Fresh June 2026 listings. Base-adjacent roles ideal — you have on-chain community + governance track record (188 members, 90+ weeks fractal). Community Moderator & DevRel hybrid roles also listed.
+   → [web3.career/developer-advocate+remote-jobs](https://web3.career/developer-advocate+remote-jobs)
+
+3. **Remote Community Manager — Web3** (Web3.career, 1 new June 2026)
+   Thin supply = less competition. Community managers with technical + governance depth (you) are rare. Worth a cold application to whoever posted fresh.
+   → [web3.career/community-manager+remote-jobs](https://web3.career/community-manager+remote-jobs)
+
+---
+
+## FARCASTER ENGAGEMENT — 2–3 Opps (June 22, 2026)
+
+> Draft replies — post as Zaal, builder voice. Don't comment. Add perspective.
+
+**1. AI agents on Farcaster — /ai channel**
+Thread topic: "Will AI agents make Farcaster the next big thing?" (active across /ai, /founders, BlockBeats picked it up)
+
+> Draft reply:
+> "Been running ZOE on Farcaster for months — AI agents aren't a future bet, they're already compressing the gap between 'idea' and 'shipped.' The interesting unlock isn't the agent itself, it's what happens when the agent has community context. When ZOE knows The ZAO's 188 members, their cast history, and our governance rules — it stops being a chatbot and starts being a contributor. That's the layer most agent builders skip."
+
+**2. Fractal governance + on-chain coordination — /founders or /governance**
+Thread topic: Building sustained community engagement / preventing churn in web3 communities (perennial /founders topic)
+
+> Draft reply:
+> "90+ weeks of fractal meetings. What keeps people coming back isn't incentives — it's the shared sense of being in a room where decisions actually happen. On-chain governance that people ignore is worse than no governance. The fix is making the governance surface the social layer, not an extra tab nobody opens. Still figuring this out at The ZAO, but the 90-week streak is evidence the weekly cadence is load-bearing."
+
+**3. Neynar acquisition of Farcaster + what it means for builders — /base or /farcaster**
+Thread topic: "Neynar acquired Farcaster protocol (Jan 2026) — good or bad for builders?"
+
+> Draft reply:
+> "Builders using Neynar already were unaffected. The infra consolidation actually makes the stack more stable for people running production agents (we use Neynar for ZOE's cast pipeline). The philosophical decentralization debate is real, but from a practical standpoint: if you're building on Farcaster today, your risk surface didn't change — Neynar was already the de facto infra layer."
+
+---
+
+*Sources: git log (last 24h), GitHub PRs, docs/daily/2026-06-21-tasks.md, doc 882, ZOE nightly processor, web3.career, cryptojobslist.com, Neynar blog, BlockBeats, t2.world*


### PR DESCRIPTION
ZOE 4:30am morning briefing additions for Monday June 22, 2026.

Nightly processor had already generated the base briefing, tasks, newsletter, and captures. This PR appends the live-run sections:

## What's added to `docs/daily/2026-06-22-briefing.md`

**Job Board — Top 3 Matches**
- Remote Web3 DevRel ($125k–$300k, CryptoJobsList) — Dev.fun role matches Zaal's builder profile cold
- Developer Advocate at Base/Blockstream/Affine (54 open on web3.career, June 2026)
- Remote Community Manager (1 fresh June 2026 listing — thin supply = low competition)

**Farcaster Engagement — 3 draft replies**
1. `/ai` channel — AI agents on Farcaster (ZOE-as-contributor angle)
2. `/founders` — 90+ week fractal streak as evidence for sustained community engagement
3. `/base` or `/farcaster` — Neynar acquiring Farcaster protocol (builder-practical take)

All drafts position Zaal as a builder with lived experience, not a commenter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMUnwFA3wP95C9FRdhtCFA)_