### PR TITLE
feat(zol): wire ZABAL Bonfire graph into cast drafting

### DIFF
--- a/bot/src/zoe/caster/__tests__/reason.test.ts
+++ b/bot/src/zoe/caster/__tests__/reason.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { draftCast } from '../reason';
+import type { RecallResult } from '../../recall';
+
+const okCompletion = {
+  choices: [{ message: { content: 'gm from zol' } }],
+  usage: { prompt_tokens: 10, completion_tokens: 5 },
+};
+
+// Capture the request bodies sent to OpenRouter so we can assert on the system prompt.
+function mockOpenRouter(): Array<{ messages: Array<{ role: string; content: string }> }> {
+  const calls: Array<{ messages: Array<{ role: string; content: string }> }> = [];
+  global.fetch = vi.fn(async (_url: unknown, init: { body: string }) => {
+    calls.push(JSON.parse(init.body));
+    return { ok: true, json: async () => okCompletion } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  process.env.OPENROUTER_API_KEY = 'test-key';
+});
+
+describe('draftCast - ZABAL Bonfire graph memory', () => {
+  it('injects graph context into the system prompt when recall returns hits', async () => {
+    const calls = mockOpenRouter();
+    const recallFn = vi.fn(
+      async (): Promise<RecallResult> => ({
+        kind: 'sdk_response',
+        query: 'who is ZAO?',
+        hits: 3,
+        text: '- ZAO is a 188-member music community [src: doc]',
+      }),
+    );
+    const r = await draftCast({ persona: 'You are ZOL', context: 'who is ZAO?', recallFn });
+    expect(recallFn).toHaveBeenCalledOnce();
+    expect(r.usedGraph).toBe(true);
+    expect(r.graphHits).toBe(3);
+    const system = calls[0].messages[0].content;
+    expect(system).toContain('ZABAL Bonfire graph');
+    expect(system).toContain('188-member music community');
+  });
+
+  it('skips recall entirely when useGraphMemory is false', async () => {
+    mockOpenRouter();
+    const recallFn = vi.fn();
+    const r = await draftCast({ persona: 'p', context: 'c', useGraphMemory: false, recallFn });
+    expect(recallFn).not.toHaveBeenCalled();
+    expect(r.usedGraph).toBe(false);
+    expect(r.graphHits).toBe(0);
+  });
+
+  it('adds no graph block when recall finds nothing (manual-relay fallback)', async () => {
+    const calls = mockOpenRouter();
+    const recallFn = vi.fn(
+      async (): Promise<RecallResult> => ({ kind: 'manual_relay_needed', query: 'c', relay: '...' }),
+    );
+    const r = await draftCast({ persona: 'p', context: 'c', recallFn });
+    expect(r.usedGraph).toBe(false);
+    expect(r.graphHits).toBe(0);
+    expect(calls[0].messages[0].content).not.toContain('ZABAL Bonfire graph');
+  });
+});

--- a/bot/src/zoe/caster/reason.ts
+++ b/bot/src/zoe/caster/reason.ts
@@ -16,6 +16,8 @@
  *   OPENROUTER_REFERER     optional HTTP-Referer header (OpenRouter attribution)
  */
 
+import { recall, type RecallRequest, type RecallResult } from '../recall';
+
 const DEFAULT_BASE = 'https://openrouter.ai/api/v1';
 const DEFAULT_MODEL = 'anthropic/claude-sonnet-4.6';
 
@@ -28,6 +30,14 @@ export interface DraftCastOpts {
   model?: string;
   /** Hard cap on cast length; Farcaster casts max 320 bytes. */
   maxChars?: number;
+  /**
+   * Pull relevant knowledge from the ZABAL Bonfire graph and inject it into the
+   * draft so ZOL casts from ZAO's memory, not just the base model. Default true.
+   * Best-effort: degrades to a no-op when the bonfire is unconfigured/empty.
+   */
+  useGraphMemory?: boolean;
+  /** Injectable recall fn for tests; defaults to the real Bonfire recall(). */
+  recallFn?: (req: RecallRequest) => Promise<RecallResult>;
 }
 
 export interface DraftResult {
@@ -35,6 +45,9 @@ export interface DraftResult {
   model: string;
   promptTokens: number | null;
   completionTokens: number | null;
+  /** Whether ZABAL graph context was injected into this draft, and how many episodes. */
+  usedGraph: boolean;
+  graphHits: number;
 }
 
 export async function draftCast(opts: DraftCastOpts): Promise<DraftResult> {
@@ -44,8 +57,25 @@ export async function draftCast(opts: DraftCastOpts): Promise<DraftResult> {
   const model = opts.model ?? process.env.OPENROUTER_MODEL ?? DEFAULT_MODEL;
   const maxChars = opts.maxChars ?? 320;
 
+  // Pull relevant knowledge from the ZABAL Bonfire graph so ZOL casts from ZAO's
+  // memory, not just the base model. Best-effort: recall() never throws and
+  // degrades to a no-op when the bonfire is unconfigured or returns no hits.
+  let graphBlock = '';
+  let graphHits = 0;
+  if (opts.useGraphMemory !== false) {
+    const doRecall = opts.recallFn ?? recall;
+    const r = await doRecall({ query: opts.context, reason: 'zol cast draft', expected_kind: 'mixed' });
+    if (r.kind === 'sdk_response' && r.text && r.text.trim()) {
+      graphHits = r.hits ?? 0;
+      graphBlock = r.text.trim();
+    }
+  }
+
   const system = [
     opts.persona.trim(),
+    graphBlock
+      ? `\nKnowledge from the ZABAL Bonfire graph (treat as ground truth; do not contradict it; weave in only what is relevant):\n${graphBlock}`
+      : '',
     '',
     `You are drafting a single Farcaster cast. Hard limit: ${maxChars} characters. ` +
       `Output ONLY the cast text - no preamble, no quotes, no markdown headers, no hashtags ` +
@@ -91,5 +121,7 @@ export async function draftCast(opts: DraftCastOpts): Promise<DraftResult> {
     model,
     promptTokens: body.usage?.prompt_tokens ?? null,
     completionTokens: body.usage?.completion_tokens ?? null,
+    usedGraph: graphBlock.length > 0,
+    graphHits,
   };
 }


### PR DESCRIPTION
## Summary
First piece of ZOL: wire the ZABAL Bonfire knowledge graph into its memory. Before drafting any cast, ZOL now calls `recall()` (the /delve graph query) with the trigger context and injects the returned episodes into the OpenRouter system prompt - so it casts from ZAO's actual knowledge, not just the base model.

- Default on (`useGraphMemory`, opt-out per call); best-effort - `recall()` never throws and degrades to a no-op when the bonfire is unconfigured or returns no hits, so a graph hiccup never blocks a cast.
- `DraftResult` now reports `usedGraph` + `graphHits` for observability.
- Reuses the existing `recall.ts` /delve path (doc bonfire-delve-recall) - no new infra.

## Test
3 vitest cases (graph hits injected into system prompt, disabled path skips recall, empty-recall adds no block). All pass. Type-clean.

## Context
ZOL = FID 3338501 / @zolbot (registered today). This is the memory layer; profile + first cast pending a small Base USDC top-up for x402 writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)