### PR TITLE
feat(zol): mention-reply connector (approval-gated)

### DIFF
--- a/bot/src/zoe/caster/__tests__/mention-listener.test.ts
+++ b/bot/src/zoe/caster/__tests__/mention-listener.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+// Mock the heavy deps so loading mention-listener does not pull the full caster/grammy chain.
+vi.mock('../index', () => ({ runCasterPipeline: vi.fn() }));
+vi.mock('../../farcaster/event-stream', () => ({ subscribeToCasts: vi.fn() }));
+
+import { mentionToTrigger } from '../mention-listener';
+import type { IncomingCast } from '../../farcaster/event-stream';
+
+const cast: IncomingCast = {
+  fid: 42,
+  hash: '0xabc123' as `0x${string}`,
+  text: 'hey @zolbot what is good in the ZAO music scene?',
+  mentions: [3338501],
+};
+
+describe('mentionToTrigger', () => {
+  it('maps a mention into a reply trigger (parent set to the mentioner)', () => {
+    const t = mentionToTrigger(cast, { zaalId: 1, persona: 'You are ZOL' });
+    expect(t.agentId).toBe('zol');
+    expect(t.persona).toBe('You are ZOL');
+    expect(t.context).toBe(cast.text);
+    expect(t.parent).toEqual({ fid: 42, hash: '0xabc123' });
+  });
+  it('honors agentId + model overrides', () => {
+    const t = mentionToTrigger(cast, { zaalId: 1, persona: 'p', agentId: 'zol-test', model: 'x' });
+    expect(t.agentId).toBe('zol-test');
+    expect(t.model).toBe('x');
+  });
+});

--- a/bot/src/zoe/caster/mention-listener.ts
+++ b/bot/src/zoe/caster/mention-listener.ts
@@ -1,0 +1,50 @@
+/**
+ * Mention listener (ZOL): wires the Farcaster event stream to the approval-gated
+ * caster pipeline. When @zolbot (FARCASTER_BOT_FID) is mentioned, this turns the
+ * incoming cast into a reply CasterTrigger and runs runCasterPipeline - which
+ * drafts (with ZABAL Bonfire memory, doc 891/PR #957), safety-checks, and sends
+ * the draft to the lead in Telegram for y/n BEFORE anything is published.
+ *
+ * Nothing is posted autonomously: the human-approval gate in runCasterPipeline
+ * stands. This module only connects "a mention arrived" -> "draft a reply for
+ * approval". Start it once at boot: startMentionListener(bot, { zaalId, persona }).
+ */
+import type { Bot } from 'grammy';
+import { subscribeToCasts, type IncomingCast } from '../farcaster/event-stream';
+import { runCasterPipeline, type CasterTrigger } from './index';
+
+export interface MentionListenerOpts {
+  /** Telegram id of the lead who approves drafts. */
+  zaalId: number;
+  /** ZOL persona / system prompt (from the persona block). */
+  persona: string;
+  /** registry agent id; defaults to 'zol'. */
+  agentId?: string;
+  /** optional model override for drafting. */
+  model?: string;
+}
+
+/** Pure: map an incoming mention into a reply trigger for the caster pipeline. */
+export function mentionToTrigger(cast: IncomingCast, opts: MentionListenerOpts): CasterTrigger {
+  return {
+    agentId: opts.agentId ?? 'zol',
+    persona: opts.persona,
+    context: cast.text,
+    parent: { fid: cast.fid, hash: cast.hash },
+    model: opts.model,
+  };
+}
+
+/**
+ * Subscribe to mentions and draft an approval-gated reply for each. Returns an
+ * unsubscribe function. Errors in a single reply never tear down the stream.
+ */
+export async function startMentionListener(bot: Bot, opts: MentionListenerOpts): Promise<() => void> {
+  return subscribeToCasts(async (cast) => {
+    try {
+      await runCasterPipeline(bot, opts.zaalId, mentionToTrigger(cast, opts));
+    } catch (e) {
+      console.error('[caster/mention-listener] reply pipeline failed:', (e as Error).message);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Adds the mention-reply connector for ZOL. The event stream (`subscribeToCasts`) and the approval-gated caster (`runCasterPipeline`) both existed but nothing connected them - this is that wire. When @zolbot is mentioned, it drafts a reply (drafting uses the ZABAL Bonfire memory from PR #957), safety-checks, and sends it to the lead on Telegram for approval before anything posts.

- `mentionToTrigger` - pure, maps an IncomingCast to a reply CasterTrigger (parent = the mentioner). Unit-tested.
- `startMentionListener(bot, {zaalId, persona})` - subscribes + runs the pipeline per mention; returns an unsubscribe; per-reply errors are isolated so one failure never kills the stream.
- Nothing casts autonomously: the human-approval gate in runCasterPipeline stands.

Not wired at boot yet (deploy decision) - this just adds the capability, ready for when @zolbot has inbound.

## Test
2 vitest cases for mentionToTrigger. Pass. Type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)