### PR TITLE
feat(zoe): task auto-tagger (rebased clean off main, supersedes #1117)

### DIFF
--- a/bot/src/zoe/__tests__/task-classifier.test.ts
+++ b/bot/src/zoe/__tests__/task-classifier.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { classifyTask, applyClassification, needsTagging, planReconciliation, type TrackerRow } from '../task-classifier';
+
+describe('needsTagging', () => {
+  it('flags rows with no themes or no next_owner', () => {
+    expect(needsTagging({ id: '1', title: 'x' })).toBe(true);
+    expect(needsTagging({ id: '2', title: 'x', metadata: { themes: ['web3'] } })).toBe(true); // no owner
+    expect(needsTagging({ id: '3', title: 'x', metadata: { next_owner: 'me' } })).toBe(true); // no themes
+  });
+  it('passes fully-tagged rows', () => {
+    expect(needsTagging({ id: '4', title: 'x', metadata: { themes: ['web3'], next_owner: 'me' } })).toBe(false);
+  });
+});
+
+describe('planReconciliation', () => {
+  it('only patches untagged rows and preserves delegated routing', () => {
+    const rows: TrackerRow[] = [
+      { id: 'a', title: 'WaveWarZ profiles' }, // untagged -> patch
+      { id: 'b', title: 'done-ish', metadata: { themes: ['ai'], next_owner: 'agent' } }, // tagged -> skip
+      { id: 'c', title: 'Songjam fork', metadata: { delegated_to: 'research-queue' } }, // untagged, delegated
+    ];
+    const patches = planReconciliation(rows, '2026-07-06');
+    const ids = patches.map((p) => p.id);
+    expect(ids).toEqual(['a', 'c']);
+    const cPatch = patches.find((p) => p.id === 'c')!.patch.metadata as Record<string, unknown>;
+    expect(cPatch.next_owner).toBe('agent'); // delegated routing preserved
+    expect(cPatch.delegated_to).toBe('research-queue'); // other metadata preserved
+  });
+  it('returns an empty plan when everything is tagged', () => {
+    const rows: TrackerRow[] = [
+      { id: 'a', title: 'x', metadata: { themes: ['ops'], next_owner: 'me' } },
+    ];
+    expect(planReconciliation(rows, '2026-07-06')).toEqual([]);
+  });
+});
+
+describe('classifyTask', () => {
+  it('tags a WaveWarZ task by brand/theme and defaults next_owner to me', () => {
+    const c = classifyTask({ title: 'Fill 6 WaveWarZ profiles' });
+    expect(c.brands).toEqual(['WaveWarZ']);
+    expect(c.themes).toContain('music');
+    expect(c.nextOwner).toBe('me');
+  });
+
+  it('routes a fractal/onchain task to web3 + governance themes and The ZAO brand', () => {
+    const c = classifyTask({ title: 'Fractal: Civil wallet fix + check ordaos' });
+    expect(c.brands).toEqual(['The ZAO']);
+    expect(c.themes).toEqual(expect.arrayContaining(['web3']));
+    expect(c.category).toBe('Site / Tech');
+  });
+
+  it('caps themes at 2', () => {
+    const c = classifyTask({ title: 'wavewarz onchain wallet mint fractal research profile campaign' });
+    expect(c.themes.length).toBeLessThanOrEqual(2);
+  });
+
+  it('forces next_owner=agent when delegated', () => {
+    const c = classifyTask({ title: 'Songjam fork', delegatedTo: 'research-queue' });
+    expect(c.nextOwner).toBe('agent');
+  });
+
+  it('forces next_owner=me when needsZaal, over a blocked status', () => {
+    const c = classifyTask({ title: 'ZAO Numbers - website analytics', needsZaal: true, status: 'blocked' });
+    expect(c.nextOwner).toBe('me');
+  });
+
+  it('maps blocked status to blocked when not delegated/needsZaal', () => {
+    const c = classifyTask({ title: 'Some task', status: 'blocked' });
+    expect(c.nextOwner).toBe('blocked');
+  });
+
+  it('falls back to The ZAO / Other / ops for unmatched text', () => {
+    const c = classifyTask({ title: 'xyzzy plugh frobnicate' });
+    expect(c.brands).toEqual(['The ZAO']);
+    expect(c.category).toBe('Other');
+    expect(c.themes).toEqual(['ops']);
+  });
+
+  it('is deterministic', () => {
+    const a = classifyTask({ title: 'ZAOstock permit', notes: 'call Roddy' });
+    const b = classifyTask({ title: 'ZAOstock permit', notes: 'call Roddy' });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('applyClassification', () => {
+  const c = classifyTask({ title: 'WaveWarZ Solana bridge test' });
+
+  it('fills brands/category when absent and always sets metadata themes/next_owner', () => {
+    const out = applyClassification({ title: 'x' }, c, '2026-07-06');
+    expect(out.brands).toEqual(['WaveWarZ']);
+    expect(out.category).toBe('Site / Tech');
+    const meta = out.metadata as Record<string, unknown>;
+    expect(meta.themes).toEqual(c.themes);
+    expect(meta.next_owner).toBe('me');
+    expect(meta.autotagged).toBe('2026-07-06');
+  });
+
+  it('does not clobber an existing brand/category', () => {
+    const out = applyClassification(
+      { title: 'x', brands: ['ZOE'], category: 'Ops' },
+      c,
+      '2026-07-06',
+    );
+    expect(out.brands).toEqual(['ZOE']); // preserved
+    expect(out.category).toBe('Ops'); // preserved
+  });
+
+  it('preserves other metadata keys', () => {
+    const out = applyClassification(
+      { title: 'x', metadata: { list: 'zaal-master', tier: 'P1' } },
+      c,
+      '2026-07-06',
+    );
+    const meta = out.metadata as Record<string, unknown>;
+    expect(meta.list).toBe('zaal-master');
+    expect(meta.tier).toBe('P1');
+    expect(meta.next_owner).toBe('me');
+  });
+
+  it('does not mutate the input row', () => {
+    const row = { title: 'x', metadata: { a: 1 } };
+    applyClassification(row, c, '2026-07-06');
+    expect(row.metadata).toEqual({ a: 1 });
+  });
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -33,6 +33,7 @@ import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidate
 import { markNudged } from './threads';
 import { flushEmitQueue } from './thread-memory';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
+import { reconcileUntaggedTasks } from './team-tracker';
 
 /** await-reflection waits overnight for Zaal's reply, so a 14h TTL not 30m. */
 const AWAIT_REFLECTION_TTL_MS = 14 * 60 * 60 * 1000;
@@ -182,6 +183,18 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           await flushEmitQueue();
         } catch (err) {
           console.warn('[zoe/scheduler] emit-queue flush failed (nbd):', (err as Error).message);
+        }
+
+        // Doc 983 Rec #4: hourly backfill of any task created untagged by a
+        // writer other than ZOE's write-path (board quick-add, meeting capture).
+        // Best-effort - a no-op when the tracker is unconfigured.
+        try {
+          const r = await reconcileUntaggedTasks();
+          if (r.ok && r.tagged > 0) {
+            console.log(`[zoe/scheduler] auto-tag reconcile: tagged ${r.tagged}/${r.scanned}`);
+          }
+        } catch (err) {
+          console.warn('[zoe/scheduler] auto-tag reconcile failed (nbd):', (err as Error).message);
         }
 
         // Build the task-queue nudge as a gate candidate (folded in). Only when

--- a/bot/src/zoe/task-classifier.ts
+++ b/bot/src/zoe/task-classifier.ts
@@ -1,0 +1,178 @@
+/**
+ * task-classifier.ts - auto-tag a task from its title + notes (doc 983 Rec #4).
+ *
+ * Deterministic keyword classifier: given a task's text, assign a ZAO brand, a
+ * board work-type category, cross-cutting theme tags, and the judgment-routing
+ * next_owner. Runs on the write-path (buildTeamTaskRow) so every ZOE-created
+ * task self-tags on insert, and in the reconciler to backfill older rows.
+ *
+ * Pure + dependency-free so it is trivially testable and reusable. Keep the rule
+ * tables in sync with the board's canonical brands (lib/brands.ts) + categories
+ * and the auto-tagger batch pass that first populated these fields.
+ */
+
+export type NextOwner = 'me' | 'agent' | 'review' | 'blocked';
+
+export interface Classification {
+  brands: string[];
+  category: string;
+  themes: string[];
+  nextOwner: NextOwner;
+}
+
+export interface ClassifyInput {
+  title: string;
+  notes?: string | null;
+  /** already-known delegation target (metadata.delegated_to) -> forces agent */
+  delegatedTo?: string | null;
+  /** already-known needs_zaal flag -> forces me */
+  needsZaal?: boolean;
+  status?: string | null;
+}
+
+type Rule = [RegExp, string];
+
+// Brand: canonical names from lib/brands.ts. First match wins; default The ZAO.
+const BRAND_RULES: Rule[] = [
+  [/wavewarz|solana bridge/i, 'WaveWarZ'],
+  [/zaostock|art of ellsworth|mainecf|fractured atlas|roddy|parklet/i, 'ZAOstock'],
+  [/zabal games|zabal gamez|zabal university/i, 'ZABAL Games'],
+  [/\bzuke\b|\bjuke\b/i, 'Juke'],
+  [/\bcoc\b|concertz/i, 'COC Concertz'],
+  [/hyperagent|\bzoe\b|\bzol\b/i, 'ZOE'],
+  [/poidh/i, 'POIDH'],
+  [/bonfire/i, 'Bonfire'],
+  [/fractal|ordao|respect|whitepaper|governance/i, 'The ZAO'],
+];
+
+// Work-type: the board's canonical CATEGORIES enum. First match wins; default Other.
+const CATEGORY_RULES: Rule[] = [
+  [/whitepaper|mint|permaweb/i, 'ZAO Devz'],
+  [/bot|bridge|deploy|migration|vercel|\bci\b|smoke|env var|test-coverage|graduation|integration|repo|skill dup|classifier|technical|data hygiene|wallet fix/i, 'Site / Tech'],
+  [/permit|sponsor|kickoff|logistics|facebook event|checklist|outreach|understud/i, 'Ops'],
+  [/profile|campaign|101 video|content|post criteria|wiki|newsletter/i, 'Content'],
+  [/\bdm\b|socials|farcaster|spaces|cast/i, 'Social'],
+  [/research|intel|re-research|doc |novelty|numbers|analytics/i, 'Other'],
+];
+
+// Theme: cross-cutting lens. Multiple can match (capped at 2). Default ops.
+const THEME_RULES: Rule[] = [
+  [/onchain|on-chain|wallet|mint|respect|solana|fractal|ordao|permaweb|nft|dao|token/i, 'web3'],
+  [/agent|hyperagent|\bzoe\b|\bzol\b|claude|classifier|automation|intelligence app|research-radar/i, 'ai'],
+  [/wavewarz|recording|artist|release|song|music|godcloud|rockumentary/i, 'music'],
+  [/zaostock|festival|coc|concertz|palooza|chella|event/i, 'events'],
+  [/profile|outreach|campaign|social|university|whop|streaming|bid-on|platform/i, 'growth'],
+  [/fractal|ordao|respect|governance|whitepaper|dao/i, 'governance'],
+  [/research|intel|re-research|hyperstition|novelty|numbers|analytics/i, 'research'],
+];
+
+function firstMatch(text: string, rules: Rule[], fallback: string): string {
+  for (const [re, val] of rules) if (re.test(text)) return val;
+  return fallback;
+}
+
+function allMatches(text: string, rules: Rule[], cap: number): string[] {
+  const out: string[] = [];
+  for (const [re, val] of rules) {
+    if (re.test(text) && !out.includes(val)) out.push(val);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+/**
+ * Classify a task. Deterministic - same input always yields the same tags.
+ */
+export function classifyTask(input: ClassifyInput): Classification {
+  const text = `${input.title} ${input.notes ?? ''}`.toLowerCase();
+  const brand = firstMatch(text, BRAND_RULES, 'The ZAO');
+  const category = firstMatch(text, CATEGORY_RULES, 'Other');
+  const themes = allMatches(text, THEME_RULES, 2);
+  if (themes.length === 0) themes.push('ops');
+
+  let nextOwner: NextOwner;
+  if (input.delegatedTo) nextOwner = 'agent';
+  else if (input.needsZaal) nextOwner = 'me';
+  else if ((input.status ?? '').toLowerCase() === 'blocked') nextOwner = 'blocked';
+  else nextOwner = 'me';
+
+  return { brands: [brand], category, themes, nextOwner };
+}
+
+/**
+ * Merge a classification into a tracker row / metadata object. Non-destructive:
+ * only fills brands/category when absent, always refreshes metadata.themes +
+ * metadata.next_owner + stamps autotagged. Returns a new object; does not mutate.
+ */
+export function applyClassification(
+  row: Record<string, unknown>,
+  c: Classification,
+  stampedAt: string,
+): Record<string, unknown> {
+  const meta = { ...((row.metadata as Record<string, unknown>) ?? {}) };
+  meta.themes = c.themes;
+  meta.next_owner = c.nextOwner;
+  meta.autotagged = stampedAt;
+  const out: Record<string, unknown> = { ...row, metadata: meta };
+  // brands/category are dedicated columns; only set when the row lacks them so a
+  // human/explicit value is never clobbered.
+  const existingBrands = row.brands;
+  if (!Array.isArray(existingBrands) || existingBrands.length === 0) out.brands = c.brands;
+  if (!row.category) out.category = c.category;
+  return out;
+}
+
+/** A task row as read from the tracker for reconciliation. */
+export interface TrackerRow {
+  id: string;
+  title: string;
+  notes?: string | null;
+  status?: string | null;
+  brands?: unknown;
+  category?: unknown;
+  metadata?: Record<string, unknown> | null;
+}
+
+/** A row needs tagging when it has no theme tags or no next_owner yet. */
+export function needsTagging(row: TrackerRow): boolean {
+  const meta = row.metadata ?? {};
+  const noThemes = !Array.isArray(meta.themes) || (meta.themes as unknown[]).length === 0;
+  const noOwner = !meta.next_owner;
+  return noThemes || noOwner;
+}
+
+export interface ReconcilePatch {
+  id: string;
+  patch: Record<string, unknown>;
+}
+
+/**
+ * Pure planner: from a batch of tracker rows, produce the PATCH bodies for the
+ * ones that need tagging. Preserves an existing delegated_to/needs_zaal so the
+ * next_owner routing stays correct. The network wrapper applies these.
+ */
+export function planReconciliation(rows: TrackerRow[], stampedAt: string): ReconcilePatch[] {
+  const patches: ReconcilePatch[] = [];
+  for (const row of rows) {
+    if (!needsTagging(row)) continue;
+    const meta = row.metadata ?? {};
+    const c = classifyTask({
+      title: row.title,
+      notes: row.notes ?? null,
+      delegatedTo: (meta.delegated_to as string) ?? null,
+      needsZaal: Boolean(meta.needs_zaal),
+      status: row.status ?? null,
+    });
+    const applied = applyClassification(
+      { title: row.title, brands: row.brands, category: row.category, metadata: meta },
+      c,
+      stampedAt,
+    );
+    // Only ship the fields the reconciler is allowed to touch.
+    const patch: Record<string, unknown> = { metadata: applied.metadata };
+    if ('brands' in applied && applied.brands !== row.brands) patch.brands = applied.brands;
+    if ('category' in applied && applied.category !== row.category) patch.category = applied.category;
+    patches.push({ id: row.id, patch });
+  }
+  return patches;
+}

--- a/bot/src/zoe/team-tracker.ts
+++ b/bot/src/zoe/team-tracker.ts
@@ -15,6 +15,8 @@
  * Read-only for now; a write path (ZOE assigns team tasks) is a follow-up.
  */
 
+import { classifyTask, applyClassification, planReconciliation, type TrackerRow } from './task-classifier';
+
 export interface TeamTask {
   title: string;
   status: string;
@@ -86,12 +88,56 @@ export function buildTeamTaskRow(t: NewTeamTask): Record<string, unknown> {
     legacy_source: 'zoe-bot',
   };
   if (t.priority) row.priority = t.priority;
-  return row;
+  // Doc 983 Rec #4: auto-tag on the write-path so every ZOE-created task lands
+  // pre-classified (brand / category / themes / next_owner) instead of naked.
+  const c = classifyTask({ title: t.title });
+  return applyClassification(row, c, new Date().toISOString().slice(0, 10));
 }
 
 export interface AddTeamTaskResult {
   ok: boolean;
   error?: string;
+}
+
+export interface ReconcileResult {
+  ok: boolean;
+  scanned: number;
+  tagged: number;
+  error?: string;
+}
+
+/**
+ * Doc 983 Rec #4 backfill: find open tasks that were created without tags (any
+ * writer other than the ZOE write-path) and classify them in place. Best-effort;
+ * never throws. Catches board quick-adds, meeting captures, external-api rows.
+ */
+export async function reconcileUntaggedTasks(limit = 100): Promise<ReconcileResult> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return { ok: false, scanned: 0, tagged: 0, error: 'team tracker not configured' };
+  const root = base.replace(/\/$/, '');
+  const headers = { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' };
+  try {
+    const getUrl =
+      `${root}/rest/v1/tasks?status=neq.done&archived_at=is.null` +
+      `&select=id,title,notes,status,brands,category,metadata&limit=${limit}`;
+    const res = await fetch(getUrl, { headers, cache: 'no-store' });
+    if (!res.ok) return { ok: false, scanned: 0, tagged: 0, error: `read ${res.status}` };
+    const rows = (await res.json()) as TrackerRow[];
+    const patches = planReconciliation(rows, new Date().toISOString().slice(0, 10));
+    let tagged = 0;
+    for (const p of patches) {
+      const patchRes = await fetch(`${root}/rest/v1/tasks?id=eq.${p.id}`, {
+        method: 'PATCH',
+        headers: { ...headers, Prefer: 'return=minimal' },
+        body: JSON.stringify(p.patch),
+      });
+      if (patchRes.ok) tagged += 1;
+    }
+    return { ok: true, scanned: rows.length, tagged };
+  } catch (e) {
+    return { ok: false, scanned: 0, tagged: 0, error: e instanceof Error ? e.message : 'reconcile failed' };
+  }
 }
 
 /**


### PR DESCRIPTION
Rebased #1117 onto main to clear the doc-collision-guard block. Only the 4 bot files (task-classifier.ts + test, scheduler hook, team-tracker) - scheduler.ts import conflict resolved keep-both. CI was green on #1117 head. Supersedes #1117.