### PR TITLE
docs: ZOE morning briefing 2026-07-02

### DIFF
--- a/docs/daily/2026-07-02-briefing.md
+++ b/docs/daily/2026-07-02-briefing.md
@@ -66,4 +66,36 @@ Doc 929 (Bonfire labeling) is sitting in PR #1029 auto-drafted by ZOE's research
 
 ---
 
-*Sources: git log (Wed July 1 -- 20 merges), GitHub PRs (2 open), docs/daily/2026-07-01-captures.md, ZOE nightly processor*
+---
+
+## JOB BOARD SCAN
+
+*Remote, web3/AI, minimum $35/hr, posted July 2026*
+
+1. **Developer Advocate -- Web3 (Remote, Worldwide)** | web3.career / multiple companies (Tether, Affine.io, Blockstream active). P2P-focused DevRel + subnet community roles. $90k-$140k range for senior. Angle: 90+ weeks fractal governance + Neynar/Farcaster API experience is rare combo. [Browse: web3.career/developer-advocate-jobs](https://web3.career/developer-advocate-jobs)
+
+2. **Community Manager -- Web3/AI (Remote)** | CryptoJobsList -- 8+ active listings July 2026. Companies want candidates who "understand AI/crypto/games and have built agents." ZAO tick: 188-member on-chain community, 90 weeks weekly ops, agent swarm live. Salary: $50k-$80k base. [Browse: cryptojobslist.com/community](https://cryptojobslist.com/community)
+
+3. **DevRel / Growth (AI Focus, Remote)** | Hybrid DevRel+growth roles combining community, events, and technical content for AI solutions. CryptoJobsList remote section has 80+ active listings July 2026 at $48k-$500k range. Filter by posted date + salary on site. [Browse: cryptojobslist.com/remote](https://cryptojobslist.com/remote)
+
+---
+
+## FARCASTER ENGAGEMENT
+
+*Conversations where you can add signal, not noise*
+
+**1. AI Agents on Farcaster** -- Bankless + BlockBeats both running pieces on Farcaster as the next AI agent hub. First-wave agents (Aether, CLANKER, ElizaOS) getting attention. Angle: ZOE is a real deployed agent loop (watcher + work-loop + event-trigger merged yesterday), not a whitepaper. Most "we're building agents" casts are vaporware. You have receipts.
+
+Draft: "The first agentic loop that actually merged to prod is boring: a watcher, a work-queue, an event trigger. No chat interface. No token. It just runs. That's the gap between the narrative and the implementation right now -- everyone's describing the destination, not many are shipping the plumbing."
+
+**2. Neynar / Farcaster Ecosystem Post-Acquisition** -- Neynar acquired Farcaster in Jan 2026. Builder community is figuring out what that means for protocol independence. Angle: you're a paying Neynar API customer running a gated community on Farcaster. You have an informed take on the builder experience, not just the protocol theory.
+
+Draft: "Six months post-Neynar acquisition: building on Farcaster feels about the same from the API side. The thing that changed is that the 'who owns the social graph' question has a clearer answer now. Whether that's good depends on what you're building. If you're building a client: probably fine. If you're building a community that depends on the graph: ask harder questions."
+
+**3. Fractal Governance / Onchain Communities** -- Ongoing builder discourse about what onchain governance actually looks like in practice vs. the ideal. Angle: 90+ weeks of weekly fractal governance ops with a 188-member community. You have more reps than most people talking about this.
+
+Draft: "Week 90 of fractal governance. The thing that surprised me: the tech is the easy part. The hard part is keeping 188 people showing up every week when there's no token price to watch. What works: small groups, rotating facilitators, the output of each session feeds the next one. That's not a protocol thing. That's a community design thing."
+
+---
+
+*Sources: web3.career, cryptojobslist.com, Bankless (farcaster-ai-agents-hub), BlockBeats (Farcaster AI agents), t2.world (Farcaster 2026 AI agents guide). ZOE morning update appended 4:30am EST July 2, 2026.*


### PR DESCRIPTION
## Summary

ZOE 4:30am morning briefing update for Thursday July 2, 2026.

- Verified nightly briefing file exists and looks good (generated by nightly processor)
- Appended job board scan: 3 remote web3/AI roles matching $35/hr+ criteria (DevRel, Community Manager, DevRel/Growth)
- Appended Farcaster engagement opportunities: 3 conversation threads with drafted replies (AI agents on Farcaster, Neynar post-acquisition builder take, fractal governance week 90)

No changes to task file or newsletter draft -- both were generated cleanly by the nightly processor.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jGzHYztnwK6C6bTZ1UD1T)_