### PR TITLE
fix(a11y): real alt on IssueReporter screenshot preview (removes eslint-disable)

### DIFF
--- a/src/components/feedback/IssueReporter.tsx
+++ b/src/components/feedback/IssueReporter.tsx
@@ -159,8 +159,7 @@ export function IssueReporter() {
               />
               {screenshot ? (
                 <div className="relative">
-                  {/* eslint-disable-next-line jsx-a11y/alt-text */}
-                  <img src={screenshot} className="w-full h-32 object-cover rounded-lg border border-white/10" />
+                  <img src={screenshot} alt="Screenshot preview" className="w-full h-32 object-cover rounded-lg border border-white/10" />
                   <button
                     onClick={() => setScreenshot(null)}
                     className="absolute top-1 right-1 bg-black/60 text-white text-xs w-6 h-6 rounded-full flex items-center justify-center"


### PR DESCRIPTION
Replaces an `eslint-disable jsx-a11y/alt-text` suppression with a proper `alt="Screenshot preview"`. Strictly better - screen readers announce the preview and the lint suppression is gone.

Context: frontend sweep this iteration found the components genuinely well-maintained (no React.FC, all 'use client' correct, 17 error boundaries, fetch handlers consistently guard with `|| []` / `Array.isArray` / `.catch`). This was the one clear improvement.