### PR TITLE
feat(zoe): route all work-loop research to the Research topic

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -309,6 +309,14 @@ async function replyAdminOnly(ctx: Context): Promise<void> {
   await ctx.reply('Group admin commands are Zaal-only. DM me if you need access.');
 }
 
+/** The ZAAL BOTZ Research topic as a work-loop reply target (env config), or
+ * undefined if not configured - then research falls back to Zaal's DM. */
+function researchTopicTarget(): { chatId: number; threadId: number } | undefined {
+  const g = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+  const t = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
+  return g && t ? { chatId: g, threadId: t } : undefined;
+}
+
 bot.command('start', async (ctx) => {
   if (!isFromZaal(ctx)) return;
   await ctx.reply(
@@ -755,6 +763,7 @@ bot.on('message:text', async (ctx) => {
         sendToZaal: (t: string) => bot.api.sendMessage(zaalId, t),
         sendToChat: (cid: number, tid: number | undefined, t: string) =>
           bot.api.sendMessage(cid, t, tid ? { message_thread_id: tid } : {}),
+        defaultResearchTarget: researchTopicTarget(),
         zaalTgId: zaalId,
         repoDir,
         currentDate: currentDateString(),
@@ -1063,6 +1072,7 @@ async function handlePrivateMessage(ctx: Context, text: string): Promise<void> {
       sendToZaal: (t: string) => bot.api.sendMessage(zaalId, t),
       sendToChat: (chatId: number, threadId: number | undefined, t: string) =>
         bot.api.sendMessage(chatId, t, threadId ? { message_thread_id: threadId } : {}),
+      defaultResearchTarget: researchTopicTarget(),
       zaalTgId: zaalId,
       repoDir,
       currentDate: currentDateString(),

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -366,10 +366,13 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
       '0 */2 * * *',
       async () => {
         try {
+          const rGid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+          const rThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
           await runWorkTick({
             sendToZaal: (t: string) => opts.bot.api.sendMessage(opts.zaalTgId, t),
             sendToChat: (chatId: number, threadId: number | undefined, t: string) =>
               opts.bot.api.sendMessage(chatId, t, threadId ? { message_thread_id: threadId } : {}),
+            defaultResearchTarget: rGid && rThread ? { chatId: rGid, threadId: rThread } : undefined,
             zaalTgId: opts.zaalTgId,
             repoDir: opts.repoDir,
             currentDate: new Date().toISOString().slice(0, 10),

--- a/bot/src/zoe/work-loop.ts
+++ b/bot/src/zoe/work-loop.ts
@@ -46,6 +46,9 @@ export interface WorkTickDeps {
   /** Send to a specific chat/topic (used to report a research result back to
    * the topic it was requested from). Falls back to sendToZaal if absent. */
   sendToChat?: (chatId: number, threadId: number | undefined, text: string) => Promise<unknown>;
+  /** Where autonomous research (no explicit reply target) reports - the Research
+   * topic. When set + sendToChat present, all research lands there not the DM. */
+  defaultResearchTarget?: { chatId: number; threadId: number };
   zaalTgId: number;
   repoDir: string;
   currentDate: string;
@@ -81,10 +84,15 @@ export async function enqueueWork(
   return item;
 }
 
-/** Report a work item's result to its topic if it has a reply target, else DM. */
+/** Report a work item's result: its own reply target > the default Research
+ * topic > Zaal's DM. */
 function reportFor(item: WorkItem, deps: WorkTickDeps): (text: string) => Promise<unknown> {
   if (item.replyTarget && deps.sendToChat) {
     const { chatId, threadId } = item.replyTarget;
+    return (text: string) => deps.sendToChat!(chatId, threadId, text);
+  }
+  if (deps.defaultResearchTarget && deps.sendToChat) {
+    const { chatId, threadId } = deps.defaultResearchTarget;
     return (text: string) => deps.sendToChat!(chatId, threadId, text);
   }
   return deps.sendToZaal;
@@ -168,9 +176,9 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
       ambiguities: [],
     };
 
-    await deps
-      .sendToZaal(`Work-loop: researching "${item.input.slice(0, 80)}" (${q.length} queued)`)
-      .catch(() => {});
+    await reportFor(item, deps)(
+      `Work-loop: researching "${item.input.slice(0, 80)}" (${q.length} queued)`,
+    ).catch(() => {});
 
     try {
       await dispatchPlan({
@@ -198,11 +206,9 @@ export async function runWorkTick(deps: WorkTickDeps): Promise<void> {
     } catch (e) {
       const errMsg = (e as Error)?.message ?? String(e);
       console.error('[zoe/work-loop] tick failed:', errMsg);
-      await deps
-        .sendToZaal(
-          `Work-loop error: failed to process "${item.input.slice(0, 60)}..." - ${errMsg.slice(0, 120)}`,
-        )
-        .catch(() => {});
+      await reportFor(item, deps)(
+        `Work-loop error: failed to process "${item.input.slice(0, 60)}..." - ${errMsg.slice(0, 120)}`,
+      ).catch(() => {});
       // Remove from queue even on error to avoid infinite retry loop
       await writeQueue((await readQueue()).filter((x) => x.id !== item.id));
     }


### PR DESCRIPTION
Autonomous work-loop research now reports (start/done/error) in the Research topic via a defaultResearchTarget, instead of the DM. typecheck 0, esbuild boot, 5 work-loop tests.