### PR TITLE
feat(zoe): orchestrator Stage 2 - act on answers

### DIFF
--- a/bot/src/zoe/__tests__/orchestrator-tick.test.ts
+++ b/bot/src/zoe/__tests__/orchestrator-tick.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { detectNewAnswers, decideNextQuestion, runOrchestratorTick } from '../orchestrator-tick';
+import { detectNewAnswers, decideNextQuestion, runOrchestratorTick, classifyAnswer, type AnswerAction } from '../orchestrator-tick';
+import * as workLoop from '../work-loop';
 
 // Override ZOE_HOME for testing
 const testHome = join(tmpdir(), `zoe-test-${Date.now()}`);
@@ -114,6 +115,73 @@ describe('decideNextQuestion', () => {
   });
 });
 
+describe('classifyAnswer (Stage 2)', () => {
+  it('classifies task-uuid with done value as board_done', () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc';
+    const action = classifyAnswer(`task-${uuid}`, 'done');
+    expect(action.kind).toBe('board_done');
+    expect(action.taskId).toBe(uuid);
+  });
+
+  it('accepts complete and ship as board_done dispositions', () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc';
+    const a1 = classifyAnswer(`task-${uuid}`, 'complete');
+    const a2 = classifyAnswer(`task-${uuid}`, 'SHIP');
+    expect(a1.kind).toBe('board_done');
+    expect(a2.kind).toBe('board_done');
+  });
+
+  it('rejects task-uuid if value is not a disposition', () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc';
+    const action = classifyAnswer(`task-${uuid}`, 'not-done');
+    // Should fall through to ask_next or skip
+    expect(action.kind).not.toBe('board_done');
+  });
+
+  it('rejects malformed task-* qids', () => {
+    const action = classifyAnswer('task-not-a-uuid', 'done');
+    expect(action.kind).not.toBe('board_done');
+  });
+
+  it('classifies research-* qids as research', () => {
+    const action = classifyAnswer('research-topic', 'my research topic');
+    expect(action.kind).toBe('research');
+    expect(action.topic).toBe('my research topic');
+  });
+
+  it('uses empty default topic for research- qid with no value', () => {
+    const action = classifyAnswer('research-audit', '');
+    expect(action.kind).toBe('research');
+    expect(action.topic).toBe('General research');
+  });
+
+  it('classifies known qid-value pairs as ask_next', () => {
+    const action = classifyAnswer('q-priority-what', 'Research');
+    expect(action.kind).toBe('ask_next');
+    expect(action.nextQuestion?.qid).toBe('q-priority-research-depth');
+  });
+
+  it('classifies unknown rules as skip', () => {
+    const action = classifyAnswer('unknown-qid', 'unknown-value');
+    expect(action.kind).toBe('skip');
+  });
+
+  it('prioritizes board_done over ask_next for task qids', () => {
+    const uuid = '12345678-1234-1234-1234-123456789abc';
+    const action = classifyAnswer(`task-${uuid}`, 'done');
+    // Even if 'done' might match a rule, it should be board_done, not ask_next
+    expect(action.kind).toBe('board_done');
+    expect(action.taskId).toBe(uuid);
+  });
+
+  it('prioritizes research over ask_next for research-* qids', () => {
+    const action = classifyAnswer('research-scope', 'Market analysis');
+    // Should be research, not try to match against ask_next rules
+    expect(action.kind).toBe('research');
+    expect(action.topic).toBe('Market analysis');
+  });
+});
+
 describe('runOrchestratorTick', () => {
   it('is a no-op when ZOE_ORCHESTRATOR_ENABLED !== "true"', async () => {
     process.env.ZOE_ORCHESTRATOR_ENABLED = 'false';
@@ -183,5 +251,126 @@ describe('runOrchestratorTick', () => {
     });
 
     expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('executes ask_next action (posts next question)', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+
+    // Set up state file with a past timestamp so new answers are detected
+    const statePath = join(testHome, 'orchestrator-state.json');
+    await fs.mkdir(testHome, { recursive: true });
+    await fs.writeFile(statePath, JSON.stringify({ lastSeenTs: '2026-01-01T00:00:00Z' }));
+
+    // Create recent file with an answer that matches a rule
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+    const turns = [
+      { from: 'zaal', text: '[answer:q-priority-what] Research', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    // Should have posted the next question (q-priority-research-depth)
+    expect(mockBot.api.sendMessage).toHaveBeenCalledWith(
+      12345,
+      'How deep should the research go?',
+      expect.objectContaining({
+        reply_markup: expect.any(Object),
+      }),
+    );
+  });
+
+  it('executes research action (enqueues work)', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'true';
+    const enqueueSpy = vi.spyOn(workLoop, 'enqueueWork').mockResolvedValue({
+      id: 'wk-test',
+      kind: 'research' as const,
+      input: 'test topic',
+      addedTs: new Date().toISOString(),
+    });
+
+    // Set up state file with a past timestamp
+    const statePath = join(testHome, 'orchestrator-state.json');
+    await fs.mkdir(testHome, { recursive: true });
+    await fs.writeFile(statePath, JSON.stringify({ lastSeenTs: '2026-01-01T00:00:00Z' }));
+
+    // Create recent file with research-* qid
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+    const turns = [
+      { from: 'zaal', text: '[answer:research-topic] AI alignment best practices', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn().mockResolvedValue({}),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    // Should have enqueued work
+    expect(enqueueSpy).toHaveBeenCalledWith('AI alignment best practices');
+    // Should have posted confirmation
+    expect(mockBot.api.sendMessage).toHaveBeenCalledWith(12345, expect.stringContaining('Queued research'));
+
+    enqueueSpy.mockRestore();
+  });
+
+  it('respects disabled flag for all actions', async () => {
+    process.env.ZOE_ORCHESTRATOR_ENABLED = 'false';
+
+    // Create recent file with multiple answer types
+    await fs.mkdir(testRecentDir, { recursive: true });
+    const recentPath = join(testRecentDir, '12345.json');
+    const turns = [
+      { from: 'zaal', text: '[answer:q-priority-what] Research', ts: '2026-01-02T00:00:00Z', sender: 'zaalbotz-btn' },
+      { from: 'zaal', text: '[answer:research-topic] test', ts: '2026-01-03T00:00:00Z', sender: 'zaalbotz-btn' },
+    ];
+    await fs.writeFile(recentPath, JSON.stringify(turns));
+
+    const enqueueSpy = vi.spyOn(workLoop, 'enqueueWork').mockResolvedValue({
+      id: 'wk-test',
+      kind: 'research' as const,
+      input: 'test',
+      addedTs: new Date().toISOString(),
+    });
+
+    const mockBot = {
+      api: {
+        sendMessage: vi.fn(),
+      },
+    };
+
+    await runOrchestratorTick({
+      bot: mockBot as any,
+      groupId: 12345,
+      zaalTgId: 9876,
+      now: new Date(),
+    });
+
+    // Should NOT have done anything
+    expect(mockBot.api.sendMessage).not.toHaveBeenCalled();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    enqueueSpy.mockRestore();
   });
 });

--- a/bot/src/zoe/orchestrator-tick.ts
+++ b/bot/src/zoe/orchestrator-tick.ts
@@ -1,16 +1,22 @@
 /**
- * orchestrator-tick.ts - VPS cron tick for the durable orchestrator (Stage 1).
+ * orchestrator-tick.ts - VPS cron tick for the durable orchestrator.
+ *
+ * Stage 1 (shipped): detects Zaal's tapped answers + posts next questions.
+ * Stage 2 (this file): ACTS on answers - enqueues research, marks tasks done, or asks next question.
  *
  * When ZOE_ORCHESTRATOR_ENABLED === 'true', this runs every 5 min via cron
  * to drive a one-question-at-a-time loop autonomously. Zaal taps answers to
  * button questions in ZAAL BOTZ Claude Code topic; the tick detects those
- * answers and posts the next question based on simple rules.
+ * answers and classifies them into ACTIONS (research, board_done, ask_next).
  *
- * Design (from scout):
+ * Design:
  *  - Read recent/<group_id>.json for Zaal's tapped answers ([answer:qid] format)
  *  - Detect NEW answers since the last stored pointer (lastSeenTs)
- *  - Decide the next question via a simple rule table (v1, no LLM)
- *  - Post the next question with tappable buttons (reusing questions.ts)
+ *  - Classify each answer via classifyAnswer() -> AnswerAction
+ *  - Execute the action:
+ *    * research: call enqueueWork(topic) to queue research for the work loop
+ *    * board_done: PATCH the team tracker task to status 'done'
+ *    * ask_next: post the next question with buttons (Stage 1 behavior)
  *  - Update state pointer
  *
  * Safe by design:
@@ -19,7 +25,8 @@
  *  - Empty queue = no messages
  *  - File-locked (one-instance only, mirrors work-loop.ts pattern)
  *  - Daily cap (ZOE_ORCHESTRATOR_DAILY, default 20)
- *  - Never posts/DMs/casts/spends/on-chain — only posts button questions
+ *  - Best-effort: one action failure doesn't kill the tick
+ *  - Never: LLM calls, posts to Farcaster/X, DMs outside General, casts, spends, on-chain, merges PRs, builds/writes code
  */
 
 import { promises as fs } from 'node:fs';
@@ -27,6 +34,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { parseQuestionCallback, questionKeyboard, encodeQuestion, type ParsedQuestion } from './questions';
 import { pushRecent, ZOE_PATHS } from './memory';
+import { enqueueWork } from './work-loop';
 
 const ORCHESTRATOR_STATE_PATH = (): string =>
   join(process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe'), 'orchestrator-state.json');
@@ -136,6 +144,69 @@ const DECISION_TABLE: Array<{
     options: ['Intro call', 'Deep discussion', 'Deal stage'],
   },
 ];
+
+/**
+ * Stage 2: ACTION classification. Maps (qid, value) -> action (research, board_done, ask_next, skip).
+ * Each action carries what's needed to execute it.
+ */
+export interface AnswerAction {
+  kind: 'research' | 'board_done' | 'ask_next' | 'skip';
+  topic?: string; // for research: the topic to enqueue
+  taskId?: string; // for board_done: the task uuid
+  nextQuestion?: { qid: string; options: string[] }; // for ask_next
+}
+
+/**
+ * Check if a string looks like a valid UUID (8-4-4-4-12 hex).
+ */
+function isValidUuid(s: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}
+
+/**
+ * Parse a qid that encodes a task id (format: 'task-<uuid>').
+ * Returns the uuid or null if not a task qid.
+ */
+function parseTaskQid(qid: string): string | null {
+  if (!qid.startsWith('task-')) return null;
+  const uuid = qid.slice(5);
+  return isValidUuid(uuid) ? uuid : null;
+}
+
+/**
+ * Classify an answer into an ACTION: research, board_done, ask_next, or skip.
+ * Pure function (no I/O), unit-testable.
+ *
+ * Rules:
+ *  - If qid = 'task-<uuid>' and value in {done, complete, ship}, return board_done
+ *  - If qid starts with 'research-' or value looks like a research topic, return research
+ *  - Else if decideNextQuestion returns a match, return ask_next
+ *  - Else return skip
+ */
+export function classifyAnswer(qid: string, value: string): AnswerAction {
+  // Check for board_done first: task-<uuid> with disposition value
+  const taskId = parseTaskQid(qid);
+  if (taskId) {
+    const disposition = value.toLowerCase().trim();
+    if (['done', 'complete', 'ship'].includes(disposition)) {
+      return { kind: 'board_done', taskId };
+    }
+  }
+
+  // Check for research: qid starts with 'research-' or value is non-empty
+  if (qid.startsWith('research-')) {
+    return { kind: 'research', topic: value || 'General research' };
+  }
+
+  // Try to match a next-question rule (Stage 1 behavior)
+  const nextQuestion = decideNextQuestion(qid, value);
+  if (nextQuestion) {
+    return { kind: 'ask_next', nextQuestion };
+  }
+
+  // No rule matched; skip silently
+  return { kind: 'skip' };
+}
 
 export interface OrchestratorState {
   lastSeenTs: string;
@@ -259,6 +330,97 @@ export function decideNextQuestion(
 }
 
 /**
+ * Stage 2: Enqueue research via the work-loop's existing pipeline.
+ * Best-effort; logs on failure but doesn't throw.
+ */
+async function actionEnqueueResearch(topic: string): Promise<boolean> {
+  try {
+    const item = await enqueueWork(topic);
+    console.log(`[zoe/orchestrator] enqueued research: "${topic}" (${item.id})`);
+    return true;
+  } catch (err) {
+    console.error('[zoe/orchestrator] failed to enqueue research:', (err as Error)?.message);
+    return false;
+  }
+}
+
+/**
+ * Stage 2: Mark a team tracker task as done via PATCH.
+ * Requires COWORK_TRACKER_URL and COWORK_TRACKER_KEY env vars.
+ * Best-effort; returns false on any error.
+ */
+async function actionMarkTaskDone(taskId: string): Promise<boolean> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) {
+    console.log(`[zoe/orchestrator] tracker not configured, skip board update for ${taskId}`);
+    return false;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    const url = `${base.replace(/\/$/, '')}/rest/v1/tasks?id=eq.${taskId}`;
+    const res = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({ status: 'done' }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+
+    if (res.ok) {
+      console.log(`[zoe/orchestrator] marked task ${taskId} as done`);
+      return true;
+    }
+
+    console.error(`[zoe/orchestrator] tracker PATCH ${taskId} returned ${res.status}`);
+    return false;
+  } catch (err) {
+    console.error(
+      '[zoe/orchestrator] failed to mark task done:',
+      (err as Error)?.message,
+    );
+    return false;
+  }
+}
+
+/**
+ * Stage 2: Post a brief confirmation message to the group after executing an action.
+ * Best-effort; doesn't throw.
+ */
+async function postActionConfirmation(
+  deps: OrchestratorTickDeps,
+  action: AnswerAction,
+  answer: { qid: string; value: string },
+): Promise<void> {
+  let msg = '';
+  switch (action.kind) {
+    case 'research':
+      msg = `Queued research: ${action.topic}`;
+      break;
+    case 'board_done':
+      msg = `Marked task done.`;
+      break;
+    case 'ask_next':
+      // No confirmation for ask_next; the question itself is the confirmation
+      return;
+    case 'skip':
+      return;
+  }
+
+  try {
+    await deps.bot.api.sendMessage(deps.groupId, msg);
+  } catch (err) {
+    console.error('[zoe/orchestrator] failed to post confirmation:', (err as Error)?.message);
+  }
+}
+
+/**
  * Build the button question text for a given qid (simple labels, not LLM).
  */
 function questionTextFor(qid: string): string | null {
@@ -309,45 +471,77 @@ export async function runOrchestratorTick(deps: OrchestratorTickDeps): Promise<v
       return;
     }
 
-    // Process each new answer: decide next question, post it
-    let posted = 0;
+    // Stage 2: Process each new answer via action classification
+    let actioned = 0;
     for (const answer of answers) {
-      const next = decideNextQuestion(answer.qid, answer.value);
-      if (!next) {
-        console.log(
-          `[zoe/orchestrator] no rule for (${answer.qid}, "${answer.value}"), silent`,
-        );
-        continue;
-      }
+      const action = classifyAnswer(answer.qid, answer.value);
 
-      const qText = questionTextFor(next.qid);
-      if (!qText) {
-        console.log(`[zoe/orchestrator] no text for qid ${next.qid}, skip`);
-        continue;
-      }
+      switch (action.kind) {
+        case 'research':
+          // Enqueue research via work-loop pipeline
+          if (await actionEnqueueResearch(action.topic!)) {
+            actioned++;
+            await postActionConfirmation(deps, action, answer);
+          }
+          break;
 
-      try {
-        await deps.bot.api.sendMessage(deps.groupId, qText, {
-          reply_markup: questionKeyboard(next.qid, next.options),
-        });
-        posted++;
-        console.log(
-          `[zoe/orchestrator] posted ${next.qid} after answer (${answer.qid}, "${answer.value}")`,
-        );
-      } catch (err) {
-        console.error(
-          '[zoe/orchestrator] failed to post next question:',
-          (err as Error)?.message,
-        );
+        case 'board_done':
+          // Mark task as done on team tracker
+          if (await actionMarkTaskDone(action.taskId!)) {
+            actioned++;
+            await postActionConfirmation(deps, action, answer);
+          }
+          break;
+
+        case 'ask_next':
+          // Stage 1: Post the next question with buttons
+          if (!action.nextQuestion) {
+            console.log(
+              `[zoe/orchestrator] ask_next but no nextQuestion for (${answer.qid}, "${answer.value}")`,
+            );
+            break;
+          }
+
+          const qText = questionTextFor(action.nextQuestion.qid);
+          if (!qText) {
+            console.log(
+              `[zoe/orchestrator] no text for qid ${action.nextQuestion.qid}, skip`,
+            );
+            break;
+          }
+
+          try {
+            await deps.bot.api.sendMessage(deps.groupId, qText, {
+              reply_markup: questionKeyboard(action.nextQuestion.qid, action.nextQuestion.options),
+            });
+            actioned++;
+            console.log(
+              `[zoe/orchestrator] posted ${action.nextQuestion.qid} after answer (${answer.qid}, "${answer.value}")`,
+            );
+          } catch (err) {
+            console.error(
+              '[zoe/orchestrator] failed to post next question:',
+              (err as Error)?.message,
+            );
+          }
+          break;
+
+        case 'skip':
+          console.log(
+            `[zoe/orchestrator] no rule for (${answer.qid}, "${answer.value}"), silent`,
+          );
+          break;
       }
     }
+
+    const posted = actioned;
 
     if (posted > 0) {
       // Advance pointer to latest answer's timestamp
       const latestTs = answers[answers.length - 1].ts;
       await writeState({ lastSeenTs: latestTs });
       await bumpToday(dateStr);
-      console.log(`[zoe/orchestrator] tick: ${answers.length} answer(s), ${posted} question(s) posted`);
+      console.log(`[zoe/orchestrator] tick: ${answers.length} answer(s), ${posted} action(s) executed`);
     }
   } finally {
     await releaseLock();


### PR DESCRIPTION
## Summary

Extends the durable orchestrator (Stage 1) with an ACTION layer that executes three types of responses to Zaal's tapped answers:

1. **RESEARCH**: enqueue topics via the work-loop's existing autonomous research pipeline
2. **BOARD_DONE**: mark team tracker tasks as done (Supabase REST PATCH, uuid-keyed)
3. **ASK_NEXT**: post the next question with buttons (Stage 1 behavior, fallback)

## How it Works

Introduces `classifyAnswer(qid, value)` — a pure classifier that maps (answer_id, tapped_value) into one of four action types:

```
task-<uuid> + {done|complete|ship} → board_done(taskId)
research-* qid                     → research(topic)
DECISION_TABLE rule match          → ask_next(nextQuestion)
no match                           → skip (silent)
```

Executed in `runOrchestratorTick` for each new answer, within existing safety guards (disabled by default, Zaal-only, file-locked, daily-capped).

## Safety (unchanged from Stage 1)

- DISABLED by default via ZOE_ORCHESTRATOR_ENABLED env flag
- Zaal-only (silently skips non-Zaal answers)
- File-locked (one instance only, mirrors work-loop pattern)
- Daily-capped (ZOE_ORCHESTRATOR_DAILY, default 20)
- Best-effort per action (one failure doesn't cascade)
- Never: LLM calls, posts to Farcaster/X, DMs, casts, spends, on-chain, merges PRs, builds/writes code

## Testing

- classifyAnswer: unit tests for all classification branches (task uuid validation, disposition values, qid patterns, fallback to ask_next)
- runOrchestratorTick: integration tests for ask_next action (posts question), research action (enqueues work via mock), disabled flag enforcement
- All 24 tests pass
- TypeScript green (npx tsc --noEmit)
- esbuild compiles cleanly

## Files Changed

- `bot/src/zoe/orchestrator-tick.ts`: +AnswerAction interface, +classifyAnswer, +actionEnqueueResearch, +actionMarkTaskDone, +postActionConfirmation, refactored runOrchestratorTick to dispatch actions
- `bot/src/zoe/__tests__/orchestrator-tick.test.ts`: +9 classifyAnswer unit tests, +3 runOrchestratorTick integration tests

## Not Included (Stage 3)

- Concierge/LLM-based follow-up logic (requires local/remote LLM, VPS CLI auth is broken)
- Voice/audio reply handling
- Complex task creation from freetext
- Board reconciliation logic

Generated with Claude Code (Stage 2 orchestrator builder).