### PR TITLE
docs: ZOE lunch ping 2026-06-30

### DIFF
--- a/docs/daily/2026-06-30-lunch.md
+++ b/docs/daily/2026-06-30-lunch.md
@@ -1,0 +1,18 @@
+# Lunch Ping — Tuesday June 30, 2026 — 11:30am EST
+
+**0 priorities done so far today. Afternoon is yours — here's where to start:**
+
+---
+
+**1. Send Jose $100 USDC — due TOMORROW morning**
+Open your wallet app now, transfer to Jose Acabrera while you eat. Do not let this slip to morning — USDC transfers need a clear head, not a rush.
+
+**2. Post Week 23 Farcaster thread — it's weeks late**
+5 casts ready at `docs/weekly/2026-W23-recap.md`. Queue them from Warpcast while you're on your phone. Check your notifications while you're there (ZOE can't pull real-time mentions).
+
+**3. Bonfire labeling — Day 15 overdue, one click**
+Dashboard → label the backlog. Unlocks: 135-doc memory backfill, cross-bot shared KG, ZOE recall vectors. Everything downstream is blocked on this one admin action.
+
+---
+
+*P0 reminder: Next.js CVE (CVSS 7.5) is also Day 15 in production. Flag for first afternoon task.*


### PR DESCRIPTION
Adds `docs/daily/2026-06-30-lunch.md` — ZOE's 11:30am lunch ping for June 30.

**3 items surfaced:**
1. Send Jose $100 USDC — due tomorrow July 1
2. Post Week 23 Farcaster thread — 5 casts ready, weeks overdue
3. Bonfire labeling — Day 15 overdue, one click unblocks the full memory stack

Task status: 0 priorities completed so far today.

---
_Generated by [Claude Code](https://claude.ai/code/session_0166GeAkoBWRWU9DK8ZoQvGW)_