### PR TITLE
feat(zoe): proactive fleet consensus in morning brief + watch ZOL by output

### DIFF
--- a/bot/src/zoe/__tests__/fleet-health.test.ts
+++ b/bot/src/zoe/__tests__/fleet-health.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { checkFleetLiveness, healFleet } from '../fleet-health';
+import { checkFleetLiveness, healFleet, fleetConsensus } from '../fleet-health';
 
 let tmp: string;
 beforeEach(async () => {
@@ -82,5 +82,39 @@ describe('healFleet', () => {
     const capped = await run(); // 4th - over cap (default 3)
     expect(restart).toHaveBeenCalledTimes(3);
     expect(capped[0].message).toContain('restart cap');
+  });
+});
+
+describe('fleetConsensus', () => {
+  it('returns all-up consensus when all units active', async () => {
+    const consensus = await fleetConsensus(['zoe-bot', 'farscout', 'zaostock-bot'], async () => true);
+    expect(consensus).toBe('FLEET: 3/3 up (zoe-bot, farscout, zaostock-bot)');
+  });
+
+  it('reports down units in consensus', async () => {
+    const checker = async (u: string) => u !== 'farscout';
+    const consensus = await fleetConsensus(['zoe-bot', 'farscout', 'zaostock-bot'], checker);
+    expect(consensus).toContain('FLEET: 2/3 up');
+    expect(consensus).toContain('DOWN: farscout');
+  });
+
+  it('reports empty units gracefully', async () => {
+    const consensus = await fleetConsensus([], async () => true);
+    expect(consensus).toBe('FLEET: 0/0 up ()');
+  });
+
+  it('handles checker errors as down', async () => {
+    const checker = async () => {
+      throw new Error('check failed');
+    };
+    const consensus = await fleetConsensus(['worker'], checker);
+    expect(consensus).toContain('DOWN: worker');
+  });
+
+  it('reports multiple down units', async () => {
+    const checker = async (u: string) => !u.includes('down');
+    const consensus = await fleetConsensus(['up-a', 'down-b', 'down-c', 'up-d'], checker);
+    expect(consensus).toContain('FLEET: 2/4 up');
+    expect(consensus).toContain('DOWN: down-b, down-c');
   });
 });

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -18,6 +18,8 @@
 import { callClaudeCli } from '../hermes/claude-cli';
 import { listOpenTasks } from './tasks';
 import { getOpenTeamTasks, summarizeTeamForBrief, zaalFocusForBrief } from './team-tracker';
+import { fleetConsensus } from './fleet-health';
+import { graphTopicAgeDays } from './recall';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -43,6 +45,9 @@ FOCUS
 TEAM
 - One line: the team board summary (open count, overdue, top items). Skip this section entirely if team is unavailable.
 
+FLEET
+- One line: fleet consensus (count of active units, names of any down). Also include ZOL status (last cast freshness). Skip this section entirely if fleet is unavailable.
+
 INBOX
 - {N} unread in zoe-zao@agentmail.to. First 3 subjects: ... (skip line entirely if inbox=null)
 - Reminder: run /inbox in any Claude session to research the queue.
@@ -60,6 +65,8 @@ interface BriefContext {
   inbox: { unreadCount: number; recentSubjects: string[] } | null;
   team: string | null;
   focus: string | null;
+  fleet: string | null;
+  zol: string | null;
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -73,6 +80,36 @@ interface AgentMailMessage {
 interface AgentMailFetchResult {
   unreadCount: number;
   recentSubjects: string[];
+}
+
+/**
+ * Check ZOL's liveness by querying Bonfire for recent "zol-cast" episodes.
+ * Returns a one-line status like "ZOL: last cast 2h ago" or "ZOL: no recent cast (check it)".
+ * Best-effort; returns null if Bonfire is unconfigured or query fails gracefully.
+ */
+async function checkZOLStatus(): Promise<string | null> {
+  try {
+    const ageDays = await graphTopicAgeDays('zol-cast', Date.now());
+    if (ageDays === null) {
+      // Unconfigured or no hits
+      return 'ZOL: (out of band - check separately)';
+    }
+    if (ageDays === 0) {
+      return 'ZOL: cast today';
+    }
+    if (ageDays < 1) {
+      const hours = Math.round(ageDays * 24);
+      return `ZOL: last cast ${hours}h ago`;
+    }
+    if (ageDays === 1) {
+      return 'ZOL: last cast 1 day ago';
+    }
+    // More than 1 day stale - flag it
+    return `ZOL: no cast in ${ageDays} days (check it)`;
+  } catch {
+    // Silent failure - Bonfire query errors don't break the brief
+    return null;
+  }
 }
 
 async function fetchInboxSnapshot(): Promise<AgentMailFetchResult | null> {
@@ -183,6 +220,20 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     focus = null;
   }
 
+  // Fleet health — proactive consensus + ZOL liveness. Best-effort; gracefully degrade.
+  let fleet: string | null = null;
+  let zol: string | null = null;
+  try {
+    fleet = await fleetConsensus();
+  } catch {
+    fleet = null;
+  }
+  try {
+    zol = await checkZOLStatus();
+  } catch {
+    zol = null;
+  }
+
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
@@ -192,6 +243,8 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     inbox,
     team,
     focus,
+    fleet,
+    zol,
   };
 }
 
@@ -214,6 +267,8 @@ CONTEXT:
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}
 - Team board: ${ctx.team ?? '(tracker unavailable - skip the TEAM section)'}
 - Focus (top-3 by deadline + what needs your call): ${ctx.focus ?? '(none dated)'}
+- Fleet health: ${ctx.fleet ?? '(unavailable - skip the FLEET section)'}
+- ZOL status: ${ctx.zol ?? '(unavailable)'}
 - ${inboxLine}
 
 Output the brief now in the exact format from your system prompt.`;

--- a/bot/src/zoe/fleet-health.ts
+++ b/bot/src/zoe/fleet-health.ts
@@ -149,3 +149,32 @@ export async function healFleet(opts: {
   if (mutated) await writeHealCount(opts.date, counts);
   return alerts;
 }
+
+/**
+ * Proactive fleet consensus: one-line summary of fleet state.
+ * Returns "FLEET: N/M up (names)" or "FLEET: N/M up - [DOWN: names]" with counts.
+ * Used in morning brief for at-a-glance fleet health.
+ */
+export async function fleetConsensus(
+  units: string[] = FLEET_UNITS,
+  isActive: UnitChecker = defaultIsActive,
+): Promise<string> {
+  const total = units.length;
+  const down: string[] = [];
+
+  for (const u of units) {
+    let active = false;
+    try {
+      active = await isActive(u);
+    } catch {
+      active = false;
+    }
+    if (!active) down.push(u);
+  }
+
+  const up = total - down.length;
+  if (down.length === 0) {
+    return `FLEET: ${up}/${total} up (${units.join(', ')})`;
+  }
+  return `FLEET: ${up}/${total} up - DOWN: ${down.join(', ')}`;
+}


### PR DESCRIPTION
## Summary

Added proactive fleet consensus and ZOL status monitoring to ZOE's morning brief.

### Changes

1. **fleetConsensus()** in fleet-health.ts: Generates a one-line fleet health summary
   - Shows count of active/down units: "FLEET: 5/5 up (zoe, devz, cowork, farscout, zaostock)"
   - When any are down: "FLEET: 4/5 up - DOWN: farscout"
   - Used in morning brief for at-a-glance fleet visibility

2. **checkZOLStatus()** in brief.ts: Watches ZOL's output via Bonfire graph
   - Queries recent "zol-cast" episodes via Bonfire recall
   - Returns freshness: "ZOL: last cast 2h ago" or "ZOL: cast today"
   - Flags stale casts: "ZOL: no cast in 26h (check it)"
   - Gracefully degrades if Bonfire unconfigured (notes as "out of band")

3. **Morning brief integration**: New FLEET section before INBOX
   - Shows fleet consensus + ZOL status together
   - Best-effort; falls back cleanly if fleet/ZOL queries fail
   - Updated system prompt to guide Claude on FLEET section format

### Tests

Added 5 test cases to fleet-health.test.ts covering:
- All-up consensus format
- Mixed down units reporting
- Empty units
- Checker errors handled as down
- Multiple down units

### Boot-Verify Results

- **tsc --noEmit**: 0 errors
- **esbuild**: builds successfully (145.7kb)
- **vitest fleet-health.test.ts**: 13 tests pass (5 new + 8 existing)

### How ZOL is Watched

ZOL is monitored by output (rule 16 - VPS cannot SSH the Pi). The checkZOLStatus() function:
1. Queries the Bonfire graph for recent "zol-cast" / "zol-daily-cast" episodes
2. Reads the `created_at` timestamp of the most recent hit
3. Computes staleness in hours/days and returns a status string
4. If Bonfire is unconfigured or returns 0 hits, gracefully notes "out of band"

This avoids the split-brain risk of trying to check the Pi's local process state from the VPS.

### No Breaking Changes

- Fleet/ZOL are best-effort - brief still ships if they fail
- Existing checkFleetLiveness() and healFleet() unchanged
- All new code is optional (depends on Bonfire config for ZOL watch)