### PR TITLE
docs: correct 759+927 orchestrator status (built, not 35%)

### DIFF
--- a/research/agents/759-agent-best-practices-and-zoe-orchestrator-gap/README.md
+++ b/research/agents/759-agent-best-practices-and-zoe-orchestrator-gap/README.md
@@ -12,6 +12,8 @@ tier: DISPATCH (intended; sub-agents stalled, parent synthesized from code reads
 
 > **Goal:** (A) Slim 2026 agent state-of-the-art synthesis. (B) Methodology PRD for a "100 best practices" list - structure only, no items. (C) Honest gap analysis: where ZOE is today vs ZOE as task-decomposing / agent-spawning / self-reviewing / self-improving orchestrator.
 
+> **STATUS 2026-06-30 (correction):** This doc OVERSTATED the gap. On inspection the orchestrator was already built + wired: decompose -> dispatch -> workers (with a per-worker critic + revision), reflexion (nightly), learn (weekly cron), and the proactive reasoning-tick all run on the VPS. The only genuinely-missing pieces were the **watcher** (shipped, doc 918 + PR #1021) and the **autonomous work-loop** (shipped, PR #1022: `queue: <topic>` -> 2h cron -> doc PR). Treat code as ground truth over this doc.
+
 ## Note on method
 
 3 sub-agents were dispatched in parallel (agent state-of-art, 100-list methodology, Anthropic SDK deep-dive); all 3 stalled on the 600s stream watchdog and returned no synthesis. Parent (Claude Opus 4.7) wrote this doc from direct code reads of `bot/src/zoe/` + `bot/src/hermes/` + the Anthropic agent essay synthesis from training. Cited claims about external frameworks (LangGraph / AutoGen / CrewAI / Letta) are stable patterns at the time of writing and should be re-verified before any framework adoption.

--- a/research/agents/927-next-gen-autonomous-loop-architecture/README.md
+++ b/research/agents/927-next-gen-autonomous-loop-architecture/README.md
@@ -12,6 +12,8 @@ tier: DISPATCH
 
 > **Goal:** Replace the current single-threaded, time-based `/loop` with a server-side, event-driven, multi-track orchestrator that keeps the ZOE brain always running + mirrors Zaal's observed preference for ZOE to be the primary dispatcher (not a side agent). Design the loop itself as a stateful process, not a Mac session task.
 
+> **STATUS 2026-06-30 (correction):** This doc OVERSTATED the gap. On inspection the orchestrator was already built + wired: decompose -> dispatch -> workers (with a per-worker critic + revision), reflexion (nightly), learn (weekly cron), and the proactive reasoning-tick all run on the VPS. The only genuinely-missing pieces were the **watcher** (shipped, doc 918 + PR #1021) and the **autonomous work-loop** (shipped, PR #1022: `queue: <topic>` -> 2h cron -> doc PR). Treat code as ground truth over this doc.
+
 ## Headline Recommendation
 
 **Migrate from Mac `/loop` skill (reactive time-based) to VPS-resident ZOE orchestrator (event-driven multi-track).** The loop becomes a persistent `zoe-loop` systemd unit on 31.97.148.88, running continuously with sub-processes for research, fleet-health, PR-babysitting, and outreach. Watcher + Critic act as in-process supervisors (no separate agents). Human gates remain on PRs to main, outbound posts, and on-chain spend. Deploy in 3 phases over 6-8 weeks.


### PR DESCRIPTION
Corrects the two stale planning docs that overstated the gap. ZOE already had decompose/dispatch/workers/critic/reflexion/learn/proactive-tick wired; the watcher (PR #1021) + work-loop (PR #1022) close the real gaps. Future sessions: code is ground truth.