### PR TITLE
feat(zoe): wire ZAOscout MCP - keyless social reading

### DIFF
--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -121,6 +121,11 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
       'mcp__playwright__browser_press_key',
       'mcp__playwright__browser_wait_for',
       'mcp__playwright__browser_close',
+      // ZAOscout MCP (doc 899): keyless social reading - Reddit/X/Farcaster/GitHub
+      // by URL, full body, no API keys. Lets ZOE monitor the wider ecosystem, not
+      // just repos. Server: ~/ZAOscout/mcp/server.js (registered via `claude mcp add scout`).
+      'mcp__scout__scout_fetch',
+      'mcp__scout__scout_digest',
       // Doc 759 Gap 2 (locked Q1=GATEWAY, Q5=8 workers): subagent dispatch via
       // Task tool. Workers live in bot/src/zoe/.claude/agents/*.md and ZOE
       // routes per the persona ROUTING block. Both 'Task' and 'Agent' added


### PR DESCRIPTION
## Summary
Wires **ZAOscout MCP** into ZOE - keyless social reading (Reddit / X incl. long-form Articles / Farcaster / GitHub) by URL, full body, **no API keys**. Lets ZOE monitor the wider ecosystem, not just repos.

Adds two tools to ZOE's allowlist: `scout_fetch` (any social URL -> clean text) and `scout_digest` (watchlist brief).

## VPS side - already done
- ZAOscout cloned at `~/ZAOscout` (zero-dep MCP server)
- `claude mcp add scout` -> **Connected**
- keyless fetch verified (pulled a live Farcaster profile + casts)

## To activate
`git pull && systemctl --user restart zoe-bot` - then ZOE can call scout_fetch/scout_digest.

## Why
From doc 899 + your "research ZAOscout, see what we can take" - the cleanest take was its zero-dep MCP. Complements farscout (running research) + Playwright (general browse) with structured keyless social fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)