### PR TITLE
fix(zoe): add missing tier to task-nudge Candidate (green typecheck)

### DIFF
--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -250,7 +250,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
             if (!nudge) return cands;
             // Score at the default threshold: it can fire when nothing outranks
             // it, but any due/overdue commitment thread (>=0.75) wins the tick.
-            cands.push({ kind: 'task-nudge', score: 0.6, message: nudge });
+            cands.push({ kind: 'task-nudge', tier: 'standard', score: 0.6, message: nudge });
           } catch {
             // ignore - return whatever events we gathered
           }


### PR DESCRIPTION
The task-nudge Candidate was missing the required 'tier' field - the one type error flagged all session. Set to 'standard' per the interface comment. tsc now fully green.