### PR TITLE
feat(zoe): watcher - dispatch-health supervisor

### DIFF
--- a/bot/src/zoe/__tests__/watcher.test.ts
+++ b/bot/src/zoe/__tests__/watcher.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeRuns, renderWatcherAlerts, DEFAULT_WATCHER, type WatcherConfig } from '../watcher';
+import type { RunRecord } from '../runs';
+
+const CFG: WatcherConfig = { dailyCostCapUsd: 8, failRateWarn: 0.34, lowScore: 70, minScoredForDecay: 3 };
+
+function run(p: Partial<RunRecord>): RunRecord {
+  return {
+    id: 'r', ts: new Date().toISOString(), goal: 'g', subtaskId: 's',
+    worker: 'research' as RunRecord['worker'], status: 'completed' as RunRecord['status'],
+    score: null, criticSummary: null, criticIssues: [], revised: false,
+    inputTokens: 0, outputTokens: 0, costUsd: 0, durationMs: 0, error: null,
+    ...p,
+  };
+}
+
+describe('analyzeRuns', () => {
+  it('returns no alerts for an empty window', () => {
+    expect(analyzeRuns([], CFG)).toEqual([]);
+  });
+
+  it('returns no alerts for healthy runs', () => {
+    const runs = [run({ costUsd: 1, score: 90 }), run({ costUsd: 1, score: 85 })];
+    expect(analyzeRuns(runs, CFG)).toEqual([]);
+  });
+
+  it('flags cost over the daily cap', () => {
+    const runs = [run({ costUsd: 5 }), run({ costUsd: 5 })];
+    const a = analyzeRuns(runs, CFG);
+    expect(a.some((x) => x.code === 'cost-over-cap')).toBe(true);
+  });
+
+  it('flags a high failure rate', () => {
+    const runs = [run({ status: 'failed', error: 'boom' }), run({ status: 'failed', error: 'boom' }), run({})];
+    const a = analyzeRuns(runs, CFG);
+    expect(a.some((x) => x.code === 'high-fail-rate')).toBe(true);
+  });
+
+  it('flags quality decay when most scored runs are low', () => {
+    const runs = [run({ score: 40 }), run({ score: 50 }), run({ score: 90 })];
+    const a = analyzeRuns(runs, CFG);
+    expect(a.some((x) => x.code === 'quality-decay')).toBe(true);
+  });
+
+  it('does not flag quality decay below the minimum scored count', () => {
+    const runs = [run({ score: 10 }), run({ score: 10 })];
+    expect(analyzeRuns(runs, CFG).some((x) => x.code === 'quality-decay')).toBe(false);
+  });
+});
+
+describe('renderWatcherAlerts', () => {
+  it('returns empty string for no alerts', () => {
+    expect(renderWatcherAlerts([])).toBe('');
+  });
+
+  it('renders a header + one line per alert', () => {
+    const out = renderWatcherAlerts([{ level: 'warn', code: 'cost-over-cap', message: 'over' }]);
+    expect(out).toContain('ZOE watcher:');
+    expect(out).toContain('- over');
+  });
+});
+
+describe('DEFAULT_WATCHER', () => {
+  it('has sane defaults', () => {
+    expect(DEFAULT_WATCHER.dailyCostCapUsd).toBeGreaterThan(0);
+    expect(DEFAULT_WATCHER.lowScore).toBeGreaterThan(0);
+  });
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -25,6 +25,7 @@ import { nextNudge, nudgesEnabled, nudgeCooldownElapsed, markNudgeSent } from '.
 import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
+import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
@@ -280,6 +281,31 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       ),
     );
   }
+
+  // Watcher (doc 927) - daily dispatch-health supervisor. Reads the run
+  // telemetry dispatch.ts records and pings Zaal ONLY on a cost / failure /
+  // quality anomaly. Most days it logs 'clean' and stays silent.
+  tasks.push(
+    cron.schedule(
+      '30 8 * * *',
+      async () => {
+        if (!(await claimFire('watcher'))) return;
+        try {
+          const alerts = await runWatcherTick();
+          if (alerts.length) {
+            await opts.bot.api.sendMessage(opts.zaalTgId, renderWatcherAlerts(alerts));
+            console.log('[zoe/scheduler] watcher: ' + alerts.length + ' alert(s) sent');
+          } else {
+            console.log('[zoe/scheduler] watcher: clean');
+          }
+        } catch (err) {
+          await releaseFire('watcher');
+          console.error('[zoe/scheduler] watcher failed:', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
 
   // Post slate v1 - random 7 pings/day of social-post drafts (build / ecosystem /
   // event / personal). Owns its own state at ~/.zao/zoe/posts/. See posts/README.md.

--- a/bot/src/zoe/watcher.ts
+++ b/bot/src/zoe/watcher.ts
@@ -1,0 +1,87 @@
+/**
+ * watcher.ts - the dispatch supervisor (the one genuinely-missing piece of the
+ * doc 927 orchestrator vision; decompose/dispatch/workers/critic/reflexion/learn
+ * already exist + are wired). Reads the run telemetry that dispatch.ts records
+ * (runs.ts) and surfaces cost / failure / quality anomalies so ZOE - and Zaal -
+ * notice when the agents under ZOE start misbehaving. Pure analysis + a tick;
+ * the scheduler decides whether to ping. No autonomous actions of its own.
+ */
+import { readRuns, type RunRecord } from './runs';
+
+export interface WatcherAlert {
+  level: 'info' | 'warn';
+  code: 'cost-over-cap' | 'high-fail-rate' | 'quality-decay';
+  message: string;
+}
+
+export interface WatcherConfig {
+  /** Soft daily spend cap across all dispatched workers (USD). */
+  dailyCostCapUsd: number;
+  /** Warn above this fraction of failed runs. */
+  failRateWarn: number;
+  /** Critic score below this counts as a low-quality run. */
+  lowScore: number;
+  /** Minimum scored runs before judging quality decay. */
+  minScoredForDecay: number;
+}
+
+export const DEFAULT_WATCHER: WatcherConfig = {
+  dailyCostCapUsd: Number(process.env.ZOE_DAILY_COST_CAP ?? 8),
+  failRateWarn: Number(process.env.ZOE_FAIL_RATE_WARN ?? 0.34),
+  lowScore: Number(process.env.ZOE_LOW_SCORE ?? 70),
+  minScoredForDecay: 3,
+};
+
+/** Pure: analyze a window of run records into zero or more alerts. */
+export function analyzeRuns(
+  runs: RunRecord[],
+  cfg: WatcherConfig = DEFAULT_WATCHER,
+): WatcherAlert[] {
+  const alerts: WatcherAlert[] = [];
+  if (runs.length === 0) return alerts;
+
+  const cost = runs.reduce((s, r) => s + (r.costUsd || 0), 0);
+  if (cost > cfg.dailyCostCapUsd) {
+    alerts.push({
+      level: 'warn',
+      code: 'cost-over-cap',
+      message: `dispatch spend $${cost.toFixed(2)} over the $${cfg.dailyCostCapUsd} daily cap (${runs.length} runs / 24h)`,
+    });
+  }
+
+  const failed = runs.filter((r) => r.status === 'failed' || r.error).length;
+  const failRate = failed / runs.length;
+  if (failRate > cfg.failRateWarn) {
+    alerts.push({
+      level: 'warn',
+      code: 'high-fail-rate',
+      message: `worker fail rate ${(failRate * 100).toFixed(0)}% (${failed}/${runs.length}) over 24h`,
+    });
+  }
+
+  const scored = runs.filter((r) => typeof r.score === 'number');
+  const low = scored.filter((r) => (r.score as number) < cfg.lowScore).length;
+  if (scored.length >= cfg.minScoredForDecay && low / scored.length > 0.5) {
+    alerts.push({
+      level: 'warn',
+      code: 'quality-decay',
+      message: `quality decay: ${low}/${scored.length} runs scored below ${cfg.lowScore}`,
+    });
+  }
+
+  return alerts;
+}
+
+/** Tick: read the last day of telemetry and return any anomalies. */
+export async function runWatcherTick(
+  cfg: WatcherConfig = DEFAULT_WATCHER,
+): Promise<WatcherAlert[]> {
+  const runs = await readRuns(1);
+  return analyzeRuns(runs, cfg);
+}
+
+/** One-line render for a Telegram ping to Zaal. */
+export function renderWatcherAlerts(alerts: WatcherAlert[]): string {
+  if (alerts.length === 0) return '';
+  return ['ZOE watcher:', ...alerts.map((a) => `- ${a.message}`)].join('\n');
+}


### PR DESCRIPTION
ZOE watcher - the one genuinely-missing piece of doc 927 (decompose/dispatch/workers/critic/reflexion/learn/proactive-tick already exist + wired). Reads dispatch run telemetry, pings Zaal ONLY on cost-over-cap / high-fail-rate / quality-decay. Daily 08:30 UTC cron, silent by default. Boot-verified: esbuild clean, tsc clean, 9/9 vitest.
