### PR TITLE
feat(overlay): generic ZABAL Games stream overlay

### DIFF
--- a/src/app/overlay/zabal-games/LiveBadge.tsx
+++ b/src/app/overlay/zabal-games/LiveBadge.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+interface Props {
+  accent: string;
+  scale: number;
+}
+
+/** Pulsing LIVE pill. Pauses animation under prefers-reduced-motion (see brand KEYFRAMES). */
+export function LiveBadge({ accent, scale }: Props) {
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6 * scale,
+        padding: `${4 * scale}px ${10 * scale}px`,
+        borderRadius: 999,
+        background: accent,
+        color: '#0a1628',
+        fontWeight: 800,
+        fontSize: 12 * scale,
+        letterSpacing: 1.5,
+        textTransform: 'uppercase',
+        flexShrink: 0,
+      }}
+    >
+      <span
+        className="zg-animated"
+        style={{
+          width: 8 * scale,
+          height: 8 * scale,
+          borderRadius: 999,
+          background: '#0a1628',
+          animation: 'zg-pulse 1.4s ease-in-out infinite',
+        }}
+      />
+      Live
+    </span>
+  );
+}

--- a/src/app/overlay/zabal-games/LowerThird.tsx
+++ b/src/app/overlay/zabal-games/LowerThird.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import type { OverlayConfig } from './page';
+import { tokensFor, withAlpha, KEYFRAMES } from './brand';
+import { LiveBadge } from './LiveBadge';
+
+interface Props {
+  cfg: OverlayConfig;
+}
+
+/**
+ * Bottom lower-third: accent rule + logo/title + subtitle, optional LIVE badge.
+ * Positioned bottom-left (default) or bottom-right via ?pos=. The workhorse overlay.
+ */
+export function LowerThird({ cfg }: Props) {
+  const t = tokensFor(cfg);
+  const alignRight = cfg.pos === 'right';
+
+  return (
+    <>
+      <style>{KEYFRAMES}</style>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: 48 * t.scale,
+          left: alignRight ? undefined : 48 * t.scale,
+          right: alignRight ? 48 * t.scale : undefined,
+          maxWidth: '60vw',
+        }}
+      >
+        <div
+          className="zg-animated"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 16 * t.scale,
+            padding: `${14 * t.scale}px ${20 * t.scale}px`,
+            background: t.panelBg,
+            borderLeft: alignRight ? undefined : `${4 * t.scale}px solid ${t.accent}`,
+            borderRight: alignRight ? `${4 * t.scale}px solid ${t.accent}` : undefined,
+            borderRadius: 10,
+            boxShadow: `0 8px 30px ${withAlpha('#000000', 0.35)}`,
+            backdropFilter: 'blur(6px)',
+            animation: 'zg-fade-up 0.5s ease both',
+          }}
+        >
+          {cfg.logo && (
+            <img
+              src={cfg.logo}
+              alt={cfg.title}
+              style={{ height: 44 * t.scale, width: 'auto', objectFit: 'contain', flexShrink: 0 }}
+            />
+          )}
+          <div style={{ minWidth: 0 }}>
+            <div
+              style={{
+                color: t.titleColor,
+                fontFamily: t.fontStack,
+                fontWeight: 800,
+                fontSize: 22 * t.scale,
+                letterSpacing: 0.3,
+                lineHeight: 1.1,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {cfg.title}
+            </div>
+            {cfg.subtitle && (
+              <div
+                style={{
+                  color: t.subtitleColor,
+                  fontFamily: t.fontStack,
+                  fontSize: 15 * t.scale,
+                  marginTop: 3 * t.scale,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {cfg.subtitle}
+              </div>
+            )}
+          </div>
+          {cfg.live && <LiveBadge accent={t.accent} scale={t.scale} />}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/overlay/zabal-games/README.md
+++ b/src/app/overlay/zabal-games/README.md
@@ -1,0 +1,55 @@
+# ZABAL Games stream overlay
+
+A generic, URL-configured browser-source overlay for ZABAL Games workshop streams.
+No login, no database, no data feed - everything is set via URL params, so any host
+can drop it into Restream Studio or OBS.
+
+Sibling to `overlay/now-playing` (which is per-user + music-data-bound). This one is
+brand-generic on purpose.
+
+## How to add it to a stream
+
+- **Restream Studio:** Add element -> Web page -> paste the overlay URL.
+- **OBS:** Sources -> add Browser source -> paste the URL. Set width 1920, height 1080,
+  and leave the background transparent (the overlay composites over your scene).
+
+## URL
+
+Base: `https://www.thezao.xyz/overlay/zabal-games`
+
+| Param | Values | Default | Notes |
+|-------|--------|---------|-------|
+| `style` | `lower-third` \| `banner` \| `scene` | `lower-third` | which layout |
+| `title` | text | `ZABAL GAMES` | main line / wordmark |
+| `subtitle` | text | (empty) | topic / message |
+| `live` | `1` \| `0` | `1` | pulsing LIVE badge (lower-third + banner) |
+| `theme` | `dark` \| `light` | `dark` | both readable over video |
+| `accent` | hex without `#` | `f5a623` | brand accent (rules, badge) |
+| `logo` | image URL | (text wordmark) | optional logo mark |
+| `pos` | `left` \| `right` | `left` | lower-third corner |
+| `size` | `small` \| `medium` \| `large` | `medium` | overall scale |
+| `scene` | `starting` \| `brb` \| `thanks` \| `custom` | `starting` | scene-card preset |
+
+Remember to URL-encode spaces (`%20`).
+
+## Examples
+
+Lower-third for a workshop:
+```
+/overlay/zabal-games?title=ZABAL%20Games&subtitle=Phase%202%20Workshop&live=1
+```
+
+Persistent top banner:
+```
+/overlay/zabal-games?style=banner&subtitle=Ship%20something%20every%20week
+```
+
+"Starting soon" full-screen card:
+```
+/overlay/zabal-games?style=scene&scene=starting&subtitle=We%20go%20live%20at%206pm%20ET
+```
+
+Custom brand color + logo:
+```
+/overlay/zabal-games?style=banner&accent=e0ddaa&logo=https://.../zabal-mark.png
+```

--- a/src/app/overlay/zabal-games/SceneCard.tsx
+++ b/src/app/overlay/zabal-games/SceneCard.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { OverlayConfig } from './page';
+import { tokensFor, withAlpha, KEYFRAMES } from './brand';
+
+interface Props {
+  cfg: OverlayConfig;
+}
+
+/** Preset copy per scene, overridable by ?title=/?subtitle=. */
+const SCENE_PRESETS: Record<string, { title: string; subtitle: string }> = {
+  starting: { title: 'Starting Soon', subtitle: 'Grab a seat — we go live shortly' },
+  brb: { title: 'Be Right Back', subtitle: 'Back in a moment' },
+  thanks: { title: 'Thanks for Watching', subtitle: 'See you next session' },
+  custom: { title: 'ZABAL GAMES', subtitle: '' },
+};
+
+/**
+ * Full-screen scene card for the between-content moments: starting / brb / thanks / custom.
+ * Centered wordmark + big headline + subtitle over a full-bleed branded ground.
+ * ?title= and ?subtitle= override the preset copy.
+ */
+export function SceneCard({ cfg }: Props) {
+  const t = tokensFor(cfg);
+  const preset = SCENE_PRESETS[cfg.scene] || SCENE_PRESETS.custom;
+  // page.tsx defaults title to "ZABAL GAMES" — treat that as "unset" so the preset headline wins.
+  const headline = cfg.title && cfg.title !== 'ZABAL GAMES' ? cfg.title : preset.title;
+  const sub = cfg.subtitle || preset.subtitle;
+  const dark = cfg.theme === 'dark';
+
+  return (
+    <>
+      <style>{KEYFRAMES}</style>
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          textAlign: 'center',
+          gap: 8 * t.scale,
+          background: dark
+            ? `radial-gradient(circle at 50% 40%, ${withAlpha(cfg.accent, 0.18)}, rgba(10,22,40,0.97) 60%)`
+            : `radial-gradient(circle at 50% 40%, ${withAlpha(cfg.accent, 0.14)}, rgba(248,246,240,0.98) 60%)`,
+          fontFamily: t.fontStack,
+        }}
+      >
+        <div
+          className="zg-animated"
+          style={{ animation: 'zg-fade-up 0.6s ease both', maxWidth: '80vw' }}
+        >
+          {cfg.logo ? (
+            <img
+              src={cfg.logo}
+              alt={cfg.title}
+              style={{ height: 72 * t.scale, width: 'auto', objectFit: 'contain', marginBottom: 24 * t.scale }}
+            />
+          ) : (
+            <div
+              style={{
+                color: t.accent,
+                fontWeight: 800,
+                fontSize: 20 * t.scale,
+                letterSpacing: 4,
+                textTransform: 'uppercase',
+                marginBottom: 20 * t.scale,
+              }}
+            >
+              {cfg.title}
+            </div>
+          )}
+          <div
+            style={{
+              color: t.titleColor,
+              fontWeight: 800,
+              fontSize: 64 * t.scale,
+              letterSpacing: -1,
+              lineHeight: 1.05,
+              textWrap: 'balance',
+            }}
+          >
+            {headline}
+          </div>
+          {sub && (
+            <div
+              style={{
+                color: t.subtitleColor,
+                fontSize: 24 * t.scale,
+                marginTop: 16 * t.scale,
+                textWrap: 'balance',
+              }}
+            >
+              {sub}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/overlay/zabal-games/TopBanner.tsx
+++ b/src/app/overlay/zabal-games/TopBanner.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { OverlayConfig } from './page';
+import { tokensFor, KEYFRAMES } from './brand';
+import { LiveBadge } from './LiveBadge';
+import { Wordmark } from './Wordmark';
+
+interface Props {
+  cfg: OverlayConfig;
+}
+
+/**
+ * Full-width top banner strip: brand wordmark left, message center, LIVE badge right.
+ * Good for a persistent header across a workshop scene.
+ */
+export function TopBanner({ cfg }: Props) {
+  const t = tokensFor(cfg);
+
+  return (
+    <>
+      <style>{KEYFRAMES}</style>
+      <div
+        className="zg-animated"
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          right: 0,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16 * t.scale,
+          padding: `${12 * t.scale}px ${28 * t.scale}px`,
+          background: t.panelBg,
+          borderBottom: `${3 * t.scale}px solid ${t.accent}`,
+          backdropFilter: 'blur(6px)',
+          animation: 'zg-fade-up 0.5s ease both',
+        }}
+      >
+        <Wordmark logo={cfg.logo} title={cfg.title} tokens={t} />
+        {cfg.subtitle && (
+          <div
+            style={{
+              flex: 1,
+              textAlign: 'center',
+              color: t.titleColor,
+              fontFamily: t.fontStack,
+              fontWeight: 600,
+              fontSize: 16 * t.scale,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {cfg.subtitle}
+          </div>
+        )}
+        {!cfg.subtitle && <div style={{ flex: 1 }} />}
+        {cfg.live && <LiveBadge accent={t.accent} scale={t.scale} />}
+      </div>
+    </>
+  );
+}

--- a/src/app/overlay/zabal-games/Wordmark.tsx
+++ b/src/app/overlay/zabal-games/Wordmark.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import type { Tokens } from './brand';
+
+interface Props {
+  logo: string;
+  title: string;
+  tokens: Tokens;
+}
+
+/** Logo image if a ?logo= URL was given, else a styled text wordmark. */
+export function Wordmark({ logo, title, tokens }: Props) {
+  if (logo) {
+    return (
+      <img
+        src={logo}
+        alt={title}
+        style={{ height: 40 * tokens.scale, width: 'auto', objectFit: 'contain', flexShrink: 0 }}
+      />
+    );
+  }
+  return (
+    <span
+      style={{
+        color: tokens.accent,
+        fontWeight: 800,
+        fontSize: 18 * tokens.scale,
+        letterSpacing: 2,
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+        flexShrink: 0,
+      }}
+    >
+      {title}
+    </span>
+  );
+}

--- a/src/app/overlay/zabal-games/brand.ts
+++ b/src/app/overlay/zabal-games/brand.ts
@@ -1,0 +1,49 @@
+import type { OverlayConfig } from './page';
+
+/** Shared visual tokens derived from config, so all three styles stay consistent. */
+export interface Tokens {
+  panelBg: string;
+  panelBorder: string;
+  titleColor: string;
+  subtitleColor: string;
+  accent: string;
+  fontStack: string;
+  scale: number;
+}
+
+const FONT_STACK =
+  '"Space Grotesk", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
+
+/** Add an alpha channel to a #rrggbb hex. alpha 0..1. */
+export function withAlpha(hex: string, alpha: number): string {
+  const h = hex.replace('#', '');
+  if (h.length !== 6) return hex;
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function tokensFor(cfg: OverlayConfig): Tokens {
+  const dark = cfg.theme === 'dark';
+  const scale = cfg.size === 'small' ? 0.82 : cfg.size === 'large' ? 1.25 : 1;
+  return {
+    // ZAO navy ground for dark, warm off-white for light — both readable over video.
+    panelBg: dark ? 'rgba(10, 22, 40, 0.92)' : 'rgba(248, 246, 240, 0.94)',
+    panelBorder: withAlpha(cfg.accent, 0.45),
+    titleColor: dark ? '#ffffff' : '#141e27',
+    subtitleColor: dark ? '#9ca3af' : '#4b5563',
+    accent: cfg.accent,
+    fontStack: FONT_STACK,
+    scale,
+  };
+}
+
+/** Keyframes string injected once per style via a plain <style> element (no dangerouslySetInnerHTML). */
+export const KEYFRAMES = `
+@keyframes zg-fade-up { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes zg-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+@media (prefers-reduced-motion: reduce) {
+  .zg-animated { animation: none !important; }
+}
+`;

--- a/src/app/overlay/zabal-games/layout.tsx
+++ b/src/app/overlay/zabal-games/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'ZABAL Games — Stream Overlay',
+  description: 'Generic OBS / Restream browser-source overlay for ZABAL Games workshops',
+  robots: 'noindex, nofollow',
+};
+
+/**
+ * Minimal layout for OBS / Restream browser source — no nav, no chrome.
+ * Transparent background so the overlay composites over the live scene.
+ * Mirrors src/app/overlay/now-playing/layout.tsx.
+ */
+export default function ZabalGamesOverlayLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ background: 'transparent', minHeight: '100vh', overflow: 'hidden' }}>
+      {children}
+    </div>
+  );
+}

--- a/src/app/overlay/zabal-games/page.tsx
+++ b/src/app/overlay/zabal-games/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { LowerThird } from './LowerThird';
+import { TopBanner } from './TopBanner';
+import { SceneCard } from './SceneCard';
+
+/**
+ * Generic ZABAL Games stream overlay — a browser source for OBS / Restream Studio.
+ *
+ * Unlike the now-playing overlay (per-user, Supabase-backed, music data), this is
+ * 100% URL-configured: no auth, no DB, no polling. Any workshop host pastes a URL
+ * into Restream's "web page" element or OBS "browser source" and gets a branded
+ * overlay. See research docs 215 (browser-source pattern) + 627 (StreamElements).
+ *
+ * URL params (all optional):
+ *   style    lower-third (default) | banner | scene
+ *   title    main text                          (default "ZABAL GAMES")
+ *   subtitle secondary line / topic             (default "")
+ *   live     1|true shows a pulsing LIVE badge  (default on for lower-third/banner)
+ *   theme    dark (default) | light
+ *   accent   hex WITHOUT the # (default f5a623) — brand accent for badges/rules
+ *   logo     image URL for a logo mark          (default: text wordmark)
+ *   pos      lower-third corner: left (default) | right
+ *   size     small | medium (default) | large
+ *   scene    scene mode: starting (default) | brb | thanks | custom
+ *
+ * Examples:
+ *   /overlay/zabal-games?title=ZABAL%20Games&subtitle=Phase%202%20Workshop&live=1
+ *   /overlay/zabal-games?style=banner&subtitle=Ship%20something%20every%20week
+ *   /overlay/zabal-games?style=scene&scene=starting&subtitle=Starting%20at%206pm%20ET
+ */
+export interface OverlayConfig {
+  title: string;
+  subtitle: string;
+  live: boolean;
+  theme: 'dark' | 'light';
+  accent: string;
+  logo: string;
+  pos: 'left' | 'right';
+  size: 'small' | 'medium' | 'large';
+  scene: string;
+}
+
+function parseConfig(params: URLSearchParams): OverlayConfig {
+  const truthy = (v: string | null, dflt: boolean): boolean => {
+    if (v === null) return dflt;
+    return v === '1' || v.toLowerCase() === 'true';
+  };
+  const accentRaw = (params.get('accent') || 'f5a623').replace(/^#/, '');
+  const accent = /^[0-9a-fA-F]{3,8}$/.test(accentRaw) ? `#${accentRaw}` : '#f5a623';
+  const theme = params.get('theme') === 'light' ? 'light' : 'dark';
+  const pos = params.get('pos') === 'right' ? 'right' : 'left';
+  const sizeRaw = params.get('size');
+  const size = sizeRaw === 'small' || sizeRaw === 'large' ? sizeRaw : 'medium';
+
+  return {
+    title: params.get('title') || 'ZABAL GAMES',
+    subtitle: params.get('subtitle') || '',
+    live: truthy(params.get('live'), true),
+    theme,
+    accent,
+    logo: params.get('logo') || '',
+    pos,
+    size,
+    scene: params.get('scene') || 'starting',
+  };
+}
+
+function OverlayInner() {
+  const searchParams = useSearchParams();
+  const style = searchParams.get('style') || 'lower-third';
+  const cfg = parseConfig(new URLSearchParams(searchParams.toString()));
+
+  switch (style) {
+    case 'banner':
+      return <TopBanner cfg={cfg} />;
+    case 'scene':
+      return <SceneCard cfg={cfg} />;
+    default:
+      return <LowerThird cfg={cfg} />;
+  }
+}
+
+export default function ZabalGamesOverlay() {
+  return (
+    <Suspense fallback={null}>
+      <OverlayInner />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
Generic, URL-configured browser-source overlay for ZABAL Games workshop streams. No login, no DB, no data feed - set via query params, drops into Restream Studio (Web page element) or OBS (Browser source).

Layouts via `?style=`: `lower-third` (default), `banner`, `scene` (starting/brb/thanks/custom). Params: title, subtitle, live, theme, accent, logo, pos, size, scene. See `src/app/overlay/zabal-games/README.md`.

WaveWarZ uses the per-user, music-bound `overlay/now-playing`. This is the brand-generic equivalent for workshops (browser-source pattern per doc 215 P0 / 532).

## Test
- typecheck clean (new files)
- `/overlay/zabal-games?title=ZABAL%20Games&subtitle=Phase%202%20Workshop&live=1`
- `/overlay/zabal-games?style=banner&subtitle=Ship%20every%20week`
- `/overlay/zabal-games?style=scene&scene=starting`