### PR TITLE
fix(zoe): fold in Fable audit fixes (type-answer capture, guards, tests)

### DIFF
--- a/bot/src/cockpit/__tests__/cockpit.test.ts
+++ b/bot/src/cockpit/__tests__/cockpit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { topThree, needsYou, blocked, findStale, buildProposals, priorityRank, daysSince, STALE_DAYS, filterReviewPRs, isHandoff, partitionHandoffs, toHandoff } from '../adapters';
+import { topThree, needsYou, blocked, findStale, buildProposals, priorityRank, daysSince, STALE_DAYS, filterReviewPRs, isHandoff, partitionHandoffs, toHandoff, isCapture, partitionCaptures, toCapture, CAPTURE_STALE_DAYS } from '../adapters';
 import { formatCockpitBrief } from '../brief';
 import type { CockpitTask, CockpitBrief } from '../types';
 
@@ -164,6 +164,34 @@ describe('handoff helpers', () => {
   it('toHandoff parses slug + carries note', () => {
     const h = toHandoff(task({ id: 'b', title: 'Papers', legacy_source: 'handoff:zao-whitepapers', notes: 'open items' }));
     expect(h).toMatchObject({ taskId: 'b', slug: 'zao-whitepapers', title: 'Papers', note: 'open items' });
+  });
+});
+
+describe('capture helpers', () => {
+  const now = Date.parse('2026-07-11T00:00:00Z');
+  it('isCapture detects the inbox: marker', () => {
+    expect(isCapture(task({ id: '1', title: 'x', legacy_source: 'inbox:flow-app' }))).toBe(true);
+    expect(isCapture(task({ id: '2', title: 'y', legacy_source: 'handoff:foo' }))).toBe(false);
+    expect(isCapture(task({ id: '3', title: 'z' }))).toBe(false);
+  });
+  it('partitionCaptures splits captures from regular tasks', () => {
+    const tasks = [
+      task({ id: 'a', title: 'real task' }),
+      task({ id: 'b', title: 'an idea', legacy_source: 'inbox:idea' }),
+    ];
+    const { captures, rest } = partitionCaptures(tasks);
+    expect(captures.map((t) => t.id)).toEqual(['b']);
+    expect(rest.map((t) => t.id)).toEqual(['a']);
+  });
+  it('toCapture flags the collector-fallacy stale threshold', () => {
+    const fresh = toCapture(task({ id: 'c', title: 'new', legacy_source: 'inbox:new', created_at: '2026-07-10T00:00:00Z' }), now);
+    expect(fresh).toMatchObject({ slug: 'new', ageDays: 1, stale: false });
+    const old = toCapture(
+      task({ id: 'd', title: 'old', legacy_source: 'inbox:old', created_at: '2026-06-25T00:00:00Z' }),
+      now,
+    );
+    expect(old.stale).toBe(true);
+    expect(old.ageDays).toBeGreaterThanOrEqual(CAPTURE_STALE_DAYS);
   });
 });
 

--- a/bot/src/zoe/__tests__/outbox.test.ts
+++ b/bot/src/zoe/__tests__/outbox.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { outboxChannelFor, outboxLine } from '../outbox';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { appendApproved, outboxChannelFor, outboxLine, outboxPathFor } from '../outbox';
 
 describe('outboxChannelFor', () => {
   it('maps -cast kinds to the cast channel', () => {
@@ -29,5 +32,41 @@ describe('outboxLine', () => {
       approvedAt: new Date(1_700_000_000_000).toISOString(),
       sent: false,
     });
+  });
+});
+
+describe('appendApproved (file I/O)', () => {
+  const orig = process.env.ZOE_HOME;
+  let dir: string;
+  beforeEach(async () => {
+    dir = join(tmpdir(), `outbox-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env.ZOE_HOME = dir;
+  });
+  afterEach(async () => {
+    if (orig === undefined) delete process.env.ZOE_HOME;
+    else process.env.ZOE_HOME = orig;
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('appends a cast draft to the cast outbox file', async () => {
+    const channel = await appendApproved('zol-cast', 'gm from ZOL');
+    expect(channel).toBe('cast');
+    const body = await fs.readFile(outboxPathFor('cast'), 'utf8');
+    const entry = JSON.parse(body.trim());
+    expect(entry).toMatchObject({ kind: 'zol-cast', text: 'gm from ZOL', sent: false });
+  });
+
+  it('appends multiple entries as separate JSONL lines', async () => {
+    await appendApproved('farcaster-cast', 'one');
+    await appendApproved('wavewarz-cast', 'two');
+    const lines = (await fs.readFile(outboxPathFor('cast'), 'utf8')).trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]).text).toBe('two');
+  });
+
+  it('returns null and writes nothing for a non-outbox kind', async () => {
+    const channel = await appendApproved('proactive-post', 'hi');
+    expect(channel).toBeNull();
+    await expect(fs.readFile(outboxPathFor('cast'), 'utf8')).rejects.toBeTruthy();
   });
 });

--- a/bot/src/zoe/__tests__/questions.test.ts
+++ b/bot/src/zoe/__tests__/questions.test.ts
@@ -23,6 +23,10 @@ describe('encode/parse round-trip', () => {
     expect(p?.isType).toBe(true);
   });
 
+  it('throws when callback_data would exceed the 64-byte cap', () => {
+    expect(() => encodeQuestion('longqid', 'x'.repeat(60))).toThrow(/too long/);
+  });
+
   it('returns null for non-question callbacks', () => {
     expect(parseQuestionCallback('post:abc123')).toBeNull();
     expect(parseQuestionCallback('skip:xyz')).toBeNull();

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -425,6 +425,12 @@ bot.command('zoldraft', async (ctx) => {
 // marks the draft posted (real per-kind routing is a follow-up), Skip drops it,
 // Edit prompts for a revision. Always answerCallbackQuery so the button spinner
 // clears.
+// When Zaal taps a question's "Type my own" button, we remember the qid keyed by
+// chat id; his NEXT free-text message in that chat is then logged as the answer
+// ("[answer:<qid>]"), so a typed answer reaches the orchestrator the same way a
+// tapped one does (Fable audit fix - without this, typed answers were untagged).
+const pendingTypeAnswers = new Map<number, string>();
+
 bot.on('callback_query:data', async (ctx) => {
   if (!isFromZaal(ctx)) {
     await ctx.answerCallbackQuery();
@@ -437,6 +443,8 @@ bot.on('callback_query:data', async (ctx) => {
   if (q) {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
     if (q.isType) {
+      const cbChat = ctx.callbackQuery.message?.chat?.id;
+      if (cbChat) pendingTypeAnswers.set(cbChat, q.qid);
       await ctx.answerCallbackQuery({ text: 'Reply with your answer.' });
       await ctx
         .reply(`Reply to this thread with your answer for "${q.qid}".`, {
@@ -479,7 +487,10 @@ bot.on('callback_query:data', async (ctx) => {
     // is Pi-only; the newsletter builder is a separate Supabase project). Rather
     // than fake "Posted", append to the durable outbox and say so honestly - a
     // future Pi/builder drainer sends from there. Other kinds keep the old path.
-    const channel = await appendApproved(draft.kind, draft.text).catch(() => null);
+    const channel = await appendApproved(draft.kind, draft.text).catch((e) => {
+      console.error('[zoe/index] outbox append failed:', (e as Error)?.message);
+      return null;
+    });
     if (channel === 'cast') {
       await ctx.answerCallbackQuery({ text: 'Approved - queued to cast.' });
       await ctx
@@ -832,6 +843,22 @@ bot.on('message:text', async (ctx) => {
     // Per-topic behavior (topic = intent, Zaal 2026-07-11): dropping a plain
     // message into a topic auto-acts per that topic. Internal actions fire now;
     // outbound casts are drafted with an Approve button (money/public gate).
+    // If Zaal just tapped a question's "Type my own" button, this message is his
+    // typed answer - log it as "[answer:<qid>]" (matching the tapped-button path)
+    // and stop, so the orchestrator reads it as the answer, not a topic action.
+    const awaitingQid = pendingTypeAnswers.get(chatId);
+    if (awaitingQid) {
+      pendingTypeAnswers.delete(chatId);
+      await pushRecent(
+        { from: 'zaal', text: `[answer:${awaitingQid}] ${text}`, sender: 'zaalbotz-type' },
+        String(zaalBotzGroupId),
+      ).catch((e) => console.error('[zoe/index] type-answer log failed:', (e as Error)?.message));
+      await ctx
+        .reply(`Got your answer for "${awaitingQid}".`, threadId ? { message_thread_id: threadId } : {})
+        .catch(() => {});
+      return;
+    }
+
     const topicName = await topicNameForThread(threadId).catch(() => undefined);
     const action = routeTopic(topicName);
     const threadOpt = threadId ? { message_thread_id: threadId } : {};

--- a/bot/src/zoe/outbox.ts
+++ b/bot/src/zoe/outbox.ts
@@ -18,8 +18,10 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
-const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
-const OUTBOX_DIR = join(ZOE_HOME, 'outbox');
+/** Outbox dir, resolved at call-time so ZOE_HOME can be overridden (e.g. tests). */
+function outboxDir(): string {
+  return join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'outbox');
+}
 
 export interface OutboxEntry {
   kind: string;
@@ -52,7 +54,7 @@ export function outboxLine(kind: string, text: string, now: number): string {
 
 /** The file an entry of this channel lands in. */
 export function outboxPathFor(channel: OutboxChannel): string {
-  return join(OUTBOX_DIR, `${channel}.jsonl`);
+  return join(outboxDir(), `${channel}.jsonl`);
 }
 
 /**
@@ -67,7 +69,7 @@ export async function appendApproved(
 ): Promise<OutboxChannel | null> {
   const channel = outboxChannelFor(kind);
   if (!channel) return null;
-  await fs.mkdir(OUTBOX_DIR, { recursive: true });
+  await fs.mkdir(outboxDir(), { recursive: true });
   await fs.appendFile(outboxPathFor(channel), outboxLine(kind, text, now) + '\n');
   return channel;
 }

--- a/bot/src/zoe/questions.ts
+++ b/bot/src/zoe/questions.ts
@@ -25,9 +25,14 @@ function b64urlEncode(s: string): string {
   return Buffer.from(s, 'utf8').toString('base64url');
 }
 
-/** Build the callback_data for one answer. */
+/** Build the callback_data for one answer. Throws if it would exceed Telegram's
+ *  64-byte callback_data cap (keep qids short + values as slug codes). */
 export function encodeQuestion(qid: string, value: string): string {
-  return `q:${qid}:${b64urlEncode(value)}`;
+  const data = `q:${qid}:${b64urlEncode(value)}`;
+  if (Buffer.byteLength(data, 'utf8') > 64) {
+    throw new Error(`callback_data too long (${Buffer.byteLength(data)}B > 64): shorten qid/value for "${value}"`);
+  }
+  return data;
 }
 
 /** Inline keyboard: one button per option (one per row for tap-safety on mobile),

--- a/scripts/zao-ops/zao-sweep
+++ b/scripts/zao-ops/zao-sweep
@@ -10,9 +10,11 @@ TOKEN=$(grep -m1 '^ZOE_BOT_TOKEN=' "$TGENV" | cut -d= -f2- | tr -d '"')
 GID=$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')
 [ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing token/gid in $TGENV"; exit 1; }
 # Build the brief on the VPS (where tracker creds + gh live), reuse the cockpit CLI.
+ERRF=$(mktemp)
 BRIEF=$(ssh -o ConnectTimeout=25 ${ZAO_VPS_HOST:-zaal@31.97.148.88} \
-  'cd ~/zao-os/bot && set -a && . ./.env 2>/dev/null && set +a && PATH="$HOME/.local/bin:$PATH" npx tsx src/cockpit/cli.ts' 2>/dev/null)
-[ -z "$BRIEF" ] && { echo "no brief returned from cockpit"; exit 1; }
+  'cd ~/zao-os/bot && set -a && . ./.env 2>/dev/null && set +a && PATH="$HOME/.local/bin:$PATH" npx tsx src/cockpit/cli.ts' 2>"$ERRF")
+if [ -z "$BRIEF" ]; then echo "no brief returned from cockpit. stderr:"; cat "$ERRF"; rm -f "$ERRF"; exit 1; fi
+rm -f "$ERRF"
 python3 - "$TOKEN" "$GID" "$BRIEF" <<'PY'
 import sys, urllib.request, urllib.parse
 token, gid, brief = sys.argv[1:4]


### PR DESCRIPTION
Fable code-audit fixes: HIGH - typed 'Type my own' answers now log as [answer:qid] so the orchestrator reads them (was untagged/broken); encodeQuestion 64B guard; outbox failure logging + call-time ZOE_HOME; appendApproved + capture-helper tests; zao-sweep surfaces stderr. 30/30 affected tests, esbuild clean.