### PR TITLE
feat(cockpit): HANDOFFS lane - surface other-terminal handoffs

### DIFF
--- a/bot/src/cockpit/__tests__/cockpit.test.ts
+++ b/bot/src/cockpit/__tests__/cockpit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { topThree, needsYou, blocked, findStale, buildProposals, priorityRank, daysSince, STALE_DAYS, filterReviewPRs } from '../adapters';
+import { topThree, needsYou, blocked, findStale, buildProposals, priorityRank, daysSince, STALE_DAYS, filterReviewPRs, isHandoff, partitionHandoffs, toHandoff } from '../adapters';
 import { formatCockpitBrief } from '../brief';
 import type { CockpitTask, CockpitBrief } from '../types';
 
@@ -13,6 +13,8 @@ function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitT
     due: null,
     project: null,
     legacy_id: null,
+    legacy_source: null,
+    notes: null,
     next_owner: null,
     updated_at: new Date(NOW).toISOString(),
     created_at: new Date(NOW).toISOString(),
@@ -113,9 +115,12 @@ describe('formatCockpitBrief', () => {
           createdAt: '2026-07-10T05:00:00Z',
         },
       ],
+      handoffs: [
+        { taskId: 'h1', slug: 'zao-whitepapers', title: 'Papers terminal', note: '12 drafts live, needs ZABAL call', createdAt: '2026-07-10T06:00:00Z' },
+      ],
       stale: [],
       blocked: [],
-      counts: { open: 2, needsYou: 1, needsReview: 1, stale: 0, blocked: 0 },
+      counts: { open: 2, needsYou: 1, needsReview: 1, handoffs: 1, stale: 0, blocked: 0 },
       proposedWrites: [],
     };
     const out = formatCockpitBrief(b);
@@ -125,7 +130,31 @@ describe('formatCockpitBrief', () => {
     expect(out).toContain('NEEDS YOUR REVIEW');
     expect(out).toContain('ZAODEVZ/ZAOcowork #174');
     expect(out).toContain('1 PRs to review');
+    expect(out).toContain('HANDOFFS (from other terminals)');
+    expect(out).toContain('zao-whitepapers: Papers terminal');
+    expect(out).toContain('1 handoffs');
     expect(out).not.toMatch(/[—\u{1F300}-\u{1FAFF}]/u); // no em dash, no emoji
+  });
+});
+
+describe('handoff helpers', () => {
+  it('isHandoff detects the legacy_source marker', () => {
+    expect(isHandoff(task({ id: '1', title: 'x', legacy_source: 'handoff:papers' }))).toBe(true);
+    expect(isHandoff(task({ id: '2', title: 'y', legacy_source: 'meeting:foo' }))).toBe(false);
+    expect(isHandoff(task({ id: '3', title: 'z' }))).toBe(false);
+  });
+  it('partitionHandoffs splits handoffs from regular tasks', () => {
+    const tasks = [
+      task({ id: 'a', title: 'real task' }),
+      task({ id: 'b', title: 'handed off', legacy_source: 'handoff:papers' }),
+    ];
+    const { handoffs, rest } = partitionHandoffs(tasks);
+    expect(handoffs.map((t) => t.id)).toEqual(['b']);
+    expect(rest.map((t) => t.id)).toEqual(['a']);
+  });
+  it('toHandoff parses slug + carries note', () => {
+    const h = toHandoff(task({ id: 'b', title: 'Papers', legacy_source: 'handoff:zao-whitepapers', notes: 'open items' }));
+    expect(h).toMatchObject({ taskId: 'b', slug: 'zao-whitepapers', title: 'Papers', note: 'open items' });
   });
 });
 

--- a/bot/src/cockpit/__tests__/orchestration.test.ts
+++ b/bot/src/cockpit/__tests__/orchestration.test.ts
@@ -28,7 +28,7 @@ const cliMock = callClaudeCli as unknown as ReturnType<typeof vi.fn>;
 
 function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitTask {
   return {
-    status: 'todo', priority: null, due: null, project: null, legacy_id: null,
+    status: 'todo', priority: null, due: null, project: null, legacy_id: null, legacy_source: null, notes: null,
     next_owner: null, updated_at: new Date(NOW).toISOString(), created_at: new Date(NOW).toISOString(), ...o,
   };
 }

--- a/bot/src/cockpit/adapters.ts
+++ b/bot/src/cockpit/adapters.ts
@@ -11,7 +11,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { classifyTask, type NextOwner } from '../zoe/task-classifier';
-import type { CockpitTask, ReviewPR, WriteProposal } from './types';
+import type { CockpitTask, Handoff, ReviewPR, WriteProposal } from './types';
 
 const execFileAsync = promisify(execFile);
 
@@ -32,6 +32,8 @@ interface RawRow {
   due: string | null;
   project: string | null;
   legacy_id: string | null;
+  legacy_source: string | null;
+  notes: string | null;
   updated_at: string | null;
   created_at: string | null;
   metadata: Record<string, unknown> | null;
@@ -51,6 +53,8 @@ function toCockpitTask(r: RawRow): CockpitTask {
     due: r.due,
     project: r.project,
     legacy_id: r.legacy_id,
+    legacy_source: r.legacy_source,
+    notes: r.notes,
     next_owner: nextOwnerOf(r.metadata),
     updated_at: r.updated_at,
     created_at: r.created_at,
@@ -66,7 +70,7 @@ export async function fetchCockpitTasks(): Promise<CockpitTask[]> {
   const url =
     `${base.replace(/\/$/, '')}/rest/v1/tasks` +
     `?status=neq.done&archived_at=is.null` +
-    `&select=id,title,status,priority,due,project,legacy_id,updated_at,created_at,metadata` +
+    `&select=id,title,status,priority,due,project,legacy_id,legacy_source,notes,updated_at,created_at,metadata` +
     `&order=due.asc.nullslast&limit=${MAX_TASKS}`;
 
   try {
@@ -144,6 +148,30 @@ export async function fetchReviewPRs(): Promise<ReviewPR[]> {
 }
 
 // ---- pure logic (unit-testable, no network) ----
+
+/** A task written by /handoff carries legacy_source "handoff:<slug>". */
+export function isHandoff(t: CockpitTask): boolean {
+  return (t.legacy_source ?? '').startsWith('handoff:');
+}
+
+/** Split handoff tasks out of the regular task set so they only show in their own lane. */
+export function partitionHandoffs(tasks: CockpitTask[]): { handoffs: CockpitTask[]; rest: CockpitTask[] } {
+  const handoffs: CockpitTask[] = [];
+  const rest: CockpitTask[] = [];
+  for (const t of tasks) (isHandoff(t) ? handoffs : rest).push(t);
+  return { handoffs, rest };
+}
+
+/** Shape a handoff task into the cockpit Handoff view, newest first when mapped over a sorted list. */
+export function toHandoff(t: CockpitTask): Handoff {
+  return {
+    taskId: t.id,
+    slug: (t.legacy_source ?? '').replace(/^handoff:/, '') || 'unknown',
+    title: t.title,
+    note: t.notes,
+    createdAt: t.created_at,
+  };
+}
 
 export function priorityRank(p: string | null): number {
   const m = (p ?? '').toUpperCase().match(/P([0-9])/);

--- a/bot/src/cockpit/brief.ts
+++ b/bot/src/cockpit/brief.ts
@@ -13,6 +13,8 @@ import { homedir } from 'node:os';
 import {
   fetchCockpitTasks,
   fetchReviewPRs,
+  partitionHandoffs,
+  toHandoff,
   topThree,
   needsYou,
   blocked,
@@ -27,21 +29,29 @@ export const COCKPIT_HOME = process.env.COCKPIT_HOME || join(homedir(), '.zao', 
 /** Build the cockpit brief. `now` is injectable for tests. */
 export async function buildCockpitBrief(mode: CockpitMode = 'brief', now = Date.now()): Promise<CockpitBrief> {
   // Tracker tasks + open PRs run in parallel; either failing degrades to [].
-  const [tasks, reviewPRs] = await Promise.all([fetchCockpitTasks(), fetchReviewPRs()]);
+  const [allTasks, reviewPRs] = await Promise.all([fetchCockpitTasks(), fetchReviewPRs()]);
+  // Handoffs (legacy_source "handoff:*") get their own lane, not the task lanes.
+  const { handoffs: handoffTasks, rest: tasks } = partitionHandoffs(allTasks);
   const you = needsYou(tasks);
   const stale = findStale(tasks, now);
   const blk = blocked(tasks);
+  const handoffs = handoffTasks
+    .slice()
+    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+    .map(toHandoff);
   return {
     date: new Date(now).toISOString().slice(0, 10),
     top3: topThree(tasks),
     needsYou: you,
     needsReview: reviewPRs,
+    handoffs,
     stale,
     blocked: blk,
     counts: {
       open: tasks.length,
       needsYou: you.length,
       needsReview: reviewPRs.length,
+      handoffs: handoffs.length,
       stale: stale.length,
       blocked: blk.length,
     },
@@ -60,9 +70,17 @@ export function formatCockpitBrief(b: CockpitBrief): string {
   const parts: string[] = [];
   parts.push(`Cockpit - ${b.date}`);
   parts.push(
-    `${b.counts.open} open | ${b.counts.needsYou} need you | ${b.counts.needsReview} PRs to review | ${b.counts.stale} stale | ${b.counts.blocked} blocked`,
+    `${b.counts.open} open | ${b.counts.needsYou} need you | ${b.counts.needsReview} PRs to review | ${b.counts.handoffs} handoffs | ${b.counts.stale} stale | ${b.counts.blocked} blocked`,
   );
   if (b.top3.length) parts.push('\nDO FIRST\n' + b.top3.map(line).join('\n'));
+  if (b.handoffs.length)
+    parts.push(
+      '\nHANDOFFS (from other terminals)\n' +
+        b.handoffs
+          .slice(0, 8)
+          .map((h) => `- ${h.slug}: ${h.title}${h.note ? `\n  ${h.note.split('\n')[0].slice(0, 120)}` : ''}`)
+          .join('\n'),
+    );
   if (b.needsReview.length)
     parts.push(
       '\nNEEDS YOUR REVIEW (open PRs)\n' +

--- a/bot/src/cockpit/cockpit.ts
+++ b/bot/src/cockpit/cockpit.ts
@@ -17,7 +17,7 @@ const COCKPIT_BUDGET_USD = 0.1;
 const COCKPIT_TIMEOUT_MS = 120_000;
 const REPO_DIR = process.env.COCKPIT_CWD || '/home/zaal/zao-os';
 
-const OPERATOR_SYSTEM = `You are Zaal's operator cockpit. You are given his task board already partitioned (do-first, needs-you, open PRs awaiting his review/merge, stale, blocked). Write his OPERATOR READ: the single most important thing to do first and why, plus any judgment call only he can make today (merging an open PR counts). If there are PRs awaiting review, say which one to look at first. 3-5 short lines.
+const OPERATOR_SYSTEM = `You are Zaal's operator cockpit. You are given his task board already partitioned (do-first, needs-you, open PRs awaiting his review/merge, handoffs from other terminals, stale, blocked). Write his OPERATOR READ: the single most important thing to do first and why, plus any judgment call only he can make today (merging an open PR counts; picking up a handoff counts). If there are PRs awaiting review or fresh handoffs, say which one to look at first. 3-5 short lines.
 
 OUTPUT: plain text only for Telegram. No markdown bold or asterisks, no # headings, no em dashes (use a hyphen), no emojis, no marketing. Spartan, active voice. Do NOT invent tasks - only reason over what you are given.`;
 
@@ -37,7 +37,7 @@ export async function runCockpit(mode: CockpitMode = 'brief', now = Date.now()):
   let operatorRead: string | null = null;
   let costUsd = 0;
 
-  if (brief.counts.open > 0 || brief.counts.needsReview > 0) {
+  if (brief.counts.open > 0 || brief.counts.needsReview > 0 || brief.counts.handoffs > 0) {
     try {
       const res = await callClaudeCli({
         model: COCKPIT_MODEL,

--- a/bot/src/cockpit/types.ts
+++ b/bot/src/cockpit/types.ts
@@ -21,9 +21,22 @@ export interface CockpitTask {
   due: string | null;
   project: string | null;
   legacy_id: string | null;
+  /** e.g. "handoff:zao-whitepapers" - marks a task written by /handoff. */
+  legacy_source: string | null;
+  /** free-text body (open items / context, used for handoffs). */
+  notes: string | null;
   next_owner: NextOwner | null;
   updated_at: string | null;
   created_at: string | null;
+}
+
+/** A handoff from another terminal, surfaced in the cockpit (the durable home). */
+export interface Handoff {
+  taskId: string;
+  slug: string; // parsed from legacy_source "handoff:<slug>"
+  title: string;
+  note: string | null; // open items / context
+  createdAt: string | null;
 }
 
 /** Cockpit run modes = the constraint flags (episode: "investigate-only" enforced by the harness, not the prompt). */
@@ -64,12 +77,14 @@ export interface CockpitBrief {
   needsYou: CockpitTask[];
   /** Open PRs across Zaal's repos awaiting his review/merge - "this stuff to see". */
   needsReview: ReviewPR[];
+  /** Handoffs from other terminals - the durable home for cross-terminal work. */
+  handoffs: Handoff[];
   /** Stale: undated P0/P1s, or no update in >= STALE_DAYS. */
   stale: CockpitTask[];
   /** Blocked (next_owner = 'blocked'). */
   blocked: CockpitTask[];
   /** Counts for the one-line summary. */
-  counts: { open: number; needsYou: number; needsReview: number; stale: number; blocked: number };
+  counts: { open: number; needsYou: number; needsReview: number; handoffs: number; stale: number; blocked: number };
   /** Gated write proposals (empty in 'brief' mode; populated in 'triage'). */
   proposedWrites: WriteProposal[];
 }


### PR DESCRIPTION
Cockpit as home: a HANDOFFS lane surfacing tasks with legacy_source 'handoff:<slug>'. Cross-machine safe (reads the cloud tracker). Slice 1 of the handoff-to-cockpit system. Verified typecheck 0, esbuild boot, 17/17 twice.