### PR TITLE
fix(overlay): ZABAL Games - LIVE off by default, steady dot, transparent bg

### DIFF
--- a/src/app/overlay/zabal-games/LiveBadge.tsx
+++ b/src/app/overlay/zabal-games/LiveBadge.tsx
@@ -5,7 +5,7 @@ interface Props {
   scale: number;
 }
 
-/** Pulsing LIVE pill. Pauses animation under prefers-reduced-motion (see brand KEYFRAMES). */
+/** Steady on-air pill - a lit dot, no blink. A stream is always live, so this reads as ambient, not a toggled status. */
 export function LiveBadge({ accent, scale }: Props) {
   return (
     <span
@@ -25,13 +25,11 @@ export function LiveBadge({ accent, scale }: Props) {
       }}
     >
       <span
-        className="zg-animated"
         style={{
           width: 8 * scale,
           height: 8 * scale,
           borderRadius: 999,
           background: '#0a1628',
-          animation: 'zg-pulse 1.4s ease-in-out infinite',
         }}
       />
       Live

--- a/src/app/overlay/zabal-games/layout.tsx
+++ b/src/app/overlay/zabal-games/layout.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
 export default function ZabalGamesOverlayLayout({ children }: { children: React.ReactNode }) {
   return (
     <div style={{ background: 'transparent', minHeight: '100vh', overflow: 'hidden' }}>
+      {/* Force the app's global navy body/html to transparent so this route is a
+          true transparent browser source (in-browser too, not only via OBS custom CSS). */}
+      <style>{'html,body{background:transparent !important;}'}</style>
       {children}
     </div>
   );

--- a/src/app/overlay/zabal-games/page.tsx
+++ b/src/app/overlay/zabal-games/page.tsx
@@ -18,7 +18,7 @@ import { SceneCard } from './SceneCard';
  *   style    lower-third (default) | banner | scene
  *   title    main text                          (default "ZABAL GAMES")
  *   subtitle secondary line / topic             (default "")
- *   live     1|true shows a pulsing LIVE badge  (default on for lower-third/banner)
+ *   live     1|true shows a steady on-air dot     (default OFF - a stream is already live)
  *   theme    dark (default) | light
  *   accent   hex WITHOUT the # (default f5a623) — brand accent for badges/rules
  *   logo     image URL for a logo mark          (default: text wordmark)
@@ -58,7 +58,7 @@ function parseConfig(params: URLSearchParams): OverlayConfig {
   return {
     title: params.get('title') || 'ZABAL GAMES',
     subtitle: params.get('subtitle') || '',
-    live: truthy(params.get('live'), true),
+    live: truthy(params.get('live'), false),
     theme,
     accent,
     logo: params.get('logo') || '',


### PR DESCRIPTION
Feedback from testing on stream:
- LIVE badge defaulted ON and blinked like a toggled status - redundant on a live stream. Now default OFF; opt-in via ?live=1, and when on it is a steady on-air dot (no blink).
- Overlay must be a true transparent browser source. Forced html/body to transparent so it is transparent in-browser too, not just via OBS custom CSS.