### PR TITLE
fix(zoe): typecheck - resume cwd + Blob cast

### DIFF
--- a/bot/src/zoe/resume.ts
+++ b/bot/src/zoe/resume.ts
@@ -40,7 +40,7 @@ Rules: stay factual, do not invent specifics not in the note. If the note only a
 
   let line = `- ${text}`;
   try {
-    const r = await callClaudeCli({ model: 'haiku', prompt, outputFormat: 'text' });
+    const r = await callClaudeCli({ model: 'haiku', prompt, cwd: ZOE_PATHS.home, allowedTools: [], outputFormat: 'text', bare: true, timeoutMs: 30000 });
     const t = (r.text || '').trim();
     if (t.startsWith('-')) line = t;
     else if (t) line = `- ${t}`;

--- a/bot/src/zoe/transcribe.ts
+++ b/bot/src/zoe/transcribe.ts
@@ -23,7 +23,7 @@ export async function transcribeAudio(
   const model = process.env.GROQ_WHISPER_MODEL || 'whisper-large-v3-turbo';
 
   const form = new FormData();
-  form.append('file', new Blob([bytes]), filename);
+  form.append('file', new Blob([bytes as BlobPart]), filename);
   form.append('model', model);
   form.append('response_format', 'text');
 


### PR DESCRIPTION
Greens the typecheck after the bot batch: resume.ts callClaudeCli needs cwd; transcribe.ts Blob cast. Runtime already fine (tsx). 🤖 Generated with [Claude Code](https://claude.com/claude-code)