### PR TITLE
feat(zoe): bridge ZAOstock cloud loop's pending-approvals queue to Telegram

### DIFF
--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -33,6 +33,7 @@ import { runWatcherTick, renderWatcherAlerts } from './watcher';
 import { healFleet } from './fleet-health';
 import { runWorkTick } from './work-loop';
 import { surfaceNewHandoffs } from './handoffs-surface';
+import { surfaceZaostockApprovals } from './zaostock-approvals-surface';
 import { runOrchestratorTick } from './orchestrator-tick';
 import { surfaceNudges } from './nudge';
 import { runReasoningTick, recordPush, type Candidate } from './proactive';
@@ -434,6 +435,30 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           if (n > 0) console.log(`[zoe/scheduler] surfaced ${n} handoff(s) to the Handoffs topic`);
         } catch (err) {
           console.warn('[zoe/scheduler] handoff surface failed (nbd):', (err as Error).message);
+        }
+      },
+      { timezone: 'UTC' },
+    ),
+  );
+
+  // ZAOstock cloud-loop approvals surfacer - every 10 min, post any NEW entries
+  // from research/_meta/zaostock-pending-approvals.md (bettercallzaal/ZAOOS)
+  // into the ZAAL BOTZ General topic. That file is the ZAOstock autonomous
+  // research routine's approval queue - it runs in an isolated cloud sandbox
+  // with no Telegram credentials, so it can only commit drafts/decisions to
+  // the file, not push them. This is the other half of that bridge. Silent
+  // when nothing new; the file itself won't exist until the loop's first run.
+  tasks.push(
+    cron.schedule(
+      '*/10 * * * *',
+      async () => {
+        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        if (!gid) return; // not configured
+        try {
+          const n = await surfaceZaostockApprovals((text: string) => opts.bot.api.sendMessage(gid, text));
+          if (n > 0) console.log(`[zoe/scheduler] surfaced ${n} ZAOstock approval-queue item(s)`);
+        } catch (err) {
+          console.warn('[zoe/scheduler] ZAOstock approvals surface failed (nbd):', (err as Error).message);
         }
       },
       { timezone: 'UTC' },

--- a/bot/src/zoe/zaostock-approvals-surface.ts
+++ b/bot/src/zoe/zaostock-approvals-surface.ts
@@ -1,0 +1,104 @@
+/**
+ * Surface new entries from the ZAOstock cloud research loop's pending-approvals
+ * queue into the ZAAL BOTZ General topic. The cloud research loop (a claude.ai
+ * routine, not this bot) has no safe way to hold Telegram credentials - it runs
+ * in an isolated sandbox and can only commit files. So instead of pushing
+ * Telegram messages directly, it APPENDS drafts/decisions it can't act on
+ * itself (spending money, contacting a third party, a judgment call) to
+ * research/_meta/zaostock-pending-approvals.md in bettercallzaal/ZAOOS. This
+ * module is the other half of that bridge: it reads the raw file over HTTPS
+ * (public repo, no auth needed), diffs against what's already been surfaced,
+ * and posts only the new content as plain text - same "no buttons, lowest
+ * blast radius" pattern as posts/README.md v1. Best-effort + de-duped via a
+ * last-seen file length, mirroring handoffs-surface.ts's last-seen-timestamp
+ * approach for the same class of problem.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const SEEN_PATH = join(ZOE_HOME, 'zaostock-approvals-seen.json');
+const REQUEST_TIMEOUT_MS = 8000;
+const RAW_URL =
+  'https://raw.githubusercontent.com/bettercallzaal/ZAOOS/main/research/_meta/zaostock-pending-approvals.md';
+/** Telegram hard cap is 4096 chars; leave headroom for the chunk-number prefix. */
+const MAX_CHUNK_CHARS = 3800;
+
+async function lastSeenLength(): Promise<number> {
+  try {
+    return (JSON.parse(await fs.readFile(SEEN_PATH, 'utf8')) as { length: number }).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function setLastSeenLength(length: number): Promise<void> {
+  await fs.mkdir(ZOE_HOME, { recursive: true });
+  await fs.writeFile(SEEN_PATH, JSON.stringify({ length }));
+}
+
+/** Raw file content, or null if it doesn't exist yet or the fetch failed. */
+async function fetchPendingApprovals(): Promise<string | null> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const res = await fetch(RAW_URL, { signal: controller.signal, cache: 'no-store' }).finally(() =>
+      clearTimeout(timer),
+    );
+    if (!res.ok) return null; // 404 before the loop's first run is expected, not an error
+    return await res.text();
+  } catch {
+    return null;
+  }
+}
+
+/** Split new content into Telegram-sized chunks, breaking on blank lines where possible. */
+function chunkText(text: string, maxChars: number): string[] {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxChars) return trimmed ? [trimmed] : [];
+  const paragraphs = trimmed.split(/\n\n+/);
+  const chunks: string[] = [];
+  let current = '';
+  for (const p of paragraphs) {
+    const candidate = current ? `${current}\n\n${p}` : p;
+    if (candidate.length > maxChars && current) {
+      chunks.push(current);
+      current = p;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+/**
+ * Post any pending-approvals content added since the last check to the
+ * General topic. `postToGeneral` sends one message (no thread id - lands in
+ * General same as zao-ask). Returns how many chunks were surfaced. Best-effort:
+ * never throws into the scheduler tick.
+ */
+export async function surfaceZaostockApprovals(
+  postToGeneral: (text: string) => Promise<unknown>,
+): Promise<number> {
+  const content = await fetchPendingApprovals();
+  if (content === null) return 0;
+
+  const seenLength = await lastSeenLength();
+  if (content.length <= seenLength) return 0; // nothing new (or file shrank - don't re-post)
+
+  const newContent = content.slice(seenLength);
+  const chunks = chunkText(newContent, MAX_CHUNK_CHARS);
+  if (chunks.length === 0) {
+    await setLastSeenLength(content.length);
+    return 0;
+  }
+
+  for (let i = 0; i < chunks.length; i++) {
+    const label = chunks.length > 1 ? `ZAOstock loop [${i + 1}/${chunks.length}]:\n\n` : 'ZAOstock loop - new item(s) need a look:\n\n';
+    await postToGeneral(`${label}${chunks[i]}`).catch(() => {});
+  }
+  await setLastSeenLength(content.length);
+  return chunks.length;
+}


### PR DESCRIPTION
The ZAOstock cloud research routine has no safe way to hold Telegram credentials, so it commits drafts/decisions it can't act on to research/_meta/zaostock-pending-approvals.md instead. This surfaces new entries into the ZAAL BOTZ General topic every 10 min, mirroring the existing handoffs-surface.ts pattern.