### PR TITLE
feat(cockpit): Slice 2 - harness orchestration via Claude CLI

### DIFF
--- a/bot/src/cockpit/__tests__/orchestration.test.ts
+++ b/bot/src/cockpit/__tests__/orchestration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// artifact store -> tmp so tests never touch ~/.zao
+vi.hoisted(() => {
+  process.env.COCKPIT_HOME = '/tmp/cockpit-test-artifacts';
+});
+
+// mock only the network read; keep the pure adapter logic real
+vi.mock('../adapters', async (importActual) => {
+  const actual = await importActual<typeof import('../adapters')>();
+  return { ...actual, fetchCockpitTasks: vi.fn() };
+});
+vi.mock('../../hermes/claude-cli', () => ({
+  callClaudeCli: vi.fn(),
+  CliAuthError: class CliAuthError extends Error {},
+  CliError: class CliError extends Error {},
+}));
+
+import { runCockpit } from '../cockpit';
+import { fetchCockpitTasks } from '../adapters';
+import { callClaudeCli, CliError } from '../../hermes/claude-cli';
+import type { CockpitTask } from '../types';
+
+const NOW = Date.parse('2026-07-09T12:00:00Z');
+const fetchMock = fetchCockpitTasks as unknown as ReturnType<typeof vi.fn>;
+const cliMock = callClaudeCli as unknown as ReturnType<typeof vi.fn>;
+
+function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitTask {
+  return {
+    status: 'todo', priority: null, due: null, project: null, legacy_id: null,
+    next_owner: null, updated_at: new Date(NOW).toISOString(), created_at: new Date(NOW).toISOString(), ...o,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  cliMock.mockReset();
+});
+
+describe('runCockpit', () => {
+  it('attaches the operator read on the happy path', async () => {
+    fetchMock.mockResolvedValue([task({ id: '1', title: 'ship it', due: '2026-07-09', priority: 'P0' })]);
+    cliMock.mockResolvedValue({ text: 'Do ship it first.', isError: false, totalCostUsd: 0.02, inputTokens: 1, outputTokens: 1, model: 'sonnet', durationMs: 1, numTurns: 1, sessionId: 's' });
+    const r = await runCockpit('brief', NOW);
+    expect(r.operatorRead).toBe('Do ship it first.');
+    expect(r.message.startsWith('Do ship it first.')).toBe(true);
+    expect(r.message).toContain('Cockpit - 2026-07-09');
+    expect(r.costUsd).toBe(0.02);
+  });
+
+  it('falls back to the deterministic brief when the CLI throws', async () => {
+    fetchMock.mockResolvedValue([task({ id: '1', title: 'a task', priority: 'P1' })]);
+    cliMock.mockRejectedValue(new CliError('rate limit'));
+    const r = await runCockpit('brief', NOW);
+    expect(r.operatorRead).toBeNull();
+    expect(r.message).toContain('Cockpit - 2026-07-09'); // brief still emitted
+    expect(r.costUsd).toBe(0);
+  });
+
+  it('skips the LLM entirely on an empty board', async () => {
+    fetchMock.mockResolvedValue([]);
+    const r = await runCockpit('brief', NOW);
+    expect(cliMock).not.toHaveBeenCalled();
+    expect(r.operatorRead).toBeNull();
+    expect(r.brief.counts.open).toBe(0);
+  });
+
+  it('triage mode attaches gated proposals but still grants no tools', async () => {
+    fetchMock.mockResolvedValue([task({ id: '1', title: 'untagged wavewarz' })]);
+    cliMock.mockResolvedValue({ text: 'read', isError: false, totalCostUsd: 0.01, inputTokens: 1, outputTokens: 1, model: 'sonnet', durationMs: 1, numTurns: 1, sessionId: 's' });
+    const r = await runCockpit('triage', NOW);
+    expect(r.brief.proposedWrites.length).toBeGreaterThan(0);
+    // read-only by construction: allowedTools passed to the CLI is empty
+    expect(cliMock).toHaveBeenCalledWith(expect.objectContaining({ allowedTools: [] }));
+  });
+});

--- a/bot/src/cockpit/cockpit.ts
+++ b/bot/src/cockpit/cockpit.ts
@@ -1,0 +1,67 @@
+/**
+ * Cockpit harness orchestration (Slice 2).
+ *
+ * Drives the loop: assemble the deterministic brief (adapters) -> add a short
+ * LLM "operator read" via the Claude CLI (Max-plan auth, no API key - Zaal's
+ * pick) -> persist the artifact -> return the message. The LLM gets NO tools,
+ * so 'brief'/'triage' modes are read-only BY CONSTRUCTION (episode lesson:
+ * enforce constraints in the harness, not the prompt). Budget + timeout capped.
+ */
+
+import { callClaudeCli, CliAuthError, CliError } from '../hermes/claude-cli';
+import { buildCockpitBrief, formatCockpitBrief, saveBriefArtifact } from './brief';
+import type { CockpitBrief, CockpitMode } from './types';
+
+const COCKPIT_MODEL = 'sonnet'; // episode: Sonnet is the operational harness model - fast, capable, cheap
+const COCKPIT_BUDGET_USD = 0.1;
+const COCKPIT_TIMEOUT_MS = 120_000;
+const REPO_DIR = process.env.COCKPIT_CWD || '/home/zaal/zao-os';
+
+const OPERATOR_SYSTEM = `You are Zaal's operator cockpit. You are given his task board already partitioned (do-first, needs-you, stale, blocked). Write his OPERATOR READ: the single most important thing to do first and why, plus any judgment call only he can make today. 3-5 short lines. Spartan, active voice. No emojis, no em dashes, no marketing, no lists longer than needed. Do NOT invent tasks - only reason over what you are given.`;
+
+export interface CockpitRun {
+  brief: CockpitBrief;
+  operatorRead: string | null; // null if the LLM step failed (brief still valid)
+  costUsd: number;
+  message: string; // full Telegram-ready text
+  artifactPath: string | null;
+}
+
+/** Run the cockpit. Read-only in 'brief'/'triage' (no tools granted to the LLM). */
+export async function runCockpit(mode: CockpitMode = 'brief', now = Date.now()): Promise<CockpitRun> {
+  const brief = await buildCockpitBrief(mode, now);
+  const briefText = formatCockpitBrief(brief);
+
+  let operatorRead: string | null = null;
+  let costUsd = 0;
+
+  if (brief.counts.open > 0) {
+    try {
+      const res = await callClaudeCli({
+        model: COCKPIT_MODEL,
+        cwd: REPO_DIR,
+        appendSystemPrompt: OPERATOR_SYSTEM,
+        allowedTools: [], // no tools => cannot write => read-only by construction
+        disallowedTools: ['Bash(git push*)', 'Bash(git commit*)', 'Write', 'Edit'],
+        outputFormat: 'json',
+        maxBudgetUsd: COCKPIT_BUDGET_USD,
+        timeoutMs: COCKPIT_TIMEOUT_MS,
+        prompt: `Here is Zaal's cockpit brief for ${brief.date}:\n\n${briefText}\n\nWrite his operator read.`,
+      });
+      if (!res.isError && res.text.trim()) {
+        operatorRead = res.text.trim();
+        costUsd = res.totalCostUsd;
+      }
+    } catch (e) {
+      // Best-effort: the deterministic brief still stands without the narration.
+      if (e instanceof CliAuthError) operatorRead = null; // auth issue - surface upstream via null
+      else if (e instanceof CliError) operatorRead = null;
+      else operatorRead = null;
+    }
+  }
+
+  const message = operatorRead ? `${operatorRead}\n\n${briefText}` : briefText;
+  const artifactPath = await saveBriefArtifact(brief);
+
+  return { brief, operatorRead, costUsd, message, artifactPath };
+}


### PR DESCRIPTION
## Summary
Slice 2 of the operator cockpit: the harness orchestration (cockpit.ts). Chosen driver = Claude CLI (Max-plan auth, no API key). 

- `runCockpit(mode)` assembles the deterministic brief, then adds a short LLM operator-read via callClaudeCli (Sonnet, maxBudgetUsd 0.10, 120s timeout).
- LLM granted NO tools => brief/triage modes are read-only BY CONSTRUCTION (episode lesson, doc 999).
- Graceful fallback: on any CLI error the deterministic brief still emits.
- Artifact persisted to ~/.zao/cockpit.

## Verify
`cd bot && npx vitest run src/cockpit` -> 13/13 pass; cockpit typechecks clean. Not wired into the running bot yet (Slice 4).

## Next
Slice 3: Telegram gated-write approval + weekly stale review. Slice 4: cron wiring + route to ZAAL BOTS group.