### PR TITLE
feat(zoe): honest Approve - queue casts/newsletter to a durable outbox

### DIFF
--- a/bot/src/zoe/__tests__/outbox.test.ts
+++ b/bot/src/zoe/__tests__/outbox.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { outboxChannelFor, outboxLine } from '../outbox';
+
+describe('outboxChannelFor', () => {
+  it('maps -cast kinds to the cast channel', () => {
+    expect(outboxChannelFor('zol-cast')).toBe('cast');
+    expect(outboxChannelFor('farcaster-cast')).toBe('cast');
+    expect(outboxChannelFor('wavewarz-cast')).toBe('cast');
+    expect(outboxChannelFor('zabal-cast')).toBe('cast');
+  });
+
+  it('maps newsletter to the newsletter channel', () => {
+    expect(outboxChannelFor('newsletter')).toBe('newsletter');
+  });
+
+  it('returns null for non-outbox kinds', () => {
+    expect(outboxChannelFor('proactive-post')).toBeNull();
+    expect(outboxChannelFor('demo')).toBeNull();
+  });
+});
+
+describe('outboxLine', () => {
+  it('produces a parseable JSONL entry marked unsent', () => {
+    const line = outboxLine('zol-cast', 'gm from ZOL', 1_700_000_000_000);
+    const parsed = JSON.parse(line);
+    expect(parsed).toEqual({
+      kind: 'zol-cast',
+      text: 'gm from ZOL',
+      approvedAt: new Date(1_700_000_000_000).toISOString(),
+      sent: false,
+    });
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -92,6 +92,7 @@ import { NOTE_PREFIX, PLAN_PREFIX, QUEUE_PREFIX, isZoeCommand } from './commands
 import { enqueueWork, queueDepth, runWorkTick } from './work-loop';
 import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
 import { routeTopic, topicNameForThread } from './topic-router';
+import { appendApproved } from './outbox';
 import { dispatchHermesRun } from '../hermes/runner';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
@@ -445,8 +446,31 @@ bot.on('callback_query:data', async (ctx) => {
     await ctx.editMessageText(`[SKIPPED] ${draft.text}`, { reply_markup: { inline_keyboard: [] } }).catch(() => {});
   } else if (parsed.action === 'post') {
     removeDraft(parsed.id);
-    await ctx.answerCallbackQuery({ text: 'Posted.' });
-    await ctx.editMessageText(`[POSTED] ${draft.text}`, { reply_markup: { inline_keyboard: [] } }).catch(() => {});
+    // Cast + newsletter drafts can't actually send from the VPS yet (ZOL signer
+    // is Pi-only; the newsletter builder is a separate Supabase project). Rather
+    // than fake "Posted", append to the durable outbox and say so honestly - a
+    // future Pi/builder drainer sends from there. Other kinds keep the old path.
+    const channel = await appendApproved(draft.kind, draft.text).catch(() => null);
+    if (channel === 'cast') {
+      await ctx.answerCallbackQuery({ text: 'Approved - queued to cast.' });
+      await ctx
+        .editMessageText(`[APPROVED to cast - queued, not yet sent] ${draft.text}`, {
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {});
+    } else if (channel === 'newsletter') {
+      await ctx.answerCallbackQuery({ text: 'Approved for the newsletter.' });
+      await ctx
+        .editMessageText(`[APPROVED for newsletter - queued] ${draft.text}`, {
+          reply_markup: { inline_keyboard: [] },
+        })
+        .catch(() => {});
+    } else {
+      await ctx.answerCallbackQuery({ text: 'Posted.' });
+      await ctx
+        .editMessageText(`[POSTED] ${draft.text}`, { reply_markup: { inline_keyboard: [] } })
+        .catch(() => {});
+    }
   } else {
     await ctx.answerCallbackQuery({ text: 'Reply with the revised text.' });
     await ctx.reply(`Send the revised text for: "${draft.text.slice(0, 80)}"`).catch(() => {});

--- a/bot/src/zoe/outbox.ts
+++ b/bot/src/zoe/outbox.ts
@@ -1,0 +1,73 @@
+/**
+ * outbox.ts - durable record of APPROVED outbound drafts.
+ *
+ * When Zaal taps Post on a cast/newsletter draft, ZOE cannot actually send it
+ * yet: the ZOL signer lives on the Pi (unreachable from the VPS) and the
+ * newsletter builder is a separate Supabase project. Rather than fake a "Posted"
+ * (dishonest - nothing sent), the tap appends the approved item here. This is
+ * the ZOE-side half of the eventual bridge: a future Pi drainer (or the
+ * newsletter sync) reads this outbox and actually casts/publishes. Until then
+ * it is an honest, durable "approved, awaiting send" queue that survives restart
+ * (the in-memory drafts do not).
+ *
+ * JSONL, one file per channel under ~/.zao/zoe/outbox/. Best-effort: a write
+ * failure returns null and the caller surfaces it - it never throws into the
+ * Telegram handler.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const OUTBOX_DIR = join(ZOE_HOME, 'outbox');
+
+export interface OutboxEntry {
+  kind: string;
+  text: string;
+  approvedAt: string;
+  sent: boolean;
+}
+
+/** Which channel a draft kind belongs to (selects the outbox file + wording). */
+export type OutboxChannel = 'cast' | 'newsletter';
+
+/** Map a draft kind to its outbox channel, or null if it is not an outbox kind
+ *  (e.g. a plain proactive-post that the current [POSTED] path already handles). */
+export function outboxChannelFor(kind: string): OutboxChannel | null {
+  if (kind.endsWith('-cast')) return 'cast';
+  if (kind === 'newsletter') return 'newsletter';
+  return null;
+}
+
+/** Build the JSONL line for an approved entry. Pure - unit-testable. */
+export function outboxLine(kind: string, text: string, now: number): string {
+  const entry: OutboxEntry = {
+    kind,
+    text,
+    approvedAt: new Date(now).toISOString(),
+    sent: false,
+  };
+  return JSON.stringify(entry);
+}
+
+/** The file an entry of this channel lands in. */
+export function outboxPathFor(channel: OutboxChannel): string {
+  return join(OUTBOX_DIR, `${channel}.jsonl`);
+}
+
+/**
+ * Append an approved draft to its channel's outbox. Returns the channel so the
+ * caller can word the confirmation, or null if the kind is not an outbox kind.
+ * Best-effort: throws only if fs is truly broken; caller catches.
+ */
+export async function appendApproved(
+  kind: string,
+  text: string,
+  now: number = Date.now(),
+): Promise<OutboxChannel | null> {
+  const channel = outboxChannelFor(kind);
+  if (!channel) return null;
+  await fs.mkdir(OUTBOX_DIR, { recursive: true });
+  await fs.appendFile(outboxPathFor(channel), outboxLine(kind, text, now) + '\n');
+  return channel;
+}


### PR DESCRIPTION
Approve on a cast/newsletter draft now appends to a durable outbox and says so honestly, instead of falsely claiming 'Posted' (ZOL signer is Pi-only + unreachable from VPS; newsletter builder is a separate Supabase project). ZOE-side half of the send bridge. 4/4 vitest, esbuild clean.