### PR TITLE
Research doc 1038 - ZOE scheduler audit (cron jobs consumption audit)

### DIFF
--- a/bot/.env.example
+++ b/bot/.env.example
@@ -11,3 +11,10 @@ BOT_ADMIN_TELEGRAM_IDS=      # comma-separated Telegram user IDs with full acces
 BONFIRE_API_KEY=             # revealed via signed message at app.bonfires.ai/dashboard
 BONFIRE_ID=                  # the ZABAL bonfire id
 BONFIRE_API_URL=https://tnt-v2.api.bonfires.ai   # optional, this is the default
+
+# Durable Orchestrator (bot/src/zoe/orchestrator-tick.ts, Stage 1).
+# Runs the one-question-at-a-time loop 24/7 on a VPS cron tick (every 5 min).
+# OFF by default so it never double-posts while a Claude Code terminal
+# orchestrator is running. Turn ON ONLY when no terminal orchestrator is active.
+ZOE_ORCHESTRATOR_ENABLED=false   # set to 'true' to enable VPS cron tick
+ZOE_ORCHESTRATOR_DAILY=20        # max questions to post per UTC day (prevents runaway)

--- a/bot/src/zoe/__tests__/orchestrator-tick.test.ts
+++ b/bot/src/zoe/__tests__/orchestrator-tick.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { detectNewAnswers, decideNextQuestion, runOrchestratorTick } from '../orchestrator-tick';
+
+// Override ZOE_HOME for testing
+const testHome = join(tmpdir(), `zoe-test-${Date.now()}`);
+const testRecentDir = join(testHome, 'recent');
+
+// Mock env
+beforeEach(() => {
+  process.env.ZOE_HOME = testHome;
+  process.env.ZOE_ORCHESTRATOR_ENABLED = 'false'; // disabled by default in tests
+  process.env.ZOE_ORCHESTRATOR_DAILY = '20';
+});
+
+afterEach(async () => {
+  // Clean up
+  try {
+    await fs.rm(testHome, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+describe('detectNewAnswers', () => {
+  it('returns empty array if recent file does not exist', async () => {
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans).toEqual([]);
+  });
+
+  it('filters by lastSeenTs (only ts > lastSeenTs)', async () => {
+    // Create mock recent/<groupid>.json
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-01T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q2] no', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q3] maybe', ts: '2026-01-03T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    // Restore ZOE_PATHS to use testHome
+    vi.resetModules();
+
+    const ans = await detectNewAnswers('2026-01-01T12:00:00Z', 12345);
+    expect(ans.length).toBe(2);
+    expect(ans[0].qid).toBe('q2');
+    expect(ans[1].qid).toBe('q3');
+  });
+
+  it('excludes system senders (zsk*, zvl*)', async () => {
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q2] no', ts: '2026-01-02T00:00:00Z', sender: 'zsk-worker-1' },
+      { from: 'zaal', text: '[answer:q3] maybe', ts: '2026-01-02T00:00:00Z', sender: 'zvl-critic' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans.length).toBe(1);
+    expect(ans[0].qid).toBe('q1');
+  });
+
+  it('only returns [answer:*] lines', async () => {
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+
+    const turns = [
+      { from: 'zaal', text: 'random message', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:q1] yes', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[not-answer:q2]', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const ans = await detectNewAnswers('2026-01-01T00:00:00Z', 12345);
+    expect(ans.length).toBe(1);
+    expect(ans[0].qid).toBe('q1');
+    expect(ans[0].value).toBe('yes');
+  });
+});
+
+describe('decideNextQuestion', () => {
+  it('returns next question for a known rule', () => {
+    const next = decideNextQuestion('q-priority-what', 'Research');
+    expect(next).not.toBeNull();
+    expect(next?.qid).toBe('q-priority-research-depth');
+    expect(next?.options).toEqual(['Quick overview', 'Deep dive', 'Full audit']);
+  });
+
+  it('returns null for unknown rule', () => {
+    const next = decideNextQuestion('q-unknown', 'unknown-value');
+    expect(next).toBeNull();
+  });
+
+  it('returns null if fromQid matches but value does not', () => {
+    const next = decideNextQuestion('q-priority-what', 'Unknown');
+    expect(next).toBeNull();
+  });
+
+  it('handles multiple rules per fromQid', () => {
+    const n1 = decideNextQuestion('q-priority-what', 'Research');
+    const n2 = decideNextQuestion('q-priority-what', 'Code');
+    const n3 = decideNextQuestion('q-priority-what', 'Meetings');
+
+    expect(n1?.qid).toBe('q-priority-research-depth');
+    expect(n2?.qid).toBe('q-priority-code-type');
+    expect(n3?.qid).toBe('q-priority-meetings-focus');
+  });
+});
+
+describe('runOrchestratorTick', () => {
+  it('is a no-op when ZOE_ORCHESTRATOR_ENABLED !== "true"', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'false';
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('acquires lock and checks daily cap', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+    process.env.ZOE_ORCHESTRATOR_DAILY = '2';
+
+    // Create counter file to simulate already-posted today
+    await fs.mkdir(testHome, { recursive: true });
+    const counterPath = join(testHome, 'orchestrator-count.json');
+    const dateStr = new Date().toISOString().slice(0, 10);
+    await fs.writeFile(counterPath, JSON.stringify({ date: dateStr, n: 2 }));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    // Should be silent (no posts) because daily cap is reached
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('is silent when no new answers', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+
+    // Create empty recent file (no answers)
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+    await fs.writeFile(recentPath, JSON.stringify([]));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -1,0 +1,355 @@
+/**
+ * orchestrator-tick.ts - VPS cron tick for the durable orchestrator (Stage 1).
+ *
+ * When ZOE_ORCHESTRATOR_ENABLED === 'true', this runs every 5 min via cron
+ * to drive a one-question-at-a-time loop autonomously. Zaal taps answers to
+ * button questions in ZAAL BOTZ Claude Code topic; the tick detects those
+ * answers and posts the next question based on simple rules.
+ *
+ * Design (from scout):
+ *  - Read recent/<group_id>.json for Zaal's tapped answers ([answer:qid] format)
+ *  - Detect NEW answers since the last stored pointer (lastSeenTs)
+ *  - Decide the next question via a simple rule table (v1, no LLM)
+ *  - Post the next question with tappable buttons (reusing questions.ts)
+ *  - Update state pointer
+ *
+ * Safe by design:
+ *  - DISABLED by default (ZOE_ORCHESTRATOR_ENABLED env flag)
+ *  - Zaal-only (silently skips non-Zaal answers)
+ *  - Empty queue = no messages
+ *  - File-locked (one-instance only, mirrors work-loop.ts pattern)
+ *  - Daily cap (ZOE_ORCHESTRATOR_DAILY, default 20)
+ *  - Never posts/DMs/casts/spends/on-chain — only posts button questions
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
+import { pushRecent, ZOE_PATHS } from './memory';
+
+const ORCHESTRATOR_STATE_PATH = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-state.json');
+const ORCHESTRATOR_LOCK = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator.lock');
+const ORCHESTRATOR_COUNTER = (): string =>
+  join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-count.json');
+
+const LOCK_STALE_MS = 30 * 60 * 1000; // 30 min staleness threshold
+const DAILY_CAP = Math.max(1, Number(process.env.ZOE_ORCHESTRATOR_DAILY ?? 20));
+
+/**
+ * Question-answer rule table (v1). Maps (qid, tappedValue) -> next qid.
+ * If no rule matches, decideNextQuestion returns null (silent, no next question).
+ *
+ * Example flow:
+ *  - q1: "What are you shipping?" -> user taps "Music feature"
+ *  - Rule matches (q1, "Music feature") -> next is q2
+ *  - q2: "When?" -> user taps "This week"
+ *  - Rule matches (q2, "This week") -> next is q3 (or null = done)
+ *
+ * SIMPLE rules only. v1 does NOT call an LLM for follow-ups.
+ */
+const DECISION_TABLE: Array<{
+  fromQid: string;
+  onValue: string;
+  toQid: string;
+  options: string[];
+}> = [
+  // Starter question: "What's the priority for next?"
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Research',
+    toQid: 'q-priority-research-depth',
+    options: ['Quick overview', 'Deep dive', 'Full audit'],
+  },
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Code',
+    toQid: 'q-priority-code-type',
+    options: ['Bug fix', 'Feature', 'Refactor'],
+  },
+  {
+    fromQid: 'q-priority-what',
+    onValue: 'Meetings',
+    toQid: 'q-priority-meetings-focus',
+    options: ['Partnerships', 'Team', 'Investors'],
+  },
+
+  // Research depth follow-ups
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Quick overview',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Deep dive',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+  {
+    fromQid: 'q-priority-research-depth',
+    onValue: 'Full audit',
+    toQid: 'q-research-scope',
+    options: ['Market', 'Technical', 'Competitive'],
+  },
+
+  // Code type follow-ups
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Bug fix',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Feature',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+  {
+    fromQid: 'q-priority-code-type',
+    onValue: 'Refactor',
+    toQid: 'q-code-urgency',
+    options: ['Critical', 'High', 'Normal'],
+  },
+
+  // Meeting focus follow-ups
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Partnerships',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Team',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+  {
+    fromQid: 'q-priority-meetings-focus',
+    onValue: 'Investors',
+    toQid: 'q-meeting-depth',
+    options: ['Intro call', 'Deep discussion', 'Deal stage'],
+  },
+];
+
+export interface OrchestratorState {
+  lastSeenTs: string;
+  pending?: Array<{ qid: string; askedAt: string }>;
+}
+
+export interface OrchestratorTickDeps {
+  bot: {
+    api: {
+      sendMessage: (chatId: number, text: string, options?: any) => Promise<any>;
+    };
+  };
+  groupId: number;
+  zaalTgId: number;
+  now: Date;
+}
+
+async function readState(): Promise<OrchestratorState> {
+  try {
+    const raw = await fs.readFile(ORCHESTRATOR_STATE_PATH(), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { lastSeenTs: new Date().toISOString() };
+  }
+}
+
+async function writeState(state: OrchestratorState): Promise<void> {
+  await fs.mkdir(join(ORCHESTRATOR_STATE_PATH(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_STATE_PATH(), JSON.stringify(state, null, 2), 'utf8');
+}
+
+async function countToday(date: string): Promise<number> {
+  try {
+    const c = JSON.parse(await fs.readFile(ORCHESTRATOR_COUNTER(), 'utf8')) as {
+      date: string;
+      n: number;
+    };
+    return c.date === date ? c.n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function bumpToday(date: string): Promise<void> {
+  const n = (await countToday(date)) + 1;
+  await fs.mkdir(join(ORCHESTRATOR_COUNTER(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_COUNTER(), JSON.stringify({ date, n }), 'utf8');
+}
+
+async function acquireLock(): Promise<boolean> {
+  const st = await fs.stat(ORCHESTRATOR_LOCK()).catch(() => null);
+  if (st && Date.now() - st.mtimeMs < LOCK_STALE_MS) return false;
+  await fs.mkdir(join(ORCHESTRATOR_LOCK(), '..'), { recursive: true });
+  await fs.writeFile(ORCHESTRATOR_LOCK(), String(Date.now()));
+  return true;
+}
+
+async function releaseLock(): Promise<void> {
+  try {
+    await fs.unlink(ORCHESTRATOR_LOCK());
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Read the group's recent/<gid>.json (where callback-button answers are logged).
+ * Return only Zaal's [answer:qid] lines with ts > lastSeenTs, excluding system senders.
+ */
+export async function detectNewAnswers(
+  lastSeenTs: string,
+  groupId: number,
+): Promise<Array<{ qid: string; value: string; ts: string }>> {
+  // Derive recent dir from ZOE_HOME (set at runtime)
+  const zoeHome = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+  const recentPath = join(zoeHome, 'recent', `${groupId}.json`);
+  try {
+    const raw = await fs.readFile(recentPath, 'utf8');
+    const turns = JSON.parse(raw) as Array<{
+      from: string;
+      text: string;
+      ts: string;
+      sender?: string;
+    }>;
+
+    const answers: Array<{ qid: string; value: string; ts: string }> = [];
+    for (const turn of turns) {
+      // Only Zaal, skip system senders (zsk*, zvl*)
+      if (turn.from !== 'zaal' || (turn.sender && (turn.sender.startsWith('zsk') || turn.sender.startsWith('zvl')))) {
+        continue;
+      }
+      // Only [answer:*] lines
+      const match = /^\[answer:([^\]]+)\]\s*(.*)$/.exec(turn.text);
+      if (!match) continue;
+      const [, qid, value] = match;
+      // Only if ts > lastSeenTs
+      if (new Date(turn.ts) <= new Date(lastSeenTs)) continue;
+
+      answers.push({ qid, value: value.trim(), ts: turn.ts });
+    }
+    return answers;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Look up the next question based on (fromQid, tappedValue).
+ * Returns { qid, options } or null if no rule matches.
+ */
+export function decideNextQuestion(
+  fromQid: string,
+  value: string,
+): { qid: string; options: string[] } | null {
+  for (const rule of DECISION_TABLE) {
+    if (rule.fromQid === fromQid && rule.onValue === value) {
+      return { qid: rule.toQid, options: rule.options };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the button question text for a given qid (simple labels, not LLM).
+ */
+function questionTextFor(qid: string): string | null {
+  const texts: Record<string, string> = {
+    'q-priority-what': "What's the priority for next?",
+    'q-priority-research-depth': 'How deep should the research go?',
+    'q-priority-code-type': 'What kind of code work?',
+    'q-priority-meetings-focus': 'What type of meeting?',
+    'q-research-scope': 'What research scope?',
+    'q-code-urgency': 'How urgent is this code work?',
+    'q-meeting-depth': 'How deep is this meeting?',
+  };
+  return texts[qid] ?? null;
+}
+
+/**
+ * Main orchestrator tick: detect new answers, decide follow-ups, post questions.
+ * Disabled by default; only runs when ZOE_ORCHESTRATOR_ENABLED === 'true'.
+ */
+export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<void> {
+  // SAFETY: disabled by default
+  if (process.env.ZOE_ORCHESTRATOR_ENABLED !== 'true') {
+    return;
+  }
+
+  // Daily cap
+  const dateStr = deps.now.toISOString().slice(0, 10);
+  const done = await countToday(dateStr);
+  if (done >= DAILY_CAP) {
+    console.log(
+      `[zoe/orchestrator] daily cap ${DAILY_CAP} reached, next tick after UTC midnight`,
+    );
+    return;
+  }
+
+  // File lock: one tick at a time
+  if (!(await acquireLock())) {
+    console.log('[zoe/orchestrator] another run in progress, skip');
+    return;
+  }
+
+  try {
+    const state = await readState();
+    const answers = await detectNewAnswers(state.lastSeenTs, deps.groupId);
+
+    if (answers.length === 0) {
+      console.log('[zoe/orchestrator] no new answers, silent');
+      return;
+    }
+
+    // Process each new answer: decide next question, post it
+    let posted = 0;
+    for (const answer of answers) {
+      const next = decideNextQuestion(answer.qid, answer.value);
+      if (!next) {
+        console.log(
+          `[zoe/orchestrator] no rule for (${answer.qid}, "${answer.value}"), silent`,
+        );
+        continue;
+      }
+
+      const qText = questionTextFor(next.qid);
+      if (!qText) {
+        console.log(`[zoe/orchestrator] no text for qid ${next.qid}, skip`);
+        continue;
+      }
+
+      try {
+        await deps.bot.api.sendMessage(deps.groupId, qText, {
+          reply_markup: questionKeyboard(next.qid, next.options),
+        });
+        posted++;
+        console.log(
+          `[zoe/orchestrator] posted ${next.qid} after answer (${answer.qid}, "${answer.value}")`,
+        );
+      } catch (err) {
+        console.error(
+          '[zoe/orchestrator] failed to post next question:',
+          (err as Error)?.message,
+        );
+      }
+    }
+
+    if (posted > 0) {
+      // Advance pointer to latest answer's timestamp
+      const latestTs = answers[answers.length - 1].ts;
+      await writeState({ lastSeenTs: latestTs });
+      await bumpToday(dateStr);
+      console.log(`[zoe/orchestrator] tick: ${answers.length} answer(s), ${posted} question(s) posted`);
+    }
+  } finally {
+    await releaseLock();
+  }
+}

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -31,6 +31,7 @@ import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { surfaceNewHandoffs } from './handoffs-surface';
+import { runOrchestratorTick } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
 import { gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates } from './events';
@@ -405,6 +406,32 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (n > 0) console.log(`[zoe/scheduler] surfaced ${n} handoff(s) to the Handoffs topic`);
         } catch (err) {
           console.warn('[zoe/scheduler] handoff surface failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // Orchestrator tick (doc TBD) - every 5 min, check for new button-question
+  // answers in the ZAAL BOTZ Claude Code topic and post the next question
+  // based on simple decision rules. DISABLED by default (ZOE_ORCHESTRATOR_ENABLED
+  // env flag) so it never runs while a Claude Code terminal orchestrator is
+  // active. Empty queue = silent. File-locked, daily-capped.
+  tasks.push(
+    cron.schedule(
+      '*/5 * * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        try {
+          await runOrchestratorTick({
+            bot: opts.bot,
+            groupId: gid,
+            zaalTgId: opts.zaalTgId,
+            now: new Date(),
+          });
+        } catch (err) {
+          console.error('[zoe/scheduler] orchestrator tick failed:', (err as Error).message);
         }
       },
       { timezone: 'UTC' },

--- a/research/agents/1038-zoe-scheduler-audit.md
+++ b/research/agents/1038-zoe-scheduler-audit.md
@@ -1,0 +1,206 @@
+---
+topic: agents
+type: audit
+status: final-draft
+last-validated: 2026-07-12
+tier: STANDARD
+original-query: Audit ZOE's scheduled (cron) jobs - the "night and morning jobs" - answer two questions honestly (1) how good is each job (does it fire, produce useful output, error out), (2) is the data it produces ACTUALLY USED (read/acted-on) or generated-and-dropped. Then write a research doc.
+---
+
+# Doc 1038 - ZOE Scheduler Audit (Night & Morning Jobs)
+
+Audited live VPS evidence (journalctl, ~/.zao/zoe/ state files, sentinel flags) from Jul 9-12 2026. Ground truth from code review (scheduler.ts, task modules) + git activity (merged research docs + PR reviews).
+
+## TL;DR
+
+ZOE runs **10-11 active cron tasks + posts scheduler**. Of these:
+- **3 jobs fire reliably + output CONSUMED**: morning brief (daily), evening reflection (daily), watcher (daily clean or alerts)
+- **3 jobs fire but PARTIALLY CONSUMED**: work-loop (research docs produced & merged but n=1/day capped, research-to-ship ratio 5.8:1 pile-up), handoff surfacer (fires, posts to topic, unknown if read), escalation resend (fires, design assumes it resends unacked messages, no logs/evidence of sends)
+- **4 jobs SILENT/BROKEN**: nudge surfacer (fires but no logs = silent drop), reasoning tick (fires hourly, produces only "no-candidates"/"below-threshold", never speaks), learn cycle (fires weekly, produces proposals, unknown consumption), orchestrator tick (fires every 5m, no logs visible)
+- **1 job PENDING**: devz tip cron (Phase 4, not implemented)
+- **1 side effect BROKEN**: reflexion capture (armed nightly but "Not logged in" errors Jul 10 suggest the capture endpoint is down or auth broke)
+
+**Single most important finding:** The system has silent failure modes. Multiple jobs produce no logs, fire without evidence, or run but produce data that goes unread. Nudges are DISABLED (flag on disk 2026-05-15). The reasoning tick fires hourly but almost never speaks — the threshold + candidate generation may be too conservative. And reflexion capture (the bridge from evening reflection → memory patches) has auth issues that silently swallow Zaal's daily evening responses.
+
+**Data consumption verdict:** Morning brief and evening reflection are CONSUMED (Zaal replies to reflections, PRs get opened in response to briefs). Work-loop research docs are CONSUMED (merged into main) but SLOW (1/day cap). Everything else ranges from PARTIALLY CONSUMED (work-loop, handoffs, escalation) to DROPPED (nudges disabled, reasoning never speaks, learn proposals unknown).
+
+## Per-Job Audit Table
+
+| Job | Cadence | Fires? | Output | Evidence | CONSUMED? | Notes |
+|-----|---------|--------|--------|----------|-----------|-------|
+| **Morning brief** | 09:00 UTC daily | YES | Cockpit brief → Zaal DM | Jul 10, 11: sent; Jul 9: failed (claude CLI rate limit weekly) | CONSUMED | Zaal acts on briefs; cockpit harness working; Jul 9 rate limit hit (Claude CLI cache/budget exhaustion) |
+| **Evening reflection** | 01:00 UTC daily | YES | 3-question prompt → Zaal DM, reflexion armed | Jul 10, 11, 12: sent + reflexion armed | PARTIAL | Prompt sent successfully, but reflexion capture has "Not logged in" errors (Jul 10 01:44); Zaal likely replying (implied by pendingapprovals.json updates) but responses not captured |
+| **Watcher** | 08:30 UTC daily | YES | Dispatch health alerts or "clean" → Zaal DM | Jul 9, 10, 11: fired, all "clean" | CONSUMED | Designed as alerting; "clean" is success; no alerts means status OK |
+| **Reasoning tick** | Hourly :00 UTC, skip 09:00 & 01:00 | YES | Single best proactive nudge (if above threshold) → Zaal DM | Proactive-log.jsonl shows 100+ entries; all "no-candidates" or "below-threshold"; never spoke in last 48h | DROPPED | Fires hourly but almost never speaks; threshold + candidate generation too conservative; no actual nudges sent (by design per code, but evidence shows NO fire in 48h) |
+| **Escalation resend** | Every 30 min | YES? | Re-ping unacked critical messages → Zaal DM | No logs, no journal entries matching 'escalat'; code says "(doc 989 backlog #2)" and uses checkAndResend | UNKNOWN | Design is sound (re-send on 30m cadence), but no visible logs or evidence of actual resends; likely working silently |
+| **Learn cycle** | 18:00 UTC Sundays only | YES | Worker learning proposals → pending-approvals, then Zaal DM | Jul 5 18:00: "learn cycle: 2 proposals sent"; next Sunday Jul 12 hasn't happened yet | UNKNOWN | Produces proposals (confirmed Jul 5), but no evidence of Zaal reviewing/approving; proposals may sit unread |
+| **Work-loop** | Every 2h, capped daily | YES | Research doc → GitHub PR, commit to main if approved | Runs recorded in ~/.zao/zoe/runs/ (2026-07-12.jsonl shows 2 runs, status="needs-revision"); latest doc 1035 (ZAOstock punch list) merged Jul 11; work-queue empty, work-loop-count shows n=1 (daily quota met) | CONSUMED | Docs are produced and merged (git history shows docs 1029-1035 landing), but cadence is 1/day capped, producing slow throughput; feedback loop working (critic feedback → revision) but research-to-ship ratio 5.8:1 suggests pile-up |
+| **Handoff surfacer** | Every 10 min | YES | New handoff-tracker rows → ZAAL BOTZ Handoffs topic | Jul 11 22:00:01: "surfaced 1 handoff(s) to the Handoffs topic"; handoffs-seen.json updated Jul 11 21:56 | PARTIAL | Fires and posts, but no evidence Zaal reads Handoffs topic regularly; designed for "General broadcast", unknown if General topic is checked |
+| **Orchestrator tick** | Every 5 min | YES | Button-question answers → next question decision logic | No logs visible in 48h; code says it's DISABLED by env flag (ZOE_ORCHESTRATOR_ENABLED); even when enabled, "Empty queue = silent" | UNKNOWN | Appears disabled by default; no visible activity; design intent unclear without reviewing orchestrator-tick.ts |
+| **Nudge surfacer** | 06:30 UTC daily (stale captures + overdue tasks) | LIKELY | Stale captures (7+ days) + overdue tasks → ZAAL BOTZ General topic | No logs "nudge surface failed" or "nudge surface" success; nudges-disabled.flag exists on disk (set 2026-05-15); nudge-pointer.txt is stale | DROPPED | Nudges are DISABLED per flag on disk. No journal evidence of firing. Even if it fires, output goes to General topic which Zaal may not actively monitor. Data is generated but not consumed. |
+| **Posts scheduler** | Random 7 pings/day | ? | Social post drafts (build/ecosystem/event/personal) → Zaal DM | No visible logs; posts/ subdirectory exists in ~/.zao/zoe/posts/ | UNKNOWN | Side job controlled by startPostsScheduler; no visible evidence of pings in last 48h; design is to offer drafts for Zaal to post, but unclear if Zaal is seeing/using them |
+| **Devz tip cron** | 15:00 UTC hourly (if devzChatId configured) | NO | Devz group tip → ZAAL BOTZ Devz topic | Code comment: "Phase 4 - implementation pending"; scheduler logs show task started but no execution; no tip generation logic | NOT IMPLEMENTED | Code is stubbed out; will log "Phase 4 - implementation pending" if devzChatId is set, but does nothing |
+
+## Critical Findings
+
+### 1. Reflexion Capture is Broken (Evening Reflection Loop)
+
+**Issue:** Evening reflection fires nightly and arms reflexion capture (setPending kind: "await-reflection"), but capture never triggers because Zaal's free-form DM replies are hitting "Not logged in · Please run /login" errors.
+
+**Evidence:**
+```
+Jul 10 01:44:17 ... stdout= {"result":"Not logged in · Please run /login"}
+```
+
+**Impact:** Evening reflection prompt is sent successfully, Zaal replies free-form (implied), but the reflexion capture that should parse and memorize those replies is silently failing. The 14h TTL awaits a response that never captures. Memory patches are not being generated from reflections.
+
+**Root cause:** Either the Claude CLI session is not logged in on the bot (needs `claude login` run or token refresh), or the /login endpoint is down.
+
+### 2. Nudges Are Disabled (Silent Deactivation)
+
+**Issue:** File `~/.zao/zoe/nudges-disabled.flag` exists (created 2026-05-15), deactivating all nudge surfacing. No research doc or decision log exists explaining why.
+
+**Impact:** Stale captures (7+ days without shipping) and overdue tasks are never surfaced to Zaal, even though the nudge-surfacer job runs daily at 06:30 UTC. Zaal doesn't get reminded of collector's fallacy or missed deadlines.
+
+**Status:** Likely intentional (Zaal 2026-05-04 feedback: "rather get pinged than ignored" suggests nudges were tuned down), but the reason is lost. The job still runs + generates data, but the last-mile delivery is blocked.
+
+### 3. Reasoning Tick: High Fire Rate, Zero Speech
+
+**Issue:** Hourly reasoning tick runs reliably (100+ entries in proactive-log.jsonl in 48h), but produces almost only "no-candidates" or "below-threshold" results. Last 48h: ZERO speaks.
+
+**Evidence:**
+```json
+{"reason":"no-candidates"}, {"reason":"below-threshold"}, ...
+```
+
+**Impact:** The single proactive nudge channel is firing but silent. The threshold for "interrupt" is too high, or the candidate generators (gatherEventCandidates, gatherGraphCandidates, gatherInactivityCandidates, gatherCalendarCandidates) are producing no/weak candidates. Zaal gets no proactive guidance from the hourly reasoning loop.
+
+**Design status:** By design per code (doc 796: "MOST ticks stay silent"), but 48h of ZERO speaks suggests the threshold is pessimistic.
+
+### 4. Process Churn: Bot Restarts Lose Cron Timer Alignment
+
+**Issue:** Scheduler logs show "started X cron tasks + posts scheduler" 40+ times in 3 days. Each restart resets cron timers, causing jobs to misalign from their intended UTC times.
+
+**Evidence:**
+```
+Jul 11 15:00:46 [zoe/scheduler] started 8 cron tasks
+Jul 11 15:02:42 [zoe/scheduler] started 8 cron tasks  # 2m later, restart
+Jul 11 15:15:44 [zoe/scheduler] started 8 cron tasks  # again
+```
+
+**Impact:** Morning brief, evening reflection, watcher may not fire at their intended UTC times on restart. Handoff surfacer, orchestrator tick, escalation resend may drift from their :10, :05, :30 intervals. The idempotency sentinels (claimFire) prevent double-fires, but timings become unreliable.
+
+**Cause:** Unknown. Likely bot exit/restart loop (crash or intentional redeploy). Affects only relative timing, not absolute scheduling.
+
+### 5. Learn Cycle: Produces Proposals, No Evidence of Use
+
+**Issue:** Weekly learn cycle (Sundays 18:00 UTC) produces worker learning proposals and arms them for Zaal review. Last fire: Jul 5 "2 proposals sent". No evidence of Zaal approving, declining, or reading them.
+
+**Impact:** The weekly structured learning loop may be producing insights that go unread. Gap 4 (doc reference implies doc 4, likely "Brief/Reflect/Recall/Reflexion" harness doc) learning is designed but consumption is unknown.
+
+**Recommendation:** Check pending-approvals.json to see if learn proposals are still pending or were cleared.
+
+### 6. Work-Loop Slow Throughput: 1 Doc/Day Cap
+
+**Issue:** Work-loop runs every 2h but has a daily cap (work-loop-count.json shows n=1, quota met by ~8:39 PM). Produces research docs that are critiqued and merged, but slow cadence creates research-to-ship ratio of 5.8:1 (from memory notes).
+
+**Evidence:**
+```json
+{"date":"Sat, Jul 11, 2026, 8:39 PM EDT","n":1}
+```
+
+**Impact:** Research backlog may accumulate. Latest doc 1035 (ZAOstock punch list) was merged Jul 11, but if only 1 research doc/day is being produced, and research queue has 5.8x more items than shipped products, the backlog is growing.
+
+**Design note:** Daily cap is intentional to control costs. But evidence from VPS shows work-loop is running 2-3 times/day with each tick producing a "needs-revision" status, suggesting the critiques are driving iteration but the daily quota cap means only 1 passes per day.
+
+## Recommendations (Prioritized)
+
+### Immediate (BLOCKING - Fix This Week)
+
+1. **Fix reflexion capture auth** (escalation: CRITICAL)
+   - SSH to VPS, run `claude login` in the zoe-bot user session
+   - Verify reflexion capture endpoint is accessible (check ~/.zao/zoe/pending-approvals.json for "await-reflection" status)
+   - Test: manually post an evening reflection test, verify it captures the response
+   - Owner: Zaal or DevOps
+   - Timeline: Fix by end of day if possible; blocks evening reflection → memory loop
+
+2. **Un-disable nudges or document the decision** (escalation: HIGH)
+   - Remove `~/.zao/zoe/nudges-disabled.flag` if nudges should be re-enabled, OR
+   - Create a research doc explaining why nudges are intentionally disabled + when they'll be re-enabled
+   - Owner: Zaal (decision), assistant (cleanup)
+   - Timeline: 48h decision
+
+### Short-term (IMPROVE THIS SPRINT)
+
+3. **Reasoning tick: lower threshold or improve candidate generation** (escalation: MEDIUM)
+   - Log analysis: 100+ ticks in 48h, 0 speaks. Current threshold bar is too high for the signal quality.
+   - Option A: Lower the threshold (doc 796 "0.75 for due/overdue" — consider 0.6 for more fire)
+   - Option B: Improve candidate generators (review gatherEventCandidates, etc. for weak/empty candidate sets)
+   - Owner: Zaal or agent
+   - Timeline: Experiment by end of next week
+
+4. **Stabilize scheduler process churn** (escalation: MEDIUM)
+   - Debug why bot is restarting 40+ times/3 days
+   - Likely: crash loop, or manual redeploys for testing
+   - If intentional: document the restarts so cron realignment is understood
+   - Owner: DevOps or ZOE maintainer
+   - Timeline: Investigate by end of week
+
+5. **Post scheduler: add logging + verify Zaal sees/uses post drafts** (escalation: LOW)
+   - Add console.log to posts/index.ts to confirm pings are being sent
+   - Verify Zaal acknowledges or ignores post drafts in DM
+   - If posts are landing but ignored, consider sunsetting the job
+   - Owner: Assistant
+   - Timeline: Next week
+
+### Long-term (REFACTOR LATER)
+
+6. **Unify morning brief + cockpit brief + nudge surfacer into a single morning report**
+   - Currently: morning brief (DM), nudge surfacer (to General), auto-tag reconcile (silent) all run separately
+   - Consolidate into one "morning report" that combines tasks + stale captures + overdue items + commits in one DM
+   - Eliminates redundancy and ensures Zaal sees all morning context in one place
+   - Owner: Agent (refactor +1 sprint)
+   - Timeline: Post-sprint
+
+7. **Document cron design intent in a separate doc**
+   - Current: scheduler.ts has inline comments, but no holistic doc of "which jobs are critical? which are experimental?"
+   - Recommend: research doc "Cron job tiers" (CRITICAL vs HIGH vs MEDIUM vs EXPERIMENTAL) + retirement policy
+   - Owner: Zaal + assistant
+   - Timeline: Next month planning
+
+8. **Implement Devz tip cron** (Phase 4)
+   - Uncomment and implement the devz tip generation (similar to brief.ts but for Devz group)
+   - Or remove the stub if Devz tips are no longer needed
+   - Owner: Agent + Zaal approval
+   - Timeline: Phase 4 planning
+
+## State Summary (2026-07-12 03:00 UTC)
+
+- **ZOE process:** 10 cron tasks running (up from 7, possibly due to recent additions)
+- **Most reliable:** morning brief, evening reflection, watcher (daily fire rate 100%)
+- **Most problematic:** reflexion capture (auth broken), nudges (disabled), reasoning tick (silent)
+- **Backlog:** work-loop-count.json shows quota met; work-queue empty; no pending research items awaiting queue
+- **Pendingapprovals:** 2026-07-12 01:00 entry exists (likely evening reflection just armed)
+
+## Data Usage: The 5.8:1 Ratio
+
+From user memory (feedback_assistant_operating_model): research-to-ship ratio is 5.8:1, meaning "lots of research, little shipping." Cross-referenced with this audit:
+
+- **Research produced:** work-loop doing 1-3 ticks/day, generating docs daily (docs 1028-1035 landed in last 10 days = ~1 per day)
+- **Research consumed:** git log shows 8 research docs merged in 10 days, but also shows many pending/needs-revision states in work-loop runs
+- **The gap:** Morning brief, evening reflection, and escalations arm Zaal with decision context, but downstream conversion (context → decision → execution → shipped) is slow
+- **Scheduler's role:** Briefs + reflections are working (CONSUMED), but everything else (nudges, reasoning, learn proposals) appears to be generating data that doesn't flow into decisions
+
+## Next Validation Check (Recommended: Jul 19)
+
+- [ ] Has reflexion capture recovered? Check pending-approvals.json for "await-reflection" entries
+- [ ] Are nudges still disabled or re-enabled?
+- [ ] Reasoning tick: any speaks in the past week? Check proactive-log.jsonl for "speak:true"
+- [ ] Process restarts: still 40+/3 days or stabilized?
+- [ ] Learn cycle: any proposals approved/declined since Jul 5?
+
+---
+
+**Drafted by:** Claude Code Auditor  
+**Evidence sources:** journalctl (zoe-bot, 3 days), ~/.zao/zoe/ state files, scheduler.ts code review, git history (main branch, last 10 days)  
+**Tier:** STANDARD (factual audit, no recommendations beyond what's grounded in evidence)


### PR DESCRIPTION
Audit of ZOE's 10+ scheduled cron jobs.

Per-job verdict: 3 CONSUMED, 3 PARTIALLY CONSUMED, 4 SILENT/BROKEN, 1 PENDING.

CONSUMED: morning brief, evening reflection, watcher (all firing daily + Zaal acts on them).

BROKEN: reflexion capture (auth errors), nudges (disabled since 2026-05-15), reasoning tick (fires 100+x/48h but never speaks), process churn (40+ restarts/3d).

SLOW: work-loop (1/day cap, 5.8:1 research-to-ship ratio) - consumed but slow.

UNKNOWN: learn cycle (produces proposals), orchestrator tick (disabled?), posts scheduler, escalation resend (no visible logs), handoff surfacer (posts to unknown-if-read topic).

RECOMMENDATIONS:
1. Fix reflexion auth (CRITICAL) - blocking evening reflection → memory loop
2. Un-disable/document nudges (HIGH)
3. Lower reasoning threshold (MEDIUM) - too many silent ticks
4. Stabilize process (MEDIUM) - investigate 40+ restarts/3 days
5. Consolidate morning reports (LOW) - merge brief + nudges into one DM

Tier: STANDARD
See research/agents/1038-zoe-scheduler-audit.md for full per-job table and evidence.