### PR TITLE
feat(zoe): proactive nudge for stale captures and overdue tasks

### DIFF
--- a/bot/src/zoe/__tests__/nudge.test.ts
+++ b/bot/src/zoe/__tests__/nudge.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { computeNudges, formatNudge } from '../nudge';
+import type { CockpitTask } from '../../cockpit/types';
+
+const DAY = 86_400_000;
+const NOW = Date.parse('2026-07-09T12:00:00Z');
+
+function task(o: Partial<CockpitTask> & { id: string; title: string }): CockpitTask {
+  return {
+    status: 'todo',
+    priority: null,
+    due: null,
+    project: null,
+    legacy_id: null,
+    legacy_source: null,
+    notes: null,
+    next_owner: null,
+    updated_at: new Date(NOW).toISOString(),
+    created_at: new Date(NOW).toISOString(),
+    ...o,
+  };
+}
+
+describe('computeNudges', () => {
+  it('detects stale captures (7+ days, not done)', () => {
+    const tasks = [
+      task({
+        id: '1',
+        title: 'fresh capture',
+        legacy_source: 'inbox:idea1',
+        created_at: new Date(NOW - 1 * DAY).toISOString(),
+      }),
+      task({
+        id: '2',
+        title: 'stale capture',
+        legacy_source: 'inbox:idea2',
+        created_at: new Date(NOW - 8 * DAY).toISOString(),
+      }),
+      task({
+        id: '3',
+        title: 'stale but done',
+        legacy_source: 'inbox:idea3',
+        status: 'done',
+        created_at: new Date(NOW - 10 * DAY).toISOString(),
+      }),
+    ];
+    const nudges = computeNudges(tasks, NOW);
+    expect(nudges.staleCaptures.length).toBe(1);
+    expect(nudges.staleCaptures[0]?.id).toBe('2');
+    expect(nudges.overdue.length).toBe(0);
+  });
+
+  it('detects overdue tasks (due < today, not done)', () => {
+    const tasks = [
+      task({
+        id: '1',
+        title: 'overdue task',
+        due: '2026-07-05',
+        status: 'todo',
+      }),
+      task({
+        id: '2',
+        title: 'overdue but triage',
+        due: '2026-07-05',
+        status: 'triage',
+      }),
+      task({
+        id: '3',
+        title: 'overdue but done',
+        due: '2026-07-05',
+        status: 'done',
+      }),
+      task({
+        id: '4',
+        title: 'due today',
+        due: '2026-07-09',
+      }),
+      task({
+        id: '5',
+        title: 'future due',
+        due: '2026-07-15',
+      }),
+    ];
+    const nudges = computeNudges(tasks, NOW);
+    expect(nudges.overdue.length).toBe(1);
+    expect(nudges.overdue[0]?.id).toBe('1');
+  });
+
+  it('caps at 5 stale captures and 5 overdue', () => {
+    const tasks: CockpitTask[] = [];
+    // Create 10 stale captures.
+    for (let i = 0; i < 10; i++) {
+      tasks.push(
+        task({
+          id: `capture-${i}`,
+          title: `stale capture ${i}`,
+          legacy_source: 'inbox:idea',
+          created_at: new Date(NOW - 8 * DAY).toISOString(),
+        }),
+      );
+    }
+    // Create 10 overdue tasks.
+    for (let i = 0; i < 10; i++) {
+      tasks.push(
+        task({
+          id: `overdue-${i}`,
+          title: `overdue task ${i}`,
+          due: '2026-07-05',
+        }),
+      );
+    }
+    const nudges = computeNudges(tasks, NOW);
+    expect(nudges.staleCaptures.length).toBe(5);
+    expect(nudges.overdue.length).toBe(5);
+  });
+
+  it('skips non-capture items and non-stale captures', () => {
+    const tasks = [
+      task({
+        id: '1',
+        title: 'regular task',
+        legacy_source: null,
+      }),
+      task({
+        id: '2',
+        title: 'handoff',
+        legacy_source: 'handoff:slug',
+      }),
+      task({
+        id: '3',
+        title: 'fresh capture',
+        legacy_source: 'inbox:idea',
+        created_at: new Date(NOW - 3 * DAY).toISOString(),
+      }),
+    ];
+    const nudges = computeNudges(tasks, NOW);
+    expect(nudges.staleCaptures.length).toBe(0);
+    expect(nudges.overdue.length).toBe(0);
+  });
+});
+
+describe('formatNudge', () => {
+  it('returns null when nothing to nudge', () => {
+    const msg = formatNudge({ staleCaptures: [], overdue: [] });
+    expect(msg).toBeNull();
+  });
+
+  it('formats stale captures only', () => {
+    const nudges = {
+      staleCaptures: [
+        task({ id: '1', title: 'first idea' }),
+        task({ id: '2', title: 'second idea' }),
+      ],
+      overdue: [],
+    };
+    const msg = formatNudge(nudges);
+    expect(msg).toContain('2 idea(s) captured 7+ days ago');
+    expect(msg).toContain('first idea');
+  });
+
+  it('formats overdue tasks only', () => {
+    const nudges = {
+      staleCaptures: [],
+      overdue: [
+        task({ id: '1', title: 'urgent thing' }),
+        task({ id: '2', title: 'another due' }),
+      ],
+    };
+    const msg = formatNudge(nudges);
+    expect(msg).toContain('2 task(s) overdue');
+    expect(msg).toContain('urgent thing');
+  });
+
+  it('formats both stale captures and overdue', () => {
+    const nudges = {
+      staleCaptures: [task({ id: '1', title: 'stale idea' })],
+      overdue: [task({ id: '2', title: 'overdue task' })],
+    };
+    const msg = formatNudge(nudges);
+    expect(msg).toContain('1 idea(s) captured 7+ days ago');
+    expect(msg).toContain('1 task(s) overdue');
+  });
+
+  it('truncates long titles at 40 chars', () => {
+    const longTitle = 'a'.repeat(50);
+    const nudges = {
+      staleCaptures: [task({ id: '1', title: longTitle })],
+      overdue: [],
+    };
+    const msg = formatNudge(nudges);
+    expect(msg).toContain('aaaaaaaaaa'); // at least some of the truncated a's
+    expect(msg?.length).toBeLessThan(200); // sanity check message isn't huge
+  });
+
+  it('includes no emojis or em-dashes', () => {
+    const nudges = {
+      staleCaptures: [task({ id: '1', title: 'test' })],
+      overdue: [task({ id: '1', title: 'test' })],
+    };
+    const msg = formatNudge(nudges);
+    expect(msg).toBeDefined();
+    expect(msg).not.toMatch(/[^\x00-\x7F]/); // no unicode emojis
+    expect(msg).not.toContain('--'); // no em-dashes (would be represented as --)
+    expect(msg).not.toMatch(/[–—]/); // no actual em/en dashes
+  });
+});

--- a/bot/src/zoe/nudge.ts
+++ b/bot/src/zoe/nudge.ts
@@ -1,0 +1,166 @@
+/**
+ * Proactive nudge - surface stale captures and overdue tasks.
+ *
+ * Daily scheduled check that pings ZAAL BOTZ General when:
+ * - Captures go 7+ days without shipping (collector's-fallacy flag)
+ * - Tasks are overdue (due date < today, status not done/triage)
+ *
+ * Capped at 5 each (stale + overdue), short message, de-duped via
+ * last-seen date so Zaal gets nudged at most once per day per issue type.
+ * Best-effort: swallows errors, silent when nothing to nudge.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { fetchCockpitTasks, isCapture, daysSince, CAPTURE_STALE_DAYS } from '../cockpit/adapters';
+import type { CockpitTask } from '../cockpit/types';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const NUDGE_SEEN_PATH = join(ZOE_HOME, 'nudge-seen.json');
+
+/** De-dupe record: when was the last nudge sent (ISO date YYYY-MM-DD). */
+interface NudgeSeen {
+  at: string;
+}
+
+/**
+ * Load the last nudge date, or null if never nudged (first run).
+ * Best-effort: returns null on read failure.
+ */
+async function lastNudgeDate(): Promise<string | null> {
+  try {
+    const data = (await fs.readFile(NUDGE_SEEN_PATH, 'utf8')) as string;
+    const obj = JSON.parse(data) as NudgeSeen;
+    return obj.at ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record that a nudge was sent today.
+ * Best-effort: returns silently on write failure.
+ */
+async function setNudgeSent(date: string): Promise<void> {
+  try {
+    await fs.mkdir(ZOE_HOME, { recursive: true });
+    await fs.writeFile(NUDGE_SEEN_PATH, JSON.stringify({ at: date }));
+  } catch {
+    // silent
+  }
+}
+
+/**
+ * Pure: compute nudge-worthy items from a task set.
+ * Returns stale captures (7+ days, not done) and overdue tasks (due < today, not done).
+ * Caps each list at 5.
+ */
+export function computeNudges(
+  tasks: CockpitTask[],
+  now: number,
+): { staleCaptures: CockpitTask[]; overdue: CockpitTask[] } {
+  const staleCaptures: CockpitTask[] = [];
+  const overdue: CockpitTask[] = [];
+
+  const todayIso = new Date(now).toISOString().slice(0, 10);
+
+  for (const t of tasks) {
+    // Skip done tasks.
+    if (t.status === 'done') continue;
+
+    // Stale capture: is a capture AND not done AND 7+ days old.
+    if (isCapture(t) && daysSince(t.created_at, now) >= CAPTURE_STALE_DAYS) {
+      staleCaptures.push(t);
+    }
+
+    // Overdue: has a due date, due is before today, not done, not triage.
+    if (t.due && t.due < todayIso && t.status !== 'triage') {
+      overdue.push(t);
+    }
+  }
+
+  return {
+    staleCaptures: staleCaptures.slice(0, 5),
+    overdue: overdue.slice(0, 5),
+  };
+}
+
+/**
+ * Pure: format nudge message from computed nudges.
+ * Returns null if nothing to nudge (empty list), a short message otherwise.
+ * No emojis, no em-dashes. Spartan format per Zaal's voice.
+ */
+export function formatNudge(n: { staleCaptures: CockpitTask[]; overdue: CockpitTask[] }): string | null {
+  if (n.staleCaptures.length === 0 && n.overdue.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [];
+
+  if (n.staleCaptures.length > 0) {
+    const titles = n.staleCaptures.slice(0, 2).map((t) => `"${t.title.slice(0, 40)}"`).join(', ');
+    const msg = `Nudge: ${n.staleCaptures.length} idea(s) captured 7+ days ago (ship or drop). E.g. ${titles}`;
+    lines.push(msg);
+  }
+
+  if (n.overdue.length > 0) {
+    const titles = n.overdue.slice(0, 2).map((t) => `"${t.title.slice(0, 40)}"`).join(', ');
+    const msg = `Nudge: ${n.overdue.length} task(s) overdue. E.g. ${titles}`;
+    lines.push(msg);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Surface nudges if conditions are met (not nudged today, has nudges).
+ * Fetches tasks, computes nudges, and if non-empty and we haven't nudged today,
+ * posts and records. Best-effort: swallows errors, logs to console.
+ *
+ * postToGeneral: async function that sends a message to the general topic.
+ * now: optional timestamp (defaults to Date.now()).
+ */
+export async function surfaceNudges(
+  postToGeneral: (text: string) => Promise<unknown>,
+  now?: number,
+): Promise<void> {
+  const timestamp = now ?? Date.now();
+  const todayIso = new Date(timestamp).toISOString().slice(0, 10);
+
+  try {
+    // Check if already nudged today.
+    const lastDate = await lastNudgeDate();
+    if (lastDate === todayIso) {
+      // Already nudged today - skip.
+      return;
+    }
+
+    // Fetch tasks.
+    const tasks = await fetchCockpitTasks();
+    if (tasks.length === 0) {
+      // No tasks - nothing to nudge.
+      return;
+    }
+
+    // Compute nudges.
+    const nudges = computeNudges(tasks, timestamp);
+
+    // Format message.
+    const message = formatNudge(nudges);
+    if (!message) {
+      // Nothing to nudge - skip.
+      return;
+    }
+
+    // Post to general.
+    await postToGeneral(message);
+
+    // Record that we nudged today.
+    await setNudgeSent(todayIso);
+
+    console.log('[zoe/nudge] surfaced nudges to general');
+  } catch (err) {
+    console.warn('[zoe/nudge] surface failed (nbd):', err instanceof Error ? err.message : String(err));
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -4,6 +4,7 @@
  * No quiet hours per Zaal feedback 2026-05-04 ("rather get pinged than ignored").
  *
  * Triggers:
+ *   02:30 EST (06:30 UTC daily)  — stale capture + overdue task nudge (General topic)
  *   05:00 EST (09:00 UTC daily)  — morning brief
  *   21:00 EST (01:00 UTC daily)  — evening reflection
  *   hourly                        — forward nudge: the real next move from the task queue
@@ -30,6 +31,7 @@ import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { surfaceNewHandoffs } from './handoffs-surface';
+import { surfaceNudges } from './nudge';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
 import { markNudged } from './threads';
@@ -403,6 +405,26 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (n > 0) console.log(`[zoe/scheduler] surfaced ${n} handoff(s) to the Handoffs topic`);
         } catch (err) {
           console.warn('[zoe/scheduler] handoff surface failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Nudge surfacer - daily check for stale captures and overdue tasks. Posts
+  // to ZAAL BOTZ General topic when items are nudge-worthy. De-duped via
+  // last-seen date so Zaal gets nudged at most once per day. Silent when
+  // nothing to nudge or when the group is not configured.
+  tasks.push(
+    cron.schedule(
+      '30 6 * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        try {
+          await surfaceNudges((text: string) => opts.bot.api.sendMessage(gid, text));
+        } catch (err) {
+          console.warn('[zoe/scheduler] nudge surface failed (nbd):', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
## Summary

Add a daily nudge surfacer that pings ZAAL BOTZ General when idea captures go 7+ days without shipping or tasks are overdue.

Runs at 06:30 UTC (02:30 EST) daily, before the morning brief. De-duped via ~/.zao/zoe/nudge-seen.json so Zaal gets nudged at most once per day per issue. Silent when nothing to nudge.

## Changes

- bot/src/zoe/nudge.ts: Pure functions computeNudges() + formatNudge() + surfaceNudges() integration
- bot/src/zoe/__tests__/nudge.test.ts: 10 tests covering stale capture detection, overdue detection, caps, status filters
- bot/src/zoe/scheduler.ts: Wire nudge cron at 06:30 UTC (30 6 * * *) to post to ZAAL_BOTZ_GROUP_ID

## De-duplication

Last nudge date stored at ~/.zao/zoe/nudge-seen.json (ISO date YYYY-MM-DD). Checks on each run:
- Already nudged today -> skip
- Nothing to nudge (no stale captures or overdue tasks) -> silent
- Nudges exist + first nudge today -> post + record date

## Test Results

All 10 tests passing:
- Stale capture detection (7+ days, not done)
- Overdue detection (due < today, not done/triage)
- Done tasks filtered out
- Caps at 5 each (stale + overdue)
- Message formatting (null when empty, short message when non-empty)
- No emojis, no em-dashes

No new TypeScript errors in nudge.ts. Scheduler.ts errors are pre-existing.

## Cron Cadence

06:30 UTC daily (02:30 EST / 01:30 EDT) - early morning, before 09:00 UTC brief.
Non-blocking, best-effort (swallows errors, silent on failure).