### PR TITLE
docs(overlay): fix ZABAL Games overlay URL to zaoos.com

### DIFF
--- a/src/app/overlay/zabal-games/README.md
+++ b/src/app/overlay/zabal-games/README.md
@@ -15,7 +15,7 @@ brand-generic on purpose.
 
 ## URL
 
-Base: `https://www.thezao.xyz/overlay/zabal-games`
+Base: `https://zaoos.com/overlay/zabal-games`
 
 | Param | Values | Default | Notes |
 |-------|--------|---------|-------|


### PR DESCRIPTION
README said thezao.xyz (the cowork app) but the overlay ships in ZAOOS, which deploys to zaoos.com. Corrects the base URL. Code unchanged.