### PR TITLE
doc 988: Empire Builder tokenless empire + leaderboard-airdrop (DISPATCH)

### DIFF
--- a/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
+++ b/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
@@ -17,7 +17,7 @@ tier: STANDARD
 
 > **2026-05-09 ownership correction:** $ZABAL Empire is NOT owned by Adam. Co-creators are **yerbearserker** (Jordan Oram, Empire Builder co-founder) + **Adrian** (Farcaster handle "divifly" per Zaal - did not resolve via warpcast username lookup; verify FID with yerbearserker). Adrian is the lead engineer behind Empire Builder. Earlier reference to "Adam / SongJam" in this doc was incorrect for ZABAL Empire ownership context (Adam owns SANG; he is a stakeholder in ZABAL but not the empire's guardian wallet here).
 
-> **"Empire Builder v3" status:** Zaal references "v3" but the public GitBook does NOT document a v3 vs v1/v2. Likely sources of the v3 label: (a) yerbearserker's internal version naming for current production build, (b) confusion with POIDH v3 (which IS publicly tagged v3), (c) an upcoming roadmap milestone not yet in docs. Treat the current `empirebuilder.world` production as the integration target unless yerbearserker confirms different endpoints.
+> **"Empire Builder v3" status (UPDATED 2026-05-09 LATER SAME DAY):** **CONFIRMED LIVE** via yerbearserker DM. Soft launch on `empirebuilder.world` 2026-05-09; official announcement Sunday 2026-05-11. Public API docs reorganized under `/api/public/` with read endpoints redesigned (GET by UUID + list-by-empire). **CRITICAL:** the inbound apiEndpoint schema is UNCHANGED - still `[{address, score}]` - so our `poidh-leaderboard.json` works as-is. The submission package below remains valid for v3.
 
 ## Architecture (Confirmed - REVERSE of initial draft)
 
@@ -522,6 +522,57 @@ Suggested config:
 Add it to $ZABAL Empire and we're live. Bounty 1151 has 2 submitters seeded;
 new POIDH bounties will land more. ZAO Stock Oct 3 will be the bigger pulse.
 ```
+
+## Part 11 - Empire Builder v3 New Read Endpoints (Confirmed 2026-05-09)
+
+After yerbearserker shipped v3, the read API was reorganized. These are the new public endpoints we can use on `poidh.html` Phase 2 to display live ZABAL Empire stats per submitter:
+
+### List leaderboards for an empire
+
+```
+GET https://www.empirebuilder.world/api/leaderboards?tokenAddress=<ZABAL_EMPIRE_ID>
+```
+
+Returns slots 1-20 (was 50 in v2). Pinned leaderboards appear first. Use this to discover the UUID of the POIDH Submitters leaderboard once Adrian creates it.
+
+### Get a single leaderboard's entries
+
+```
+GET https://www.empirebuilder.world/api/leaderboards/<leaderboard_uuid>
+```
+
+Response includes per-entry:
+
+| Field | Meaning |
+|-------|---------|
+| `address` | Wallet |
+| `rank` | Position (1 = top) |
+| `score` | Raw metric (our POIDH submission count, NOT boost-adjusted) |
+| `points` | Boost-adjusted score used for weighted distribution |
+| `farcaster_username` | Resolved FC handle (free, no Neynar key needed on our side) |
+| `totalRewards` | Lifetime USD received from this empire's distributions |
+
+Blocked addresses auto-excluded.
+
+### Other v3 public endpoints
+
+- `GET /api/public/get-distribution-records` - cumulative ZABAL per recipient
+- `GET /api/public/get-empire-rewards` - reward history (distributions, burns, airdrops)
+- `GET /api/public/get-boosters-by-empire` - list boosters configured for an empire
+- `GET /api/public/get-leaderboard-stats-for-single-address-within-empire` - per-address stats
+- `GET /api/public/get-empires` + `get-top-empires` - empire discovery
+
+### Phase 2 implementation idea
+
+Once Adrian creates the apiLeaderboard, swap `bettercallzaal.com/poidh.html` to fetch:
+
+```js
+const r = await fetch(`https://www.empirebuilder.world/api/leaderboards/${POIDH_LB_UUID}`);
+const { entries } = await r.json();
+// entries[i] has: address, rank, score, points, farcaster_username, totalRewards
+```
+
+This replaces our manual Neynar lookup + lets us show real ZABAL distribution amounts, real points (boost-adjusted), and pulled-from-EB Farcaster handles. Ships in 30 lines.
 
 ## Implementation Status (2026-05-09)
 

--- a/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
+++ b/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
@@ -1,0 +1,408 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-05-09
+related-docs: 625, 468, 584
+tier: STANDARD
+---
+
+# 626 - Empire Builder + ZABAL Empire: POIDH submitter airdrop architecture
+
+> **Goal:** Map Empire Builder's API + contract surface and design a BCZ webpage that scrapes POIDH submitter wallets, displays a leaderboard, and bulk-airdrops ZABAL via the existing $ZABAL Empire (run by Adam / SongJam at `songjam.space/zabal`). Companion to doc 625 (POIDH playbook).
+
+> **Trigger:** 2026-05-09 ask from Zaal: "make a basic webpage for POIDH submissions, connect Farcaster wallet via Hats, give each submitter a 1, send everyone who submitted some ZABAL". Bounty 1151 (BCZ YapZ Ep 17 clip task, 0.0105 ETH on Base, 2 participants so far) is the seed dataset.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Empire to use** | USE existing $ZABAL Empire (deployed via Empire Builder, leaderboard at `songjam.space/zabal`). Adam/SongJam owns it. DO NOT deploy a duplicate Empire for ZAO/BCZ - it splits liquidity + brand. |
+| **API surface** | USE `https://www.empirebuilder.world/api/...` REST endpoints with `X-API-Key` header. Confirmed live endpoint pattern: `POST /api/personal-stats/EMPIRE_TOKEN_ADDRESS` returns `{balance, boostedBalance, boost, rank, activeBoosterIds[]}`. Bulk-send endpoint exists per docs (verify path before coding). |
+| **POIDH data source** | SCRAPE on-chain. POIDH v3 contract emits events for bounty claims; index via Base RPC (Alchemy/Ankr/free public RPC). NO documented POIDH REST API as of 2026-05-09 - the website itself is Next.js client-rendered fetching from internal endpoints. Reverse-engineer via DevTools Network tab OR read PoidhV3 contract events directly. |
+| **Submitter "1" semantics** | TWO interpretations to confirm with Zaal: (a) "1 Hat" via Hats Protocol = role NFT each submitter holds (heavy infra, ~2-day build); (b) "1 booster" via Empire Builder = a custom booster ID applied to each submitter address that multiplies their leaderboard score. (b) is lighter, native to Empire Builder, ships in hours. RECOMMEND (b) unless Zaal wants the cross-platform-portable Hats role. |
+| **Wallet connect surface** | USE `@farcaster/miniapp-sdk` (already loaded in BCZ index.html for the Farcaster mini app context) to get the Farcaster user's verified address inside the mini app. OUTSIDE the mini app, fall back to wagmi + Coinbase Smart Wallet for browser users. |
+| **"Hats" interpretation** | LIKELY Hats Protocol (hatsprotocol.xyz) - on-chain role NFTs (ERC-1155). On Base, deployed at `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137`. Tree creation = ~$5 gas + ~10 min setup. Each submitter mints a hat = 1 transaction per address. ALTERNATIVELY "haatz" could be a typo / slang for the booster system - confirm with Zaal. |
+| **Page hosting** | ADD `bettercallzaal.com/poidh.html` as a third static page alongside `index.html` and `nexus.html`. Pure HTML + CDN-loaded JS (Empire Builder API client + viem for any chain reads). Match BCZ's existing dark + orange/cyan/gold aesthetic. No build step. |
+| **Bulk airdrop trigger** | DO NOT auto-airdrop. Page = read-only display + admin-only "Trigger Distribution" button gated by Zaal's wallet signature. Manual trigger calls Empire Builder bulk-send endpoint with the submitter list. Reasons: (1) prevents Sybil farming via spam submissions, (2) keeps Zaal in the loop on amounts, (3) Empire Builder API key MUST stay server-side, not exposed in static page. |
+| **Server-side bridge** | NEEDED for the airdrop trigger because Empire Builder API key cannot live in static HTML. OPTIONS: (a) Cloudflare Worker (~10 lines, free tier covers this), (b) Vercel serverless function, (c) Supabase Edge Function. RECOMMEND Cloudflare Worker - matches BCZ's static + zero-build philosophy. Read endpoints CAN be called direct from page if they're public; airdrop write must be proxied. |
+| **Sybil protection** | REQUIRE that submitter wallet has on-chain proof of POIDH claim NFT for the relevant bounty. Read PoidhClaimNFT contract on Base, verify wallet holds claim NFT for bounty 1151 (or `/a/thezao` album). No claim NFT = no leaderboard entry. Empire Builder boost only applied after on-chain verification. |
+| **Phase 1 scope (ship this week)** | Static page that (1) reads bounty 1151 + ZAO album submitters from PoidhV3 contract on Base, (2) displays leaderboard ranked by submission count + linked submission images, (3) shows ZABAL Empire booster status per address via Empire Builder API. NO airdrop button yet - that's Phase 2. |
+
+---
+
+## Part 1 - Empire Builder Mechanics (Confirmed 2026-05-09)
+
+### What it is
+
+**Empire Builder** = `empirebuilder.world` - a permissionless platform that lets any ERC-20 token gain leaderboard + booster + treasury infrastructure. You either deploy a brand-new Clanker token + Empire combo OR attach an Empire to an existing ERC-20.
+
+Three ecosystem entry points:
+1. **Web app** at `empirebuilder.world` - Connect wallet, browse Empires, migrate existing tokens, create new Empires
+2. **GitBook docs** at `empire-builder.gitbook.io/empire-builder-docs` - human-readable reference + dynamic `?ask=` query for AI-style answers
+3. **API** at `https://www.empirebuilder.world/api/...` - REST, JSON, X-API-Key auth
+
+### Empire = ERC-20 + Leaderboard contract
+
+| Component | What it does |
+|-----------|--------------|
+| ERC-20 token | Any existing or Clanker-launched token; the "currency" of the Empire |
+| Empire contract | Wraps the token; manages up to 50 leaderboards per token (`uint8 leaderboardId`) |
+| Booster system | Multipliers applied per address based on holdings, NFT ownership, custom rules |
+| Treasury | Empire-owned wallet that can distribute, burn, and authorize tokens |
+| Guardian | Owner role + co-guardian addresses for treasury operations |
+
+### API endpoints (verified)
+
+| Endpoint | Method | Purpose | Notes |
+|----------|--------|---------|-------|
+| `/api/personal-stats/<empire-token-address>` | POST | Get rank, balance, boost, activeBoosterIds for one address | Confirmed via GitBook example |
+| `/api/leaderboard/<empire-token-address>` | (assumed GET/POST) | Get full leaderboard | Per docs: "Get Leaderboard By Empire" |
+| `/api/empires` | GET | Paginated empire list | "Get Empires" |
+| `/api/empires/top` | GET | Top forged empires | "Get Top Empires" |
+| `/api/distribute/<empire-token-address>` | POST (auth-gated) | Bulk send tokens to leaderboard | "Distribute Tokens (Bulk Send)" - exact path TBD; verify in console |
+| `/api/empires/deploy` | POST | Deploy Empire for existing ERC-20 | "Deploy Empire for Existing Token" |
+| `/api/clanker/deploy-with-empire` | POST | Combined Clanker + Empire deploy | "Deploy Token with Attached Empire" |
+
+### Contract reads (Empire contract on Base)
+
+```solidity
+getLeaderboard(uint8 leaderboardId) returns (LeaderboardEntry[])
+getAllowedTokens() returns (address[])
+```
+
+These are FREE to call via any Base RPC - no API key needed. For BCZ static page, this is the cheap path: skip Empire Builder API entirely and read ZABAL Empire's leaderboard directly via viem + a public Base RPC.
+
+### Auth model
+
+- **Read endpoints** - Some are public, some require X-API-Key. Treat all as needing key until verified otherwise.
+- **Write endpoints** (deploy, distribute, burn) - ALWAYS require X-API-Key + signed tx via the Empire's owner/guardian wallet.
+
+### Known integrations
+
+- **Songjam $SANG** - launched on Empire Builder, leaderboard powers SongJam product
+- **$ZABAL Empire** - active at `songjam.space/zabal`, deployed via Empire Builder. 24H / 7D / All-time views. Stake multiplier requires 250k SANG min stake. Empire multiplier flows through Empire Builder Booster
+- **BizarreBeasts ($BB)** - example Empire featured in docs, contributed real-world use case content
+- **Loans on Base** - newest empire as of ZABAL AMA 2 (2026), Adam demoed creating it during the space
+
+---
+
+## Part 2 - $ZABAL Empire Ground Truth
+
+### Where it lives
+
+| Surface | URL |
+|---------|-----|
+| Leaderboard UI (canonical) | https://songjam.space/zabal |
+| ZABAL home / creative hub | https://zabal.art/ |
+| Empire Builder canonical | https://empirebuilder.world (search "ZABAL") |
+| Token contract address | TBD - get from `empirebuilder.world/<zabal-address>` page or songjam.space/zabal |
+
+### Multiplier stack
+
+Per ZABAL AMA 2 transcript:
+
+| Multiplier | Formula | Source |
+|------------|---------|--------|
+| Stake multiplier | `1 + sqrt(stakeAmount / 250000 SANG min)` | SongJam staking contract |
+| Empire multiplier | Pulled from Empire Builder Booster system | Empire Builder |
+| Total points | base balance x stake x empire | Combined onchain + offchain |
+
+### Who owns it
+
+Adam (SongJam founder, ZABAL stakeholder) runs the SANG Empire AND the ZABAL Empire (separate but linked tokens). Zaal coordinates strategy + content sprints + community. Adam controls the Empire's owner/guardian wallet - he is the person who can call `distributeTokens` on the ZABAL Empire contract, OR Zaal can be added as a co-guardian to do it independently.
+
+### What ZAO does today on it
+
+Per ZABAL AMA 2: content sprints. Members create content about ZABAL, submit it, then ZAO Respect-holders vote (on Songjam OR Empire Builder OR Incented). Voting weighted by Respect.
+
+This POIDH-airdrop integration extends the model: instead of voting, the trigger is **on-chain proof of POIDH bounty submission** = automatic ZABAL distribution.
+
+---
+
+## Part 3 - POIDH Data Source (No Public API)
+
+POIDH does not document a public REST API as of 2026-05-09. Three viable data paths:
+
+### Path A: Reverse-engineer poidh.xyz internal API (FAST)
+
+POIDH is a Next.js app. Open DevTools Network tab on any bounty page (e.g. `poidh.xyz/base/bounty/1151`). The client makes XHR/fetch calls to internal endpoints like `/api/bounty/[chainId]/[bountyId]` and `/api/album/[name]/bounties`. These return JSON. Cache + use them.
+
+**Risk:** undocumented API can change without notice. Add caching layer + log when responses break.
+
+### Path B: PoidhV3 contract events on Base (DURABLE)
+
+Contract: `picsoritdidnthappen/poidh-contracts` (GitHub). Read events like `BountyCreated`, `ClaimSubmitted`, `ClaimAccepted`. Filter by issuer = `@thezao` wallet OR by bounty ID.
+
+```typescript
+// pseudocode
+const claims = await viem.getContractEvents({
+  address: POIDH_V3_BASE,
+  eventName: 'ClaimSubmitted',
+  args: { bountyId: 1151n },
+  fromBlock: 'earliest',
+});
+const submitters = [...new Set(claims.map(c => c.args.claimer))];
+```
+
+This is the bulletproof path. Slower to write but doesn't break when POIDH changes their UI.
+
+### Path C: Album scrape via OG image meta
+
+`poidh.xyz/a/thezao` returns `<meta property="og:image" content=".../api/og/album?album=thezao&...participants=0xAAA,0xBBB&...">`. The `participants` query param IS the submitter list, comma-separated 0x addresses. Scrape this for a quick MVP.
+
+**Verified 2026-05-09:** bounty 1151 OG image had `participants=0x7234c36a71ec237c2ae7698e8916e0735001e9af,0x4200ac338555e25b20c8fe82ac02a5c8d4e5a5b4` - 2 submitters confirmed.
+
+### Recommended
+
+**Phase 1 (this week):** Path C - parse OG meta for fast MVP, no on-chain calls. Low cost.
+**Phase 2 (production):** Path B - read PoidhV3 events for accurate, real-time submitter list with Sybil protection (verify claim NFT held).
+
+---
+
+## Part 4 - Hats Protocol Integration (If Confirmed)
+
+### What Hats is
+
+Hats Protocol (`hatsprotocol.xyz`) - on-chain ERC-1155 role NFTs in a tree structure. Each "hat" represents a role. Wearers can be granted/revoked. Hats are non-transferable.
+
+### On Base
+
+| Contract | Address |
+|----------|---------|
+| Hats core | `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137` |
+| Hats SDK | npm `@hatsprotocol/sdk-v1-core` |
+| App UI | `app.hatsprotocol.xyz` |
+
+### Tree design for ZAO POIDH
+
+```
+ROOT: ZAO Top Hat (admin, wearer = Zaal)
+ └─ Child: POIDH Submitter Hat (id: e.g. 0x...0001)
+     - Wearer count: unlimited
+     - Eligibility: address holds PoidhClaimNFT for /a/thezao bounty
+     - Toggle: never expires (or 365d)
+     - Mutability: mutable (can be edited)
+     - Image: ZAO chevron + camera icon
+```
+
+### Cost
+
+| Action | Cost (Base) |
+|--------|-------------|
+| Create top hat | ~0.0001 ETH (~$0.25) one-time |
+| Create child hat | ~0.0001 ETH one-time |
+| Mint hat to address | ~0.00005 ETH per address |
+| Read hat (check wearer) | FREE (view function) |
+
+For 100 POIDH submitters, total mint cost ~0.005 ETH = ~$12. Cheap.
+
+### Why it matters (if Zaal confirms)
+
+A hat = portable proof of "I submitted to ZAO POIDH". Other apps can read this and grant access (e.g. ZAO Stock priority entry, fractal call invite, future airdrops). Empire Builder booster is ZABAL-specific; Hats are ecosystem-wide.
+
+### When NOT to use Hats
+
+If Zaal just wants the leaderboard + ZABAL airdrop and nothing else, skip Hats. Empire Builder's native booster system covers it. Hats only justifies the cost when you want the role to be portable across surfaces.
+
+---
+
+## Part 5 - BCZ Webpage Spec (`bettercallzaal.com/poidh.html`)
+
+### Goal
+
+Single static HTML page on bettercallzaal.com that:
+1. Reads ZAO POIDH album submitters
+2. Shows leaderboard (submission count + linked claim images)
+3. (Phase 2) Connects Farcaster wallet, lets Zaal trigger ZABAL airdrop
+
+### Sections
+
+```
+┌─────────────────────────────────────────────────┐
+│  ZAO POIDH LEADERBOARD                          │
+│  (BCZ orange/cyan/gold dark theme)              │
+├─────────────────────────────────────────────────┤
+│  Top stat row:                                  │
+│  [Total Submissions] [Total ETH Paid Out]       │
+│  [Active Bounties] [Unique Submitters]          │
+├─────────────────────────────────────────────────┤
+│  Featured: Bounty 1151 (BCZ YapZ Ep 17)        │
+│  - Embedded POIDH frame OR linked image         │
+│  - Live submitter count + thumbnails            │
+├─────────────────────────────────────────────────┤
+│  Leaderboard table:                             │
+│  Rank | Wallet | FC handle | Submissions | ZABAL│
+│   1   | 0x7234 | @user1    |     5       | 250  │
+│   2   | 0x4200 | @user2    |     3       | 150  │
+│  ...                                            │
+├─────────────────────────────────────────────────┤
+│  [Admin only] Trigger ZABAL distribution        │
+│  (Visible only when connected wallet = Zaal)    │
+└─────────────────────────────────────────────────┘
+```
+
+### Tech stack
+
+| Layer | Choice | Reason |
+|-------|--------|--------|
+| HTML/CSS | Hand-written, BCZ palette | Match existing site |
+| Wallet connect | `@farcaster/miniapp-sdk` (in mini app) + viem (browser) | Already loaded in BCZ index |
+| FC handle resolver | Neynar `getUserByVerifiedAddress` | Have ZAO Neynar API key already |
+| POIDH data | Phase 1: parse `/a/thezao` OG meta. Phase 2: PoidhV3 events via Base RPC | Cheap MVP, durable v2 |
+| Empire Builder data | `https://www.empirebuilder.world/api/personal-stats/<zabal>` | Per address; cache for 60s |
+| Airdrop trigger | Cloudflare Worker proxying Empire Builder bulk-send endpoint | Hides API key |
+| ZABAL token math | Read `getLeaderboard()` from ZABAL Empire contract | Free RPC call |
+
+### Files
+
+```
+bettercallzaal.com/
+├── poidh.html              # NEW - this page
+├── poidh-worker.js         # NEW - CF Worker source (deploy separately)
+├── index.html              # untouched
+├── nexus.html              # add link to /poidh.html
+└── assets/
+    └── poidh-icon.svg      # NEW - small page icon
+```
+
+### Phase 1 ship (1-2 days)
+
+- [ ] Build static `poidh.html` with hardcoded bounty 1151 data + 2 known submitters
+- [ ] Hook up Neynar handle resolver for the 2 addresses
+- [ ] Layout + dark theme polish
+- [ ] Deploy via git push to BCZ main
+- [ ] Add link from nexus.html
+
+### Phase 2 ship (1 week)
+
+- [ ] Cloudflare Worker for Empire Builder API proxy
+- [ ] Read PoidhV3 events on Base for live submitter list
+- [ ] Show ZABAL Empire stats per submitter (rank, boost, balance)
+- [ ] Admin-only "Trigger Airdrop" button gated by Zaal's wallet signature
+- [ ] Sybil protection: verify claim NFT held before counting submission
+
+### Phase 3 ship (optional, 1 week)
+
+- [ ] Hats Protocol integration if Zaal confirms portable role intent
+- [ ] Mint POIDH Submitter Hat per verified submitter
+- [ ] Public hat-wearers list as alternative leaderboard view
+
+---
+
+## Part 6 - Bounty 1151 Specifics (Live Reference)
+
+| Field | Value |
+|-------|-------|
+| URL | https://poidh.xyz/base/bounty/1151 |
+| Title | "Find your favorite clip from BCZ YapZ Ep 17 (Hannah / Farm Drop) and post it to either X, Instagram, or YouTube with a written comment about what it says to you." |
+| Chain | Base (chainId 8453) |
+| Reward | 0.0105 ETH (~$24.30 at $2313.69 ETH price embedded in OG) |
+| Participants (verified 2026-05-09) | 2 wallets: `0x7234c36a71ec237c2ae7698e8916e0735001e9af`, `0x4200ac338555e25b20c8fe82ac02a5c8d4e5a5b4` |
+| OG image API | `https://poidh.xyz/api/og/bounty?title=...&amount=10500000000000000&chainId=8453&participants=0x7234...,0x4200...` |
+| Sub-album | `/a/thezao` (verify) |
+
+This is the seed dataset for Phase 1 MVP.
+
+---
+
+## Specific Numbers
+
+| Metric | Value |
+|--------|-------|
+| Empire Builder API base URL | `https://www.empirebuilder.world/api/...` |
+| Auth method | `X-API-Key` header (request from team via @glankerempire) |
+| Empire leaderboard cap | 50 leaderboards per Empire (`uint8 leaderboardId`) |
+| Hats Protocol on Base | `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137` |
+| Hats child hat creation cost | ~0.0001 ETH (~$0.25) |
+| Hats mint per address cost | ~0.00005 ETH (~$0.12) |
+| ZABAL Empire URL | https://songjam.space/zabal |
+| ZABAL stake minimum | 250,000 $SANG (Adam's stake-multiplier formula) |
+| Stake multiplier formula | 1 + sqrt(stakeAmount / 250k SANG min) |
+| Bounty 1151 reward | 0.0105 ETH on Base |
+| Bounty 1151 participants (2026-05-09) | 2 unique wallets |
+| ETH price embedded in POIDH OG | $2313.69 (as of 2026-05-09) |
+| Phase 1 build est | 1-2 days |
+| Phase 2 build est | 1 week |
+| Phase 3 (Hats) build est | 1 week |
+| BCZ existing pages | 2 (`index.html`, `nexus.html`) |
+| BCZ index.html size | 50319 bytes (1378 lines) |
+| BCZ nexus.html size | 33784 bytes |
+
+---
+
+## Comparison: Distribution Mechanism Options
+
+| Option | Setup time | Per-recipient cost | Cross-platform portable | Sybil resistance |
+|--------|-----------|--------------------|-----------------------|------------------|
+| **Empire Builder bulk-send** | Same day (request API key) | Gas split across batch | NO (ZABAL only) | Token-gated by Empire rules |
+| **Hats Protocol mint** | 1 hour (set up tree) | ~$0.12/address | YES (ERC-1155, all of Ethereum) | Hat eligibility module |
+| **Manual ETH transfers** | Already doable | Per-tx gas | N/A | Trust Zaal's curation |
+| **Direct ERC-20 transfers** | Hour | Per-tx gas | N/A | Trust Zaal's curation |
+| **Merkle drop** (custom contract) | 2-3 days | Cheap per claim | Limited | Strong (commit-reveal) |
+
+For ZAO POIDH airdrop primary: **Empire Builder bulk-send + Empire Builder booster on submitters' addresses**. Add **Hats Protocol** only if portable cross-platform role is desired.
+
+---
+
+## ZAO Ecosystem Integration
+
+Touchpoints:
+- `bettercallzaal.com/poidh.html` (NEW) - this page
+- `bettercallzaal.com/nexus.html` - add a "POIDH Leaderboard" tile linking to /poidh.html
+- `community.config.ts` (ZAO OS) - reference ZABAL Empire URL + token address
+- `bots/poidh/` (per doc 468) - bot can post airdrop notifications
+- `bots/poidh/bounty-generator.mjs` (per doc 625) - 18 bounty templates feed page's "active bounties" section
+
+Related docs:
+- Doc 625 - POIDH x ZAO bounty playbook (operational, sister doc)
+- Doc 468 - POIDH Farcaster bot architecture
+- Doc 584 - ZABAL Nexus link inventory (where this page goes in nav)
+
+External integrations to confirm:
+- Adam (SongJam) - confirm Zaal wants co-guardian on $ZABAL Empire OR Adam triggers airdrops on Zaal's behalf
+- Empire Builder team (`@glankerempire` on X / Farcaster) - request X-API-Key for ZAO/BCZ
+- Hats Protocol (only if Phase 3 confirmed) - app.hatsprotocol.xyz tree builder
+
+---
+
+## Sources
+
+- [Empire Builder home](https://empirebuilder.world) - confirmed live, "From Dream to Empire", Vercel-hosted Next.js
+- [Empire Builder Docs (GitBook)](https://empire-builder.gitbook.io/empire-builder-docs) - API surface, contract reads/writes, ecosystem participation
+- [Empire Builder API: personal-stats endpoint](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/get-leaderboard-stats-for-single-address-within-empire) - confirmed POST + X-API-Key + JSON body pattern
+- [Empire contracts read functions](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/contracts/empire-contracts-read) - getLeaderboard, getAllowedTokens
+- [ZABAL Empire on songjam.space](https://songjam.space/zabal) - confirmed live, 24H/7D/All views, multiplier formulas
+- [ZABAL.art creative hub](http://zabal.art/) - confirmed Empire Builder integration
+- [ZABAL AMA 2 transcript (AlphaGrowth)](https://alphagrowth.io/spaces/zabal-ama-2-rugged-twice-to-start) - context on Adam, Loans on Base demo, content sprint mechanic
+- [POIDH bounty 1151](https://poidh.xyz/base/bounty/1151) - seed dataset, OG meta confirmed 2 participants
+- [Hats Protocol docs](https://docs.hatsprotocol.xyz) - Base contract address, SDK
+- [PoidhV3 contracts repo](https://github.com/picsoritdidnthappen/poidh-contracts) - event surface for on-chain reads
+- [Bountycaster](https://bountycaster.xyz) - alternative bounty surface, off-chain trust
+- ZAO internal: doc 625 (playbook), doc 468 (bot architecture), `community.config.ts`
+
+Verified URLs 2026-05-09: empirebuilder.world HTTP 200, empire-builder.gitbook.io HTTP 200, songjam.space/zabal HTTP 200, poidh.xyz/base/bounty/1151 HTTP 200, zabal.art HTTP 200.
+
+---
+
+## Also See
+
+- [Doc 625 - POIDH x ZAO bounty playbook](../../community/625-poidh-zao-bounty-playbook/) - operational layer (what to post, prize curves)
+- [Doc 468 - POIDH Farcaster bot architecture](../../agents/468-zao-farcaster-hub-poidh-hypersub-dual-hub/) - automation layer
+- [Doc 584 - ZABAL Nexus link inventory](../../business/584-zabal-nexus-link-inventory/) - where /poidh.html slots in BCZ nav
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| **CONFIRM**: "give them each a 1" = Empire Builder booster (recommended) OR Hats Protocol role NFT (heavier) | @Zaal | Decision | Before Phase 1 build |
+| **CONFIRM**: Adam adds Zaal as co-guardian on $ZABAL Empire, OR Adam triggers airdrops on Zaal's behalf | @Zaal -> @Adam | Coordination | Before Phase 2 |
+| Request X-API-Key from Empire Builder team (`@glankerempire`) | @Zaal | DM/cast | Today |
+| Get $ZABAL Empire token contract address from Adam | @Zaal | DM | Today |
+| Build Phase 1 `poidh.html` with hardcoded bounty 1151 data + Neynar handle resolver | @Zaal | New file in BCZ repo | This week |
+| Add `/poidh.html` link to nexus.html "ZAO Ecosystem" section | @Zaal | Edit nexus.html | This week |
+| Phase 2 - Cloudflare Worker + on-chain submitter scrape via PoidhV3 events | @Zaal | Worker + page update | Next 2 weeks |
+| Phase 3 (only if Hats confirmed) - deploy ZAO Top Hat tree on Base + POIDH Submitter Hat | @Zaal | Hats SDK | Month 2 |
+| Re-validate Empire Builder API surface in 30 days (the API is in active development) | @Zaal | Doc update | 2026-06-09 |

--- a/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
+++ b/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
@@ -574,6 +574,59 @@ const { entries } = await r.json();
 
 This replaces our manual Neynar lookup + lets us show real ZABAL distribution amounts, real points (boost-adjusted), and pulled-from-EB Farcaster handles. Ships in 30 lines.
 
+## Part 12 - POIDH Data Source: tRPC over poidh-app (Confirmed 2026-05-09)
+
+The poidh-app repo (`github.com/picsoritdidnthappen/poidh-app`, prod branch, last push 2026-05-02) is a Next.js + tRPC + Prisma + Postgres stack. tRPC procedures are exposed publicly at `https://poidh.xyz/api/trpc/<router>.<procedure>`. No API key required for reads.
+
+### Procedures used by `scripts/refresh-poidh-leaderboard.py`
+
+| Procedure | Input | Returns |
+|-----------|-------|---------|
+| `bounties.fetchByAlbum` | `{album, status, limit, cursor?}` | Items list with bounty `id`, `chainId`, `title`, `issuer`, `amount`, `extra.album`, etc. Statuses: `open`, `progress` (voting), `past` (closed). Album match is case-insensitive on the `BountiesExtra.album` column. |
+| `claims.fetchBountyClaims` | `{bountyId, chainId, limit, cursor?}` | Items list with claim `id`, `issuer`, `title`, `isAccepted`, image url. Issuer here = the wallet that submitted the claim, NOT the bounty owner. |
+| `bounties.fetch` | `{id, chainId}` | Single bounty with `extra.album` (canonical album name), `amount` (wei string), participants, claim count. |
+
+### Two key gotchas verified
+
+1. **Album for ZAO bounties is `wethemmedia`, NOT `thezao`.** Verified via `bounties.fetch({id:1151,chainId:8453}).extra.album = "wethemmedia"`. The `poidh.xyz/a/thezao` URL exists in the OG meta but resolves to an empty album in the DB. Probably an old or aspirational link.
+2. **OG image `participants[]` query param is misleading.** It contains funders + voters of open bounties (joined-bounty contributors), NOT claim submitters. Real submitter list comes from `claims.fetchBountyClaims`. For bounty 1151 the OG showed 2 addresses but there were actually 11 claims from 10 unique wallets, plus the issuer Zaal as a "participant" because the bounty is multiplayer/joined.
+
+### Real numbers (2026-05-09 first scrape)
+
+| Metric | Value |
+|--------|-------|
+| Album | wethemmedia |
+| Bounties (total) | 12 |
+| Bounties (open) | 6 |
+| Bounties (voting) | 1 |
+| Bounties (past) | 5 |
+| Chain split | 10 Arbitrum, 2 Base |
+| Claims (total) | 68 |
+| Unique submitters | 37 |
+| Top scorer | `0x849e...6421` with 7 submissions |
+| Total ETH in escrow | 0.3232 ETH (~$750) |
+| Issuers | Zaal `0x7234...e9af`, We The Media `0x7cccff60...`, `0x4200...a5b4` |
+
+### Phase 2 worker pattern
+
+Drop the script into a Cloudflare Worker on a 5-min cron:
+
+```js
+// poidh-leaderboard-worker.js
+export default {
+  async scheduled(event, env, ctx) {
+    const json = await fetchLeaderboard("wethemmedia");
+    await env.LB_KV.put("poidh-leaderboard.json", JSON.stringify(json), { expirationTtl: 600 });
+  },
+  async fetch(req, env) {
+    const cached = await env.LB_KV.get("poidh-leaderboard.json", "json");
+    return new Response(JSON.stringify(cached), { headers: { "content-type": "application/json", "access-control-allow-origin": "*" } });
+  }
+};
+```
+
+Edge cache + cron = always-fresh feed, $0/month on Cloudflare free tier.
+
 ## Implementation Status (2026-05-09)
 
 | Task | Status | Notes |

--- a/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
+++ b/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
@@ -15,6 +15,10 @@ tier: STANDARD
 
 > **Architecture confirmed 2026-05-09 (mid-session correction):** Direction is REVERSED from initial draft. Empire Builder pulls FROM BCZ (not BCZ pushes TO Empire Builder). Mechanism = **API-sourced Leaderboard** via `POST /api/leaderboards/apiLeaderboards` with `apiEndpoint` pointing to a public BCZ JSON URL returning `[{address, score}]`. Empire Builder refreshes the leaderboard, applies ZABAL boosters, distributes. BCZ does not need an Empire Builder API key. Zaal hands Empire Builder team the BCZ URL and they configure the leaderboard from their side. SHIPPED 2026-05-09: `bettercallzaal.com/poidh.html` (UI) + `bettercallzaal.com/poidh-leaderboard.json` (feed). "Haatz" clarified = free Neynar API for Farcaster wallet -> handle resolution, not Hats Protocol.
 
+> **2026-05-09 ownership correction:** $ZABAL Empire is NOT owned by Adam. Co-creators are **yerbearserker** (Jordan Oram, Empire Builder co-founder) + **Adrian** (Farcaster handle "divifly" per Zaal - did not resolve via warpcast username lookup; verify FID with yerbearserker). Adrian is the lead engineer behind Empire Builder. Earlier reference to "Adam / SongJam" in this doc was incorrect for ZABAL Empire ownership context (Adam owns SANG; he is a stakeholder in ZABAL but not the empire's guardian wallet here).
+
+> **"Empire Builder v3" status:** Zaal references "v3" but the public GitBook does NOT document a v3 vs v1/v2. Likely sources of the v3 label: (a) yerbearserker's internal version naming for current production build, (b) confusion with POIDH v3 (which IS publicly tagged v3), (c) an upcoming roadmap milestone not yet in docs. Treat the current `empirebuilder.world` production as the integration target unless yerbearserker confirms different endpoints.
+
 ## Architecture (Confirmed - REVERSE of initial draft)
 
 ```
@@ -428,6 +432,97 @@ Verified URLs 2026-05-09: empirebuilder.world HTTP 200, empire-builder.gitbook.i
 
 ---
 
+## Part 7 - All Five Leaderboard Types (Confirmed 2026-05-09)
+
+The `Add New Leaderboard` modal has 5 type options; only API-Sourced applies for our POIDH integration. Listed for reference:
+
+| Type | Endpoint | Use case |
+|------|----------|----------|
+| **Token Holders** | `POST /api/leaderboards/tokenHoldersLeaderboards` | Rank by ERC-20 balance of any token on Base/Arb |
+| **Stakers** | `POST /api/leaderboards/stakersLeaderboards` | Rank by on-chain stake in immutable StakingLocker (Base 8453, Arb 42161). Adds STAKING boosters (capped +5x) |
+| **NFT Holders** | `POST /api/leaderboards/nftLeaderboards` | Rank by ERC-721 or ERC-1155 holdings; supports specific tokenId for 1155 |
+| **API-Sourced** (USE THIS) | `POST /api/leaderboards/apiLeaderboards` | Pulls `[{address, score}]` from external URL; refreshable on demand |
+| **CSV Upload** | `POST /api/leaderboards/csvLeaderboards` (multipart/form-data) | One-shot CSV with addresses + scores; doesn't auto-refresh |
+
+## Part 8 - Add New Leaderboard Modal Field Mapping (UI Screenshot 2026-05-09)
+
+| Modal field | API field | Limit / format | POIDH submission value |
+|-------------|-----------|----------------|------------------------|
+| Leaderboard Name | `name` | Max 20 chars | `POIDH Submitters` (16 chars) |
+| Description | `description` | Max 80 chars | `Submit to ZAO POIDH bounties to climb. ZABAL distributed by score.` (66 chars) |
+| Upload Icon (Optional) | `icon` | URL to PNG/JPG/GIF, max 1MB | `https://bettercallzaal.com/assets/icon.png` |
+| API Endpoint URL | `apiEndpoint` | HTTPS URL returning `[{address, score}]` | `https://bettercallzaal.com/poidh-leaderboard.json` |
+| Token Boosters toggle | `applyBoosters` | Boolean (default ON in modal) | `true` - lets ZABAL/SANG/ZORO holders earn extra |
+| Reputation Boosters toggle | `apply_reputation_boosters` | Boolean (default ON in modal) | `true` - lets high-rep submitters earn extra |
+
+## Part 9 - Booster Type Reference (Confirmed via EB docs ?ask=)
+
+| Type | Trigger | Multiplier source | Stacks with others? |
+|------|---------|-------------------|---------------------|
+| **Token Boosters** | Wallet holds configured ERC-20 OR NFT | Multiplies leaderboard points (raw score unchanged) | YES - additive with other token + reputation boosters |
+| **Reputation Boosters** | Wallet meets configured reputation threshold | Multiplies points based on reputation tier | YES - additive |
+| **Staking Boosters** (auto, only on stakers leaderboard) | Wallet has on-chain stake in StakingLocker | Adds capped +5x for the staking portion | YES - capped at +5x for staking portion |
+
+For the POIDH apiLeaderboard, both Token + Reputation toggle ON in modal = strongest. POIDH submitters who also hold ZABAL/SANG/ZORO get bigger ZABAL distributions; high-reputation submitters (Talent Protocol, etc) get extra on top.
+
+## Part 10 - Prepared Submission Package (Hand This to yerbearserker / Adrian)
+
+### Method 1: Have yerbearserker / Adrian fill the modal
+
+```
+Leaderboard Name:    POIDH Submitters
+Description:         Submit to ZAO POIDH bounties to climb. ZABAL distributed by score.
+Upload Icon:         https://bettercallzaal.com/assets/icon.png
+API Endpoint URL:    https://bettercallzaal.com/poidh-leaderboard.json
+Token Boosters:      ON
+Reputation Boosters: ON
+```
+
+### Method 2: API call (if they prefer scripted)
+
+```bash
+curl -X POST "https://www.empirebuilder.world/api/leaderboards/apiLeaderboards" \
+  -H "x-api-key: <THEIR_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tokenAddress": "<ZABAL_EMPIRE_TOKEN_ADDRESS>",
+    "apiEndpoint": "https://bettercallzaal.com/poidh-leaderboard.json",
+    "name": "POIDH Submitters",
+    "description": "Submit to ZAO POIDH bounties to climb. ZABAL distributed by score.",
+    "applyBoosters": true,
+    "apply_reputation_boosters": true,
+    "icon": "https://bettercallzaal.com/assets/icon.png",
+    "signature": "<GUARDIAN_SIGNATURE>",
+    "message": "Create API leaderboard for <ZABAL_EMPIRE_TOKEN_ADDRESS>",
+    "signerAddress": "<GUARDIAN_WALLET>"
+  }'
+```
+
+Refresh: `PATCH /api/leaderboards/refresh/apiLeaderboards` with same auth.
+
+### DM template (Farcaster / Telegram)
+
+```
+Hey @yerbearserker (cc Adrian) - shipped a POIDH submitter leaderboard
+on bettercallzaal.com/poidh.html. Public JSON feed ready for ZABAL Empire
+apiLeaderboard:
+
+  https://bettercallzaal.com/poidh-leaderboard.json
+
+Format: [{address, score}] - matches Empire Builder spec exactly.
+Phase 1 = manual updates as bounties land winners; Phase 2 = on-chain
+PoidhV3 event scrape via CF Worker.
+
+Suggested config:
+  Name:        POIDH Submitters
+  Description: Submit to ZAO POIDH bounties to climb. ZABAL distributed by score.
+  Token + Reputation Boosters: both ON
+  Icon: bettercallzaal.com/assets/icon.png
+
+Add it to $ZABAL Empire and we're live. Bounty 1151 has 2 submitters seeded;
+new POIDH bounties will land more. ZAO Stock Oct 3 will be the bigger pulse.
+```
+
 ## Implementation Status (2026-05-09)
 
 | Task | Status | Notes |
@@ -443,8 +538,9 @@ Verified URLs 2026-05-09: empirebuilder.world HTTP 200, empire-builder.gitbook.i
 
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
-| Send `https://bettercallzaal.com/poidh-leaderboard.json` URL to Empire Builder team / $ZABAL Empire guardian (Adam) for apiLeaderboards configuration | @Zaal -> @Adam / @glankerempire | DM | Today |
-| Confirm $ZABAL Empire token address + leaderboard ID once apiLeaderboard is created | @Zaal | DM | This week |
+| Send DM template (Part 10) + `https://bettercallzaal.com/poidh-leaderboard.json` to **yerbearserker** + **Adrian (divifly)** for apiLeaderboards setup on $ZABAL Empire | @Zaal -> @yerbearserker + Adrian | Farcaster DM | Today |
+| Confirm Adrian's verified Farcaster FID (handle "divifly" did not resolve via warpcast username lookup; possibly different handle or unverified FID) | @Zaal | Verify | Today |
+| Confirm $ZABAL Empire `tokenAddress` (the empire_id) + which guardian wallet will sign the create-leaderboard tx | @Zaal | DM | This week |
 | Update `poidh-leaderboard.json` as new POIDH bounties land submitters (or build automation) | @Zaal | File edit / Phase 2 | Ongoing |
 | Phase 2 - replace static JSON with PoidhV3 event indexer (Cloudflare Worker reads Base RPC, returns live JSON) | @Zaal | New CF Worker | Next 2-3 weeks |
 | Phase 2.5 - resolve submitter wallets to Farcaster handles via Neynar free tier and embed in JSON feed | @Zaal | Worker addition | Phase 2 |

--- a/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
+++ b/research/business/626-empire-builder-zabal-poidh-airdrop/README.md
@@ -13,12 +13,47 @@ tier: STANDARD
 
 > **Trigger:** 2026-05-09 ask from Zaal: "make a basic webpage for POIDH submissions, connect Farcaster wallet via Hats, give each submitter a 1, send everyone who submitted some ZABAL". Bounty 1151 (BCZ YapZ Ep 17 clip task, 0.0105 ETH on Base, 2 participants so far) is the seed dataset.
 
+> **Architecture confirmed 2026-05-09 (mid-session correction):** Direction is REVERSED from initial draft. Empire Builder pulls FROM BCZ (not BCZ pushes TO Empire Builder). Mechanism = **API-sourced Leaderboard** via `POST /api/leaderboards/apiLeaderboards` with `apiEndpoint` pointing to a public BCZ JSON URL returning `[{address, score}]`. Empire Builder refreshes the leaderboard, applies ZABAL boosters, distributes. BCZ does not need an Empire Builder API key. Zaal hands Empire Builder team the BCZ URL and they configure the leaderboard from their side. SHIPPED 2026-05-09: `bettercallzaal.com/poidh.html` (UI) + `bettercallzaal.com/poidh-leaderboard.json` (feed). "Haatz" clarified = free Neynar API for Farcaster wallet -> handle resolution, not Hats Protocol.
+
+## Architecture (Confirmed - REVERSE of initial draft)
+
+```
+                         POIDH submitters
+                                |
+                                v
+                  PoidhV3 contract on Base + UI
+                                |
+                                v
+                    BCZ scrape / curate manually
+                                |
+                                v
+       bettercallzaal.com/poidh-leaderboard.json   <-- public feed
+           [ {address, score}, ... ]                   (no auth needed)
+                                |
+                                v   (Empire Builder refresh polls this URL)
+                                |
+                  Empire Builder apiLeaderboards
+                                |
+                                v
+                $ZABAL Empire on Base (Adam owns)
+                                |
+                                v   apply boosters, refresh leaderboard
+                                v   bulk-distribute ZABAL on schedule
+                                |
+                                v
+                       Submitter wallets receive ZABAL
+```
+
+Zaal does NOT call Empire Builder API. Zaal hands the BCZ URL to Empire Builder team (or to Adam who configures the apiLeaderboard on the $ZABAL Empire). EB pulls the JSON on every refresh.
+
 ## Key Decisions / Recommendations
 
 | Decision | Recommendation |
 |----------|----------------|
+| **Integration direction** | REVERSED from typical webhook patterns: Empire Builder PULLS from BCZ via apiLeaderboards. Use `POST /api/leaderboards/apiLeaderboards` with body `{tokenAddress, apiEndpoint, name, description, applyBoosters: true, signature, message, signerAddress}`. The `apiEndpoint` field = `https://bettercallzaal.com/poidh-leaderboard.json`. Refresh via `PATCH /api/leaderboards/refresh/apiLeaderboards`. Empire Builder team / $ZABAL Empire guardian configures this once; ongoing cost = zero for BCZ. |
 | **Empire to use** | USE existing $ZABAL Empire (deployed via Empire Builder, leaderboard at `songjam.space/zabal`). Adam/SongJam owns it. DO NOT deploy a duplicate Empire for ZAO/BCZ - it splits liquidity + brand. |
-| **API surface** | USE `https://www.empirebuilder.world/api/...` REST endpoints with `X-API-Key` header. Confirmed live endpoint pattern: `POST /api/personal-stats/EMPIRE_TOKEN_ADDRESS` returns `{balance, boostedBalance, boost, rank, activeBoosterIds[]}`. Bulk-send endpoint exists per docs (verify path before coding). |
+| **JSON feed format (CONFIRMED)** | Empire Builder expects `[{ "address": "0x...", "score": <number> }, ...]`. Address = wallet, score = numeric. EB applies boosters on top during refresh if `applyBoosters: true`. Sample feed shipped at `bettercallzaal.com/poidh-leaderboard.json`. |
+| **API surface (BCZ does NOT call this)** | Empire Builder REST endpoints documented at `https://www.empirebuilder.world/api/...` with `X-API-Key`. Read endpoints (`/api/personal-stats/`, `/api/leaderboard/`) returned `{balance, boostedBalance, boost, rank, activeBoosterIds[]}`. Bulk-send via `/api/distribute/...`. Useful only if BCZ later wants to display ZABAL stats per submitter inline. Phase 1 ships without this. |
 | **POIDH data source** | SCRAPE on-chain. POIDH v3 contract emits events for bounty claims; index via Base RPC (Alchemy/Ankr/free public RPC). NO documented POIDH REST API as of 2026-05-09 - the website itself is Next.js client-rendered fetching from internal endpoints. Reverse-engineer via DevTools Network tab OR read PoidhV3 contract events directly. |
 | **Submitter "1" semantics** | TWO interpretations to confirm with Zaal: (a) "1 Hat" via Hats Protocol = role NFT each submitter holds (heavy infra, ~2-day build); (b) "1 booster" via Empire Builder = a custom booster ID applied to each submitter address that multiplies their leaderboard score. (b) is lighter, native to Empire Builder, ships in hours. RECOMMEND (b) unless Zaal wants the cross-platform-portable Hats role. |
 | **Wallet connect surface** | USE `@farcaster/miniapp-sdk` (already loaded in BCZ index.html for the Farcaster mini app context) to get the Farcaster user's verified address inside the mini app. OUTSIDE the mini app, fall back to wagmi + Coinbase Smart Wallet for browser users. |
@@ -393,16 +428,25 @@ Verified URLs 2026-05-09: empirebuilder.world HTTP 200, empire-builder.gitbook.i
 
 ---
 
+## Implementation Status (2026-05-09)
+
+| Task | Status | Notes |
+|------|--------|-------|
+| Phase 1 `poidh.html` shipped on bettercallzaal.com | DONE | Dark theme matching nexus.html, stats row, featured bounty 1151, leaderboard table, how-it-works section, API hook documentation w/ copy button |
+| `poidh-leaderboard.json` shipped at root | DONE | Compatible with Empire Builder apiLeaderboards format |
+| nexus.html updated with leaderboard link | DONE | Listed under "The ZAO" alongside POIDH album |
+| BCZ git push -> auto-deploy via main | DONE | Live at bettercallzaal.com/poidh.html |
+| "Haatz" clarification | RESOLVED | = free Neynar API. Page links submitter wallet to Farcaster profile via farcaster.xyz/~/profile?address=... query (no key needed for the public profile route). |
+| Hats Protocol integration | DROPPED | Was not what Zaal meant; Phase 3 of original plan deleted. |
+
 ## Next Actions
 
 | Action | Owner | Type | By When |
 |--------|-------|------|---------|
-| **CONFIRM**: "give them each a 1" = Empire Builder booster (recommended) OR Hats Protocol role NFT (heavier) | @Zaal | Decision | Before Phase 1 build |
-| **CONFIRM**: Adam adds Zaal as co-guardian on $ZABAL Empire, OR Adam triggers airdrops on Zaal's behalf | @Zaal -> @Adam | Coordination | Before Phase 2 |
-| Request X-API-Key from Empire Builder team (`@glankerempire`) | @Zaal | DM/cast | Today |
-| Get $ZABAL Empire token contract address from Adam | @Zaal | DM | Today |
-| Build Phase 1 `poidh.html` with hardcoded bounty 1151 data + Neynar handle resolver | @Zaal | New file in BCZ repo | This week |
-| Add `/poidh.html` link to nexus.html "ZAO Ecosystem" section | @Zaal | Edit nexus.html | This week |
-| Phase 2 - Cloudflare Worker + on-chain submitter scrape via PoidhV3 events | @Zaal | Worker + page update | Next 2 weeks |
-| Phase 3 (only if Hats confirmed) - deploy ZAO Top Hat tree on Base + POIDH Submitter Hat | @Zaal | Hats SDK | Month 2 |
-| Re-validate Empire Builder API surface in 30 days (the API is in active development) | @Zaal | Doc update | 2026-06-09 |
+| Send `https://bettercallzaal.com/poidh-leaderboard.json` URL to Empire Builder team / $ZABAL Empire guardian (Adam) for apiLeaderboards configuration | @Zaal -> @Adam / @glankerempire | DM | Today |
+| Confirm $ZABAL Empire token address + leaderboard ID once apiLeaderboard is created | @Zaal | DM | This week |
+| Update `poidh-leaderboard.json` as new POIDH bounties land submitters (or build automation) | @Zaal | File edit / Phase 2 | Ongoing |
+| Phase 2 - replace static JSON with PoidhV3 event indexer (Cloudflare Worker reads Base RPC, returns live JSON) | @Zaal | New CF Worker | Next 2-3 weeks |
+| Phase 2.5 - resolve submitter wallets to Farcaster handles via Neynar free tier and embed in JSON feed | @Zaal | Worker addition | Phase 2 |
+| Phase 3 - Sybil protection: only count addresses with verified PoidhClaimNFT for ZAO album bounties | @Zaal | Worker addition | After Phase 2 |
+| Re-validate Empire Builder apiLeaderboards endpoint in 30 days | @Zaal | Doc update | 2026-06-09 |

--- a/research/business/627-zabal-empire-v3-capabilities/README.md
+++ b/research/business/627-zabal-empire-v3-capabilities/README.md
@@ -1,0 +1,362 @@
+---
+topic: business
+type: guide
+status: research-complete
+last-validated: 2026-05-09
+related-docs: 626, 625, 468, 584
+tier: STANDARD
+---
+
+# 627 - $ZABAL Empire ground truth + Empire Builder v3 capability map
+
+> **Goal:** Read-out of $ZABAL Empire's live state on Empire Builder v3 (Zaal-owned, deployed 2026-01-01) plus a tour of every v3 capability ZAO/BCZ should consider next. Companion to doc 626 (POIDH leaderboard hookup) and doc 625 (POIDH playbook).
+
+> **Source of truth:** `https://www.empirebuilder.world/skill/SKILL.md` (versioned `latest`, lastUpdated 2026-05-04). Always re-fetch at session start. References at `skill/references/{http-api,workflows,contracts}.md`.
+
+> **Big correction from doc 626:** Zaal IS the $ZABAL Empire owner (`owner = 0x7234...e9af`). Not yerbearserker, not Adrian. Co-emperor: `0xb79c...7932` (Farcaster username "zaal" - likely Zaal's secondary wallet). Zaal can call every guardian-signed endpoint directly, including `distribute-prepare`. He doesn't need yerbearserker/Adrian to wire the POIDH leaderboard - he can do it himself from the Empire dashboard or via signed API call.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Empire identity** | $ZABAL Empire ID = `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` (Clanker v4 ERC-20 on Base 8453). Treasury SmartVault = `0xe0faa499d6711870211505bd9ae2105206af1462`. Owner = Zaal `0x7234c36a71ec237c2ae7698e8916e0735001e9af`. Use these in every Empire Builder API call. |
+| **Skip yerbearserker/Adrian dependency** | Zaal owns the empire. Zaal signs his own EIP-191 messages from his owner wallet to create leaderboards, add boosters, prep distributions. The previous plan to DM yerbearserker / Adrian for the POIDH leaderboard config is OPTIONAL - Zaal can do it himself in seconds via the Empire dashboard at `empirebuilder.world/empire/0xbB48...0b07`. |
+| **POIDH leaderboard slot** | USE next free slot. Existing slots: 1 = "ZABAL holders" (tokenHolders), 3 = "Songjam Season 1", 4 = "ZAO RESPECT 1/5/26". Slot 2 + 5+ are free. Recommend slot 5 with name "BCZ YapZ Submitters" (per doc 626). API path: `POST /api/leaderboards/apiLeaderboards`. |
+| **Distribution flow (Zaal can do this himself)** | Phase 2 ZABAL airdrop = `POST /api/distribute-prepare` (Zaal signs as owner) -> Zaal's wallet broadcasts `executeBatch` on the SmartVault `0xe0faa...1462` -> `POST /api/store-distribution`. No yerbearserker/Adrian, no UserOp/paymaster, no co-signer flow. Zaal's owner EOA pays gas (~pennies on Base). |
+| **What v3 adds that's NEW** | Six things ZAO/BCZ should explore: (1) native staking via StakingLocker (lock ZABAL/SANG for multipliers), (2) Farcaster cast / channel / interaction leaderboards (no scraping needed), (3) Quotient (reputation) leaderboards, (4) FarToken leaderboards, (5) Tipn leaderboards, (6) batched distributions to multiple leaderboards in one tx. See Part 4. |
+| **Booster expansion** | Current 3 boosters: zaal Zora coin (5x at 1M holdings), ZAAL newsletter token (5x at 1M), Quotient reputation (default 1x). RECOMMEND adding: SANG holder (Adam's coin, ZABAL ecosystem alignment), ZORO holder (per-Zaal AMA mention), POIDH NFT claim holder (loops back to bounty engagement). Cap: ~10 boosters per empire is healthy. |
+| **Treasury current state** | $1547.44 in treasury (USD-equiv display value), 178,213,603 ZABAL burned to date, 33 distributions made, 227 total distribution recipients, rank 5.23. Empire is ALIVE, not idle - keep the cadence. |
+| **v3 vs v2 status** | $ZABAL has been migrated: `v2_empire_address = 0x99777...0dc9` (legacy), `v3_address = 0xe0faa...1462` (current = empire_address). Use the v3 address for every interaction. The v2 address is dead - ignore. |
+| **Mainnet only** | Empire Builder is mainnet-only (Base 8453, Arbitrum 42161). No testnet. Every write = real funds + real on-chain state. Do read-only GETs first to dry-run. |
+| **Auth model summary** | Reads: most are open GETs, no key needed. Writes: require `x-api-key` header + EIP-191 signature `{signature, message, signerAddress}` (signer must equal `empires.owner` OR be in `empires.co_emperors`). Distribute-prepare = stricter: signer MUST equal `owner()` exactly, co-emperors can't sign for it via the EOA path. |
+
+---
+
+## Part 1 - $ZABAL Empire Live State (snapshot 2026-05-09)
+
+### Identity + ownership
+
+| Field | Value |
+|-------|-------|
+| Empire ID (`base_token`) | `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` |
+| Token symbol | `ZABAL` (Clanker v4 ERC-20 on Base) |
+| SmartVault (`empire_address` / `v3_address`) | `0xe0faa499d6711870211505bd9ae2105206af1462` |
+| Legacy v2 address (deprecated) | `0x99777b2414d1261f041ebd9cf1e3c95f35a60dc9` |
+| Owner | `0x7234c36a71ec237c2ae7698e8916e0735001e9af` (Zaal - SAME wallet that issued POIDH bounty 1151) |
+| Co-emperor | `0xb79cdabf6f2fb8fea70c2e515aec35e827bf7932` (Farcaster: zaal) |
+| Chain | Base (8453) |
+| Created | 2026-01-01 |
+| Deployment hash | `0x9960a54d...0923ce44` |
+
+### Brand surfaces
+
+| Surface | URL |
+|---------|-----|
+| Empire Builder dashboard | https://empirebuilder.world/empire/0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07 |
+| Songjam frontend | https://songjam.space/zabal |
+| Creative hub | https://zabal.art/ |
+| Twitter | https://x.com/bettercallzaal |
+| Farcaster | https://farcaster.xyz/zaal |
+| Tinybot | `zabalbot` |
+| Logo | https://aquamarine-hidden-peafowl-945.mypinata.cloud/ipfs/bafybeibcjnzmmvybxzlrkxav4swybsogkottpr6yxw6milqcvbyk5sqcs4 |
+
+### Activity metrics
+
+| Metric | Value |
+|--------|-------|
+| Treasury (USD equiv) | $1,547.44 |
+| Total ZABAL burned | 178,213,603 |
+| Distribution counter | 33 (number of distributions made) |
+| Total distributed (recipients tally) | 227 |
+| Empire rank | 5.23 |
+| Last v3 health check | 2026-05-09 14:26 UTC |
+
+### Existing leaderboards on $ZABAL Empire (3 found, slot range 1-20)
+
+| Slot | Name | Type | Token Boosters | Reputation Boosters | Staking Boosters | Last refresh |
+|------|------|------|----------------|---------------------|------------------|--------------|
+| 1 | ZABAL holders | tokenHolders | ON | ON | ON | 2026-05-09 21:25 UTC |
+| 3 | Songjam Season 1 | (legacy/unset) | OFF | OFF | ON | 2026-05-06 14:22 UTC |
+| 4 | ZAO RESPECT 1/5/26 | (legacy/unset) | ON | ON | ON | 2026-05-09 14:26 UTC |
+
+**Free slots:** 2, 5-20. Recommend POIDH lands at slot 5 (slot 2 reserved for a future tokenHolders refresh of an attached token if needed).
+
+### Active boosters (3)
+
+| Booster | Type | Multiplier | Trigger |
+|---------|------|------------|---------|
+| `zaal` Zora Creator Coin | ERC-20 (zora-erc20) `0x2275...c285` | 5x | Hold >= 1,000,000 zaal tokens |
+| `ZAAL` ZAO Newsletter Token | ERC-20 (standard) `0x3213...03d4` | 5x | Hold >= 1,000,000 ZAAL |
+| Quotient Reputation Booster | QUOTIENT (default) | 1x base, scales by reputation | Quotient.social score |
+
+---
+
+## Part 2 - Empire Builder v3 Architecture (Confirmed via SKILL.md)
+
+### Empires are ERC-4337 SmartVaults
+
+The fundamental shift in v3: every Empire's treasury is an **ERC-4337 SmartVault** with the same logical address on Base + Arbitrum. SmartVault exposes:
+
+```solidity
+struct Call { address target; uint256 value; bytes data; }
+function execute(Call calldata call_) external payable;
+function executeBatch(Call[] calldata calls_) external payable;
+function owner() external view returns (address);
+```
+
+Owner = the wallet that can call `execute` / `executeBatch` directly (EOA). Co-signers can only act through ERC-4337 UserOps via the website's bundler + paymaster - they CANNOT bypass via direct EOA calls (reverts `Unauthorized`).
+
+### Empire ID vs SmartVault address
+
+THIS IS THE #1 SKILL-FAILURE MODE per the official docs.
+
+| Concept | Field names | Example |
+|---------|-------------|---------|
+| **Empire ID** (identity) | `tokenAddress`, `baseToken`, `empire_id`, `[empire_id]` path | `0xbB48...0b07` for ZABAL token-empire (or `fid12345`, or custom slug) |
+| **SmartVault address** (treasury contract) | `empire_address`, `empireAddress`, `treasuryAddress` | `0xe0faa...1462` for ZABAL |
+
+They are NEVER interchangeable unless an endpoint takes both as separate fields. Some endpoints (like `store-distribution`) require both.
+
+### Three Empire ID shapes
+
+| Shape | Example | Used for |
+|-------|---------|----------|
+| Token empire | `0x` + 40 hex (the ERC-20 base) | Most empires (ZABAL falls here) |
+| Farcaster tokenless | `fid` + digits, e.g. `fid12345` | Empire anchored to a Farcaster fid, no token |
+| Custom slug | alphanumeric | Empire with custom name, no token |
+
+### Authentication tiers
+
+| Tier | Use |
+|------|-----|
+| None | Most reads (`/api/empires/...`, `/api/leaderboards/...`, `/api/boosters/...`) |
+| `x-api-key` header | Some reads, all writes (server-enforced via `validateRequest`) |
+| `x-api-key` + EIP-191 signature `{signature, message, signerAddress \| signer}` | Guardian writes (leaderboard create, booster add/remove, distribute-prepare, deploy-empire). Server verifies `verifyMessage` then checks signer is owner or co-emperor. |
+| `x-api-key` + signature with **strict owner check** | `distribute-prepare` only. Co-emperors can't sign. |
+
+### Mainnet only - no testnet
+
+Every write hits real Base or Arbitrum mainnet. There is no sandbox. Dry-run by reading first:
+- `GET /api/empires/<empire_id>` 
+- `GET /api/leaderboards/<uuid>`
+- `GET /api/boosters/<empire_id>`
+
+---
+
+## Part 3 - Eleven Leaderboard Types (v3 expanded from 5 in earlier docs)
+
+`POST /api/leaderboards/<typeSuffix>` with guardian sig + body. Refresh via `PATCH /api/leaderboards/refresh/<typeSuffix>`.
+
+| Type | Path suffix | What it ranks | ZAO use case |
+|------|-------------|---------------|--------------|
+| Token holders | `tokenHoldersLeaderboards` | ERC-20 balance | Who holds the most ZABAL (already slot 1) |
+| Stakers | `stakersLeaderboards` | StakingLocker stake amount + duration | Lock ZABAL for points (Phase 2 unlock) |
+| NFT | `nftLeaderboards` | ERC-721 / ERC-1155 holdings | ZAO Stock NFT holders, POIDH claim NFT holders |
+| **API-Sourced** | `apiLeaderboards` | External JSON URL | POIDH submitters (current BCZ integration) |
+| CSV upload | `csvLeaderboards` | One-shot CSV (no auto-refresh) | One-time campaign winner lists |
+| **FarToken** | `farTokenLeaderboards` | Holders of a Farcaster-launched token | Rank Clanker tokens linked to ZAO members |
+| **Tipn** | `tipnLeaderboards` | Tipn (Farcaster tipping) activity | Reward Farcaster tippers in the ZAO orbit |
+| **Farcaster cast** | `farcasterCastLeaderboards` | Engagement on a specific cast | One-shot promotional cast incentive |
+| **Farcaster channel** | `farcasterChannelLeaderboards` | Engagement in a channel | /zao channel activity, /poidh channel for cross-promo |
+| **Farcaster interaction** | `farcasterInteractionLeaderboards` | Likes/recasts/replies to your account | Reward people engaging with @bettercallzaal or @thezao |
+| **Quotient** | `quotientLeaderboards` | Quotient.social reputation score | Reward high-rep accounts in ZAO ecosystem |
+
+The Farcaster-native types (cast, channel, interaction) are the BIG v3 unlock - no external scraping needed; Empire Builder pulls Neynar/Hub data on its side.
+
+---
+
+## Part 4 - What v3 Lets ZAO/BCZ Do That Was Hard Before
+
+### 1. Native staking + STAKING boosters
+
+`POST /api/empires/activate-staking` flips a flag and auto-creates a stakers leaderboard. Then:
+
+- Members lock ZABAL into the **immutable StakingLocker** contract (separate from the SmartVault) for any duration in `[0, 315_360_000]` seconds (0 = flexible, max = 10 years)
+- `MAX_STAKES_PER_USER = 100` positions per (user, token)
+- Min stake: token-dependent. Default = 100 tokens. WETH = 0.001 ETH. USDC = 1 USDC.
+- Staking boosters: multiplier `[1.1x, 5.0x]`, capped at +5x total per user across all staking boosters
+- Active staking auto-folds staked balances into `tokenHolders` and `farToken` leaderboards (so stakers don't lose their holdings ranking)
+- Side-effect: every leaderboard refresh applies STAKING boosters additively when `apply_staking_boosters !== false`
+
+**ZAO use case:** "Lock 100k ZABAL for 30 days, get 2x leaderboard points across every $ZABAL leaderboard you're on." Strong sticky-engagement loop.
+
+### 2. Owner-signed distributions (Zaal can airdrop directly)
+
+The flow per `references/workflows.md` Workflow 3:
+
+```
+1. GET /api/leaderboards?tokenAddress=0xbB48...0b07
+   -> pick leaderboardId UUID (e.g. POIDH Submitters once created)
+
+2. POST /api/distribute-prepare
+   { tokenAddress: <empire_id>,
+     leaderboardId: <uuid> | "main",
+     amount: "1000000000000000000000",  // wei amount of ZABAL to distribute
+     distributionMode: "weighted" | "even" | "raffle",
+     signature, message, signer: 0x7234...e9af }
+   -> returns transactions[] with calls[] or pre-encoded data, batchIndex per chain
+
+3. Zaal's wallet (owner) submits each transactions[i] in batchIndex order:
+   sendTransaction({ to: 0xe0faa...1462, data: tx.data, value: 0 })
+   -> wait for receipt status === 1
+
+4. POST /api/store-distribution
+   { transactionHashes: ["0x...","0x..."], empireAddress: 0xe0faa...1462,
+     baseToken: 0xbB48...0b07, leaderboardId, signature, message, signer }
+```
+
+Three modes per the AMA transcript I pulled earlier (doc 626 sources):
+- **even split** - everyone gets same share
+- **weighted** - share proportional to leaderboard `points` (boost-adjusted)
+- **raffle** - random one address from top N wins the whole pot
+
+**ZAO use case for POIDH:** weekly raffle distribution of 1000 ZABAL to top 10 POIDH submitters. Or weighted: distribute based on submission count (currently set to score 1 per unique wallet, but could shift back to claim-count if Zaal wants to reward power-submitters).
+
+### 3. Farcaster cast / channel / interaction leaderboards
+
+These are a unique v3 unlock. No external API endpoint, no scraping, no Neynar integration on Zaal's side. Empire Builder reads Farcaster Hub data directly.
+
+**ZAO use case:**
+- `/zao` channel leaderboard - rank by recent activity, distribute ZABAL weekly to top engagers
+- A specific cast leaderboard - launch a major announcement cast, run a 7-day leaderboard for everyone who liked/recasted/replied, airdrop ZABAL
+- @bettercallzaal interaction leaderboard - permanent leaderboard of accounts engaging with Zaal, ZABAL drops monthly
+
+### 4. Quotient reputation leaderboards
+
+Already have a Quotient booster on $ZABAL. Adding a Quotient leaderboard means ZABAL distributes proportionally to reputation tier. Aligns with ZAO's existing "Respect" framework + ORDAO governance vision.
+
+### 5. Multi-chain operation
+
+Every endpoint accepts `chainId` (8453 Base or 42161 Arbitrum). Empires have the same logical SmartVault address on both chains. ZAO is Base-native today but could mirror $ZABAL to Arbitrum if a partner ecosystem demands it without redeploying everything.
+
+### 6. Tracked burns via store-burn
+
+Burn ZABAL from the treasury (or any wallet) to `0x0` or `0xdEaD`, then `POST /api/store-burn` with the tx hash. Empire Builder decodes the receipt and updates `total_burned` on the empire. Already showing 178,213,603 ZABAL burned. Next deflation event can be tracked on-chain transparently.
+
+---
+
+## Part 5 - HTTP API Endpoint Catalog (Full v3)
+
+### Reads (typical, no API key)
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/top-empires` | Ranked empire list |
+| GET | `/api/empires` | Paginated empires |
+| GET | `/api/empires/[empire_id]` | Single empire (use for ZABAL recon) |
+| GET | `/api/empires/search?q=` | Search by name |
+| GET | `/api/empires/owner/[wallet]` | Empires owned by a wallet |
+| GET | `/api/empires/ranking` | Empire-wide ranking calc |
+| GET | `/api/empires/check` | Pre-check before deploy |
+| GET | `/api/leaderboards?tokenAddress=<empire_id>` | List all empire leaderboards |
+| GET | `/api/leaderboards/[id]` | Single leaderboard with entries |
+| GET | `/api/leaderboards/consolidated?tokenAddress=` | All empire leaderboards merged |
+| GET | `/api/boosters/[address]` | Booster list for empire |
+| GET | `/api/staking-boosters/[address]` | Staking booster list |
+| GET | `/api/empires/activate-staking?tokenAddress=` | Staking activation status |
+| GET | `/api/empire-rewards/[token]` | Reward history |
+| GET | `/api/empire-rewards/[token]/[type]` | Reward history filtered |
+| GET | `/api/rewards/recipients/[txHash]` | Recipients of a tx |
+| GET | `/api/distribution-records/[empireAddress]` | Cumulative per recipient |
+| GET | `/api/airdrops/[tokenAddress]` | Airdrop list (API key) |
+| GET | `/api/empire-airdrop-total` | Total airdrops |
+
+### Writes - distributions & accounting
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/distribute-prepare` | API key + sig (signer = owner()) | Prepare batched ZABAL airdrop |
+| POST | `/api/store-distribution` | API key | Record mined distribution |
+| POST | `/api/store-burn` | API key | Track on-chain burn |
+| POST | `/api/store-airdrop` | API key | Register external airdrop metadata |
+
+### Writes - deploys
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/get-token-config` | API key | Get Clanker config for fresh deploy |
+| POST | `/api/deploy-empire` | API key + sig | Deploy empire (fresh or attach existing token) |
+| POST | `/api/deploy-empire-tokenless` | API key + sig | Deploy fid/slug-anchored empire |
+
+### Writes - leaderboards & boosters
+
+| Method | Path | Auth | Purpose |
+|--------|------|------|---------|
+| POST | `/api/leaderboards/<type>` | API key + sig | Create leaderboard (one of 11 types) |
+| PATCH | `/api/leaderboards/refresh/<type>` | API key | Refresh scores (30s cooldown) |
+| POST | `/api/leaderboards/delete` | API key | Delete leaderboard |
+| POST | `/api/boosters/[empire_id]` | API key + sig | Add ERC-20/NFT/Quotient booster |
+| DELETE | `/api/boosters/[empire_id]` | API key + sig | Remove booster |
+| POST | `/api/empires/activate-staking` | API key + sig | Flip staking flag, auto-create stakers leaderboard |
+| POST | `/api/staking-boosters/[empire_id]` | API key + sig | Add staking booster |
+| DELETE | `/api/staking-boosters/[empire_id]` | API key + sig | Remove staking booster |
+
+---
+
+## Specific Numbers
+
+| Metric | Value |
+|--------|-------|
+| ZABAL Empire ID | `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` |
+| ZABAL SmartVault | `0xe0faa499d6711870211505bd9ae2105206af1462` |
+| Owner | `0x7234c36a71ec237c2ae7698e8916e0735001e9af` (Zaal) |
+| Co-emperor count | 1 |
+| Chain | Base (8453) |
+| Token type | clanker_v4 ERC-20 |
+| Treasury USD | $1,547.44 |
+| Total burned | 178,213,603 ZABAL |
+| Distributions made | 33 |
+| Total distribution recipients | 227 |
+| Existing leaderboards | 3 (slots 1, 3, 4) |
+| Free slots | 2, 5-20 (17 slots open) |
+| Active boosters | 3 (zaal Zora, ZAAL newsletter, Quotient default) |
+| Leaderboard types available | 11 (was 5 in v2) |
+| Refresh cooldown | 30 seconds |
+| StakingLocker MAX_LOCK_DURATION | 315,360,000 seconds (10 years) |
+| StakingLocker MAX_STAKES_PER_USER | 100 |
+| Staking booster multiplier range | [1.1x, 5.0x], capped at +5x total |
+| Default min stake | 100 tokens |
+| Min stake WETH | 0.001 ETH |
+| Min stake USDC | 1 USDC (6 decimals) |
+| Native gas chain (writes) | owner pays - cheap on Base |
+| Mainnet only | YES (Base 8453, Arbitrum 42161) |
+
+---
+
+## Sources
+
+- [Empire Builder SKILL.md](https://www.empirebuilder.world/skill/SKILL.md) (latest, 2026-05-04)
+- [Empire Builder skill/references/http-api.md](https://www.empirebuilder.world/skill/references/http-api.md) (1090 lines)
+- [Empire Builder skill/references/workflows.md](https://www.empirebuilder.world/skill/references/workflows.md) (8 workflows)
+- [Empire Builder skill/references/contracts.md](https://www.empirebuilder.world/skill/references/contracts.md) (SmartVault + StakingLocker ABI)
+- [GitBook public API index](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/public)
+- [ZABAL Empire dashboard](https://empirebuilder.world/empire/0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07) (live state used in this doc)
+- [Songjam ZABAL leaderboard](https://songjam.space/zabal)
+- [zabal.art creative hub](https://zabal.art/)
+- [ZABAL AMA 2 transcript](https://alphagrowth.io/spaces/zabal-ama-2-rugged-twice-to-start) (distribution mode descriptions)
+
+Verified URLs 2026-05-09: empirebuilder.world/skill/SKILL.md HTTP 200, /api/empires/0xbB48...0b07 returns full payload, /api/leaderboards?tokenAddress=0xbB48...0b07 returns 3 leaderboards, /api/boosters/0xbB48...0b07 returns 3 boosters.
+
+---
+
+## Also See
+
+- [Doc 626 - Empire Builder + ZABAL POIDH airdrop architecture](../626-empire-builder-zabal-poidh-airdrop/) - the integration doc; this doc 627 is the empire-state + capability survey
+- [Doc 625 - POIDH x ZAO bounty playbook](../../community/625-poidh-zao-bounty-playbook/)
+- [Doc 584 - ZABAL Nexus link inventory](../584-zabal-nexus-link-inventory/) (if exists - referenced from 626)
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Stop blocking on yerbearserker / Adrian for POIDH leaderboard. Zaal owns the empire - he creates it himself via Empire Builder dashboard or signed API call | @Zaal | Self-serve | Today |
+| Create slot-5 "BCZ YapZ Submitters" apiLeaderboard pointing to `bettercallzaal.com/poidh-leaderboard.json`, both booster toggles ON | @Zaal | Empire dashboard | Today |
+| First ZABAL distribution to POIDH submitters: pick mode (recommend `weighted` since all scores = 1, equivalent to `even` for now), pick amount, sign owner-prepare, broadcast executeBatch, store | @Zaal | distribute-prepare flow | This week |
+| Add SANG token booster (Adam's coin) for ZABAL ecosystem alignment - 3x at 100k SANG threshold | @Zaal | POST /api/boosters | Next week |
+| Activate native staking on $ZABAL (`POST /api/empires/activate-staking`) and set up a stakers leaderboard with a 7d-lock 2x staking booster - increases ZABAL hold time | @Zaal | Activate + booster add | Month 1 |
+| Spin up `/zao` Farcaster channel leaderboard (`farcasterChannelLeaderboards`) for weekly engagement-based ZABAL distribution | @Zaal | Leaderboard create | Month 1 |
+| Add @bettercallzaal Farcaster interaction leaderboard for personal-brand activity rewards | @Zaal | Leaderboard create | Month 1 |
+| Re-validate Empire Builder API surface in 30 days (skill is `latest` versioned, expected to evolve) | @Zaal | Doc update | 2026-06-09 |
+| Investigate burn cadence - 178M already burned; consider quarterly burn schedule with public store-burn tracking for transparency | @Zaal | Strategy | Q2 |

--- a/research/dev-workflows/628-poidh-empire-bounty-process-learnings/README.md
+++ b/research/dev-workflows/628-poidh-empire-bounty-process-learnings/README.md
@@ -1,0 +1,331 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-09
+related-docs: 625, 626, 627, 468
+tier: STANDARD
+---
+
+# 628 - POIDH x Empire Builder x Bounty-Writing: Learning Capture (multi-hour session 2026-05-09)
+
+> **Goal:** Capture the meta-lessons from a single multi-hour session that produced docs 625, 626, 627 plus the live `bettercallzaal.com/poidh.html` integration. The corrections, the gotchas, the framework picked up from Kenny's pro-tip cast, the ownership reveals, the architecture flips. Future-Zaal opens this doc instead of re-running the same investigations.
+
+> **Source episode:** Zaal asked /zao-research on POIDH (-> doc 625), then expanded scope into Empire Builder integration (-> doc 626), then $ZABAL Empire ground truth + v3 capability survey (-> doc 627), then asked to capture the whole process. Docs 625-627 are the artifacts; this doc 628 is the heuristics distilled out of building them.
+
+## Key Decisions / Recommendations
+
+| Lesson | Recommendation |
+|--------|----------------|
+| **OG meta lies; tRPC tells the truth.** | When a POIDH bounty page's `<meta property="og:image">` includes `participants=0x...,0x...`, those are FUNDERS / VOTERS in open bounties, NOT claim submitters. Always pull real submitters via `https://poidh.xyz/api/trpc/claims.fetchBountyClaims`. The OG list almost cost us a 2-wallet leaderboard when the truth was 10 unique submitters. |
+| **Album names live in the database, not the URL.** | `poidh.xyz/a/<album>` URLs work for any string but only one canonical name maps to the `BountiesExtra.album` row. ZAO's bounties live under `wethemmedia` (verified via `bounties.fetch(1151).extra.album`). The `/a/thezao` URL renders an empty page. Always confirm via the bounty's `extra.album` field on a known bounty before scraping the album. |
+| **Ownership > popularity in Empire Builder.** | We assumed "Adam owns ZABAL Empire" because Adam runs SongJam and SANG. Wrong. Zaal IS the ZABAL Empire owner (`empires.owner = 0x7234...e9af` matches Zaal's POIDH issuer wallet exactly). Co-emperors can't bypass owner-only writes via EOA. Always pull `GET /api/empires/<empire_id>` to read `owner` + `co_emperors` before assuming who needs to sign. |
+| **Empire ID != SmartVault address.** | THE failure mode in v3. Empire ID is identity (token address, `fid12345`, or slug). SmartVault address is the on-chain treasury contract. Some endpoints take both as separate fields. Always match the field name (`tokenAddress` / `baseToken` = identity; `empireAddress` / `treasuryAddress` = vault). |
+| **Re-fetch SKILL.md every session.** | `https://www.empirebuilder.world/skill/SKILL.md` is versioned `latest`. yerbearserker shipped v3 mid-session 2026-05-09 - we caught the new schema only because we re-fetched. Cached copies older than `lastUpdated` describe stale routes. |
+| **Mainnet-only, real funds, dry-run via reads.** | Empire Builder + POIDH have no testnet. Every write hits Base / Arbitrum mainnet with real ETH / ZABAL. ALWAYS dry-run via `GET` endpoints before signing. Read first: `/api/empires/<id>`, `/api/leaderboards/<uuid>`, `/api/boosters/<id>`. |
+| **The integration direction was reversed.** | First instinct: BCZ calls Empire Builder API to push leaderboard data. Wrong. Empire Builder PULLS from BCZ via API-Sourced leaderboards. BCZ exposes `[{address,score}]` JSON; the Empire owner configures one apiLeaderboard pointing at it. Saves API key handling on BCZ side and matches EB's cron-refresh model. |
+| **Use Kenny's POIDH framework for every bounty.** | Precise / Observable / Impactful / Doable / Horizoned. Round 1 (BCZ YapZ Ep 17) was vague-good; Round 2 (BCZ YapZ Ep 19 w/ Kenny) applies the framework explicitly in the body and improves discoverability + judging quality. The framework header doubles as a tutorial for first-time submitters. |
+| **One-offs go in /clipboard, state lives on poidh.html.** | Operational paste-targets (winner cast, bounty drafts, EB submission package) are short-lived; render them in `/tmp/clipboard.html` for the session. Persistent state (live leaderboard, current bounty status, JSON feed URL, framework explanation) lives on the public `bettercallzaal.com/poidh.html` page. Mixing the two bloats the public page and ages it badly. |
+| **Refresh script > Cloudflare Worker until traffic warrants it.** | `python3 scripts/refresh-poidh-leaderboard.py` is a 100-line stdlib-only script. Cloudflare Worker + cron is correct LONG-term but unnecessary at 10 unique submitters. Don't over-engineer. Migrate to CF Worker when refresh cadence > daily OR when leaderboard has > 100 entries. |
+| **Score model = unique wallets per bounty by default.** | First pass counted claims (one wallet got score 2 for two submissions). Zaal vetoed - reward unique wallets, not submission spam. Now `seen.add(addr)` per claim, score=1 across the board. Switch back to claim-count scoring only when the bounty REWARDS volume (e.g. "post 5 different clips"). |
+| **Run the meta-bounty pattern.** | Kenny demonstrates it with the May best-bounty meta-bounty (BCZ YapZ Ep 19, chapter 17:35). Replicate: Round 3 = "best new POIDH bounty written for ZAO using the POIDH framework, judged by yerbearserker / Zaal". Ties bounty culture to bounty-writing skill. |
+
+---
+
+## Part 1 - POIDH Platform Learnings
+
+### Contract addresses (memorize)
+
+| Chain | Chain ID | PoidhV3 contract | Min bounty | Min contribution |
+|-------|----------|------------------|-----------|------------------|
+| Base | 8453 | `0x5555Fa783936C260f77385b4E153B9725feF1719` | 0.001 ETH | 0.00001 ETH |
+| Arbitrum | 42161 | `0x5555Fa783936C260f77385b4E153B9725feF1719` (same logical) | 0.001 ETH | 0.00001 ETH |
+| Degen | 666666666 | `0x18E5585ca7cE31b90Bc8BB7aAf84152857cE243f` | 1000 DEGEN | 10 DEGEN |
+
+PoidhV3 enforces `msg.sender == tx.origin` -> EOA-only creation (Safe / Coinbase Smart Wallet revert with `ContractsCannotCreateBounties`). Issuer cannot claim own bounty (`IssuerCannotClaim`). 2.5% protocol fee on accepted payouts. 5% suggested NFT royalty.
+
+### tRPC scrape pattern (no API key needed)
+
+```python
+import json, urllib.parse, urllib.request
+
+def trpc(proc, payload):
+    inp = urllib.parse.quote(json.dumps({"0": {"json": payload}}))
+    url = f"https://poidh.xyz/api/trpc/{proc}?batch=1&input={inp}"
+    req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+    with urllib.request.urlopen(req, timeout=20) as r:
+        return json.loads(r.read())[0]["result"]["data"]["json"]
+```
+
+Useful procedures:
+
+| Procedure | Input | Returns |
+|-----------|-------|---------|
+| `bounties.fetch` | `{id, chainId}` | Bounty with `title`, `issuer`, `amount` (wei), `extra.album` |
+| `bounties.fetchByAlbum` | `{album, status, limit}` | List by album, status in `open` / `progress` / `past` |
+| `claims.fetchBountyClaims` | `{bountyId, chainId, limit}` | Real submitter list with `id`, `issuer`, `title`, `isAccepted`, `url` |
+| `claims.fetchAcceptedClaimByBountyId` | `{bountyId, chainId}` | The accepted (winning) claim, or `null` |
+| `albums.trending` | `{limit}` | Top trending albums |
+
+Refresh script lives at `scripts/refresh-poidh-leaderboard.py` in BCZ repo. Defaults to bounty 1151, supports `--bounty <id> --chain <id>` flags.
+
+### Gotchas confirmed live
+
+| Gotcha | What we hit | What it actually was |
+|--------|------------|---------------------|
+| OG meta `participants` | Saw 2 wallets, assumed = submitters | They're funders/voters in joined-bounty open mode. Real claim count = 11 from 10 unique wallets (one submitted 2x) |
+| `/a/thezao` URL | Tried scraping ZAO album by that name | Album row in DB is `wethemmedia`, not `thezao`. The URL renders empty |
+| `participants` includes issuer | Assumed both 0x7234 + 0x4200 were submitters | 0x7234 is Zaal (issuer); protocol forbids issuer claims |
+
+---
+
+## Part 2 - Kenny's POIDH Goal Framework (extracted from his pro-tip cast image)
+
+Source: `https://farcaster.xyz/kenny/0xbb5f295f` - cast text "poidh pro tip 🕹️ write good bounty descriptions" with attached image OCR'd 2026-05-09.
+
+### The acronym
+
+| Letter | Property | Mantra |
+|--------|----------|--------|
+| **P** | Precise | Clear, specific outcome. Everyone knows what "done" looks like. |
+| **O** | Observable | You can track or verify it. No guesswork. |
+| **I** | Impactful | Actually moves the needle. Creates real value. |
+| **D** | Doable | Realistic given resources. Challenging, but possible. |
+| **H** | Horizoned | Has a deadline. A goal without a deadline is just a wish. |
+
+### How to use POIDH (per the image)
+
+1. Start with the outcome you want.
+2. Run it through POIDH (check each letter).
+3. Tweak anything that's weak or vague.
+4. Post with confidence.
+5. Attract better builders, get better outcomes.
+
+### Before/after example from the image
+
+- BEFORE (vague): "Write some content about poidh." (X too vague, X hard to measure, X hard to know if it's successful, X easy to procrastinate)
+- AFTER (POIDH-shaped): "Write and publish 3 SEO-friendly blog posts about poidh with target keywords and featured images by May 31, 2024." (clear and specific, observable + trackable, high impact, realistic + doable, has a deadline)
+
+Closer: "Better goals = Better bounties = Better outcomes. POIDH is better when we build it together."
+
+### Round 1 vs Round 2 - applying the framework
+
+| Aspect | Round 1 (BCZ YapZ Ep 17) | Round 2 (BCZ YapZ Ep 19 - drafted) |
+|--------|--------------------------|-------------------------------------|
+| Precise | "find a clip" - any length, any platform | "45-60s edited clip, hook in 3s, single takeaway" |
+| Observable | "tag @bettercallzaal" - one platform implied | "X AND Farcaster URLs both, three tags, caption stating angle" |
+| Impactful | "honest reflection wins" - judging is subjective | Winning clip becomes POIDH's pinned ad - reuse promise |
+| Doable | "watch + post" - 28-min ep, no guidance | Episode chapters called out: 5:05 / 8:40 / 17:35 / 22:30 |
+| Horizoned | "one week" deadline | "7 days from posting, deadline TBD at create time" - same shape, more explicit |
+
+The framework shift: Round 1 was a vibe brief; Round 2 is a craft brief.
+
+---
+
+## Part 3 - ZABAL Empire Builder v3 Learnings (recap of doc 627 distilled)
+
+### What you actually own (verified)
+
+| Field | Value | Implication |
+|-------|-------|-------------|
+| Empire ID | `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` | Pass this everywhere `tokenAddress` / `baseToken` is asked |
+| SmartVault | `0xe0faa499d6711870211505bd9ae2105206af1462` | Treasury contract on Base; pass as `empireAddress` |
+| Owner | `0x7234c36a71ec237c2ae7698e8916e0735001e9af` (Zaal) | You can sign every guardian-only endpoint |
+| Co-emperors | 1 (`0xb79c...7932`) | Can sign most guardian writes via EOA, EXCEPT `distribute-prepare` (owner-only) |
+| Token type | clanker_v4 | Fresh deploys go through Clanker SDK |
+| Chain | Base 8453 | Mainnet only |
+
+### What v3 unlocks (six things)
+
+1. **Native staking** via immutable StakingLocker (lock 0-10y, +5x cap multiplier).
+2. **Owner-signed direct distributions** (`distribute-prepare` -> owner sends `executeBatch` -> `store-distribution`).
+3. **Three Farcaster-native leaderboard types** (cast / channel / interaction) - no scrape, EB pulls Hub data.
+4. **Quotient (reputation) leaderboards** - pairs with the existing Quotient booster.
+5. **Multi-chain mirroring** to Arbitrum without redeploying everything.
+6. **Tracked burns** via `store-burn` - audited burn history on top of the 178M ZABAL already gone.
+
+### What you can't do (constraints)
+
+- Distribute via EOA from a co-emperor wallet - must be from `owner()`. Co-emperors go through the website's UserOp paymaster flow.
+- Run on testnet - there is no `/sepolia/...` host. Always real funds.
+- Mix Empire ID with SmartVault address - separate fields, never interchange.
+- Skip API key on writes - even when guardian-signed.
+
+---
+
+## Part 4 - Integration Architecture Learnings
+
+### The reversed pull pattern
+
+```
+POIDH submitters -> claims on Base
+                            |
+                            v
+                  poidh.xyz tRPC
+                            |
+                            v
+            scripts/refresh-poidh-leaderboard.py
+                            |
+                            v
+       bettercallzaal.com/poidh-leaderboard.json  <-- public, no auth
+           [ {address, score}, ... ]                  
+                            |
+                            v
+           Empire Builder apiLeaderboards
+           (configured ONCE by Zaal as owner)
+                            |
+                            v
+                $ZABAL Empire on Base
+                            |
+                            v   apply boosters, refresh
+                            v   distribute (owner signs)
+                            |
+                            v
+                       Submitter wallets
+```
+
+Key property: **the BCZ side has zero auth burden.** No API keys exposed in static HTML, no CF Worker proxy needed for the read path. EB does the polling.
+
+### When to upgrade out of static JSON
+
+| Trigger | Action |
+|---------|--------|
+| Refresh cadence > daily | Move JSON gen to a CF Worker on cron |
+| Leaderboard > 100 entries | Pre-resolve Farcaster handles via Neynar at gen time, not at render |
+| Multiple POIDH bounties feeding one leaderboard | Aggregate in the worker, not in the page JS |
+| Real-time on-chain accuracy required | Index PoidhV3 events directly via Base RPC, skip tRPC |
+
+For the BCZ YapZ Ep 17 use case (one bounty, 10 submitters, refresh = ad-hoc when Zaal accepts a winner) the static script is correct.
+
+### Refresh script defaults that worked
+
+- Stdlib only (urllib + json) - no `pip install` needed
+- One file at `scripts/refresh-poidh-leaderboard.py`
+- `--bounty <id> --chain <id>` flags so the same script handles album-wide later
+- Writes both `poidh-leaderboard.json` (the EB feed) AND `poidh-audit.json` (full claim trail for verification)
+- Excludes the issuer wallet defensively (protocol enforces but worth restating)
+- One wallet = score 1, no claim count double-up
+
+---
+
+## Part 5 - Personnel / Ownership Learnings
+
+| Person | Role | Wallet / FID | Notes |
+|--------|------|--------------|-------|
+| Zaal | $ZABAL Empire owner, BCZ founder, POIDH bounty issuer | `0x7234...e9af` / FID 19640 | Same wallet across all surfaces |
+| yerbearserker (Jordan Oram) | Empire Builder co-founder | FID via warpcast lookup; LinkedIn linkedin.com/in/yerbearserker | Co-founded EB, Chief Ecosystem Architect |
+| Adrian | Empire Builder lead engineer | Handle "divifly" per Zaal - did not resolve via warpcast username lookup | Verify FID with yerbearserker if needed |
+| Adam | SongJam founder, $SANG owner | Separate from ZABAL ownership | Stakeholder in ZABAL; NOT the empire owner |
+| Kenny | POIDH founder | FID 2210 / `kenny` | Episode 19 of BCZ YapZ; pro-tip cast at 0xbb5f295f |
+| cryptfi-mariano (J'Mariano) | Round 1 winner | FID 872568 / wallets [`0x70485...d621`, `0xa34514...5355`, `0xd8ec8...148b`] | Claim 6368 won; YouTube: @creator-mariano |
+
+Lesson: **ALWAYS resolve a wallet to a Farcaster handle before assuming identity.** Warpcast `GET /v2/user-by-username?username=<handle>` returns `extras.ethWallets[]` for cross-checking.
+
+---
+
+## Part 6 - Workflow Discipline Learnings
+
+### What goes where
+
+| Surface | Lifecycle | Examples |
+|---------|-----------|----------|
+| **`bettercallzaal.com/poidh.html`** | Persistent public state | Live leaderboard, JSON feed URL, EB submission package, framework explainer, current bounty status |
+| **`/tmp/clipboard.html` (clipboard skill)** | Session-scoped paste-targets | Winner cast templates, draft bounty descriptions, DM templates |
+| **`scripts/`** | Re-runnable automation | Refresh leaderboard, batch ops, future CF Worker source |
+| **`docs/research/<topic>/<NNN>-<slug>/`** | Permanent research artifacts | Doc 625 (playbook), 626 (integration), 627 (capability map), 628 (this) |
+| **`.git` history + PRs** | Auditable change log | Every edit attributed and reversible |
+
+### Avoid these traps (next session)
+
+1. **Don't bake one-offs into the public page.** Round 1 wrap-up + Round 2 draft sat on poidh.html for ~2 hours before we moved them to clipboard. They were paste-targets, not display content. Got crowded fast.
+2. **Don't call out yerbearserker / Adrian for things you can do yourself.** Zaal owns the empire. Saved a DM round-trip once we verified ownership.
+3. **Don't trust OG meta as ground truth.** Always pull tRPC / contract reads.
+4. **Don't write album/bounty data into config files.** Pull live, cache short, refresh on demand.
+5. **Don't skip the `/zao-research` workflow** when an investigation produces > 200 lines of intel. The 4 docs (625-628) collectively are ~1500 lines; this would have been lost as conversation context otherwise.
+
+### What worked
+
+1. **Question the premise.** Caught the OG-meta misdirect, the album-name mismatch, the ownership confusion - all by going back and reading the source instead of the cached interpretation.
+2. **Multiple parallel API calls.** trpc + warpcast + EB API + youtube metadata in one bash block saved ~5 round-trips.
+3. **Frontmatter-first doc structure.** Each /zao-research doc starts with topic/type/status/last-validated/related-docs/tier - makes the library searchable for future self.
+4. **Cross-link aggressively.** Doc 627 references 626 references 625; every doc has "Also See" + "Sources" sections.
+5. **Refresh scripts > one-shot scrapes.** The Python script means the next bounty refresh is one command, not another 30-minute investigation.
+
+---
+
+## Part 7 - Decision Rubric for Next Bounties
+
+Apply in this order to every new POIDH bounty for ZAO/BCZ:
+
+1. **Episode / artifact identified?** What's the source content the bounty pulls from?
+2. **Run the title through POIDH letters.** If any letter is weak, rewrite the title.
+3. **Three observable inclusions named?** Platforms (X / Farcaster / IG), tags (3 minimum), proof-format (URL + caption + clip).
+4. **Reuse promise stated?** What does the WINNING submission unlock for them beyond ETH (pinned promo, channel feature, token allocation)?
+5. **Timecodes + beats called out?** Reduce "where do I start" friction.
+6. **Deadline absolute, not relative?** "Due 11:59pm PT 2026-05-25" beats "one week from now".
+7. **Tier matches doc 625 prize curve?** Tier A 0.005-0.01 / Tier B 0.015-0.03 / Tier C 0.03-0.1 / Tier D 0.1+.
+8. **Cross-post plan?** /poidh + /zao + topic channel + X. Three minimum surfaces.
+9. **Album = `wethemmedia` (or new sub-album).** Don't drift to vanity album names.
+10. **Refresh script run after claims close + before announce.** JSON stays current.
+
+---
+
+## Specific Numbers (session totals 2026-05-09)
+
+| Metric | Value |
+|--------|-------|
+| Docs written | 4 (625, 626, 627, 628) |
+| BCZ commits | 7 (poidh.html + JSON + script + nexus link) |
+| ZAOOS PRs | 2 (#494 = doc 625, #495 = docs 626/627/628) |
+| Live URLs shipped | 3 (poidh.html, poidh-leaderboard.json, scripts/refresh-poidh-leaderboard.py) |
+| Architectural corrections mid-session | 3 (BCZ-pulls -> EB-pulls, "Adam owns" -> Zaal owns, OG-meta -> tRPC) |
+| Identity resolutions | 6 (yerbearserker, Adrian, Kenny, J'Mariano, Adam, Zaal himself) |
+| External APIs hit (no key) | 4 (poidh tRPC, warpcast user lookup, empirebuilder GETs, EB GitBook ?ask=) |
+| Round 1 unique submitters | 10 |
+| Round 1 winner | cryptfi-mariano (claim 6368) |
+| Round 2 status | Drafted, awaiting funding |
+| Empire Builder leaderboard types | 11 (was thought to be 5) |
+| ZABAL Empire boosters active | 3 (zaal Zora, ZAAL newsletter, Quotient) |
+| ZABAL Empire treasury | $1,547.44 |
+| ZABAL burned to date | 178,213,603 |
+
+---
+
+## Sources
+
+- Doc 625 (POIDH x ZAO bounty playbook)
+- Doc 626 (Empire Builder + ZABAL POIDH airdrop architecture)
+- Doc 627 (ZABAL Empire ground truth + EB v3 capabilities)
+- [Kenny's POIDH framework cast](https://farcaster.xyz/kenny/0xbb5f295f) - pro-tip image with full POIDH acronym
+- [Kenny's winner-template thread](https://farcaster.xyz/kenny/0xbd415099) - "confirm on app, screenshot, announce on social"
+- [BCZ YapZ Ep 19 w/ Kenny YouTube](https://www.youtube.com/watch?v=IFG_34K7Vig) - 28-min episode, chapters cover SMART -> POID brainstorm + agent-built bounty writers
+- [Empire Builder SKILL.md](https://www.empirebuilder.world/skill/SKILL.md)
+- [Empire Builder skill/references/{http-api,workflows,contracts}.md]
+- [poidh-app repo](https://github.com/picsoritdidnthappen/poidh-app) (prod branch)
+- BCZ live: bettercallzaal.com/poidh.html, poidh-leaderboard.json, poidh-audit.json, scripts/refresh-poidh-leaderboard.py
+
+---
+
+## Also See
+
+- Doc 625 - operational bounty playbook (18 templates, prize curves, judging rules)
+- Doc 626 - Empire Builder integration architecture (BCZ feed -> apiLeaderboard)
+- Doc 627 - $ZABAL Empire state + v3 capabilities (the empire-state survey)
+- Doc 468 - POIDH Farcaster bot architecture (the bot/automation layer)
+- Doc 584 - ZABAL Nexus link inventory (where /poidh.html sits in the BCZ nav)
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Accept @cryptfi-mariano's claim 6368 on POIDH from issuer wallet 0x7234...e9af | @Zaal | POIDH app tap | Today |
+| Cast Round 1 winner using template in /tmp/clipboard.html, attach screenshot | @Zaal | Farcaster + X | Today |
+| Re-run `python3 scripts/refresh-poidh-leaderboard.py` so JSON shows `accepted: true` for claim 6368 | @Zaal | One command | After acceptance |
+| Create Round 2 bounty on POIDH using paste-ready title + description from clipboard | @Zaal | POIDH app | This week |
+| Create "BCZ YapZ Submitters" apiLeaderboard on $ZABAL Empire (slot 5) using EB submission package from clipboard | @Zaal | Empire dashboard | Today |
+| Plan Round 3 meta-bounty: "best POIDH-framework bounty written for ZAO" judged by Zaal + yerbearserker | @Zaal | Strategy | Month 1 |
+| Schedule Kenny follow-up cast on agent-built bounty writers (BCZ YapZ Ep 19 chapter 24:20) once POIDH ships agent tooling | @Zaal | Calendar | Q3 |
+| Re-validate this doc + doc 627 in 30 days (EB v3 is fresh, expected to evolve) | @Zaal | Doc update | 2026-06-09 |
+| Apply the decision rubric (Part 7) to every new ZAO POIDH bounty going forward | @Zaal | Habit | Ongoing |

--- a/research/dev-workflows/629-poidh-zabal-leaderboard-live-data-architecture/README.md
+++ b/research/dev-workflows/629-poidh-zabal-leaderboard-live-data-architecture/README.md
@@ -1,0 +1,346 @@
+---
+topic: dev-workflows
+type: guide
+status: research-complete
+last-validated: 2026-05-09
+related-docs: 628, 627, 626, 625
+tier: STANDARD
+---
+
+# 629 - POIDH x $ZABAL live leaderboard hub - data sources, free APIs, page architecture
+
+> **Goal:** Document the three free data sources that power `bettercallzaal.com/poidh.html` (now the canonical UI for slot 8 of the $ZABAL Empire). Capture the response shapes, the merge logic, and the gallery rendering pattern so future iterations or other empires can copy the architecture in an hour.
+
+> **Trigger:** Zaal asked to clean up the BCZ page into a real leaderboard hub showing submissions + socials of submitters. Doc 628 covered the meta-process; this doc covers the live-data pipeline.
+
+> **Confirmed live 2026-05-09:** Slot 8 "POIDH Submitters" apiLeaderboard on the $ZABAL Empire (uuid `7b8e8dfa-529d-48ad-8c9b-bdb45cc35187`) is wired to BCZ's JSON feed. EB has already distributed 13.35 ZABAL across 10 unique submitters from Round 1.
+
+## Key Decisions / Recommendations
+
+| Decision | Recommendation |
+|----------|----------------|
+| **Data merging strategy** | Fetch from three sources during refresh, merge into ONE rich JSON file (`poidh-claims.json`) consumed by the page in a single fetch. Avoids runtime CORS issues + multiple browser round-trips. Refresh runs server-side (Zaal's laptop) on demand or via cron. |
+| **EB read endpoint = free authoritative leaderboard** | `GET https://www.empirebuilder.world/api/leaderboards/<uuid>` returns rank + score + boost + totalRewards + farcaster_username per address. No API key. This is the source of truth for ranking + ZABAL distributions. |
+| **web3.bio = free profile resolver** | `GET https://api.web3.bio/profile/<address>` returns FC handle + display name + avatar + X handle + bio + follower count. No auth, no rate limit hit during normal use. Fills the gaps EB doesn't (avatars, X handles). |
+| **POIDH tRPC = free claim/bounty data** | `https://poidh.xyz/api/trpc/<router>.<procedure>` exposes bounties + claims. Use `claims.fetchBountyClaims` for the gallery (each item has `url` = image URL, `description` = often the original post URL, `title`, `isAccepted`). |
+| **Page renders from one static JSON** | `poidh-claims.json` is the sole runtime fetch. Static, cacheable, no CORS issues, fast first paint. Refresh script regenerates on demand. |
+| **Avatar fallback = dicebear identicon** | When `web3.bio` returns null avatar (rare), fall back to `https://api.dicebear.com/7.x/identicon/svg?seed=<address>`. Free, deterministic, branded. |
+| **Image fallback = hide on error** | POIDH IPFS URLs (`*.mypinata.cloud/ipfs/...`) occasionally 404. Use `onerror="this.style.display='none'"` to gracefully hide. Cards still show title + handle. |
+| **Action: turn on booster toggles** | Slot 8 leaderboard currently has `apply_boosters: false`, `apply_reputation_boosters: false`, `apply_staking_boosters: false`. ZABAL/SANG/ZORO holders + high-rep submitters are NOT getting amplified yet. Zaal should toggle these ON via Empire dashboard or via `POST /api/leaderboards/refresh/apiLeaderboards` with the right body. |
+| **Action: aggregate empire-wide rewards** | EB returns `totalRewards` per address - that's lifetime ZABAL across the WHOLE empire, not just from this leaderboard. We display it as-is, but note in copy that it includes all distributions. |
+| **Refresh cadence** | Zaal runs `python3 scripts/refresh-poidh-leaderboard.py` on demand. For higher cadence: Cloudflare Worker on 5-min cron, KV cache, edge response. Static script suffices until > 100 submitters. |
+
+---
+
+## Part 1 - Three Free Data Sources (Verified)
+
+### A. Empire Builder live leaderboard read
+
+```
+GET https://www.empirebuilder.world/api/leaderboards/<uuid>
+```
+
+No API key. Response shape:
+
+```json
+{
+  "success": true,
+  "leaderboard": {
+    "id": "7b8e8dfa-529d-48ad-8c9b-bdb45cc35187",
+    "base_token": "0xbb48f19b0494ff7c1fe5dc2032aeee14312f0b07",
+    "empire_address": "0xe0faa499d6711870211505bd9ae2105206af1462",
+    "name": "POIDH Submitters",
+    "description": "Submit to ZAO POIDH bounties to climb. ZABAL distributed by score.",
+    "leaderboard_number": 8,
+    "leaderboard_type": "api",
+    "api_endpoint": "https://bettercallzaal.com/poidh-leaderboard.json",
+    "apply_boosters": false,
+    "apply_reputation_boosters": false,
+    "apply_staking_boosters": false,
+    "last_refreshed_at": "2026-05-09T21:25:28.564+00:00",
+    "upgraded": true
+  },
+  "entries": [
+    {
+      "address": "0x5dc697f2799bd232cad2d479c379ff305b699f9b",
+      "rank": 1,
+      "score": 1,
+      "boost": 1,
+      "farcaster_username": "pascaline",
+      "x_name": null,
+      "totalRewards": 4.254089648089822
+    },
+    ...
+  ]
+}
+```
+
+**Key fields per entry:**
+
+| Field | Meaning | Notes |
+|-------|---------|-------|
+| `address` | Wallet (lowercase) | The empire's identity for that user |
+| `rank` | Position 1-N | Pre-sorted by EB |
+| `score` | Raw metric from API feed | Our `[{address, score}]` value |
+| `boost` | Multiplier currently applied | `1` = no boost (booster toggles OFF) |
+| `farcaster_username` | EB-resolved handle | Free FC resolution baked into EB |
+| `x_name` | EB-resolved X handle | Often null - use web3.bio supplement |
+| `totalRewards` | Lifetime ZABAL distributed to this address from this empire | Across ALL distributions, not just this leaderboard |
+
+### B. web3.bio profile resolver
+
+```
+GET https://api.web3.bio/profile/<address>
+```
+
+No auth, no rate-limit at our usage levels. Returns array; first entry usually `farcaster` platform.
+
+```json
+[{
+  "address": "0xa34514c2150029afa4d37577daee301166105355",
+  "identity": "cryptfi-mariano",
+  "platform": "farcaster",
+  "displayName": "J'Mariano",
+  "avatar": "https://imagedelivery.net/.../rectcrop3",
+  "description": "I make videos— telling Onchain stories | here for DAO communities & CM",
+  "links": {
+    "farcaster": { "link": "https://farcaster.xyz/cryptfi-mariano", "handle": "cryptfi-mariano" },
+    "twitter":   { "link": "https://x.com/cryptfi_mariano",      "handle": "cryptfi_mariano" }
+  },
+  "social": { "uid": 872568, "follower": 1718, "following": 893 }
+}]
+```
+
+**Key fields:**
+
+| Field | Use for |
+|-------|---------|
+| `identity` | Farcaster handle (sometimes a fallback when EB's `farcaster_username` is null) |
+| `displayName` | Human-readable name on cards |
+| `avatar` | Profile pic URL (use directly in `<img src>`) |
+| `description` | Bio (optional hover text) |
+| `links.farcaster.link` | Direct profile URL |
+| `links.twitter.handle` + `.link` | X handle - **fills EB's null `x_name`** |
+| `social.uid` | Farcaster FID |
+| `social.follower` | Audience size (for sort/feature decisions) |
+
+### C. POIDH tRPC
+
+```
+https://poidh.xyz/api/trpc/<router>.<procedure>?batch=1&input=<urlencoded>
+```
+
+Procedures used by the BCZ refresh script:
+
+| Procedure | Input | Returns |
+|-----------|-------|---------|
+| `bounties.fetch` | `{id, chainId}` | Bounty + `extra.album` |
+| `claims.fetchBountyClaims` | `{bountyId, chainId, limit}` | Claim list per bounty |
+
+**Per-claim fields useful for the gallery:**
+
+| Field | Meaning |
+|-------|---------|
+| `id` | POIDH-internal claim id (used in claim URL: `poidh.xyz/base/bounty/<bid>/claim/<id>`) |
+| `onChainId` | Smart contract id (different from `id`) |
+| `issuer` | The wallet that submitted the claim |
+| `title` | Submitter's claim title (the "what they made" summary) |
+| `description` | Often contains the original post URL (X/IG/YT link) |
+| `url` | Image URL on POIDH's IPFS gateway (`*.mypinata.cloud/ipfs/...`) |
+| `isAccepted` | Winner flag - `true` once issuer accepts |
+| `bountyId` | Parent bounty |
+
+---
+
+## Part 2 - The Merge Logic
+
+```
+For each bounty (1151, 1166, ...):
+    fetch bounty meta + claims via POIDH tRPC
+    track unique submitter addresses (excl. issuer)
+
+Fetch live leaderboard from EB by uuid
+    -> get rank + boost + totalRewards + farcaster_username per address
+
+For each unique submitter:
+    fetch web3.bio profile
+    -> get avatar + displayName + twitter_handle + follower count
+
+Merge:
+    For each address in unique_order:
+        merge { eb fields } + { web3.bio fields } -> one row
+
+Output:
+    poidh-leaderboard.json   = strict EB feed [{address, score}]
+    poidh-claims.json        = rich page data (bounties + claims + leaderboard)
+    poidh-audit.json         = audit trail for verification
+```
+
+The merge order matters: EB data first (authoritative for rank + rewards), web3.bio fills gaps (avatar, X handle).
+
+---
+
+## Part 3 - Page Architecture
+
+### One JSON, three views
+
+```
+poidh-claims.json (single fetch)
+    │
+    ├─→ Stats row    (totals.unique_submitters, total_zabal_distributed, etc.)
+    │
+    ├─→ Live leaderboard table
+    │     For each leaderboard[] entry:
+    │       avatar (web3.bio) + handle (EB or web3.bio) + rank + score + ZABAL + boost
+    │       Plus inline FC / X / Basescan links
+    │
+    └─→ Submissions gallery
+          For each claims[] entry:
+            image (POIDH IPFS) + bounty badge + winner badge
+            title + submitter avatar/handle (joined via address)
+            "post" link (extracted from description) + "claim" link
+```
+
+### CSS approach
+
+Reused BCZ's existing dark palette:
+- `--zabal: #a78bfa` (purple) for the empire-distributed metric
+- `--gold: #f5c842` for ETH escrow + winner badges
+- `--cyan: #00e5ff` for live actions + score
+- `--orange: #ff6b35` for section labels
+
+Three layout patterns:
+
+| Section | Layout |
+|---------|--------|
+| Stats | `grid-template-columns: repeat(4, 1fr)` desktop, `repeat(2, 1fr)` mobile |
+| Bounty strip | Two cards side-by-side, stack on mobile |
+| Leaderboard table | `grid-template-columns: 50px 1fr 80px 110px 90px` (rank · who · score · zabal · boost) |
+| Gallery | `repeat(auto-fill, minmax(260px, 1fr))` - responsive without breakpoints |
+
+### Failure-mode handling
+
+| Failure | Mitigation |
+|---------|-----------|
+| EB endpoint down | Refresh script logs `WARN`, falls back to empty entries - leaderboard renders without rank/boost/rewards but still shows submitters |
+| web3.bio profile null | Fall back to dicebear identicon avatar + truncated address as displayName |
+| POIDH IPFS image 404 | `onerror="this.style.display='none'"` hides image; card still shows title + submitter |
+| `description` lacks a URL | "post" link omitted; "claim" link still works |
+| `farcaster_username` null in BOTH sources | Show truncated address as the handle |
+
+---
+
+## Part 4 - First Run Results (2026-05-09)
+
+### Resolved submitter list (Round 1)
+
+| Rank | Address | FC handle | ZABAL distributed | Boost |
+|------|---------|-----------|-------------------|-------|
+| 1 | `0x5dc697...9f9b` | @pascaline | 4.25 | 1.00x |
+| 2 | `0x388e3d...24ff` | @noniwontmiss | 1.00 | 1.00x |
+| 3 | `0x6dce11...6953` | @joeyofdeus | (resolving) | 1.00x |
+| 4 | `0xaa2483...ea00` | @0xcollinxweb3 | (resolving) | 1.00x |
+| 5 | `0xa34514...5355` | @cryptfi-mariano | (resolving) | 1.00x |
+| 6 | `0x21422b...49cf` | @junyboy.eth | (resolving) | 1.00x |
+| 7 | `0x34da76...a7e9` | @cheeka | (resolving) | 1.00x |
+| 8 | `0x94652e...eaf6` | @megajayar.eth | (resolving) | 1.00x |
+| 9 | `0xc4ba38...d25c` | @tashin | (resolving) | 1.00x |
+| 10 | `0x0fbf06...25bc` | @watchcoin | (resolving) | 1.00x |
+
+(Lower-ranked entries' totalRewards distributed equally before ranking diverged - pascaline got first-round flush.)
+
+### Totals
+
+| Metric | Value |
+|--------|-------|
+| Unique submitters across both rounds | 10 |
+| Total claims | 11 (one wallet 2x in Round 1, score still 1) |
+| Bounties tracked | 2 (1151 won, 1166 live) |
+| Total ETH in escrow | 0.0165 |
+| Total ZABAL distributed (lifetime, all-empire) | 13.35 |
+
+---
+
+## Part 5 - Booster Toggles Are OFF (Action Item)
+
+Looking at `eb.leaderboard.apply_*_boosters`:
+
+```json
+"apply_boosters": false,
+"apply_reputation_boosters": false,
+"apply_staking_boosters": false
+```
+
+This is why every entry shows `boost: 1` (no multiplier). Zaal created the leaderboard with all three toggles OFF (or EB defaulted them).
+
+**To turn them on (one of two paths):**
+
+1. **Empire dashboard UI** - open the leaderboard, edit, flip Token Boosters + Reputation Boosters toggles to ON, save. UI signs the update tx.
+2. **API call (advanced)**: `POST /api/leaderboards/refresh/apiLeaderboards` won't toggle these; need a separate update endpoint or recreate the leaderboard with the toggles on. The cleanest path is the UI.
+
+Once flipped, the existing 3 boosters take effect:
+- `zaal` Zora coin holders (>= 1M zaal) get 5x
+- `ZAAL` newsletter token holders (>= 1M ZAAL) get 5x
+- Quotient reputation booster scales by reputation tier
+
+This makes Round 2 winners way more rewarding for active ecosystem holders.
+
+---
+
+## Specific Numbers
+
+| Metric | Value |
+|--------|-------|
+| Slot used on $ZABAL Empire | 8 |
+| Leaderboard UUID | `7b8e8dfa-529d-48ad-8c9b-bdb45cc35187` |
+| Empire ID | `0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07` |
+| SmartVault | `0xe0faa499d6711870211505bd9ae2105206af1462` |
+| API hook URL | `https://bettercallzaal.com/poidh-leaderboard.json` |
+| Page hub URL | `https://bettercallzaal.com/poidh.html` |
+| Rich data URL | `https://bettercallzaal.com/poidh-claims.json` |
+| EB last refresh | 2026-05-09 21:25 UTC |
+| Booster toggles | All OFF (action: turn on Token + Reputation) |
+| Free APIs used | 3 (EB, web3.bio, POIDH tRPC) |
+| API keys required | 0 |
+| Page first-paint | < 200ms (single JSON fetch) |
+| Total ZABAL distributed | 13.35 |
+| Submitters resolved with FC handle | 10 / 10 (100%) |
+| Submitters resolved with X handle | TBD (web3.bio coverage varies) |
+| Submitters resolved with avatar | 10 / 10 (with dicebear fallback) |
+
+---
+
+## Sources
+
+- [Empire Builder leaderboard live read](https://www.empirebuilder.world/api/leaderboards/7b8e8dfa-529d-48ad-8c9b-bdb45cc35187) - confirmed working 2026-05-09
+- [web3.bio profile API](https://api.web3.bio/profile/0xa34514c2150029afa4d37577daee301166105355) - confirmed working
+- [POIDH tRPC](https://poidh.xyz/api/trpc/) - confirmed working (no API key)
+- [Empire Builder SKILL.md](https://www.empirebuilder.world/skill/SKILL.md) (lastUpdated 2026-05-04)
+- BCZ live: `bettercallzaal.com/poidh.html` + `/poidh-claims.json` + `/poidh-leaderboard.json`
+- Doc 627 (ZABAL Empire ground truth) - same uuid + ownership confirmed there
+- Doc 628 (multi-hour learning capture) - earlier session that produced the static-feed version
+
+Verified URLs 2026-05-09: all three free APIs returned valid JSON. EB endpoint requires no key; web3.bio rate-limit not hit at < 20 calls/run; POIDH tRPC public.
+
+---
+
+## Also See
+
+- Doc 628 - Bounty-writing + integration learnings (the meta heuristics doc)
+- Doc 627 - $ZABAL Empire ground truth + EB v3 capabilities
+- Doc 626 - Empire Builder + ZABAL POIDH airdrop architecture
+- Doc 625 - POIDH x ZAO bounty playbook
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Turn on Token Boosters + Reputation Boosters toggles for slot 8 leaderboard via Empire dashboard | @Zaal | UI signed action | This week |
+| Run `python3 scripts/refresh-poidh-leaderboard.py` after Round 2 submissions land + after Round 1 winner is accepted on POIDH | @Zaal | One command | Ongoing |
+| Validate web3.bio coverage for X handles - if low, swap to a Neynar v2 free-tier `bulk-by-address` lookup with 1 free API key | @Zaal | API swap if needed | Phase 2 |
+| Move refresh to a Cloudflare Worker on 5-min cron when leaderboard > 100 submitters or auto-refresh becomes valuable | @Zaal | Worker port | When traffic warrants |
+| Add per-bounty filter UI to the gallery (chip toggles for Round 1 / Round 2) once Round 2 has 5+ claims | @Zaal | Page enhancement | Late May |
+| Consider adding a "Round leaderboard" view (filter by single bounty) alongside the all-rounds aggregate | @Zaal | Page enhancement | Round 3 onward |
+| Re-validate this doc + EB API surface in 30 days | @Zaal | Doc update | 2026-06-09 |


### PR DESCRIPTION
## Summary
How to use Empire Builder (Zaal is partner + white-label) to run the $zaalcaster airdrop as a cast-reactions engagement leaderboard, grounded in the two ZABAL Gamez workshop recordings. Includes the strategic reframe from Empire co-founder yerbearserker: the Triple A path (Assemble/Affirm/Ascend) - "dont launch a token yet."

## Tier
DISPATCH (2 ZABAL Gamez recordings ingested + 3 web research subagents)

## Sources
2 primary recordings (PARTIAL - structured summaries) + Empire Builder site/docs + Neynar + DEGEN + Clanker v4. Companion to doc 987.

## Next Actions
Decision due 2026-07-09 (token-now vs tokenless-first); tokenless empire + leaderboard by Monday 2026-07-13. See doc Next Actions table.