### PR TITLE
feat(zoe): research results report back to the Research topic

### DIFF
--- a/bot/src/zoe/__tests__/work-loop.test.ts
+++ b/bot/src/zoe/__tests__/work-loop.test.ts
@@ -31,6 +31,14 @@ describe('work-loop queue', () => {
     expect(await queueDepth()).toBe(1);
   });
 
+  it('stores a reply target when given (research-from-topic routing)', async () => {
+    const { enqueueWork } = await import('../work-loop');
+    const item = await enqueueWork('from the research topic', { chatId: -100123, threadId: 8 });
+    expect(item.replyTarget).toEqual({ chatId: -100123, threadId: 8 });
+    const plain = await enqueueWork('from a DM');
+    expect(plain.replyTarget).toBeUndefined();
+  });
+
   it('preserves FIFO order across multiple enqueues', async () => {
     const { enqueueWork, queueDepth } = await import('../work-loop');
     await enqueueWork('first');

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -695,12 +695,21 @@ bot.on('message:text', async (ctx) => {
     // are normal ZOE chat. Thread ids are env config (private-instance).
     const researchThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
     if (researchThread && threadId === researchThread) {
-      await enqueueWork(text).catch((e) =>
+      await enqueueWork(text, { chatId, threadId }).catch((e) =>
         console.error('[zoe/index] research enqueue failed:', (e as Error)?.message),
       );
       await ctx
-        .reply("On it - researching this. I'll post the doc + PR when it lands.")
+        .reply("On it - researching this. I'll post the doc + PR here when it lands.")
         .catch(() => {});
+      // Kick the work-loop now so it starts immediately (else waits for the 2h cron).
+      void runWorkTick({
+        sendToZaal: (t: string) => bot.api.sendMessage(zaalId, t),
+        sendToChat: (cid: number, tid: number | undefined, t: string) =>
+          bot.api.sendMessage(cid, t, tid ? { message_thread_id: tid } : {}),
+        zaalTgId: zaalId,
+        repoDir,
+        currentDate: currentDateString(),
+      }).catch((e) => console.error('[zoe/index] research kick failed:', (e as Error).message));
       return;
     }
     const quotedG = ctx.message.reply_to_message?.text ?? ctx.message.reply_to_message?.caption;
@@ -1003,6 +1012,8 @@ async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
       .catch(() => {});
     void runWorkTick({
       sendToZaal: (t: string) => bot.api.sendMessage(zaalId, t),
+      sendToChat: (chatId: number, threadId: number | undefined, t: string) =>
+        bot.api.sendMessage(chatId, t, threadId ? { message_thread_id: threadId } : {}),
       zaalTgId: zaalId,
       repoDir,
       currentDate: currentDateString(),

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -368,6 +368,8 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
         try {
           await runWorkTick({
             sendToZaal: (t: string) => opts.bot.api.sendMessage(opts.zaalTgId, t),
+            sendToChat: (chatId: number, threadId: number | undefined, t: string) =>
+              opts.bot.api.sendMessage(chatId, t, threadId ? { message_thread_id: threadId } : {}),
             zaalTgId: opts.zaalTgId,
             repoDir: opts.repoDir,
             currentDate: new Date().toISOString().slice(0, 10),

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -36,10 +36,16 @@ export interface WorkItem {
   kind: 'research';
   input: string;
   addedTs: string;
+  /** Where to report the result. When set (e.g. a request from the Research
+   * topic), the completion lands there instead of Zaal's DM. */
+  replyTarget?: { chatId: number; threadId?: number };
 }
 
 export interface WorkTickDeps {
   sendToZaal: (text: string) => Promise<unknown>;
+  /** Send to a specific chat/topic (used to report a research result back to
+   * the topic it was requested from). Falls back to sendToZaal if absent. */
+  sendToChat?: (chatId: number, threadId: number | undefined, text: string) => Promise<unknown>;
   zaalTgId: number;
   repoDir: string;
   currentDate: string;
@@ -58,17 +64,30 @@ async function writeQueue(q: WorkItem[]): Promise<void> {
   await fs.writeFile(QUEUE(), JSON.stringify(q, null, 2));
 }
 
-export async function enqueueWork(input: string): Promise<WorkItem> {
+export async function enqueueWork(
+  input: string,
+  replyTarget?: { chatId: number; threadId?: number },
+): Promise<WorkItem> {
   const q = await readQueue();
   const item: WorkItem = {
     id: 'wk-' + Date.now().toString(36),
     kind: 'research',
     input: input.trim(),
     addedTs: new Date().toISOString(),
+    ...(replyTarget ? { replyTarget } : {}),
   };
   q.push(item);
   await writeQueue(q);
   return item;
+}
+
+/** Report a work item's result to its topic if it has a reply target, else DM. */
+function reportFor(item: WorkItem, deps: WorkTickDeps): (text: string) => Promise<unknown> {
+  if (item.replyTarget && deps.sendToChat) {
+    const { chatId, threadId } = item.replyTarget;
+    return (text: string) => deps.sendToChat!(chatId, threadId, text);
+  }
+  return deps.sendToZaal;
 }
 
 export async function queueDepth(): Promise<number> {
@@ -164,13 +183,12 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
           onSubtaskDone: async (st, r) => {
             if (st.worker === 'research-worker' && r.status === 'completed' && r.output) {
               const doc = await commitResearchDoc({ question: item.input, findings: r.output });
-              await deps
-                .sendToZaal(
-                  doc.ok
-                    ? `Work-loop done: doc ${doc.num} -> ${doc.prUrl}`
-                    : `Work-loop: doc save failed - ${doc.error}`,
-                )
-                .catch(() => {});
+              // Report the result to the topic it was requested from (else DM).
+              await reportFor(item, deps)(
+                doc.ok
+                  ? `Work-loop done: doc ${doc.num} -> ${doc.prUrl}`
+                  : `Work-loop: doc save failed - ${doc.error}`,
+              ).catch(() => {});
             }
           },
         },


### PR DESCRIPTION
Research requests from the Research topic now report their doc+PR result IN that topic (WorkItem.replyTarget + sendToChat), and the work-loop kicks immediately instead of waiting for the 2h cron. typecheck 0, esbuild boot, 5 work-loop tests.