### PR TITLE
feat(zoe): morning brief FOCUS - top-3 by deadline + what needs Zaal (doc 983)

### DIFF
--- a/bot/src/zoe/__tests__/team-tracker.test.ts
+++ b/bot/src/zoe/__tests__/team-tracker.test.ts
@@ -1,5 +1,36 @@
 import { describe, it, expect } from 'vitest';
-import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, buildTeamTaskRow, type TeamTask } from '../team-tracker';
+import { formatTeamTasks, teamTrackerConfigured, summarizeTeamForBrief, zaalFocusForBrief, buildTeamTaskRow, type TeamTask } from '../team-tracker';
+
+describe('zaalFocusForBrief', () => {
+  it('returns null when nothing is dated and nothing needs Zaal', () => {
+    const tasks: TeamTask[] = [
+      { title: 'no date', status: 'todo', priority: 'P3', due: null, project: null, legacy_id: '1' },
+    ];
+    expect(zaalFocusForBrief(tasks)).toBeNull();
+  });
+  it('lists the top 3 by deadline, soonest first, and counts next_owner=me', () => {
+    const tasks: TeamTask[] = [
+      { title: 'C', status: 'todo', priority: 'P2', due: '2026-07-10', project: null, legacy_id: '3', metadata: { next_owner: 'me' } },
+      { title: 'A', status: 'todo', priority: 'P1', due: '2026-07-07', project: null, legacy_id: '1', metadata: { next_owner: 'me' } },
+      { title: 'B', status: 'todo', priority: 'P1', due: '2026-07-08', project: null, legacy_id: '2', metadata: { next_owner: 'agent' } },
+      { title: 'D', status: 'todo', priority: 'P3', due: '2026-07-20', project: null, legacy_id: '4' },
+    ];
+    const out = zaalFocusForBrief(tasks)!;
+    // soonest-first ordering, asserted on the unambiguous due-date strings
+    expect(out.indexOf('2026-07-07')).toBeLessThan(out.indexOf('2026-07-08'));
+    expect(out.indexOf('2026-07-08')).toBeLessThan(out.indexOf('2026-07-10'));
+    expect(out).not.toContain('2026-07-20'); // D is beyond the top-3
+    expect(out).toMatch(/2 tasks waiting on your call/);
+  });
+  it('ignores rows with a malformed due and still surfaces the needs-me count', () => {
+    const tasks: TeamTask[] = [
+      { title: 'bad', status: 'todo', priority: 'P1', due: 'someday', project: null, legacy_id: '1', metadata: { next_owner: 'me' } },
+    ];
+    const out = zaalFocusForBrief(tasks)!;
+    expect(out).toMatch(/1 task waiting on your call/);
+    expect(out).not.toContain('TOP 3');
+  });
+});
 
 describe('summarizeTeamForBrief', () => {
   it('returns null when empty (so the brief skips the section)', () => {

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -17,7 +17,7 @@
  */
 import { callClaudeCli } from '../hermes/claude-cli';
 import { listOpenTasks } from './tasks';
-import { getOpenTeamTasks, summarizeTeamForBrief } from './team-tracker';
+import { getOpenTeamTasks, summarizeTeamForBrief, zaalFocusForBrief } from './team-tracker';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -36,6 +36,9 @@ LAST 24H COMMITS
 
 OPEN PRS
 - List of open PRs by number + title.
+
+FOCUS
+- Lead with this. The top 3 tasks by deadline and how many need Zaal's call. This is the "what needs me today" answer. Skip entirely if focus is (none dated).
 
 TEAM
 - One line: the team board summary (open count, overdue, top items). Skip this section entirely if team is unavailable.
@@ -56,6 +59,7 @@ interface BriefContext {
   open_prs: Array<{ number: number; title: string }>;
   inbox: { unreadCount: number; recentSubjects: string[] } | null;
   team: string | null;
+  focus: string | null;
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -166,11 +170,17 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
   const inbox = await fetchInboxSnapshot();
 
   // Team board state (cowork tracker). Best-effort; null if unconfigured/unreachable.
+  // Doc 983: also compute the judgment-routing focus (top-3 by deadline + how many
+  // tasks are waiting on Zaal's call) from the same fetch.
   let team: string | null = null;
+  let focus: string | null = null;
   try {
-    team = summarizeTeamForBrief(await getOpenTeamTasks());
+    const teamTasks = await getOpenTeamTasks();
+    team = summarizeTeamForBrief(teamTasks);
+    focus = zaalFocusForBrief(teamTasks);
   } catch {
     team = null;
+    focus = null;
   }
 
   return {
@@ -181,6 +191,7 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     open_prs: prs,
     inbox,
     team,
+    focus,
   };
 }
 
@@ -202,6 +213,7 @@ CONTEXT:
 - Recent activity across ALL Zaal's repos: ${ctx.cross_repo_24h.length === 0 ? '(none)' : ctx.cross_repo_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
 - Team board: ${ctx.team ?? '(tracker unavailable - skip the TEAM section)'}
+- Focus (top-3 by deadline + what needs your call): ${ctx.focus ?? '(none dated)'}
 - ${inboxLine}
 
 Output the brief now in the exact format from your system prompt.`;

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -22,6 +22,10 @@ export interface TeamTask {
   due: string | null;
   project: string | null;
   legacy_id: string | null;
+  // Doc 983: metadata jsonb carries next_owner (me/agent/review/blocked) for the
+  // judgment-routing focus line in the morning brief. Optional - null when the
+  // row predates the auto-tagger.
+  metadata?: Record<string, unknown> | null;
 }
 
 const MAX_TASKS = 30;
@@ -42,7 +46,7 @@ export async function getOpenTeamTasks(): Promise<TeamTask[]> {
   const url =
     `${base.replace(/\/$/, '')}/rest/v1/tasks` +
     `?status=neq.done&archived_at=is.null` +
-    `&select=title,status,priority,due,project,legacy_id` +
+    `&select=title,status,priority,due,project,legacy_id,metadata` +
     `&order=due.asc.nullslast&limit=${MAX_TASKS}`;
 
   try {
@@ -182,4 +186,23 @@ export function summarizeTeamForBrief(tasks: TeamTask[]): string | null {
     .map((t) => t.title)
     .join('; ');
   return `${tasks.length} open${overdue ? `, ${overdue} overdue` : ''}${top ? `. Top: ${top}` : ''}`;
+}
+
+/**
+ * Doc 983: the judgment-routing focus for the morning brief - the top 3 tasks by
+ * DEADLINE (not priority) plus a count of items whose next move belongs to Zaal
+ * (metadata.next_owner === 'me'). This answers "what needs me next" rather than
+ * "what is the whole board". Pure; returns null when there is nothing dated.
+ */
+export function zaalFocusForBrief(tasks: TeamTask[]): string | null {
+  const dated = tasks
+    .filter((t) => typeof t.due === 'string' && /^\d{4}-\d{2}-\d{2}/.test(t.due))
+    .sort((a, b) => String(a.due).localeCompare(String(b.due)));
+  const top3 = dated.slice(0, 3).map((t) => `${t.title} (due ${String(t.due).slice(0, 10)})`);
+  const needsMe = tasks.filter((t) => (t.metadata?.next_owner ?? '') === 'me').length;
+  if (top3.length === 0 && needsMe === 0) return null;
+  const parts: string[] = [];
+  if (top3.length) parts.push(`TOP 3 BY DEADLINE: ${top3.join(' | ')}`);
+  if (needsMe) parts.push(`${needsMe} task${needsMe === 1 ? '' : 's'} waiting on your call`);
+  return parts.join('. ');
 }


### PR DESCRIPTION
## Summary
Rec #3 from doc 983. Adds a FOCUS line to ZOE's 5am morning brief: the **top 3 tasks by deadline** + **how many need Zaal's call** (metadata.next_owner===me), computed from the existing getOpenTeamTasks fetch. Led at the top of the brief. The existing team summary (priority-based) stays.

## Changes
- team-tracker.ts: TeamTask gains optional metadata; select pulls metadata; new pure zaalFocusForBrief()
- brief.ts: compute focus alongside team summary, inject into context + prompt, new FOCUS section in system prompt
- team-tracker.test.ts: +3 tests (null case, deadline ordering, malformed-due). 13/13 pass.

## Verify
- esbuild boot-check clean on both files; bot tsc --noEmit clean; vitest 13/13 pass

## DEPLOY (needs Zaal go)
This is a ZOE bot code change. After merge it needs: `ssh VPS -> cd ~/zao-os && git pull && systemctl --user restart zoe-bot`. Do NOT auto-deploy - confirm with Zaal first per bot-change rules.