### PR TITLE
fix(zoe): read quote-reply thread context + stop inventing command conventions

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -609,11 +609,18 @@ bot.on('message:text', async (ctx) => {
   // DM path: Zaal-only allowlist preserved.
   if (chatType === 'private') {
     if (!isFromZaal(ctx)) return;
+    // Thread context: when Zaal QUOTE-REPLIES a message, fold what he replied to
+    // into the turn so a short reply ("zol yes") anchors to the right draft
+    // instead of arriving context-free. Telegram only gives us the quoted text.
+    const quoted = ctx.message.reply_to_message?.text ?? ctx.message.reply_to_message?.caption;
+    const turnText = quoted
+      ? `[Zaal is replying to your earlier message:\n"${quoted.slice(0, 1200)}"]\n\nHis reply: ${text}`
+      : text;
     // doc 872 (live steering / "finish then apply"): run the turn OFF the poll
     // loop so a new message is received mid-turn instead of blocking the bot.
     // Same-chat turns are serialized in turn-queue; a deferred turn gets a quick
     // ack so Zaal knows it landed and will run after the current one.
-    enqueueTurn(chatId, () => handlePrivateMessage(ctx, text), {
+    enqueueTurn(chatId, () => handlePrivateMessage(ctx, turnText), {
       onDeferred: () => {
         ctx
           .reply("Got that - finishing what I'm on, then I'll pick it up.")

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -55,6 +55,7 @@ ANTI-PATTERNS:
 - Never repeat a task back before doing it
 - Never fabricate facts. If unsure, say so OR query Bonfire via RECALL.
 - Never claim memory state changes that didn't happen.
+- Never offer a command convention you cannot execute. Do NOT write "reply 'zol yes' to post", "reply X to do Y", or any action shortcut unless a real handler for it exists. If you cannot take an action yourself, say what Zaal should do plainly - do not invent a command you have no code to run.
 
 ROUTING (Q1=GATEWAY locked 2026-05-26 per doc 759 + project_zoe_orchestrator_locked memory):
 You are the GATEWAY. ALL agent dispatch flows through you. You own the master task graph and learn from every run.


### PR DESCRIPTION
Fixes the 'zol yes' bug: ZOE ignored the quoted message (read only the replier id, not the text) so a threaded reply arrived context-free; and it invented 'reply X to post' conventions with no handler. Fix folds the quoted text into the turn + adds a persona anti-pattern. typecheck 0, esbuild boot, 294 tests green.