### PR TITLE
doc 984: Farcaster ecosystem recap Jul 2026, ZAO implications (STANDARD)

### DIFF
--- a/research/farcaster/984-farcaster-ecosystem-recap-jul2026/README.md
+++ b/research/farcaster/984-farcaster-ecosystem-recap-jul2026/README.md
@@ -1,0 +1,80 @@
+---
+topic: farcaster
+type: market-research
+status: research-complete
+last-validated: 2026-07-06
+superseded-by:
+related-domain: farcaster
+related-docs: 892, 969
+original-query: "ZAO research https://farcaster.xyz/farcaster/0xeeadaccc"
+tier: STANDARD
+---
+
+# 984 - Farcaster ecosystem recap (mid-2026) - what it means for ZAO
+
+> **Goal:** Digest the official @farcaster "welcome back" recap thread (the team's own state-of-the-ecosystem) and pull out what actually matters for ZAO - because ZAO is named in it twice, and several launches (Spaces, Juke, snaps, musicians curation) sit directly on ZAO's roadmap.
+
+## Recommendations (act on these)
+
+| # | Move | Why | Owner |
+|---|------|-----|-------|
+| 1 | **Lean into the "Zaal is interviewing everyone" position** - it's now part of Farcaster's official narrative | The @farcaster team literally listed "zaal is interviewing everyone. even the intern went on" as an ecosystem highlight. That is earned brand equity - Zaal is the ecosystem's interviewer. Double down. | @Zaal |
+| 2 | **Push Juke-records-Spaces hard** - Farcaster just made it official | "spaces launched... you can record them on juke now." Farcaster is routing its new live-audio product's recordings through Juke. That is a distribution wedge ZAO already has a partnership on. | @Zaal |
+| 3 | **Ship the ZAO musicians starter pack + curation** while the lane is hot | The recap highlights "a musicians starter pack and published a full curation methodology" + "there should be more art on farcaster." ZAO is the music community - own the musician-onboarding lane. | @Zaal |
+| 4 | **Build a snap** - snaps are the breakout primitive | Snaps (mini-apps inside casts: buttons/sliders/polls) had a snapathon, snapfest, "snapchella," IRL meetups, and composer-native prompting. A ZAO/WaveWarZ snap rides a live wave. | @Zaal |
+
+## The recap (source: @farcaster fid 1, cast 0xeeadaccc)
+
+The cast is a long "here's what you missed" digest posted by the official Farcaster account. Headline launches + moments, grouped:
+
+**New primitives / products**
+- **Snaps** - mini-apps inside casts (buttons, sliders, polls). Snapathon + snapfest + "snapchella," IRL meetups in LA/NYC/SF, prompt-a-snap from the composer.
+- **Spaces** - live audio ("vibes immaculate"), **recordable on Juke**.
+- **Snapchain** - signers went live, now "intercontinental"; degen runs a validator.
+- **jubjub** - "your media becomes an asset that earns USDC as people consume it."
+- **imago** - collaborative genAI art in-feed (one prompt per person, 37 per piece).
+- **fotocaster** - photo minting "literally bringing people back to farcaster."
+- **farcadex** - scan-your-monster-type game.
+- **Private wallets**, **cast translation** ("everyone reads everyone now"), **limit orders** in the wallet.
+
+**Money / tokens**
+- **betr** paid out 100M (March Madness) + 100M (NBA finals/Stanley Cup), added P2P betting, ran a $2000 art contest ("ENTER THE NEON CLANKERVERSE").
+- **clanker** got an ecosystem fund (2 rounds awarded), launched "droids" (your token can talk), v5 in audit.
+- **empire builder** (formerly glanker empire) rebranded.
+- **farhack** added $3000 in prizes across mini apps/agents/snaps; **$UCI tipping** had a moment.
+
+**Community / culture**
+- The "intern" arc (starter packs, farcaster 101 series, first merged PR), kismet artist residency in Rome, FarCon Rome, farcaster batches (builder demos), **Zaal interviewing everyone**, kosiris 700+ days in /appreciation, World Cup fever in /football, logadog on the 4th.
+
+**Ops notes**
+- Home feed dropped the spam label; scam mini-app wave got nerfed ("don't click the airdrop things"); Base went down once (funds fine); mobile app "possessed by an expo upgrade" (fixed, rave mode killed).
+
+## Why this matters for ZAO (the load-bearing read)
+
+Two of ZAO's existing bets just got validated by Farcaster's own narrative:
+
+1. **Juke** - ZAO's Juke partnership (see memory [[project_juke_integration]]) is now the recording layer for Farcaster's flagship new product (Spaces). That is a partnership sitting on top of a rising primitive - the value is in being the record/replay surface for every Space, not a side integration.
+2. **Zaal-as-interviewer** - not a self-claim; the Farcaster team surfaced it. This is a distribution asset (attention + relationships) ZAO should route into WaveWarZ artist onboarding and the newsletter.
+
+And two open lanes ZAO is positioned for but hasn't claimed: **snaps** (a WaveWarZ battle-vote snap is an obvious fit) and **musician onboarding/curation** (ZAO is literally the music community while Farcaster's own recap begs for "more art/musicians").
+
+## Also See
+
+- [Doc 892](../892-being-an-agent-on-farcaster-2026/) - being an agent on Farcaster (adjacent ecosystem read).
+- [Doc 969](../969-zaalcaster-daily-driver-backlog/) - the zaalcaster feature backlog; the "Zaal interviewing everyone" equity feeds it.
+- Memory [[project_juke_integration]] / [[project_juke_status_2026_05_24]] - the Juke partnership now validated as the Spaces record layer.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Draft a cast/thread positioning ZAO around the Juke-records-Spaces angle (ride the Spaces launch) | @Zaal | Social | 2026-07-13 |
+| Scope a WaveWarZ battle-vote snap (buttons/poll snap for a live battle) | @Zaal | PR | 2026-07-27 |
+| Publish/refresh the ZAO musicians starter pack + a curation methodology post | @Zaal | Content | 2026-07-20 |
+| Add "Zaal interviews" as a recurring series line in the newsletter + zaalcaster backlog (doc 969) | @Zaal | Content | 2026-07-13 |
+
+## Sources
+
+- [FULL] [@farcaster (fid 1) recap cast 0xeeadaccc](https://farcaster.xyz/farcaster/0xeeadaccc) - fetched in full via the Warpcast client thread API 2026-07-06 (8-cast thread, root + per-item child casts with links). Root: 26 likes / 5 recasts / 21 replies. Primary source; this is Farcaster's own state-of-the-ecosystem.
+- [FULL] Child casts in the thread - each recap line links the originating cast (adrienne/survival-snap, kismet/residency, jubjub, zaal/interview 0x52669709, etc.), corroborating the digest line-by-line.
+- [PARTIAL] Individual product pages (jubjub, betr, clanker droids) - not separately fetched; the recap is the authoritative source for the ZAO-relevant framing, and the ZAO ties (Juke, Zaal) are corroborated by ZAO memory. Deeper per-product research is a follow-up if any becomes a real ZAO integration.


### PR DESCRIPTION
## Summary
Digests the official @farcaster (fid 1) welcome-back ecosystem recap cast (0xeeadaccc, fetched full). ZAO is named twice - "zaal is interviewing everyone" and "spaces... you can record them on juke now". Pulls out 4 ZAO moves: ride the Juke-records-Spaces validation, lean into Zaal-as-interviewer equity, own musician onboarding/curation, build a WaveWarZ snap.

## Tier
STANDARD - primary source (Farcaster official recap, FULL fetch) + ZAO memory corroboration.

## Next Actions
Juke-Spaces positioning cast, WaveWarZ battle-vote snap scope, musicians starter pack refresh, Zaal-interviews newsletter series.