### PR TITLE
feat(zoe): fold ZAOstock promo calendar (doc 1033) into the event drafter

### DIFF
--- a/bot/src/zoe/posts/README.md
+++ b/bot/src/zoe/posts/README.md
@@ -17,8 +17,19 @@ ZOE drafts 4 categories of social posts and DMs Zaal random suggestions througho
 |---|---|---|
 | `build` | Last 24h commits + open PRs (`gh pr list`) | Vercel deploy status, test runs |
 | `ecosystem` | Last 7d commits to ZAOOS as proxy for ZAO momentum | Farcaster /thezao channel, ZABAL Base contract activity, member roster diffs |
-| `event` | `~/.zao/zoe/events/{today,tomorrow}.txt` (manually seeded) | Google Calendar MCP via Claude CLI subprocess |
+| `event` | `~/.zao/zoe/events/{today,tomorrow}.txt` (manually seeded) + `zaostock-promo-calendar.ts` (see below) | Google Calendar MCP via Claude CLI subprocess |
 | `personal` | `~/.zao/zoe/voice-memos/YYYY-MM-DD.md` (one-liner captures via `/voicememo`) | Lunch stream transcripts via `zao-transcribe`, persona + recent Telegram messages |
+
+### ZAOstock promo calendar (folded into `event`, not a separate category)
+
+`zaostock-promo-calendar.ts` is a pure, hardcoded lookup of research doc 1033's 12-week
+Mon/Wed/Fri photo + artist-track calendar (Jul 13 - Oct 3, 2026). `gatherEventSignals()`
+appends today's line to `todaysEvents` automatically when today is a scheduled slot -
+silent every other day, and after Oct 3 (the festival itself hands off to doc 1030's
+live-event media plan instead). This folds into the same event-category drafter by
+design - doc 1033 explicitly calls for one content slate, not a competing parallel
+campaign. To retire it after the 2026 run, remove the `zaostock-promo-calendar` import
++ call in `sources.ts`.
 
 ## Cadence
 

--- a/bot/src/zoe/posts/__tests__/zaostock-promo-calendar.test.ts
+++ b/bot/src/zoe/posts/__tests__/zaostock-promo-calendar.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTodaysZaostockPromoLine,
+  ZAOSTOCK_PROMO_CALENDAR_START,
+  ZAOSTOCK_PROMO_CALENDAR_END,
+  ZAOSTOCK_PROMO_WEEKS,
+} from '../zaostock-promo-calendar';
+
+describe('getTodaysZaostockPromoLine', () => {
+  it('returns null before the calendar starts', () => {
+    expect(getTodaysZaostockPromoLine('2026-07-12')).toBeNull(); // Sunday, day before start
+  });
+
+  it('returns null after the calendar ends', () => {
+    expect(getTodaysZaostockPromoLine('2026-10-04')).toBeNull();
+  });
+
+  it('returns null on Oct 3 itself (festival day, hands off to doc 1030)', () => {
+    expect(getTodaysZaostockPromoLine(ZAOSTOCK_PROMO_CALENDAR_END)).toBeNull();
+  });
+
+  it('returns null on non-Mon/Wed/Fri days inside the window', () => {
+    expect(getTodaysZaostockPromoLine('2026-07-14')).toBeNull(); // Tuesday
+    expect(getTodaysZaostockPromoLine('2026-07-16')).toBeNull(); // Thursday
+    expect(getTodaysZaostockPromoLine('2026-07-18')).toBeNull(); // Saturday
+    expect(getTodaysZaostockPromoLine('2026-07-19')).toBeNull(); // Sunday
+  });
+
+  it('returns the week-1 place theme on the opening Monday', () => {
+    const line = getTodaysZaostockPromoLine(ZAOSTOCK_PROMO_CALENDAR_START);
+    expect(line).toContain('PLACE PHOTO');
+    expect(line).toContain('Downtown Ellsworth intro');
+  });
+
+  it('returns the week-1 place theme on the opening Friday too', () => {
+    const line = getTodaysZaostockPromoLine('2026-07-17');
+    expect(line).toContain('PLACE PHOTO');
+    expect(line).toContain('Downtown Ellsworth intro');
+  });
+
+  it('returns the artist/event track on Wednesday', () => {
+    const line = getTodaysZaostockPromoLine('2026-07-15');
+    expect(line).toContain('ARTIST/EVENT TRACK');
+    expect(line).toContain('ZAOstock explainer post');
+  });
+
+  it('advances to week 3 (Fellenz) on its Wednesday', () => {
+    const line = getTodaysZaostockPromoLine('2026-07-29');
+    expect(line).toContain('Fellenz');
+  });
+
+  it('lands on the final week (countdown) for the last scheduled Friday before Oct 3', () => {
+    const line = getTodaysZaostockPromoLine('2026-10-02'); // Friday of week 12
+    expect(line).toContain('Countdown week');
+  });
+
+  it('covers all 12 weeks from doc 1033', () => {
+    expect(ZAOSTOCK_PROMO_WEEKS).toHaveLength(12);
+  });
+});

--- a/bot/src/zoe/posts/sources.ts
+++ b/bot/src/zoe/posts/sources.ts
@@ -6,6 +6,7 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { ZOE_PATHS } from '../memory';
 import type { PostSourceSnapshot } from './types';
+import { getTodaysZaostockPromoLine } from './zaostock-promo-calendar';
 
 const VOICE_MEMOS_DIR = join(ZOE_PATHS.home, 'voice-memos');
 
@@ -52,7 +53,7 @@ export async function gatherEcosystemSignals(repoDir: string): Promise<PostSourc
   return { repoActivity };
 }
 
-export async function gatherEventSignals(): Promise<PostSourceSnapshot['event']> {
+export async function gatherEventSignals(now: number = Date.now()): Promise<PostSourceSnapshot['event']> {
   // v1 stub: drop a file at ~/.zao/zoe/events/today.txt + tomorrow.txt with one event per
   // line. Cron or manual seeding writes it. v2: wire Google Calendar MCP via Claude CLI
   // subprocess (Hermes pattern) once the MCP is authenticated on VPS.
@@ -71,6 +72,15 @@ export async function gatherEventSignals(): Promise<PostSourceSnapshot['event']>
   } catch {
     tomorrowsEvents = [];
   }
+
+  // Doc 1033's 12-week ZAOstock promo calendar folds into this SAME event
+  // category by design (doc 1033: "run inside that same 12-week frame rather
+  // than compete with it"), not a separate category. Mon/Wed/Fri only, Jul 13
+  // - Oct 3, 2026; silent (adds nothing) every other day.
+  const todayIso = new Date(now).toISOString().slice(0, 10);
+  const promoLine = getTodaysZaostockPromoLine(todayIso);
+  if (promoLine) todaysEvents = [...todaysEvents, promoLine];
+
   return { todaysEvents, tomorrowsEvents };
 }
 

--- a/bot/src/zoe/posts/zaostock-promo-calendar.ts
+++ b/bot/src/zoe/posts/zaostock-promo-calendar.ts
@@ -1,0 +1,126 @@
+// ZAOstock photo + promo calendar (research doc 1033) - pure date lookup.
+//
+// The 12-week Mon/Wed/Fri cadence doc 1033 designed to fold into the SAME
+// content slate the event category already drives, not run as a competing
+// parallel campaign (doc 1033 Key Decisions, "Run two content tracks in
+// parallel, not sequentially"). Monday + Friday carry the place-photo theme;
+// Wednesday carries the artist/event track. Silent (returns null) on every
+// other day, and outside the Jul 13 - Oct 3, 2026 window - Oct 3 itself is
+// the festival day and hands off to doc 1030's live-event media plan instead.
+
+interface CalendarWeek {
+  /** Monday of this week, YYYY-MM-DD. */
+  start: string;
+  placeTheme: string;
+  artistTrack: string;
+}
+
+// Verbatim from doc 1033's "The Calendar" table.
+const WEEKS: CalendarWeek[] = [
+  {
+    start: '2026-07-13',
+    placeTheme:
+      'Downtown Ellsworth intro - Historic Main Street, Riverwalk. Establish "this is the town" before the park.',
+    artistTrack: 'ZAOstock explainer post.',
+  },
+  {
+    start: '2026-07-20',
+    placeTheme: 'Downtown continued - Harbor Park, working waterfront.',
+    artistTrack: 'Highlights from past ZAO events (PALOOZA/CHELLA).',
+  },
+  {
+    start: '2026-07-27',
+    placeTheme: 'Acadia opens: Sand Beach, Otter Cliffs + Boulder Beach.',
+    artistTrack: 'First confirmed-artist post - Fellenz.',
+  },
+  {
+    start: '2026-08-03',
+    placeTheme: 'Jordan Pond + the Bubbles, Park Loop Road.',
+    artistTrack: 'Second confirmed-artist post - Dcoop.',
+  },
+  {
+    start: '2026-08-10',
+    placeTheme: 'Cadillac Mountain, Thunder Hole (tide-timed).',
+    artistTrack: 'Artist video #1, if that route is confirmed.',
+  },
+  {
+    start: '2026-08-17',
+    placeTheme: 'Bass Harbor Head Light, Schoodic Point.',
+    artistTrack: "Sponsor/partner spotlight (ties to doc 1031's HoE relationship track).",
+  },
+  {
+    start: '2026-08-24',
+    placeTheme: 'Schoodic Head, Eagle Lake.',
+    artistTrack: 'Artist video #2, if confirmed.',
+  },
+  {
+    start: '2026-08-31',
+    placeTheme: 'Somes Sound, Winter Harbor lighthouse.',
+    artistTrack: 'Volunteer/team spotlight - a real name, not a role.',
+  },
+  {
+    start: '2026-09-07',
+    placeTheme:
+      "Woodlawn Estate, granite/quarry detail shots (teases the Union River Sculpture Trail's local-stone story).",
+    artistTrack: 'Sponsor/partner spotlight #2.',
+  },
+  {
+    start: '2026-09-14',
+    placeTheme: 'Early foliage begins - revisit Jordan Pond and Eagle Lake with first color showing.',
+    artistTrack: "\"Lineup so far\" recap post, folding in any newly confirmed artists.",
+  },
+  {
+    start: '2026-09-21',
+    placeTheme: 'Union River Sculpture Trail launch content, Somes Sound with early color.',
+    artistTrack: 'Day-of logistics teaser (parking/what-to-bring, from doc 1032).',
+  },
+  {
+    start: '2026-09-28',
+    placeTheme: 'Countdown week - Franklin Street Parklet itself, featured for the first time as the actual venue.',
+    artistTrack: "Final push - Oct 3 hands off directly to doc 1030's live-event media plan.",
+  },
+];
+
+const CALENDAR_START = '2026-07-13';
+const CALENDAR_END = '2026-10-03';
+
+function weekFor(dateIso: string): CalendarWeek | undefined {
+  // Weeks are Monday-Sunday, so the matching week is the last one whose
+  // start is <= dateIso (WEEKS is in ascending start-date order).
+  let match: CalendarWeek | undefined;
+  for (const w of WEEKS) {
+    if (w.start <= dateIso) match = w;
+    else break;
+  }
+  return match;
+}
+
+/**
+ * Today's ZAOstock promo line, or null if today isn't a scheduled Mon/Wed/Fri
+ * slot inside the Jul 13 - Oct 3, 2026 window. dateIso is YYYY-MM-DD in the
+ * America/New_York calendar day (caller's responsibility - matches how the
+ * rest of posts/sources.ts treats "today").
+ */
+export function getTodaysZaostockPromoLine(dateIso: string): string | null {
+  if (dateIso < CALENDAR_START || dateIso > CALENDAR_END) return null;
+
+  const dow = new Date(`${dateIso}T00:00:00Z`).getUTCDay(); // 0=Sun..6=Sat
+  if (dow !== 1 && dow !== 3 && dow !== 5) return null; // Mon/Wed/Fri only
+
+  const week = weekFor(dateIso);
+  if (!week) return null;
+
+  if (dow === 3) {
+    // Wednesday = artist/event track.
+    return `ARTIST/EVENT TRACK: ${week.artistTrack}`;
+  }
+  // Monday or Friday = place-photo theme. Distinguish so the drafter can note
+  // week-open vs week-close framing if useful; content is the same theme.
+  const slot = dow === 1 ? 'Mon' : 'Fri';
+  return `PLACE PHOTO (${slot}, week of ${week.start}): ${week.placeTheme}`;
+}
+
+/** Exposed for tests - the raw calendar the lookup is built on. */
+export const ZAOSTOCK_PROMO_WEEKS = WEEKS;
+export const ZAOSTOCK_PROMO_CALENDAR_START = CALENDAR_START;
+export const ZAOSTOCK_PROMO_CALENDAR_END = CALENDAR_END;


### PR DESCRIPTION
## Summary
- Adds `zaostock-promo-calendar.ts`, a pure Mon/Wed/Fri lookup of doc 1033's 12-week ZAOstock photo + artist-track calendar (Jul 13 - Oct 3, 2026)
- Wires it into `gatherEventSignals()` so Zoe's existing event-category post drafter surfaces today's theme automatically on scheduled days, silent otherwise
- Folds into the existing `event` category by design rather than adding a competing 5th category, matching doc 1033's own call to run one content slate

## Test plan
- [x] 10 new unit tests covering date-boundary and Mon/Wed/Fri lookup logic - all pass
- [x] Existing posts/ test suite still passes (select-best.test.ts)
- [x] Typecheck clean on the changed files (pre-existing grammy-not-installed errors elsewhere are unrelated to this change)