### PR TITLE
feat(bots): classify claude CLI errors (doc 888 #3)

### DIFF
--- a/bot/src/hermes/__tests__/claude-error-classify.test.ts
+++ b/bot/src/hermes/__tests__/claude-error-classify.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { classifyClaudeError } from '../claude-cli';
+
+describe('classifyClaudeError', () => {
+  it('detects auth/OAuth expiry (the 2026-06-23 fleet outage)', () => {
+    expect(classifyClaudeError('API Error: 401 Invalid authentication credentials').kind).toBe('auth');
+    expect(classifyClaudeError('Failed to authenticate. Please run /login').kind).toBe('auth');
+    expect(classifyClaudeError('oauth token expired').kind).toBe('auth');
+  });
+
+  it('detects usage/quota limits before generic rate limits', () => {
+    expect(classifyClaudeError('You have reached your usage limit').kind).toBe('usage_limit');
+    expect(classifyClaudeError('quota exceeded for this plan').kind).toBe('usage_limit');
+  });
+
+  it('detects rate limiting / overload', () => {
+    expect(classifyClaudeError('HTTP 429 Too Many Requests').kind).toBe('rate_limit');
+    expect(classifyClaudeError('529 overloaded, try again').kind).toBe('rate_limit');
+  });
+
+  it('detects timeouts', () => {
+    expect(classifyClaudeError('request timed out').kind).toBe('timeout');
+    expect(classifyClaudeError('ETIMEDOUT').kind).toBe('timeout');
+  });
+
+  it('falls back to unknown for unrecognized output', () => {
+    expect(classifyClaudeError('some random parse error').kind).toBe('unknown');
+    expect(classifyClaudeError('').kind).toBe('unknown');
+  });
+
+  it('always returns a non-empty actionable hint', () => {
+    for (const s of ['401', 'usage limit', '429', 'timeout', 'weird']) {
+      expect(classifyClaudeError(s).hint.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -35,6 +35,32 @@ const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
  *
  * Returns the assistant's final text result + usage stats (parsed from --output-format json).
  */
+export type ClaudeErrorKind = 'auth' | 'usage_limit' | 'rate_limit' | 'timeout' | 'unknown';
+
+/**
+ * Classify a claude CLI failure from its combined stderr+stdout so callers can
+ * surface an actionable message (e.g. "auth expired -> /login") instead of a
+ * generic blob. The auth case is the one that silently broke the whole fleet
+ * (2026-06-23): the Max-plan OAuth token expired and every failure looked the
+ * same. Pure + exported for unit testing.
+ */
+export function classifyClaudeError(text: string): { kind: ClaudeErrorKind; hint: string } {
+  const t = (text || '').toLowerCase();
+  if (/\b401\b|invalid authentication|unauthorized|not logged in|please run.*\/login|oauth token (expired|revoked)|authentication_error/.test(t)) {
+    return { kind: 'auth', hint: 'claude login/OAuth expired - run `claude` then /login on the host' };
+  }
+  if (/usage limit|quota exceeded|out of credit|insufficient.*credit|plan limit reached/.test(t)) {
+    return { kind: 'usage_limit', hint: 'plan usage/quota reached - check the Claude plan' };
+  }
+  if (/\b429\b|\b529\b|rate.?limit|too many requests|overloaded/.test(t)) {
+    return { kind: 'rate_limit', hint: 'rate-limited/overloaded - retry shortly' };
+  }
+  if (/timed out|timeout|etimedout/.test(t)) {
+    return { kind: 'timeout', hint: 'model call timed out' };
+  }
+  return { kind: 'unknown', hint: 'unclassified claude CLI failure - check logs' };
+}
+
 export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> {
   return new Promise((resolve, reject) => {
     const outputFormat = opts.outputFormat ?? 'json';
@@ -126,9 +152,10 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
           '\n  stdout=', stdout.slice(0, 800) || '(empty)',
           '\n  args=', JSON.stringify(args).slice(0, 400),
         );
+        const cls = classifyClaudeError(`${stderr} ${stdout}`);
         reject(
           new Error(
-            `claude CLI exited ${code}. stderr: ${stderr.slice(0, 400) || '(empty)'} | stdout: ${stdout.slice(0, 400) || '(empty)'}`,
+            `claude CLI exited ${code} [${cls.kind}: ${cls.hint}]. stderr: ${stderr.slice(0, 400) || '(empty)'} | stdout: ${stdout.slice(0, 400) || '(empty)'}`,
           ),
         );
         return;
@@ -137,7 +164,8 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
       // Empty stdout means Claude exited silently - log everything we have.
       if (!stdout.trim()) {
         console.error('[hermes/claude-cli] empty stdout. exit_code=', code, 'stderr=', stderr.slice(0, 800), 'args=', JSON.stringify(args).slice(0, 800));
-        reject(new Error(`claude CLI returned empty stdout. exit=${code}. stderr: ${stderr.slice(0, 400) || '(empty)'}`));
+        const clsEmpty = classifyClaudeError(stderr);
+        reject(new Error(`claude CLI returned empty stdout [${clsEmpty.kind}: ${clsEmpty.hint}]. exit=${code}. stderr: ${stderr.slice(0, 400) || '(empty)'}`));
         return;
       }
 
@@ -157,7 +185,8 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
           };
           if (parsed.is_error) {
             console.error('[hermes/claude-cli] is_error=true full payload:', JSON.stringify(parsed).slice(0, 1200));
-            reject(new Error(`claude CLI reported is_error=true: ${(parsed.result ?? '').slice(0, 400) || '(no result body)'}`));
+            const clsErr = classifyClaudeError(parsed.result ?? '');
+            reject(new Error(`claude CLI reported is_error=true [${clsErr.kind}: ${clsErr.hint}]: ${(parsed.result ?? '').slice(0, 400) || '(no result body)'}`));
             return;
           }
           if (!parsed.result || !parsed.result.trim()) {


### PR DESCRIPTION
## Summary
Every claude-max failure across ZOE / Hermes / cowork-agent was a generic error blob - the 2026-06-23 auth-expiry outage (Max-plan OAuth token died) was indistinguishable from a bad flag or JSON error, so it failed silently ~12x/day with no actionable signal.

Adds `classifyClaudeError()` to `bot/src/hermes/claude-cli.ts` (kinds: auth / usage_limit / rate_limit / timeout / unknown, each with a hint) and prefixes the classification onto the reject messages at all three CLI failure points. The user-facing error ZOE shows now reads e.g. `[auth: claude login/OAuth expired - run /login]` instead of a mute blob.

Message/typing only - **no retry or control-flow change** (deliberately low-risk; retry is a separate follow-up per doc 888).

## Test
6 new vitest cases in `bot/src/hermes/__tests__/claude-error-classify.test.ts`, all passing. Pre-existing tsc errors (missing grammy types, devz `any`) are unrelated.

## Context
Doc 888 decision #3. Pairs with the VPS auth-monitor (alerts Zaal on auth death) + the board degraded pill (already shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)