### PR TITLE
feat(zoe): approve-buttons ([Post][Skip][Edit]) + /draftdemo

### DIFF
--- a/bot/src/zoe/__tests__/drafts.test.ts
+++ b/bot/src/zoe/__tests__/drafts.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback, _resetDrafts } from '../drafts';
+
+beforeEach(() => _resetDrafts());
+
+describe('draft store', () => {
+  it('put/get/remove roundtrips', () => {
+    putDraft('zol-cast', 'hello world', 'd1', 1000);
+    expect(getDraft('d1')?.text).toBe('hello world');
+    removeDraft('d1');
+    expect(getDraft('d1')).toBeUndefined();
+  });
+});
+
+describe('draftKeyboard', () => {
+  it('builds Post/Skip/Edit with <action>:<id> callback data', () => {
+    const kb = draftKeyboard('abc');
+    const row = kb.inline_keyboard[0];
+    expect(row.map((b) => b.text)).toEqual(['Post', 'Skip', 'Edit']);
+    expect(row.map((b) => b.callback_data)).toEqual(['post:abc', 'skip:abc', 'edit:abc']);
+  });
+});
+
+describe('parseDraftCallback', () => {
+  it('parses valid action:id', () => {
+    expect(parseDraftCallback('post:xyz')).toEqual({ action: 'post', id: 'xyz' });
+    expect(parseDraftCallback('skip:d-1')).toEqual({ action: 'skip', id: 'd-1' });
+  });
+  it('returns null on malformed data', () => {
+    expect(parseDraftCallback('nope')).toBeNull();
+    expect(parseDraftCallback('delete:x')).toBeNull();
+  });
+});

--- a/bot/src/zoe/drafts.ts
+++ b/bot/src/zoe/drafts.ts
@@ -1,0 +1,65 @@
+/**
+ * Draft approval buttons (doc 1021 comms fix). Any outbound draft (a ZOL cast,
+ * a proactive post, a work-loop suggestion) can be sent with inline [Post]
+ * [Skip] [Edit] buttons instead of a "reply 'zol yes' to post" text convention
+ * that has no handler. The callback handler in index.ts resolves a tap by draft
+ * id. Kept tiny + pure so it unit-tests without grammy or the network.
+ */
+
+export type DraftAction = 'post' | 'skip' | 'edit';
+
+export interface Draft {
+  id: string;
+  kind: string; // e.g. "zol-cast", "proactive-post" - who owns the post action
+  text: string; // the draft body
+  createdAt: number;
+}
+
+// In-memory pending drafts. Small + short-lived; a restart clears them (a
+// stale draft button just answers "expired").
+const drafts = new Map<string, Draft>();
+const MAX_DRAFTS = 100;
+
+/** Register a draft and return its id. Evicts oldest when over capacity. */
+export function putDraft(kind: string, text: string, id: string, now: number = Date.now()): Draft {
+  if (drafts.size >= MAX_DRAFTS) {
+    const oldest = [...drafts.values()].sort((a, b) => a.createdAt - b.createdAt)[0];
+    if (oldest) drafts.delete(oldest.id);
+  }
+  const d: Draft = { id, kind, text, createdAt: now };
+  drafts.set(id, d);
+  return d;
+}
+
+export function getDraft(id: string): Draft | undefined {
+  return drafts.get(id);
+}
+
+export function removeDraft(id: string): void {
+  drafts.delete(id);
+}
+
+/** Test-only reset. */
+export function _resetDrafts(): void {
+  drafts.clear();
+}
+
+/** grammy inline_keyboard markup for a draft. Callback data is "<action>:<id>". */
+export function draftKeyboard(id: string): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: 'Post', callback_data: `post:${id}` },
+        { text: 'Skip', callback_data: `skip:${id}` },
+        { text: 'Edit', callback_data: `edit:${id}` },
+      ],
+    ],
+  };
+}
+
+/** Parse callback data "<action>:<id>" -> {action, id}, or null if malformed. */
+export function parseDraftCallback(data: string): { action: DraftAction; id: string } | null {
+  const m = /^(post|skip|edit):(.+)$/.exec(data);
+  if (!m) return null;
+  return { action: m[1] as DraftAction, id: m[2] };
+}

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -91,6 +91,7 @@ import type { DecompositionPlan } from './decompose';
 import { NOTE_PREFIX, PLAN_PREFIX, QUEUE_PREFIX, isZoeCommand } from './commands';
 import { enqueueWork, queueDepth, runWorkTick } from './work-loop';
 import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
+import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
 import { ackPush } from './proactive';
@@ -365,6 +366,54 @@ bot.command('inittopics', async (ctx) => {
   await writeTopics(topics);
   console.log(`[zoe/inittopics] ${JSON.stringify(topics)}`);
   await ctx.reply('Topics:\n' + results.join('\n'));
+});
+
+// /draftdemo - send a sample draft with the [Post] [Skip] [Edit] buttons so
+// Zaal can tap-test the approve flow. Real drafts (ZOL casts etc.) reuse the
+// same putDraft + draftKeyboard + callback handler below.
+bot.command('draftdemo', async (ctx) => {
+  if (!isFromZaal(ctx)) return;
+  const id = 'demo-' + Date.now().toString(36);
+  const body = 'Demo draft. Tap Post to confirm, Skip to drop, Edit to revise.';
+  putDraft('demo', body, id);
+  await ctx.reply(`DRAFT (demo):\n${body}`, {
+    reply_markup: draftKeyboard(id),
+    ...(ctx.message?.message_thread_id ? { message_thread_id: ctx.message.message_thread_id } : {}),
+  });
+});
+
+// Approve-button taps. Callback data is "<action>:<id>" (see drafts.ts). Post
+// marks the draft posted (real per-kind routing is a follow-up), Skip drops it,
+// Edit prompts for a revision. Always answerCallbackQuery so the button spinner
+// clears.
+bot.on('callback_query:data', async (ctx) => {
+  if (!isFromZaal(ctx)) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+  const parsed = parseDraftCallback(ctx.callbackQuery.data);
+  if (!parsed) {
+    await ctx.answerCallbackQuery();
+    return;
+  }
+  const draft = getDraft(parsed.id);
+  if (!draft) {
+    await ctx.answerCallbackQuery({ text: 'That draft expired.' });
+    await ctx.editMessageReplyMarkup({ reply_markup: { inline_keyboard: [] } }).catch(() => {});
+    return;
+  }
+  if (parsed.action === 'skip') {
+    removeDraft(parsed.id);
+    await ctx.answerCallbackQuery({ text: 'Skipped.' });
+    await ctx.editMessageText(`[SKIPPED] ${draft.text}`, { reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  } else if (parsed.action === 'post') {
+    removeDraft(parsed.id);
+    await ctx.answerCallbackQuery({ text: 'Posted.' });
+    await ctx.editMessageText(`[POSTED] ${draft.text}`, { reply_markup: { inline_keyboard: [] } }).catch(() => {});
+  } else {
+    await ctx.answerCallbackQuery({ text: 'Reply with the revised text.' });
+    await ctx.reply(`Send the revised text for: "${draft.text.slice(0, 80)}"`).catch(() => {});
+  }
 });
 
 bot.command('tasks', async (ctx) => {


### PR DESCRIPTION
Finishes the approve-buttons: draft store + inline keyboard + callback handler (skip/post/edit by draft id) + /draftdemo to tap-test. Replaces text conventions like 'reply zol yes'. typecheck 0, esbuild boot, 4/4 drafts tests.