### PR TITLE
feat(zoe): bridge cast approvals to ZOL queue

### DIFF
--- a/bot/src/zoe/__tests__/zol-queue.test.ts
+++ b/bot/src/zoe/__tests__/zol-queue.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildZolRow } from '../zol-queue';
+
+describe('buildZolRow', () => {
+  it('truncates text to 300 chars', () => {
+    const longText = 'a'.repeat(500);
+    const row = buildZolRow(longText, 'test-id');
+    expect((row.title as string).length).toBeLessThanOrEqual(300);
+    expect(row.title).toBe('a'.repeat(300));
+  });
+
+  it('trims whitespace from title', () => {
+    const textWithSpaces = '  hello world  ';
+    const row = buildZolRow(textWithSpaces, 'test-id');
+    expect(row.title).toBe('hello world');
+  });
+
+  it('sets legacy_source to zolcast:<id>', () => {
+    const row = buildZolRow('test text', 'my-cast-id');
+    expect(row.legacy_source).toBe('zolcast:my-cast-id');
+  });
+
+  it('sets status to todo', () => {
+    const row = buildZolRow('test text', 'id1');
+    expect(row.status).toBe('todo');
+  });
+
+  it('sets project to zol', () => {
+    const row = buildZolRow('test text', 'id1');
+    expect(row.project).toBe('zol');
+  });
+
+  it('builds a complete row with all required fields', () => {
+    const row = buildZolRow('hello world', 'abc123');
+    expect(row).toEqual({
+      title: 'hello world',
+      legacy_source: 'zolcast:abc123',
+      status: 'todo',
+      project: 'zol',
+    });
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -94,6 +94,7 @@ import { STANDARD_TOPICS, readTopics, writeTopics } from './topics';
 import { routeTopic, topicNameForThread } from './topic-router';
 import { brandBoxFor, fetchIcmBrain, brandSystemPreamble } from './brand-brain';
 import { appendApproved } from './outbox';
+import { enqueueZolCast } from './zol-queue';
 import { dispatchHermesRun } from '../hermes/runner';
 import { putDraft, getDraft, removeDraft, draftKeyboard, parseDraftCallback } from './drafts';
 import { parseQuestionCallback } from './questions';
@@ -500,9 +501,14 @@ bot.on('callback_query:data', async (ctx) => {
       return null;
     });
     if (channel === 'cast') {
-      await ctx.answerCallbackQuery({ text: 'Approved - queued to cast.' });
+      // Enqueue the cast for @zolbot to pick up from the cowork tracker.
+      // Best-effort - if this fails, the cast is still in the outbox.jsonl.
+      await enqueueZolCast(draft.text).catch((e) => {
+        console.error('[zoe/index] zol queue enqueue failed:', (e as Error)?.message);
+      });
+      await ctx.answerCallbackQuery({ text: 'Approved - queued for @zolbot.' });
       await ctx
-        .editMessageText(`[APPROVED to cast - queued, not yet sent] ${draft.text}`, {
+        .editMessageText(`[APPROVED to cast - queued for @zolbot] ${draft.text}`, {
           reply_markup: { inline_keyboard: [] },
         })
         .catch(() => {});

--- a/bot/src/zoe/zol-queue.ts
+++ b/bot/src/zoe/zol-queue.ts
@@ -1,0 +1,84 @@
+/**
+ * ZOL queue - bridge ZOE cast approvals to the cowork tracker.
+ *
+ * When Zaal approves a cast draft via ZOE, enqueueZolCast() writes a row to the
+ * cowork tracker (public.tasks) with legacy_source='zolcast:<id>'. A Pi drainer
+ * reads 'zolcast:%' rows and casts them via the signer.
+ *
+ * Config (env, server-only):
+ *   COWORK_TRACKER_URL   e.g. https://<ref>.supabase.co
+ *   COWORK_TRACKER_KEY   a Supabase key with write access to public.tasks
+ *
+ * If either is missing, enqueueZolCast() returns {ok:false} and the cast still
+ * lands in the outbox.jsonl (so it's never lost). Best-effort: never throws.
+ */
+
+export interface ZolQueueResult {
+  ok: boolean;
+  id?: string;
+  error?: string;
+}
+
+/**
+ * Build the row for an INSERT into the cowork tasks table for a ZOL cast.
+ * Pure - exported for unit testing.
+ *
+ * Row shape:
+ *   - title: first 300 chars of text
+ *   - legacy_source: "zolcast:<id>" to identify as Pi casting task
+ *   - status: "todo"
+ *   - project: "zol"
+ */
+export function buildZolRow(text: string, id: string): Record<string, unknown> {
+  return {
+    title: text.slice(0, 300).trim(),
+    legacy_source: `zolcast:${id}`,
+    status: 'todo',
+    project: 'zol',
+  };
+}
+
+/**
+ * Enqueue a cast approval for ZOL to pick up. Posts a row to the cowork tracker.
+ * Returns {ok:true,id} on success, {ok:false,error} on any failure.
+ * Best-effort: never throws, never blocks the approval path.
+ */
+export async function enqueueZolCast(text: string): Promise<ZolQueueResult> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) {
+    return { ok: false, error: 'zol queue not configured' };
+  }
+
+  const id = Date.now().toString(36);
+  const row = buildZolRow(text, id);
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    const res = await fetch(`${base.replace(/\/$/, '')}/rest/v1/tasks`, {
+      method: 'POST',
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify(row),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timer));
+
+    if (!res.ok) {
+      return { ok: false, error: `tracker returned ${res.status}` };
+    }
+
+    // Parse response to extract the id (PostgREST returns the inserted row)
+    const inserted = (await res.json()) as Array<Record<string, unknown>>;
+    const rowId = Array.isArray(inserted) && inserted.length > 0 ? String(inserted[0].id ?? id) : id;
+
+    return { ok: true, id: rowId };
+  } catch (e: unknown) {
+    const errMsg = e instanceof Error ? e.message : 'enqueue failed';
+    return { ok: false, error: errMsg };
+  }
+}


### PR DESCRIPTION
## Summary

Wire ZOE cast approvals into the cowork tracker so a Pi drainer can enqueue them for @zolbot. When Zaal taps Post on a cast draft, ZOE now:

1. Writes the approved cast to outbox.jsonl (existing behavior - honest queue)
2. Posts a row to public.tasks with legacy_source='zolcast:<id>' (NEW - Pi drainer picks up)
3. Updates the message to show "[APPROVED to cast - queued for @zolbot]"

Cast remains safe in outbox if the tracker call fails (best-effort).

## Changes

- **bot/src/zoe/zol-queue.ts** (NEW): 
  - `buildZolRow(text, id)` - pure function, exports row shape for testing
  - `enqueueZolCast(text)` - async best-effort, posts to tracker, never throws
  - Config: COWORK_TRACKER_URL + COWORK_TRACKER_KEY (Supabase write key)
  
- **bot/src/zoe/index.ts**: 
  - Import enqueueZolCast
  - Hook into cast approval path (after appendApproved)
  - Update confirmation message
  - Catch failure, log to console (doesn't block approval)

- **bot/src/zoe/__tests__/zol-queue.test.ts** (NEW):
  - Test buildZolRow for title truncation (300 char limit)
  - Test legacy_source prefix 'zolcast:'
  - Test status='todo', project='zol'

## Row shape

```json
{
  "title": "first 300 chars of cast text",
  "legacy_source": "zolcast:<timestamp36id>",
  "status": "todo",
  "project": "zol"
}
```

## Test plan

- [x] tsc --noEmit passes (0 errors, no `any`)
- [x] Tests pass (buildZolRow truncation, prefix, tags)
- [x] Cast approval path updated (appendApproved + enqueueZolCast both called)
- [x] Message reflects new behavior ("queued for @zolbot")
- [x] Newsletter approval unchanged (best-effort pattern only affects 'cast' channel)
- [x] No secrets leaked (env vars read safely, no PII)

DO NOT merge yet. Pi-side drainer needs to be wired up separately.

Generated by Claude Code
https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3