### PR TITLE
feat(zoe): one-question-at-a-time answer buttons (orchestrator loop)

### DIFF
--- a/bot/src/zoe/__tests__/questions.test.ts
+++ b/bot/src/zoe/__tests__/questions.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  encodeQuestion,
+  parseQuestionCallback,
+  questionKeyboard,
+  TYPE_SENTINEL,
+} from '../questions';
+
+describe('encode/parse round-trip', () => {
+  it('round-trips a simple value', () => {
+    const p = parseQuestionCallback(encodeQuestion('oss4ai', 'speak'));
+    expect(p).toEqual({ qid: 'oss4ai', value: 'speak', isType: false });
+  });
+
+  it('round-trips a value containing a colon', () => {
+    const p = parseQuestionCallback(encodeQuestion('poidh', 'real ad: not a clip dump'));
+    expect(p?.value).toBe('real ad: not a clip dump');
+    expect(p?.isType).toBe(false);
+  });
+
+  it('flags the Type sentinel', () => {
+    const p = parseQuestionCallback(encodeQuestion('poidh', TYPE_SENTINEL));
+    expect(p?.isType).toBe(true);
+  });
+
+  it('returns null for non-question callbacks', () => {
+    expect(parseQuestionCallback('post:abc123')).toBeNull();
+    expect(parseQuestionCallback('skip:xyz')).toBeNull();
+    expect(parseQuestionCallback('q:')).toBeNull();
+    expect(parseQuestionCallback('q:onlyqid')).toBeNull();
+  });
+});
+
+describe('questionKeyboard', () => {
+  it('builds one row per option plus a Type row', () => {
+    const kb = questionKeyboard('oss4ai', ['speak', 'recruit']);
+    expect(kb.inline_keyboard).toHaveLength(3);
+    expect(kb.inline_keyboard[0][0].text).toBe('speak');
+    expect(kb.inline_keyboard[2][0].text).toBe('Type my own');
+    // every button parses back
+    for (const row of kb.inline_keyboard) {
+      expect(parseQuestionCallback(row[0].callback_data)?.qid).toBe('oss4ai');
+    }
+  });
+
+  it('omits the Type row when includeType is false', () => {
+    const kb = questionKeyboard('yn', ['yes', 'no'], false);
+    expect(kb.inline_keyboard).toHaveLength(2);
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -95,6 +95,7 @@ import { routeTopic, topicNameForThread } from './topic-router';
 import { appendApproved } from './outbox';
 import { dispatchHermesRun } from '../hermes/runner';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
+import { parseQuestionCallback } from './questions';
 import { applyThreadOps, summarizeThreadOps } from './thread-ops';
 import { loadThreads, deleteThread, renderOpenThreadsBlock } from './threads';
 import { ackPush } from './proactive';
@@ -429,6 +430,34 @@ bot.on('callback_query:data', async (ctx) => {
     await ctx.answerCallbackQuery();
     return;
   }
+  // Orchestrator question buttons ("q:<qid>:<b64>") - the one-question-at-a-time
+  // loop. A tap (or the Type button) logs the answer to recent/ so the open
+  // Claude Code session reads it via the bridge and posts the next question.
+  const q = parseQuestionCallback(ctx.callbackQuery.data);
+  if (q) {
+    const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    if (q.isType) {
+      await ctx.answerCallbackQuery({ text: 'Reply with your answer.' });
+      await ctx
+        .reply(`Reply to this thread with your answer for "${q.qid}".`, {
+          ...(ctx.callbackQuery.message?.message_thread_id
+            ? { message_thread_id: ctx.callbackQuery.message.message_thread_id }
+            : {}),
+        })
+        .catch(() => {});
+    } else {
+      await ctx.answerCallbackQuery({ text: 'Got it.' });
+      await ctx
+        .editMessageText(`Answered (${q.qid}): ${q.value}`, { reply_markup: { inline_keyboard: [] } })
+        .catch(() => {});
+      await pushRecent(
+        { from: 'zaal', text: `[answer:${q.qid}] ${q.value}`, sender: 'zaalbotz-btn' },
+        String(gid),
+      ).catch((e) => console.error('[zoe/index] q-answer log failed:', (e as Error)?.message));
+    }
+    return;
+  }
+
   const parsed = parseDraftCallback(ctx.callbackQuery.data);
   if (!parsed) {
     await ctx.answerCallbackQuery();

--- a/bot/src/zoe/questions.ts
+++ b/bot/src/zoe/questions.ts
@@ -1,0 +1,62 @@
+/**
+ * questions.ts - one-question-at-a-time buttons for the orchestrator loop.
+ *
+ * An open Claude Code session (the conductor) posts a single question to the
+ * ZAAL BOTZ Claude Code topic with tappable answer buttons + a "Type my own"
+ * button (freetext) + optional multi-choice. Zaal taps or types; the answer is
+ * logged to recent/ so the session reads it via the inbox bridge and posts the
+ * next question. Pure helpers so they unit-test without grammy.
+ *
+ * callback_data is "q:<qid>:<base64url(value)>" - base64 so an option's text
+ * can't collide with the ':' delimiter. Telegram caps callback_data at 64 bytes,
+ * so keep qids short and option labels concise (use "Type my own" for anything long).
+ */
+
+/** A tapped answer: the question id + the decoded value ('__type__' = freetext). */
+export interface ParsedQuestion {
+  qid: string;
+  value: string;
+  isType: boolean;
+}
+
+export const TYPE_SENTINEL = '__type__';
+
+function b64urlEncode(s: string): string {
+  return Buffer.from(s, 'utf8').toString('base64url');
+}
+
+/** Build the callback_data for one answer. */
+export function encodeQuestion(qid: string, value: string): string {
+  return `q:${qid}:${b64urlEncode(value)}`;
+}
+
+/** Inline keyboard: one button per option (one per row for tap-safety on mobile),
+ *  then a "Type my own" freetext button unless suppressed. */
+export function questionKeyboard(
+  qid: string,
+  options: string[],
+  includeType = true,
+): { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> } {
+  const rows = options.map((o) => [{ text: o, callback_data: encodeQuestion(qid, o) }]);
+  if (includeType) {
+    rows.push([{ text: 'Type my own', callback_data: encodeQuestion(qid, TYPE_SENTINEL) }]);
+  }
+  return { inline_keyboard: rows };
+}
+
+/** Parse a "q:<qid>:<b64>" callback, or null if it is not a question callback. */
+export function parseQuestionCallback(data: string): ParsedQuestion | null {
+  if (!data.startsWith('q:')) return null;
+  const rest = data.slice(2);
+  const sep = rest.indexOf(':');
+  if (sep < 0) return null;
+  const qid = rest.slice(0, sep);
+  if (!qid) return null;
+  let value: string;
+  try {
+    value = Buffer.from(rest.slice(sep + 1), 'base64url').toString('utf8');
+  } catch {
+    return null;
+  }
+  return { qid, value, isType: value === TYPE_SENTINEL };
+}


### PR DESCRIPTION
Inline answer buttons + a Type-my-own freetext button for the orchestrator loop. A tap logs the answer to recent/ so the open Claude Code session reads it via the bridge and posts the next question. Turns the wall-of-text board into one question at a time. 6/6 tests, esbuild clean.