### PR TITLE
doc 836: ZAOOS repo census refresh (STANDARD)

### DIFF
--- a/research/infrastructure/836-zaoos-repo-estate-census/README.md
+++ b/research/infrastructure/836-zaoos-repo-estate-census/README.md
@@ -2,16 +2,51 @@
 topic: infrastructure
 type: audit
 status: research-complete
-last-validated: 2026-06-10
+last-validated: 2026-07-03
 superseded-by:
-related-docs: 819, 601, 471
-original-query: "can we do a full overview of this repo and how it all works look through all our git commits aswell and confirm what we have updated what is missing and we still need to build - a status on all the different parts of the repo. Plus a read-only Vercel + Supabase token census mapping projects to repos into a costed kill-list, and add that access to the repo."
+related-docs: 819, 601, 471, 942, 943, 944
+original-query: "can we do a full overview of this repo and how it all works look through all our git commits aswell and confirm what we have updated what is missing and we still need to build - a status on all the different parts of the repo. Plus a read-only Vercel + Supabase token census mapping projects to repos into a costed kill-list, and add that access to the repo. Re-researched 2026-07-03: refresh the code census (routes/components/hooks/lib/pages counts), live-vs-stale map, hot-spots, and what has/has-not graduated - grounded in the live code."
 tier: STANDARD
 ---
 
 # Doc 836 - ZAOOS Repo + Estate Census
 
 > **Goal:** Full overview of the ZAOOS monorepo (what is built, in flight, missing) plus a live census of the paid Vercel + Supabase estate mapped to repos, with a kill-list. The cloud half is reproducible via `scripts/estate-audit/audit.sh`.
+
+## REFRESH 2026-07-03 (code census re-run against live code)
+
+Sections 2-9 below are the 2026-06-09/10 baseline (kept for the delta). This block is the current code census, measured against the working tree 2026-07-03. The paid Vercel/Supabase estate (section 7) was NOT re-run this pass - it needs `scripts/estate-audit/audit.sh` + short-lived tokens; treat those numbers as the 2026-06-10 snapshot.
+
+### Current counts (measured, with method)
+
+| Metric | 2026-07-03 | 2026-06-09 baseline | Method |
+|--------|-----------|---------------------|--------|
+| API route handlers | **306** | 302 | `find src/app/api -name route.ts` |
+| API domains | **57** (~56 real + `__tests__`) | 54 | top-level dirs under `src/app/api` |
+| Components (.tsx in src/components) | **296** | ~360 (broader glob) | `find src/components -name '*.tsx'` - metric differs from baseline; use this going forward |
+| Component feature dirs | **35** | 34 | top-level dirs under `src/components` |
+| Custom hooks | **18** | 18 | unchanged |
+| lib domains | **44** | 41 | top-level dirs under `src/lib` |
+| Pages (page.tsx) | **59** | not measured | `find src/app -name page.tsx` |
+| Test files | **79** | not measured | `find src -name '*.test.ts*'` |
+| src TS/TSX LOC | **~142,000** | not measured | `wc -l` over src ts/tsx |
+| Research doc dirs (numbered) | **963** | ~820 active / 1,234 md files | numbered `NNN-slug` dirs under research/ |
+| Commits, last 30 days | **431** (~14/day) | 752 (~25/day) | `git log --since=30d` - still very active, off the June peak |
+
+### New subsystems since the June census (grounded in the domain lists)
+- **`livepeer`** (both `src/app/api/livepeer` and `src/lib/livepeer`) - streaming/clipping, from the Restream+Livepeer research thread.
+- **`unlock`** (`src/lib/unlock`) - Unlock Protocol integration, from the zabalgamez embeds + proof-of-submission work (doc 943).
+- Continued growth in `stock` (ZAOstock), `sopha`, `solana` (WaveWarZ), `openrank`, `jina`.
+
+### Hot spots (most-changed dirs, last 60 days)
+`src/app/api` (184 file-changes), **`src/app/stock` (63)**, `src/components/spaces` (56), `src/lib/spaces` (47), `src/lib/scrape` (36), `src/app/spaces` (28), `src/app/zabal` (20), `src/app/live` (13). Translation: the live work is API surface, ZAOstock, live audio (spaces), scraping, and the zabal surface.
+
+### Honest findings
+1. **ZAOstock has NOT graduated.** CLAUDE.md says it is "spinning out to its own repo," but `src/app/stock` is the #2 hottest area (63 changes/60d). It is still very much inside ZAOOS. The spinout is a plan, not a done fact - the doc/reality drift should be closed (either graduate it or update CLAUDE.md).
+2. **The repo is still growing, not consolidating.** +4 routes, +3 domains, +3 lib domains, +2 new subsystems since June. The "monorepo as lab" is accreting; no major graduation-delete has happened since COC Concertz.
+3. **Component count metric was inconsistent.** The "~360" baseline used a broader glob (likely counting `src/app` .tsx too). The clean `src/components` count is 296. Standardize on the explicit method above so future deltas are real, not artifacts.
+4. **Velocity cooled but stayed high** - 431 commits/30d vs June's 752. Sustained, not a slowdown to worry about.
+5. **Research library outgrew the repo's own doc-count claim** - 963 numbered doc dirs vs CLAUDE.md's "~820 active." Update CLAUDE.md's number.
 
 ## Key Decisions
 
@@ -166,11 +201,15 @@ Supabase projects to clean up. The cloud estate is now censused and reproducible
 | Delete 2 INACTIVE Supabase projects after confirming no data needed | @Zaal | Manual (Supabase dashboard) | Next cleanup |
 | Cross-check live projects against Vercel usage dashboard for bandwidth/cron spend | @Zaal | Manual | Optional |
 | Fix CLAUDE.md / project-map `contracts/` drift (dir does not exist) | @Zaal | PR | Next docs pass |
-| Schedule test-coverage push for the 38 untested API domains | @Team | Planning | Backlog |
+| Resolve the ZAOstock-graduation drift: either spin `stock/` out to its own repo or update CLAUDE.md to say it is still in-repo (it is the #2 hot area, not graduated) | @Zaal | Decision + PR | Next docs pass |
+| Update CLAUDE.md counts to current: 306 routes / 57 domains / 296 components / 44 lib domains / 963 research doc dirs | @Claude | PR | Next docs pass |
+| Rename one of the two doc-836s (agents/x-account-mining vs infrastructure/repo-census collide) | @Claude | PR | Next docs pass |
+| Schedule test-coverage push for the untested API domains (79 test files vs 306 routes) | @Team | Planning | Backlog |
 
 ## Sources
 
-- [FULL] Vercel REST API `/v9/projects` + `/v2/teams` - censused 2026-06-10, 86 unique projects (raw dump `~/.zao/private/vercel-estate-20260610-155641.json`)
-- [FULL] Supabase Management API `/v1/projects` - censused 2026-06-10, 4 projects (raw dump `~/.zao/private/supabase-estate-20260610-160236.json`)
+- [FULL] ZAOOS working tree, code census re-run 2026-07-03 - `find`/`git log`/`wc` over `src/`, `bot/`, `research/` (counts + hot-spots + domain lists in the REFRESH block; commands reproducible)
+- [FULL] Vercel REST API `/v9/projects` + `/v2/teams` - censused 2026-06-10, 86 unique projects (raw dump `~/.zao/private/vercel-estate-20260610-155641.json`) [NOT re-run 2026-07-03]
+- [FULL] Supabase Management API `/v1/projects` - censused 2026-06-10, 4 projects (raw dump `~/.zao/private/supabase-estate-20260610-160236.json`) [NOT re-run 2026-07-03]
 - [FULL] ZAOOS git history + working tree - 2,659 commits, scanned 2026-06-09 via 5 parallel exploration agents
-- [FULL] `scripts/estate-audit/audit.sh` - the reproducible census tool shipped in this PR
+- [FULL] `scripts/estate-audit/audit.sh` - the reproducible census tool shipped in the original PR


### PR DESCRIPTION
## Summary
Re-research of doc 836 (ZAOOS repo census), code half re-run against the live tree (2026-07-03).

**Current census:** 306 API routes / 57 domains, 296 components / 35 feature dirs, 18 hooks, 44 lib domains, 59 pages, 79 test files, ~142k src LOC, 963 numbered research-doc dirs, 431 commits/30d (still very active, off the June peak of 752).

**New subsystems since June:** `livepeer` (streaming), `unlock` (Unlock Protocol / zabalgamez embeds).

**Honest findings:** (1) ZAOstock has NOT graduated - `src/app/stock` is the #2 hottest area, drift vs CLAUDE.md's "spinning out"; (2) repo is still accreting, no graduation-delete since COC; (3) component-count metric standardized (baseline "~360" used a broader glob; clean src/components count is 296); (4) two docs collide on number 836.

Paid Vercel/Supabase estate section left as the 2026-06-10 snapshot (needs the audit.sh + tokens, not re-run this pass).

## Tier
STANDARD (re-research of existing doc 836, in place)

## Sources
Live working-tree census (find/git/wc, reproducible) FULL; prior estate census retained.

## Next Actions
See doc 836 Next Actions: resolve the ZAOstock drift, update CLAUDE.md counts, rename the colliding 836.