### PR TITLE
feat(zoe): voice/audio intake - voice-answer ZOE

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -51,6 +51,7 @@ import { startScheduler } from './scheduler';
 import { disableNudges, enableNudges, nudgesEnabled } from './nudges';
 import { mirrorTurn, recall } from './recall';
 import { fanOutKnowledgeExtractors, EXTRACT_MIN_LEN } from './extractors';
+import { transcriptionConfigured, transcribeTelegramFile } from './transcribe';
 import {
   addAllowlistMember,
   getGroupConfig,
@@ -582,6 +583,38 @@ bot.on('message:text', async (ctx) => {
   enqueueTurn(chatId, () => handleGroupMessage(ctx, text, String(chatId))).catch((e) =>
     console.error('[zoe/index] group turn failed:', (e as Error)?.message),
   );
+});
+
+// Voice / audio intake (Zaal DM only): transcribe via Groq Whisper, then run it
+// through the exact same turn path as a typed message. Lets Zaal voice-answer.
+bot.on(['message:voice', 'message:audio'], async (ctx) => {
+  if (ctx.chat.type !== 'private' || !isFromZaal(ctx)) return;
+  const chatId = ctx.chat.id;
+  const fileId = ctx.message.voice?.file_id ?? ctx.message.audio?.file_id;
+  if (!fileId) return;
+  if (!transcriptionConfigured()) {
+    await ctx
+      .reply('Voice received, but transcription is off. Add GROQ_API_KEY to bot/.env (free at console.groq.com) and restart me.')
+      .catch(() => {});
+    return;
+  }
+  let transcript: string;
+  try {
+    transcript = await transcribeTelegramFile(token, fileId);
+  } catch (err) {
+    await ctx.reply(`Could not transcribe that - ${(err as Error).message.slice(0, 160)}`).catch(() => {});
+    return;
+  }
+  if (!transcript) {
+    await ctx.reply('(that voice note came through empty)').catch(() => {});
+    return;
+  }
+  await ctx.reply(`Heard: "${transcript.slice(0, 300)}"`).catch(() => {});
+  enqueueTurn(chatId, () => handlePrivateMessage(ctx, transcript), {
+    onDeferred: () => {
+      ctx.reply("Got that - finishing what I'm on, then I'll pick it up.").catch(() => {});
+    },
+  }).catch((e) => console.error('[zoe/index] voice turn failed:', (e as Error)?.message));
 });
 
 async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {

--- a/bot/src/zoe/transcribe.ts
+++ b/bot/src/zoe/transcribe.ts
@@ -1,0 +1,64 @@
+// transcribe.ts — voice/audio -> text for ZOE, via Groq's Whisper API.
+//
+// Why Groq: the fleet box has no local whisper/ffmpeg, and Groq's whisper
+// endpoint is free-tier, fast, and accepts Telegram's .ogg/opus directly (it
+// handles decoding server-side). No new npm dep - just `fetch` + a key.
+//
+// Setup: add GROQ_API_KEY to bot/.env (free key from console.groq.com).
+// Optional GROQ_WHISPER_MODEL (default whisper-large-v3-turbo).
+
+const GROQ_URL = 'https://api.groq.com/openai/v1/audio/transcriptions';
+
+export function transcriptionConfigured(): boolean {
+  return !!process.env.GROQ_API_KEY;
+}
+
+/** Transcribe raw audio bytes (e.g. a Telegram voice .ogg) to text. */
+export async function transcribeAudio(
+  bytes: Uint8Array,
+  filename = 'voice.ogg',
+): Promise<string> {
+  const key = process.env.GROQ_API_KEY;
+  if (!key) throw new Error('GROQ_API_KEY not configured');
+  const model = process.env.GROQ_WHISPER_MODEL || 'whisper-large-v3-turbo';
+
+  const form = new FormData();
+  form.append('file', new Blob([bytes]), filename);
+  form.append('model', model);
+  form.append('response_format', 'text');
+
+  const res = await fetch(GROQ_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${key}` },
+    body: form,
+    signal: AbortSignal.timeout(60_000),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`groq transcription ${res.status}: ${detail.slice(0, 200)}`);
+  }
+  return (await res.text()).trim();
+}
+
+/** Download a Telegram file (voice/audio) by file_id and transcribe it. */
+export async function transcribeTelegramFile(
+  botToken: string,
+  fileId: string,
+): Promise<string> {
+  const metaRes = await fetch(
+    `https://api.telegram.org/bot${botToken}/getFile?file_id=${encodeURIComponent(fileId)}`,
+    { signal: AbortSignal.timeout(15_000) },
+  );
+  const meta = (await metaRes.json()) as { ok: boolean; result?: { file_path?: string } };
+  const filePath = meta.result?.file_path;
+  if (!meta.ok || !filePath) throw new Error('telegram getFile failed');
+
+  const fileRes = await fetch(
+    `https://api.telegram.org/file/bot${botToken}/${filePath}`,
+    { signal: AbortSignal.timeout(30_000) },
+  );
+  if (!fileRes.ok) throw new Error(`telegram file download ${fileRes.status}`);
+  const bytes = new Uint8Array(await fileRes.arrayBuffer());
+  const name = filePath.split('/').pop() || 'voice.ogg';
+  return transcribeAudio(bytes, name);
+}


### PR DESCRIPTION
## Summary
Lets you **voice-answer ZOE** on Telegram. Adds:
- `transcribe.ts` - Groq Whisper via `fetch` (no new npm dep; accepts Telegram `.ogg`/opus directly, decoding handled server-side).
- a grammy `message:voice` / `message:audio` handler - transcribes a Zaal DM voice note, replies with what it heard, and runs the transcript through the **exact same turn path** as a typed message.

## Why Groq
The fleet box has no local whisper/ffmpeg. Groq Whisper is free-tier, fast, and takes the `.ogg` as-is. Only a key is needed - no install.

## Activate
1. Free key at console.groq.com -> add `GROQ_API_KEY=...` to `bot/.env`
2. `git pull && npm run typecheck && systemctl --user restart zoe-bot`

## Safety / blast radius
Contained: the handler only fires on voice/audio messages; text handling is untouched. With no key set it replies with a one-line "transcription off" notice and does nothing else. DM + isFromZaal gated.

## Note
Local typecheck could not run (bot deps not installed in this env; bot runs via `tsx` at runtime). Please run `npm run typecheck` on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)