### PR TITLE
feat(zoe): tier taxonomy for proactive candidates (doc 1015)

### DIFF
--- a/bot/src/zoe/__tests__/proactive.test.ts
+++ b/bot/src/zoe/__tests__/proactive.test.ts
@@ -56,6 +56,7 @@ test('overdue thread scores high and is a thread-nudge', () => {
   assert.ok(c);
   assert.equal(c.kind, 'thread-nudge');
   assert.ok(c.score >= 0.75, `expected >=0.75, got ${c.score}`);
+  assert.equal(c.tier, 'standard');
   assert.match(c.message, /did it land/);
 });
 
@@ -66,12 +67,15 @@ test('overdue score climbs with how late it is, capped at 0.95', () => {
   assert.ok(a && b && c);
   assert.ok(b.score > a.score);
   assert.ok(c.score <= 0.95);
+  assert.equal(a.tier, 'standard');
+  assert.equal(c.tier, 'critical'); // >24h overdue = critical
 });
 
 test('due-soon thread is a 0.6 baseline nudge', () => {
   const c = scoreThreadCandidate(thread({ dueAt: new Date(NOW + 3600_000).toISOString() }), NOW);
   assert.ok(c);
   assert.equal(c.score, 0.6);
+  assert.equal(c.tier, 'standard');
   assert.match(c.message, /still on track/);
 });
 
@@ -80,6 +84,7 @@ test('two-snooze thread is a thread-decision at 0.8', () => {
   assert.ok(c);
   assert.equal(c.kind, 'thread-decision');
   assert.equal(c.score, 0.8);
+  assert.equal(c.tier, 'critical');
   assert.match(c.message, /reschedule it, drop it/);
 });
 
@@ -87,9 +92,9 @@ test('two-snooze thread is a thread-decision at 0.8', () => {
 
 test('pickBest returns the single highest-scoring candidate', () => {
   const cands: Candidate[] = [
-    { kind: 'thread-nudge', score: 0.6, message: 'a' },
-    { kind: 'thread-decision', score: 0.8, message: 'b' },
-    { kind: 'inactivity', score: 0.5, message: 'c' },
+    { kind: 'thread-nudge', score: 0.6, tier: 'standard', message: 'a' },
+    { kind: 'thread-decision', score: 0.8, tier: 'critical', message: 'b' },
+    { kind: 'inactivity', score: 0.5, tier: 'signal', message: 'c' },
   ];
   assert.equal(pickBest(cands)?.message, 'b');
 });

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -107,6 +107,7 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     out.push({
       kind: 'github-event',
       score: 0.65, // actionable: clears the 0.6 bar, but a due commitment still outranks
+      tier: 'standard',
       message: `[STALE PR] ${repoName(pr)} #${pr.number} has sat ${days}d with no movement: "${pr.title}". Merge it, close it, or want me to look?`,
     });
   }
@@ -124,6 +125,7 @@ export async function gatherEventCandidates(now: number = Date.now()): Promise<C
     out.push({
       kind: 'github-event',
       score: 0.82, // a broken build outranks a stale PR + most nudges
+      tier: 'critical',
       message: `[CI FAIL] ${repoName(pr)} #${pr.number} has failing checks: "${pr.title}". Want me to look at what broke?`,
     });
   }
@@ -195,6 +197,7 @@ export async function gatherGraphCandidates(now: number = Date.now()): Promise<C
     {
       kind: 'graph-event',
       score: 0.62, // clears the 0.6 bar but a due commitment/CI-fail outranks
+      tier: 'signal',
       message: `[GRAPH] Nothing new on "${coldest.topic}" in the graph for ${coldest.days}d. Still active, or want to log an update?`,
     },
   ];
@@ -249,6 +252,7 @@ export async function gatherInactivityCandidates(now: number = Date.now()): Prom
     {
       kind: 'inactivity',
       score: 0.62, // just clears the 0.6 bar — lowest interrupt priority
+      tier: 'signal',
       message: `You've been quiet for ${hrs}h. Everything on track, or anything stuck?`,
     },
   ];
@@ -317,6 +321,7 @@ export async function gatherCalendarCandidates(now: number = Date.now()): Promis
     out.push({
       kind: 'calendar',
       score: 0.72,
+      tier: 'standard',
       message: `[CALENDAR] "${ev.summary ?? 'Event'}" in ${minsAway}m. Anything to prep?`,
     });
   }

--- a/bot/src/zoe/proactive.ts
+++ b/bot/src/zoe/proactive.ts
@@ -49,11 +49,14 @@ export const UNACKED_WINDOW_MS = 24 * 60 * 60 * 1000;
 const THRESHOLD_STEP = 0.1;
 
 export type CandidateKind = 'thread-nudge' | 'thread-decision' | 'task-nudge' | 'inactivity' | 'calendar' | 'github-event' | 'graph-event';
+export type CandidateTier = 'critical' | 'standard' | 'signal';
 
 export interface Candidate {
   kind: CandidateKind;
   /** 0..1 relevance. Compared against the threshold. */
   score: number;
+  /** Interrupt tier: critical (P0/blocker), standard (due/overdue), signal (inactivity). */
+  tier: CandidateTier;
   /** The message ZOE would send (already in voice). */
   message: string;
   /** Linked open thread, when the candidate came from one. */
@@ -102,6 +105,7 @@ export function scoreThreadCandidate(t: OpenThread, now: number = Date.now()): C
     return {
       kind: 'thread-decision',
       score: 0.8,
+      tier: 'critical',
       threadId: t.id,
       message:
         `You've pushed "${t.summary}" twice now. Rather than ping again — ` +
@@ -111,15 +115,20 @@ export function scoreThreadCandidate(t: OpenThread, now: number = Date.now()): C
 
   // nudge
   let score = 0.6; // due-soon baseline
+  let tier: CandidateTier = 'standard';
   if (action.overdue && t.dueAt) {
     const overdueHrs = (now - Date.parse(t.dueAt)) / 3_600_000;
     score = Math.min(0.75 + overdueHrs * 0.02, 0.95);
+    if (overdueHrs > 24) {
+      tier = 'critical'; // significantly overdue
+    }
   }
   const when = action.overdue ? 'You said' : "You're on the hook for";
   const tail = action.overdue ? '— did it land?' : '— still on track?';
   return {
     kind: 'thread-nudge',
     score,
+    tier,
     threadId: t.id,
     message: `${when} "${t.summary}" ${tail}`,
   };
@@ -335,6 +344,7 @@ export async function runReasoningTick(deps: ReasoningTickDeps = {}): Promise<Pr
     threshold,
     best: round2(best.score),
     kind: best.kind,
+    tier: best.tier,
     threadId: best.threadId,
     considered: candidates.length,
     unacked,


### PR DESCRIPTION
Adds CandidateTier (critical/standard/signal) to the Candidate interface + tier assignment in scoreThreadCandidate and event sources. Purely additive (15 insertions, 0 deletions) - no existing gating/threshold logic changed; unblocks tier-aware escalation from doc 1015. Verified: typecheck 0 errors, esbuild boot ok, 13/13 proactive tests. Re-opened clean after the original #1192 raced onto the wrong head branch.