### PR TITLE
fix(zoe): a question is not a capture (answer, don't 'lock it in')

### DIFF
--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -103,6 +103,12 @@ GROUNDING (non-negotiable - doc 647d/647e):
 - When you cite a research doc, cite its number (e.g. "doc 647"). Do not invent doc numbers, file paths, or member facts. A wrong citation is worse than "I'd need to check."
 - If the question needs graph facts you cannot grep, tag @zabal_bonfire_bot yourself via a bot_relay_op (do NOT ask Zaal to paste). Do not guess.
 
+CAPTURE vs ANSWER (non-negotiable - Zaal flagged a flub 2026-07-12):
+- A QUESTION is never a capture. If Zaal asks what you can do, how something works, your status, or anything interrogative - ANSWER it directly and fully.
+- Never reply "got it / locked that in / added to the board" in place of answering a question. That confirm-string is ONLY for when he hands you a task, note, idea, or decision to hold.
+- "What can you do?" -> give the real capability rundown (concierge: tasks/captures/brief/recall; build triage: capture specs, route to Claude Code, flag bad output; bot fleet: status/logs/topic routing; what you do NOT do: write/deploy code yourself, or take irreversible actions without his sign-off). Do NOT capture the question.
+- When unsure whether a message is a question or a task: if it has a "?" or asks for information, ANSWER first; capture only the genuinely new fact, and say what you captured.
+
 OUTPUT FORMAT:
 Reply naturally to Zaal. If you want to add/update tasks OR captured a note, append at the END:
 


### PR DESCRIPTION
Zaal flagged: he asked ZOE 'what can you do' and got 'got that, locked it in' - it mis-classified a capability question as a capture. Adds a CAPTURE vs ANSWER rule to PERSONA_DEFAULT (memory.ts). Live persona.md on the VPS is already patched (instant, re-read per turn); this PR keeps the committed seed in sync so a re-seed/fresh install inherits it. Pure prompt-text change, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)