### PR TITLE
feat(cockpit): idea-inbox captures lane + terminal CLI

### DIFF
--- a/bot/src/cockpit/__tests__/cockpit.test.ts
+++ b/bot/src/cockpit/__tests__/cockpit.test.ts
@@ -118,9 +118,13 @@ describe('formatCockpitBrief', () => {
       handoffs: [
         { taskId: 'h1', slug: 'zao-whitepapers', title: 'Papers terminal', note: '12 drafts live, needs ZABAL call', createdAt: '2026-07-10T06:00:00Z' },
       ],
+      captures: [
+        { taskId: 'c1', slug: 'flow-app', title: 'Flow energy meter app', createdAt: '2026-07-11T00:00:00Z', ageDays: 1, stale: false },
+        { taskId: 'c2', slug: 'old-idea', title: 'An idea I hoarded', createdAt: '2026-06-25T00:00:00Z', ageDays: 16, stale: true },
+      ],
       stale: [],
       blocked: [],
-      counts: { open: 2, needsYou: 1, needsReview: 1, handoffs: 1, stale: 0, blocked: 0 },
+      counts: { open: 2, needsYou: 1, needsReview: 1, handoffs: 1, captures: 2, stale: 0, blocked: 0 },
       proposedWrites: [],
     };
     const out = formatCockpitBrief(b);
@@ -133,6 +137,11 @@ describe('formatCockpitBrief', () => {
     expect(out).toContain('HANDOFFS (from other terminals)');
     expect(out).toContain('zao-whitepapers: Papers terminal');
     expect(out).toContain('1 handoffs');
+    expect(out).toContain('IDEA INBOX (captures)');
+    expect(out).toContain('Flow energy meter app');
+    expect(out).toContain('STALE 16d'); // collector's-fallacy flag
+    expect(out).toContain('1 stale, ship or drop');
+    expect(out).toContain('2 captures');
     expect(out).not.toMatch(/[—\u{1F300}-\u{1FAFF}]/u); // no em dash, no emoji
   });
 });

--- a/bot/src/cockpit/adapters.ts
+++ b/bot/src/cockpit/adapters.ts
@@ -11,12 +11,16 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { classifyTask, type NextOwner } from '../zoe/task-classifier';
-import type { CockpitTask, Handoff, ReviewPR, WriteProposal } from './types';
+import type { Capture, CockpitTask, Handoff, ReviewPR, WriteProposal } from './types';
 
 const execFileAsync = promisify(execFile);
 
 /** A task with no update in this many days (and not recurring) is stale. Doc 983. */
 export const STALE_DAYS = 14;
+
+/** An idea capture older than this (with no ship) trips the collector's-fallacy
+ * flag - hoarding an idea without acting is procrastination (doc 1031). */
+export const CAPTURE_STALE_DAYS = 7;
 
 /** GitHub users/orgs whose open PRs land in Zaal's review lane. */
 const REVIEW_OWNERS = ['bettercallzaal', 'ZAODEVZ'];
@@ -170,6 +174,34 @@ export function toHandoff(t: CockpitTask): Handoff {
     title: t.title,
     note: t.notes,
     createdAt: t.created_at,
+  };
+}
+
+/** An idea capture (the "one door") carries legacy_source "inbox:<slug>". This
+ * is the second-brain resurface lane (doc 1031). */
+export function isCapture(t: CockpitTask): boolean {
+  return (t.legacy_source ?? '').startsWith('inbox:');
+}
+
+/** Split idea captures out of the regular task set so they show in their own lane. */
+export function partitionCaptures(tasks: CockpitTask[]): { captures: CockpitTask[]; rest: CockpitTask[] } {
+  const captures: CockpitTask[] = [];
+  const rest: CockpitTask[] = [];
+  for (const t of tasks) (isCapture(t) ? captures : rest).push(t);
+  return { captures, rest };
+}
+
+/** Shape a capture into the cockpit Capture view. `stale` trips the
+ * collector's-fallacy flag: captured but not shipped in CAPTURE_STALE_DAYS. */
+export function toCapture(t: CockpitTask, now: number): Capture {
+  const ageDays = daysSince(t.created_at, now);
+  return {
+    taskId: t.id,
+    slug: (t.legacy_source ?? '').replace(/^inbox:/, '') || 'unknown',
+    title: t.title,
+    createdAt: t.created_at,
+    ageDays: Number.isFinite(ageDays) ? Math.floor(ageDays) : 0,
+    stale: ageDays >= CAPTURE_STALE_DAYS,
   };
 }
 

--- a/bot/src/cockpit/brief.ts
+++ b/bot/src/cockpit/brief.ts
@@ -14,7 +14,9 @@ import {
   fetchCockpitTasks,
   fetchReviewPRs,
   partitionHandoffs,
+  partitionCaptures,
   toHandoff,
+  toCapture,
   topThree,
   needsYou,
   blocked,
@@ -30,8 +32,9 @@ export const COCKPIT_HOME = process.env.COCKPIT_HOME || join(homedir(), '.zao', 
 export async function buildCockpitBrief(mode: CockpitMode = 'brief', now = Date.now()): Promise<CockpitBrief> {
   // Tracker tasks + open PRs run in parallel; either failing degrades to [].
   const [allTasks, reviewPRs] = await Promise.all([fetchCockpitTasks(), fetchReviewPRs()]);
-  // Handoffs (legacy_source "handoff:*") get their own lane, not the task lanes.
-  const { handoffs: handoffTasks, rest: tasks } = partitionHandoffs(allTasks);
+  // Handoffs ("handoff:*") + idea captures ("inbox:*") each get their own lane.
+  const { handoffs: handoffTasks, rest: afterHandoffs } = partitionHandoffs(allTasks);
+  const { captures: captureTasks, rest: tasks } = partitionCaptures(afterHandoffs);
   const you = needsYou(tasks);
   const stale = findStale(tasks, now);
   const blk = blocked(tasks);
@@ -39,12 +42,17 @@ export async function buildCockpitBrief(mode: CockpitMode = 'brief', now = Date.
     .slice()
     .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
     .map(toHandoff);
+  const captures = captureTasks
+    .slice()
+    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+    .map((t) => toCapture(t, now));
   return {
     date: new Date(now).toISOString().slice(0, 10),
     top3: topThree(tasks),
     needsYou: you,
     needsReview: reviewPRs,
     handoffs,
+    captures,
     stale,
     blocked: blk,
     counts: {
@@ -52,6 +60,7 @@ export async function buildCockpitBrief(mode: CockpitMode = 'brief', now = Date.
       needsYou: you.length,
       needsReview: reviewPRs.length,
       handoffs: handoffs.length,
+      captures: captures.length,
       stale: stale.length,
       blocked: blk.length,
     },
@@ -70,9 +79,23 @@ export function formatCockpitBrief(b: CockpitBrief): string {
   const parts: string[] = [];
   parts.push(`Cockpit - ${b.date}`);
   parts.push(
-    `${b.counts.open} open | ${b.counts.needsYou} need you | ${b.counts.needsReview} PRs to review | ${b.counts.handoffs} handoffs | ${b.counts.stale} stale | ${b.counts.blocked} blocked`,
+    `${b.counts.open} open | ${b.counts.needsYou} need you | ${b.counts.needsReview} PRs to review | ${b.counts.handoffs} handoffs | ${b.counts.captures} captures | ${b.counts.stale} stale | ${b.counts.blocked} blocked`,
   );
   if (b.top3.length) parts.push('\nDO FIRST\n' + b.top3.map(line).join('\n'));
+  if (b.captures?.length) {
+    const staleCount = b.captures.filter((c) => c.stale).length;
+    const header = staleCount
+      ? `\nIDEA INBOX (captures) - ${staleCount} stale, ship or drop`
+      : '\nIDEA INBOX (captures)';
+    parts.push(
+      header +
+        '\n' +
+        b.captures
+          .slice(0, 10)
+          .map((c) => `- ${c.title}${c.stale ? ` (STALE ${c.ageDays}d)` : ''}`)
+          .join('\n'),
+    );
+  }
   if (b.handoffs.length)
     parts.push(
       '\nHANDOFFS (from other terminals)\n' +

--- a/bot/src/cockpit/cli.ts
+++ b/bot/src/cockpit/cli.ts
@@ -1,0 +1,18 @@
+/**
+ * cli.ts - the operator cockpit from a terminal.
+ *
+ * Prints the exact same brief ZOE's /cockpit command shows, so the cockpit is
+ * equally reachable from the desktop (via the ~/bin/zao-cockpit wrapper) and
+ * from Telegram. Read-only. Run: `npx tsx src/cockpit/cli.ts`.
+ */
+import { buildCockpitBrief, formatCockpitBrief } from './brief';
+
+async function main(): Promise<void> {
+  const brief = await buildCockpitBrief('brief');
+  console.log(formatCockpitBrief(brief));
+}
+
+main().catch((e: unknown) => {
+  console.error('cockpit cli failed:', e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});

--- a/bot/src/cockpit/types.ts
+++ b/bot/src/cockpit/types.ts
@@ -39,6 +39,17 @@ export interface Handoff {
   createdAt: string | null;
 }
 
+/** An idea capture (the "one door" second brain), surfaced in the cockpit. */
+export interface Capture {
+  taskId: string;
+  slug: string; // parsed from legacy_source "inbox:<slug>"
+  title: string;
+  createdAt: string | null;
+  ageDays: number;
+  /** collector's-fallacy flag: captured but not shipped in CAPTURE_STALE_DAYS. */
+  stale: boolean;
+}
+
 /** Cockpit run modes = the constraint flags (episode: "investigate-only" enforced by the harness, not the prompt). */
 export type CockpitMode =
   | 'brief' // read-only: assemble + emit the cockpit brief, no writes
@@ -79,12 +90,14 @@ export interface CockpitBrief {
   needsReview: ReviewPR[];
   /** Handoffs from other terminals - the durable home for cross-terminal work. */
   handoffs: Handoff[];
+  /** Idea captures (the "one door" second brain), newest first; stale ones flagged. */
+  captures: Capture[];
   /** Stale: undated P0/P1s, or no update in >= STALE_DAYS. */
   stale: CockpitTask[];
   /** Blocked (next_owner = 'blocked'). */
   blocked: CockpitTask[];
   /** Counts for the one-line summary. */
-  counts: { open: number; needsYou: number; needsReview: number; handoffs: number; stale: number; blocked: number };
+  counts: { open: number; needsYou: number; needsReview: number; handoffs: number; captures: number; stale: number; blocked: number };
   /** Gated write proposals (empty in 'brief' mode; populated in 'triage'). */
   proposedWrites: WriteProposal[];
 }


### PR DESCRIPTION
Second-brain resurface (doc 1031): captures lane (legacy_source inbox:*) with a 7-day collector-fallacy stale flag, + a terminal CLI so the cockpit is equally reachable from desktop (zao-cockpit wrapper) and ZOE (/cockpit). 17/17 cockpit tests, esbuild clean, CLI verified live against the tracker.