### PR TITLE
fix(zoe): stop truncating Zaal's messages in working memory (280->800)

### DIFF
--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -543,7 +543,7 @@ export async function buildMemoryBlocks(
       : recentTurns
           .map((t) => {
             const label = t.from === 'zaal' ? 'Zaal' : t.from === 'zoe' ? 'ZOE' : t.sender ?? 'Other';
-            return `[${t.ts.slice(11, 16)}] ${label}: ${t.text.slice(0, 280)}`;
+            return `[${t.ts.slice(11, 16)}] ${label}: ${t.text.slice(0, 800)}`;
           })
           .join('\n');
 

--- a/bot/src/zoe/threads.ts
+++ b/bot/src/zoe/threads.ts
@@ -175,7 +175,7 @@ export async function addThread(input: NewThreadInput, now: number = Date.now())
   const t: OpenThread = {
     id: newThreadId(now),
     summary: input.summary.trim(),
-    sourceTurn: input.sourceTurn.slice(0, 500),
+    sourceTurn: input.sourceTurn.slice(0, 1200),
     createdAt: new Date(now).toISOString(),
     dueAt: input.dueAt ?? null,
     status: 'open',


### PR DESCRIPTION
ZOE felt like it 'cut off' long messages. Root cause: the concierge working-memory block rendered each prior turn at 280 chars (`memory.ts:546`) and thread provenance at 500 (`threads.ts:178`). Inbound receive + outbound chunking were both fine - only the context render was clipped.

Bumps to 800 / 1200. After merge: on the VPS, `git pull && systemctl --user restart zoe-bot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)