### PR TITLE
feat(zao-ops): donate phone-first operator toolkit to the team

### DIFF
--- a/scripts/zao-ops/README.md
+++ b/scripts/zao-ops/README.md
@@ -1,0 +1,64 @@
+# zao-ops - phone-first operator toolkit for the ZAO team
+
+Three small CLIs that turn ZOE (your Telegram bot) into a control surface: you
+conduct from your phone, terminals do the work, and every decision comes back to
+you as a button in one place.
+
+Donated to the ZAO team 2026-07-11 (built in the ZAOOS lab). Generic + config-
+driven - point them at your own bot + group and they work.
+
+## The tools
+
+| Tool | What it does |
+|------|--------------|
+| `zao-ask` | Fire a button-question into your Telegram General topic. Any terminal/worker calls it when it needs a decision; the answer routes back by question id. |
+| `zao-cockpit` | Print your operator brief in the terminal (do-first, needs-you, PRs to review, idea inbox, stale items) - reads the shared cowork tracker. |
+| `zao-sweep` | Post that same brief into General so your morning is one place: read the digest, click the waiting buttons. Cron it for an auto-morning sweep. |
+
+## The loop they create
+
+```
+capture -> a worker grinds -> it hits a decision -> zao-ask fires a button into General
+        -> you sweep the buttons -> the answer routes back -> the worker ships
+```
+
+Work fans **out** (many terminals in parallel). Your input fans **in** (one button queue). You stay the conductor.
+
+## Setup
+
+1. A Telegram bot (BotFather) that is an admin of a forum-enabled group (Topics on).
+2. Config file `~/.zao/private/tg.env` (chmod 600, never committed):
+
+   ```
+   ZOE_BOT_TOKEN=123456:your-bot-token
+   ZAAL_BOTZ_GROUP_ID=-1001234567890
+   ```
+
+3. `ZAO_VPS_HOST` env var pointing at the host that runs the cockpit brief
+   (defaults to the ZAO ops box). `zao-cockpit`/`zao-sweep` ssh there to build
+   the brief where the tracker creds live.
+4. Put the scripts on your PATH: `ln -s "$PWD"/scripts/zao-ops/zao-* ~/bin/`.
+
+## Usage
+
+```bash
+# ask a question (buttons + a "Type my own" freetext option)
+zao-ask publish "Publish the newsletter now?" "Publish" "Hold"
+
+# read the cockpit in your terminal
+zao-cockpit
+
+# push the cockpit digest into General
+zao-sweep
+```
+
+Question ids should be namespaced per terminal/task, e.g. `zaostock-publish`, so
+each terminal reads back its own answers. Answers are logged by the bot to its
+`recent/` store; an open session reads them via the inbox bridge.
+
+## Notes
+
+- No secrets in these scripts - the bot token lives only in `tg.env` (gitignored).
+- Telegram caps `callback_data` at 64 bytes, so `zao-ask` sends short slug codes
+  on the buttons (the label is the full text).
+- Design + rationale: `research/dev-workflows/1031-second-brain-system-design/`.

--- a/scripts/zao-ops/zao-ask
+++ b/scripts/zao-ops/zao-ask
@@ -1,0 +1,41 @@
+#!/bin/bash
+# zao-ask <qid> "<question>" [opt1] [opt2] ...
+# Post a button-question to the ZAAL BOTZ General topic so Zaal can batch-click
+# answers from one place. ANY terminal/session calls this; the answer is logged
+# by ZOE to recent/<groupid>.json (the inbox bridge), and the asking terminal
+# reads it back by its <qid> namespace (convention: "<terminal>-<slug>", e.g.
+# "zaostock-publish"). Buttons wait until tapped; a "Type my own" button is
+# always added for freetext. No options = a freetext-only ask.
+#
+# Usage:
+#   zao-ask oss4ai "Speak yourself or recruit a speaker?" "Speak" "Recruit"
+#   zao-ask pub192 "Publish newsletter Day 192 now?" "Publish now" "Hold"
+set -e
+QID="$1"; Q="$2"; shift 2 2>/dev/null || true
+[ -z "$QID" ] || [ -z "$Q" ] && { echo 'usage: zao-ask <qid> "<question>" [opt1] [opt2] ...'; exit 1; }
+TGENV="$HOME/.zao/private/tg.env"
+TOKEN=$(grep -m1 '^ZOE_BOT_TOKEN=' "$TGENV" | cut -d= -f2- | tr -d '"')
+GID=$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')
+[ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing ZOE_BOT_TOKEN or ZAAL_BOTZ_GROUP_ID in $TGENV"; exit 1; }
+python3 - "$TOKEN" "$GID" "$QID" "$Q" "$@" <<'PY'
+import sys, json, base64, re, urllib.request, urllib.parse
+token, gid, qid, q = sys.argv[1:5]
+opts = sys.argv[5:]
+def enc(qid, v): return f"q:{qid}:" + base64.urlsafe_b64encode(v.encode()).decode().rstrip("=")
+def slug(o): return (re.sub(r'[^a-z0-9]', '', o.lower())[:14] or "opt")
+rows = [[{"text": o, "callback_data": enc(qid, slug(o))}] for o in opts]
+rows.append([{"text": "Type my own", "callback_data": enc(qid, "__type__")}])
+# guard the 64-byte callback_data cap
+for r in rows:
+    if len(r[0]["callback_data"].encode()) > 64:
+        print("option too long for a button code:", r[0]["text"]); sys.exit(1)
+body = {"chat_id": gid, "text": f"[{qid}] {q}", "reply_markup": json.dumps({"inline_keyboard": rows})}
+# omit message_thread_id -> lands in the General topic
+data = urllib.parse.urlencode(body).encode()
+try:
+    r = json.load(urllib.request.urlopen(urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/sendMessage", data=data), timeout=15))
+    print("asked:", qid) if r.get("ok") else print("FAIL:", r.get("description"))
+except Exception as e:
+    print("ERR:", e); sys.exit(1)
+PY

--- a/scripts/zao-ops/zao-cockpit
+++ b/scripts/zao-ops/zao-cockpit
@@ -1,0 +1,6 @@
+#!/bin/bash
+# zao-cockpit - the operator cockpit from your desktop.
+# Same brief ZOE's /cockpit shows, run on the VPS (where tracker creds + gh live).
+# Usage: zao-cockpit
+ssh -o ConnectTimeout=25 ${ZAO_VPS_HOST:-zaal@31.97.148.88} \
+  'cd ~/zao-os/bot && set -a && . ./.env 2>/dev/null && set +a && PATH="$HOME/.local/bin:$PATH" npx tsx src/cockpit/cli.ts'

--- a/scripts/zao-ops/zao-sweep
+++ b/scripts/zao-ops/zao-sweep
@@ -1,0 +1,27 @@
+#!/bin/bash
+# zao-sweep - post the operator cockpit brief into the ZAAL BOTZ General topic.
+# Your morning (or anytime) = one command -> open General -> read the digest ->
+# click the waiting button-questions. Pairs with zao-ask (questions) + the
+# cockpit (state). Team-donatable: generic, reads the shared tracker.
+# Cron it on the VPS for an auto-morning-sweep (cheap: no LLM, just reads+posts).
+set -e
+TGENV="$HOME/.zao/private/tg.env"
+TOKEN=$(grep -m1 '^ZOE_BOT_TOKEN=' "$TGENV" | cut -d= -f2- | tr -d '"')
+GID=$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')
+[ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing token/gid in $TGENV"; exit 1; }
+# Build the brief on the VPS (where tracker creds + gh live), reuse the cockpit CLI.
+BRIEF=$(ssh -o ConnectTimeout=25 ${ZAO_VPS_HOST:-zaal@31.97.148.88} \
+  'cd ~/zao-os/bot && set -a && . ./.env 2>/dev/null && set +a && PATH="$HOME/.local/bin:$PATH" npx tsx src/cockpit/cli.ts' 2>/dev/null)
+[ -z "$BRIEF" ] && { echo "no brief returned from cockpit"; exit 1; }
+python3 - "$TOKEN" "$GID" "$BRIEF" <<'PY'
+import sys, urllib.request, urllib.parse
+token, gid, brief = sys.argv[1:4]
+text = "MORNING SWEEP\n\n" + brief + "\n\nClick the waiting button-questions below to clear your input queue."
+data = urllib.parse.urlencode({"chat_id": gid, "text": text[:4000]}).encode()
+try:
+    urllib.request.urlopen(urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/sendMessage", data=data), timeout=15)
+    print("swept -> General")
+except Exception as e:
+    print("ERR:", e); sys.exit(1)
+PY


### PR DESCRIPTION
Packages zao-ask / zao-cockpit / zao-sweep into scripts/zao-ops/ with a README, generalized (config-driven VPS host + tg.env) so any ZAO team member can adopt them. The fan-out-work / fan-in-input control surface, donated. Design: doc 1031.