### PR TITLE
doc 986: Ellsworth local intel for ZAOstock (STANDARD)

### DIFF
--- a/research/events/986-ellsworth-local-intel-zaostock/README.md
+++ b/research/events/986-ellsworth-local-intel-zaostock/README.md
@@ -1,0 +1,67 @@
+---
+topic: events
+type: market-research
+status: research-complete
+last-validated: 2026-07-07
+superseded-by:
+related-docs: 846
+original-query: "Research: Ellsworth local intel for ZAO Stock / festivals - Franklin St Parklet, Thursday concert series Jul23-Oct1, 16 State"
+tier: STANDARD
+---
+
+# 986 - Ellsworth local intel for ZAOstock (Oct 3, Franklin St Parklet)
+
+> **Goal:** Ground ZAOstock (Oct 3 2026, Franklin St Parklet) in the actual Ellsworth landscape - who runs the venue, the Thursday concert series it overlaps, the anchor local partner, and the real sponsor/grant money. Directly answers the open "Art of Ellsworth deadline + Oct 1-4 overlap" question on the board (Thu 7/9 main topic).
+
+## Recommendations (act on these)
+
+| # | Move | Why | Owner |
+|---|------|-----|-------|
+| 1 | **Make Heart of Ellsworth the anchor partner, not a bypass** | They run the Parklet, the Thursday concert series, Art of Ellsworth, AND the 16 State makerspace. ZAOstock aligning WITH them = instant local legitimacy + their sponsor network. Going around them = friction with the org that controls the space. | @Zaal |
+| 2 | **Frame ZAOstock as the capstone to the Thursday series** | The Downtown Summer Concert Series runs Thursdays Jul 23 - **Oct 1**; ZAOstock is **Oct 3 (Fri)**. That is not a conflict - it's a hand-off: the series' final week (Oct 1) rolls straight into ZAOstock two days later. Pitch it that way to the City + Heart of Ellsworth. | @Zaal |
+| 3 | **Book through Black Moon Public House** | Black Moon curates the 2026 concert lineup and sits ON the Parklet (between Elizabeth's Fine Goods and Black Moon). They are the de-facto booking gatekeeper + a natural F&B partner for ZAOstock. | @Zaal |
+| 4 | **Chase the real local money: the bank consortium + Heart of Ellsworth Downtown Grants** | Year-one ZAOstock money is local sponsors, not state grants (per [Doc 846]). The proven local pool is already mapped (below). | @Zaal |
+
+## The ground truth (all measured from live City of Ellsworth + Heart of Ellsworth sources)
+
+### The venue - Franklin Street Parklet
+- Seasonal: Franklin Street closes ~**May 10**, Parklet set up the week of May 11, runs through the fall season. Address: **125 Franklin St, Ellsworth ME 04605**, between Elizabeth's Fine Goods and Black Moon Public House.
+- Run by the **City of Ellsworth Parks, Recreation & Facilities** dept. Director: **Roddy Ehrlenbach** (the contact already on Zaal's board for the permit/co-sponsorship call). The City explicitly offers the Parklet as "a flexible space for local businesses and organizations to host events, **in partnership with the City's Parks and Recreation team**" - i.e., ZAOstock's path is a City partnership, exactly the co-sponsorship angle already flagged.
+- Created + grown by **Heart of Ellsworth** (see below). The City credits them for it.
+
+### The overlap - Downtown Summer Concert Series (this answers the Oct 1-4 question)
+- **Free** live music, **every Thursday July 23 - October 1, 2026** (11 weeks). Start times: 7pm (Jul 23-Aug 20), **6pm (Aug 27-Oct 1)**.
+- Curated by **Black Moon Public House**; partners: **Wallace Events**, concert sponsors.
+- **The Oct 1-4 window:** Oct 1 (Thu) = the series FINALE ("Downtown Barn Dance with Alice Slater and Friends"). **ZAOstock Oct 3 (Fri)** falls two days after. So the Parklet is active and primed the same week - ZAOstock is a capstone, not a clash.
+
+### The anchor partner - Heart of Ellsworth
+- 501(c)3 (since 2016), **Main Street America nationally-accredited community since Sept 2024** (one of 10 Maine Main Street communities via the Maine Downtown Center).
+- Runs: the Parklet, the concert series (their signature summer event), **Art of Ellsworth (Maine Craft Weekend)**, Maine Outdoor Film Festival, and the **Makerspace at 16 State Street**.
+- **16 State Street Makerspace**: a downtown arts hub (exhibitions, workshops, vendor opportunities) - in its "advancement phase," actively seeking partnerships + funding. A natural ZAO artist-showcase venue + partnership entry point. Working artists include Curt Larson, Ellen Lancaster, Rosalie Kell, Amy Reisman.
+
+### The money - who actually funds downtown Ellsworth events
+- **Heart of Ellsworth Downtown Grant Program**: micro-grants ($5,000 / $3,000 / $500) for downtown Ellsworth businesses/start-ups (must operate downtown OR partner with a downtown establishment - ZAOstock qualifies via the Parklet). 4th year in 2025. Lead sponsor **Franklin Savings Bank**; also **Bangor Federal Credit Union, First National Bank, Machias Savings Bank**. -> that four-bank consortium is the local sponsor target list.
+- **The Grand** (non-profit performing-arts venue, Main St, art-deco): 30,000 patrons/yr, serves Hancock/Washington/Waldo (pop 122,000). Sponsorships **$250-$10,000**. Media reach via **Star 97.7** + **The Ellsworth American**. A potential co-presenter/venue + a model for ZAOstock's own sponsor tiers.
+
+## Also See
+
+- [Doc 846](../../business/846-zao-festivals-funding-strategy/) - the ZAO festivals funding strategy (local-sponsors-first for year one); this doc supplies the concrete Ellsworth sponsor list.
+- Tracker: "ZAOstock: confirm Art of Ellsworth deadline + Oct 1-4 overlap" (Thu 7/9 main topic) - this doc resolves the overlap; the Art of Ellsworth (Maine Craft Weekend) date still needs a direct Heart of Ellsworth confirm.
+- Memory [[project_roddy_parklet_contact]] - Roddy Ehrlenbach, the parklet/permit contact.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Call Roddy Ehrlenbach (Parks & Rec) to lock the Parklet for Oct 3 + float City co-sponsorship, framing ZAOstock as the concert-series capstone | @Zaal | Call | 2026-07-09 |
+| Email Heart of Ellsworth to propose ZAOstock as a partner event + ask the exact Art of Ellsworth (Maine Craft Weekend) date | @Zaal | Email | 2026-07-11 |
+| Reach Black Moon Public House re: booking/F&B partnership on the Parklet | @Zaal | Outreach | 2026-07-16 |
+| Build the local-sponsor ask list from the four-bank consortium (Franklin Savings, Bangor Federal CU, First National, Machias Savings) + apply to Heart of Ellsworth Downtown Grants | @Zaal | Ops | 2026-07-20 |
+
+## Sources
+
+- [FULL] [2026 Downtown Summer Concerts - City of Ellsworth](https://www.ellsworthmaine.gov/2026-downtown-summer-concerts-thursday-nights-are-about-to-get-a-whole-lot-more-fun-in-downtown-ellsworth/) (2026-06-16) - full series dates, times, lineup, Roddy quote, Black Moon/Wallace/Heart of Ellsworth partners.
+- [FULL] [Franklin Street to Close for Seasonal Parklet - City of Ellsworth](https://www.ellsworthmaine.gov/franklin-street-to-close-for-seasonal-parklet-beginning-may-10-2026/) (2026-05-04) - Parklet season, City-partnership event path, Roddy as Director.
+- [FULL] [Makerspace at 16 State - Heart of Ellsworth](https://www.heartofellsworth.org/makerspace-at-16-state) + [Downtown Grant Program](https://www.heartofellsworth.org/grantprogram2025) + [Heart of Ellsworth home](https://www.heartofellsworth.org/) - the org, the makerspace, the grant tiers + bank sponsors, the Main Street accreditation.
+- [FULL] [The Grand - Partners](https://yourgrand.org/partners) - venue reach (30k/yr, 122k pop), sponsor tiers $250-$10k, media partners.
+- [PARTIAL] Art of Ellsworth / Maine Craft Weekend exact 2026 date - referenced by Heart of Ellsworth as a signature program but the specific date was not published on the pages fetched; flagged as a direct-confirm Next Action.


### PR DESCRIPTION
## Summary
Ground intel for ZAOstock (Oct 3, Franklin St Parklet). Answers the Oct 1-4 overlap: the Downtown Summer Concert Series runs Thursdays Jul 23-Oct 1, so ZAOstock (Oct 3 Fri) is a capstone 2 days after the finale, not a clash. Maps the anchor partner (Heart of Ellsworth - runs the parklet, series, Art of Ellsworth, 16 State makerspace), the booking gatekeeper (Black Moon Public House), and the real local money (4-bank consortium + Heart of Ellsworth Downtown Grants $5k/$3k/$500; The Grand sponsor model $250-$10k).

## Tier
STANDARD - City of Ellsworth + Heart of Ellsworth + The Grand primary sources (FULL). Art of Ellsworth exact date PARTIAL (flagged for direct confirm).

## Next Actions
Roddy call (Oct 3 + co-sponsorship), Heart of Ellsworth partner email + Art of Ellsworth date, Black Moon F&B, 4-bank sponsor list + Downtown Grants.