### PR TITLE
feat(zoe): team board state in the morning brief (doc 890)

### DIFF
--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { formatTeamTasks, teamTrackerConfigured, type TeamTask } from '../team-tracker';
+import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, type TeamTask } from '../team-tracker';
+
+describe('summarizeTeamForBrief', () => {
+  it('returns null when empty (so the brief skips the section)', () => {
+    expect(summarizeTeamForBrief([])).toBeNull();
+  });
+  it('summarizes open/overdue and top non-recurring items', () => {
+    const tasks: TeamTask[] = [
+      { title: 'Daily standup [STANDING]', status: 'todo', priority: 'P1', due: null, project: null, legacy_id: '1' },
+      { title: 'Ship feature', status: 'todo', priority: 'P1', due: '2020-01-01', project: null, legacy_id: '2' },
+    ];
+    const out = summarizeTeamForBrief(tasks)!;
+    expect(out).toMatch(/2 open/);
+    expect(out).toMatch(/1 overdue/);
+    expect(out).toContain('Ship feature');
+    expect(out).not.toContain('Daily standup'); // recurring excluded from "Top"
+  });
+});
 
 describe('formatTeamTasks', () => {
   it('renders an empty state when there are no tasks', () => {

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -17,6 +17,7 @@
  */
 import { callClaudeCli } from '../hermes/claude-cli';
 import { listOpenTasks } from './tasks';
+import { getOpenTeamTasks, summarizeTeamForBrief } from './team-tracker';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -36,6 +37,9 @@ LAST 24H COMMITS
 OPEN PRS
 - List of open PRs by number + title.
 
+TEAM
+- One line: the team board summary (open count, overdue, top items). Skip this section entirely if team is unavailable.
+
 INBOX
 - {N} unread in zoe-zao@agentmail.to. First 3 subjects: ... (skip line entirely if inbox=null)
 - Reminder: run /inbox in any Claude session to research the queue.
@@ -51,6 +55,7 @@ interface BriefContext {
   cross_repo_24h: string[];
   open_prs: Array<{ number: number; title: string }>;
   inbox: { unreadCount: number; recentSubjects: string[] } | null;
+  team: string | null;
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -160,6 +165,14 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
 
   const inbox = await fetchInboxSnapshot();
 
+  // Team board state (cowork tracker). Best-effort; null if unconfigured/unreachable.
+  let team: string | null = null;
+  try {
+    team = summarizeTeamForBrief(await getOpenTeamTasks());
+  } catch {
+    team = null;
+  }
+
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
@@ -167,6 +180,7 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     cross_repo_24h: crossRepo24h,
     open_prs: prs,
     inbox,
+    team,
   };
 }
 
@@ -187,6 +201,7 @@ CONTEXT:
 - Last 24h commits (ZAOOS): ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
 - Recent activity across ALL Zaal's repos: ${ctx.cross_repo_24h.length === 0 ? '(none)' : ctx.cross_repo_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
+- Team board: ${ctx.team ?? '(tracker unavailable - skip the TEAM section)'}
 - ${inboxLine}
 
 Output the brief now in the exact format from your system prompt.`;

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -108,3 +108,19 @@ export function formatTeamTasks(tasks: TeamTask[]): string {
     tasks.length > MAX_SHOWN ? `\n\n+${tasks.length - MAX_SHOWN} more (full board: thezao.xyz)` : '';
   return `${header}\n\n${lines.join('\n')}${more}`;
 }
+
+/**
+ * One-line team summary for the morning brief: "5 open, 3 overdue. Top: ...".
+ * Returns null when there's nothing to report (so the brief can skip the line).
+ */
+export function summarizeTeamForBrief(tasks: TeamTask[]): string | null {
+  if (tasks.length === 0) return null;
+  const overdue = tasks.filter((t) => isOverdue(t.due)).length;
+  const top = [...tasks]
+    .filter((t) => !isRecurring(t.title))
+    .sort((a, b) => priorityRank(a.priority) - priorityRank(b.priority))
+    .slice(0, 3)
+    .map((t) => t.title)
+    .join('; ');
+  return `${tasks.length} open${overdue ? `, ${overdue} overdue` : ''}${top ? `. Top: ${top}` : ''}`;
+}


### PR DESCRIPTION
## Summary
ZOE's morning brief was personal-only (tasks, commits, PRs, inbox). This folds in the **team board state** - a TEAM line with open count, overdue count, and top non-recurring items from the cowork tracker - so Zaal sees personal + team in one glance each morning. Builds on the /team read path (#946).

Env-gated + best-effort: skips the TEAM section if the tracker is unconfigured/unreachable.

## Test
8 vitest cases (2 new for `summarizeTeamForBrief`: null-when-empty, summary with overdue + recurring excluded from Top). All pass. Type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)