### PR TITLE
docs: renumber 964->965 (collision fix)

### DIFF
--- a/research/business/965-youtube-zao-growth-what-content-funnel-converts/README.md
+++ b/research/business/965-youtube-zao-growth-what-content-funnel-converts/README.md
@@ -9,7 +9,7 @@ original-query: "YouTube/ZAO growth: What content funnel converts WaveWarZ Short
 tier: STANDARD
 ---
 
-# 964 - YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe
+# 965 - YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe
 
 > Drafted by ZOE's research-worker from "YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring live-battle participants and ZAO community members, and which YouTube formats drive each step of that path most efficiently in 2026?". Auto-committed to main for durability; review + deepen as needed.
 

--- a/research/business/README.md
+++ b/research/business/README.md
@@ -92,4 +92,4 @@
 | 914 | [research this](./914-research-this/) | DISPATCH | ZOE research: https://www.reddit.com/r/ClaudeCode/s/FmLRNnUvL0 research this |
 | 929 | [Bonfire knowledge-graph admin labeling - what unblocks agent writes (r](./929-bonfire-knowledge-graph-admin-labeling-what-unblocks/) | DISPATCH | ZOE research: Bonfire knowledge-graph admin labeling - what unblocks agent writes (recurring blocker acr |
 | 956 | [YouTube/ZAO growth: What content angle drives highest subscriber conve](./956-youtube-zao-growth-what-content-angle-drives/) | DISPATCH | ZOE research: YouTube/ZAO growth: What content angle drives highest subscriber conversion for a sub-10K  |
-| 964 | [YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe](./964-youtube-zao-growth-what-content-funnel-converts/) | DISPATCH | ZOE research: YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring li |
+| 965 | [YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewe](./965-youtube-zao-growth-what-content-funnel-converts/) | DISPATCH | ZOE research: YouTube/ZAO growth: What content funnel converts WaveWarZ Shorts viewers into recurring li |


### PR DESCRIPTION
ZOE nightly research claimed 964 which #1070 had just taken. Renumbered to 965. Docs-only, will auto-merge.