### PR TITLE
doc 924: Artizen reach + funding maximization (BCZ + ZAO Festivals)

### DIFF
--- a/research/business/924-artizen-reach-maximization/README.md
+++ b/research/business/924-artizen-reach-maximization/README.md
@@ -1,0 +1,59 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-06-30
+related-docs: 917, 919, 922
+original-query: "/zao-research artizen and ways i can get out there more and add more info to all of the projects im working on"
+tier: STANDARD
+---
+
+# 924 — Artizen reach + funding maximization (BCZ Strategies + ZAO Festivals)
+
+> **Goal:** Net-new reach/distribution tactics + per-project content adds to grow Zaal's two live Artizen funds. Builds on the BCZ Strategies handoff (mechanics already known - do not re-derive).
+
+## Top reach tactics (ranked, net-new vs the existing playbook)
+
+1. **Multi-fund curation multiplier** - get each project approved across 3-4 thematic funds at once; each independent fund backer triples match on the same $10 artifact. BCZ -> Artist Support + Creator Economy + Impact; ZAO Festivals -> Art/Culture + Music + Community.
+2. **Fund-category dominance, not platform-wide** - stop competing vs 500 projects; own one fund's ~50-80 category. ZAO Festivals = "Music x Community"; BCZ = "Creator Economy + Emerging Talent".
+3. **Voting velocity + streaks** - Artizen rewards daily-voting streaks/bonuses. Run a standing "Vote Day" in ZAO Devz + BCZ community calls; a small daily-voting core beats casual one-offs.
+4. **Artifact essence design** - the $10 artifact must be collectible standalone. BCZ = a visual of "artists thriving full-time", not a logo; ZAO Festivals = the event vibe in one image.
+5. **Console (creator-only community)** - active posting there gives early intel on competing launches + fund priorities + reciprocal cross-promo. (Access process not publicly documented - find the link in-platform.)
+6. **Seasonal phase alignment** - build voters in the Curation phase, unleash sales promo in the Competition phase; misalignment wastes ~half the momentum.
+7. **Voter-cohort mapping** - after each round, ID who drove wins (repeat curators, high-value backers) and recruit them early next round with personal outreach.
+8. **Multi-channel first-hour blitz** - 30-50 buys in hours 0-6 trips the leaderboard; coordinate X + Farcaster + Telegram + email + in-person in one window.
+
+## Content to ADD per project page
+
+**BCZ Strategies:** success-story section (2-3 artist testimonials, before/after); FAQ ("how match works", "what In Your Corner includes - calls? DMs? intros? portfolio review?" - ambiguity kills conversion); a video/podcast proof clip; spell out the reward concretely.
+
+**ZAO Festivals:** "by the numbers" block (date, location, artists, past attendance, budget split); testimonial grid (past attendees/performers, public Farcaster handles OK); 15-30s teaser video; "what's at stake" (tie $ to outcomes - "$X books Y artists at living wages"); reward tiers tied to concrete deliverables.
+
+## Weekly cross-promo cadence (keep votes flowing all season, not just launch)
+
+- Launch week: Mon long-form Farcaster + X thread w/ artifact visuals (tag @ArtizenFund); Wed Telegram + email/SMS; Fri Discord + Console.
+- Voting weeks: Mon "Vote Day" frame ("vote + tag 3"); Wed rotating testimonial spotlight; Fri progress update (votes/match) + ask for recasts.
+- Competition weeks: Mon artifact-drop email/Telegram; Wed Farcaster purchase frame; Fri milestone celebration.
+
+## 3 levers that specifically hit top-30%-by-votes curation
+
+A. **2+ fund approvals before launch** - the single highest-correlated curation signal (dual match + legitimacy). Start fund outreach 4-6 weeks out.
+B. **40-50 first-hour artifact sales** - early momentum cascades in the curation feed.
+C. **Daily voting-streak curve** - aim +5-10 net votes/day across the season; a steady curve beats one spike.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Submit BCZ + ZAO Festivals to 3-4 funds each w/ custom "For [X]" loglines | Zaal | Artizen | this week |
+| Add success-story + FAQ + reward-clarity to BCZ page; by-numbers + teaser to ZAO Festivals | Zaal | Content | this week |
+| Stand up a weekly "Vote Day" in ZAO Devz + BCZ calls | Zaal | Ops | ongoing |
+| Drop fresh testimonials (WaveWarZ crew, Moses, Gneric, KOSBAAR) | Zaal | Outreach | this week |
+
+## Sources
+
+- [Artizen Playbook](https://news.artizen.fund/p/artizen-playbook) - FULL
+- [Artizen Guide to Funding Big Ideas](https://news.artizen.fund/p/ultimate-guide-to-raising-money) - FULL
+- [How to Amplify Your Creativity](https://news.artizen.fund/p/how-to-amplify-your-creativity) - FULL
+- [The Art and Chaos of Curation](https://news.artizen.fund/p/the-art-and-chaos-of-curation) - FULL
+- UNVERIFIED: current endowment size (brief says ~$4M; public sources cite $2.3M awarded historically, not current pool); Console access process (exists, no public signup link found).


### PR DESCRIPTION
Net-new Artizen reach tactics + per-project content adds for BCZ Strategies + ZAO Festivals. Builds on the BCZ handoff.

Top levers: multi-fund curation multiplier, fund-category dominance, voting streaks, 2+ fund approvals + 40-50 first-hour sales for top-30% curation. Includes a weekly cross-promo cadence.

Sourced to Artizen own playbook. Endowment size + Console access flagged unverified.
