### PR TITLE
feat(zoe): topic-router - ZAAL BOTZ topics auto-act by intent

### DIFF
--- a/bot/src/zoe/__tests__/topic-router.test.ts
+++ b/bot/src/zoe/__tests__/topic-router.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { routeTopic, topicNameForThread } from '../topic-router';
+
+const { readTopicsMock } = vi.hoisted(() => ({ readTopicsMock: vi.fn() }));
+vi.mock('../topics', () => ({ readTopics: readTopicsMock }));
+
+describe('routeTopic', () => {
+  it('routes Research to the research pipeline', () => {
+    expect(routeTopic('Research')).toEqual({ kind: 'research' });
+  });
+
+  it('routes Coding to the auto-PR pipeline', () => {
+    expect(routeTopic('Coding')).toEqual({ kind: 'coding' });
+  });
+
+  it('routes Ideas to a tagged capture', () => {
+    expect(routeTopic('Ideas')).toEqual({ kind: 'capture', project: 'ideas' });
+  });
+
+  it('routes cast topics to a draft with the right kind', () => {
+    expect(routeTopic('Farcaster')).toMatchObject({ kind: 'draft', draftKind: 'farcaster-cast' });
+    expect(routeTopic('ZOL')).toMatchObject({ kind: 'draft', draftKind: 'zol-cast' });
+    expect(routeTopic('Newsletter')).toMatchObject({ kind: 'draft', draftKind: 'newsletter' });
+  });
+
+  it('brand topics also capture a tagged note', () => {
+    expect(routeTopic('WaveWarZ')).toMatchObject({ kind: 'draft', alsoCapture: 'wavewarz' });
+    expect(routeTopic('ZABAL Games')).toMatchObject({ kind: 'draft', alsoCapture: 'zabal-games' });
+  });
+
+  it('passive + unknown topics fall through to chat', () => {
+    expect(routeTopic('Handoffs')).toEqual({ kind: 'chat' });
+    expect(routeTopic('Claude Code')).toEqual({ kind: 'chat' });
+    expect(routeTopic('Something Else')).toEqual({ kind: 'chat' });
+    expect(routeTopic(undefined)).toEqual({ kind: 'chat' });
+  });
+});
+
+describe('topicNameForThread', () => {
+  const origEnv = process.env.ZAAL_BOTZ_RESEARCH_THREAD;
+  afterEach(() => {
+    readTopicsMock.mockReset();
+    process.env.ZAAL_BOTZ_RESEARCH_THREAD = origEnv;
+  });
+
+  it('returns undefined for the General thread (no id)', async () => {
+    readTopicsMock.mockResolvedValue({});
+    expect(await topicNameForThread(undefined)).toBeUndefined();
+  });
+
+  it('maps a thread id to its topic name via topics.json', async () => {
+    readTopicsMock.mockResolvedValue({ Coding: 19, Ideas: 21 });
+    expect(await topicNameForThread(19)).toBe('Coding');
+    expect(await topicNameForThread(21)).toBe('Ideas');
+  });
+
+  it('falls back to the Research env thread', async () => {
+    process.env.ZAAL_BOTZ_RESEARCH_THREAD = '8';
+    readTopicsMock.mockResolvedValue({});
+    expect(await topicNameForThread(8)).toBe('Research');
+  });
+
+  it('returns undefined for an unmapped thread', async () => {
+    readTopicsMock.mockResolvedValue({ Coding: 19 });
+    expect(await topicNameForThread(999)).toBeUndefined();
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -91,6 +91,8 @@ import type { DecompositionPlan } from './decompose';
 import { NOTE_PREFIX, PLAN_PREFIX, QUEUE_PREFIX, isZoeCommand } from './commands';
 import { enqueueWork, queueDepth, runWorkTick } from './work-loop';
 import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
+import { routeTopic, topicNameForThread } from './topic-router';
+import { dispatchHermesRun } from '../hermes/runner';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
@@ -774,11 +776,14 @@ bot.on('message:text', async (ctx) => {
   const zaalBotzGroupId = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
   if (zaalBotzGroupId && chatId === zaalBotzGroupId && isFromZaal(ctx)) {
     const threadId = ctx.message.message_thread_id;
-    // Per-topic behavior: the Research topic turns any message into a research
-    // request (the work-loop researches it + commits a doc + PR). Other topics
-    // are normal ZOE chat. Thread ids are env config (private-instance).
-    const researchThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
-    if (researchThread && threadId === researchThread) {
+    // Per-topic behavior (topic = intent, Zaal 2026-07-11): dropping a plain
+    // message into a topic auto-acts per that topic. Internal actions fire now;
+    // outbound casts are drafted with an Approve button (money/public gate).
+    const topicName = await topicNameForThread(threadId).catch(() => undefined);
+    const action = routeTopic(topicName);
+    const threadOpt = threadId ? { message_thread_id: threadId } : {};
+
+    if (action.kind === 'research') {
       await enqueueWork(text, { chatId, threadId }).catch((e) =>
         console.error('[zoe/index] research enqueue failed:', (e as Error)?.message),
       );
@@ -797,6 +802,56 @@ bot.on('message:text', async (ctx) => {
       }).catch((e) => console.error('[zoe/index] research kick failed:', (e as Error).message));
       return;
     }
+
+    if (action.kind === 'coding') {
+      // Full auto-PR: the coder+critic pipeline (PR-only, own daily-cap guard).
+      // A human still merges. Progress + the PR link report back into the topic.
+      await ctx.reply('On it - running the coder+critic pipeline. PR link lands here.').catch(() => {});
+      const say = (t: string) => bot.api.sendMessage(chatId, t, threadOpt).catch(() => {});
+      void dispatchHermesRun(
+        { triggered_by_telegram_id: zaalId, triggered_in_chat_id: chatId, issue_text: text },
+        {
+          onPrOpened: async (_id, prNumber, prUrl, score) => {
+            await say(`Coding done: PR #${prNumber} (critic ${score}/10)\n${prUrl}`);
+          },
+          onEscalated: async (_id, reason) => {
+            await say(`Coding escalated - needs your eyes: ${reason.slice(0, 200)}`);
+          },
+          onFailed: async (_id, reason) => {
+            await say(`Coding failed: ${reason.slice(0, 200)}`);
+          },
+        },
+      ).catch((e) => say(`Coding pipeline error: ${(e as Error).message.slice(0, 160)}`));
+      return;
+    }
+
+    if (action.kind === 'capture') {
+      const res = await addTeamTask({ title: text.slice(0, 300), project: action.project }).catch(
+        (e) => ({ ok: false as const, error: (e as Error).message }),
+      );
+      await ctx
+        .reply(res.ok ? `Filed under ${action.project}.` : `Could not file it - ${res.error}`)
+        .catch(() => {});
+      return;
+    }
+
+    if (action.kind === 'draft') {
+      // Also file a tagged note for brand topics (WaveWarZ / ZABAL Games).
+      if (action.alsoCapture) {
+        await addTeamTask({ title: text.slice(0, 300), project: action.alsoCapture }).catch(() => {});
+      }
+      const id = `${action.draftKind}-${Date.now().toString(36)}`;
+      putDraft(action.draftKind, text, id);
+      await bot.api
+        .sendMessage(chatId, `${action.label}:\n${text}`, {
+          ...threadOpt,
+          reply_markup: draftKeyboard(id),
+        })
+        .catch(() => {});
+      return;
+    }
+
+    // action.kind === 'chat': normal ZOE conversation (Handoffs, Claude Code, etc).
     const quotedG = ctx.message.reply_to_message?.text ?? ctx.message.reply_to_message?.caption;
     const turnTextG = quotedG
       ? `[Zaal is replying to your earlier message:\n"${quotedG.slice(0, 1200)}"]\n\nHis reply: ${text}`

--- a/bot/src/zoe/topic-router.ts
+++ b/bot/src/zoe/topic-router.ts
@@ -1,0 +1,85 @@
+/**
+ * topic-router.ts - map a ZAAL BOTZ forum topic to a behavior.
+ *
+ * "Topic = intent" (Zaal's call 2026-07-11): when Zaal drops a plain message
+ * into a topic, ZOE auto-acts per that topic instead of just chatting. Internal
+ * actions (research, capture, draft) happen immediately; anything OUTBOUND
+ * (posting a cast, publishing) is drafted with an Approve button and never fires
+ * without his tap - the standing money/public/irreversible gate.
+ *
+ * This module is a PURE classifier (name -> action) plus a thread-id -> name
+ * lookup off topics.json, so index.ts owns all the bot/api side-effects and the
+ * routing table stays unit-testable.
+ */
+import { readTopics } from './topics';
+
+/** What ZOE does with a plain message dropped into a topic. */
+export type TopicAction =
+  | { kind: 'research' }
+  /** Run the coder+critic auto-PR pipeline; report the PR link in the topic. */
+  | { kind: 'coding' }
+  /** File a tagged capture on the cowork board under `project`. */
+  | { kind: 'capture'; project: string }
+  /** Draft the topic-appropriate thing + Approve button. `draftKind` selects the
+   *  Post-side routing; `alsoCapture` (if set) also files a tagged note. */
+  | { kind: 'draft'; draftKind: string; label: string; alsoCapture?: string }
+  /** No special behavior - normal ZOE conversation (Handoffs, Claude Code, etc). */
+  | { kind: 'chat' };
+
+/**
+ * The routing table. Topic names match the ones ZOE created via createForumTopic
+ * (stored in topics.json). Unknown / passive topics fall through to chat.
+ */
+export function routeTopic(topicName: string | undefined): TopicAction {
+  switch (topicName) {
+    case 'Research':
+      return { kind: 'research' };
+    case 'Coding':
+      return { kind: 'coding' };
+    case 'Ideas':
+      return { kind: 'capture', project: 'ideas' };
+    case 'Newsletter':
+      return { kind: 'draft', draftKind: 'newsletter', label: 'Newsletter draft' };
+    case 'Farcaster':
+      return { kind: 'draft', draftKind: 'farcaster-cast', label: 'Farcaster draft' };
+    case 'ZOL':
+      return { kind: 'draft', draftKind: 'zol-cast', label: 'ZOL draft' };
+    case 'WaveWarZ':
+      return {
+        kind: 'draft',
+        draftKind: 'wavewarz-cast',
+        label: 'WaveWarZ draft',
+        alsoCapture: 'wavewarz',
+      };
+    case 'ZABAL Games':
+      return {
+        kind: 'draft',
+        draftKind: 'zabal-cast',
+        label: 'ZABAL Games draft',
+        alsoCapture: 'zabal-games',
+      };
+    default:
+      // Handoffs + Claude Code are passive (auto-surface only); anything unknown
+      // is just a chat room.
+      return { kind: 'chat' };
+  }
+}
+
+/**
+ * Resolve a forum thread id to its topic name via topics.json. Falls back to the
+ * Research env thread so the Research topic still routes even if topics.json is
+ * missing it. Returns undefined for the group's General thread (no id) or an
+ * unmapped topic.
+ */
+export async function topicNameForThread(
+  threadId: number | undefined,
+): Promise<string | undefined> {
+  if (!threadId) return undefined;
+  const researchThread = Number(process.env.ZAAL_BOTZ_RESEARCH_THREAD ?? 0);
+  if (researchThread && threadId === researchThread) return 'Research';
+  const topics = await readTopics().catch(() => ({}) as Record<string, number>);
+  for (const [name, id] of Object.entries(topics)) {
+    if (id === threadId) return name;
+  }
+  return undefined;
+}

--- a/bot/src/zoe/topics.ts
+++ b/bot/src/zoe/topics.ts
@@ -11,8 +11,20 @@ import { homedir } from 'node:os';
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const TOPICS_PATH = join(ZOE_HOME, 'topics.json');
 
-/** The standard ZAAL BOTZ topics ZOE manages. Order is the create order. */
-export const STANDARD_TOPICS = ['Research', 'ZOL', 'Handoffs', 'Claude Code'] as const;
+/** The standard ZAAL BOTZ topics ZOE manages. Order is the create order.
+ * Each has a behavior in topic-router.ts (topic = intent). */
+export const STANDARD_TOPICS = [
+  'Research',
+  'ZOL',
+  'Handoffs',
+  'Claude Code',
+  'Farcaster',
+  'Coding',
+  'Ideas',
+  'Newsletter',
+  'WaveWarZ',
+  'ZABAL Games',
+] as const;
 
 /** name -> message_thread_id */
 export type TopicMap = Record<string, number>;


### PR DESCRIPTION
## Summary
Each ZAAL BOTZ forum topic now auto-acts by intent when Zaal drops a plain message in it (his call 2026-07-11), instead of treating every topic as plain chat.

## Behavior map
- Research -> research + doc/PR (existing, moved into the router)
- Coding -> coder+critic auto-PR pipeline; PR link reports back into the topic
- Ideas -> tagged capture on the cowork board
- Newsletter / Farcaster / ZOL -> draft + Approve button (outbound gate)
- WaveWarZ / ZABAL Games -> tagged note + brand-voice draft + Approve
- Handoffs / Claude Code / unknown -> passive (normal chat)

## Design
`topic-router.ts` is a pure classifier (`routeTopic`) + a thread-id->name lookup off `topics.json`; `index.ts` owns all bot side-effects. Internal actions fire immediately; every outbound cast stays behind the Approve button.

## Verify
- 10/10 vitest (topic-router.test.ts)
- esbuild bundle clean; zero new type errors (grammy resolves on VPS deps; only the pre-existing scheduler.ts error remains)

## Follow-up
- Real casting on Approve (ZOL via Pi relay) - separate PR, needs the Pi cast endpoint.
- Newsletter Approve -> feed the zabalnewsletterbuilder queue.