### PR TITLE
fix(zoe): work-loop silent failure - notify Zaal on dispatch error

### DIFF
--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -153,32 +153,41 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
       .sendToZaal(`Work-loop: researching "${item.input.slice(0, 80)}" (${q.length} queued)`)
       .catch(() => {});
 
-    await dispatchPlan({
-      goal: item.input,
-      plan,
-      context: ctx,
-      chatId: deps.zaalTgId,
-      zaalTgId: deps.zaalTgId,
-      hooks: {
-        onSubtaskDone: async (st, r) => {
-          if (st.worker === 'research-worker' && r.status === 'completed' && r.output) {
-            const doc = await commitResearchDoc({ question: item.input, findings: r.output });
-            await deps
-              .sendToZaal(
-                doc.ok
-                  ? `Work-loop done: doc ${doc.num} -> ${doc.prUrl}`
-                  : `Work-loop: doc save failed - ${doc.error}`,
-              )
-              .catch(() => {});
-          }
+    try {
+      await dispatchPlan({
+        goal: item.input,
+        plan,
+        context: ctx,
+        chatId: deps.zaalTgId,
+        zaalTgId: deps.zaalTgId,
+        hooks: {
+          onSubtaskDone: async (st, r) => {
+            if (st.worker === 'research-worker' && r.status === 'completed' && r.output) {
+              const doc = await commitResearchDoc({ question: item.input, findings: r.output });
+              await deps
+                .sendToZaal(
+                  doc.ok
+                    ? `Work-loop done: doc ${doc.num} -> ${doc.prUrl}`
+                    : `Work-loop: doc save failed - ${doc.error}`,
+                )
+                .catch(() => {});
+            }
+          },
         },
-      },
-    });
-
-    await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
-    await bumpToday(deps.currentDate);
-  } catch (e) {
-    console.error('[zoe/work-loop] tick failed:', (e as Error).message);
+      });
+      await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
+      await bumpToday(deps.currentDate);
+    } catch (e) {
+      const errMsg = (e as Error)?.message ?? String(e);
+      console.error('[zoe/work-loop] tick failed:', errMsg);
+      await deps
+        .sendToZaal(
+          `Work-loop error: failed to process "${item.input.slice(0, 60)}..." - ${errMsg.slice(0, 120)}`,
+        )
+        .catch(() => {});
+      // Remove from queue even on error to avoid infinite retry loop
+      await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
+    }
   } finally {
     await releaseLock();
   }


### PR DESCRIPTION
## Summary

ZOE's work-loop had a critical silent failure: when `dispatchPlan` threw an error during autonomous research execution, the error was logged to console only, never reported to Zaal, and the work item remained in the queue forever, causing infinite retry.

## Problem

1. A queued research item is dequeued and processed
2. `dispatchPlan` throws an error (network issue, Claude timeout, etc.)
3. The error is caught and logged with `console.error`
4. The item is NOT removed from the queue (cleanup only runs on success)
5. Zaal has NO notification of the failure
6. Next tick, the same item is retried indefinitely

This is exactly the "failed tasks are silent" leak mentioned in doc 928.

## Fix

- Wrap `dispatchPlan` in an inner try/catch
- On error: send failure notification to Zaal with error details
- Remove item from queue even on error to prevent infinite retry
- Ensure daily counter consistency

Now when dispatch fails:
- Zaal gets: "Work-loop error: failed to process [...] - <error details>"
- The item is removed so it doesn't retry
- The daily cap counter is not bumped (error doesn't count toward spend)
- The error is still logged for debugging

## Verification

- `npm run typecheck` passes (0 errors)
- esbuild boots the bot bundle successfully
- No secrets in diff
- No breaking changes to work-loop queue semantics