### PR TITLE
fix(api): stop leaking internal error details from fc-identity/check (+ test)

### DIFF
--- a/src/app/api/fc-identity/check/__tests__/check-route.test.ts
+++ b/src/app/api/fc-identity/check/__tests__/check-route.test.ts
@@ -51,4 +51,13 @@ describe('GET /api/fc-identity/check', () => {
     expect(body.score).toBe('10');
     expect(body.eligible).toBe(true);
   });
+
+  it('502 with no leaked error details when the chain read throws', async () => {
+    mockCheckGating.mockRejectedValue(new Error('RPC timeout at 0xdeadbeef internal'));
+    const res = await GET(req(`?address=${VALID_ADDR}`));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toBe('Chain read failed');
+    expect(body.details).toBeUndefined(); // internal error string must not reach the client
+  });
 });

--- a/src/app/api/fc-identity/check/route.ts
+++ b/src/app/api/fc-identity/check/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { checkGatingEligibility, getFcQualityScoreByFid } from '@/lib/fc-identity';
+import { logger } from '@/lib/logger';
 
 const checkQuerySchema = z
   .object({
@@ -50,6 +51,7 @@ export async function GET(req: NextRequest) {
       });
     }
   } catch (err) {
-    return NextResponse.json({ error: 'Chain read failed', details: String(err) }, { status: 502 });
+    logger.error('[fc-identity] chain read failed:', err);
+    return NextResponse.json({ error: 'Chain read failed' }, { status: 502 });
   }
 }


### PR DESCRIPTION
The 502 catch in fc-identity/check returned `details: String(err)` to the client, exposing internal error strings (RPC URLs, addresses, stack hints) - violates the sanitized-500 rule - and didn't log server-side. Fixed: log via `logger.error`, return only `{ error: 'Chain read failed' }`. Adds a test asserting the 502 body has no `details`. typecheck green, 5 tests pass.

Closes the error-info-disclosure item I flagged in iteration 11 (held until the #928 same-file PR merged - now done).