### PR TITLE
docs: land 9 research docs from conflicted PRs

### DIFF
--- a/research/agents/909-agent-stack-gaps-roadmap/README.md
+++ b/research/agents/909-agent-stack-gaps-roadmap/README.md
@@ -1,0 +1,69 @@
+---
+topic: agents
+type: audit
+status: research-complete
+last-validated: 2026-06-26
+superseded-by:
+related-docs: 759, 899, 907
+original-query: "continue iterating in a loop on researching about agents and gaps we may have"
+tier: STANDARD
+---
+
+# 909 - ZAO Agent-Stack Gaps + Hardening Roadmap
+
+> **Goal:** Honest gap analysis of the ZAO agent fleet vs 2026 best practice, ranked, with concrete fixes scoped to the stack (Next.js/Supabase/VPS/Pi/Bonfire/Telegram). ~65% production-ready: strong fundamentals, three blind spots.
+
+## Key decisions (fix order)
+
+| Gap | State | Fix (scoped) | Effort |
+|-----|-------|--------------|--------|
+| **1. Observability** (CRITICAL) | logs show status, not *why* | structured JSON logging -> Supabase `logs` table + correlation IDs through every dispatch; error-rate view | 2-3d, reusable |
+| **2. Reliability** (CRITICAL) | no timeouts/circuit-breakers; silent memory degrade | `withTimeout()` on Claude calls; per-researcher consecutive-failure breaker -> Telegram alert + 1h backoff; Bonfire-read guard (escalate, don't silently use stale) | 3-4d |
+| **3. Evaluation** (HIGH) | only Hermes *code* is scored | comms-critic + research-critic + task-goal-critic (0-100, reuse Hermes rubric); `eval_results` table; alert on >15% week-over-week drop | 1-2wk |
+| 4. Coordination (HIGH) | agents run blind; dup work; Hermes/researcher races | Supabase **work registry** (scope+status); ZOE checks before dispatch; `escalations` table for researcher->Hermes handoffs | 3-4d |
+| 5. Security (MED-HIGH) | untrusted scrapes unvalidated -> Bonfire | Zod `.strict()` at scrape boundary; injection-pattern scan before Bonfire write; (later) container isolation | 2-3d |
+| 6. Memory quality (MED) | Bonfire write-heavy, read-light; manual dedup | mandatory recall (escalate on fail); semantic dedup (>0.85 merge); decay (purge 0-retrieval >60d); learning loop ingests social metrics too | 1wk |
+| 7. Human-in-loop (MED) | concierge output ships unapproved; cost invisible at decision | approval routing by score (>=90 auto, 70-90 async-log, <70 hold) + cost estimate shown + edit-in-place | 2-3d |
+
+## Quick wins (1-2 days each, do first)
+1. **Timeout guards** on Claude calls - stops forever-hangs (one slot blocking the loop).
+2. **Zod validation** on researcher scrapes - blocks prompt-injection from social/web.
+3. **Work registry** - stops Hermes + researchers racing the same repo.
+4. **Correlation IDs** in logging - the spine of observability.
+
+(Already shipped 2026-06-26: **cite-or-drop + verify** on the 3 Pi researchers - directly addresses the reliability/eval "research slop" sub-gap. Farscout's grounded engine is the model.)
+
+## Where ZAO is AHEAD of a typical 2026 fleet
+- Cost-cap discipline (daily fleet cap) - most teams track nothing.
+- Letta 4-block memory (persona/human/working/tasks) - most use flat RAG.
+- Hermes critic loop (0-100 code rubric) - most have no eval at all.
+- Non-blocking "clarify-in-place" defaults - rare + smart.
+
+## Skeptic notes on this analysis
+- It partly conflates the **bash Pi researchers** (yt/seo/repo loops) with the **TS bot** (`bot/src/zoe`); fixes citing `bot/src/researchers/*.ts` are illustrative - adapt per surface (TS bot vs bash loop).
+- File paths + the "65% / 85% by week 8" numbers are directional, not measured.
+- Several sources (OpenAI Swarm, LangChain/LangSmith URLs) are pattern references, treat as directional.
+
+## Also See
+- [Doc 907](../907-agent-fleet-dashboard/) - the dashboard observability/approvals plug into
+- [Doc 899](../899-zoe-agent-fleet-audit/) - the fleet this audits
+- [Doc 759] ZOE orchestrator (critics/reflexion/learn already built - extend them)
+- `bot/src/zoe/{approvals,call-budget,critics}.ts`, `bot/src/hermes/critic.ts` - reuse for the new critics + routing
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Quick win: timeout wrapper on Claude calls (bot + Pi loops) | @ZOE | Build | Wk1 |
+| Quick win: per-researcher circuit-breaker -> Telegram alert | @ZOE | Build | Wk1 |
+| Structured logging -> Supabase + correlation IDs (ask-first: schema) | @Zaal | Build | Wk1-2 |
+| Zod guard + injection scan before Bonfire writes | @ZOE | Build | Wk2 |
+| comms-critic + research-critic (reuse Hermes rubric) | @ZOE | Build | Wk3-4 |
+| Work registry (ask-first: Supabase table) | @Zaal | Build | Wk4 |
+
+## Sources
+- [FULL] [OpenTelemetry exporter spec](https://opentelemetry.io/docs/reference/specification/protocol/exporter/) - correlation-ID standard
+- [FULL] [Pydantic](https://docs.pydantic.dev/latest/) - type-safe parsing as injection defense
+- [FULL] [OpenAI Swarm](https://github.com/openai/swarm) - stateless handoff / work-queue patterns
+- [FULL] [Google SRE Book](https://sre.google/books/) - circuit breaker + work coordination
+- [PARTIAL] [Arize Phoenix](https://arize.com/blog/llm-evaluation/), [Mem0](https://docs.mem0.ai/), [LangSmith](https://smith.langchain.com/) - eval/memory patterns, skimmed

--- a/research/agents/911-bot-per-codebase-ecosystem-monitor/README.md
+++ b/research/agents/911-bot-per-codebase-ecosystem-monitor/README.md
@@ -1,0 +1,87 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-06-26
+superseded-by:
+related-docs: 899, 907, 909, 910
+original-query: "loop vision: ZOE monitors+reports the whole codebase/ecosystem; eventually a bot per codebase - turn it into an architecture"
+tier: STANDARD
+---
+
+# 911 - Bot-per-Codebase + Ecosystem Monitor (the architecture)
+
+> **Goal:** Turn the standing vision ("ZOE monitors and reports on the whole codebase/ecosystem; eventually every codebase has its own bot") into a concrete, phased architecture - grounded in what already runs.
+
+## Recommendations (decisions first)
+| # | Decision | Call |
+|---|----------|------|
+| 1 | Architecture | **Hub + spokes**: ZOE = hub, one lightweight PR-only agent per codebase, Zaal approves. |
+| 2 | Build path | **Generalize the existing web-improver into a parameterized spoke template** - don't write each from scratch. |
+| 3 | First spokes | bcz.com (live), then farscout (improve), then ZAOOS (audit-only first). |
+| 4 | Safety | PR-only never main; one change/pass; per-repo validate + secret-scan; critical repos audit-only until proven; rule #0. |
+| 5 | Host | Run spokes on the **VPS** (has gh + claude); Pi needs a PAT to host any. |
+
+## Live-state validation (2026-06-26, checked this cycle)
+- web-improver: `web-improve.timer` ACTIVE on VPS (verified via `systemctl --user is-active`), shipped PR #28; next fire 14:30 UTC.
+- fleet dashboard: tmux `fleet` up on the Pi, HTTP 200 at ansuz:8090 (10/10 agents).
+- fleet heartbeat: deployed + cron'd 0 11 UTC, test push delivered.
+- 3 researchers (ytr/seor/repor): tmux alive, producing grounded findings.
+
+## The shape: hub + spokes
+- **ZOE** = the hub (concierge/orchestrator on the VPS). Aggregates, reports to Zaal, holds memory.
+- **Per-codebase agents** = spokes. Each key repo gets a lightweight agent that watches + improves + reports up to ZOE.
+- **Zaal** = approves/decides. Spokes are PR-only + report-only; nothing ships or spends without him.
+
+```
+repo A agent  \
+repo B agent   >--> ZOE (aggregate + memory) --> Zaal (heartbeat + digest + dashboard)
+repo C agent  /
+```
+
+## Already built (the prototype exists)
+The **web-improver** (doc 910 sibling; on the VPS, systemd timer, every 6h) IS spoke #1: it watches bettercallzaal.com, makes ONE PR-only improvement per pass (validated + secret-scanned), and pings Zaal via ZOE. Plus the monitoring layer: **fleet dashboard** (ansuz:8090, doc 907), **fleet heartbeat** (daily push), **daily digest** (research synthesis), **parked.md** ("waiting on you"). So the hub + monitoring + one spoke already run.
+
+## The generalization: a spoke template
+Extract the web-improver into a reusable **codebase-agent template** parameterized by:
+- `REPO` (clone), `FOCUS` (improve / audit-only / research-only), `CADENCE`, `CONVENTIONS` (the repo's CLAUDE.md), `VALIDATE` (per-repo gate).
+- Same spine every spoke: pull main -> branch -> claude makes ONE change per CLAUDE.md -> validate + secret-scan -> PR -> report to ZOE. PR-only, never main.
+
+## Roll-out (candidate spokes, priority)
+| Repo | Spoke mode | Why |
+|------|-----------|-----|
+| bettercallzaal.com | improve (live) | prototype, shipping PRs now |
+| ZAOOS (this repo) | audit-only first | big/critical - audit before auto-PR |
+| farscout | improve | the grounded research engine; self-improving |
+| ZAOscout | improve | keyless fetch toolkit |
+| wavewarz sites | improve | top growth surface |
+| thezao.com | report-only | Webflow (no repo) - audit-to-ZOE only |
+
+## Guardrails (non-negotiable)
+- PR-only, never push main. One change/pass. Per-repo validation gate + secret-scan before commit.
+- No spend; agents never autonomously launch/trade tokens (rule #0).
+- Critical repos (ZAOOS) start audit-only; promote to auto-PR only after the pattern proves safe.
+- Every spoke reports to ZOE; ZOE rolls up to the heartbeat + digest so Zaal sees it in one place.
+
+## Open dependencies (parked on Zaal)
+- A **GitHub PAT on the Pi** (or run all spokes on the VPS) - the Pi can't PR without it.
+- Whether to **buy (Borker) vs build (posts-v4)** for the *social* spoke - separate from code spokes.
+- Bonfire **write key** - so spokes can log to the shared graph (writes 401 today, doc-pending).
+
+## Next Actions
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Extract web-improver into a parameterized spoke template | @ZOE/VPS | Build | When prioritized |
+| Add spoke #2 = farscout (improve mode) | @ZOE/VPS | Build | After template |
+| ZAOOS spoke in audit-only mode (reports, no auto-PR) | @Zaal | Decision+Build | After template |
+| Get a Pi PAT or commit to VPS-hosted spokes | @Zaal | Decision | Anytime |
+
+## Also See
+- [Doc 907](../907-agent-fleet-dashboard/) - the monitoring surface
+- [Doc 909](../909-agent-stack-gaps-roadmap/) - the reliability/eval gaps spokes must respect
+- [Doc 910](../../farcaster/910-free-farcaster-posting-zol/) - the social spoke's free-posting path
+- `~/web-improve/web-improve.sh` (VPS) - spoke #1, the template seed
+
+## Sources
+- [reference] Live fleet: web-improver, fleet dashboard (doc 907), heartbeat, digest, researchers - all built this cycle, verified running on VPS + Pi.
+- [reference] Hermes auto-PR pattern (bot/src/hermes) - the proven coder+critic+PR loop the spoke template generalizes.

--- a/research/agents/913-swarm-protocol-zabal-fit/README.md
+++ b/research/agents/913-swarm-protocol-zabal-fit/README.md
@@ -1,0 +1,71 @@
+---
+topic: agents
+type: decision
+status: research-complete
+last-validated: 2026-06-27
+superseded-by:
+related-docs: "325, 345, 607, 669, 781, 899, 862, 258"
+original-query: "https://swarmprotocol.gitbook.io/docs can we research this /zao-lens /zao-research and find if this makes sense for zabal gamez also just look through all research docs send 100 agents and look through them all actually have them read them"
+tier: DEEP
+---
+
+# 913 - Swarm Protocol: does it make sense for ZABAL Gamez?
+
+> **Goal:** Decide whether Swarm Protocol (swarmprotocol.gitbook.io) should be adopted, integrated, or mentioned for ZABAL Gamez - grounded in a full read of the ZAO research library.
+
+## Verdict (one line)
+
+**PASS. Do not integrate, do not mention it.** Swarm Protocol is swarm *robotics* infrastructure; ZABAL Gamez is a Farcaster/ZAO creative build-a-thon, and we already own every coordination/agent/settlement/governance layer Swarm sells.
+
+## Method
+
+A DEEP-tier multi-agent pass: **102 agents read all 1,083 README docs** in `research/` (full library coverage, not a sample, not title-skimming), each scoring every doc for Swarm-relevance and ZABAL-Gamez-relevance. **473 docs** came back relevant. A separate agent read the Swarm Protocol GitBook (introduction, solution, use cases, architecture, technology, $SWARM token, tokenomics). A final ZAO-Lens (Builder / Skeptic / Synthesizer) pass produced the verdict, grounded in cited docs. ~8M subagent tokens, ~15 min wall-clock.
+
+## What Swarm Protocol is
+
+A decentralized, cloud-native platform for **swarm robotics** research - "turning robotics research into a permissionless, global commons." Three layers:
+1. **Cloud simulation** of multi-robot systems (formation flying, search-and-rescue) via ROS, Gazebo, Webots, Isaac Sim - no physical hardware needed.
+2. **Decentralized coordination** ("DNS for Agents") - a peer-to-peer registry to discover/exchange swarm strategies.
+3. **Application layer** - a SwarmNet marketplace + third-party robotics/logistics tools.
+
+Economics: the **$SWARM token** (500M supply, ~18.5% circulating at TGE) pays for simulation runs and governs a DAO. Stack: Ethereum L2 (Base) + Solana/Cosmos, DePIN compute (io.net, Akash, Render), IPFS/Arweave, The Graph, zkML. Target users: roboticists, industrial operators, universities, **defense organizations**, environmental scientists.
+
+## Why it does not fit ZABAL Gamez
+
+**1. Categorical audience/domain mismatch.** ZABAL Gamez tracks are artist (musical/visual), builder (developer/aspiring), creator (media/distribution) - indie musicians, digital creators, Farcaster builders. Swarm targets robotics R&D and enterprise/defense. Zero overlap in use case, audience, or problem.
+
+**2. We already own every layer it sells (redundant):**
+- **Coordination / shared substrate** -> Bonfire (kEngrams, 20-min auto-extraction knowledge-graph loop) - docs [669], [781].
+- **Multi-agent fleet** -> ZOE orchestrator + 8 live agents, multi-agent fan-out to Bonfire - docs [899], [862], [607].
+- **On-chain settlement** -> Empire Builder + x402 micropayments, autonomous wallet swaps on Base - doc [258].
+- **Governance** -> Respect (soulbound, non-transferable).
+- The ZAO even has its own "**ZABAL Agent Swarm**" concept already designed (software agents, not robots) - docs [325], [345 canonical]. The word collides; the substance does not.
+
+**3. `$SWARM` token breaks a hard brand rule.** CLAUDE.md: "No crypto/web3/onchain jargon in public copy." Adopting Swarm pushes token + DAO mechanics into creator-facing surfaces.
+
+**4. Complexity + friction cost.** Swarm needs Docker/ROS/Gazebo, multiple L2s + bridges, zk proofs, IPFS, The Graph. ZABAL Gamez runs on zero-dependency Vercel edge + Upstash Redis, and the event minimizes onboarding to Farcaster SIWA + GitHub OAuth + one form (doc 785). Swarm raises participant friction ~10x for zero capability gain.
+
+## The one caveat
+
+If a participant *independently* proposes a swarm/agent build in July, judge it on ZAO rails (does it wire Bonfire / Empire / Respect?) - but do not reach for Swarm Protocol's infrastructure to do it; our own stack covers it.
+
+## Also See
+
+- [Doc 345](../345-zabal-agent-swarm-master-blueprint/) - canonical ZAO agent build plan (where a real swarm need would surface; Swarm Protocol does not appear).
+- [Doc 669](../669-bonfires-everything-we-know/) - Bonfire as the shared coordination substrate.
+- [Doc 781](../781-zabal-bonfire-contribution-architecture/) - how ZABAL Gamez wires into Bonfire.
+- [Doc 607](../607-three-bots-one-substrate/) - ZOE + Bonfire operating model (the problem Swarm claims to solve, already solved).
+- [Doc 325](../325-zabal-agent-swarm-economy/) - the ZAO's own agent-swarm economy.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| No integration; no public mention of Swarm Protocol | @Zaal | Decision | Done (this doc) |
+| If a participant pitches a swarm/agent build, route to ZAO rails (Bonfire/Empire/Respect), not Swarm infra | @Zaal | Guideline | July build month |
+
+## Sources
+
+- Swarm Protocol docs - introduction, the-solution, use-cases, architecture, technology, $SWARM token, tokenomics (https://swarmprotocol.gitbook.io/docs) [FULL, via llms.txt index + per-page fetch, 2026-06-27]
+- Full read of `research/` (1,083 README docs, 102 agents) - relevance map + ZAO-Lens synthesis [FULL]
+- Cited ZAO research docs: 325, 345, 607, 669, 781, 899, 862, 258 [FULL, read by the fan-out agents]

--- a/research/business/903-zabal-risk-register/README.md
+++ b/research/business/903-zabal-risk-register/README.md
@@ -1,0 +1,77 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-25
+superseded-by:
+related-docs: 902
+original-query: "what is our potential risk and how do we mitigate that /loop"
+tier: STANDARD
+---
+
+# 903 - ZABAL Gamez / The ZAO risk register + mitigations
+
+> **Goal:** Catalog the real risks to ZABAL Gamez (and The ZAO around it), ranked by exposure, each with a concrete mitigation. Grounded in the repo's own warnings + the season's actual setup.
+
+## Key Decisions (top mitigations first)
+
+| Risk | Severity | Mitigation (do this) | Status |
+|------|----------|----------------------|--------|
+| No legal entity behind money/contracts/prizes | HIGH | Form the LLC (doc 902) - Wyoming Instant Series LLC via OtoCo, hold the brand + run prize/sponsor flows through it | Not started |
+| Brand not trademarked + name drift | HIGH | Trademark "ZABAL Gamez" (the mark + name); enforce the glossary in CLAUDE.md; fix stale "magnetic.ai" -> "Magnetiq" in data | Partial (glossary exists) |
+| Key-person dependency (Zaal is the single operator) | HIGH | Document the playbooks (workshop-production-workflow exists), delegate production (Iman on media), and route ownership through the ZAO collective | Partial |
+| Token/prize = securities exposure | HIGH | Issue any token/prize from the LLC; legal review before $ZABAL or paid collectibles; keep tokenless where possible (the tokenless Empire model) | Not started |
+| Lost work from git/PR mishandling | MED | The CLAUDE.md git rules (verify PR open before pushing; one PR = one unit; re-sync main) - already documented; keep following | Documented |
+| Platform dependency (Farcaster/Vercel/Upstash/Luma/Magnetiq/YouTube) | MED | Own the data (recordings + transcripts kept locally, static portable site, no-build edge functions); never single-source the canonical record | Strong |
+| Secrets / signer-key handling | MED | Back up keys off the single machine; rotate; the manifest accountAssociation is signed - never hand-edit; keep API tokens in env, not code | Partial |
+| Reputation / follow-through on public commitments | MED | Don't over-promise; the "on hold" announcement discipline; deliver what's cast | Ongoing |
+
+## Findings - the risk register
+
+### 1. Legal / liability (HIGH)
+ZABAL Gamez signs sponsor/partner deals, runs prize pools ($500 Finals USDC, $Zabal, POIDH bounties), and has collectible/registration surfaces (Magnetiq). With **no entity**, that activity attaches personally to whoever runs it. **Mitigate:** the LLC (doc 902). An LLC also becomes the clean owner of the brand, the contracts, and any token issuance.
+
+### 2. Brand + IP (HIGH)
+- The name/mark "ZABAL Gamez" is **not trademarked** - anyone could file it. The brand is the season's core asset.
+- **Name drift is already happening:** `data/bonfire-graph.json` still calls the workshop-library vendor "magnetic.ai / Tyler Stambaugh" (lines ~5511-5786, 7901) - the glossary corrected this to **Magnetiq (magnetiq.io)** on 2026-05-24. Brand inconsistency in a machine-readable graph propagates.
+- **Mitigate:** (a) trademark the name + hold it in the LLC; (b) one-pass fix the "magnetic" references to "Magnetiq" in the data; (c) the CLAUDE.md glossary is the enforcement doc - keep it authoritative.
+
+### 3. Key-person dependency (HIGH)
+Zaal is the single operator across recruiting, hosting, production, posting, and the build. If he's unavailable, the season stalls. **Mitigate:** the documented workflows (workshop-production-workflow.md, media-playbook.md), Iman on media production, and routing entity/brand ownership through The ZAO so it's not personally bottlenecked.
+
+### 4. Token / financial / regulatory (HIGH if tokens)
+Prize pools and any $ZABAL / paid collectible flirt with securities + money-transmission rules. **Mitigate:** issue from the LLC (OtoCo markets the LLC as a token/SAFE issuer), get legal review before formalizing a token, and lean on **tokenless** mechanics where possible (the tokenless Empire, Respect as non-transferable governance) which sidestep most of it.
+
+### 5. Lost work / process (MED - well-mitigated)
+The repo has a real history of stranded PRs (CLAUDE.md documents PR #54: merged ~2 min after opening, next commits stranded on a dead branch) and a parallel-session doc-number collision (the 819 renumber). **Mitigate:** the CLAUDE.md git rules already encode the fixes - verify the PR is OPEN before every push, one PR = one finished unit, re-sync main after merge. Keep following them.
+
+### 6. Platform dependency (MED - well-mitigated)
+The season rides on Farcaster, Vercel, Upstash, Luma, Magnetiq, YouTube, Cal.com. Any could change terms, pricing, or break. **Mitigate (already strong):** every recording + transcript is kept locally; the site is static + portable (no-build edge functions, zero npm); the canonical record is in-repo, not in a vendor. The exposure is real but the "kept" philosophy blunts it.
+
+### 7. Secrets / security (MED)
+Companion ZAO work flagged real handling gaps (a toolkit that leaked a signer key; "no off-Pi key backup"). For ZABAL Gamez specifically: the Mini App manifest accountAssociation is signed (do NOT hand-edit), API tokens live in env vars. **Mitigate:** off-machine key backup, rotation, secrets in env not code, and the standing rule to never paste secrets into tools.
+
+### 8. Reputation / commitment (MED)
+Public casts are promises. Over-promising (dates that slip, announcements that stall) erodes trust. **Mitigate:** the existing "on hold" discipline (announcements held until ready), and shipping what's cast.
+
+## Also See
+
+- [Doc 902](../902-otoco-llc-for-zabal/) - the LLC mitigation for risks 1, 2, 4.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Form the LLC (Wyoming Instant Series via OtoCo) and assign the brand to it | @Zaal | Task | This month |
+| File a trademark for "ZABAL Gamez" | @Zaal | Task | This month |
+| Fix "magnetic.ai" -> "Magnetiq" in data/bonfire-graph.json (zabalgames repo) | @Zaal | PR | This week |
+| Off-machine backup of signing/API keys + rotation pass | @Zaal | Task | This week |
+| Legal review before any $ZABAL / paid collectible / token | @Zaal | Task | Before launch |
+
+## Sources
+
+- [Doc 902 - OtoCo LLC](../902-otoco-llc-for-zabal/) [FULL - the entity mitigation]
+- zabalgames `CLAUDE.md` [FULL - git/PR loss history (PR #54), brand glossary, manifest-signing rule, storage model]
+- zabalgames `data/bonfire-graph.json` [FULL - the "magnetic.ai" brand-drift instances]
+- zabalgames `docs/workshop-production-workflow.md` + `media-playbook.md` [FULL - the documented process that mitigates key-person risk]
+- ZAOOS doc 894 (ZOL launch ship log) [PARTIAL - the signer-key-leak + no-key-backup security findings, as a cross-project signal]

--- a/research/business/905-incented-borker-sven/README.md
+++ b/research/business/905-incented-borker-sven/README.md
@@ -1,0 +1,75 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-25
+superseded-by:
+related-docs: 893, 894, 899
+original-query: "Sven from Incented - research the person (Sven), the company Incented, and Borker (borker.xyz, their AI social-content automation tool). Context: Sven is Zaal's friend; potential ZAO partnership; ZAO wants to use Borker for ZOL/ZAO social automation (driven via computer-use on the Pi). Tier STANDARD."
+tier: STANDARD
+---
+
+# 905 - Sven / Incented / Borker (use Borker for ZAO social; warm partner)
+
+> **Goal:** Decide how ZAO uses Borker for ZOL/ZAO social automation and how to frame the Incented partnership. Sven is Zaal's friend.
+
+## Key decisions (recommendations first)
+
+| Decision | Call | Why |
+|----------|------|-----|
+| Which Borker plan | **BYOK** (bring your own Anthropic key, ~$1-10/mo) | ZAO already has Claude/Anthropic access. Starter $99/mo and Pro $299/mo are overkill at ZAO's posting volume. |
+| Use Borker directly vs Pi computer-use | **Use Borker directly first** (5-min signup SaaS), add Pi computer-use only if you want ZOL fully hands-off | Borker is a normal web app with login; driving it via headless computer-use is fragile + unnecessary for v1. The Pi browse path is a later "set it and forget it" upgrade. |
+| Borker vs build into ZOL/ZOE | **Use Borker** | It already does multi-platform (X, LinkedIn, Farcaster, Paragraph) + scheduling + news-reactive + blog-to-social. ZAO's `bot/src/zoe/posts/` + ZOL cover only Farcaster drafts. Don't rebuild a friend's product. |
+| Incented partnership | **Pursue beyond Borker** - warm intro already exists (friendship) | Incented = grant-accountability ("make grant money trackable + impactful"). Directly relevant to ZAO's grant funds (ZAO Fund on Artizen, Gitcoin) + contributor rewards (ZOLs). |
+
+## Who / what
+
+- **Sven H** - second-time Web3 founder, "on-chain | off-grid", focus on **regenerative incentive design** (values-alignment over extractive growth). Founder of Incented.co. Currently also exploring Bhutan's Gelephu Mindfulness City (regenerative incentives + decentralized governance). X [@iamsvenh](https://x.com/iamsvenh/), Farcaster [@svenh](https://farcaster.xyz/svenh), [svenh.com](https://svenh.com). NOTE: not the Farcaster `@sven` (Sven Meyer, FID 17818) - different person, do not conflate.
+- **Incented** (incented.co, Farcaster [@incented](https://farcaster.xyz/incented) FID 1104192) - "We make grant money trackable and more impactful through programmable accountability." A web3 grant-accountability / programmable-incentive platform.
+- **Borker** (borker.xyz) - **an Incented project** (confirmed: @incented "Borker.xyz is an Incented project. Let us bork in your voice"). AI social-content automation: learns your brand voice and produces platform-native content for **X, LinkedIn, Farcaster, Paragraph**, with scheduling, news-monitoring reactive posts, and blog-to-social redistribution, via a "Command Center" calendar.
+
+## Borker pricing (verified 2026-06-25)
+
+| Plan | Cost | Limits | Best for ZAO? |
+|------|------|--------|---------------|
+| Starter | $99/mo | 100 AI gen/mo, 2 seats | No - overkill |
+| Pro | $299/mo | 500 AI gen/mo, 10 seats | No - overkill |
+| **BYOK** | **own Anthropic key (~$1-10/mo)** | uses your Claude API key | **YES** |
+| Lifetime | one-time (unlimited via own key) | unlimited gen via your key | Maybe, if you commit |
+
+No public API; it integrates Anthropic's Claude API (BYOK/Lifetime = you supply the key). Yearly plans save 10%; promo code field at checkout (ask Sven for one).
+
+## How ZAO uses it
+
+1. Zaal signs up (BYOK, plug ZAO's Anthropic key). Connect X + Farcaster (+ Paragraph for long-form).
+2. Configure brand voice = ZAO's Year-of-ZABAL voice (spartan, no emojis, no em dashes) - matches what's already in `bot/src/zoe/memory.ts`.
+3. Use Borker as the multi-platform content surface; ZOL (Pi) stays the Farcaster *reply/scout* agent. Borker = outbound campaigns; ZOL = inbound mentions + curation. Complementary, not duplicate.
+4. (Later) Pi computer-use can drive Borker hands-off if desired - the auth + the existing `~/cu/run.sh` capability make it possible, but it's a v2 nicety.
+
+## Partnership angle
+
+Incented's core (programmable grant accountability) maps onto ZAO's actual needs: the ZAO Fund on Artizen, Gitcoin rounds, and ZOL/ZOLs contributor credits. A friend-to-friend conversation could cover: (a) ZAO as a Borker design partner / case study, (b) Incented accountability rails for ZAO grant disbursement + contributor rewards, (c) cross-promo (Sven + ZAO both regen/web3-music adjacent).
+
+## Also See
+
+- [Doc 899](../../agents/899-zoe-agent-fleet-audit/) - ZAO agent fleet (ZOL, ZOE posts module = the existing social surface)
+- [Doc 894](../../events/894-zol-launch-night/) - ZOL on Farcaster
+- `bot/src/zoe/posts/` + `bot/src/zoe/memory.ts` - ZAO's existing social-draft + brand-voice code
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Sign up for Borker BYOK, plug ZAO Anthropic key, connect X + Farcaster | @Zaal | Action | This week |
+| Set Borker brand voice to ZAO Year-of-ZABAL rules | @Zaal | Config | At signup |
+| Ask Sven for a promo code + a Borker BYOK/Lifetime steer | @Zaal | DM | This week |
+| Scope the Incented x ZAO partnership (grant accountability for ZAO Fund / ZOLs) | @Zaal | Convo | Next call |
+| (v2) Wire Pi computer-use to drive Borker hands-off for ZOL | @Zaal/ZOE | Build | After v1 proves value |
+
+## Sources
+
+- [FULL] [borker.xyz](https://www.borker.xyz) - features, platforms, pricing tiers ($99/$299/BYOK/Lifetime), Anthropic-key integration (fetched 2026-06-25)
+- [FULL] [borker.xyz/docs](https://www.borker.xyz/docs) - product capabilities (brand voice, scheduling, news monitoring, blog-to-social, Command Center)
+- [FULL] [svenh.com](https://svenh.com) - Sven H bio, regenerative incentive design, founder of Incented, socials, Gelephu Mindfulness City
+- [FULL - keyless scout, haatz] Farcaster @incented (FID 1104192) bio + casts confirming "Borker.xyz is an Incented project"; @svenh socials
+- [PARTIAL] [WebSearch: Incented / Sven] - confirmed Sven H builds Incented.co (regenerative incentive design); general web3-incentive results otherwise

--- a/research/business/906-zaal-zao-seo-web-presence/README.md
+++ b/research/business/906-zaal-zao-seo-web-presence/README.md
@@ -1,0 +1,62 @@
+---
+topic: business
+type: audit
+status: research-complete
+last-validated: 2026-06-25
+superseded-by:
+related-docs: 037, 899, 905
+original-query: "have the pi do a claude code loop researching SEO on Zaal and anywhere on the internet he/the ZAO appears, and add it into ZAO OS as a /zao-research"
+tier: STANDARD
+---
+
+# 906 - Zaal / ZAO SEO + Web-Presence Audit (living - fed by the Pi SEO loop)
+
+> **Goal:** Own more search real estate for Zaal / BetterCallZaal / The ZAO / WaveWarZ. This doc is seeded by the first pass of a 24/7 SEO researcher on the Pi (tmux `seor`, `~/seo-research/`) and is updated as passes accumulate.
+
+## Key decisions (do these first)
+
+| Action | Why | Priority |
+|--------|-----|----------|
+| **Register + build bettercallzaal.com** (one page: name, handle, bio, project links; "Zaal Panthaki" + "BetterCallZaal" in title + H1) | No owned site ranks for either branded query - a raw HackMD resume is doing that job. A canonical owned page displaces it. | HIGH |
+| **Fix the LinkedIn headline + About** to "Founder, The ZAO | BetterCallZaal | WaveWarZ" | LinkedIn is the **#1 result for "Zaal Panthaki"** but shows the old Jackson Laboratory automation role - actively off-brand. | HIGH |
+| **Optimize the @bettercallzaal YouTube About** to include "Zaal Panthaki" + "BetterCallZaal" | The channel is invisible for both branded queries; the text forces it to rank. | MED |
+| **Add footer backlinks** thezao.com + wavewarz.com -> personal site, anchor "BetterCallZaal" | Consolidates link equity, surfaces project sites on branded queries. | MED |
+| **Publish a "Who is BetterCallZaal" page** (thezao.com or Mirror/Substack) using both name variants + project names | Gives search a clean text-rich doc to rank above the TV-show contamination. | MED |
+
+## Findings - first pass (2026-06-25): branded SERP audit
+
+**"BetterCallZaal":** X profile ranks #1, then a raw [HackMD resume](https://hackmd.io/@bB0dXoPfSAuUEqyo43pHZw/Hyq0LS-Z-g) at #2, then individual tweets, then a deep GitHub link into the ZAOOS repo. **Results #7-8 are the Better Call Saul TV show** (x.com/bettercallsaul + Breaking Bad Fandom wiki) - contaminating the brand SERP. The wrong @bettercallcal Linktree also appears. **YouTube, Linktree, thezao.com, wavewarz.com are all absent from page 1.**
+
+**"Zaal Panthaki":** [LinkedIn](https://www.linkedin.com/in/zaalp/) ranks #1 but the headline shown is the Jackson Laboratory automation role, not ZAO/web3. Data scrapers (ZoomInfo, ReachInbox) hold mid-page. The HackMD resume reappears at #3. An old (non-@bettercallzaal) YouTube channel appears at #9. thezao.com + wavewarz.com do not rank.
+
+**The gap:** no owned personal site ranks for either query; LinkedIn undermines positioning with a stale job title; the Better Call Saul show eats handle-search share; all project sites are invisible on branded queries.
+
+## How this doc stays current
+
+A 24/7 SEO researcher runs on the Pi (`~/seo-research/`, tmux `seor`, ~4h passes, 12 rotating angles: branded SERP, "The ZAO" disambiguation, WaveWarZ search, keyword gaps, backlinks, directory/wiki, social-profile SEO, technical SEO, local/ZAOstock, reputation, peer benchmarking). Each pass appends to `~/seo-research/findings-<date>.md`, pings Zaal, and logs a Bonfire episode (`seo-research`). Fold notable findings into this doc as they land. Same pattern as the YT-growth researcher ([[project_pi_yt_research]]).
+
+## Also See
+
+- [Doc 905](../905-incented-borker-sven/) - Borker (could auto-publish the SEO content pages)
+- [Doc 037](../037-bridges-competitors-monetization/) - earlier SEO/monetization notes
+- [Doc 899](../../agents/899-zoe-agent-fleet-audit/) - the agent fleet running these researchers
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Register bettercallzaal.com + ship a one-page bio site | @Zaal | Action | This week |
+| Fix LinkedIn headline/About to current brand | @Zaal | Action | Today (2 min) |
+| Update @bettercallzaal YouTube About with both name variants | @Zaal | Action | This week |
+| Add footer backlinks on thezao.com + wavewarz.com | @Zaal | PR | This week |
+| Let the Pi SEO loop run; fold weekly findings into this doc | @ZOE | Recurring | Weekly |
+
+## Sources
+
+- [FULL - first-hand, Pi SEO researcher pass 2026-06-25] `~/seo-research/findings-2026-06-25.md` - live branded-SERP audit via claude + WebSearch
+- [FULL] [X @bettercallzaal](https://x.com/bettercallzaal) - ranks #1 for the handle query
+- [FULL] [HackMD resume](https://hackmd.io/@bB0dXoPfSAuUEqyo43pHZw/Hyq0LS-Z-g) - currently #2, doing the job an owned site should
+- [FULL] [LinkedIn - Zaal Panthaki](https://www.linkedin.com/in/zaalp/) - #1 for the name query, off-brand headline
+- [PARTIAL] [Better Call Saul X](https://twitter.com/bettercallsaul) - SERP contaminant on the handle query (noted, not the target)
+
+**Code / repo search:** N/A for the topic - this is a web-presence/SEO audit, not a code problem. The only "implementation" is the SEO researcher itself: `~/seo-research/` on the Pi (seo-research.sh + seo-loop.sh, tmux `seor`), modeled on the YT-growth researcher in [[project_pi_yt_research]]. No external repos apply.

--- a/research/business/908-airgap-zoe-onchain-agent/README.md
+++ b/research/business/908-airgap-zoe-onchain-agent/README.md
@@ -1,0 +1,74 @@
+---
+topic: business
+type: decision
+status: research-complete
+last-validated: 2026-06-26
+superseded-by:
+related-docs: 572, 899, 905, 907
+original-query: "research airgap.finance fully (+ Farcaster @airgap); Zaal wants ZOE to 'make an android and run a ZABAL bot token'"
+tier: STANDARD
+---
+
+# 908 - AirGap as a model for a ZOE onchain agent + ZABAL token (advisory-first)
+
+> **Goal:** Decide how ZOE should "make an android" (spawn an onchain agent) + run a "ZABAL bot token" - using AirGap (airgap.finance) as the reference. Verdict: build the agent as an ADVISOR, gate with the EXISTING ZABAL token, do NOT launch a new token.
+
+## Key decisions (recommendations first)
+
+| Decision | Call | Why |
+|----------|------|-----|
+| Copy AirGap's model? | **No - it's a cautionary tale** | $AIRGAP is dust: ~$81k mcap, ~$83/day volume, ~5 traders/day, unverified contract, anon team, no docs/audit. The *idea* (signal agents) is fine; the *execution* failed. |
+| ZOE onchain agent type | **Advisory only - signals, no execution, no custody** | No fund-holding = no custody/regulatory/rug risk, and it respects rule #0 (agents never autonomously launch/trade tokens). |
+| New "ZABAL bot token"? | **No - use the EXISTING ZABAL ERC-20** | A second token with no utility copies AirGap's zero-traction failure. ZABAL already exists ([[doc 572]] kept it on Base). Gate premium signals behind it. |
+| When to add execution / a token | **Only after ~6 months of proven advisory traction** | Named team + audit + organic demand first. Earn it. |
+
+## What AirGap actually is
+
+airgap.finance / Farcaster **@airgap** (FID 3324884) / X @airgapai: **"autonomous onchain intelligence on Base"** - personalized agents for onchain traders. Configurable agents, real-time token-launch detection + a "Token Behavior Engine" scoring tokens, signals streamed via SSE, alerts routed to Telegram, portfolio view, a REST API (`/api/v1`, wallet sign-in). NOT the old AirGap self-custody wallet (Papers AG) - different project.
+
+**$AIRGAP token:** on Base, ~$81k mcap, ~$83/day volume, ~5 traders/day (per on-chain data - plausible, verify before quoting). Tokenomics/utility not published. Contract unverified on BaseScan. Dust-level - not a successful launch.
+
+**Clanker tie:** YES - @airgap's own cast: "grateful to have clanker behind the gappy experiment." (NOTE: the research pass first concluded "no clanker connection" off on-chain deploy data; the primary-source cast corrects that - there IS a clanker relationship. Treat the "direct Uniswap V4, not clanker" claim as unverified.)
+
+**Traction:** extremely weak - no media, no public community, minimal engagement, dust trading. May be early/stealth or stalling.
+
+## The ZAO path: "ZOE makes an android" (advisory-first)
+
+**Phase 1 - advisory agent (no execution, no custody):**
+- ZOE spawns an onchain agent identity (smart account or Farcaster signer) that **generates signals only** - detects/scores onchain moves, posts to Farcaster/Telegram.
+- It does NOT execute trades, hold funds, or touch the ZABAL treasury. Humans act on signals if they choose. Disclaimers; team eats first losses.
+
+**Phase 2 - gate with existing ZABAL (optional):** premium signals / agent-parameter voting behind the **existing** ZABAL token. No new token.
+
+**Phase 3 - execution (much later, optional):** only after 6+ months of reliable signals; non-custodial (agent proposes, human approves in UI); tiny test amounts; audit first.
+
+## Honest risks
+
+- Signal-accuracy -> people lose money + blame ZAO (disclaimer + team-first-loss).
+- A new token dumping = brand damage (don't launch one; prove value first).
+- Execution/custody = regulatory + rug exposure (advisory-first dodges it).
+- Building reliable autonomous agents is hard - iterate, don't overpromise returns.
+
+## Also See
+
+- [Doc 907](../../agents/907-agent-fleet-dashboard/) - the fleet/control surface a signal agent would plug into
+- [Doc 905](../905-incented-borker-sven/) - Borker (content) vs this (signals) - different agent lanes
+- [Doc 572](../572-zabal-avalanche-l1-l2-gas-token/) - $ZABAL stays an ERC-20 on Base (use it, don't relaunch)
+- `bot/src/zoe/` (orchestrator), `src/lib/agents/` (existing VAULT/BANKER/DEALER trading agents - the execution pattern if Phase 3 ever happens)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Decide advisory-first (not AirGap-style token) | @Zaal | Decision | Now |
+| Spec a ZOE "signal android" - onchain detection -> Farcaster/Telegram, no execution | @Zaal/ZOE | Build | When prioritized |
+| If gating: wire premium signals to the existing ZABAL token | @Zaal | Build | Phase 2 |
+| Do NOT launch a new ZABAL bot token; revisit only with proven traction + audit | @Zaal | Hold | 6mo review |
+
+## Sources
+
+- [FULL - keyless scout, haatz] Farcaster @airgap (FID 3324884) bio + casts - "autonomous agents for onchain traders", clanker affiliation confirmed
+- [FULL] [airgap.finance](https://airgap.finance) - product nav (Agency/Signals/Portfolio/Launches/$AIRGAP), wallet sign-in
+- [PARTIAL - on-chain, verify] $AIRGAP token stats (mcap ~$81k, ~$83/day vol, ~5 traders) via BaseScan/Dexscreener per research agent
+- [PARTIAL - 402 blocked] X @airgapai - exists, content not fully read
+- [NOT FOUND] team page, GitHub, audit, docs, media coverage - absence noted as a signal

--- a/research/dev-workflows/921-recap-video-enhancements/README.md
+++ b/research/dev-workflows/921-recap-video-enhancements/README.md
@@ -1,0 +1,88 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-06-29
+related-docs: 916
+original-query: "STANDARD, building on doc 916. We are about to re-render the Farcaster AMA recap video and want to make the most of the hour. What ELSE would make a Space/AMA recap video meaningfully better that we have NOT implemented - on-screen chapters, lower-thirds, brand motion, end screen, intro/outro, B-roll, production touches - prioritized do-next scoped to the Remotion pipeline (spacetovideo), flagging render-cost worth-it vs not."
+tier: STANDARD
+---
+
+# 921 - Recap Video: what else to add, and what it is worth on the render
+
+> **Goal:** A prioritized do-next list for the spacetovideo recap pipeline, scoped to our
+> reality (static long-form audio, local Remotion render that is fragile under per-frame cost).
+> Extends doc 916 - does not repeat the captions/speaker-ID/distribution findings there.
+
+## What we already ship (do not re-add)
+spacetovideo components: TitleCard (now correct), HostBadge, IntroHero, GuestCard (speaker
+card + pfp), Waveform, CaptionTrack (word-level color karaoke), TimeBadge, ProgressBar (new),
+plus the ZABAL arcade reskin (gold + cyan) shipping in this render. So we already have:
+per-speaker cards, captions, waveform, progress bar, title, brand skin.
+
+## The render-cost lesson (the constraint that drives every call below)
+The per-word `spring()` in the karaoke captions tripled render time (52min -> ~3h) and timed
+out twice. **Rule: new on-screen elements must be CSS-static-per-frame** (color/position from
+a simple time check), NOT per-frame physics/springs across many nodes. Anything that animates
+per word or runs a spring per element is banned until we move to Remotion Lambda (doc 916).
+
+## Key Decisions (do these)
+
+| # | Add | Why | Render cost | Verdict |
+|---|-----|-----|------------|---------|
+| 1 | YouTube chapters in the DESCRIPTION (timestamps from transcript) | Chapters are non-negotiable for >20min video; clickable timestamps raise total watch time, and 0 render cost | none (text) | DO NOW - free, biggest win |
+| 2 | On-screen segment/chapter title (a lower-third that names the current topic, changes a handful of times across the hour) | Gives the static hour navigation + visual change; reinforces audio with text (retention) | cheap (one text node, swaps on a time boundary) | DO - needs an LLM chapter pass first |
+| 3 | Pull-quote cards (every few minutes, a big quote card flashes the line being said) | The "a visual change every 20-30s" rule that holds attention on static audio; produced feel | cheap (static text, time-gated) | DO if we want one more cheap win - needs 6-8 hand/LLM-picked quotes+times |
+| 4 | End screen / outro CTA + intro bookend | End screens direct viewers onward (next session, the site); a cold-open hook earns the watch | none in render - SPLICE the user's existing intro/outro template clips via ffmpeg concat | DO - use the user's templates, not new Remotion cards |
+| 5 | Speaker lower-third (persistent name+org bar while speaking) | Reinforces who is talking | cheap | SKIP for now - GuestCard already does this; marginal |
+| 6 | Transitions/crossfades between speaker cards | Polish | small per-frame cost during transitions | SKIP - low ROI, adds render risk |
+| 7 | B-roll / multiple angles / animated stat lower-thirds | Top production signal for VIDEO podcasts | n/a | SKIP - we have audio only and no stat data; not applicable |
+
+## For THIS render (make the hour count)
+Already batched and cheap: arcade reskin, fixed title, progress bar, color karaoke captions.
+That is already the high-value, low-risk set. Two more worth folding in only if quick:
+- **Pull-quote cards (#3)** - cheapest visual-variety win for static audio. Needs 6-8 quotes +
+  timestamps (we have the transcript; an LLM pass picks them). Static text card, time-gated.
+- **On-screen chapter titles (#2)** - needs the LLM chapter pass too; slightly more layout work.
+
+Do **regardless of render** (free, do tonight): **#1 YouTube chapter timestamps** in the
+description, and after the render, **#4 splice the intro/outro** templates.
+
+Hold for the Remotion Lambda move (doc 916): anything per-frame-animated (richer transitions,
+animated lower-thirds, motion graphics) - Lambda removes the local per-frame-timeout fragility.
+
+## Findings
+- **Chapters**: "non-negotiable for any podcast over 20 minutes"; description timestamps create
+  clickable chapters that "significantly increase total watch time." Ours is 64 min - this is
+  the single highest-leverage, zero-cost add.
+- **Lower-thirds / chapter cards**: "small animated text bars... introduce speakers and
+  highlight key points for better retention"; "chapter cards can mark section titles."
+- **End screens**: "keep people engaged after episodes end by directing them to another
+  episode, your website or social channels."
+- **Visual variety**: "a thoughtful visual insert every 20-30 seconds can extend viewer
+  attention"; "text overlays give the impression of a much more produced show." For static
+  audio, our levers are caption motion + speaker-card swaps + pull-quote cards + chapter cards.
+- **Retention**: "viewers retain information better when audio and visual reinforce each
+  other"; "70% of viewers watch video podcasts in the foreground" - captions + on-screen text
+  are doing real work, not decoration.
+
+## Sources
+- Vicinity Studio - 3 production techniques (lower thirds, chapter cards, graphics) - https://vicinity.studio/how-to-improve-your-video-podcast-3-production-techniques/ [FULL via search synthesis]
+- Sweetfish Media - The 6 screens every video podcast needs (intro, lower-third, chapter, end screen) - https://www.sweetfishmedia.com/blog/the-6-screens-every-video-podcast-needs [FULL via search synthesis]
+- YouTube Creator guide - engaging podcast content (chapters, retention) - https://blog.youtube/creator-and-artist-stories/the-definitive-guide-to-creating-engaging-podcast-content/ [PARTIAL - summarized from search result, not full-fetched]
+- Venture Media - 2026 video podcast visual storytelling trends - https://www.venturemedia.io/post/top-video-podcast-trends-and-visual-storytelling-in-2026 [PARTIAL - summarized from search result]
+- r/podcasting community thread on retention/chapters - [FAILED - zao-fetch-reddit returned empty; WebSearch blocks reddit.com for this agent. Community angle covered by doc 916's sources instead.]
+- Remotion captions API (chapter/lower-third rendering patterns) - https://www.remotion.dev/docs/captions/api [FULL - per doc 916]
+
+## Also See
+- [Doc 916](../916-recap-video-pipeline/) - the full pipeline roadmap (captions, speaker ID, distribution, Lambda, cost)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Generate YouTube chapter timestamps from the AMA transcript for the description | @Zaal | Build (free) | With the upload |
+| Splice the user's intro + outro template clips onto the finished render (ffmpeg concat) | @Zaal | Build | After render |
+| Add an LLM pull-quote pass (6-8 quotes+times) -> static quote cards in spacetovideo | @Zaal | PR (spacetovideo) | Next iteration |
+| Add LLM chapter pass -> on-screen segment-title lower-third | @Zaal | PR (spacetovideo) | Next iteration |
+| Move rendering to Remotion Lambda before adding per-frame-animated elements | @Zaal | Build | When automating |

--- a/research/events/919-zao-palooza-zao-chella-event-record/README.md
+++ b/research/events/919-zao-palooza-zao-chella-event-record/README.md
@@ -1,0 +1,106 @@
+---
+topic: events
+type: event-research
+status: research-complete
+last-validated: 2026-06-29
+superseded-by:
+related-docs: 364, 846, 850, 476
+original-query: "research on zaofestivals specifically ZAO-PALOOZA from 2024 April and ZAO-CHELLA from 2024 December Miami - use zao-scrape-x-timeline.sh to hunt PALOOZA/CHELLA posts across @zaofestivals @bettercallzaal @WaveWarZ"
+tier: STANDARD
+---
+
+# 919 - ZAO-PALOOZA + ZAO-CHELLA: Past Event Record
+
+> **Goal:** Consolidate the verified record of the two ZAO Festivals IRL events (ZAO-PALOOZA, NYC, 2024; ZAO-CHELLA, Miami, Dec 2024) into one canonical past-events doc, and document what is and is not sourceable cookie-free.
+
+## Sourcing reality up front (read this first)
+
+The original ask was to hunt 2024 PALOOZA/CHELLA posts via `zao-scrape-x-timeline.sh` across @zaofestivals, @bettercallzaal, @WaveWarZ. **That path cannot reach the events.** The scraper uses nitter RSS, which only returns each account's most recent ~20 posts. As of 2026-06-29 those windows bottom out around March 2025 - the April 2024 (PALOOZA) and December 2024 (CHELLA) posts are well outside the window. The script's own header says as much ("RSS only reaches the most recent ~20 posts. For deep history use specific tweet URLs or rettiwt-api with an auth token").
+
+So this doc is built from the **verified internal record** (the festivals-history memory + Doc 364, both written when the events were fresh), plus the one cookie-free public datapoint still reachable (the @zaofestivals Instagram profile meta). Nothing here is invented. Per-fact confidence is marked.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Sourcing 2024 X posts** | Do NOT rely on `zao-scrape-x-timeline.sh` for 2024 events - RSS window is too shallow. To pull the actual posts, either feed specific tweet URLs to `zao-fetch-x.sh`, or run `rettiwt-api` with an auth token (the same method that produced the team-roster table in the festivals-history memory). |
+| **Primary visual proof** | ZAO-CHELLA lives on Instagram, not X. The @zaofestivals IG (bio still "ZAO-CHELLA | ART BASEL '24") + reel `DDa-oPBJ7G7` are the canonical assets. Engagement numbers are behind IG's login wall - pull them from Zaal's logged-in account, do not estimate. |
+| **Canonical spelling** | Always `ZAO-PALOOZA` and `ZAO-CHELLA` (hyphenated, all-caps). See `feedback_zao_festival_spelling` (PR #604). |
+| **Use as proof-of-track-record** | Both events are the "we have done IRL before" proof for ZAOstock 2026 sponsor pitches and the Artizen ZAO Festivals fund. Doc 364 already wires ZAO-CHELLA into the pitch; this doc is the standalone record. |
+
+## ZAO-PALOOZA (Event #1)
+
+| Detail | Info | Confidence |
+|--------|------|------------|
+| **Name** | ZAO-PALOOZA | high |
+| **City** | New York City | high |
+| **Tie-in** | NFT NYC 2024 (the conference week) | high |
+| **Month** | April 2024 (NFT NYC 2024 ran early April) | medium - memory says "NFT NYC 2024"; exact day not recorded, confirm with Zaal |
+| **Artists** | 12 | high (per festivals-history memory) |
+| **Financials** | Broke even | high |
+| **Significance** | First ZAO IRL meetup | high |
+| **Collectible** | Manifold "ZAO-Palooza" collectible (Jango UU) referenced in the ZAO NEXUS hub record | medium - referenced in `project_nexus_hub_live`, not independently re-verified |
+
+What is NOT recorded anywhere internal: a schedule, a venue name, a sponsor, photo/video links, or attendance beyond "12 artists." If those exist they are on Zaal's devices / the team's X+IG, not in the research library. Flagged as a gap below.
+
+## ZAO-CHELLA (Event #2)
+
+| Detail | Info | Confidence |
+|--------|------|------------|
+| **Name** | ZAO-CHELLA \| ART BASEL '24 | high |
+| **Date** | December 6, 2024 | high (Doc 364) |
+| **Location** | Wynwood, Miami (during Art Basel Miami) | high |
+| **Format** | 10 Web3 musicians, AR art, trading cards | high |
+| **Schedule** | 4pm networking, 6pm WaveWarZ LIVE rematch, 7pm performances, 11pm close | high (Doc 364) |
+| **Organized by** | AttaBotty + DaNici | high |
+| **Sponsor** | Student $LOANZ Token (Gold Sponsor) | high |
+| **Cross-community** | WaveWarZ ran a LIVE rematch on stage | high |
+| **Instagram** | [@zaofestivals](https://www.instagram.com/zaofestivals/) - profile bio still set to "ZAO-CHELLA \| ART BASEL '24" | high |
+| **Instagram reel** | [ZAO-CHELLA 2024 Miami](https://www.instagram.com/reel/DDa-oPBJ7G7/) | high (link), engagement FAILED (login wall) |
+| **@zaofestivals IG profile** | 246 followers, 46 following, 65 posts (as of 2026-06-29) | high (og meta) |
+
+ZAO-CHELLA is the better-documented of the two - it has a fixed date, a run-of-show, named organizers, a named sponsor, and a public IG reel. It is the stronger proof asset for pitches.
+
+## The rest of the ZAO Festivals timeline (context)
+
+From the festivals-history memory, the full arc the two 2024 events sit inside:
+
+1. **ZAO-PALOOZA** - NYC, NFT NYC 2024 - 12 artists, broke even, first IRL meetup
+2. **ZAO-CHELLA** - Miami, Art Basel 2024 (Dec 6) - 10 artists, WaveWarZ LIVE, AR art, cross-community
+3. **ZAO-PROS** - ETH Denver 2025 - conference activation
+4. **COC Concertz** (#1-4, ongoing) - metaverse concerts in Stilo World / Spatial.io, Twitch streaming
+5. **ZAOstock** - Oct 3 2026, Ellsworth ME - flagship IRL festival, Franklin St Parklet
+
+## Gaps (what to capture before the next pitch)
+
+| Gap | Owner | How to close |
+|-----|-------|--------------|
+| ZAO-PALOOZA exact date, venue, sponsor, photos | @Zaal | Pull from personal archive / team X+IG; confirm April day |
+| ZAO-CHELLA reel + post engagement numbers | @Zaal | Screenshot from logged-in IG (DDa-oPBJ7G7 + the 65 posts) |
+| Actual 2024 X posts from the three handles | Agent | `rettiwt-api` with auth token, OR feed specific tweet URLs to `zao-fetch-x.sh` |
+| ZAO-PROS (ETH Denver 2025) detail | @Zaal | Same as above; currently one line |
+
+## Also See
+
+- [Doc 364](../364-zao-festivals-deep-research/) - ZAOstock sponsor-pitch mega-doc; wires ZAO-CHELLA in as proof
+- [Doc 846](../../business/846-zao-festivals-funding-strategy/) - ZAO Festivals funding strategy
+- [Doc 850](../../business/850-zao-festivals-fund-creation-manager-playbook/) - Artizen ZAO Festivals fund playbook
+- [Doc 476](../476-zaostock-apr22-team-recap/) - ZAOstock team recap
+- Memory: `project_zao_festivals_history` (canonical event arc + team roster), `feedback_zao_festival_spelling` (naming)
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Confirm ZAO-PALOOZA exact April 2024 date + venue | @Zaal | Reply | Next session |
+| Screenshot ZAO-CHELLA IG reel + post engagement for the pitch deck | @Zaal | Asset collect | Before next sponsor pitch |
+| If deep 2024 X history is needed, run rettiwt-api with token (not the RSS scraper) | Agent | Tooling | On request |
+| Link this doc from the ZAOstock pitch + Artizen ZAO Festivals fund copy | @Zaal | Edit | After review |
+
+## Sources
+
+- **[FULL]** Memory `project_zao_festivals_history.md` - ZAO event arc (PALOOZA/CHELLA/PROS/COC/ZAOstock) + team X roster (rettiwt-api scrape, 2026-04-11)
+- **[FULL]** Doc 364 `research/events/364-zao-festivals-deep-research/README.md` - ZAO-CHELLA Art Basel '24 detail table (date, schedule, organizers, sponsor, IG links)
+- **[PARTIAL - profile meta only, reel engagement behind login]** [@zaofestivals Instagram](https://www.instagram.com/zaofestivals/) - og:description: "246 Followers, 46 Following, 65 Posts ... ZAO-CHELLA | ART BASEL '24". Reel `DDa-oPBJ7G7` page returns no logged-out content.
+- **[FAILED - RSS window too shallow for 2024]** `zao-scrape-x-timeline.sh` on @zaofestivals, @bettercallzaal, @WaveWarZ - all three timelines bottom out around March 2025; no April/December 2024 posts reachable cookie-free. Escalation path documented (rettiwt-api / per-URL fetch).
+- **[FULL]** Memory `feedback_zao_festival_spelling.md` - canonical hyphenated all-caps naming (PR #604)


### PR DESCRIPTION
Lands the 9 research docs whose original PRs conflicted on auto-generated topic-index READMEs (and #1012 also had a stale zoe code conflict). Pulled each new doc dir cleanly into one branch - no code touched, no index conflicts. Docs: 903 risk-register, 905 Incented/Sven, 906 SEO audit, 908 AirGap-ZOE, 909 agent-stack gaps, 911 bot-per-codebase, 913 Swarm Protocol, 919 ZAO-PALOOZA/CHELLA, 921 recap-video. Originals (979,980,981,984,985,989,998,1012,1013) closed in favor of this.
