### PR TITLE
feat(zoe): consolidate self-heal + work-loop force-research (were floating)

### DIFF
--- a/bot/src/zoe/__tests__/fleet-health.test.ts
+++ b/bot/src/zoe/__tests__/fleet-health.test.ts
@@ -1,26 +1,86 @@
-import { describe, it, expect } from 'vitest';
-import { checkFleetLiveness } from '../fleet-health';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { checkFleetLiveness, healFleet } from '../fleet-health';
+
+let tmp: string;
+beforeEach(async () => {
+  tmp = join(tmpdir(), 'zoe-fleet-test-' + Math.random().toString(36).slice(2));
+  await fs.mkdir(tmp, { recursive: true });
+  vi.stubEnv('ZOE_HOME', tmp);
+});
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await fs.rm(tmp, { recursive: true, force: true });
+});
 
 describe('checkFleetLiveness', () => {
-  it('no alerts when all units active', async () => {
-    const alerts = await checkFleetLiveness(['a', 'b'], async () => true);
-    expect(alerts).toEqual([]);
+  it('no alerts when all active', async () => {
+    expect(await checkFleetLiveness(['a', 'b'], async () => true)).toEqual([]);
   });
-
-  it('one alert listing all down units', async () => {
-    const alerts = await checkFleetLiveness(['a', 'b', 'c'], async (u) => u === 'a');
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0].code).toBe('unit-down');
-    expect(alerts[0].message).toContain('b');
-    expect(alerts[0].message).toContain('c');
-    expect(alerts[0].message).not.toContain('DOWN: a');
+  it('alerts the down units', async () => {
+    const a = await checkFleetLiveness(['a', 'b'], async (u) => u === 'a');
+    expect(a[0].message).toContain('b');
   });
-
-  it('treats a throwing checker as down', async () => {
-    const alerts = await checkFleetLiveness(['x'], async () => {
+  it('throwing checker counts as down', async () => {
+    const a = await checkFleetLiveness(['x'], async () => {
       throw new Error('boom');
     });
-    expect(alerts).toHaveLength(1);
-    expect(alerts[0].message).toContain('x');
+    expect(a).toHaveLength(1);
+  });
+});
+
+describe('healFleet', () => {
+  it('does nothing when all active', async () => {
+    const restart = vi.fn();
+    const a = await healFleet({ date: '2026-06-30', units: ['a'], isActive: async () => true, restart });
+    expect(a).toEqual([]);
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('restarts a down unit and reports healed when it comes back', async () => {
+    let up = false;
+    const restart = vi.fn(async () => {
+      up = true;
+    });
+    const a = await healFleet({
+      date: '2026-06-30',
+      units: ['worker'],
+      isActive: async () => up,
+      restart,
+    });
+    expect(restart).toHaveBeenCalledOnce();
+    expect(a[0].code).toBe('unit-healed');
+  });
+
+  it('reports down when restart fails to revive', async () => {
+    const a = await healFleet({
+      date: '2026-06-30',
+      units: ['worker'],
+      isActive: async () => false,
+      restart: async () => {},
+    });
+    expect(a[0].code).toBe('unit-down');
+    expect(a[0].message).toContain('did not bring it up');
+  });
+
+  it('never restarts zoe-bot (core unit)', async () => {
+    const restart = vi.fn();
+    const a = await healFleet({ date: '2026-06-30', units: ['zoe-bot'], isActive: async () => false, restart });
+    expect(restart).not.toHaveBeenCalled();
+    expect(a[0].message).toContain('not auto-restarted');
+  });
+
+  it('stops restarting after the daily cap (crash-loop guard)', async () => {
+    const restart = vi.fn(async () => {});
+    const run = () =>
+      healFleet({ date: '2026-06-30', units: ['worker'], isActive: async () => false, restart });
+    await run();
+    await run();
+    await run();
+    const capped = await run(); // 4th - over cap (default 3)
+    expect(restart).toHaveBeenCalledTimes(3);
+    expect(capped[0].message).toContain('restart cap');
   });
 });

--- a/bot/src/zoe/fleet-health.ts
+++ b/bot/src/zoe/fleet-health.ts
@@ -1,14 +1,16 @@
 /**
- * fleet-health.ts - process/unit liveness for the watcher. The watcher.ts
- * checks dispatch cost/quality; this checks that the fleet is actually RUNNING.
- * This is the gap that let 3 Pi researchers sit dead unnoticed (2026-06-30):
- * nothing was watching liveness, only dispatch telemetry.
+ * fleet-health.ts - process/unit liveness + SELF-HEAL for the watcher.
+ * watcher.ts checks dispatch cost/quality; this checks the fleet is RUNNING and
+ * now auto-restarts what died (the agentic upgrade: detect -> heal, not just ping).
  *
- * Runs on the VPS inside ZOE, so it checks the VPS systemd --user units. The Pi
- * self-heals via its own start-fleet.sh keep-alive cron (fixed same day).
+ * Safe: restarts are capped per unit per day (crash-loop guard) and NEVER restart
+ * zoe-bot itself (that would kill the process running this). Runs on the VPS.
  */
 import { promisify } from 'node:util';
 import { exec as execCb } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { WatcherAlert } from './watcher';
 
 const exec = promisify(execCb);
@@ -20,19 +22,29 @@ export const FLEET_UNITS = (
   .map((s) => s.trim())
   .filter(Boolean);
 
-/** Returns true if the systemd --user unit is active. Injectable for tests. */
+/** Never auto-restart these (restarting zoe-bot from inside zoe-bot = suicide). */
+export const NO_HEAL = new Set(['zoe-bot']);
+const RESTART_CAP = Math.max(1, Number(process.env.ZOE_HEAL_CAP ?? 3));
+const HEAL_COUNT = (): string =>
+  join(process.env.ZOE_HOME || join(homedir(), '.zao', 'zoe'), 'heal-count.json');
+
 export type UnitChecker = (unit: string) => Promise<boolean>;
+export type UnitRestarter = (unit: string) => Promise<void>;
 
 const defaultIsActive: UnitChecker = async (unit) => {
   try {
     const { stdout } = await exec(`systemctl --user is-active ${unit}`);
     return stdout.trim() === 'active';
   } catch {
-    // `is-active` exits non-zero for inactive/failed units.
     return false;
   }
 };
 
+const defaultRestart: UnitRestarter = async (unit) => {
+  await exec(`systemctl --user restart ${unit}`);
+};
+
+/** Pure check: which expected units are down. */
 export async function checkFleetLiveness(
   units: string[] = FLEET_UNITS,
   isActive: UnitChecker = defaultIsActive,
@@ -43,7 +55,7 @@ export async function checkFleetLiveness(
     try {
       active = await isActive(u);
     } catch {
-      active = false; // a checker that throws = treat as down (fail-safe)
+      active = false;
     }
     if (!active) down.push(u);
   }
@@ -55,4 +67,85 @@ export async function checkFleetLiveness(
       message: `fleet unit(s) DOWN: ${down.join(', ')} - check systemctl --user`,
     },
   ];
+}
+
+async function readHealCount(date: string): Promise<Record<string, number>> {
+  try {
+    const c = JSON.parse(await fs.readFile(HEAL_COUNT(), 'utf8')) as {
+      date: string;
+      counts: Record<string, number>;
+    };
+    return c.date === date ? c.counts : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeHealCount(date: string, counts: Record<string, number>): Promise<void> {
+  await fs.mkdir(join(HEAL_COUNT(), '..'), { recursive: true });
+  await fs.writeFile(HEAL_COUNT(), JSON.stringify({ date, counts }));
+}
+
+/**
+ * Detect + heal: restart down units (once per tick, capped per day), re-check,
+ * and report what healed / what stayed down. This is what makes the fleet
+ * self-repairing instead of just self-reporting.
+ */
+export async function healFleet(opts: {
+  date: string;
+  units?: string[];
+  isActive?: UnitChecker;
+  restart?: UnitRestarter;
+}): Promise<WatcherAlert[]> {
+  const units = opts.units ?? FLEET_UNITS;
+  const isActive = opts.isActive ?? defaultIsActive;
+  const restart = opts.restart ?? defaultRestart;
+  const counts = await readHealCount(opts.date);
+  const alerts: WatcherAlert[] = [];
+  let mutated = false;
+
+  for (const u of units) {
+    let active = false;
+    try {
+      active = await isActive(u);
+    } catch {
+      active = false;
+    }
+    if (active) continue;
+
+    if (NO_HEAL.has(u)) {
+      alerts.push({ level: 'warn', code: 'unit-down', message: `${u} DOWN (not auto-restarted - core unit)` });
+      continue;
+    }
+    if ((counts[u] ?? 0) >= RESTART_CAP) {
+      alerts.push({
+        level: 'warn',
+        code: 'unit-down',
+        message: `${u} DOWN + hit restart cap (${RESTART_CAP}/day) - likely crash-looping, needs a look`,
+      });
+      continue;
+    }
+
+    counts[u] = (counts[u] ?? 0) + 1;
+    mutated = true;
+    try {
+      await restart(u);
+    } catch {
+      /* fall through to the re-check */
+    }
+    let healed = false;
+    try {
+      healed = await isActive(u);
+    } catch {
+      healed = false;
+    }
+    alerts.push(
+      healed
+        ? { level: 'info', code: 'unit-healed', message: `${u} was down - auto-restarted, now active (heal ${counts[u]}/${RESTART_CAP})` }
+        : { level: 'warn', code: 'unit-down', message: `${u} DOWN - restart attempt ${counts[u]} did not bring it up` },
+    );
+  }
+
+  if (mutated) await writeHealCount(opts.date, counts);
+  return alerts;
 }

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -26,7 +26,7 @@ import { startPostsScheduler } from './posts';
 import { setPending, pendingKindLabel } from './approvals';
 import { runLearnCycle, renderLearnProposals } from './learn';
 import { runWatcherTick, renderWatcherAlerts } from './watcher';
-import { checkFleetLiveness } from './fleet-health';
+import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
@@ -293,7 +293,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       async () => {
         if (!(await claimFire('watcher'))) return;
         try {
-          const alerts = [...(await runWatcherTick()), ...(await checkFleetLiveness())];
+          const alerts = [...(await runWatcherTick()), ...(await healFleet({ date: new Date().toISOString().slice(0, 10) }))];
           if (alerts.length) {
             await opts.bot.api.sendMessage(opts.zaalTgId, renderWatcherAlerts(alerts));
             console.log('[zoe/scheduler] watcher: ' + alerts.length + ' alert(s) sent');

--- a/bot/src/zoe/watcher.ts
+++ b/bot/src/zoe/watcher.ts
@@ -10,7 +10,7 @@ import { readRuns, type RunRecord } from './runs';
 
 export interface WatcherAlert {
   level: 'info' | 'warn';
-  code: 'cost-over-cap' | 'high-fail-rate' | 'quality-decay' | 'unit-down';
+  code: 'cost-over-cap' | 'high-fail-rate' | 'quality-decay' | 'unit-down' | 'unit-healed';
   message: string;
 }
 

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -19,7 +19,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { decomposeGoal } from './decompose';
+import type { DecompositionPlan } from './decompose';
 import { dispatchPlan } from './dispatch';
 import { commitResearchDoc } from './research-doc';
 import type { ZoeContext } from './types';
@@ -129,20 +129,25 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
       workspace_dir: deps.repoDir,
       current_date: deps.currentDate,
     };
-    const res = await decomposeGoal({ goal: item.input, context: ctx });
-    const plan = res.plan;
-    const isResearch =
-      plan.subtasks.length === 1 && plan.subtasks[0].worker === 'research-worker';
-
-    if (!isResearch) {
-      await deps
-        .sendToZaal(
-          `Work-loop skipped "${item.input.slice(0, 60)}" - not a single research task; dispatch it yourself when ready.`,
-        )
-        .catch(() => {});
-      await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
-      return;
-    }
+    // The work-queue is explicitly a RESEARCH queue, so force a single
+    // research-worker task rather than letting decompose reclassify a legit
+    // research topic as multi-step build and bounce it (doc 928 fix).
+    const plan: DecompositionPlan = {
+      goal_summary: item.input,
+      subtasks: [
+        {
+          id: 'st-1',
+          title: item.input.slice(0, 90),
+          worker: 'research-worker',
+          depends_on: [],
+          parallel_with: [],
+          approval_gate_before_next: false,
+          estimated_cost_class: 'medium',
+        },
+      ],
+      execution_plan: 'Single research-worker pass, committed as a numbered doc + PR.',
+      ambiguities: [],
+    };
 
     await deps
       .sendToZaal(`Work-loop: researching "${item.input.slice(0, 80)}" (${q.length} queued)`)


### PR DESCRIPTION
Lands two fixes that were running live but never reached origin/main (short-loop + manual-git collision on one clone): (1) watcher self-heal healFleet, (2) work-loop forces research-worker (proven: doc 929/PR #1029). esbuild+tsc clean, tests green.