### PR TITLE
chore(lib): console -> logger in src/lib (hygiene)

### DIFF
--- a/src/lib/bluesky/client.ts
+++ b/src/lib/bluesky/client.ts
@@ -1,4 +1,5 @@
 import { AtpAgent, RichText } from '@atproto/api';
+import { logger } from '@/lib/logger';
 
 let communityAgent: AtpAgent | null = null;
 let communitySessionExpiry = 0;
@@ -12,7 +13,7 @@ async function getCommunityAgent(): Promise<AtpAgent | null> {
   const password = process.env.BLUESKY_APP_PASSWORD;
 
   if (!handle || !password) {
-    console.warn('[bluesky] Community account not configured — set BLUESKY_HANDLE and BLUESKY_APP_PASSWORD');
+    logger.warn('[bluesky] Community account not configured — set BLUESKY_HANDLE and BLUESKY_APP_PASSWORD');
     return null;
   }
 

--- a/src/lib/bluesky/labeler.ts
+++ b/src/lib/bluesky/labeler.ts
@@ -1,4 +1,5 @@
 import { AtpAgent } from '@atproto/api';
+import { logger } from '@/lib/logger';
 
 /**
  * Apply "ZAO Member" label to a Bluesky account.
@@ -24,7 +25,7 @@ export async function applyMemberLabel(
         },
       },
     });
-    console.info(`[labeler] Applied ZAO Member label to ${targetDid}`);
+    logger.info(`[labeler] Applied ZAO Member label to ${targetDid}`);
     return true;
   } catch (err) {
     // Self-labels can only be applied to own account.

--- a/src/lib/ens/subnames.ts
+++ b/src/lib/ens/subnames.ts
@@ -20,6 +20,7 @@ import {
 } from 'viem';
 import { mainnet } from 'viem/chains';
 import { privateKeyToAccount } from 'viem/accounts';
+import { logger } from '@/lib/logger';
 
 // ── Contract addresses ──
 
@@ -233,7 +234,7 @@ export async function createSubname(
           });
           await publicClient.waitForTransactionReceipt({ hash: textTx });
         } catch (err) {
-          console.warn(`[ens/subnames] Failed to set text record "${key}":`, err);
+          logger.warn(`[ens/subnames] Failed to set text record "${key}":`, err);
         }
       }
     }

--- a/src/lib/hindsight.ts
+++ b/src/lib/hindsight.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/lib/logger';
 // Hindsight client — lazy import to avoid build failure when package isn't installed
 // Install with: npm install @vectorize-io/hindsight-client
 
@@ -20,7 +21,7 @@ export async function getHindsightClient() {
     _client = new HindsightClient({ baseUrl: HINDSIGHT_BASE_URL }) as HindsightClientInterface;
     return _client;
   } catch {
-    console.warn('[hindsight] @vectorize-io/hindsight-client not installed — skipping');
+    logger.warn('[hindsight] @vectorize-io/hindsight-client not installed — skipping');
     return null;
   }
 }

--- a/src/lib/memory-recall.ts
+++ b/src/lib/memory-recall.ts
@@ -1,4 +1,5 @@
 import { getHindsightClient } from './hindsight';
+import { logger } from '@/lib/logger';
 
 // ============================================================================
 // Types
@@ -161,7 +162,7 @@ export async function recallMemoriesByType(
     return results;
   } catch (error) {
     // Fallback to regular recall if metadataFilter not supported
-    console.warn(`Metadata filter not supported, falling back to regular recall:`, error);
+    logger.warn(`Metadata filter not supported, falling back to regular recall:`, error);
     return recallMemories(userFid, `${eventType} ${query}`, limit);
   }
 }

--- a/src/lib/publish/lens.ts
+++ b/src/lib/publish/lens.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NormalizedContent } from '@/lib/publish/normalize';
+import { logger } from '@/lib/logger';
 
 const LENS_API = 'https://api.lens.xyz/graphql';
 
@@ -44,7 +45,7 @@ export async function publishToLens(
   const storageClient = StorageClient.create();
   const { uri: contentURI } = await storageClient.uploadAsJson(metadata);
 
-  console.info('[lens] Uploaded to Grove:', contentURI);
+  logger.info('[lens] Uploaded to Grove:', contentURI);
 
   // Post with the lens:// URI
   const postResult = await lensPost(token, contentURI);
@@ -93,7 +94,7 @@ async function lensPost(token: string, contentURI: string): Promise<{ result?: L
 
     const post = data?.data?.post;
     if (post?.hash) {
-      console.info('[lens] Post transaction hash:', post.hash);
+      logger.info('[lens] Post transaction hash:', post.hash);
       return {
         result: {
           postId: post.hash,

--- a/src/lib/publish/x-insights.ts
+++ b/src/lib/publish/x-insights.ts
@@ -10,6 +10,7 @@
  */
 
 import { getXClient } from '@/lib/publish/x';
+import { logger } from '@/lib/logger';
 
 export interface XMetrics {
   views: number;
@@ -41,7 +42,7 @@ export async function fetchXInsights(tweetId: string): Promise<XMetrics> {
     const pm = tweet.data.public_metrics;
 
     if (!pm) {
-      console.warn(`[x-insights] No public_metrics for tweet ${tweetId}`);
+      logger.warn(`[x-insights] No public_metrics for tweet ${tweetId}`);
       return zeroed();
     }
 

--- a/src/lib/push/vapid.ts
+++ b/src/lib/push/vapid.ts
@@ -1,4 +1,5 @@
 import webpush from 'web-push';
+import { logger } from '@/lib/logger';
 
 // VAPID keys for Web Push — set these in .env
 // Generate with: npx web-push generate-vapid-keys
@@ -30,7 +31,7 @@ export async function sendPushNotification(
   payload: PushPayload
 ): Promise<boolean> {
   if (!VAPID_PUBLIC_KEY || !VAPID_PRIVATE_KEY) {
-    console.warn('[push] VAPID keys not configured — skipping push notification');
+    logger.warn('[push] VAPID keys not configured — skipping push notification');
     return false;
   }
 
@@ -41,7 +42,7 @@ export async function sendPushNotification(
     const statusCode = (error as { statusCode?: number }).statusCode;
     // 404 or 410 means the subscription is no longer valid
     if (statusCode === 404 || statusCode === 410) {
-      console.log('[push] Subscription expired or invalid, should be removed');
+      logger.info('[push] Subscription expired or invalid, should be removed');
       return false;
     }
     console.error('[push] Failed to send notification:', error);


### PR DESCRIPTION
## Summary
Extends the console->logger hygiene pass (#950, routes) into `src/lib`. 10 `console.*` calls across 8 modules now use `logger.*`:
hindsight, memory-recall, ens/subnames, publish/x-insights, bluesky/labeler, bluesky/client, push/vapid, publish/lens.

`console.log`->`logger.info`, `warn`->`warn`, `info`->`info`. Added the `@/lib/logger` import to each. `logger.warn/error` stay visible in production; `info`/`debug` suppress - matching intent.

## Test
`tsc --noEmit` clean (0 errors). No logic change, just the logging call + import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)