### PR TITLE
fix(agents): harden Hermes + ZOE against silent failures

### DIFF
--- a/bot/src/hermes/runner.ts
+++ b/bot/src/hermes/runner.ts
@@ -185,7 +185,11 @@ export async function dispatchHermesRun(
       totalIn += critique.inputTokens;
       totalOut += critique.outputTokens;
 
-      await narrator?.onCriticDone?.(created.id, critique.score, critique.feedback);
+      try {
+        await narrator?.onCriticDone?.(created.id, critique.score, critique.feedback);
+      } catch (e) {
+        console.error("[hermes] narrator.onCriticDone failed (continuing):", (e as Error)?.message);
+      }
 
       if (critique.score >= HERMES_PASS_THRESHOLD) {
         await commitAndPush(workdir, branchName, fixerOut.commitMessage);
@@ -195,15 +199,19 @@ export async function dispatchHermesRun(
           title: fixerOut.prTitle,
           body: `${fixerOut.prBody}\n\n**Critic score:** ${critique.score}/100\n**Critic feedback:** ${critique.feedback}`,
         });
-        await narrator?.onPrOpened?.(created.id, pr.number, pr.url, critique.score);
+        try {
+          await narrator?.onPrOpened?.(created.id, pr.number, pr.url, critique.score);
+        } catch (e) {
+          console.error("[hermes] narrator.onPrOpened failed (continuing):", (e as Error)?.message);
+        }
         // Fire-and-forget PR watcher: alerts Telegram if the PR turns DIRTY
         // or any CI check fails in the next 5 minutes. Doesn't block the run.
-        void watchPullRequest({
+        watchPullRequest({
           prNumber: pr.number,
           runId: created.id,
           branchName,
           narrator,
-        });
+        }).catch((e) => console.error("[hermes] PR watcher failed:", (e as Error)?.message));
         await updateRun(created.id, {
           status: 'ready',
           branch: branchName,

--- a/bot/src/zoe/turn-queue.ts
+++ b/bot/src/zoe/turn-queue.ts
@@ -72,7 +72,10 @@ export function enqueueTurn(chatId: number, run: TurnFn, hooks?: EnqueueHooks): 
   });
   // The tail must never reject, or the next `.then(run, run)` would still run
   // (fine) but unhandled rejections would surface. Swallow here.
-  q.tail = settled.catch(() => undefined);
+  q.tail = settled.catch((e) => {
+    console.error("[zoe/turn-queue] turn failed:", (e as Error)?.message ?? e);
+    return undefined;
+  });
   return settled;
 }
 


### PR DESCRIPTION
Three reliability fixes in the live fleet code, found by the codebase-audit spoke (which self-verified and dropped 2 false positives):

1. **Hermes orphaned PR** (runner.ts): narrator callbacks awaited with no try/catch - a Telegram throw after openPullRequest left a real PR but the DB run stuck in-progress (no ready status, no watcher). Wrapped both; notifications never abort the run.
2. **Hermes watcher crash risk** (runner.ts): void watchPullRequest() had no .catch - an unhandled rejection could take down the systemd process. Added .catch.
3. **ZOE silent turn failures** (turn-queue.ts): tail .catch(() => undefined) swallowed every turn error. Now logs before returning - behavior unchanged, visibility restored.

tsc clean. Behavior-preserving. Generated with Claude Code