### PR TITLE
infra(n8n): workflow 1 - Farcaster mentions to Telegram (doc 1002)

### DIFF
--- a/infra/n8n/README.md
+++ b/infra/n8n/README.md
@@ -15,6 +15,8 @@ reference them as `{{$env.VAR}}` so no key lands in a workflow JSON. Host `.env`
 
 ```
 NEYNAR_API_KEY=...          # Farcaster reads (from bot/.env)
+NEYNAR_ZAAL_FID=19640        # optional, workflow 1 defaults to 19640 if unset
+NEYNAR_WATCH_KEYWORDS=thezao,zabal   # optional, comma-separated brand watchlist for workflow 1 - add words here, no JSON edits needed
 TELEGRAM_BOT_TOKEN=...       # ZOE bot or a dedicated n8n-alerts bot
 TELEGRAM_CHAT_ID=1447437687
 COWORK_TRACKER_URL=...       # Supabase PostgREST
@@ -23,7 +25,7 @@ GITHUB_TOKEN=...             # read-only, watched repos
 ```
 
 ## Workflow build queue (doc 1002 top-3, built in a loop)
-1. **Farcaster mention -> Telegram** - scheduled poll of Neynar mentions for @zaal / @thezao -> Telegram alert. Poll-based (no inbound webhook = no public exposure needed). `workflows/01-farcaster-mentions.json`.
+1. **Farcaster mention -> Telegram** - scheduled poll of Neynar mentions for @zaal + a keyword watchlist (`NEYNAR_WATCH_KEYWORDS` env, default `thezao,zabal` - add more brand terms there, no workflow edit needed) -> Telegram alert. Poll-based (no inbound webhook = no public exposure needed). `workflows/01-farcaster-mentions.json`.
 2. **Newsletter publish -> auto cross-post** - Paragraph/RSS new-post -> draft cross-posts. `workflows/02-newsletter-crosspost.json`.
 3. **GitHub PR merged -> tracker row + announce** - PR merge -> cowork tracker row + Telegram. `workflows/03-github-pr-tracker.json`.
 

--- a/infra/n8n/workflows/01-farcaster-mentions.json
+++ b/infra/n8n/workflows/01-farcaster-mentions.json
@@ -67,6 +67,19 @@
     },
     {
       "parameters": {
+        "jsCode": "// Comma-separated brand/keyword watchlist, editable in ~/n8n/.env without\n// touching this workflow - e.g. NEYNAR_WATCH_KEYWORDS=thezao,zabal,zabalgames\nconst raw = $env.NEYNAR_WATCH_KEYWORDS || 'thezao,zabal';\nconst keywords = raw.split(',').map((k) => k.trim()).filter(Boolean);\n\nreturn keywords.map((keyword) => ({ json: { keyword } }));"
+      },
+      "id": "get-watch-keywords",
+      "name": "Get Watch Keywords",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        460,
+        420
+      ]
+    },
+    {
+      "parameters": {
         "method": "GET",
         "url": "https://api.neynar.com/v2/farcaster/cast/search",
         "sendQuery": true,
@@ -74,7 +87,7 @@
           "parameters": [
             {
               "name": "q",
-              "value": "thezao"
+              "value": "={{ $json.keyword }}"
             },
             {
               "name": "limit",
@@ -95,12 +108,12 @@
           "timeout": 10000
         }
       },
-      "id": "http-neynar-thezao",
-      "name": "Search TheZAO Mentions",
+      "id": "http-neynar-keywords",
+      "name": "Search Keyword Mentions",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        460,
+        680,
         420
       ]
     },
@@ -113,7 +126,7 @@
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
       "position": [
-        700,
+        920,
         300
       ]
     },
@@ -126,7 +139,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        920,
+        1140,
         300
       ]
     },
@@ -160,7 +173,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1140,
+        1360,
         300
       ]
     }
@@ -175,7 +188,7 @@
             "index": 0
           },
           {
-            "node": "Search TheZAO Mentions",
+            "node": "Get Watch Keywords",
             "type": "main",
             "index": 0
           }
@@ -193,7 +206,18 @@
         ]
       ]
     },
-    "Search TheZAO Mentions": {
+    "Get Watch Keywords": {
+      "main": [
+        [
+          {
+            "node": "Search Keyword Mentions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search Keyword Mentions": {
       "main": [
         [
           {

--- a/infra/n8n/workflows/01-farcaster-mentions.json
+++ b/infra/n8n/workflows/01-farcaster-mentions.json
@@ -1,0 +1,233 @@
+{
+  "name": "01 - Farcaster Mentions to Telegram",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 10
+            }
+          ]
+        }
+      },
+      "id": "schedule-trigger",
+      "name": "Every 10 min",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        220,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "https://api.neynar.com/v2/farcaster/notifications",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "fid",
+              "value": "={{ $env.NEYNAR_ZAAL_FID || 19640 }}"
+            },
+            {
+              "name": "type",
+              "value": "mentions"
+            },
+            {
+              "name": "limit",
+              "value": "25"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $env.NEYNAR_API_KEY }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "http-neynar-zaal",
+      "name": "Get Zaal Mentions",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        460,
+        180
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "https://api.neynar.com/v2/farcaster/cast/search",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "q",
+              "value": "thezao"
+            },
+            {
+              "name": "limit",
+              "value": "25"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $env.NEYNAR_API_KEY }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "http-neynar-thezao",
+      "name": "Search TheZAO Mentions",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        460,
+        420
+      ]
+    },
+    {
+      "parameters": {
+        "mode": "append"
+      },
+      "id": "merge-results",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [
+        700,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Flatten Neynar notifications + cast-search responses into one list,\n// then drop anything already alerted on a previous poll (tracked in\n// this node's workflow static data so it survives across executions).\nconst staticData = $getWorkflowStaticData('node');\nif (!staticData.seenHashes) staticData.seenHashes = [];\nconst seen = new Set(staticData.seenHashes);\n\nconst out = [];\n\nfor (const item of $input.all()) {\n  const j = item.json || {};\n  const list = j.notifications || (j.result && j.result.casts) || j.casts || [];\n\n  for (const entry of list) {\n    const cast = entry.cast || entry;\n    const hash = cast && cast.hash;\n    if (!hash || seen.has(hash)) continue;\n    seen.add(hash);\n\n    const username = (cast.author && cast.author.username) || 'unknown';\n    out.push({\n      json: {\n        hash,\n        author: username,\n        text: cast.text || '',\n        url: `https://warpcast.com/${username}/${hash.slice(0, 10)}`,\n        type: entry.type || 'search',\n        timestamp: entry.most_recent_timestamp || cast.timestamp || null\n      }\n    });\n  }\n}\n\n// Cap growth of the seen-set so static data doesn't grow unbounded.\nstaticData.seenHashes = Array.from(seen).slice(-500);\n\nreturn out;"
+      },
+      "id": "filter-new",
+      "name": "Filter New",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        920,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.telegram.org/bot{{ $env.TELEGRAM_BOT_TOKEN }}/sendMessage",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "chat_id",
+              "value": "={{ $env.TELEGRAM_CHAT_ID }}"
+            },
+            {
+              "name": "text",
+              "value": "=New Farcaster mention from @{{ $json.author }}:\n\n{{ $json.text }}\n\n{{ $json.url }}"
+            },
+            {
+              "name": "disable_web_page_preview",
+              "value": "true"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "http-telegram",
+      "name": "Telegram sendMessage",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1140,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Every 10 min": {
+      "main": [
+        [
+          {
+            "node": "Get Zaal Mentions",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Search TheZAO Mentions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Zaal Mentions": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search TheZAO Mentions": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge": {
+      "main": [
+        [
+          {
+            "node": "Filter New",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter New": {
+      "main": [
+        [
+          {
+            "node": "Telegram sendMessage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": false
+}

--- a/infra/n8n/workflows/01-farcaster-mentions.json
+++ b/infra/n8n/workflows/01-farcaster-mentions.json
@@ -1,4 +1,5 @@
 {
+  "id": "da785c1c-00ad-4a99-a61e-44d62dbc0772",
   "name": "01 - Farcaster Mentions to Telegram",
   "nodes": [
     {


### PR DESCRIPTION
## Summary
- First of the doc-1002 top-3 n8n build queue: Schedule Trigger (10min) -> Neynar notifications (mentions, @zaal fid) + Neynar cast search ("thezao") -> dedupe against seen cast hashes (workflow static data) -> Telegram sendMessage.
- Poll-based by design, no inbound webhook, no public exposure.
- All secrets referenced as `{{$env.VAR}}` - none hardcoded. Needs on host `~/n8n/.env`: `NEYNAR_API_KEY`, `NEYNAR_ZAAL_FID` (defaults 19640 if unset), `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`.
- Ships **inactive**. Will import headlessly via `n8n import:workflow` and do a manual test run before pinging Zaal to try it.

## Test plan
- [ ] Import on VPS: `docker exec zao-n8n n8n import:workflow --input=/path/01-farcaster-mentions.json`
- [ ] Confirm it appears via `n8n list:workflow`
- [ ] Manual execute once real `.env` secrets are in place on the VPS
- [ ] Zaal confirms Telegram alert fires clean before activation