### PR TITLE
zao-ops: zao-notify - DM a person by name, fall back to a flagged General note

### DIFF
--- a/scripts/zao-ops/README.md
+++ b/scripts/zao-ops/README.md
@@ -1,6 +1,6 @@
 # zao-ops - phone-first operator toolkit for the ZAO team
 
-Three small CLIs that turn ZOE (your Telegram bot) into a control surface: you
+Four small CLIs that turn ZOE (your Telegram bot) into a control surface: you
 conduct from your phone, terminals do the work, and every decision comes back to
 you as a button in one place.
 
@@ -16,6 +16,7 @@ driven - point them at your own bot + group and they work.
 | `zao-ask` | Fire a button-question into your Telegram General topic. Any terminal/worker calls it when it needs a decision; the answer routes back by question id. |
 | `zao-cockpit` | Print your operator brief in the terminal (do-first, needs-you, PRs to review, idea inbox, stale items) - reads the shared cowork tracker. |
 | `zao-sweep` | Post that same brief into General so your morning is one place: read the digest, click the waiting buttons. Cron it for an auto-morning sweep. |
+| `zao-notify` | DM a specific team member by name (looked up in `team_members`). No Telegram contact on file, or the DM fails? Falls back to a clearly-flagged note in General so you can relay it yourself - never silently drops the message. |
 
 ## The loop they create
 
@@ -39,7 +40,10 @@ Work fans **out** (many terminals in parallel). Your input fans **in** (one butt
 3. `ZAO_VPS_HOST` env var pointing at the host that runs the cockpit brief
    (defaults to the ZAO ops box). `zao-cockpit`/`zao-sweep` ssh there to build
    the brief where the tracker creds live.
-4. Put the scripts on your PATH: `ln -s "$PWD"/scripts/zao-ops/zao-* ~/bin/`.
+4. For `zao-notify`: `SUPABASE_URL` + `SUPABASE_SERVICE_KEY` in `~/.zao/zao.env`
+   (same cowork-tracker credentials `zao-tracker` already uses) so it can look
+   up a team member's `telegram_id`.
+5. Put the scripts on your PATH: `ln -s "$PWD"/scripts/zao-ops/zao-* ~/bin/`.
 
 ## Usage
 
@@ -52,7 +56,17 @@ zao-cockpit
 
 # push the cockpit digest into General
 zao-sweep
+
+# DM a specific person - falls back to a flagged General note if it can't reach them
+zao-notify Ohnahji "Confirmed as ZAOstock livestream lead - loop in on doc 1030/1036 when you get a sec"
 ```
+
+`zao-notify` looks up `team_members.telegram_id` for the name you give it. Most
+team members don't have one on file yet (they've never started a chat with
+ZOE) - until they do, every `zao-notify` call for them lands as a flagged note
+in General instead, and you relay it yourself. Once someone DMs ZOE for the
+first time, their `telegram_id` can be recorded and `zao-notify` starts
+reaching them directly, no code change needed.
 
 Question ids should be namespaced per terminal/task, e.g. `zaostock-publish`, so
 each terminal reads back its own answers. Answers are logged by the bot to its

--- a/scripts/zao-ops/zao-notify
+++ b/scripts/zao-ops/zao-notify
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# zao-notify <person-name> "<message>"
+# Try to DM a specific team member directly via Telegram; if there's no
+# telegram_id on file for them (or the DM fails - bot blocked, they've never
+# started a chat with ZOE), fall back to a clearly-flagged note in the ZAAL
+# BOTZ General topic so Zaal can relay it himself. Never silently drops a
+# message - one of the two always happens, and the fallback always says why.
+#
+# Looks up <person-name> (case-insensitive, matches team_members.name) via the
+# cowork tracker (Supabase project etwvzrmlxeobinrlytza, public.team_members -
+# same source zao-tracker reads). Reads SUPABASE_URL + SUPABASE_SERVICE_KEY
+# from ~/.zao/zao.env, and ZOE_BOT_TOKEN + ZAAL_BOTZ_GROUP_ID from
+# ~/.zao/private/tg.env.
+#
+# Usage:
+#   zao-notify Ohnahji "Confirmed as ZAOstock livestream lead - loop in on doc 1030/1036 when you get a sec"
+set -euo pipefail
+
+PERSON="$1"; MSG="${2:-}"
+[ -z "$PERSON" ] || [ -z "$MSG" ] && { echo 'usage: zao-notify <person-name> "<message>"'; exit 1; }
+
+ZAOENV="$HOME/.zao/zao.env"
+TGENV="$HOME/.zao/private/tg.env"
+[ -f "$ZAOENV" ] && set -a && source "$ZAOENV" && set +a
+[ -z "${SUPABASE_URL:-}" ] || [ -z "${SUPABASE_SERVICE_KEY:-}" ] && { echo "missing SUPABASE_URL/SUPABASE_SERVICE_KEY in $ZAOENV"; exit 1; }
+TOKEN=$(grep -m1 '^ZOE_BOT_TOKEN=' "$TGENV" | cut -d= -f2- | tr -d '"')
+GID=$(grep -m1 '^ZAAL_BOTZ_GROUP_ID=' "$TGENV" | cut -d= -f2- | tr -d '"')
+[ -z "$TOKEN" ] || [ -z "$GID" ] && { echo "missing ZOE_BOT_TOKEN or ZAAL_BOTZ_GROUP_ID in $TGENV"; exit 1; }
+
+python3 - "$SUPABASE_URL" "$SUPABASE_SERVICE_KEY" "$TOKEN" "$GID" "$PERSON" "$MSG" <<'PY'
+import sys, json, urllib.request, urllib.parse
+
+supabase_url, supabase_key, token, gid, person, msg = sys.argv[1:7]
+
+def lookup_member(name):
+    url = (f"{supabase_url.rstrip('/')}/rest/v1/team_members"
+           f"?select=name,telegram_id,telegram_username"
+           f"&name=ilike.{urllib.parse.quote(name)}&limit=1")
+    req = urllib.request.Request(url, headers={
+        "apikey": supabase_key, "Authorization": f"Bearer {supabase_key}",
+    })
+    with urllib.request.urlopen(req, timeout=10) as r:
+        rows = json.load(r)
+    return rows[0] if rows else None
+
+def send(chat_id, text):
+    body = {"chat_id": chat_id, "text": text}
+    req = urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        data=urllib.parse.urlencode(body).encode(),
+    )
+    with urllib.request.urlopen(req, timeout=15) as r:
+        return json.load(r)
+
+member = lookup_member(person)
+tg_id = member.get("telegram_id") if member else None
+tg_user = member.get("telegram_username") if member else None
+real_name = member.get("name") if member else person
+
+if tg_id:
+    try:
+        r = send(tg_id, msg)
+        if r.get("ok"):
+            print(f"DMed {real_name} directly (telegram_id {tg_id}).")
+            sys.exit(0)
+        else:
+            fail_reason = r.get("description", "unknown error")
+    except Exception as e:
+        fail_reason = str(e)
+else:
+    fail_reason = "no telegram_id on file" if member else f'"{person}" not found in team_members'
+
+# Fallback: flagged note in ZAAL BOTZ General so Zaal can relay manually.
+who = f"{real_name}" + (f" (@{tg_user})" if tg_user else "")
+fallback_text = (
+    f"[notify-fallback] Couldn't DM {who} directly ({fail_reason}).\n"
+    f"Please relay to them yourself:\n\n{msg}"
+)
+r = send(gid, fallback_text)
+if r.get("ok"):
+    print(f"Could not DM {who} ({fail_reason}) - posted to ZAAL BOTZ for Zaal to relay.")
+else:
+    print(f"FAIL: could not DM {who} AND could not post fallback to ZAAL BOTZ: {r.get('description')}")
+    sys.exit(1)
+PY


### PR DESCRIPTION
Zaal's call: stay in ZAAL BOTZ (no separate ZAOstock group). Adds zao-notify - DM a specific team member directly if their telegram_id is on file, otherwise post a clearly-flagged fallback note in General for Zaal to relay manually. Tested live against the real Ohnahji case - correctly fell back since no contact info exists for him yet.