### PR TITLE
docs: ZOE lunch ping 2026-06-23

### DIFF
--- a/docs/daily/2026-06-23-lunch.md
+++ b/docs/daily/2026-06-23-lunch.md
@@ -1,0 +1,9 @@
+Lunch window — 3 things:
+
+1. **Merge 4 PRs from GitHub mobile** — All conflict-free, no review needed. #920 (agents/DOCTRINE), #921 (Zod unauthed 2), #922 (members username), #923 (tests + .nvmrc). Tap merge × 4. Done in 2 minutes.
+
+2. **Post W23 Farcaster thread** — 5 posts sitting in `docs/weekly/2026-W23-recap.md`. Three weeks late. Copy-paste first post while you eat. Threads are your build-in-public flywheel — ship one today.
+
+3. **Bonfire labeling run** — One admin action in the Bonfires dashboard. 9 days overdue. Everything downstream (135-doc memory backfill, ZOE recall, cross-bot KG) is blocked on this one click. Do it while you're thinking about it.
+
+Task status: 0/many priorities done. The 4 PRs are the easiest wins on the board — close them before the afternoon.


### PR DESCRIPTION
ZOE 11:30am lunch ping — `docs/daily/2026-06-23-lunch.md`

3 actionable items for Zaal's 1-hour lunch window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEHW7wheGQkfsa5pjH8AtL)_