### PR TITLE
feat(zoe): fleet-health liveness in the watcher

### DIFF
--- a/bot/src/zoe/__tests__/fleet-health.test.ts
+++ b/bot/src/zoe/__tests__/fleet-health.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { checkFleetLiveness } from '../fleet-health';
+
+describe('checkFleetLiveness', () => {
+  it('no alerts when all units active', async () => {
+    const alerts = await checkFleetLiveness(['a', 'b'], async () => true);
+    expect(alerts).toEqual([]);
+  });
+
+  it('one alert listing all down units', async () => {
+    const alerts = await checkFleetLiveness(['a', 'b', 'c'], async (u) => u === 'a');
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].code).toBe('unit-down');
+    expect(alerts[0].message).toContain('b');
+    expect(alerts[0].message).toContain('c');
+    expect(alerts[0].message).not.toContain('DOWN: a');
+  });
+
+  it('treats a throwing checker as down', async () => {
+    const alerts = await checkFleetLiveness(['x'], async () => {
+      throw new Error('boom');
+    });
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('x');
+  });
+});

--- a/bot/src/zoe/fleet-health.ts
+++ b/bot/src/zoe/fleet-health.ts
@@ -1,0 +1,58 @@
+/**
+ * fleet-health.ts - process/unit liveness for the watcher. The watcher.ts
+ * checks dispatch cost/quality; this checks that the fleet is actually RUNNING.
+ * This is the gap that let 3 Pi researchers sit dead unnoticed (2026-06-30):
+ * nothing was watching liveness, only dispatch telemetry.
+ *
+ * Runs on the VPS inside ZOE, so it checks the VPS systemd --user units. The Pi
+ * self-heals via its own start-fleet.sh keep-alive cron (fixed same day).
+ */
+import { promisify } from 'node:util';
+import { exec as execCb } from 'node:child_process';
+import type { WatcherAlert } from './watcher';
+
+const exec = promisify(execCb);
+
+export const FLEET_UNITS = (
+  process.env.ZOE_FLEET_UNITS || 'zoe-bot,zao-devz-stack,cowork-agent,farscout,zaostock-bot'
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+/** Returns true if the systemd --user unit is active. Injectable for tests. */
+export type UnitChecker = (unit: string) => Promise<boolean>;
+
+const defaultIsActive: UnitChecker = async (unit) => {
+  try {
+    const { stdout } = await exec(`systemctl --user is-active ${unit}`);
+    return stdout.trim() === 'active';
+  } catch {
+    // `is-active` exits non-zero for inactive/failed units.
+    return false;
+  }
+};
+
+export async function checkFleetLiveness(
+  units: string[] = FLEET_UNITS,
+  isActive: UnitChecker = defaultIsActive,
+): Promise<WatcherAlert[]> {
+  const down: string[] = [];
+  for (const u of units) {
+    let active = false;
+    try {
+      active = await isActive(u);
+    } catch {
+      active = false; // a checker that throws = treat as down (fail-safe)
+    }
+    if (!active) down.push(u);
+  }
+  if (down.length === 0) return [];
+  return [
+    {
+      level: 'warn',
+      code: 'unit-down',
+      message: `fleet unit(s) DOWN: ${down.join(', ')} - check systemctl --user`,
+    },
+  ];
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -26,6 +26,7 @@ import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 import { runWatcherTick, renderWatcherAlerts } from './watcher';
+import { checkFleetLiveness } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
@@ -292,7 +293,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       async () => {
         if (!(await claimFire('watcher'))) return;
         try {
-          const alerts = await runWatcherTick();
+          const alerts = [...(await runWatcherTick()), ...(await checkFleetLiveness())];
           if (alerts.length) {
             await opts.bot.api.sendMessage(opts.zaalTgId, renderWatcherAlerts(alerts));
             console.log('[zoe/scheduler] watcher: ' + alerts.length + ' alert(s) sent');

--- a/bot/src/zoe/watcher.ts
+++ b/bot/src/zoe/watcher.ts
@@ -10,7 +10,7 @@ import { readRuns, type RunRecord } from './runs';
 
 export interface WatcherAlert {
   level: 'info' | 'warn';
-  code: 'cost-over-cap' | 'high-fail-rate' | 'quality-decay';
+  code: 'cost-over-cap' | 'high-fail-rate' | 'quality-decay' | 'unit-down';
   message: string;
 }
 


### PR DESCRIPTION
Watcher liveness - closes the gap that hid 3 dead Pi researchers. The watcher checked dispatch cost/quality but not whether processes are RUNNING. checkFleetLiveness() checks the VPS systemd units (zoe-bot/devz/cowork/farscout/zaostock) and folds DOWN alerts into the daily watcher cron. Fail-safe. Pi self-heals via its own start-fleet.sh keep-alive (fixed same day). esbuild clean, 16/16 vitest.
