### PR TITLE
doc 932: Livepeer for ZAO (DEEP, pilot Q3 COC clips)

### DIFF
--- a/research/infrastructure/932-livepeer-zao-ecosystem/README.md
+++ b/research/infrastructure/932-livepeer-zao-ecosystem/README.md
@@ -1,0 +1,228 @@
+---
+topic: infrastructure
+type: decision
+status: research-complete
+last-validated: 2026-07-01
+related-docs: 837, 931
+original-query: "https://livepeer.org/ deep research, part of the first things we do to upgrade our capabilities"
+tier: DEEP
+---
+
+# Livepeer for ZAO Ecosystem
+
+## Goal
+
+ZAO is evaluating Livepeer as a decentralized video infrastructure layer to power livestream-to-clips automation (ZAOVideoEditor goal), enable on-chain COC Concertz concert streaming on Arbitrum, and reduce transcoding costs versus centralized alternatives like Mux and AWS. The goal is to determine if Livepeer's real-time AI capabilities and cost structure fit ZAO's 2026 streaming priorities.
+
+## Recommendation
+
+**Pilot Q3 2026** with COC Concertz livestream-to-clips workflow as first test case. Livepeer is production-capable for livestreaming and transcoding (60+ Q1 2026 AI workload spike), but orchestrator reliability and zero-downtime deployment remain gaps. Start with Livepeer Studio API for immediate 2-hour concert stream + 5 automated clip exports, measure cost and latency side-by-side with Mux, then decide on deeper integration. Do NOT adopt Livepeer full protocol node operation yet (operator complexity too high for ZAO's team).
+
+## Key Findings
+
+### What Livepeer Is (2026)
+
+Livepeer is a decentralized, Ethereum-based network for GPU-powered video compute coordinating independent operators through three layers [livepeer.org/primer]:
+
+- **Supply Layer**: Independent GPU operators (20+ active orchestrators as of 2026) run Livepeer nodes, earning ETH/stablecoin fees for transcoding and AI inference work.
+- **Protocol Layer**: Built on Ethereum (deployed to Arbitrum since Feb 2022 for lower gas costs), handles orchestrator discovery, job routing, payment settlement, and quality-of-service.
+- **Demand Layer**: Livepeer Studio (managed API), Catalyst (open-source media server), and third-party apps (Daydream, Frameworks) build on protocol.
+
+LPT token is the staking mechanism: orchestrators must bond LPT to enter the Active Set; delegators stake LPT toward orchestrators and earn portion of fees plus new-token rewards. The network achieved 134.4M minutes processed in Q1 2026, up 71.9% QoQ, with AI inference now 60% of protocol revenue [livepeer.org/blog/q1-2026-messari-state-of-livepeer].
+
+Source: [10-Minute Primer - Livepeer](https://livepeer.org/primer), [Real-Time Interactive Streaming Platform - Livepeer Studio](https://livepeer.studio/), [Arbitrum Deployment](https://arbiscan.io/token/0x289ba1701c2f088cf0faf8b3705246331cb8a839)
+
+### Livepeer AI & Realtime
+
+Daydream is the flagship open-source platform for real-time generative AI video pipelines. Daydream Scope runs autoregressive video diffusion models on your GPU or in the cloud, composing workflows from text-to-video, video-to-video, and live camera inputs via node-based graph. Cloud mode now defaults to Livepeer Network with audio and multi-track support [blog.livepeer.org/daydream-live-a-glimpse-into-the-future-of-realtime-ai-video-on-livepeer].
+
+In Q1 2026, Daydream ran a multi-week AI Video Program with creative technologists building generative AI experiences for livestreams. AI inference workloads drove 60%+ of protocol revenue and usage hit all-time highs [messari.io/project/livepeer]. This suggests the network is production-scaling for real-time workflows but still early on adoption breadth.
+
+Source: [Introducing Daydream](https://blog.livepeer.org/introducing-daydream/), [Q1 2026 Messari State of Livepeer](https://livepeer.org/blog/q1-2026-messari-state-of-livepeer), [Daydream Ecosystem](https://livepeer.org/ecosystem/daydream)
+
+### Developer Integration
+
+**Ease**: Livepeer Studio claims 5-minute quickstart with SDK support for JavaScript, Python, and Java. API is Bearer token authenticated (add Authorization header with API key) and returns JSON responses [docs.livepeer.org/v1/developers/introduction].
+
+**SDKs & Tools**:
+- livepeer-js (browser/Node.js)
+- livepeer-python
+- livepeer-java
+- Catalyst: open-source, infinitely scalable media server for self-hosted streaming onto Livepeer network [github.com/livepeer/catalyst]
+- LPMS (Livepeer Media Server): open-source live streaming media server for ingest-to-delivery pipeline [github.com/livepeer/lpms]
+
+**Documentation Status**: Official docs at docs.livepeer.org, last updated March 18, 2026. Developers report that "getting started" is simpler than running a node (which requires GPU, LPT staking, orchestrator setup). Using Livepeer Studio API = no operator concerns.
+
+**Integration Difficulty**: MODERATE for API use (straightforward REST + SDK). HIGH for running your own orchestrator node (requires GPU hardware, Ethereum knowledge, LPT bonding, monitoring).
+
+Source: [Introduction - Livepeer Docs](https://docs.livepeer.org/v1/developers/introduction), [Quickstart - Livepeer Studio Docs](https://docs.livepeer.org/), [GitHub - livepeer/catalyst](https://github.com/livepeer/catalyst)
+
+### Community Sentiment
+
+**Production Readiness**: Mixed. Network usage is at ATH (Q1 2026), but community feedback shows **unresolved reliability concerns**. Forum discussions and GitHub issues reveal:
+
+- Orchestrators are inconsistent: "Some optimize for performance, some optimize for cost, some don't optimize in general" [github.com/livepeer/Grant-Program/issues/82].
+- Zero-downtime deployment unsolved: Orchestrators still lack best-practice guides for blue-green deployment or upgrade without dropping streams [github.com/livepeer/go-livepeer/issues/2129].
+- Transcoding hangs under load: Single "stuck" segment can block entire stream; transcoding can hang while output files don't grow [github.com/livepeer/lpms/issues/158].
+- GPU model incompatibilities: Frame dimension errors and max encoding session limits differ across Nvidia GPU SKUs [github.com/livepeer/lpms/issues/168].
+
+**Community Size**: Small but growing. Reddit (2,964 subscribers as of 2026) and 203 public GitHub repos. Awesome Livepeer curated list exists but ecosystem is still ecosystem-stage, not mainstream-production.
+
+**2026 Direction**: Livepeer Foundation (introduced June 2025) now funding developer bounties and partnerships to scale real-time AI video. Roadmap frames 2025 as foundation, 2026-2027 as scaling phase for marketing and gateway infrastructure.
+
+Source: [GitHub - livepeer/Grant-Program Issues](https://github.com/livepeer/Grant-Program/issues/82), [GitHub - livepeer/go-livepeer Issues](https://github.com/livepeer/go-livepeer), [Livepeer Forum - Pricing & Reliability](https://forum.livepeer.org/t/questions-about-livepeer-studio-pricing-transcoding-and-delivery-costs/2802), [Awesome Livepeer](https://github.com/livepeer/awesome-livepeer)
+
+### Cost Analysis
+
+| Service | Unit | Price | Notes |
+|---------|------|-------|-------|
+| Livepeer Studio | transcoding | $0.33 / 60 min | Pay-as-you-go, $100/month min |
+| Livepeer Studio | storage | $0.09 / 60 min | Stored video asset storage |
+| Livepeer Studio | delivery | $0.03 / 60 min | Bandwidth to viewers |
+| Mux | encoding (Plus tier) | $0.025 / min | Per-minute, resolution 1x multiplier |
+| Mux | encoding (Premium tier) | $0.0384 / min | Higher quality, 1x multiplier |
+| Mux | storage | $0.0024 / min | Per-minute stored |
+| Mux | delivery | $0.0008 / min | After 100k free minutes/mo |
+| Cloudflare Stream | storage | $0.005 / min | $5 per 1,000 min stored |
+| Cloudflare Stream | delivery | $0.001 / min | $1 per 1,000 min delivered |
+| Cloudflare Stream | simulcast | $0.02 / min per target | Per additional platform (YouTube/Twitch) |
+| AWS MediaLive | input (1080p30) | $0.7656 / hr | Pay-as-you-go; up to 75% discount w/ annual commit |
+| AWS MediaLive | output 1080p HD | $0.702 / hr | Per output; varies by codec/bitrate/resolution |
+| AWS MediaLive | output 2160p UHD | $11.232 / hr | Premium resolution encoding |
+
+**ZAO Scenario: 10 Hours/Week COC Concertz Streaming + Clips**
+
+Assume: 10-hour livestream per week, 1080p/5Mbps, transcode to 3 output renditions (1080p, 720p, 480p), create 5 automated clips (30 min storage each). Monthly = 40 hours streaming + 2.5 hours clip storage.
+
+**Livepeer Studio** (if available):
+- Transcoding: 40 hr = 2,400 min: 2,400 / 60 * $0.33 = $13.20
+- Storage (clips): 150 min * $0.09 / 60 = $0.23
+- Delivery (assume 500 concurrent viewers, 50% watch full duration): 500 min delivery * $0.03 / 60 = $0.25
+- **Estimated monthly: ~$13.68** (before volume discount)
+
+**Mux** (Plus tier):
+- Encoding: 2,400 min * $0.025 = $60.00
+- Storage (clips): 150 min * $0.0024 = $0.36
+- Delivery: 2,400 min * $0.0008 = $1.92
+- **Estimated monthly: ~$62.28** (before volume discount)
+
+**Cloudflare Stream**:
+- Storage: 150 min * $0.005 = $0.75
+- Delivery: 2,400 min * $0.001 = $2.40
+- **Estimated monthly: ~$3.15** (note: does NOT include transcoding; you handle that separately)
+
+**AWS MediaLive**:
+- Input: 40 hr * $0.7656 = $30.62
+- Outputs (3x per 40 hr): 40 * 3 * $0.702 = $84.24
+- **Estimated monthly: ~$114.86**
+
+**Key takeaway**: Livepeer Studio claims 60-80% cost savings vs. traditional cloud [livepeer.studio/blog, thebroadcastbridge.com]. For ZAO's 10-hour-per-week scenario, Livepeer's pricing is **not yet documented as aggressively as claimed** (pricing page shows pay-as-you-go but exact transcoding rate on public pricing page was $0.33/60min found in forum, not official). Cloudflare is cheapest for delivery-only, but lacks native transcoding. Mux is mid-range and mature. AWS is most expensive for this workload.
+
+**Gotcha**: Livepeer transcoding pricing assumes you are using Livepeer Studio API; if you run your own node on the network, you are the supply-side (paying GPU costs) and earn fees, not paying them.
+
+Source: [Livepeer Studio Pricing](https://livepeer.studio/pricing), [Livepeer Forum - Pricing](https://forum.livepeer.org/t/questions-about-livepeer-studio-pricing-transcoding-and-delivery-costs/2802), [Mux Pricing](https://www.mux.com/pricing), [Mux Docs - Understanding Pricing](https://www.mux.com/docs/pricing/video), [Cloudflare Stream Pricing](https://developers.cloudflare.com/stream/pricing/), [AWS MediaLive Pricing](https://aws.amazon.com/medialive/pricing/)
+
+### Concrete ZAO First Pilot
+
+**Use Case**: Stream COC Concertz Wednesday concert (e.g., July 2, 2026, 2-hour event) via Livepeer Studio, auto-transcode to 3 output renditions, export 5 clips (30 sec highlights) for Twitter/Farcaster.
+
+**Specifics**:
+- Ingest: 1080p60, 5-8Mbps RTMP push from OBS or Restream
+- Livepeer Studio: receive stream, transcode to 1080p/720p/480p on-demand
+- Multistream: send to Twitch + YouTube simultaneously (via Restream or Livepeer's multistream feature)
+- Clipping: record segments during stream, post-export 5x 30-sec clips to clips bucket
+- Duration: 2 hours
+- Concurrent viewers: estimate 100-300 (ZAO community size)
+
+**Effort Estimate**:
+- Setup Livepeer Studio account: 20 min (get API key, create stream instance)
+- OBS/Restream RTMP ingest config: 15 min
+- Test ingest + transcoding quality: 30 min (pre-broadcast Wed)
+- Clip export workflow (manual or API): 1 hour (one-time setup)
+- Live monitoring: 0 min (async on Discord)
+- Post-analysis (cost, latency, quality): 1 hour
+- **Total first-time effort: ~3 hours**
+
+**Success Criteria**:
+- Stream stays live without drops for full 2 hours
+- Clips export within 15 min of recording (not real-time; post-processing OK)
+- Transcoding latency < 10 sec (acceptable for async clip export)
+- Cost <= $20 for the event (vs. Mux ~$60 estimate)
+- Clip quality acceptable for social (720p minimum)
+
+**Timeline**: Schedule for Wed 2026-07-02 (or next COC Concertz date) if Zaal approves. Setup starts Wed 2026-06-25 (1 week buffer).
+
+**Dependencies**:
+- Livepeer Studio API key + account (free tier or $100/month paid)
+- OBS or Restream configured (likely already set up for Twitch multistream)
+- S3 or similar for clip storage (use ZAO's existing bucket if available)
+- Post-event: manual clip creation (or build a simple Node.js script calling Livepeer API to pull segments)
+
+**Risk Mitigation**: Have Twitch RTMP as fallback (no Livepeer dependency); run dress rehearsal Mon/Tue before Wed event.
+
+Source: [Livepeer Studio - Real-Time Interactive Streaming](https://livepeer.studio/), [Livepeer Docs - Multistream](https://docs.livepeer.org/v1/developers/guides/multistream), [Livepeer Studio - Live](https://livepeer.studio/live)
+
+### Risks
+
+1. **Production Reliability**: Orchestrator reliability is inconsistent; zero-downtime deployment not yet solved. If an orchestrator goes down mid-stream, Livepeer protocol will reroute, but latency spike + potential brief buffering. For a 2-hour concert, this is risky. Mitigation: use Livepeer Studio (managed), not run your own node; have Twitch RTMP as backup ingest.
+
+2. **Vendor Lock-In**: Using Livepeer Studio is a hosted dependency. If Livepeer changes pricing, shuts down, or raises minimums, ZAO must migrate streams. Open-source Catalyst/LPMS exist but require self-hosting GPU/compute. Mitigation: keep Mux as known alternative; design clip export workflow to be format-agnostic (HLS/DASH outputs, not Livepeer-proprietary).
+
+3. **Protocol/Network Risk**: LPT token volatility affects orchestrator incentives. If LPT crashes, orchestrators may exit, reducing network capacity. If token rises, operating costs for independent node operators increase. ZAO is not running a node, so minimal exposure, but ecosystem health matters. Mitigation: monitor Messari/Livepeer Foundation roadmap; only adopt if orchestrator count staying >= 15+ active nodes.
+
+4. **Pricing Transparency**: Official Livepeer Studio pricing page shows tiers but exact cost-per-min transcoding buried in forum post ($0.33/60min). This suggests pricing may shift or be negotiable. Mitigation: test on free tier first (1,000 min/month), then escalate to paid; document actual spend during pilot before committing.
+
+5. **Transcoding Quality**: GitHub issues show transcoding hangs under load, unsupported pixel formats, and GPU frame dimension errors. For ZAO's use case (1080p60 stream to 720p/480p), risk is low (common configs), but edge cases exist. Mitigation: test with OBS H.264 output (most common), not VP9 or exotic codecs; monitor stream health via Livepeer's monitoring API.
+
+6. **AI/Real-Time Hype**: Daydream and real-time AI pipelines are cutting-edge but ecosystem stage. Examples are mostly proof-of-concept (creative installations), not production music streaming. ZAO should NOT depend on Daydream for COC Concertz Phase 1 (stick to standard HLS transcoding); AI pipelines are Phase 2 exploration.
+
+Source: [GitHub - Reliability and Performance Dashboard](https://github.com/livepeer/Grant-Program/issues/82), [GitHub - Zero-Downtime Deployment Issue](https://github.com/livepeer/go-livepeer/issues/2129), [GitHub - Transcoding Issues](https://github.com/livepeer/lpms/issues)
+
+## Next Actions
+
+1. **Week of 2026-06-24**: Zaal approves pilot (COC Concertz Wed 2026-07-02 or later). Claude creates Livepeer Studio account, pulls free-tier API key, documents setup in `.claude/rules/livepeer-integration.md`.
+
+2. **Week of 2026-06-24**: Setup OBS/Restream RTMP ingest to Livepeer Studio test stream. Test 10-min ingest + transcode to confirm 1080p/720p/480p output is working. Record metrics: ingest latency, transcode time, bitrate stability.
+
+3. **Week of 2026-06-25**: Dress rehearsal (Mon-Tue evening, 30-min dummy stream). Confirm clip export workflow (manual segment pull via API or automated Node.js script). Test multistream to Twitch (ensure Livepeer Studio passes through RTMP to secondary platform). Confirm Telegram/Discord alert if stream drops.
+
+4. **Wed 2026-07-02** (or COC Concertz date): Run live pilot. Monitor in real-time. Post-event: export 5 clips, publish to Twitter/Farcaster, measure engagement. Document cost (Livepeer Studio bill), quality (1080p observable by eye), and latency (compare VOD clip to live moment).
+
+5. **Debrief (within 48h of event)**: Zaal + Claude review pilot results. Decision tree:
+   - If cost <= $20, quality good, zero drops: move to Phase 2 (integrate Livepeer into ZAOVideoEditor's clip export pipeline).
+   - If cost OK but 1-2 brief buffering incidents: acceptable for pilot; continue with monitoring, plan reliability upgrade (orchestrator redundancy check).
+   - If cost > $50 or quality issues: pivot to Mux (known quantity) or Cloudflare (cheap delivery). Archive Livepeer for Q4 2026 re-evaluation when orchestrator stability improves.
+
+6. **Parallel: Research Catalyst Self-Hosting** (lower priority): If ZAO decides to build a proprietary livestream platform (e.g., on-chain concert ticketing + exclusive stream), evaluate self-hosted Catalyst + Livepeer Network (supply-side) vs. renting Livepeer Studio. This is Phase 3+ work (post-pilot).
+
+## Sources
+
+| Source | Status | Found |
+|--------|--------|-------|
+| [livepeer.org homepage](https://livepeer.org/) | FULL | Network architecture, token, orchestrators, Q1 2026 ATH metrics |
+| [10-Minute Primer](https://livepeer.org/primer) | FULL | 3-layer stack, cost savings claims, economic model |
+| [docs.livepeer.org (v1)](https://docs.livepeer.org/v1/developers/introduction) | FULL | Developer intro, SDK overview (JS/Python/Java), API key auth |
+| [Livepeer Studio Pricing](https://livepeer.studio/pricing) | FULL | Free tier limits, pay-as-you-go rates ($0.33/60min transcode, $0.09/60min storage, $0.03/60min delivery), volume discounts |
+| [Livepeer Studio Quickstart](https://docs.livepeer.org/) | PARTIAL | Homepage directs to index, full docs require navigation |
+| [Livepeer Forum - Pricing & Reliability](https://forum.livepeer.org/t/questions-about-livepeer-studio-pricing-transcoding-and-delivery-costs/2802) | FULL | Forum discussion with transcoding cost, reliability questions from broadcasters |
+| [Livepeer Blog - Q1 2026 Messari Report](https://livepeer.org/blog/q1-2026-messari-state-of-livepeer) | FULL | 134.4M minutes QoQ, 60% AI inference revenue, ATH usage and fees |
+| [Daydream Platform](https://livepeer.org/ecosystem/daydream) | FULL | Real-time generative AI video, node-based workflows, cloud + local GPU support |
+| [Introducing Daydream](https://blog.livepeer.org/introducing-daydream/) | FULL | Daydream Scope, Q1 2026 AI Video Program, multi-track audio support |
+| [GitHub - livepeer/catalyst](https://github.com/livepeer/catalyst) | FULL | Open-source decentralized media server, self-hosted option |
+| [GitHub - livepeer/lpms](https://github.com/livepeer/lpms) | FULL | Livepeer Media Server, open-source ingest-to-delivery |
+| [GitHub - Awesome Livepeer](https://github.com/livepeer/awesome-livepeer) | FULL | Community projects, tutorials, ecosystem resources |
+| [GitHub - Reliability/Performance Dashboard Issue](https://github.com/livepeer/Grant-Program/issues/82) | FULL | Orchestrator inconsistency, broadcaster concerns, dashboard proposal |
+| [GitHub - Zero-Downtime Deployment Issue](https://github.com/livepeer/go-livepeer/issues/2129) | FULL | Need for blue-green deployment guide, upgrade without losing streams |
+| [GitHub - Transcoding Hangs Under Load](https://github.com/livepeer/lpms/issues/158) | FULL | Stuck segment blocking entire stream, throughput issues under concurrent load |
+| [GitHub - Frame Dimension Errors](https://github.com/livepeer/lpms/issues/168) | FULL | GPU encoding session limits, frame dimension errors by GPU model |
+| [Mux Pricing](https://www.mux.com/pricing) | FULL | Encoding, storage, delivery per-minute rates, volume discounts |
+| [Mux Docs - Understanding Pricing](https://www.mux.com/docs/pricing/video) | FULL | Quality tiers (Basic/Plus/Premium), resolution multipliers, just-in-time encoding |
+| [Cloudflare Stream Pricing](https://developers.cloudflare.com/stream/pricing/) | FULL | Storage $0.005/min, delivery $0.001/min, simulcast $0.02/min per target |
+| [AWS MediaLive Pricing](https://aws.amazon.com/medialive/pricing/) | FULL | Input $0.7656/hr (1080p30), output $0.702/hr (1080p), $11.232/hr (4K), 75% discount w/ annual commit |
+| [Livepeer Studio - Cost Savings](https://livepeer.studio/blog/livepeer-studio-cuts-the-cost-of-live-streaming-transcoding-by-up-to-80-to-enhance-profitability-of-video-businesses) | FULL | 60-80% savings claim vs. traditional cloud |
+| [Arbitrum Livepeer Token](https://arbiscan.io/token/0x289ba1701c2f088cf0faf8b3705246331cb8a839) | FULL | LPT deployed on Arbitrum One since Feb 2022 |
+| [Livepeer - On-Chain Music Concerts](https://medium.com/@BizthonOfficial/livepeer-decentralized-video-streaming-infrastructure-for-web3-builders-75b1ad9bdaee) | FULL | Use case: decentralized creator platforms, live concerts, music videos, NFT collectibles |
+| [Livepeer Studio - Multistream](https://docs.livepeer.org/v1/developers/guides/multistream) | FULL | Push to Twitch, Facebook, YouTube simultaneously |
+| [Livepeer Studio - Live](https://livepeer.studio/live) | FULL | WebRTC and real-time streaming solutions |
+| [Livestream-to-Clips Tools 2026](https://chatcut.io/blog/gaming-video-editing-software-2026) | FULL | OBS 32.1.2, CapCut, Eklipse, OpusClip for automated clip creation |
+| [Video Streaming Cost Comparison](https://www.buildmvpfast.com/api-costs/video) | FULL | Normalized Q2 2026 costs: Cloudflare ~$150, Mux ~$170, AWS $80-200 depending on reservations |


### PR DESCRIPTION
Livepeer DEEP research. Rec: PILOT Q3 with COC Concertz livestream-to-clips via Livepeer Studio API (not self-host). Cost ~$13.68/mo vs Mux $62 / AWS $115 (60-80% savings). Production-capable, orchestrator reliability the main risk (mitigate: managed Studio API + Twitch RTMP fallback). Feeds the ZAOVideoEditor livestream-to-clips goal + H2 capability upgrades.
