### PR TITLE
feat(zoe): cost ledger - per-model spend visibility (doc 972)

### DIFF
--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -9,6 +9,7 @@
  * from PERSONA_DEFAULT in memory.ts on first boot, hand-editable after).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
+import { recordCall } from './cost-ledger';
 import type { ConciergeOptions, ConciergeResult, TaskOp, QuestOp, ZoeCaptureNote, BotRelayOp, CrmOp, ThreadOp } from './types';
 import { selectModel, ZOE_DEFAULT_MODEL } from './types';
 import type { MemoryBlocks } from './memory';
@@ -161,6 +162,8 @@ export async function runConciergeTurn(opts: ConciergeOptions): Promise<Concierg
     // a session.
     bare: false,
   });
+
+  recordCall('concierge', result);
 
   const { reply, taskOps, questOps, captures, botRelayOps, crmOps, threadOps } = splitReplyAndOps(result.text);
 

--- a/bot/src/zoe/cost-ledger.ts
+++ b/bot/src/zoe/cost-ledger.ts
@@ -1,0 +1,111 @@
+// cost-ledger.ts - ZOE per-model spend visibility.
+//
+// The frontier "cost observability" gap (research doc 972): callClaudeCli
+// already returns model + tokens + cost on every call (ClaudeCliResult), but
+// nothing captured it - ZOE's daily call-budget counter counts CALLS, not
+// tokens or dollars. This records each call so spend is visible per model per
+// day, without changing any behavior.
+//
+// Storage (mirrors the ZOE_HOME convention used by memory/tasks):
+//   ~/.zao/zoe/cost/<YYYY-MM-DD>.jsonl   one line per call
+//   ~/.zao/zoe/cost/<YYYY-MM-DD>.md      human-readable daily rollup (per model + total)
+//
+// Fully fail-safe: any error is swallowed - cost logging must never break a turn.
+
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const COST_DIR = process.env.ZOE_HOME
+  ? join(process.env.ZOE_HOME, 'cost')
+  : join(homedir(), '.zao', 'zoe', 'cost');
+
+/** The subset of ClaudeCliResult the ledger needs. */
+export interface CallCost {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalCostUsd: number;
+}
+
+export interface ModelRollup {
+  model: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Record one Claude CLI call. `caller` labels the source (concierge/worker/reflexion)
+ * so spend can be attributed. Never throws.
+ */
+export function recordCall(caller: string, r: CallCost): void {
+  try {
+    mkdirSync(COST_DIR, { recursive: true });
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      caller,
+      model: r.model,
+      in: r.inputTokens ?? 0,
+      out: r.outputTokens ?? 0,
+      usd: r.totalCostUsd ?? 0,
+    });
+    appendFileSync(join(COST_DIR, `${today()}.jsonl`), `${line}\n`);
+    writeDailySummary();
+  } catch {
+    /* cost logging is best-effort - never break a turn over it */
+  }
+}
+
+/** Aggregate today's calls per model. Returns [] if nothing logged / on error. */
+export function todaySummary(day = today()): ModelRollup[] {
+  try {
+    const raw = readFileSync(join(COST_DIR, `${day}.jsonl`), 'utf8');
+    const byModel = new Map<string, ModelRollup>();
+    for (const l of raw.split('\n')) {
+      if (!l.trim()) continue;
+      let rec: { model?: string; in?: number; out?: number; usd?: number };
+      try {
+        rec = JSON.parse(l) as typeof rec;
+      } catch {
+        continue;
+      }
+      const model = rec.model ?? 'unknown';
+      const m = byModel.get(model) ?? { model, calls: 0, inputTokens: 0, outputTokens: 0, costUsd: 0 };
+      m.calls += 1;
+      m.inputTokens += rec.in ?? 0;
+      m.outputTokens += rec.out ?? 0;
+      m.costUsd += rec.usd ?? 0;
+      byModel.set(model, m);
+    }
+    return [...byModel.values()].sort((a, b) => b.costUsd - a.costUsd);
+  } catch {
+    return [];
+  }
+}
+
+/** Render a one-line-per-model text summary of a day's spend, for the /cost view + brief. */
+export function summaryText(day = today()): string {
+  const rows = todaySummary(day);
+  if (rows.length === 0) return `No ZOE model calls logged for ${day}.`;
+  const total = rows.reduce((s, r) => s + r.costUsd, 0);
+  const totalCalls = rows.reduce((s, r) => s + r.calls, 0);
+  const lines = rows.map(
+    (r) => `- ${r.model}: ${r.calls} calls, ${(r.inputTokens + r.outputTokens).toLocaleString()} tok, $${r.costUsd.toFixed(4)}`,
+  );
+  return [`ZOE spend ${day} - $${total.toFixed(4)} across ${totalCalls} calls:`, ...lines].join('\n');
+}
+
+function writeDailySummary(): void {
+  try {
+    const day = today();
+    writeFileSync(join(COST_DIR, `${day}.md`), `# ZOE spend - ${day}\n\n${summaryText(day)}\n`);
+  } catch {
+    /* best-effort */
+  }
+}

--- a/bot/src/zoe/reflect.ts
+++ b/bot/src/zoe/reflect.ts
@@ -10,6 +10,7 @@
  * captures them as Bonfire-eligible notes (status + priorities update).
  */
 import { callClaudeCli } from '../hermes/claude-cli';
+import { recordCall } from './cost-ledger';
 import { listOpenTasks } from './tasks';
 import { listLiveThreads, isOverdue, type OpenThread } from './threads';
 
@@ -124,6 +125,8 @@ ${
     permissionMode: 'default',
     bare: false,
   });
+
+  recordCall('reflect', result);
 
   const trimmed = result.text.trim();
   if (trimmed.length < 60) {

--- a/bot/src/zoe/workers.ts
+++ b/bot/src/zoe/workers.ts
@@ -20,6 +20,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { callClaudeCli, CliAuthError, CliError } from '../hermes/claude-cli';
+import { recordCall } from './cost-ledger';
 import { ZOE_DEFAULT_MODEL, ZOE_QUICK_MODEL } from './types';
 import type { ZoeContext } from './types';
 import type { Subtask, WorkerKind } from './decompose';
@@ -336,8 +337,8 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
     };
   }
 
-  const call = async (criticFeedback?: string, budgetUsd: number = cfg.maxBudgetUsd) =>
-    callClaudeCli({
+  const call = async (criticFeedback?: string, budgetUsd: number = cfg.maxBudgetUsd) => {
+    const r = await callClaudeCli({
       model: cfg.model,
       prompt: buildWorkerPrompt(args, criticFeedback),
       cwd: args.context.workspace_dir,
@@ -349,6 +350,9 @@ export async function runClaudeWorker(args: RunWorkerArgs): Promise<WorkerResult
       maxBudgetUsd: budgetUsd,
       bare: false,
     });
+    recordCall('worker:' + worker, r);
+    return r;
+  };
 
   try {
     const first = await call();


### PR DESCRIPTION
## Summary
The one genuine gap from doc 972 (agent-tooling comparison). ZOE already had multi-model routing (`selectModel`: haiku/sonnet/opus) and a self-improve loop (`reflexion`) - the research agents overstated those because they had no code access. The real miss was cost/token observability: `callClaudeCli` returns model+tokens+cost on every call, but nothing captured it (`call-budget` counts calls only).

## What this adds
- `bot/src/zoe/cost-ledger.ts` - fail-safe ledger: records each call to `~/.zao/zoe/cost/<date>.jsonl` + a human-readable daily `.md` rollup (per model + total). Never throws.
- Wired `recordCall` into all three call sites: concierge, workers (all worker runs), reflect.
- Exposes `todaySummary()` / `summaryText()` for a future `/cost` command + morning-brief line.

## Zero behavior change
Additive only - reads the result, writes a log. No routing/model/turn logic touched.

## Validation
esbuild bundle-check clean (syntax + local imports). Deploy note: ships with the next `zao-devz-stack`/`zoe-bot` deploy.

## Follow-on (not in this PR)
`/cost` command in the message router + surface today spend in the morning brief.