### PR TITLE
docs: ZOE lunch ping 2026-07-01

### DIFF
--- a/docs/daily/2026-07-01-lunch.md
+++ b/docs/daily/2026-07-01-lunch.md
@@ -1,0 +1,9 @@
+# Lunch Ping — July 1, 2026 (11:30am EST)
+
+Lunch window — 3 things:
+
+1. **Send Jose $100 USDC** — due TODAY. One transfer, one checkbox. Don't let this ride into afternoon.
+2. **Post Week 23 Farcaster thread** — 5 posts ready in `docs/weekly/2026-W23-recap.md`. Queue from Warpcast mobile while you eat. Weeks late.
+3. **Thought prompt:** H2 Day 1. llms.txt is a free 20-min win after lunch — adds you to AI search indexes for zaos.com + thezao.com. No blocker, just needs doing (Doc 917).
+
+Task status: 0/4 Top Priorities done. P0 CVE (Next.js) is Day 16. Bonfire labeling is Day 16. Get Jose paid and you're 1/4. You've got this — 5 PRs shipped yesterday.


### PR DESCRIPTION
Automated ZOE lunch ping for July 1, 2026. Adds `docs/daily/2026-07-01-lunch.md` with 3 actionable items for Zaal's 1-hour lunch window.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8Uth2MF1XLsN8rr9eA9BQ)_