### PR TITLE
feat(zoe): /team - read the team tracker (doc 890)

### DIFF
--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatTeamTasks, teamTrackerConfigured, type TeamTask } from '../team-tracker';
+
+describe('formatTeamTasks', () => {
+  it('renders an empty state when there are no tasks', () => {
+    expect(formatTeamTasks([])).toMatch(/no open team tasks/i);
+  });
+
+  it('lists tasks with project, priority, due, and status', () => {
+    const tasks: TeamTask[] = [
+      { title: 'Ship the board', status: 'doing', priority: 'high', due: '2026-06-25', project: 'ZAOstock', legacy_id: '42' },
+      { title: 'Write recap', status: 'todo', priority: 'normal', due: null, project: null, legacy_id: '43' },
+    ];
+    const out = formatTeamTasks(tasks);
+    expect(out).toMatch(/2 open/);
+    expect(out).toContain('ZAOstock: Ship the board');
+    expect(out).toContain('[high]');
+    expect(out).toContain('due 2026-06-25');
+    expect(out).toContain('doing');
+    // normal priority is not shown as a tag
+    expect(out).not.toContain('[normal]');
+  });
+});
+
+describe('teamTrackerConfigured', () => {
+  it('is false without both env vars', () => {
+    const url = process.env.COWORK_TRACKER_URL;
+    const key = process.env.COWORK_TRACKER_KEY;
+    delete process.env.COWORK_TRACKER_URL;
+    delete process.env.COWORK_TRACKER_KEY;
+    expect(teamTrackerConfigured()).toBe(false);
+    if (url) process.env.COWORK_TRACKER_URL = url;
+    if (key) process.env.COWORK_TRACKER_KEY = key;
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -27,6 +27,7 @@ import { applyTaskOps, seedInitialTasks } from './tasks';
 import { applyQuestOps, buildQuestsBlock, formatQuestList } from './sidequests';
 import { runBotRelayOps, summarizeRelayResults } from './relay';
 import { runCrmOps, summarizeCrmResults } from './crm';
+import { getOpenTeamTasks, formatTeamTasks, teamTrackerConfigured } from './team-tracker';
 import { decomposeGoal, renderPlanForApproval, shouldDecompose } from './decompose';
 import {
   buildMemoryBlocks,
@@ -251,6 +252,18 @@ bot.command('tasks', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const blocks = await buildMemoryBlocks('private');
   await replyChunked(ctx, `Open tasks:\n\n${blocks.tasks}`);
+});
+
+bot.command('team', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  if (!teamTrackerConfigured()) {
+    await ctx.reply(
+      'Team tracker not wired up yet - set COWORK_TRACKER_URL + COWORK_TRACKER_KEY in bot/.env to read the team board.',
+    );
+    return;
+  }
+  const tasks = await getOpenTeamTasks();
+  await replyChunked(ctx, formatTeamTasks(tasks));
 });
 
 bot.command('seed', async (ctx) => {

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -1,0 +1,74 @@
+/**
+ * Team tracker read access for ZOE (doc 890 - bridge ZOE to the coworking system).
+ *
+ * ZOE manages Zaal's personal tasks (tasks.json). The TEAM's work lives in the
+ * cowork-zaodevz Supabase tracker (public.tasks). These were two silos: ZOE
+ * couldn't answer "what's the team blocked on?". This module gives ZOE a
+ * read path into the team board via PostgREST.
+ *
+ * Config (env, server-only - add to bot/.env on the VPS):
+ *   COWORK_TRACKER_URL   e.g. https://<ref>.supabase.co
+ *   COWORK_TRACKER_KEY   a Supabase key with read access to public.tasks
+ * If either is missing, the integration is a no-op (teamTrackerConfigured()
+ * returns false) so ZOE keeps working before the creds are seeded.
+ *
+ * Read-only for now; a write path (ZOE assigns team tasks) is a follow-up.
+ */
+
+export interface TeamTask {
+  title: string;
+  status: string;
+  priority: string | null;
+  due: string | null;
+  project: string | null;
+  legacy_id: string | null;
+}
+
+const MAX_TASKS = 30;
+
+export function teamTrackerConfigured(): boolean {
+  return Boolean(process.env.COWORK_TRACKER_URL && process.env.COWORK_TRACKER_KEY);
+}
+
+/**
+ * Fetch open (not done, not archived) team tasks, soonest-due first.
+ * Returns [] if unconfigured or on any error (best-effort - never throws).
+ */
+export async function getOpenTeamTasks(): Promise<TeamTask[]> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return [];
+
+  const url =
+    `${base.replace(/\/$/, '')}/rest/v1/tasks` +
+    `?status=neq.done&archived_at=is.null` +
+    `&select=title,status,priority,due,project,legacy_id` +
+    `&order=due.asc.nullslast&limit=${MAX_TASKS}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    const res = await fetch(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    }).finally(() => clearTimeout(timer));
+    if (!res.ok) return [];
+    const data = (await res.json()) as TeamTask[];
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Render team tasks as a compact, scannable list for a Telegram reply. */
+export function formatTeamTasks(tasks: TeamTask[]): string {
+  if (tasks.length === 0) return 'No open team tasks (or the tracker is not wired up).';
+  const lines = tasks.map((t) => {
+    const due = t.due ? ` (due ${t.due})` : '';
+    const pri = t.priority && t.priority !== 'normal' ? ` [${t.priority}]` : '';
+    const proj = t.project ? `${t.project}: ` : '';
+    return `- ${proj}${t.title}${pri}${due} - ${t.status}`;
+  });
+  return `Team tracker - ${tasks.length} open:\n\n${lines.join('\n')}`;
+}


### PR DESCRIPTION
## Summary
First step of bridging ZOE to the coworking system (doc 890). ZOE managed only Zaal's personal tasks; the team's work lives in the cowork-zaodevz Supabase tracker. This adds a **read path**:

- `bot/src/zoe/team-tracker.ts` - PostgREST fetch of open (not-done, not-archived) team tasks, soonest-due first. Env-gated (`COWORK_TRACKER_URL` + `COWORK_TRACKER_KEY`); no-op if unset, like the Bonfire integration. Best-effort, never throws.
- `/team` command - so "what is the team blocked on?" works in ZOE.

To activate: add `COWORK_TRACKER_URL` (https://etwvzrmlxeobinrlytza.supabase.co) + `COWORK_TRACKER_KEY` to bot/.env on the VPS.

Write path (ZOE assigns team tasks) + folding team state into the morning brief are follow-ups.

## Test
3 vitest cases for the formatter + config gate, all passing. No new tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)