### PR TITLE
feat(zoe): /chatid command for wiring group topics

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -314,6 +314,21 @@ bot.command('start', async (ctx) => {
   );
 });
 
+// /chatid - report this chat's id + (in a forum topic) its topic thread id, so
+// Zaal can wire a group + topics without a third-party id bot. Works in DMs,
+// groups, and topics; commands reach the bot even in privacy mode.
+bot.command('chatid', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const chatId = ctx.chat.id;
+  const title = 'title' in ctx.chat ? ctx.chat.title : '(dm)';
+  const threadId = ctx.message?.message_thread_id;
+  const line = threadId
+    ? `chat: ${chatId} ("${title}")\ntopic thread id: ${threadId}`
+    : `chat: ${chatId} ("${title}")`;
+  console.log(`[zoe/chatid] ${line.replace(/\n/g, ' | ')}`);
+  await ctx.reply(line, threadId ? { message_thread_id: threadId } : {});
+});
+
 bot.command('tasks', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   const blocks = await buildMemoryBlocks('private');


### PR DESCRIPTION
Adds /chatid - Zaal types it in any topic and ZOE replies with the chat id + topic thread id (also logged). Needed to wire the ZAAL BOTZ group + per-stream topics without a third-party id bot. typecheck 0, esbuild boot.