### PR TITLE
docs: ZOE morning briefing 2026-07-10

### DIFF
--- a/docs/daily/2026-07-10-briefing.md
+++ b/docs/daily/2026-07-10-briefing.md
@@ -87,3 +87,31 @@ Farcaster DAU down ~40% from peak. Builders openly asking why communities bleed 
 Farcastle + Eden Fractal bringing fractal back into discussion via Frames. Skeptics noting most experiments die in weeks. Cast type: *"Fractal governance looks elegant on paper. Every real experiment I've seen dies after 4-8 weeks. Is anyone running this consistently?"*
 
 > Draft: "The ZAO has run fractal every week for 90+ consecutive weeks on Base — probably one of the longest-running live experiments anywhere. The first month is brutal because you're building ritual from zero. Around week 6-8 it becomes culture: not showing up means something socially. The drop-off you're seeing is entropy, not a governance flaw. You have to push through it."
+
+---
+
+## 4:30AM REFRESH
+
+*Added by ZOE morning run — supplements nightly processor output.*
+
+### Job Board (3 additional verified open roles)
+
+| Role | Company | Pay | Fit | Notes |
+|------|---------|-----|-----|-------|
+| **Community Lead** | Sui Foundation | $80K–$120K | 5–8+ yrs community mgmt + DeFi. Zaal's 90-week fractal + 188-member on-chain community maps directly. | ~2 days old (closest to 24h). Apply: ashbyhq.com/suifoundation |
+| **Developer Advocate P2P** | Tether Operations | $126K–$138K | 100% remote worldwide, no geo restriction. Developer advocacy + community building. Content, events, "voice of the developer." | Still open as of July 2026. careers.tether.io |
+| **DeFi Marketing Lead** | Bond Labs | $80K–$100K + token vesting | Remote. Owns marketing end-to-end for multi-chain EVM superapp. Sets strategy AND writes the threads. Build-in-public profile fits exactly. | ~2 weeks old, still accepting |
+
+### Farcaster Engagement (fresh context for nightly drafts)
+
+The nightly opps above remain valid. Fresh context from 4:30am search:
+
+**Active structural debate: "AI agents can't actually build community" (`/ai`, `/founders`)**
+Neynar's agent-first vision post-acquisition is drawing pushback from builders. The argument loops because no one in the thread has empirical retention data.
+> Drop-in: *"Running an AI orchestrator (ZOE) alongside a 188-member onchain community for 90+ consecutive weeks — agents help with throughput, but the fractal governance cadence is what drives retention. Agents surface signal; humans have to create the reason to return."*
+
+**State of Farcaster, 6 months post-Neynar (`/farcaster`, `/base`)**
+July 2026 = 6-month mark since acquisition. Community openly asking: distribution rail or community platform?
+> Drop-in: *"Six months post-acquisition, Farcaster's value for us is verifiable identity + onchain action in one context. Built The ZAO's client on it for that reason. Watching whether Neynar leans into that or tries to rebuild DAUs the old way."*
+
+**Where to engage:** Log into Warpcast, check `/ai`, `/founders`, `/base`, `/dao`. The drafts above + the nightly three are all plug-and-play.


### PR DESCRIPTION
## Summary

- Verified nightly processor briefing for July 10, 2026 (confirmed complete)
- Appended 4:30am refresh section to `docs/daily/2026-07-10-briefing.md`

### 4:30am additions
- **3 additional verified open remote roles** distinct from nightly's 3: Sui Foundation Community Lead ($80K–$120K, ~2 days old), Tether Developer Advocate P2P ($126K–$138K, still open), Bond Labs DeFi Marketing Lead ($80K–$100K + token)
- **Fresh Farcaster engagement context**: agent-vs-community debate (Neynar agent-first thesis getting pushback), 6-month Neynar acquisition check-in thread — both with plug-and-play drop-in drafts

No code changes. Docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExKQaFJpJZMMzEYzeY7QFW)_