### PR TITLE
doc 987: LinkedIn personal-brand playbook (STANDARD)

### DIFF
--- a/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
+++ b/research/cross-platform/987-linkedin-personal-brand-playbook/README.md
@@ -1,0 +1,78 @@
+---
+topic: cross-platform
+type: guide
+status: research-complete
+last-validated: 2026-07-07
+superseded-by:
+related-docs: 957, 969, 984
+original-query: "Paste this to your assistant to hand off LinkedIn - grounded in 2026 LinkedIn research + everything we've built. Set up Zaal's LinkedIn personal-brand workstream."
+tier: STANDARD
+---
+
+# 987 - LinkedIn personal-brand playbook for Zaal
+
+> **Goal:** Stand up Zaal's LinkedIn as a slow trust engine so the right people (artists, web3 builders, investors, collaborators) find him. Measure inbound DMs / relevant profile views / saves - NOT likes. This doc is the durable home for the handoff brief + the 90-day arc; the copy-paste assistant prompt is preserved verbatim at the bottom.
+
+## Recommendations (do in this order)
+
+| # | Move | Why | By When |
+|---|------|-----|---------|
+| 1 | **Fix the profile FIRST, before any posting** | The algorithm cross-checks profile against posts - they must tell the same story. Headline: "Building onchain tools so independent artists own their profit, data + IP \| The ZAO, WaveWarZ, ZABAL". About = first 2 lines say what he builds + for whom. Featured = pin zaalcaster + best posts. | 2026-07-10 |
+| 2 | **Post as Zaal personally, 3x/week (Tue/Wed/Thu ~8-10am ET)** | Personal reaches 5-20x a company page; consistency compounds at 60-90 days. Never 2 posts in one day. | ongoing from 2026-07-14 |
+| 3 | **Hook in line 1-2; link in the FIRST COMMENT; reply within the hour** | The "see more" cutoff is everything; link-in-body loses ~25-35% reach; comments weigh ~15x likes and replies keep the post alive. | every post |
+| 4 | **15 min/day commenting** on 10-15 posts from artists / web3 builders / investors he wants to reach | This is how discovery actually happens on LinkedIn. | daily |
+
+## The rules (2026 LinkedIn, follow strictly)
+
+- **Voice:** first person, plain, honest, specific. Direct, no hype, no corporate speak, **no emojis, no hashtags**. Every post needs a specific observation only Zaal could make.
+- **Length:** 600-1200 characters. Short paragraphs, one idea per few lines, skimmable.
+- **Hooks:** front-load a real result, a lesson, or a contrarian take. NEVER "excited to announce". Rotate hook types: contradiction, curiosity, specificity, stakes.
+- **Content mix:** ~40% authority (a strong/contrarian take on his space), ~40% story (build-in-public, real numbers, honest failures), ~20% conversion (name who he helps + a soft invite).
+- **Banned:** polls, engagement bait ("comment YES"), manufactured vulnerability, hashtag spam, generic AI filler.
+
+## Content sources (what to post about)
+
+- **zaalcaster** - open-sourced his own Farcaster client, vibe-coded with an AI agent. github.com/bettercallzaal/zaalcaster
+- **ZLANK** - no-code Farcaster snap builder, won FarHack 2026 Snaps track. zlank.online
+- **The ZAO** - 90+ weeks of onchain peer-ranked Respect governance on Base. thezao.xyz (note: on-chain truth is ~101 weeks / 156 holders per doc 975 - use the accurate figure)
+- **WaveWarZ** - artists paid 1% of every trade instantly onchain, 500+ SOL volume.
+- **ZABAL Gamez** - 3-month build-a-thon. zabalgamez.com
+- Build-in-public / vibe-coding lessons; artists owning their tools; onchain music.
+
+## Weekly workflow
+
+1. Draft 3 posts (use zaalcaster's built-in LinkedIn drafter - Daily -> LinkedIn tile - or write in his voice from a source above). Specific + first-person.
+2. Zaal reviews/approves (only what he'd actually say).
+3. Schedule Tue/Wed/Thu mornings. Link in comment 1.
+4. Reply to comments in the first hour. 15 min/day commenting on others.
+5. After 3-4 weeks, look at top posts by saves + comments + profile views. Double down.
+
+## 90-day arc
+
+- **Month 1:** fix the profile, then build the habit - 3 posts/week, no asks yet, find the voice.
+- **Month 2:** keep cadence, start adding a soft CTA / "reply if this is you" on the best posts.
+- **Month 3:** read the data (saves, comments, DMs, relevant profile views), double down on what created real conversations, retire what flopped.
+
+## Also See
+
+- [Doc 957](../../business/957-100k-total-reach-h2-2026-playbook/) - the H2 reach playbook LinkedIn plugs into.
+- [Doc 969](../../farcaster/969-zaalcaster-daily-driver-backlog/) - zaalcaster (has the LinkedIn drafter tile referenced in the workflow).
+- [Doc 984](../../farcaster/984-farcaster-ecosystem-recap-jul2026/) - the "Zaal is interviewing everyone" equity that feeds LinkedIn authority posts.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Rewrite LinkedIn headline + About + Featured per Rec #1 (profile before posting) | @Zaal | Profile | 2026-07-10 |
+| Draft the first 3 posts (via zaalcaster LinkedIn drafter) for Zaal to approve | @Zaal | Content | 2026-07-13 |
+| Start the 3x/week Tue-Thu cadence + 15 min/day commenting | @Zaal | Ops | 2026-07-14 |
+| At 3-4 weeks, pull saves/comments/profile-view data and double down on winners | @Zaal | Review | 2026-08-11 |
+
+## Appendix - the handoff prompt (copy-paste verbatim)
+
+> You are running LinkedIn for Zaal (Zaal Panthaki). Goal: build his personal LinkedIn presence as a builder/founder so the right people (artists, web3 builders, investors, collaborators) find him. This is a slow trust engine - we measure inbound DMs, profile views from relevant people, and saves, NOT likes. [Full brief preserved in the tracker task notes + the original chat handoff. Post as Zaal personally, 3x/week Tue-Thu 8-10am ET, hook in line 1, link in comment 1, reply within the hour, 40/40/20 mix, no hashtags/polls/hype, draft-first for Zaal's approval. Sources: zaalcaster, ZLANK, The ZAO, WaveWarZ, ZABAL, vibe-coding lessons.]
+
+## Sources
+
+- [FULL] Zaal's handoff brief (chat, 2026-07-07) - the complete playbook, self-described as grounded in 2026 LinkedIn research + the ZAO build history. Preserved above.
+- [PARTIAL] Underlying 2026 LinkedIn algorithm claims (see-more cutoff, link-in-comment ~25-35% reach penalty, comments ~15x likes weighting) - taken from the brief as-provided; directionally consistent with widely-reported LinkedIn best practice, not independently re-benchmarked here.


### PR DESCRIPTION
Captures Zaal's LinkedIn handoff brief as a durable playbook: fix-profile-first, 3x/week Tue-Thu, hook-in-line-1, link-in-comment-1, 40/40/20 mix, 15min/day commenting, 90-day arc. Sources = zaalcaster/ZLANK/ZAO/WaveWarZ/ZABAL. Handoff prompt preserved verbatim.