### PR TITLE
feat(zoe): pin open questions, unpin on answer

### DIFF
--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -444,6 +444,12 @@ bot.on('callback_query:data', async (ctx) => {
   const q = parseQuestionCallback(ctx.callbackQuery.data);
   if (q) {
     const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+    // Unpin the question once Zaal engages with it (zao-ask pins each question so
+    // open ones stay easy to find; answering clears it from the pin list).
+    const pinnedMid = ctx.callbackQuery.message?.message_id;
+    if (pinnedMid) {
+      await ctx.api.unpinChatMessage(gid, pinnedMid).catch(() => {});
+    }
     if (q.isType) {
       const cbChat = ctx.callbackQuery.message?.chat?.id;
       if (cbChat) pendingTypeAnswers.set(cbChat, q.qid);


### PR DESCRIPTION
Zaal asked to pin messages that need answering. zao-ask (Mac-side, already live) now pins each question on send. This PR is the other half: ZOE unpins a question the moment Zaal taps an answer (the callback carries the message_id), so the Telegram pin list always shows exactly the still-open questions. Boot-verified: tsc clean, esbuild bundles, secret-scan clean. Deploy = git pull + restart zoe-bot after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)