### PR TITLE
feat(zoe): durable orchestrator Stage 1 - VPS cron tick

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -11,3 +11,10 @@ BOT_ADMIN_TELEGRAM_IDS=      # comma-separated Telegram user IDs with full acces
 BONFIRE_API_KEY=             # revealed via signed message at app.bonfires.ai/dashboard
 BONFIRE_ID=                  # the ZABAL bonfire id
 BONFIRE_API_URL=https://tnt-v2.api.bonfires.ai   # optional, this is the default
+
+# Durable Orchestrator (bot/src/zoe/orchestrator-tick.ts, Stage 1).
+# Runs the one-question-at-a-time loop 24/7 on a VPS cron tick (every 5 min).
+# OFF by default so it never double-posts while a Claude Code terminal
+# orchestrator is running. Turn ON ONLY when no terminal orchestrator is active.
+ZOE_ORCHESTRATOR_ENABLED=false   # set to 'true' to enable VPS cron tick
+ZOE_ORCHESTRATOR_DAILY=20        # max questions to post per UTC day (prevents runaway)

--- a/bot/src/zoe/__tests__/orchestrator-tick.test.ts
+++ b/bot/src/zoe/__tests__/orchestrator-tick.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { detectNewAnswers, decideNextQuestion, runOrchestratorTick } from '../orchestrator-tick';
+
+// Override ZOE_HOME for testing
+const testHome = join(tmpdir(), `zoe-test-${Date.now()}`);
+const testRecentDir = join(testHome, 'recent');
+
+// Mock env
+beforeEach(() => {
+  process.env.ZOE_HOME = testHome;
+  process.env.ZOE_ORCHESTRATOR_ENABLED = 'false'; // disabled by default in tests
+  process.env.ZOE_ORCHESTRATOR_DAILY = '20';
+});
+
+afterEach(async () => {
+  // Clean up
+  try {
+    await fs.rm(testHome, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('detectNewAnswers', () => {
+  it('returns empty array if recent file does not exist', async () => {
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans).toEqual([]);
+  });
+
+  it('filters by lastSeenTs (only ts > lastSeenTs)', async () => {
+    // Create mock recent/<groupid>.json
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-01T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q2] no', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q3] maybe', ts: '2026-01-03T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    // Restore ZOE_PATHS to use testHome
+    vi.resetModules();
+
+    const ans = await detectNewAnswers('2026-01-01T12:00:00Z', 12345);
+    expect(ans.length).toBe(2);
+    expect(ans[0].qid).toBe('q2');
+    expect(ans[1].qid).toBe('q3');
+  });
+
+  it('excludes system senders (zsk*, zvl*)', async () => {
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q2] no', ts: '2026-01-02T00:00:00Z', sender: 'zsk-worker-1' },
+      { from: 'zaal', text: '[answer:q3] maybe', ts: '2026-01-02T00:00:00Z', sender: 'zvl-critic' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans.length).toBe(1);
+    expect(ans[0].qid).toBe('q1');
+  });
+
+  it('only returns [answer:*] lines', async () => {
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: 'random message', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[not-answer:q2]', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans.length).toBe(1);
+    expect(ans[0].qid).toBe('q1');
+    expect(ans[0].value).toBe('yes');
+  });
+});
+
+describe('decideNextQuestion', () => {
+  it('returns next question for a known rule', () => {
+    const next = decideNextQuestion('q-priority-what', 'Research');
+    expect(next).not.toBeNull();
+    expect(next?.qid).toBe('q-priority-research-depth');
+    expect(next?.options).toEqual(['Quick overview', 'Deep dive', 'Full audit']);
+  });
+
+  it('returns null for unknown rule', () => {
+    const next = decideNextQuestion('q-unknown', 'unknown-value');
+    expect(next).toBeNull();
+  });
+
+  it('returns null if fromQid matches but value does not', () => {
+    const next = decideNextQuestion('q-priority-what', 'Unknown');
+    expect(next).toBeNull();
+  });
+
+  it('handles multiple rules per fromQid', () => {
+    const n1 = decideNextQuestion('q-priority-what', 'Research');
+    const n2 = decideNextQuestion('q-priority-what', 'Code');
+    const n3 = decideNextQuestion('q-priority-what', 'Meetings');
+
+    expect(n1?.qid).toBe('q-priority-research-depth');
+    expect(n2?.qid).toBe('q-priority-code-type');
+    expect(n3?.qid).toBe('q-priority-meetings-focus');
+  });
+});
+
+describe('runOrchestratorTick', () => {
+  it('is a no-op when ZOE_ORCHESTRATOR_ENABLED !== "true"', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'false';
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('acquires lock and checks daily cap', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+    process.env.ZOE_ORCHESTRATOR_DAILY = '2';
+
+    // Create counter file to simulate already-posted today
+    await fs.mkdir(testHome, { recursive: true });
+    const counterPath = join(testHome, 'orchestrator-count.json');
+    const dateStr = new Date().toISOString().slice(0, 10);
+    await fs.writeFile(counterPath, JSON.stringify({ date: dateStr, n: 2 }));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    // Should be silent (no posts) because daily cap is reached
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('is silent when no new answers', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+
+    // Create empty recent file (no answers)
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+    await fs.writeFile(recentPath, JSON.stringify([]));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -1,0 +1,355 @@
+/**
+ * orchestrator-tick.ts - VPS cron tick for the durable orchestrator (Stage 1).
+ *
+ * When ZOE_ORCHESTRATOR_ENABLED === 'true', this runs every 5 min via cron
+ * to drive a one-question-at-a-time loop autonomously. Zaal taps answers to
+ * button questions in ZAAL BOTZ Claude Code topic; the tick detects those
+ * answers and posts the next question based on simple rules.
+ *
+ * Design (from scout):
+ *  - Read recent/<group_id>.json for Zaal's tapped answers ([answer:qid] format)
+ *  - Detect NEW answers since the last stored pointer (lastSeenTs)
+ *  - Decide the next question via a simple rule table (v1, no LLM)
+ *  - Post the next question with tappable buttons (reusing questions.ts)
+ *  - Update state pointer
+ *
+ * Safe by design:
+ *  - DISABLED by default (ZOE_ORCHESTRATOR_ENABLED env flag)
+ *  - Zaal-only (silently skips non-Zaal answers)
+ *  - Empty queue = no messages
+ *  - File-locked (one-instance only, mirrors work-loop.ts pattern)
+ *  - Daily cap (ZOE_ORCHESTRATOR_DAILY, default 20)
+ *  - Never posts/DMs/casts/spends/on-chain — only posts button questions
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
+import { pushRecent, ZOE_PATHS } from './memory';
+
+const ORCHESTRATOR_STATE_PATH = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-state.json');
+const ORCHESTRATOR_LOCK = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator.lock');
+const ORCHESTRATOR_COUNTER = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-count.json');
+
+const LOCK_STALE_MS = 30 * 60 * 1000; // 30 min staleness threshold
+const DAILY_CAP = Math.max(1, Number(process.env.ZOE_ORCHESTRATOR_DAILY ?? 20));
+
+/**
+ * Question-answer rule table (v1). Maps (qid, tappedValue) -> next qid.
+ * If no rule matches, decideNextQuestion returns null (silent, no next question).
+ *
+ * Example flow:
+ *  - q1: "What are you shipping?" -> user taps "Music feature"
+ *  - Rule matches (q1, "Music feature") -> next is q2
+ *  - q2: "When?" -> user taps "This week"
+ *  - Rule matches (q2, "This week") -> next is q3 (or null = done)
+ *
+ * SIMPLE rules only. v1 does NOT call an LLM for follow-ups.
+ */
+const DECISION_TABLE: Array<{
+  fromQid: string;
+  onValue: string;
+  toQid: string;
+  options: string[];
+}> = [
+  // Starter question: "What's the priority for next?"
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Research',
+    toQid: 'q-priority-research-depth',
+    options: ['Quick overview', 'Deep dive', 'Full audit'],
+  },
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Code',
+    toQid: 'q-priority-code-type',
+    options: ['Bug fix', 'Feature', 'Refactor'],
+  },
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Meetings',
+    toQid: 'q-priority-meetings-focus',
+    options: ['Partnerships', 'Team', 'Investors'],
+  },
+
+  // Research depth follow-ups
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Quick overview',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Deep dive',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Full audit',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+
+  // Code type follow-ups
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Bug fix',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Feature',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Refactor',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+
+  // Meeting focus follow-ups
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Partnerships',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Team',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Investors',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+];
+
+export interface OrchestratorState {
+  lastSeenTs: string;
+  pending?: Array<{ qid: string; askedAt: string }>;
+}
+
+export interface OrchestratorTickDeps {
+  bot: {
+    api: {
+      sendMessage: (chatId: number, text: string, options?: any) => Promise<any>;
+    };
+  };
+  groupId: number;
+  zaalTgId: number;
+  now: Date;
+}
+
+async function readState(): Promise<OrchestratorState> {
+  try {
+    const raw = await fs.readFile(ORCHESTRATOR_STATE_PATH(), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { lastSeenTs: new Date().toISOString() };
+  }
+}
+
+async function writeState(state: OrchestratorState): Promise<void> {
+  await fs.mkdir(join(ORCHESTRATOR_STATE_PATH(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_STATE_PATH(), JSON.stringify(state, null, 2), 'utf8');
+}
+
+async function countToday(date: string): Promise<number> {
+  try {
+    const c = JSON.parse(await fs.readFile(ORCHESTRATOR_COUNTER(), 'utf8')) as {
+      date: string;
+      n: number;
+    };
+    return c.date === date ? c.n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function bumpToday(date: string): Promise<void> {
+  const n = (await countToday(date)) + 1;
+  await fs.mkdir(join(ORCHESTRATOR_COUNTER(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_COUNTER(), JSON.stringify({ date, n }), 'utf8');
+}
+
+async function acquireLock(): Promise<boolean> {
+  const st = await fs.stat(ORCHESTRATOR_LOCK()).catch(() => null);
+  if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
+  await fs.mkdir(join(ORCHESTRATOR_LOCK(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_LOCK(), String(Date.now()));
+  return true;
+}
+
+async function releaseLock(): Promise<void> {
+  try {
+    await fs.unlink(ORCHESTRATOR_LOCK());
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Read the group's recent/<gid>.json (where callback-button answers are logged).
+ * Return only Zaal's [answer:qid] lines with ts > lastSeenTs, excluding system senders.
+ */
+export async function detectNewAnswers(
+  lastSeenTs: string,
+  groupId: number,
+): Promise<Array<{ qid: string; value: string; ts: string }>> {
+  // Derive recent dir from ZOE_HOME (set at runtime)
+  const zoeHome = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+  const recentPath = join(zoeHome, 'recent', `${groupId}.json`);
+  try {
+    const raw = await fs.readFile(recentPath, 'utf8');
+    const turns = JSON.parse(raw) as Array<{
+      from: string;
+      text: string;
+      ts: string;
+      sender?: string;
+    }>;
+
+    const answers: Array<{ qid: string; value: string; ts: string }> = [];
+    for (const turn of turns) {
+      // Only Zaal, skip system senders (zsk*, zvl*)
+      if (turn.from !== 'zaal' || (turn.sender && (turn.sender.startsWith('zsk') || turn.sender.startsWith('zvl')))) {
+        continue;
+      }
+      // Only [answer:*] lines
+      const match = /^\[answer:([^\]]+)\]\s*(.*)$/.exec(turn.text);
+      if (!match) continue;
+      const [, qid, value] = match;
+      // Only if ts > lastSeenTs
+      if (new Date(turn.ts) <= new Date(lastSeenTs)) continue;
+
+      answers.push({ qid, value: value.trim(), ts: turn.ts });
+    }
+    return answers;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Look up the next question based on (fromQid, tappedValue).
+ * Returns { qid, options } or null if no rule matches.
+ */
+export function decideNextQuestion(
+  fromQid: string,
+  value: string,
+): { qid: string; options: string[] } | null {
+  for (const rule of DECISION_TABLE) {
+    if (rule.fromQid === fromQid && rule.onValue === value) {
+      return { qid: rule.toQid, options: rule.options };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the button question text for a given qid (simple labels, not LLM).
+ */
+function questionTextFor(qid: string): string | null {
+  const texts: Record<string, string> = {
+    'q-priority-what': "What's the priority for next?",
+    'q-priority-research-depth': 'How deep should the research go?',
+    'q-priority-code-type': 'What kind of code work?',
+    'q-priority-meetings-focus': 'What type of meeting?',
+    'q-research-scope': 'What research scope?',
+    'q-code-urgency': 'How urgent is this code work?',
+    'q-meeting-depth': 'How deep is this meeting?',
+  };
+  return texts[qid] ?? null;
+}
+
+/**
+ * Main orchestrator tick: detect new answers, decide follow-ups, post questions.
+ * Disabled by default; only runs when ZOE_ORCHESTRATOR_ENABLED === 'true'.
+ */
+export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<void> {
+  // SAFETY: disabled by default
+  if (process.env.ZOE_ORCHESTRATOR_ENABLED !== 'true') {
+    return;
+  }
+
+  // Daily cap
+  const dateStr = deps.now.toISOString().slice(0, 10);
+  const done = await countToday(dateStr);
+  if (done >= DAILY_CAP) {
+    console.log(
+      `[zoe/orchestrator] daily cap ${DAILY_CAP} reached, next tick after UTC midnight`,
+    );
+    return;
+  }
+
+  // File lock: one tick at a time
+  if (!(await acquireLock())) {
+    console.log('[zoe/orchestrator] another run in progress, skip');
+    return;
+  }
+
+  try {
+    const state = await readState();
+    const answers = await detectNewAnswers(state.lastSeenTs, deps.groupId);
+
+    if (answers.length === 0) {
+      console.log('[zoe/orchestrator] no new answers, silent');
+      return;
+    }
+
+    // Process each new answer: decide next question, post it
+    let posted = 0;
+    for (const answer of answers) {
+      const next = decideNextQuestion(answer.qid, answer.value);
+      if (!next) {
+        console.log(
+          `[zoe/orchestrator] no rule for (${answer.qid}, "${answer.value}"), silent`,
+        );
+        continue;
+      }
+
+      const qText = questionTextFor(next.qid);
+      if (!qText) {
+        console.log(`[zoe/orchestrator] no text for qid ${next.qid}, skip`);
+        continue;
+      }
+
+      try {
+        await deps.bot.api.sendMessage(deps.groupId, qText, {
+          reply_markup: questionKeyboard(next.qid, next.options),
+        });
+        posted++;
+        console.log(
+          `[zoe/orchestrator] posted ${next.qid} after answer (${answer.qid}, "${answer.value}")`,
+        );
+      } catch (err) {
+        console.error(
+          '[zoe/orchestrator] failed to post next question:',
+          (err as Error)?.message,
+        );
+      }
+    }
+
+    if (posted > 0) {
+      // Advance pointer to latest answer's timestamp
+      const latestTs = answers[answers.length - 1].ts;
+      await writeState({ lastSeenTs: latestTs });
+      await bumpToday(dateStr);
+      console.log(`[zoe/orchestrator] tick: ${answers.length} answer(s), ${posted} question(s) posted`);
+    }
+  } finally {
+    await releaseLock();
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -31,6 +31,7 @@ import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { surfaceNewHandoffs } from './handoffs-surface';
+import { runOrchestratorTick } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
@@ -405,6 +406,32 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (n > 0) console.log(`[zoe/scheduler] surfaced ${n} handoff(s) to the Handoffs topic`);
         } catch (err) {
           console.warn('[zoe/scheduler] handoff surface failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Orchestrator tick (doc TBD) - every 5 min, check for new button-question
+  // answers in the ZAAL BOTZ Claude Code topic and post the next question
+  // based on simple decision rules. DISABLED by default (ZOE_ORCHESTRATOR_ENABLED
+  // env flag) so it never runs while a Claude Code terminal orchestrator is
+  // active. Empty queue = silent. File-locked, daily-capped.
+  tasks.push(
+    cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        try {
+          await runOrchestratorTick({
+            bot: opts.bot,
+            groupId: gid,
+            zaalTgId: opts.zaalTgId,
+            now: new Date(),
+          });
+        } catch (err) {
+          console.error('[zoe/scheduler] orchestrator tick failed:', (err as Error).message);
         }
       },
       { timezone: 'UTC' },


### PR DESCRIPTION
## Summary

Stage 1 of ZOE's durable orchestrator: a VPS cron tick that runs the one-question-at-a-time loop 24/7 without a terminal session.

When Zaal taps button answers to questions in ZAAL BOTZ Claude Code topic, the orchestrator detects those answers and posts the next question based on simple decision-table rules.

## Design

- Reads recent/<gid>.json for [answer:qid] lines logged by the callback handler
- Detects NEW answers since a stored pointer (lastSeenTs)
- Decides next question via a simple rule table (v1, no LLM - 3 top-level questions x 3-4 follow-ups)
- Posts the next question with tappable button options
- Updates state pointer

## Safety Guardrails (Non-negotiable)

- **DISABLED by default** - ZOE_ORCHESTRATOR_ENABLED env flag. When false, tick returns immediately (no-op)
- **Zaal-only** - silently skips non-Zaal answers + system senders (zsk*, zvl*)
- **Empty queue = zero messages** - if no new answers detected, silent
- **File-locked** - one instance at a time (mirrors work-loop pattern, 30min staleness threshold)
- **Daily cap** - ZOE_ORCHESTRATOR_DAILY default 20 questions/day, prevents runaway
- **Limited scope** - only posts button questions to group topic, never DMs/casts/posts/spends/on-chain

## Decision Table (v1)

```
q-priority-what
├─ "Research" → q-priority-research-depth [Quick overview | Deep dive | Full audit]
├─ "Code" → q-priority-code-type [Bug fix | Feature | Refactor]
└─ "Meetings" → q-priority-meetings-focus [Partnerships | Team | Investors]

(each branch continues for 1-2 more levels)
```

No LLM involved in decision-making (v1 scope). Follow-up: add Sonnet reasoning layer if rule table becomes complex.

## Files

- `bot/src/zoe/orchestrator-tick.ts` (355 lines)
  - `detectNewAnswers(lastSeenTs, groupId)`: reads recent/, filters by ts + sender
  - `decideNextQuestion(fromQid, value)`: looks up rule in DECISION_TABLE
  - `runOrchestratorTick(deps)`: main entry point (disabled by default, acquires lock, daily cap, silent on empty)
  
- `bot/src/zoe/scheduler.ts`: wired in as 5-min cron `*/5 * * * *` UTC
  - Early return when ZOE_ORCHESTRATOR_ENABLED !== 'true'
  - Calls runOrchestratorTick with bot, groupId, zaalTgId, now
  
- `bot/.env.example`: added 2 lines
  - ZOE_ORCHESTRATOR_ENABLED=false (disabled by default)
  - ZOE_ORCHESTRATOR_DAILY=20 (daily question cap)
  
- `bot/src/zoe/__tests__/orchestrator-tick.test.ts` (187 lines)
  - 11 unit tests, all passing
  - Covers detectNewAnswers (filters, exclusions, edge cases)
  - Covers decideNextQuestion (known/unknown rules)
  - Covers runOrchestratorTick (disabled by default, daily cap, empty queue)

## Testing & Verification

- All 11 tests pass: `npm run test src/zoe/__tests__/orchestrator-tick.test.ts`
- Typecheck green: `npm run typecheck`
- Decision table is explicit + testable (no magic)
- Disabled by default means zero risk of double-posting while terminal orchestrator is active

## Critical Note for Zaal

This is shipped **DISABLED by default**. It stays inert until you explicitly set:

```bash
# In bot/.env (VPS deployment)
ZOE_ORCHESTRATOR_ENABLED=true
```

This ensures no risk of split-brain or double-posting while the Claude Code terminal orchestrator is running. Once enabled, it will drive the one-question-at-a-time loop autonomously every 5 minutes.