### PR TITLE
feat(cockpit): Slice 4 - cockpit replaces the 5am morning brief

### DIFF
--- a/bot/src/cockpit/cockpit.ts
+++ b/bot/src/cockpit/cockpit.ts
@@ -17,7 +17,9 @@ const COCKPIT_BUDGET_USD = 0.1;
 const COCKPIT_TIMEOUT_MS = 120_000;
 const REPO_DIR = process.env.COCKPIT_CWD || '/home/zaal/zao-os';
 
-const OPERATOR_SYSTEM = `You are Zaal's operator cockpit. You are given his task board already partitioned (do-first, needs-you, stale, blocked). Write his OPERATOR READ: the single most important thing to do first and why, plus any judgment call only he can make today. 3-5 short lines. Spartan, active voice. No emojis, no em dashes, no marketing, no lists longer than needed. Do NOT invent tasks - only reason over what you are given.`;
+const OPERATOR_SYSTEM = `You are Zaal's operator cockpit. You are given his task board already partitioned (do-first, needs-you, stale, blocked). Write his OPERATOR READ: the single most important thing to do first and why, plus any judgment call only he can make today. 3-5 short lines.
+
+OUTPUT: plain text only for Telegram. No markdown bold or asterisks, no # headings, no em dashes (use a hyphen), no emojis, no marketing. Spartan, active voice. Do NOT invent tasks - only reason over what you are given.`;
 
 export interface CockpitRun {
   brief: CockpitBrief;

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -19,6 +19,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { Bot } from 'grammy';
 import { generateMorningBrief } from './brief';
+import { runCockpit } from '../cockpit/cockpit';
 import { generateEveningReflection } from './reflect';
 import { ZOE_PATHS } from './memory';
 import { nextNudge, nudgesEnabled, nudgeCooldownElapsed, markNudgeSent } from './nudges';
@@ -90,9 +91,21 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       async () => {
         if (!(await claimFire('morning-brief'))) return;
         try {
-          const brief = await generateMorningBrief({ repoDir: opts.repoDir });
+          // Cockpit is the primary morning brief (doc 997 harness). Falls back to
+          // the legacy brief if the cockpit read fails. Note: cockpit is task-
+          // focused; commits/PRs/inbox from the legacy brief are a follow-up adapter.
+          let brief: string;
+          try {
+            brief = (await runCockpit('brief')).message;
+          } catch (cockpitErr) {
+            console.warn(
+              '[zoe/scheduler] cockpit brief failed, using legacy brief:',
+              (cockpitErr as Error).message,
+            );
+            brief = await generateMorningBrief({ repoDir: opts.repoDir });
+          }
           await opts.bot.api.sendMessage(opts.zaalTgId, brief);
-          console.log('[zoe/scheduler] morning brief sent');
+          console.log('[zoe/scheduler] morning brief sent (cockpit)');
         } catch (err) {
           await releaseFire('morning-brief');
           console.error('[zoe/scheduler] morning brief failed:', (err as Error).message);


### PR DESCRIPTION
## Summary
Slice 4: the cockpit becomes the primary 5am morning brief (you chose "replace"). Scheduler morning-brief cron -> runCockpit(brief).message, legacy generateMorningBrief as fallback. Operator-read prompt tightened to plain Telegram text (no bold/em-dash/emoji).

## Tradeoff (flagged)
Cockpit brief is task-focused, so this drops commits/PRs/inbox from the 5am ping. Follow-up: a commits/PRs/inbox adapter if you want them back.

## Verify
cockpit+scheduler typecheck clean (grammy err pre-existing/local); esbuild bundles src/index.ts; 13 cockpit tests pass; live VPS sample confirmed (143 open, operator read, 79 gated proposals, $0.097).

## DEPLOY NOTE
Takes effect only after the VPS pulls + restarts: cd ~/zao-os && git pull && systemctl --user restart zoe-bot.