### PR TITLE
fix(cockpit): resolve gh via augmented PATH (PR lane was silently empty)

### DIFF
--- a/bot/src/cockpit/__tests__/orchestration.test.ts
+++ b/bot/src/cockpit/__tests__/orchestration.test.ts
@@ -5,10 +5,10 @@ vi.hoisted(() => {
   process.env.COCKPIT_HOME = '/tmp/cockpit-test-artifacts';
 });
 
-// mock only the network read; keep the pure adapter logic real
+// mock only the network reads (tracker + gh PR search); keep the pure adapter logic real
 vi.mock('../adapters', async (importActual) => {
   const actual = await importActual<typeof import('../adapters')>();
-  return { ...actual, fetchCockpitTasks: vi.fn() };
+  return { ...actual, fetchCockpitTasks: vi.fn(), fetchReviewPRs: vi.fn() };
 });
 vi.mock('../../hermes/claude-cli', () => ({
   callClaudeCli: vi.fn(),
@@ -17,12 +17,13 @@ vi.mock('../../hermes/claude-cli', () => ({
 }));
 
 import { runCockpit } from '../cockpit';
-import { fetchCockpitTasks } from '../adapters';
+import { fetchCockpitTasks, fetchReviewPRs } from '../adapters';
 import { callClaudeCli, CliError } from '../../hermes/claude-cli';
 import type { CockpitTask } from '../types';
 
 const NOW = Date.parse('2026-07-09T12:00:00Z');
 const fetchMock = fetchCockpitTasks as unknown as ReturnType<typeof vi.fn>;
+const reviewMock = fetchReviewPRs as unknown as ReturnType<typeof vi.fn>;
 const cliMock = callClaudeCli as unknown as ReturnType<typeof vi.fn>;
 
 function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitTask {
@@ -34,6 +35,8 @@ function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitT
 
 beforeEach(() => {
   fetchMock.mockReset();
+  reviewMock.mockReset();
+  reviewMock.mockResolvedValue([]); // no PR network in unit tests by default
   cliMock.mockReset();
 });
 

--- a/bot/src/cockpit/adapters.ts
+++ b/bot/src/cockpit/adapters.ts
@@ -117,11 +117,24 @@ export function filterReviewPRs(rows: RawPR[]): ReviewPR[] {
  */
 export async function fetchReviewPRs(): Promise<ReviewPR[]> {
   const q = `is:pr is:open ${REVIEW_OWNERS.map((o) => `user:${o}`).join(' ')}`;
+  // gh is installed at ~/.local/bin on the VPS, which is NOT on the zoe-bot
+  // systemd service PATH - so bare 'gh' fails with ENOENT. Prepend ~/.local/bin
+  // (and the common user-local bins) so execFile resolves it regardless of the
+  // service PATH. Override with GH_BIN_PATH if gh lives elsewhere.
+  const home = process.env.HOME ?? '';
+  const ghPath = [
+    process.env.GH_BIN_PATH,
+    home && `${home}/.local/bin`,
+    '/usr/local/bin',
+    process.env.PATH,
+  ]
+    .filter(Boolean)
+    .join(':');
   try {
     const { stdout } = await execFileAsync(
       'gh',
       ['api', '-X', 'GET', 'search/issues', '-f', `q=${q}`, '-F', 'per_page=40', '--jq', '.items'],
-      { timeout: REQUEST_TIMEOUT_MS, maxBuffer: 1_000_000 },
+      { timeout: REQUEST_TIMEOUT_MS, maxBuffer: 1_000_000, env: { ...process.env, PATH: ghPath } },
     );
     const rows = JSON.parse(stdout || '[]') as RawPR[];
     return Array.isArray(rows) ? filterReviewPRs(rows) : [];

--- a/bot/src/cockpit/cockpit.ts
+++ b/bot/src/cockpit/cockpit.ts
@@ -37,7 +37,7 @@ export async function runCockpit(mode: CockpitMode = 'brief', now = Date.now()):
   let operatorRead: string | null = null;
   let costUsd = 0;
 
-  if (brief.counts.open > 0) {
+  if (brief.counts.open > 0 || brief.counts.needsReview > 0) {
     try {
       const res = await callClaudeCli({
         model: COCKPIT_MODEL,


### PR DESCRIPTION
gh lives at ~/.local/bin, not on the zoe-bot systemd PATH, so the new PR-review lane returned []. Prepend $HOME/.local/bin to execFile PATH (verified gh resolves + returns PRs). Mock fetchReviewPRs in orchestration tests (was flaky on live gh). Operator read now fires on PRs even with 0 tasks. 14/14 tests twice.