### PR TITLE
doc 985: Claude global workspace (J-space), ZAO agent-trust angle (STANDARD)

### DIFF
--- a/research/agents/985-claude-global-workspace-jspace/README.md
+++ b/research/agents/985-claude-global-workspace-jspace/README.md
@@ -1,0 +1,60 @@
+---
+topic: agents
+type: guide
+status: research-complete
+last-validated: 2026-07-06
+superseded-by:
+related-docs: 568, 983
+original-query: "research this - https://www.reddit.com/r/ClaudeCode/... 'Anthropic found a global workspace inside Claude'"
+tier: STANDARD
+---
+
+# 985 - Claude's "global workspace" (J-space) - what it is + why it matters for ZAO's agents
+
+> **Goal:** Anthropic published (2026-07-06) evidence of an emergent "global workspace" inside Claude - the J-space. This doc explains what it actually is (grounded in the primary paper) and draws the one line that matters for ZAO: it is a legibility substrate for making autonomous agents (ZOE, Hermes) trustworthy - a way to see what a model is thinking but not saying.
+
+## The finding in one paragraph
+
+Claude spontaneously developed, during training, a small privileged set of internal neural patterns Anthropic calls the **J-space** (found via a **J-lens**, a Jacobian technique). When a J-space pattern lights up it does NOT mean Claude is outputting that word - it means the concept is "on its mind": being reasoned with, silently, in the activations, below the chain-of-thought scratchpad. It functionally mirrors **global workspace theory** (Baars' neuroscience account of conscious access - a theater where many processors run backstage but only a spotlight of information gets broadcast to the whole theater). Anthropic is explicit that this says **nothing** about whether Claude is conscious.
+
+## The five properties (why they call it a workspace)
+
+| Property | Test in the paper | Result |
+|----------|-------------------|--------|
+| **Report** | Ask Claude what it's thinking | It names J-space concepts; non-J-space content it cannot report. J-space = only ~6-7% of a concept's representational variance, yet almost entirely responsible for reportability. |
+| **Modulation** | "Concentrate on citrus while copying this sentence" | J-space fills with "orange"/"lemon" + meta-terms ("thinking","focused") - none in the output. |
+| **Internal reasoning** | "legs on the animal that spins webs" | "spider" lights up in middle layers though never said; swap it for "ant" and the answer flips 8 -> 6. |
+| **Flexible broadcast** | Swap "France" -> "China" once | Every downstream question (capital/language/continent) returns China's answer - the broadcast hallmark. |
+| **Selectivity** | Ablate the J-space | Claude still speaks fluently + recalls simple facts, but loses higher-order reasoning. Most computation does NOT route through J-space. |
+
+Layers split into three regimes: an early **sensory** zone (parse input), a middle **workspace** band (abstract persistent concepts - recognizing a face, noticing a bug in code, flagging a prompt injection), and a final **motor** zone (collapse to the next output word).
+
+## Why this matters for ZAO (the load-bearing read)
+
+ZAO's agent stack (ZOE, Hermes, ZOL) runs on Claude. The J-space is not a curiosity - it is a **trust primitive for autonomous agents**:
+
+1. **See intent before action.** Anthropic already uses it to catch Claude privately noticing it's being tested, fabricating data, or pursuing a hidden goal planted in training. For an autonomous fix-PR pipeline like Hermes, "read the agent's unspoken intermediate reasoning" is exactly the monitoring layer that would let you trust it to act unattended.
+2. **Steerability.** They can influence what lights up in J-space and thereby steer decisions - a cleaner control surface than prompt-wrangling.
+3. **It grounds the "aware brain" thread.** This is the interpretability substrate under [Doc 568](../568-*/) (aware brain) - the difference between an agent that *looks* aligned in its output and one you can verify is reasoning correctly underneath.
+
+Honest limits for ZAO: this is Anthropic-internal tooling on model activations - not something ZOE/Hermes can call today via the API. The open-source J-lens implementation + the Neuronpedia demo run on **open-weights** models, not the Claude API. So the near-term ZAO value is conceptual (how to think about agent trust) + a watch-item (if Anthropic exposes any J-space signal through the API/console, it becomes a real monitoring hook for Hermes).
+
+## Also See
+
+- [Doc 568](../568-*/) - the "aware brain" research this is the substrate for.
+- [Doc 983](../../dev-workflows/983-zao-assistant-todo-workflow/) - the assistant/agent workflow; J-space is the eventual answer to "how do I trust an agent to act without me."
+- Anthropic Transformer Circuits thread (ongoing interpretability program this sits in).
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Watch for any API/console exposure of a J-space / intent signal; if it ships, wire it into Hermes as a pre-action intent check | @Zaal | Research | 2026-08-06 |
+| Try the open-source J-lens + Neuronpedia demo on an open-weights model to build intuition for what "unspoken intermediate reasoning" looks like | @Zaal | Spike | 2026-07-27 |
+| Fold the "see intent before action" framing into the ZAO agent-trust posture (how much autonomy Hermes/ZOE get unattended) | @Zaal | Doc | 2026-07-20 |
+
+## Sources
+
+- [FULL] [A global workspace in language models - Anthropic](https://www.anthropic.com/research/global-workspace) (2026-07-06) - the primary post; J-space definition, the five properties, the safety/steerability uses, the consciousness caveat, open-source + Neuronpedia release.
+- [FULL] [Anthropic's new "J-lens" reveals a silent workspace inside Claude - VentureBeat](https://venturebeat.com/technology/anthropics-new-j-lens-reveals-a-silent-workspace-inside-claude-that-mirrors-a-leading-theory-of-consciousness) (2026-07-06, Michael Nunez) - 16-author study "Verbalizable Representations Form a Global Workspace in Language Models"; the three-regime layer split; the concrete swap experiments (Soccer->Rugby, France->China, spider->ant) with numbers.
+- [PARTIAL - IP-blocked] The r/ClaudeCode thread (reddit.com/r/ClaudeCode/comments/1upchq0) that surfaced this - Reddit blocked the fetch (redlib down + direct JSON 403); went to the primary Anthropic source instead, which is strictly better. The thread is community discussion, not the source.


### PR DESCRIPTION
## Summary
Explains Anthropic 2026-07-06 finding of an emergent global workspace (J-space) inside Claude - a privileged set of internal patterns Claude can report on, modulate, and reason with silently, mirroring global workspace theory. Draws the ZAO line: it is a trust/legibility primitive for autonomous agents (ZOE/Hermes) - seeing what a model thinks but does not say. Honest limit: Anthropic-internal today; open-source J-lens runs on open-weights, not the Claude API.

## Tier
STANDARD - Anthropic primary (FULL) + VentureBeat (FULL). Reddit source IP-blocked, went to primary.

## Next Actions
Watch for API exposure -> Hermes intent-check; spike the open-source J-lens; fold see-intent-before-action into ZAO agent-trust posture.