### PR TITLE
Support a dedicated ZAOstock team Telegram group

### DIFF
--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -443,16 +443,20 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
 
   // ZAOstock cloud-loop approvals surfacer - every 10 min, post any NEW entries
   // from research/_meta/zaostock-pending-approvals.md (bettercallzaal/ZAOOS)
-  // into the ZAAL BOTZ General topic. That file is the ZAOstock autonomous
-  // research routine's approval queue - it runs in an isolated cloud sandbox
-  // with no Telegram credentials, so it can only commit drafts/decisions to
-  // the file, not push them. This is the other half of that bridge. Silent
-  // when nothing new; the file itself won't exist until the loop's first run.
+  // into a Telegram group. That file is the ZAOstock autonomous research
+  // routine's approval queue - it runs in an isolated cloud sandbox with no
+  // Telegram credentials, so it can only commit drafts/decisions to the file,
+  // not push them. This is the other half of that bridge. Prefers a dedicated
+  // ZAOSTOCK_TEAM_GROUP_ID (e.g. the actual ZAOstock team's own Telegram group,
+  // once ZOE is added there) so this content lands where the team already is,
+  // rather than mixed into the general ZAAL BOTZ ops firehose; falls back to
+  // ZAAL_BOTZ_GROUP_ID if that's not configured yet. Silent when nothing new;
+  // the file itself won't exist until the loop's first run.
   tasks.push(
     cron.schedule(
       '*/10 * * * *',
       async () => {
-        const gid = Number(process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
+        const gid = Number(process.env.ZAOSTOCK_TEAM_GROUP_ID ?? process.env.ZAAL_BOTZ_GROUP_ID ?? 0);
         if (!gid) return; // not configured
         try {
           const n = await surfaceZaostockApprovals((text: string) => opts.bot.api.sendMessage(gid, text));

--- a/bot/src/zoe/zaostock-approvals-surface.ts
+++ b/bot/src/zoe/zaostock-approvals-surface.ts
@@ -1,17 +1,18 @@
 /**
  * Surface new entries from the ZAOstock cloud research loop's pending-approvals
- * queue into the ZAAL BOTZ General topic. The cloud research loop (a claude.ai
- * routine, not this bot) has no safe way to hold Telegram credentials - it runs
- * in an isolated sandbox and can only commit files. So instead of pushing
- * Telegram messages directly, it APPENDS drafts/decisions it can't act on
- * itself (spending money, contacting a third party, a judgment call) to
- * research/_meta/zaostock-pending-approvals.md in bettercallzaal/ZAOOS. This
- * module is the other half of that bridge: it reads the raw file over HTTPS
- * (public repo, no auth needed), diffs against what's already been surfaced,
- * and posts only the new content as plain text - same "no buttons, lowest
- * blast radius" pattern as posts/README.md v1. Best-effort + de-duped via a
- * last-seen file length, mirroring handoffs-surface.ts's last-seen-timestamp
- * approach for the same class of problem.
+ * queue into a Telegram group (whichever chat the caller targets - see
+ * scheduler.ts's ZAOSTOCK_TEAM_GROUP_ID / ZAAL_BOTZ_GROUP_ID fallback). The
+ * cloud research loop (a claude.ai routine, not this bot) has no safe way to
+ * hold Telegram credentials - it runs in an isolated sandbox and can only
+ * commit files. So instead of pushing Telegram messages directly, it APPENDS
+ * drafts/decisions it can't act on itself (spending money, contacting a third
+ * party, a judgment call) to research/_meta/zaostock-pending-approvals.md in
+ * bettercallzaal/ZAOOS. This module is the other half of that bridge: it reads
+ * the raw file over HTTPS (public repo, no auth needed), diffs against what's
+ * already been surfaced, and posts only the new content as plain text - same
+ * "no buttons, lowest blast radius" pattern as posts/README.md v1. Best-effort
+ * + de-duped via a last-seen file length, mirroring handoffs-surface.ts's
+ * last-seen-timestamp approach for the same class of problem.
  */
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
@@ -74,13 +75,13 @@ function chunkText(text: string, maxChars: number): string[] {
 }
 
 /**
- * Post any pending-approvals content added since the last check to the
- * General topic. `postToGeneral` sends one message (no thread id - lands in
- * General same as zao-ask). Returns how many chunks were surfaced. Best-effort:
- * never throws into the scheduler tick.
+ * Post any pending-approvals content added since the last check to the target
+ * chat. `postToTarget` sends one message (no thread id - lands in the chat's
+ * General/default stream, same as zao-ask). Returns how many chunks were
+ * surfaced. Best-effort: never throws into the scheduler tick.
  */
 export async function surfaceZaostockApprovals(
-  postToGeneral: (text: string) => Promise<unknown>,
+  postToTarget: (text: string) => Promise<unknown>,
 ): Promise<number> {
   const content = await fetchPendingApprovals();
   if (content === null) return 0;
@@ -97,7 +98,7 @@ export async function surfaceZaostockApprovals(
 
   for (let i = 0; i < chunks.length; i++) {
     const label = chunks.length > 1 ? `ZAOstock loop [${i + 1}/${chunks.length}]:\n\n` : 'ZAOstock loop - new item(s) need a look:\n\n';
-    await postToGeneral(`${label}${chunks[i]}`).catch(() => {});
+    await postToTarget(`${label}${chunks[i]}`).catch(() => {});
   }
   await setLastSeenLength(content.length);
   return chunks.length;

--- a/scripts/zao-ops/README.md
+++ b/scripts/zao-ops/README.md
@@ -58,6 +58,20 @@ Question ids should be namespaced per terminal/task, e.g. `zaostock-publish`, so
 each terminal reads back its own answers. Answers are logged by the bot to its
 `recent/` store; an open session reads them via the inbox bridge.
 
+### Targeting a different chat
+
+If your bot (ZOE) is a member of more than one group - e.g. a project-specific
+team chat alongside your main ops group - redirect a batch of asks without a
+second copy of the script:
+
+```bash
+ZAO_ASK_TARGET_GID=-1009876543210 zao-ask siteleadconfirm "Confirmed for Site Lead?" "Yes" "No"
+```
+
+Falls back to `ZAAL_BOTZ_GROUP_ID` from `tg.env` when unset, so existing calls
+are unaffected. `/chatid` (in the bot's other repo, `bot/src/zoe/index.ts`)
+gives you the target group's id from inside that chat.
+
 ## Notes
 
 - No secrets in these scripts - the bot token lives only in `tg.env` (gitignored).

--- a/scripts/zao-ops/zao-ask
+++ b/scripts/zao-ops/zao-ask
@@ -5,13 +5,18 @@
 # truncated); the buttons are compact numbers (1,2,3...) + "Type my own". A tap
 # logs the chosen option's slug to recent/ (the bridge); the asking terminal
 # reads it back by <qid>. No options = a freetext-only ask.
+#
+# Target override: set ZAO_ASK_TARGET_GID to redirect a batch of asks to a
+# different chat Zoe is also in (e.g. a dedicated ZAOstock team group) without
+# needing a second copy of this script. Falls back to ZAAL_BOTZ_GROUP_ID from
+# tg.env when unset - existing calls are unaffected.
 set -e
 QID="$1"; Q="$2"; shift 2 2>/dev/null || true
 [ -z "$QID" ] || [ -z "$Q" ] && { echo 'usage: zao-ask <qid> "<question>" [opt1] [opt2] ...'; exit 1; }
 TGENV="$HOME/.zao/private/tg.env"
 TOKEN=$(grep -m1 '^ZOE_BOT_TOKEN=' "$TGENV" | cut -d= -f2- | tr -d '"')
-GID=$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')
-[ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing ZOE_BOT_TOKEN or ZAAL_BOTZ_GROUP_ID in $TGENV"; exit 1; }
+GID="${ZAO_ASK_TARGET_GID:-$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')}"
+[ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing ZOE_BOT_TOKEN in $TGENV, or no group id (set ZAAL_BOTZ_GROUP_ID in tg.env or export ZAO_ASK_TARGET_GID)"; exit 1; }
 python3 - "$TOKEN" "$GID" "$QID" "$Q" "$@" <<'PY'
 import sys, json, base64, re, urllib.request, urllib.parse
 token, gid, qid, q = sys.argv[1:5]


### PR DESCRIPTION
Prep for moving ZAOstock's zao-ask questions and pending-approvals surfacing into the actual ZAOstock team's own Telegram group instead of the general ZAAL BOTZ ops chat, once ZOE is added there. Both zao-ask and the approvals-surface scheduler tick now support a target-group override, falling back to current behavior until configured.