### PR TITLE
doc 964: YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe (ZOE research)

### DIFF
--- a/research/business/964-youtube-zao-growth-what-content-funnel-converts/README.md
+++ b/research/business/964-youtube-zao-growth-what-content-funnel-converts/README.md
@@ -1,0 +1,102 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-07-04
+superseded-by:
+related-docs:
+original-query: "YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring live-battle participants and ZAO community members, and which YouTube formats drive each step of that path most efficiently in 2026?"
+tier: STANDARD
+---
+
+# 964 - YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe
+
+> Drafted by ZOE's research-worker from "YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring live-battle participants and ZAO community members, and which YouTube formats drive each step of that path most efficiently in 2026?". Auto-committed to main for durability; review + deepen as needed.
+
+I have all sources verified. Now I'll write the properly structured research output.
+
+---
+
+```
+---
+topic: YouTube/WaveWarZ Shorts-to-live-battle content funnel
+type: research
+status: complete
+last-validated: 2026-07-04
+related-docs: "722k, 951, 423, 812"
+original-query: "What content funnel converts WaveWarZ Shorts viewers into recurring live-battle participants and ZAO community members, and which YouTube formats drive each step of that path most efficiently in 2026?"
+---
+```
+
+## Key Decisions
+
+| Decision | Recommendation | Confidence | Source |
+|----------|---------------|------------|--------|
+| Shorts content structure | Cliffhanger format only - show 60% of the battle, direct to live for the outcome. Never reveal the winner in the Short. | High | Chartlex, Fluxnote |
+| Bridge format | Build a "Start Here" playlist (5-8 videos, accessible to in-depth) and link in every Short's pinned comment - this is the mechanism that converts Shorts viewers to live participants | High | Fluxnote |
+| Posting cadence | 2-3 Shorts/week + 1 long-form every 2-4 weeks. Posting more than 4 Shorts/week yields diminishing returns | High | Chartlex |
+| YouTube policy risk | Frame all WaveWarZ content as "music competition/prediction" not "trading" - YouTube's gambling policy is a platform-level threat that jurisdiction cannot fix | High | Doc 951 |
+| Comment engagement | Reply to the first 50 comments on every Short within 2 hours - triggers the algorithm test window boost | Medium | Dataslayer |
+
+---
+
+## Findings
+
+**The funnel has four distinct stages, and most of the conversion work happens in the bridge between Shorts and live.**
+
+WaveWarZ already has its live anchor: 11 shows per week on YouTube Live (Mon-Fri 8:30 PM ET quick battles, Mon-Fri 11 AM ET community AMA, Sun 7 PM main events), having transitioned from X Spaces in March 2026 (Doc 722k). The production infrastructure is not the gap. The gap is that there is no documented Shorts pipeline converting cold viewers to those shows - Doc 722k explicitly lists YouTube non-YapZ as "PAUSED" with "no upload pipeline."
+
+**Stage 1 - Discovery (Shorts, cold audience)**
+
+Shorts reach cold audiences that the channel cannot reach through long-form or live alone. However, the 2026 algorithm update formally separated the Shorts and long-form recommendation systems (Dataslayer). Poor Short performance no longer damages long-form reach, but Shorts also no longer passively pull viewers into the long-form feed. Conversion is now an intentional design problem.
+
+The Hacker News creator community consensus (item 42710602) is that Shorts' recommendation algorithm underperforms TikTok for niche content - it defaults to demographic targeting rather than behavioral learning, which means WaveWarZ battle clips will surface to general music fans, not pre-qualified battle rap / music competition audiences. This is not a reason to skip Shorts; it sets a realistic expectation that conversion rates will be low and the funnel must be explicit.
+
+Conversion baseline: 1 million Shorts views generates approximately 500-5,000 new subscribers (0.05-0.5% rate, Fluxnote). Artists who use Shorts as teasers - delivering partial value then directing to long-form - see subscriber conversion rates approximately 40% higher than those publishing Shorts as standalone content (Chartlex). For WaveWarZ, the direct application is: show two rounds of a battle, then cut to "find out who won tonight at 8:30 PM ET - link in bio." The live show becomes the payoff, not a separate product.
+
+**Stage 2 - Interest bridge (long-form VODs and playlists)**
+
+Long-form converts Shorts viewers to engaged subscribers at 8-15% versus 2-5% for Shorts-only channels (Chartlex). Depth of engagement per viewer is categorically different: long-form viewers comment, watch older videos, and click through to linked profiles. Shorts viewers do not do this at equivalent rates.
+
+The primary mechanism here is the "Start Here" playlist: 5-8 videos ordered from most accessible to most in-depth. Channels implementing this retain 35-50% of Shorts-driven subscribers past the 90-day mark, compared to 15-25% without it (Fluxnote). For WaveWarZ, this playlist should be sequenced as: (1) "What is WaveWarZ" explainer, (2) a top-performing featured battle VOD, (3) an artist profile, (4) a full Sunday main event VOD. This playlist link goes in every Short's pinned comment.
+
+**Stage 3 - Activation (live battle attendance)**
+
+Live streams deliver strong subscriber signals and high satisfaction in the 2026 algorithm weighting (Dataslayer). However, live reach is "moderate while live, lower as VOD" - momentum decays fast after the broadcast. This means live streams do not self-distribute; they serve the already-interested viewer, not the cold Shorts viewer. Monthly live Q&A events that concentrate engagement create "high-satisfaction moments that lift returns to channel within 7 days" (Dataslayer).
+
+The Monday-through-Friday 8:30 PM ET cadence (Doc 722k) is the live engine. The Shorts funnel drives viewers to discover WaveWarZ exists; the "Start Here" playlist converts them to subscribers; a single high-production Sunday main event VOD (clipped into Shorts the following week) closes the loop.
+
+**Stage 4 - Retention (ZAO community membership)**
+
+This stage has no verified external data specific to WaveWarZ's situation. Community membership conversion from YouTube to off-platform community (Farcaster, ZAO Discord) is not addressed in the sources reviewed. Mark as TBD - requires a separate research dispatch.
+
+**Platform policy risk**
+
+Doc 951 documents that YouTube flagged WaveWarZ content for "gambling-like" content. Greg's legal analysis confirms: YouTube's platform rules apply regardless of entity jurisdiction. The content framing fix - emphasizing music competition and prediction, not trading mechanics - must precede any significant Shorts volume increase. A community strike during a Shorts growth push would collapse the funnel at Stage 1.
+
+---
+
+## Recommended Action
+
+| Action | Owner | By When | Success Metric |
+|--------|-------|---------|----------------|
+| Audit all existing WaveWarZ YouTube content for gambling-policy risk; reframe descriptions and thumbnails before launching Shorts campaign | Hurricane/Samantha | Before first Short ships | Zero content strikes within 30 days of campaign launch |
+| Build "Start Here" playlist (5-8 videos): explainer -> featured battle -> artist profile -> full Sunday VOD | Hurricane + Zaal | Week 1 | Playlist built and linked in channel header |
+| Launch Shorts clip pipeline: 2-3 Shorts/week cut from Sunday main event battles; all clips use cliffhanger format (stop before winner is revealed) | Hurricane (content), ZOE (pipeline) | Week 2 | Shorts publishing on schedule 2 weeks after launch |
+| Pin "Start Here" playlist link in every Short's first comment within 1 hour of upload | Content ops (ZOE hook candidate) | Ongoing from Week 2 | Pinned comment on 100% of Shorts within 2 hours |
+| Reply to first 50 comments on each Short within 2 hours of posting | Hurricane or Samantha | Ongoing from Week 2 | Comment reply rate verified weekly |
+| Track Shorts-to-live-show conversion: measure whether live concurrent viewers rise on weeks with Shorts output vs. weeks without | Zaal | Monthly review | Measurable lift in live concurrent viewers on Shorts-active weeks |
+
+---
+
+## Sources
+
+- [FULL - verified live] YouTube Shorts vs Long-Form for Musicians 2026 - https://www.chartlex.com/blog/marketing/youtube-shorts-vs-long-form-musicians-2026
+- [FULL - verified live] YouTube Shorts to Subscribers Strategy 2026 - https://fluxnote.io/guides/youtube-shorts-to-subscribers-strategy-2026
+- [FULL - verified live] YouTube Algorithm 2026: How to Get Your Videos Recommended - https://www.dataslayer.ai/blog/youtube-algorithm-2025-how-to-get-your-videos-recommended
+- [FULL - community - verified live] HN: "As a casual observer, I don't understand why YouTube Shorts isn't the obvious su..." - https://news.ycombinator.com/item?id=42710602
+- [FAILED - both raw and old.reddit.com blocked] Reddit r/NewTubers - Shorts-to-community conversion creator discussion
+- [INTERNAL] Doc 722k - ZAO content social cadence (WaveWarZ live cadence, YouTube transition)
+- [INTERNAL] Doc 951 - Greg x Autonomous x WaveWarZ legal (YouTube gambling policy risk)
+- [INTERNAL] Doc 423 - Music x Crypto Connect Sesh (WaveWarZ Quick BattleZ PMF signal)
+- [INTERNAL] Doc 812 - Atta streaming setup (Restream multi-platform infrastructure)

--- a/research/business/README.md
+++ b/research/business/README.md
@@ -92,3 +92,4 @@
 | 914 | [research this](./914-research-this/) | DISPATCH | ZOE research: https://www.reddit.com/r/ClaudeCode/s/FmLRNnUvL0 research this |
 | 929 | [Bonfire knowledge-graph admin labeling - what unblocks agent writes (r](./929-bonfire-knowledge-graph-admin-labeling-what-unblocks/) | DISPATCH | ZOE research: Bonfire knowledge-graph admin labeling - what unblocks agent writes (recurring blocker acr |
 | 956 | [YouTube/ZAO growth: What content angle drives highest subscriber conve](./956-youtube-zao-growth-what-content-angle-drives/) | DISPATCH | ZOE research: YouTube/ZAO growth: What content angle drives highest subscriber conversion for a sub-10K  |
+| 964 | [YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe](./964-youtube-zao-growth-what-content-funnel-converts/) | DISPATCH | ZOE research: YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring li |


### PR DESCRIPTION
Auto-drafted by ZOE's research-worker from: YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring live-battle participants and ZAO community members, and which YouTube formats drive each step of that path most efficiently in 2026?

Review + deepen as needed.