### PR TITLE
feat(cockpit): Slice 1 - operator cockpit adapters + schema + read-only brief

### DIFF
--- a/bot/src/cockpit/README.md
+++ b/bot/src/cockpit/README.md
@@ -1,0 +1,44 @@
+# Personal Operator Cockpit (harness)
+
+Zaal's daily operator loop as a Claude Agent SDK harness. WRAPS ZOE's existing
+tracker (does not rebuild it) and adds the doc-983 gaps: a structured cockpit
+brief, gated writes (owner-axis / archive), an artifact store, and (next) a
+weekly stale review. Design: `research/agents/997` + `999`; gaps: doc 983.
+
+## Why a harness (How I AI episode, doc 999)
+A harness = specific context + specific actions + specific outcomes around the
+model. Applied here:
+- **Opinionated adapters, not generic tools** (`adapters.ts`) - pull only the
+  tracker fields the cockpit needs, in the shape it needs.
+- **Fixed output schema** (`types.ts` `CockpitBrief`) - defined in the harness,
+  not the prompt.
+- **Constraint flags** (`CockpitMode`: brief | triage | apply) - "read-only"
+  enforced by the mode, not by asking the model nicely.
+- **Artifact store** (`~/.zao/cockpit/brief-<date>.json`) - run evidence persists.
+
+## Slices
+- [x] **Slice 1 (this PR):** schema + opinionated adapters (read tracker,
+  partition by owner-axis, top-3, stale, build gated proposals, apply-one) +
+  read-only brief assembler/formatter + artifact store + unit tests. No SDK
+  wiring yet, no live writes fired.
+- [ ] **Slice 2:** Claude Agent SDK orchestration (`cockpit.ts`) - the loop that
+  calls the adapters as tools, in brief/triage/apply modes.
+- [ ] **Slice 3:** gated-write approval flow via Telegram (propose -> Zaal
+  approves -> `applyWriteProposal`), + weekly stale review cadence.
+- [ ] **Slice 4:** cron wiring (replace/augment ZOE's morning brief) + route to
+  the ZAAL BOTS group.
+
+## Files
+- `types.ts` - CockpitBrief + WriteProposal + CockpitMode (the schema).
+- `adapters.ts` - opinionated adapters; pure logic (topThree/needsYou/findStale/
+  buildProposals) is exported separately for tests.
+- `brief.ts` - assemble + format + persist the brief.
+- `__tests__/cockpit.test.ts` - unit tests for the pure logic.
+
+## Config (env, VPS bot/.env)
+- `COWORK_TRACKER_URL` + `COWORK_TRACKER_KEY` - tracker read/write (already used by ZOE).
+- `COCKPIT_HOME` - artifact store dir (default `~/.zao/cockpit`).
+
+## Safety
+Writes are GATED: `buildProposals` only PROPOSES; `applyWriteProposal` runs one
+approved proposal at a time. Nothing writes without Zaal's approval (Slice 3).

--- a/bot/src/cockpit/__tests__/cockpit.test.ts
+++ b/bot/src/cockpit/__tests__/cockpit.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { topThree, needsYou, blocked, findStale, buildProposals, priorityRank, daysSince, STALE_DAYS } from '../adapters';
+import { formatCockpitBrief } from '../brief';
+import type { CockpitTask, CockpitBrief } from '../types';
+
+const DAY = 86_400_000;
+const NOW = Date.parse('2026-07-09T12:00:00Z');
+
+function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitTask {
+  return {
+    status: 'todo',
+    priority: null,
+    due: null,
+    project: null,
+    legacy_id: null,
+    next_owner: null,
+    updated_at: new Date(NOW).toISOString(),
+    created_at: new Date(NOW).toISOString(),
+    ...o,
+  };
+}
+
+describe('priorityRank', () => {
+  it('parses P0-P9, defaults 5', () => {
+    expect(priorityRank('P0')).toBe(0);
+    expect(priorityRank('p1')).toBe(1);
+    expect(priorityRank(null)).toBe(5);
+    expect(priorityRank('urgent')).toBe(5);
+  });
+});
+
+describe('daysSince', () => {
+  it('returns Infinity for null/bad dates', () => {
+    expect(daysSince(null, NOW)).toBe(Number.POSITIVE_INFINITY);
+    expect(daysSince('not-a-date', NOW)).toBe(Number.POSITIVE_INFINITY);
+  });
+  it('computes whole days', () => {
+    expect(Math.round(daysSince(new Date(NOW - 5 * DAY).toISOString(), NOW))).toBe(5);
+  });
+});
+
+describe('topThree', () => {
+  it('soonest due first, undated last, caps at 3', () => {
+    const tasks = [
+      task({ id: '1', title: 'no due' }),
+      task({ id: '2', title: 'later', due: '2026-07-20' }),
+      task({ id: '3', title: 'soon', due: '2026-07-10' }),
+      task({ id: '4', title: 'sooner', due: '2026-07-09' }),
+    ];
+    const t = topThree(tasks);
+    expect(t.map((x) => x.id)).toEqual(['4', '3', '2']);
+  });
+});
+
+describe('needsYou', () => {
+  it('picks next_owner=me and unrouted P0/P1', () => {
+    const tasks = [
+      task({ id: 'a', title: 'mine', next_owner: 'me' }),
+      task({ id: 'b', title: 'agent', next_owner: 'agent' }),
+      task({ id: 'c', title: 'hot unrouted', priority: 'P1' }),
+      task({ id: 'd', title: 'cold unrouted', priority: 'P3' }),
+    ];
+    expect(needsYou(tasks).map((x) => x.id).sort()).toEqual(['a', 'c']);
+  });
+});
+
+describe('blocked', () => {
+  it('picks next_owner=blocked', () => {
+    const tasks = [task({ id: 'a', title: 'x', next_owner: 'blocked' }), task({ id: 'b', title: 'y' })];
+    expect(blocked(tasks).map((x) => x.id)).toEqual(['a']);
+  });
+});
+
+describe('findStale', () => {
+  it('flags undated P1 and no-update-in-14d, skips recurring', () => {
+    const tasks = [
+      task({ id: 'a', title: 'undated hot', priority: 'P0' }),
+      task({ id: 'b', title: 'cold', updated_at: new Date(NOW - (STALE_DAYS + 1) * DAY).toISOString(), created_at: new Date(NOW - 30 * DAY).toISOString() }),
+      task({ id: 'c', title: '[recurring] standup', updated_at: new Date(NOW - 60 * DAY).toISOString() }),
+      task({ id: 'd', title: 'fresh dated', due: '2026-07-15', priority: 'P1' }),
+    ];
+    expect(findStale(tasks, NOW).map((x) => x.id).sort()).toEqual(['a', 'b']);
+  });
+});
+
+describe('buildProposals', () => {
+  it('proposes owner for untagged and archive for very-stale', () => {
+    const tasks = [
+      task({ id: 'a', title: 'wavewarz thing' }), // untagged -> set_owner
+      task({ id: 'b', title: 'tagged', next_owner: 'agent' }), // skip
+      task({ id: 'c', title: 'ancient', next_owner: 'review', updated_at: new Date(NOW - (STALE_DAYS * 2 + 1) * DAY).toISOString(), created_at: new Date(NOW - 90 * DAY).toISOString() }),
+    ];
+    const p = buildProposals(tasks, NOW);
+    expect(p.some((x) => x.taskId === 'a' && x.kind === 'set_owner')).toBe(true);
+    expect(p.some((x) => x.taskId === 'c' && x.kind === 'archive_stale')).toBe(true);
+    expect(p.some((x) => x.taskId === 'b')).toBe(false);
+  });
+});
+
+describe('formatCockpitBrief', () => {
+  it('renders sections + counts, no emojis/em dashes', () => {
+    const b: CockpitBrief = {
+      date: '2026-07-09',
+      top3: [task({ id: '1', title: 'do this', due: '2026-07-09', priority: 'P0' })],
+      needsYou: [task({ id: '2', title: 'your call', next_owner: 'me' })],
+      stale: [],
+      blocked: [],
+      counts: { open: 2, needsYou: 1, stale: 0, blocked: 0 },
+      proposedWrites: [],
+    };
+    const out = formatCockpitBrief(b);
+    expect(out).toContain('Cockpit - 2026-07-09');
+    expect(out).toContain('DO FIRST');
+    expect(out).toContain('NEEDS YOU');
+    expect(out).not.toMatch(/[—\u{1F300}-\u{1FAFF}]/u); // no em dash, no emoji
+  });
+});

--- a/bot/src/cockpit/adapters.ts
+++ b/bot/src/cockpit/adapters.ts
@@ -1,0 +1,191 @@
+/**
+ * Cockpit opinionated adapters.
+ *
+ * The How I AI episode's #1 lesson: custom, opinionated adapters beat generic
+ * MCPs - pull only the data the job needs, in the shape the job needs. These
+ * wrap the cowork tracker (PostgREST) + reuse ZOE's classifier. The pure
+ * partition/stale/rank functions are exported separately so they unit-test
+ * without the network.
+ */
+
+import { classifyTask, type NextOwner } from '../zoe/task-classifier';
+import type { CockpitTask, WriteProposal } from './types';
+
+/** A task with no update in this many days (and not recurring) is stale. Doc 983. */
+export const STALE_DAYS = 14;
+
+const MAX_TASKS = 200;
+const REQUEST_TIMEOUT_MS = 8000;
+
+interface RawRow {
+  id: string;
+  title: string;
+  status: string;
+  priority: string | null;
+  due: string | null;
+  project: string | null;
+  legacy_id: string | null;
+  updated_at: string | null;
+  created_at: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+function nextOwnerOf(meta: Record<string, unknown> | null): NextOwner | null {
+  const v = meta?.next_owner;
+  return v === 'me' || v === 'agent' || v === 'review' || v === 'blocked' ? v : null;
+}
+
+function toCockpitTask(r: RawRow): CockpitTask {
+  return {
+    id: r.id,
+    title: r.title,
+    status: r.status,
+    priority: r.priority,
+    due: r.due,
+    project: r.project,
+    legacy_id: r.legacy_id,
+    next_owner: nextOwnerOf(r.metadata),
+    updated_at: r.updated_at,
+    created_at: r.created_at,
+  };
+}
+
+/** Read open (not done, not archived) tasks with the fields the cockpit needs. Best-effort: returns [] on any failure. */
+export async function fetchCockpitTasks(): Promise<CockpitTask[]> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return [];
+
+  const url =
+    `${base.replace(/\/$/, '')}/rest/v1/tasks` +
+    `?status=neq.done&archived_at=is.null` +
+    `&select=id,title,status,priority,due,project,legacy_id,updated_at,created_at,metadata` +
+    `&order=due.asc.nullslast&limit=${MAX_TASKS}`;
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: controller.signal,
+      cache: 'no-store',
+    }).finally(() => clearTimeout(timer));
+    if (!res.ok) return [];
+    const rows = (await res.json()) as RawRow[];
+    return rows.map(toCockpitTask);
+  } catch {
+    return [];
+  }
+}
+
+// ---- pure logic (unit-testable, no network) ----
+
+export function priorityRank(p: string | null): number {
+  const m = (p ?? '').toUpperCase().match(/P([0-9])/);
+  return m ? Number(m[1]) : 5;
+}
+
+function isRecurring(title: string): boolean {
+  return /\[(standing|recurring)\]/i.test(title);
+}
+
+export function daysSince(iso: string | null, now: number): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? Number.POSITIVE_INFINITY : (now - t) / 86_400_000;
+}
+
+/** Top 3 "do first": soonest due wins; undated sinks; ties broken by priority. */
+export function topThree(tasks: CockpitTask[]): CockpitTask[] {
+  return [...tasks]
+    .sort((a, b) => {
+      const da = a.due ? Date.parse(a.due) : Number.POSITIVE_INFINITY;
+      const db = b.due ? Date.parse(b.due) : Number.POSITIVE_INFINITY;
+      if (da !== db) return da - db;
+      return priorityRank(a.priority) - priorityRank(b.priority);
+    })
+    .slice(0, 3);
+}
+
+/** Tasks routed to Zaal: next_owner === 'me', OR unrouted AND high-priority (P0/P1). */
+export function needsYou(tasks: CockpitTask[]): CockpitTask[] {
+  return tasks.filter(
+    (t) => t.next_owner === 'me' || (t.next_owner === null && priorityRank(t.priority) <= 1),
+  );
+}
+
+export function blocked(tasks: CockpitTask[]): CockpitTask[] {
+  return tasks.filter((t) => t.next_owner === 'blocked');
+}
+
+/** Stale: not recurring AND (undated P0/P1, OR no update in >= STALE_DAYS). */
+export function findStale(tasks: CockpitTask[], now: number): CockpitTask[] {
+  return tasks.filter((t) => {
+    if (isRecurring(t.title)) return false;
+    const undatedHot = !t.due && priorityRank(t.priority) <= 1;
+    const cold = daysSince(t.updated_at ?? t.created_at, now) >= STALE_DAYS;
+    return undatedHot || cold;
+  });
+}
+
+/** Build gated write proposals: route untagged tasks + flag stale-for-archive. Never applied here. */
+export function buildProposals(tasks: CockpitTask[], now: number): WriteProposal[] {
+  const proposals: WriteProposal[] = [];
+  for (const t of tasks) {
+    if (t.next_owner === null) {
+      const c = classifyTask({ title: t.title, notes: null });
+      proposals.push({
+        taskId: t.id,
+        title: t.title,
+        kind: 'set_owner',
+        nextOwner: c.nextOwner,
+        reason: `untagged - classifier routes to '${c.nextOwner}'`,
+      });
+    }
+  }
+  for (const t of findStale(tasks, now)) {
+    const d = daysSince(t.updated_at ?? t.created_at, now);
+    if (Number.isFinite(d) && d >= STALE_DAYS * 2) {
+      proposals.push({
+        taskId: t.id,
+        title: t.title,
+        kind: 'archive_stale',
+        reason: `no update in ${Math.round(d)}d - propose archive`,
+      });
+    }
+  }
+  return proposals;
+}
+
+/** Apply one approved write proposal (PATCH). GATED: only call after Zaal approves. Best-effort. */
+export async function applyWriteProposal(p: WriteProposal): Promise<{ ok: boolean; error?: string }> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return { ok: false, error: 'tracker not configured' };
+
+  const patch: Record<string, unknown> = {};
+  if (p.kind === 'set_owner' && p.nextOwner) patch.metadata = { next_owner: p.nextOwner };
+  else if (p.kind === 'archive_stale') patch.archived_at = new Date().toISOString();
+  else if (p.kind === 'add_tags' && p.tags) patch.brands = p.tags;
+  else return { ok: false, error: `unsupported proposal kind ${p.kind}` };
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(`${base.replace(/\/$/, '')}/rest/v1/tasks?id=eq.${encodeURIComponent(p.taskId)}`, {
+      method: 'PATCH',
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(patch),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+    if (!res.ok) return { ok: false, error: `patch returned ${res.status}` };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : 'patch failed' };
+  }
+}

--- a/bot/src/cockpit/brief.ts
+++ b/bot/src/cockpit/brief.ts
@@ -1,0 +1,76 @@
+/**
+ * Cockpit brief - assemble the fixed CockpitBrief schema from the adapters,
+ * format it for Telegram, and persist it to the artifact store (episode lesson:
+ * save run evidence to the filesystem so context persists across sessions).
+ *
+ * Read-only in 'brief' mode; 'triage' additionally attaches gated write
+ * proposals (still not applied). Applying is a separate, approved step.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import {
+  fetchCockpitTasks,
+  topThree,
+  needsYou,
+  blocked,
+  findStale,
+  buildProposals,
+} from './adapters';
+import type { CockpitBrief, CockpitMode } from './types';
+
+/** Artifact store root - mirrors ~/.zao/zoe convention. Override with $COCKPIT_HOME. */
+export const COCKPIT_HOME = process.env.COCKPIT_HOME || join(homedir(), '.zao', 'cockpit');
+
+/** Build the cockpit brief. `now` is injectable for tests. */
+export async function buildCockpitBrief(mode: CockpitMode = 'brief', now = Date.now()): Promise<CockpitBrief> {
+  const tasks = await fetchCockpitTasks();
+  const you = needsYou(tasks);
+  const stale = findStale(tasks, now);
+  const blk = blocked(tasks);
+  return {
+    date: new Date(now).toISOString().slice(0, 10),
+    top3: topThree(tasks),
+    needsYou: you,
+    stale,
+    blocked: blk,
+    counts: { open: tasks.length, needsYou: you.length, stale: stale.length, blocked: blk.length },
+    proposedWrites: mode === 'brief' ? [] : buildProposals(tasks, now),
+  };
+}
+
+function line(t: { title: string; due: string | null; priority: string | null }): string {
+  const due = t.due ? ` (due ${t.due.slice(0, 10)})` : '';
+  const pri = t.priority ? ` [${t.priority}]` : '';
+  return `- ${t.title}${pri}${due}`;
+}
+
+/** Format the brief in ZOE's voice (spartan, no emojis/em dashes). */
+export function formatCockpitBrief(b: CockpitBrief): string {
+  const parts: string[] = [];
+  parts.push(`Cockpit - ${b.date}`);
+  parts.push(`${b.counts.open} open | ${b.counts.needsYou} need you | ${b.counts.stale} stale | ${b.counts.blocked} blocked`);
+  if (b.top3.length) parts.push('\nDO FIRST\n' + b.top3.map(line).join('\n'));
+  if (b.needsYou.length) parts.push('\nNEEDS YOU\n' + b.needsYou.slice(0, 8).map(line).join('\n'));
+  if (b.stale.length) parts.push('\nSTALE (review)\n' + b.stale.slice(0, 8).map(line).join('\n'));
+  if (b.blocked.length) parts.push('\nBLOCKED\n' + b.blocked.slice(0, 6).map(line).join('\n'));
+  if (b.proposedWrites.length)
+    parts.push(
+      '\nPROPOSED (approve to apply)\n' +
+        b.proposedWrites.slice(0, 10).map((p) => `- [${p.kind}] ${p.title} - ${p.reason}`).join('\n'),
+    );
+  return parts.join('\n');
+}
+
+/** Persist the brief to the artifact store. Best-effort - never throws. */
+export async function saveBriefArtifact(b: CockpitBrief): Promise<string | null> {
+  try {
+    await fs.mkdir(COCKPIT_HOME, { recursive: true });
+    const path = join(COCKPIT_HOME, `brief-${b.date}.json`);
+    await fs.writeFile(path, JSON.stringify(b, null, 2));
+    return path;
+  } catch {
+    return null;
+  }
+}

--- a/bot/src/cockpit/types.ts
+++ b/bot/src/cockpit/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Personal Operator Cockpit - shared types.
+ *
+ * The cockpit is a Claude Agent SDK harness (built in slices) that wraps ZOE's
+ * existing tracker adapters and adds: a structured cockpit brief, a weekly
+ * stale-task review, gated writes (owner-axis / tags / archive), and an
+ * artifact store. Design: research/agents/997 + 999, gaps from doc 983.
+ *
+ * This file is the fixed OUTPUT SCHEMA (per the How I AI episode: specify the
+ * exact shape inside the harness, not in the prompt).
+ */
+
+import type { NextOwner } from '../zoe/task-classifier';
+
+/** A tracker task as the cockpit needs it (superset of TeamTask - carries id + timestamps for stale-detection + writes). */
+export interface CockpitTask {
+  id: string;
+  title: string;
+  status: string;
+  priority: string | null;
+  due: string | null;
+  project: string | null;
+  legacy_id: string | null;
+  next_owner: NextOwner | null;
+  updated_at: string | null;
+  created_at: string | null;
+}
+
+/** Cockpit run modes = the constraint flags (episode: "investigate-only" enforced by the harness, not the prompt). */
+export type CockpitMode =
+  | 'brief' // read-only: assemble + emit the cockpit brief, no writes
+  | 'triage' // read + PROPOSE writes (tags/owner-axis/archive), still no apply
+  | 'apply'; // execute an already-approved set of write proposals
+
+/** A single gated write the cockpit wants to make - never applied until approved. */
+export interface WriteProposal {
+  taskId: string;
+  title: string;
+  kind: 'set_owner' | 'add_tags' | 'archive_stale';
+  /** For set_owner. */
+  nextOwner?: NextOwner;
+  /** For add_tags. */
+  tags?: string[];
+  /** Why the cockpit proposes this - shown to Zaal at approval time. */
+  reason: string;
+}
+
+/** The fixed cockpit brief shape. */
+export interface CockpitBrief {
+  date: string; // ISO date the brief was built for
+  /** Top 3 by due-date then priority - "what to do first". */
+  top3: CockpitTask[];
+  /** Tasks routed to Zaal (next_owner = 'me', or undated P0/P1) - "what needs YOU". */
+  needsYou: CockpitTask[];
+  /** Stale: undated P0/P1s, or no update in >= STALE_DAYS. */
+  stale: CockpitTask[];
+  /** Blocked (next_owner = 'blocked'). */
+  blocked: CockpitTask[];
+  /** Counts for the one-line summary. */
+  counts: { open: number; needsYou: number; stale: number; blocked: number };
+  /** Gated write proposals (empty in 'brief' mode; populated in 'triage'). */
+  proposedWrites: WriteProposal[];
+}


### PR DESCRIPTION
## Summary
Slice 1 of the Personal Operator Cockpit harness (chosen: wrap+extend ZOE, Claude Agent SDK base, read + gated writes). This slice = the opinionated-adapter core + fixed output schema + read-only brief, per the How I AI episode (doc 999): custom adapters over generic tools, schema in the harness not the prompt, artifact store, constraint-flag modes.

## What is in it
- `types.ts` - CockpitBrief + WriteProposal + CockpitMode (brief|triage|apply).
- `adapters.ts` - opinionated adapters wrapping the cowork tracker + ZOE classifier; pure logic (topThree/needsYou/findStale/buildProposals) exported for tests; applyWriteProposal is GATED (one approved proposal at a time).
- `brief.ts` - assemble + format (ZOE voice) + persist to ~/.zao/cockpit artifact store.
- `__tests__/cockpit.test.ts` - 9 unit tests (all pass).

## Safety
No live writes fired - buildProposals only PROPOSES; nothing applies without approval (Slice 3). PR-only, not deployed.

## Verify
- `cd bot && npx vitest run src/cockpit` -> 9/9 pass
- cockpit files typecheck clean (pre-existing bot tsc errors unrelated)

## Next slices
2: Claude Agent SDK orchestration. 3: Telegram gated-write approval + weekly stale review. 4: cron wiring + route to ZAAL BOTS group.

Design: research/agents/997, 999; gaps doc 983.