### PR TITLE
fix(hermes): agentic-coding silent-failure guards (doc 1006 #4+#5)

### DIFF
--- a/bot/src/hermes/claude-cli.ts
+++ b/bot/src/hermes/claude-cli.ts
@@ -219,6 +219,14 @@ export function callClaudeCli(opts: ClaudeCliOptions): Promise<ClaudeCliResult> 
             reject(err);
             return;
           }
+          // Doc 1006 fix: a cut-off run (max-turns / execution error) can come
+          // back with is_error=false + a PARTIAL result. subtype!=='success' is
+          // the finish_reason-equivalent - never treat a truncated run as done.
+          if (parsed.subtype && parsed.subtype !== 'success') {
+            console.error('[hermes/claude-cli] non-success subtype:', parsed.subtype, JSON.stringify(parsed).slice(0, 800));
+            reject(new CliError(`claude CLI did not finish cleanly (subtype=${parsed.subtype}) - output may be truncated, not treating as done. turns=${parsed.num_turns}`, 'unknown'));
+            return;
+          }
           if (!parsed.result || !parsed.result.trim()) {
             console.error('[hermes/claude-cli] empty result. full payload:', JSON.stringify(parsed).slice(0, 1200));
             reject(new CliError(`claude CLI returned empty result. duration=${parsed.duration_ms}ms turns=${parsed.num_turns}. session=${parsed.session_id}`, 'unknown'));

--- a/bot/src/hermes/preflight.ts
+++ b/bot/src/hermes/preflight.ts
@@ -10,6 +10,7 @@ export interface PreFlightResult {
     forbiddenPaths: 'pass' | 'fail';
     typecheck: 'pass' | 'fail' | 'skipped';
     tests: 'pass' | 'fail' | 'skipped';
+    boot: 'pass' | 'fail' | 'skipped';
   };
 }
 
@@ -40,6 +41,7 @@ export async function runPreFlightGate(input: {
     forbiddenPaths: 'pass',
     typecheck: 'skipped',
     tests: 'skipped',
+    boot: 'skipped',
   };
   const scope = detectScope(input.filesChanged);
 
@@ -87,6 +89,26 @@ export async function runPreFlightGate(input: {
         checks,
       };
     }
+    // Doc 1006 fix: tsc passing != the bot boots. esbuild-bundle the entry to
+    // catch import/bundle crashes tsc misses (feedback_validate_bot_changes_with_boot).
+    const boot = await runCmd(
+      'npx',
+      ['esbuild', 'src/index.ts', '--bundle', '--platform=node', '--format=esm', '--outfile=/dev/null', '--packages=external'],
+      `${input.workTreePath}/bot`,
+      heapEnv,
+    );
+    if (boot.exitCode !== 0) {
+      checks.boot = 'fail';
+      const out = (boot.stdout + '\n' + boot.stderr).slice(0, 1500);
+      return {
+        ok: false,
+        error: `Bot boot-verify (esbuild bundle) failed - tsc passed but the bundle is broken. Fix before retrying:\n\n${out}`,
+        durationMs: Date.now() - start,
+        scope,
+        checks,
+      };
+    }
+    checks.boot = 'pass';
   }
   if (scope === 'app-only' || scope === 'mixed') {
     const tc = await runCmd('npm', ['run', '--silent', 'typecheck'], input.workTreePath, heapEnv);


### PR DESCRIPTION
Two effort-1 fixes from the doc-1006 audit:

1. **finish_reason/subtype check** (claude-cli.ts): a cut-off run (max-turns / execution error) can return is_error=false + a PARTIAL result. Now rejects on subtype!=='success' so a truncated run is never treated as done - the silent-failure bug.
2. **boot-verify in preflight** (preflight.ts): after bot typecheck, esbuild-bundle src/index.ts to catch import/bundle crashes tsc misses (the tsc-passes-but-bot-crashes failure the feedback rule warns about). Adds a boot check to the gate.

Boot-verified: typecheck clean + esbuild bundles (143kb). PR-only, not deployed.

Numbering fix (#1) held - Zaal wants a cleaner scheme than ranges-per-agent.