### PR TITLE
chore(fleet): version-control live units + agent fleet audit (doc 918)

### DIFF
--- a/bot/systemd/cowork-agent.service
+++ b/bot/systemd/cowork-agent.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ZAO Cowork agent (@ZAOcoworkingBot) - migrated from 187.77.3.104
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/migrated-cowork/cowork-zaodevz/agent
+ExecStart=%h/migrated-cowork/cowork-zaodevz/agent/node_modules/.bin/tsx %h/migrated-cowork/cowork-zaodevz/agent/src/index.ts
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+EnvironmentFile=%h/migrated-cowork/cowork-zaodevz/agent/.env
+Environment=PATH=/home/zaal/node22/bin:/home/zaal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target

--- a/bot/systemd/ecosystem-watch.service
+++ b/bot/systemd/ecosystem-watch.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=ZAO ecosystem watch - daily repo pulse to Telegram
+[Service]
+Type=oneshot
+Environment=PATH=/home/zaal/.local/bin:/usr/local/bin:/usr/bin:/bin
+ExecStart=/usr/bin/python3 /home/zaal/ecosystem-watch.py

--- a/bot/systemd/ecosystem-watch.timer
+++ b/bot/systemd/ecosystem-watch.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Daily ZAO ecosystem watch
+[Timer]
+OnCalendar=*-*-* 13:00:00 UTC
+Persistent=true
+[Install]
+WantedBy=timers.target

--- a/bot/systemd/farscout.service
+++ b/bot/systemd/farscout.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Farscout scraper - migrated from 187.77.3.104
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/migrated-cowork/farscout
+ExecStart=/usr/bin/node %h/migrated-cowork/farscout/index.js
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+EnvironmentFile=%h/migrated-cowork/farscout/.env
+Environment=PATH=/home/zaal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target

--- a/bot/systemd/fleet-claude-auth.service
+++ b/bot/systemd/fleet-claude-auth.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Check claude CLI auth + alert Zaal on failure
+[Service]
+Type=oneshot
+ExecStart=%h/fleet-heartbeat/claude-auth-check.sh

--- a/bot/systemd/fleet-claude-auth.timer
+++ b/bot/systemd/fleet-claude-auth.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=claude auth check every 10 min
+[Timer]
+OnBootSec=120
+OnUnitActiveSec=10min
+[Install]
+WantedBy=timers.target

--- a/bot/systemd/fleet-heartbeat.service
+++ b/bot/systemd/fleet-heartbeat.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Fleet heartbeat poster -> thezao.xyz bots board
+[Service]
+Type=oneshot
+ExecStart=%h/fleet-heartbeat/heartbeat.sh

--- a/bot/systemd/fleet-heartbeat.timer
+++ b/bot/systemd/fleet-heartbeat.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Run fleet heartbeat every 60s
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=60
+[Install]
+WantedBy=timers.target

--- a/bot/systemd/zao-devz-stack.service
+++ b/bot/systemd/zao-devz-stack.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ZAO Devz dual-bot (Coder + Critic)
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/zaostock-bot
+ExecStart=%h/zaostock-bot/node_modules/.bin/tsx %h/zaostock-bot/src/devz/index.ts
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+EnvironmentFile=%h/zaostock-bot/.env
+
+[Install]
+WantedBy=default.target

--- a/bot/systemd/zoe-bot.service
+++ b/bot/systemd/zoe-bot.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=ZOE concierge bot (bot/src/zoe Hermes-brain)
+After=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/zao-os/bot
+ExecStart=%h/zao-os/bot/node_modules/.bin/tsx %h/zao-os/bot/src/zoe/index.ts
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+EnvironmentFile=%h/zao-os/bot/.env
+Environment=PATH=/home/zaal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=default.target

--- a/research/agents/918-zao-agent-fleet-audit/README.md
+++ b/research/agents/918-zao-agent-fleet-audit/README.md
@@ -1,0 +1,74 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-06-29
+related-docs: 601, 759, 888, 911
+original-query: "all agent information and make fixes that are needed"
+tier: DEEP
+---
+
+# 918 — ZAO agent fleet audit: intended vs live, gaps, fixes
+
+> **Goal:** Map every agent in the ZAO fleet, compare intended (docs) vs live (VPS), and tag every needed fix SAFE vs RISKY.
+
+## Key findings (live VPS check 2026-06-29, 31.97.148.88)
+
+| Surface (intended) | Unit | Live state | Note |
+|---|---|---|---|
+| ZOE @zaoclaw_bot | zoe-bot.service | ACTIVE, 0 restarts, 0 err/1h | healthy, solo (409 dup fixed earlier today) |
+| ZAO Devz @zaodevz_bot | zao-devz-stack.service | ACTIVE, clean | |
+| Cowork @ZAOcoworkingBot | cowork-agent.service | ACTIVE, clean | migrated from Iman box |
+| ZAOstock @ZAOstockTeamBot | zaostock-bot.service | ACTIVE, clean | |
+| Hermes @zoe_hermes_bot | (none) | **NOT RUNNING - no unit installed** | doc lists it as a live Primary Surface; it is not on the box |
+| Brand bots (Magnetiq/AttaBotty) | zao-team-bots.service | **INACTIVE/dead, unit not registered** | UnitFileState empty |
+| Farscout (Farcaster scout) | farscout.service | ACTIVE, enabled | running but not in CLAUDE.md 5-surface list |
+
+Disk 73% used / 27G free, load ~0. No resource pressure.
+
+### Finding 1 - Hermes is documented-live but not running
+CLAUDE.md Primary Surfaces + doc 601 list Hermes (@zoe_hermes_bot, coder+critic+auto-PR) as live. The VPS has no hermes unit (`systemctl --user list-unit-files | grep hermes` = none). Either it was never installed here or was removed. Doc/reality drift.
+
+### Finding 2 - Unit-file drift (reproducibility gap)
+5 units run live but only 3 (.service) were committed in bot/systemd/ (zao-fleet-agent, zao-team-bots, zaostock-bot). The actual running units (zoe-bot, zao-devz-stack, cowork-agent, farscout) + the timers (ecosystem-watch, fleet-claude-auth, fleet-heartbeat) were hand-installed, not version-controlled. This PR commits all live unit files (secret-scanned clean - EnvironmentFile refs only) so the fleet is reproducible.
+
+### Finding 3 - ZOE orchestrator is 35% ready (doc 759)
+The v2 vision (parallel dispatch + critic + watcher + fleet-coord) is mostly unbuilt:
+- Gap 1 (15%): goal decomposition - cannot route to specialist agents. 
+- Gap 2 (10%): Agent tool not in ZOE allowedTools (bot/src/zoe/concierge.ts ~line 73) - the unlock for multi-agent dispatch.
+- Gap 3 (20%): no non-code critics (research/comms/task) - Hermes critic template exists to copy.
+- Gap 4 (5%): no reflexion.ts memory auto-update.
+- Gap 5 (3%): no learn.ts weekly failure-clustering.
+- Explicit TODO: bot/src/zoe/scheduler.ts ~line 170 (Phase 4 tip generator).
+
+### Decommissioned - do NOT build (doc 601 / CLAUDE.md)
+OpenClaw container + 7-agent squad, Composio AO, FISHBOWLZ, 10-bot branded fleet, ZOE v2 redesign, bot-to-bot autonomy bridge.
+
+## Fixes - tagged
+
+SAFE (this PR, no live behavior change):
+- Commit all live unit files to bot/systemd/ (reproducibility). DONE in this PR.
+- This audit doc.
+
+RISKY (need boot-verify + Zaal go - NOT auto-applied):
+- Decide Hermes: reinstall its unit, or update docs to drop it from live surfaces. (doc/reality must reconcile.)
+- zao-team-bots: restart + fix unit registration, or formally retire the brand bots.
+- ZOE v2 gaps 1-5 (concierge allowedTools + critics + reflexion + learn) - this is the "build v2" track; each a boot-verified PR.
+- scheduler.ts Phase 4 TODO.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Merge this unit-file + doc PR | Zaal | PR | tonight |
+| Decide Hermes: reinstall unit or drop from docs | Zaal | Decision | tomorrow |
+| Decide team-bots: restart or retire | Zaal | Decision | tomorrow |
+| Build ZOE v2 gaps 1-5 (boot-verified PRs) | Zaal+Claude | Build | the "build v2" track |
+
+## Sources
+
+- research/agents/601-agent-stack-cleanup-decision/README.md - FULL
+- research/agents/759-agent-best-practices-and-zoe-orchestrator-gap/README.md - FULL
+- research/agents/888-zoe-improvements-reliability-memory-routing/README.md - FULL
+- bot/AGENTS.md, bot/src/zoe/{concierge,scheduler}.ts - FULL
+- Live VPS systemctl/journalctl 2026-06-29 - FULL


### PR DESCRIPTION
SAFE-fix PR from the agent-fleet audit (map + safe fixes).

What this changes (safe, no live bot behavior change):
- Commits the 10 live systemd unit files to bot/systemd/ (were hand-installed, not version-controlled). Secret-scanned clean (EnvironmentFile refs only).
- Adds doc 918 - full fleet audit: intended vs live, gaps, fixes.

Key findings (live VPS check):
- Hermes (@zoe_hermes_bot) is documented as a live Primary Surface but is NOT running (no unit). Doc/reality drift.
- zao-team-bots inactive/dead, unit not registered.
- Unit-file drift fixed by this PR.
- ZOE orchestrator 35% ready (doc 759 gaps 1-5).

RISKY items NOT touched (need your go / boot-verify): Hermes reinstall-or-drop, team-bots restart-or-retire, ZOE v2 gaps (the build v2 track).