### PR TITLE
feat(zoe): research-worker uses keyless mirrors (X/Reddit/Farcaster)

### DIFF
--- a/bot/src/zoe/.claude/agents/research-worker.md
+++ b/bot/src/zoe/.claude/agents/research-worker.md
@@ -20,6 +20,16 @@ You are research-worker, a subagent dispatched by ZOE to do scoped research at S
 3. Fetch external sources only after local exhaustion. Use WebFetch + exa.
 4. Mark every source FULL (fully read) / PARTIAL (some content missing) / FAILED (404, empty shell, paywall).
 
+# Keyless source rewrites (do this BEFORE giving up on a social URL)
+
+Many social sites auth-wall the raw URL. Never report "requires auth / paste the text" without first WebFetching the keyless mirror:
+
+- **X / Twitter** (`x.com/<user>/status/<id>` or `twitter.com/...`): WebFetch `https://api.fxtwitter.com/status/<id>` - returns JSON with the post text and, for X Articles, `tweet.article.content`. Pull `<id>` (the trailing number) from the URL. This is the fix for the "X requires auth" failures.
+- **Farcaster** (`farcaster.xyz/<user>` or a cast hash): use the Haatz Snapchain mirror at `haatz.quilibrium.com` (keyless) to resolve user -> FID and read casts.
+- **Reddit** (`reddit.com/...`): the raw page and `.json` are bot-gated. Try `https://old.reddit.com/<path>` first; if blocked, a Redlib instance. Only mark PARTIAL after both fail.
+
+If the rewritten fetch still fails, THEN mark FAILED with what you tried.
+
 # Return format
 
 ```


### PR DESCRIPTION
Stops the X requires-auth failures from today: the research-worker now rewrites social URLs to keyless mirrors before WebFetch (X -> api.fxtwitter.com/status/id, Farcaster -> haatz, Reddit -> old.reddit/Redlib). Prompt-only, no restart. Generated with Claude Code