### PR TITLE
chore(api): console.info -> logger.info in routes (hygiene)

### DIFF
--- a/src/app/api/music/radio/route.ts
+++ b/src/app/api/music/radio/route.ts
@@ -124,7 +124,7 @@ export async function GET() {
     }
   }
 
-  console.info(`[radio] Resolved ${playlists.length} playlists with ${playlists.reduce((n, p) => n + p.tracks.length, 0)} total tracks`);
+  logger.info(`[radio] Resolved ${playlists.length} playlists with ${playlists.reduce((n, p) => n + p.tracks.length, 0)} total tracks`);
 
   return NextResponse.json({ playlists }, {
     headers: { 'Cache-Control': 'public, max-age=300, s-maxage=300' },

--- a/src/app/api/platforms/lens/route.ts
+++ b/src/app/api/platforms/lens/route.ts
@@ -31,7 +31,7 @@ async function checkLensProfile(wallet: string) {
   const items = data?.data?.accountsAvailable?.items || [];
   // Log what we got to debug missing usernames
   if (items.length > 0) {
-    console.info('[lens] Found account for', wallet, ':', JSON.stringify(items[0]));
+    logger.info('[lens] Found account for', wallet, ':', JSON.stringify(items[0]));
   }
   return items;
 }
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    console.info('[lens] Checking wallets:', [...walletsToCheck]);
+    logger.info('[lens] Checking wallets:', [...walletsToCheck]);
 
     // Check each wallet for a Lens profile
     let handle: string | null = null;
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
               || acct?.username?.value
               || acct?.metadata?.name
               || null;
-            console.info('[lens] Direct account lookup:', JSON.stringify(acct));
+            logger.info('[lens] Direct account lookup:', JSON.stringify(acct));
           } catch { /* ignore fallback failure */ }
         }
 

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -345,7 +345,7 @@ async function checkExpiredProposalsForPublish(proposals: ProposalSummary[]) {
           .eq('id', p.id)
           .eq('status', 'open');
 
-        console.info(`[proposals] Auto-approved proposal ${p.id} — deadline passed, ${forWeight}/${threshold}R threshold met`);
+        logger.info(`[proposals] Auto-approved proposal ${p.id} — deadline passed, ${forWeight}/${threshold}R threshold met`);
       } catch (err) {
         logger.error(`[proposals] Auto-approve failed for ${p.id}:`, err);
       }

--- a/src/app/api/respect/transfers/route.ts
+++ b/src/app/api/respect/transfers/route.ts
@@ -153,7 +153,7 @@ async function syncTransfersFromAlchemy(filterAddress?: string) {
           }, { onConflict: 'tx_hash,to_address,token_type' });
         }
 
-        console.info(`[transfers-sync] ${contract.type}: stored ${transfers.length} transfers (page ${pages + 1})`);
+        logger.info(`[transfers-sync] ${contract.type}: stored ${transfers.length} transfers (page ${pages + 1})`);
         pages++;
       } catch (err) {
         logger.error(`[transfers-sync] ${contract.type} page ${pages} failed:`, err);

--- a/src/app/api/stream/rooms/[id]/route.ts
+++ b/src/app/api/stream/rooms/[id]/route.ts
@@ -102,7 +102,7 @@ async function syncStreamTitle(fid: number, title: string) {
   if (token) {
     const ok = await updateTwitchChannel(token.accessToken, token.userId, { title });
     if (ok) {
-      console.info('[twitch-sync] Title updated to:', title);
+      logger.info('[twitch-sync] Title updated to:', title);
     }
   }
   // YouTube title sync could go here in the future

--- a/src/app/api/stream/rooms/route.ts
+++ b/src/app/api/stream/rooms/route.ts
@@ -91,7 +91,7 @@ async function syncTwitchOnCreate(fid: number, title: string) {
   });
 
   if (ok) {
-    console.info(`[room-create] Twitch channel set — title: "${title}", category: ${gameId}`);
+    logger.info(`[room-create] Twitch channel set — title: "${title}", category: ${gameId}`);
   }
 }
 

--- a/src/app/api/webhooks/alchemy/route.ts
+++ b/src/app/api/webhooks/alchemy/route.ts
@@ -120,7 +120,7 @@ export async function POST(req: NextRequest) {
               .update({ onchain_og: (Number(member.onchain_og) || 0) + mintAmount })
               .eq('id', member.id);
           }
-          console.info(`[alchemy-webhook] ${tokenType} mint: +${mintAmount} to ${toAddress.slice(0, 10)}...`);
+          logger.info(`[alchemy-webhook] ${tokenType} mint: +${mintAmount} to ${toAddress.slice(0, 10)}...`);
         }
       }
 
@@ -136,7 +136,7 @@ export async function POST(req: NextRequest) {
           .from('users')
           .update({ member_tier: 'respect_holder' })
           .eq('id', user.id);
-        console.info(`[alchemy-webhook] Upgraded ${toAddress.slice(0, 10)}... to respect_holder`);
+        logger.info(`[alchemy-webhook] Upgraded ${toAddress.slice(0, 10)}... to respect_holder`);
       }
     }
 


### PR DESCRIPTION
## Summary
First main-app-quality pass. The app typechecks clean and routes are well-guarded (session checks, manual validation, even GraphQL-injection defenses), so this targets the one clear rule violation: raw `console.info` in production routes (banned by `.claude/rules/typescript-hygiene.md`).

10 `console.info` calls across 7 routes -> `logger.info`. `logger` is already imported in all 7, and `logger.info` is suppressed in production (the intended behavior). Pure swap, no logic change.

Files: music/radio, platforms/lens, stream/rooms (+[id]), respect/transfers, webhooks/alchemy, proposals.

## Test
Type-safe swap (logger.info accepts the same args). Typecheck was already clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)