### PR TITLE
security: cowork tracker RLS hardening proposal (REVIEW ONLY, do not apply blind)

### DIFF
--- a/research/security/1024-cowork-tracker-rls-hardening/README.md
+++ b/research/security/1024-cowork-tracker-rls-hardening/README.md
@@ -1,0 +1,386 @@
+# Doc 1024: ZAOstock Cowork Tracker RLS Hardening Proposal
+
+**Date:** 2026-07-12  
+**Tier:** SECURITY (CRITICAL)  
+**Status:** REVIEW ONLY - Do Not Apply Blind  
+**Author:** Claude Code (Security Audit)  
+**Related:** Doc 841 (ZAOOS over-audit 2026-06), Secret Hygiene rules
+
+---
+
+## Executive Summary
+
+The ZAOstock cowork tracker database (Supabase project `etwvzrmlxeobinrlytza`) has a critical RLS (Row-Level Security) exposure: 13 tables allow ANY holder of an authenticated Supabase token to read and write ALL rows, with zero ownership scoping.
+
+**Tables exposed:**
+- activity_log, artists, budget_entries, circle_members, circles, contact_log, goals, meeting_notes, sponsors, suggestions, tasks (stock_todos), team_members, volunteers
+
+**Policy pattern:** Each table has a single policy named `<table>_authenticated_all` with:
+- Command: ALL (SELECT, INSERT, UPDATE, DELETE)
+- Role: authenticated
+- USING: true
+- WITH CHECK: true
+
+**Blast radius:** Any developer with the Supabase project's anon key, or any compromised frontend code, can directly write to every row of every table. This is the same exposure class as a prior ZAOcowork incident.
+
+**Recommended fix:** Two cases, determined by the app's authentication model. This proposal documents both; a developer must choose one based on code review.
+
+---
+
+## The Exposure
+
+### Verification
+
+Exposure verified 2026-07-12 via read-only query of the live Supabase project:
+```sql
+SELECT tablename, policyname, cmd, roles, qual, with_check
+FROM pg_policies
+WHERE tablename IN (
+  'activity_log', 'artists', 'budget_entries', 'circle_members', 'circles',
+  'contact_log', 'goals', 'meeting_notes', 'sponsors', 'suggestions',
+  'tasks', 'team_members', 'volunteers'
+)
+AND policyname LIKE '%authenticated_all%';
+```
+
+All 13 rows returned: `cmd=ALL, roles=authenticated, qual=true, with_check=true`.
+
+### Why It Matters
+
+The Supabase project is internet-facing. The anon key is already public (embedded in client-side code). An attacker with the anon key could:
+
+1. **Read all team data:** Member names, email, phone, roles, meeting notes, sponsor deal terms, artist contacts, budget details, etc.
+2. **Corrupt data:** Modify artist status, budget entries, team member roles, sponsor contact info, etc.
+3. **Inject false records:** Add fake volunteers, meetings, contacts, goals, etc.
+4. **Enumerate relationships:** Discover circle memberships, sponsor-artist pairings, team structures via reverse engineering the schema.
+
+The cowork app is team-internal (not public-facing), so the data is NOT meant to be accessed directly from the browser. All mutations should go through authenticated API routes on the server.
+
+### Root Cause
+
+The Supabase project was bootstrapped with "Service role full access" policies for all tables (see `scripts/archive/2026-04-25-cleanup/stock-schema.sql`). These were later changed to permissive authenticated ALL policies, either:
+- By a migration that wasn't tracked in ZAOOS
+- By direct Supabase dashboard edits (no git history)
+- By an accident/drift during project setup
+
+The policies were never hardened after the project went live.
+
+---
+
+## The App's Auth Model
+
+To choose the right fix, review the app's auth pattern:
+
+### Current Pattern (Verified)
+
+**Iron-session + Service Role:**
+- Client authentication: iron-session cookies (server-side, not Supabase auth)
+- Database access: `getSupabaseAdmin()` / `supabaseAdmin` (service role key)
+- Example: `src/lib/stock/members.ts` calls `getSupabaseAdmin().from('stock_sponsors').select(...)`
+- All mutations happen via server routes, not direct browser-to-DB queries
+
+This means the app is in **CASE B** (service-role-only).
+
+### Alternative Pattern (Hypothetical)
+
+If the app instead used Supabase auth directly (each user a Supabase auth UUID), RLS policies could scope writes by `owner_id = auth.uid()`. This would be **CASE A** (per-user auth). The codebase does NOT currently use this pattern.
+
+---
+
+## Two Fix Cases
+
+Both cases remove the overly permissive authenticated ALL policies. The difference is what replaces them.
+
+### Case A: Per-User Auth with Ownership Scoping
+
+**Apply this if:**
+- Each team member authenticates as a Supabase auth user (auth.uid() is meaningful)
+- Tables have ownership columns that map to auth.uid() (e.g., owner_id, created_by, user_id)
+- Writes should be scoped by owner (you can only write rows you own)
+- Reads are team-wide (you can read all rows to see shared data)
+
+**Example policies:**
+```sql
+-- Scoped write: owner_id must equal your auth.uid()
+CREATE POLICY "todos_owner_write" ON stock_todos
+  FOR UPDATE
+  USING (owner_id = auth.uid())
+  WITH CHECK (owner_id = auth.uid());
+
+-- Team read: any authenticated user can select
+CREATE POLICY "todos_team_read" ON stock_todos
+  FOR SELECT
+  USING (true);
+```
+
+**Challenges for ZAOOS:**
+- The app uses iron-session, not Supabase auth. There's no `auth.uid()` column in team_members.
+- Would need a user_mapping table or a schema change to tie Supabase auth users to team members.
+- Column naming varies (owner_id, created_by, outreach_by, recruited_by, contacted_by, actor_id, etc.).
+- Some tables have no ownership column at all (budget_entries, goals, suggestions).
+
+**Recommendation:** Only use CASE A if you plan to migrate the app to Supabase auth. Current auth model doesn't support it.
+
+### Case B: Service-Role-Only (Current App Pattern)
+
+**Apply this if:**
+- The app uses service role (`supabaseAdmin`) for all mutations
+- The client (browser) has NO direct write access to these tables
+- Client reads are optional (can be read-only or disabled entirely)
+
+**Policy approach:**
+1. Drop all permissive authenticated ALL policies
+2. Keep service-role full access (or add it if missing)
+3. If client-side reads are needed (e.g., listings), add scoped authenticated SELECT policies
+
+**Example policies:**
+```sql
+-- Service role (server-side) can do anything
+-- (This is the default when RLS is enabled and no policies forbid it)
+
+-- Client can read (if listing page needs current data)
+-- Decide: READ-ONLY, or NOTHING (cached data only)
+-- For now, we recommend NOTHING (reads via API route + cache)
+
+-- Client cannot write (all writes must go through /api/stock/... routes)
+```
+
+**Implementation notes:**
+- The app currently uses `getSupabaseAdmin()` everywhere (verified in `src/lib/stock/`).
+- Reads from the client can be:
+  - **Full reads:** Add `CREATE POLICY "read_all" FOR SELECT USING (true)`
+  - **Read-only:** Already enforced at the API level; no UPDATE/DELETE/INSERT policies
+  - **Disabled:** Client never queries directly; reads via API route + cache
+- Writes are always server-side (service role bypasses RLS anyway).
+
+**Recommendation:** CASE B is the right fix for the current app. No auth schema changes needed.
+
+---
+
+## The Hardening Script
+
+**File:** `scripts/cowork-rls-hardening.sql`  
+**Status:** REVIEW ONLY - do not apply blind
+
+The script includes:
+
+1. **Guard:** Will not run without setting `app.apply_rls_hardening='1'` (prevents accidents)
+2. **Case A block** (commented out): Per-user auth with scoped policies
+3. **Case B block** (active): Service-role-only, drop permissive ALL policies
+4. **Verification query:** Check policies after hardening
+5. **Rollback section** (commented out): How to revert if needed
+
+### How to Apply
+
+1. **Determine your case:** Review `src/lib/auth/stock-team-session.ts` and `src/lib/stock/*.ts`
+2. **Choose Case A or B:** (Case B recommended for current app)
+3. **Test first:** Apply to a Supabase staging/branch database
+4. **Verify reads/writes:** Ensure the cowork app still functions after hardening
+5. **Review columns:** If using CASE A, verify ownership column names match the code
+6. **Opt-in explicitly:** Set `app.apply_rls_hardening='1'` before running
+7. **Apply to production:** In a low-usage window, after human review
+
+### Guard Mechanism
+
+The script will not execute unless a reviewer explicitly opts in:
+
+```sql
+-- SET SESSION app.apply_rls_hardening = '1';
+-- \include scripts/cowork-rls-hardening.sql
+```
+
+This prevents accidents from copy-pasting or CI pipelines auto-applying security scripts.
+
+---
+
+## Secondary Issues
+
+### 1. SECURITY DEFINER Function: `rls_auto_enable`
+
+**Finding:** A function named `rls_auto_enable` has the SECURITY DEFINER flag and is executable by anon/authenticated roles.
+
+**Risk:** SECURITY DEFINER functions execute with the creator's privileges. If anon/authenticated can execute `rls_auto_enable`, they could run database operations as the function owner (likely service role).
+
+**Action:** Review what `rls_auto_enable` does. If it's not meant for client use, revoke anon/authenticated execute privileges:
+
+```sql
+REVOKE EXECUTE ON FUNCTION rls_auto_enable() FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION rls_auto_enable() TO service_role;
+```
+
+### 2. Functions with Mutable Search Path
+
+**Finding:** Some functions may have mutable `search_path` (non-immutable, `provolatility != 'i'`) and `SECURITY DEFINER` set.
+
+**Risk:** Unintended table access via injected schema/function names in parameters.
+
+**Action:** Find these:
+
+```sql
+SELECT proname, provolatility, prosecdef
+FROM pg_proc
+WHERE prosecdef = true
+  AND provolatility != 'i';
+```
+
+Review each one. If immutability is possible (function doesn't change behavior), mark it as `IMMUTABLE`. If SECURITY DEFINER is not needed, remove it.
+
+---
+
+## Test-First Runbook
+
+### Step 1: Create a Staging Branch
+
+In Supabase, create a preview/branch database (if available):
+```
+Supabase Dashboard > Branches > Create Preview
+```
+
+Or use a separate test project.
+
+### Step 2: Apply the Hardening Script
+
+```bash
+# Set opt-in flag
+set -a
+export PGPASSWORD="<supabase-password>"
+set +a
+
+# Determine your case (A or B)
+# Review scripts/cowork-rls-hardening.sql carefully
+
+# Apply (example for Case B)
+psql -h <db-host> -U postgres -d postgres -f scripts/cowork-rls-hardening.sql \
+  -v "ON_ERROR_STOP=1"
+```
+
+Or directly in Supabase SQL Editor (copy-paste with guard opt-in).
+
+### Step 3: Verify Policies
+
+Run the verification query from the script:
+
+```sql
+SELECT table_name, policy_name, action, roles
+FROM pg_policies
+WHERE table_name IN (
+  'activity_log', 'artists', 'budget_entries', 'circle_members', 'circles',
+  'contact_log', 'goals', 'meeting_notes', 'sponsors', 'suggestions',
+  'tasks', 'team_members', 'volunteers'
+)
+ORDER BY table_name, action;
+```
+
+**Expected:** No rows with `action='ALL'` and `roles='authenticated'`.
+
+### Step 4: Test the Cowork App
+
+On the staging database, run the cowork app:
+
+```bash
+# Redirect DB to staging
+export SUPABASE_URL="<staging-project-url>"
+export SUPABASE_ANON_KEY="<staging-anon-key>"
+export SUPABASE_SERVICE_ROLE_KEY="<staging-service-role-key>"
+
+npm run dev
+
+# Open cowork tracker
+# http://localhost:3000/spaces/stock-team-dashboard
+
+# Test reads:
+# - Can you load the dashboard?
+# - Can you see artists, sponsors, volunteers, goals, etc.?
+
+# Test writes (as team member):
+# - Can you add/edit an artist?
+# - Can you add a sponsor contact log entry?
+# - Can you add a goal?
+
+# If using Case A (per-user auth):
+# - Can you only edit your own records?
+```
+
+### Step 5: Monitor for Errors
+
+Watch the app logs and Supabase logs for RLS policy errors:
+
+```
+Failed to read from table: insufficient privileges
+42501 (insufficient_privileges)
+```
+
+If these appear, you may have scoped the policies too narrowly. Adjust and re-test.
+
+### Step 6: Coordinate a Production Window
+
+Once staging is solid:
+1. Schedule a 30-minute maintenance window during low-usage time (2-4am PT, typical)
+2. Notify the team via Telegram
+3. Apply the hardening script to production
+4. Run verification query
+5. Do a quick smoke test of the cowork app
+6. Announce completion
+
+---
+
+## Rollback Plan
+
+If the hardening script causes issues:
+
+1. **In Supabase SQL Editor**, run the rollback section from the script (currently commented out)
+2. **OR**, recreate the original policies:
+   ```sql
+   CREATE POLICY "activity_log_authenticated_all" ON activity_log
+     FOR ALL USING (true) WITH CHECK (true);
+   -- ... repeat for all 13 tables
+   ```
+
+The rollback will restore full access to authenticated roles (same as before). Be prepared to roll back within 5 minutes if the app breaks.
+
+**Note:** Always test rollback on staging first. Ensure you can apply and revert cleanly.
+
+---
+
+## Ownership and Next Steps
+
+- **PR:** `security: cowork tracker RLS hardening proposal (REVIEW ONLY, do not apply blind)` will be opened as a community review
+- **Decider:** Zaal (project lead) must choose Case A or B based on auth model
+- **Implementer:** Developer with Supabase admin access applies to staging, verifies, then production
+- **Followup:** After hardening is live, implement secondary fixes (rls_auto_enable, search_path)
+
+---
+
+## References
+
+- Supabase RLS docs: https://supabase.com/docs/guides/auth/row-level-security
+- ZAOOS security rules: `.claude/rules/secret-hygiene.md`, `api-routes.md`
+- Prior ZAOOS RLS fix: `scripts/spaces-rls-hardening.sql`
+- Incident precedent: Prior ZAOcowork RLS exposure (exact doc number not found, but noted in exposure brief)
+
+---
+
+## Appendix: Table Schema Recap
+
+For reference, the 13 exposed tables and their key columns:
+
+| Table | Key Columns | Ownership Column | Notes |
+|-------|-------------|------------------|-------|
+| activity_log | id, fid, activity_type, activity_date | N/A (read-only audit) | Team-wide read only |
+| artists | id, name, status, outreach_by | outreach_by | Shared team write |
+| budget_entries | id, type, category, amount, status | N/A (shared) | Shared team write |
+| circle_members | member_id, circle_id | N/A (FK join) | Shared team read/write |
+| circles | id, slug, name, coordinator_member_id | N/A (shared, coords rotate) | Shared team read/write |
+| contact_log | id, entity_type, entity_id, contacted_by | contacted_by | Shared team write, attributed to actor |
+| goals | id, title, status, category | N/A (shared) | Shared team read/write |
+| meeting_notes | id, meeting_date, title, created_by | created_by | Attributed to author |
+| sponsors | id, name, status, amount_committed, owner_id | owner_id | Per-sponsor ownership |
+| suggestions | id, suggestion, status | N/A (open submission) | May allow anon submit in future |
+| tasks (stock_todos) | id, title, status, owner_id, created_by | owner_id, created_by | Per-task ownership or per-creator |
+| team_members | id, name, role, scope, active | N/A (team-wide) | Shared team read/write |
+| volunteers | id, name, role, shift, confirmed, recruited_by | recruited_by | Attributed to recruiter |
+
+---
+
+**Doc 1024 — ZAOstock Cowork Tracker RLS Hardening Proposal**  
+Prepared 2026-07-12 | CRITICAL SECURITY REVIEW | Do Not Apply Blind

--- a/scripts/cowork-rls-hardening.sql
+++ b/scripts/cowork-rls-hardening.sql
@@ -1,0 +1,227 @@
+-- ============================================================================
+-- ZAOstock Cowork Tracker RLS Hardening
+-- ============================================================================
+-- SECURITY EXPOSURE FIX (verified 2026-07-12)
+--
+-- 13 tables currently have overly permissive RLS policies allowing any
+-- authenticated Supabase token to read AND write ALL rows:
+-- activity_log, artists, budget_entries, circle_members, circles,
+-- contact_log, goals, meeting_notes, sponsors, suggestions, tasks (stock_todos),
+-- team_members, volunteers
+--
+-- Policy pattern: <table>_authenticated_all with cmd=ALL, role=authenticated,
+-- USING(true), WITH CHECK(true)
+--
+-- Net effect: any holder of an authenticated token can read/write every row
+-- with no ownership or access control scoping.
+--
+-- RISK: If the app uses service role (supabaseAdmin) for all writes, the
+-- authenticated ALL policies are unnecessary attack surface. An anon key or
+-- compromised frontend code could write directly. If the app relies on RLS
+-- for access control, the policies are missing ownership scoping entirely.
+--
+-- FIX: This script handles TWO cases explicitly. READ BOTH before applying.
+--
+-- CASE A (Per-User Auth): If each team member authenticates as their own
+-- Supabase auth user and ownership columns exist (e.g. owner_id, created_by,
+-- user_id), scope write policies by = auth.uid() and keep team-wide reads.
+-- Columns to verify before applying: see VERIFY COLUMN NAMES section below.
+--
+-- CASE B (Shared/Service Pattern): If the app uses supabaseAdmin (service
+-- role) for all mutations, remove the permissive authenticated ALL policies
+-- and grant the client only what it truly needs (read-only for listings,
+-- or nothing - writes via service role on the server).
+--
+-- INSTRUCTIONS:
+-- 1. This script WILL NOT RUN without explicit opt-in. See guard below.
+-- 2. Determine your case (A or B) by reviewing src/lib/auth/* and
+--    src/app/api routes that access these tables.
+-- 3. Uncomment ONLY the case block you need (A or B).
+-- 4. Read the VERIFY COLUMN NAMES section for your case.
+-- 5. Update column names if they differ from defaults (e.g. user_id vs owner_id).
+-- 6. Test on a Supabase branch/staging database FIRST.
+-- 7. Verify the app still works after applying (reads/writes as intended).
+-- 8. Only then apply to production in a low-usage window.
+--
+-- DO NOT RUN THIS SCRIPT BLIND. Set APPLY=1 after reviewing.
+-- ============================================================================
+
+-- ============================================================================
+-- GUARD: This script will NOT RUN unless a reviewer sets APPLY=1
+-- ============================================================================
+DO $$
+BEGIN
+  IF current_setting('app.apply_rls_hardening', true) IS NULL OR
+     current_setting('app.apply_rls_hardening', true) != '1' THEN
+    RAISE EXCEPTION 'RLS hardening guard active. Review both cases A and B above, then set app.apply_rls_hardening=1 before applying.';
+  END IF;
+END $$;
+
+BEGIN;
+
+-- ============================================================================
+-- CASE A: Per-User Auth with Ownership Scoping
+-- ============================================================================
+-- Uncomment this section ONLY if:
+-- - Each team member authenticates as a Supabase auth user
+-- - Tables have ownership columns (owner_id, created_by, user_id, etc.)
+-- - You want to scope writes by owner = auth.uid()
+--
+-- VERIFY COLUMN NAMES before uncommenting:
+-- - stock_todos / tasks: owner_id (FK to team_members.id)
+--   ISSUE: auth.uid() is a Supabase auth UUID, team_members.id is a different
+--   UUID system. You may need a user_mapping table (auth.uid() -> team_members.id)
+--   or a different scoping strategy. Verify this before applying.
+--
+-- - stock_sponsors: owner_id
+-- - stock_artists: outreach_by
+-- - stock_volunteers: recruited_by
+-- - stock_meeting_notes: created_by
+-- - stock_budget_entries: no ownership column (shared team write)
+-- - stock_activity_log: actor_id (read-only for team)
+-- - stock_contact_log: contacted_by
+-- - stock_goals: no ownership column (shared team write)
+-- - stock_suggestions: no ownership column (allow anon submit + team review)
+-- - circle_members: no direct ownership (circles are team-shared)
+-- - circles: no direct ownership (circles are team-shared)
+--
+-- NOTE: This case requires careful column naming review. If column names
+-- differ, update the policy USING/WITH CHECK clauses below.
+--
+-- UNCOMMENTING CASE A DISABLED FOR THIS DRAFT:
+-- The auth model does not appear to use Supabase auth UIDs in the codebase.
+-- See src/lib/auth/stock-team-session.ts (iron-session, not Supabase auth).
+-- Uncomment only if you change to Supabase auth with proper user_mapping.
+
+-- -- Case A: Drop all authenticated ALL policies
+-- DROP POLICY IF EXISTS "activity_log_authenticated_all" ON activity_log;
+-- DROP POLICY IF EXISTS "artists_authenticated_all" ON artists;
+-- DROP POLICY IF EXISTS "budget_entries_authenticated_all" ON budget_entries;
+-- DROP POLICY IF EXISTS "circle_members_authenticated_all" ON circle_members;
+-- DROP POLICY IF EXISTS "circles_authenticated_all" ON circles;
+-- DROP POLICY IF EXISTS "contact_log_authenticated_all" ON contact_log;
+-- DROP POLICY IF EXISTS "goals_authenticated_all" ON goals;
+-- DROP POLICY IF EXISTS "meeting_notes_authenticated_all" ON meeting_notes;
+-- DROP POLICY IF EXISTS "sponsors_authenticated_all" ON sponsors;
+-- DROP POLICY IF EXISTS "suggestions_authenticated_all" ON suggestions;
+-- DROP POLICY IF EXISTS "tasks_authenticated_all" ON tasks;
+-- DROP POLICY IF EXISTS "team_members_authenticated_all" ON team_members;
+-- DROP POLICY IF EXISTS "volunteers_authenticated_all" ON volunteers;
+--
+-- -- Case A: Scoped write policies (example: stock_todos/tasks)
+-- -- VERIFY: owner_id exists and equals the user's team_members.id (via mapping)
+-- CREATE POLICY "todos_owner_write" ON stock_todos
+--   FOR UPDATE
+--   USING (owner_id = (SELECT id FROM stock_team_members WHERE auth_uid = auth.uid()))
+--   WITH CHECK (owner_id = (SELECT id FROM stock_team_members WHERE auth_uid = auth.uid()));
+--
+-- -- Case A: Shared team SELECT (reads are team-wide, but writes are scoped)
+-- CREATE POLICY "todos_team_read" ON stock_todos
+--   FOR SELECT
+--   USING (EXISTS (
+--     SELECT 1 FROM stock_team_members tm
+--     WHERE tm.auth_uid = auth.uid() AND tm.active = true
+--   ));
+
+-- ============================================================================
+-- CASE B: Service-Role-Only (Shared/Server-Side Auth)
+-- ============================================================================
+-- Uncomment this section ONLY if:
+-- - The app uses getSupabaseAdmin() / supabaseAdmin (service role) for all mutations
+-- - The client (browser) has NO direct write access to these tables
+-- - The cowork app talks to the server via API routes + iron-session
+--
+-- This is the current app architecture (verified in src/lib/auth/stock-team-session.ts
+-- and src/lib/stock/*.ts which all use getSupabaseAdmin()).
+--
+-- FIX: Remove overly permissive authenticated ALL policies. Keep reads as needed.
+--
+-- CASE B: Drop all overly permissive authenticated ALL policies
+DROP POLICY IF EXISTS "activity_log_authenticated_all" ON activity_log;
+DROP POLICY IF EXISTS "artists_authenticated_all" ON artists;
+DROP POLICY IF EXISTS "budget_entries_authenticated_all" ON budget_entries;
+DROP POLICY IF EXISTS "circle_members_authenticated_all" ON circle_members;
+DROP POLICY IF EXISTS "circles_authenticated_all" ON circles;
+DROP POLICY IF EXISTS "contact_log_authenticated_all" ON contact_log;
+DROP POLICY IF EXISTS "goals_authenticated_all" ON goals;
+DROP POLICY IF EXISTS "meeting_notes_authenticated_all" ON meeting_notes;
+DROP POLICY IF EXISTS "sponsors_authenticated_all" ON sponsors;
+DROP POLICY IF EXISTS "suggestions_authenticated_all" ON suggestions;
+DROP POLICY IF EXISTS "tasks_authenticated_all" ON tasks;
+DROP POLICY IF EXISTS "team_members_authenticated_all" ON team_members;
+DROP POLICY IF EXISTS "volunteers_authenticated_all" ON volunteers;
+
+-- CASE B: If client-side reads are needed (e.g. public listings), add scoped policies
+-- For now, keep policies minimal. If the frontend needs to read these tables,
+-- add authenticated SELECT policies here. Example:
+--
+-- CREATE POLICY "artists_team_read" ON artists
+--   FOR SELECT
+--   USING (true);  -- Only if reads are truly team-internal
+--
+-- Do NOT use USING(true) for writes — that's the original exposure.
+-- If you need authenticated reads, be explicit about the intent.
+
+-- ============================================================================
+-- Secondary: Review and Fix Other Security Issues
+-- ============================================================================
+
+-- 1. SECURITY DEFINER function `rls_auto_enable` - check execution privileges
+--    Recommended: Review what this function does and if anon/authenticated should execute it
+--    Command to find: SELECT p.proname, p.prosecdef FROM pg_proc p WHERE p.proname = 'rls_auto_enable';
+
+-- 2. Functions with mutable search_path - potential for unintended table access
+--    Command to find: SELECT proname, prosecdef FROM pg_proc WHERE provolatility != 'i' AND prosecdef = true;
+
+-- ============================================================================
+-- Verification: Policies after hardening
+-- ============================================================================
+SELECT
+  table_name,
+  policy_name,
+  action,
+  roles,
+  qual as using_clause,
+  with_check
+FROM pg_policies
+WHERE table_name IN (
+  'activity_log', 'artists', 'budget_entries', 'circle_members', 'circles',
+  'contact_log', 'goals', 'meeting_notes', 'sponsors', 'suggestions',
+  'tasks', 'team_members', 'volunteers'
+)
+ORDER BY table_name, action, policy_name;
+
+-- Expected result: NO rows with action='ALL' and roles='authenticated' and qual='true'
+-- (The hardening has removed those.) Remaining policies should be:
+-- - Service role full access (if kept) or
+-- - Scoped authenticated SELECT (if reads are needed)
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK: If you need to undo this hardening
+-- ============================================================================
+-- This rollback restores the original permissive policies (NOT recommended for production).
+-- Only use this for testing/reverting in non-production.
+--
+-- DO NOT UNCOMMENT THIS UNLESS YOU EXPLICITLY NEED TO ROLLBACK.
+--
+-- BEGIN;
+--
+-- DROP POLICY IF EXISTS "todos_owner_write" ON stock_todos;
+-- DROP POLICY IF EXISTS "todos_team_read" ON stock_todos;
+-- -- ... repeat for other tables ...
+--
+-- -- Restore original permissive policies (CASE A/B both used these originally)
+-- CREATE POLICY "activity_log_authenticated_all" ON activity_log
+--   FOR ALL USING (true) WITH CHECK (true);
+-- CREATE POLICY "artists_authenticated_all" ON artists
+--   FOR ALL USING (true) WITH CHECK (true);
+-- -- ... repeat for other tables ...
+--
+-- COMMIT;
+--
+-- Note: If you used CASE A scoped policies, you'll need to drop those first,
+-- then re-create the original permissive ones above. The rollback pattern is:
+-- 1. DROP POLICY IF EXISTS the new scoped policy
+-- 2. CREATE POLICY the original permissive policy


### PR DESCRIPTION
## Summary

Comprehensive RLS hardening proposal for ZAOstock cowork tracker. Addresses critical exposure: 13 tables allow any authenticated Supabase token to read/write all rows with zero ownership scoping.

Exposed tables: activity_log, artists, budget_entries, circle_members, circles, contact_log, goals, meeting_notes, sponsors, suggestions, tasks, team_members, volunteers.

## Deliverables

- **scripts/cowork-rls-hardening.sql** - Hardening SQL with guard, two fix cases, verification, rollback
- **research/security/1024-cowork-tracker-rls-hardening/README.md** - Audit doc with exposure analysis, blast radius, both cases, test-first runbook

## Critical Notes

- **REVIEW ONLY** — do not apply blind
- **Two cases:** CASE A (per-user auth), CASE B (service-role-only, recommended)
- **Guard:** Script will not run without setting `app.apply_rls_hardening='1'`
- **Test first:** Apply to staging database, verify cowork app reads/writes work
- **Production:** Coordinate team notification and low-usage window

## Recommended Path

**CASE B (Service-Role-Only)** — Current app architecture uses `getSupabaseAdmin()` for all mutations (verified in src/lib/stock/ and src/lib/auth/stock-team-session.ts).

Fix: Drop overly permissive authenticated ALL policies. Keep service role full access (app bypasses RLS anyway). No auth schema changes needed.

## Test Plan

1. Review auth model in src/lib/auth/stock-team-session.ts and src/lib/stock/members.ts
2. Choose CASE A or B in scripts/cowork-rls-hardening.sql
3. Apply to staging Supabase database
4. Verify cowork app loads (reads test: dashboard, artists, sponsors, goals)
5. Verify cowork app mutations work (writes test: add artist, add sponsor contact, add goal)
6. Check app logs for RLS policy errors (42501 insufficient_privileges)
7. Confirm production readiness with team
8. Apply to production during low-usage window (2-4am PT typical)

## Secondary Items

- Review `rls_auto_enable` SECURITY DEFINER function (anon/authenticated access risk)
- Audit functions with mutable search_path + SECURITY DEFINER (unintended table access via injection)

---

Generated with Claude Code | https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3