### PR TITLE
feat(zoe): /inittopics - ZOE creates forum topics itself (admin)

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -90,6 +90,7 @@ import {
 import type { DecompositionPlan } from './decompose';
 import { NOTE_PREFIX, PLAN_PREFIX, QUEUE_PREFIX, isZoeCommand } from './commands';
 import { enqueueWork, queueDepth, runWorkTick } from './work-loop';
+import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
 import { ackPush } from './proactive';
@@ -327,6 +328,43 @@ bot.command('chatid', async (ctx) => {
     : `chat: ${chatId} ("${title}")`;
   console.log(`[zoe/chatid] ${line.replace(/\n/g, ' | ')}`);
   await ctx.reply(line, threadId ? { message_thread_id: threadId } : {});
+});
+
+// /inittopics - ZOE creates the standard ZAAL BOTZ topics itself (it is a group
+// admin) and stores each name -> thread id in topics.json. Run it inside the
+// group. Skips topics already known (e.g. Research), so it is safe to re-run.
+bot.command('inittopics', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const chatId = ctx.chat.id;
+  const groupId = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+  if (!groupId || chatId !== groupId) {
+    await ctx.reply('Run /inittopics inside the ZAAL BOTZ group.');
+    return;
+  }
+  const topics = await readTopics();
+  // Seed Research from env so ZOE does not create a duplicate of the manual one.
+  const researchThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
+  if (researchThread && !topics.Research) topics.Research = researchThread;
+
+  const results: string[] = [];
+  for (const name of STANDARD_TOPICS) {
+    if (topics[name]) {
+      results.push(`${name}: ${topics[name]} (exists)`);
+      continue;
+    }
+    try {
+      const t = await ctx.api.createForumTopic(chatId, name);
+      topics[name] = t.message_thread_id;
+      results.push(`${name}: ${t.message_thread_id} (created)`);
+    } catch (e) {
+      results.push(
+        `${name}: FAILED - ${e instanceof Error ? e.message : 'error'} (does ZOE have the Manage Topics admin right?)`,
+      );
+    }
+  }
+  await writeTopics(topics);
+  console.log(`[zoe/inittopics] ${JSON.stringify(topics)}`);
+  await ctx.reply('Topics:\n' + results.join('\n'));
 });
 
 bot.command('tasks', async (ctx) => {

--- a/bot/src/zoe/topics.ts
+++ b/bot/src/zoe/topics.ts
@@ -1,0 +1,36 @@
+/**
+ * Forum-topic registry for the ZAAL BOTZ ops group. ZOE (a group admin with
+ * can_manage_topics) creates the standard topics itself and stores each
+ * name -> message_thread_id here, so the code never needs a hand-copied id.
+ * Persisted to ~/.zao/zoe/topics.json (private-instance config, doc 1025).
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const TOPICS_PATH = join(ZOE_HOME, 'topics.json');
+
+/** The standard ZAAL BOTZ topics ZOE manages. Order is the create order. */
+export const STANDARD_TOPICS = ['Research', 'ZOL', 'Handoffs', 'Claude Code'] as const;
+
+/** name -> message_thread_id */
+export type TopicMap = Record<string, number>;
+
+export async function readTopics(): Promise<TopicMap> {
+  try {
+    return JSON.parse(await fs.readFile(TOPICS_PATH, 'utf8')) as TopicMap;
+  } catch {
+    return {};
+  }
+}
+
+export async function writeTopics(map: TopicMap): Promise<void> {
+  await fs.mkdir(ZOE_HOME, { recursive: true });
+  await fs.writeFile(TOPICS_PATH, JSON.stringify(map, null, 2));
+}
+
+/** Thread id for a named topic, or undefined if not created yet. */
+export async function getTopicThread(name: string): Promise<number | undefined> {
+  return (await readTopics())[name];
+}


### PR DESCRIPTION
ZOE (group admin) creates the standard ZAAL BOTZ topics via createForumTopic and stores name->thread_id in topics.json - no manual /chatid. Seeds Research from env to avoid a duplicate; safe to re-run. typecheck 0, esbuild boot.