### PR TITLE
docs(icm): AI-readable context boxes (Zaal, The ZAO, ZABAL Games, WaveWarZ)

### DIFF
--- a/research/identity/icm-boxes/README.md
+++ b/research/identity/icm-boxes/README.md
@@ -16,8 +16,9 @@ useicm.com to mint each box. Cousin of our GEO / llms.txt work (own the AI answe
 | `wavewarz.llm.txt` | wavewarz | WaveWarZ live-traded music battles |
 
 ## Rules for these boxes
-- Use the canonical ZAO framing (decentralized impact network returning profit/data/IP to
-  artists). Do NOT use the stale "ZTalent Artist Organization" wording.
+- ZAO = ZTalent Artist Organization (the acronym / etymology). Describe what it IS as a
+  decentralized impact network returning profit/data/IP to artists. Use both correctly;
+  do NOT describe it as merely "a music community."
 - Facts only - no invented numbers or dates. On-chain Respect figures verified 2026-07-05.
 - Keep each box tight and composable; link related boxes at the bottom.
 

--- a/research/identity/icm-boxes/README.md
+++ b/research/identity/icm-boxes/README.md
@@ -1,0 +1,27 @@
+# ICM boxes - AI-readable context for the ZAO ecosystem
+
+ICM (useicm.com) gives every person/project a permanent, AI-readable address holding an
+`llm.txt`-style plain-text context that any assistant (ChatGPT, Claude, Cursor) can fetch.
+These are the ZAO ecosystem's context boxes - source of truth kept here, pasted into
+useicm.com to mint each box. Cousin of our GEO / llms.txt work (own the AI answer for
+"what is The ZAO").
+
+## Boxes
+
+| File | Box | Covers |
+|------|-----|--------|
+| `zaal.llm.txt` | zaal (bettercallzaal) | Zaal Panthaki - founder, what he runs, how he works, links |
+| `thezao.llm.txt` | thezao | The ZAO impact network - canonical framing, Respect/Fractal, lanes |
+| `zabalgamez.llm.txt` | zabalgamez | ZABAL Games 3-month build-a-thon - arc, how to enter |
+| `wavewarz.llm.txt` | wavewarz | WaveWarZ live-traded music battles |
+
+## Rules for these boxes
+- Use the canonical ZAO framing (decentralized impact network returning profit/data/IP to
+  artists). Do NOT use the stale "ZTalent Artist Organization" wording.
+- Facts only - no invented numbers or dates. On-chain Respect figures verified 2026-07-05.
+- Keep each box tight and composable; link related boxes at the bottom.
+
+## Source
+Grounded in the ZAO research library + memory (canonical pitch, Respect on-chain facts,
+ZABAL Games state doc, WaveWarZ canonical). Origin: 2026-07-08, from the Chris Dolinsky /
+Viniapp brainstorm (doc 952) where ICM + per-project context boxes were decided.

--- a/research/identity/icm-boxes/thezao.llm.txt
+++ b/research/identity/icm-boxes/thezao.llm.txt
@@ -1,6 +1,8 @@
 # ICM: The ZAO
 
-The ZAO is a decentralized impact network focused on bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Founded by Zaal Panthaki (BetterCallZaal). Priority stack: music first, community second, technology third.
+ZAO stands for ZTalent Artist Organization. The ZAO is a decentralized impact network focused on bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Founded by Zaal Panthaki (BetterCallZaal). Priority stack: music first, community second, technology third.
+
+Name note: the acronym ZAO = ZTalent Artist Organization; the descriptor for what it is today is a decentralized impact network. Both are correct - use the acronym for etymology, the impact-network framing for what it does.
 
 ## What it is
 Not a record label or a "music community" - an impact network whose first artist domain is music. It returns three things to artists: profit margin, data, and IP rights. Technology is the means, not the headline.

--- a/research/identity/icm-boxes/thezao.llm.txt
+++ b/research/identity/icm-boxes/thezao.llm.txt
@@ -1,0 +1,27 @@
+# ICM: The ZAO
+
+The ZAO is a decentralized impact network focused on bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Founded by Zaal Panthaki (BetterCallZaal). Priority stack: music first, community second, technology third.
+
+## What it is
+Not a record label or a "music community" - an impact network whose first artist domain is music. It returns three things to artists: profit margin, data, and IP rights. Technology is the means, not the headline.
+
+## Governance - the Fractal and Respect
+- Respect is the on-chain contribution currency: a soulbound OG ERC-20 plus a ZOR ERC-1155, on Optimism.
+- A weekly Respect Game ranks contributions; OREC optimistic execution settles outcomes; a Fibonacci curve shapes rewards.
+- Verified on-chain (2026-07-05): 156 Respect holders, OG Gini roughly 0.73.
+
+## Production lanes
+- WaveWarZ - live-traded music battles
+- ZABAL Games - the 3-month build-a-thon
+- The ZAO festivals - ZAOstock, ZAOville, ZAO-PALOOZA, ZAO-CHELLA
+- ZAO OS - the lab and monorepo where new ZAO things get prototyped before they graduate
+
+## Find it
+- thezao.xyz and zaoos.com
+- Papers: thezao.xyz/papers (whitepaper, technical whitepaper, manifesto)
+- Farcaster: the /zao and /zabal channels
+
+## Related boxes
+- Zaal (zaal)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)

--- a/research/identity/icm-boxes/wavewarz.llm.txt
+++ b/research/identity/icm-boxes/wavewarz.llm.txt
@@ -1,0 +1,22 @@
+# ICM: WaveWarZ
+
+WaveWarZ is live-traded music battles: artists battle, fans trade and earn. Part of The ZAO ecosystem.
+
+## What it is
+- A prediction-market-style music battle platform on Solana (mainnet), with a Base testnet and a Base-to-Solana bridge (via Mayan and Wormhole).
+- Quick battles run on weekdays; main events run on Sundays.
+- Artists compete; fans trade positions on the outcome and earn.
+
+## In the ZAO ecosystem
+- One of the ZAO production lanes alongside ZABAL Games and the festivals.
+- August ZABAL Games Finals integrate WaveWarZ-Base for on-chain settlement.
+
+## Find it
+- wavewarz.com
+- X: @WaveWarZ
+- Farcaster: the /wavewarz channel
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- ZABAL Games (zabalgamez)

--- a/research/identity/icm-boxes/zaal.llm.txt
+++ b/research/identity/icm-boxes/zaal.llm.txt
@@ -4,7 +4,7 @@ Identifier: zaal (aka bettercallzaal)
 Role: Founder of The ZAO. Builder, connector, and operator across web3, music, and community.
 
 ## Who
-Zaal Panthaki, known as BetterCallZaal. Founder of The ZAO, a decentralized impact network bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Electrical engineer (BS EE, RIT 2022). Maine-based. Builds in public.
+Zaal Panthaki, known as BetterCallZaal. Founder of The ZAO (ZAO = ZTalent Artist Organization), a decentralized impact network bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Electrical engineer (BS EE, RIT 2022). Maine-based. Builds in public.
 
 ## What he runs
 - The ZAO - the impact network (music first, community second, technology third)

--- a/research/identity/icm-boxes/zaal.llm.txt
+++ b/research/identity/icm-boxes/zaal.llm.txt
@@ -1,0 +1,31 @@
+# ICM: Zaal Panthaki (BetterCallZaal)
+
+Identifier: zaal (aka bettercallzaal)
+Role: Founder of The ZAO. Builder, connector, and operator across web3, music, and community.
+
+## Who
+Zaal Panthaki, known as BetterCallZaal. Founder of The ZAO, a decentralized impact network bringing the profit margin, data, and IP rights back to artists using emerging technology like blockchain and AI. Electrical engineer (BS EE, RIT 2022). Maine-based. Builds in public.
+
+## What he runs
+- The ZAO - the impact network (music first, community second, technology third)
+- BetterCallZaal Strategies LLC - his operating and consulting entity
+- COC Concertz - live concert series
+- ZABAL Games - a 3-month build-a-thon for artists, builders, and creators
+- The ZAO festivals - ZAOstock and ZAOville
+- WaveWarZ - live-traded music battles, part of the ZAO ecosystem
+
+## How he works
+- Ships MVP-first and iterates. Builds in public and documents the journey.
+- Mobile-first, dark theme. Farcaster-native. Uses Claude Code heavily.
+- Prefers open-source and owned distribution over rented platforms.
+
+## Find him
+- Farcaster: @zaal (also posts as @bettercallzaal)
+- X and YouTube: @bettercallzaal
+- GitHub: github.com/bettercallzaal
+- Sites: bettercallzaal.com, thezao.xyz, zaoos.com
+
+## Related boxes
+- The ZAO (thezao)
+- ZABAL Games (zabalgamez)
+- WaveWarZ (wavewarz)

--- a/research/identity/icm-boxes/zabalgamez.llm.txt
+++ b/research/identity/icm-boxes/zabalgamez.llm.txt
@@ -1,0 +1,23 @@
+# ICM: ZABAL Games (ZABAL Gamez)
+
+ZABAL Games is The ZAO's 3-month build-a-thon. Free to join, anyone welcome, three tracks: artist, builder, creator. The real audience is the 100+ member ZAO community - build for a real community, not a weekend you forget.
+
+## The arc
+- June: workshops
+- July: open-build month (goal: 200 distinct builders, multiple submissions each)
+- August: Finals, with WaveWarZ-Base integration and on-chain settlement
+
+## How it works
+- Submit in any format. Partial and work-in-progress drafts count.
+- Submissions land on the board at zabalgamez.com/submissions.
+- August mentors pair with open-submission builders and share evaluation criteria.
+- A generic stream overlay is available for workshop and Finals streams: zaoos.com/overlay/zabal-games (Restream or OBS browser source).
+
+## Find it
+- zabalgamez.com
+- Farcaster: the /zabal channel; tag posts with "zabal gamez"
+
+## Related boxes
+- The ZAO (thezao)
+- Zaal (zaal)
+- WaveWarZ (wavewarz)


### PR DESCRIPTION
First set of ICM (useicm.com) context boxes for the ZAO ecosystem - permanent AI-readable llm.txt-style context any assistant can fetch. Cousin of the GEO / llms.txt work.

Boxes: zaal, thezao, zabalgamez, wavewarz + an index README. Grounded in the research library + memory; facts only. ZAO = ZTalent Artist Organization (acronym) and a decentralized impact network (descriptor). Origin: the Chris Dolinsky / Viniapp brainstorm (doc 952) where per-project ICM boxes were decided.

Paste each into useicm.com to mint the box; keep this folder as source of truth.