### PR TITLE
feat(zoe): reply to @zoe comments on board tasks

### DIFF
--- a/bot/src/zoe/__tests__/task-comment-replies.test.ts
+++ b/bot/src/zoe/__tests__/task-comment-replies.test.ts
@@ -1,0 +1,126 @@
+import { test, beforeEach, afterEach } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  findUnansweredMentions,
+  runTaskCommentReplies,
+  boardConfigured,
+  type BoardTask,
+  type BoardComment,
+} from '../task-comment-replies';
+
+function task(id: string, comments: BoardComment[]): BoardTask {
+  return { id, legacy_id: null, title: `Task ${id}`, notes: null, status: 'todo', metadata: { comments } };
+}
+
+test('findUnansweredMentions: no comments -> empty', () => {
+  assert.deepEqual(findUnansweredMentions([task('a', [])]), []);
+});
+
+test('findUnansweredMentions: an @zoe comment with no reply is surfaced', () => {
+  const found = findUnansweredMentions([
+    task('a', [{ id: 'c1', userId: 'iman', content: '@zoe how do I test this?' }]),
+  ]);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].comment.id, 'c1');
+});
+
+test('findUnansweredMentions: an @zoe comment already answered by ZOE is skipped', () => {
+  const found = findUnansweredMentions([
+    task('a', [
+      { id: 'c1', userId: 'iman', content: '@zoe status?' },
+      { id: 'c2', userId: 'zoe', displayName: 'ZOE', content: 'It shipped in PR #12.' },
+    ]),
+  ]);
+  assert.equal(found.length, 0);
+});
+
+test('findUnansweredMentions: ZOE tagging itself is ignored', () => {
+  const found = findUnansweredMentions([
+    task('a', [{ id: 'c1', userId: 'zoe', content: 'reminder @zoe follow up' }]),
+  ]);
+  assert.equal(found.length, 0);
+});
+
+test('findUnansweredMentions: a plain comment (no @zoe) is ignored', () => {
+  const found = findUnansweredMentions([
+    task('a', [{ id: 'c1', userId: 'iman', content: 'looks good to me' }]),
+  ]);
+  assert.equal(found.length, 0);
+});
+
+test('findUnansweredMentions: re-mention after a ZOE reply is surfaced again', () => {
+  const found = findUnansweredMentions([
+    task('a', [
+      { id: 'c1', userId: 'iman', content: '@zoe q1' },
+      { id: 'c2', userId: 'zoe', content: 'a1' },
+      { id: 'c3', userId: 'iman', content: '@zoe follow-up q2' },
+    ]),
+  ]);
+  assert.equal(found.length, 1);
+  assert.equal(found[0].comment.id, 'c3');
+});
+
+// --- runTaskCommentReplies integration (mocked fetch + model) ---
+
+const ENV = { ...process.env };
+beforeEach(() => {
+  process.env.COWORK_TRACKER_URL = 'https://x.supabase.co';
+  process.env.COWORK_TRACKER_KEY = 'test-key';
+});
+afterEach(() => {
+  process.env = { ...ENV };
+});
+
+/** Fake fetch: returns `list` for the candidate/by-id GETs, records PATCH bodies. */
+function makeFetch(list: BoardTask[], patched: unknown[]): typeof fetch {
+  return (async (url: string, init?: RequestInit) => {
+    if (init?.method === 'PATCH') {
+      patched.push(JSON.parse(String(init.body)));
+      return { ok: true, status: 200 } as Response;
+    }
+    // GET by-id returns the single matching task; candidate GET returns all.
+    const m = /id=eq\.([^&]+)/.exec(url);
+    const body = m ? list.filter((t) => t.id === m[1]) : list;
+    return { ok: true, status: 200, json: async () => body } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+const fakeCall = (async () =>
+  ({ text: 'Here is the answer about the task.', isError: false })) as never;
+
+test('boardConfigured reflects env', () => {
+  assert.equal(boardConfigured(), true);
+  delete process.env.COWORK_TRACKER_KEY;
+  assert.equal(boardConfigured(), false);
+});
+
+test('runTaskCommentReplies is a no-op when unconfigured', async () => {
+  delete process.env.COWORK_TRACKER_URL;
+  const r = await runTaskCommentReplies(makeFetch([], []), fakeCall);
+  assert.deepEqual(r, { answered: 0, scanned: 0 });
+});
+
+test('runTaskCommentReplies answers an unanswered @zoe mention and PATCHes a reply', async () => {
+  const patched: unknown[] = [];
+  const list = [task('t1', [{ id: 'c1', userId: 'iman', content: '@zoe whats left here?' }])];
+  const r = await runTaskCommentReplies(makeFetch(list, patched), fakeCall);
+  assert.equal(r.answered, 1);
+  assert.equal(patched.length, 1);
+  const md = (patched[0] as { metadata: { comments: Array<{ userId: string; content: string }> } }).metadata;
+  assert.equal(md.comments.length, 2, 'original + ZOE reply');
+  assert.equal(md.comments[1].userId, 'zoe');
+  assert.match(md.comments[1].content, /answer about the task/);
+});
+
+test('runTaskCommentReplies does not re-answer an already-answered mention', async () => {
+  const patched: unknown[] = [];
+  const list = [
+    task('t1', [
+      { id: 'c1', userId: 'iman', content: '@zoe done?' },
+      { id: 'c2', userId: 'zoe', content: 'yes' },
+    ]),
+  ];
+  const r = await runTaskCommentReplies(makeFetch(list, patched), fakeCall);
+  assert.equal(r.answered, 0);
+  assert.equal(patched.length, 0);
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -43,6 +43,7 @@ import { flushEmitQueue } from './thread-memory';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
 import { reconcileUntaggedTasks } from './team-tracker';
 import { ingestInbox } from './inbox-ingest';
+import { runTaskCommentReplies } from './task-comment-replies';
 
 /** await-reflection waits overnight for Zaal's reply, so a 14h TTL not 30m. */
 const AWAIT_REFLECTION_TTL_MS = 14 * 60 * 60 * 1000;
@@ -242,6 +243,17 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           }
         } catch (err) {
           console.warn('[zoe/scheduler] inbox-ingest failed (nbd):', (err as Error).message);
+        }
+
+        // Reply to any @zoe comments left on board tasks (thezao.xyz/board).
+        // Best-effort - a no-op when COWORK_TRACKER_URL/KEY are unset.
+        try {
+          const rep = await runTaskCommentReplies();
+          if (rep.answered > 0) {
+            console.log(`[zoe/scheduler] task-comment-replies: answered ${rep.answered}`);
+          }
+        } catch (err) {
+          console.warn('[zoe/scheduler] task-comment-replies failed (nbd):', (err as Error).message);
         }
 
         // Doc 983 Rec #4: hourly backfill of any task created untagged by a

--- a/bot/src/zoe/task-comment-replies.ts
+++ b/bot/src/zoe/task-comment-replies.ts
@@ -1,0 +1,252 @@
+/**
+ * task-comment-replies.ts - ZOE watches the cowork board for task comments that
+ * tag @zoe and replies in-thread.
+ *
+ * The board (thezao.xyz/board, ZAODEVZ/ZAOcowork) already stores per-task
+ * comments in public.tasks.metadata.comments, where each comment is
+ * { id, userId, displayName, content, createdAt }. A teammate can already type
+ * "@zoe how do I test this?" in a task's comment box - it saves fine. The only
+ * missing piece (this module) is ZOE noticing those @zoe comments and replying.
+ *
+ * Flow each tick:
+ *   1. Fetch recent non-archived tasks that have comments (via PostgREST).
+ *   2. Find @zoe-tagging comments with no ZOE reply after them.
+ *   3. Answer each with the task loaded as context (callClaudeCli, cheap model).
+ *   4. Re-fetch the task, re-check it's still unanswered (concurrency guard),
+ *      append ZOE's reply to metadata.comments, PATCH the row.
+ *
+ * Config: reuses COWORK_TRACKER_URL + COWORK_TRACKER_KEY (team-tracker.ts); the
+ * key needs PATCH access to public.tasks. Best-effort: no-op when unconfigured,
+ * capped per tick, never throws into the scheduler.
+ */
+
+import { callClaudeCli } from '../hermes/claude-cli';
+
+export interface BoardComment {
+  id: string;
+  userId?: string;
+  displayName?: string;
+  content: string;
+  createdAt?: string;
+  editedAt?: string;
+}
+
+export interface BoardTask {
+  id: string; // uuid (DB primary key)
+  legacy_id: string | null;
+  title: string;
+  notes?: string | null;
+  status?: string | null;
+  metadata?: (Record<string, unknown> & { comments?: BoardComment[] }) | null;
+}
+
+const ZOE_USER_ID = 'zoe';
+const ZOE_DISPLAY = 'ZOE';
+const MENTION_RE = /@zoe\b/i;
+const MAX_REPLIES_PER_TICK = 5;
+const CANDIDATE_LIMIT = 200;
+
+export function boardConfigured(): boolean {
+  return Boolean(process.env.COWORK_TRACKER_URL && process.env.COWORK_TRACKER_KEY);
+}
+
+function commentsOf(t: BoardTask): BoardComment[] {
+  const c = t.metadata?.comments;
+  return Array.isArray(c) ? c : [];
+}
+
+/** True if the comment tags @zoe and was NOT authored by ZOE itself. */
+function tagsZoe(c: BoardComment): boolean {
+  return (
+    typeof c.content === 'string' && MENTION_RE.test(c.content) && c.userId !== ZOE_USER_ID
+  );
+}
+
+/**
+ * Every @zoe-tagging comment that has no ZOE reply after it. A reply is any
+ * ZOE-authored comment (userId === 'zoe') appearing later in the ordered
+ * comments array. Pure + exported for unit testing.
+ */
+export function findUnansweredMentions(
+  tasks: BoardTask[],
+): Array<{ task: BoardTask; comment: BoardComment }> {
+  const out: Array<{ task: BoardTask; comment: BoardComment }> = [];
+  for (const task of tasks) {
+    const comments = commentsOf(task);
+    for (let i = 0; i < comments.length; i++) {
+      const c = comments[i];
+      if (!tagsZoe(c)) continue;
+      const answered = comments.slice(i + 1).some((later) => later.userId === ZOE_USER_ID);
+      if (!answered) out.push({ task, comment: c });
+    }
+  }
+  return out;
+}
+
+function trackerHeaders(key: string): Record<string, string> {
+  return { apikey: key, Authorization: `Bearer ${key}` };
+}
+
+const SELECT = 'select=id,legacy_id,title,notes,status,metadata';
+
+/**
+ * Recent non-archived tasks that carry metadata (candidate comment holders).
+ * PostgREST can't substring-match inside a jsonb array, so we fetch a bounded
+ * recent set and filter for @zoe in JS.
+ */
+async function fetchCandidateTasks(fetchImpl: typeof fetch): Promise<BoardTask[]> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return [];
+  const url =
+    `${base.replace(/\/$/, '')}/rest/v1/tasks` +
+    `?archived_at=is.null&metadata=not.is.null&${SELECT}` +
+    `&order=updated_at.desc.nullslast&limit=${CANDIDATE_LIMIT}`;
+  try {
+    const res = await fetchImpl(url, {
+      headers: trackerHeaders(key),
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as BoardTask[];
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Fetch a single task fresh (for the pre-write concurrency re-check). */
+async function fetchTaskById(id: string, fetchImpl: typeof fetch): Promise<BoardTask | null> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return null;
+  const url = `${base.replace(/\/$/, '')}/rest/v1/tasks?id=eq.${id}&${SELECT}&limit=1`;
+  try {
+    const res = await fetchImpl(url, {
+      headers: trackerHeaders(key),
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as BoardTask[];
+    return Array.isArray(data) && data[0] ? data[0] : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ask the model to answer a @zoe task comment, with the task as context.
+ * Returns the reply text, or null on any failure. Exported for testing via an
+ * injectable caller.
+ */
+export async function answerMention(
+  task: BoardTask,
+  comment: BoardComment,
+  call: typeof callClaudeCli = callClaudeCli,
+): Promise<string | null> {
+  const system = [
+    'You are ZOE, replying inside a comment thread on a ZAO board task.',
+    `Task: "${task.title}" (status: ${task.status ?? 'unknown'}).`,
+    task.notes ? `Task notes: ${String(task.notes).slice(0, 800)}` : '',
+    'A teammate tagged you in a comment. Answer their question about THIS task,',
+    "concisely (2-5 sentences), in ZOE's plain voice. No emojis, no em dashes.",
+    "If you genuinely cannot answer from the task, say what you'd need. Never invent facts.",
+  ]
+    .filter(Boolean)
+    .join('\n');
+  try {
+    const res = await call({
+      model: 'haiku',
+      prompt: `Comment tagging you: ${comment.content}`,
+      cwd: process.cwd(),
+      appendSystemPrompt: system,
+      allowedTools: ['Read', 'Grep', 'Glob'],
+      timeoutMs: 90_000,
+      maxBudgetUsd: 0.25,
+    });
+    const text = (res.text || '').trim();
+    return text && !res.isError ? text : null;
+  } catch (err) {
+    console.warn('[zoe/task-replies] answer failed (nbd):', (err as Error).message);
+    return null;
+  }
+}
+
+/** Append ZOE's reply to a task's metadata.comments and PATCH the row. */
+async function postReply(
+  task: BoardTask,
+  answer: string,
+  fetchImpl: typeof fetch,
+): Promise<boolean> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return false;
+  const reply: BoardComment = {
+    id: `zoe-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    userId: ZOE_USER_ID,
+    displayName: ZOE_DISPLAY,
+    content: answer,
+    createdAt: new Date().toISOString(),
+  };
+  const metadata = { ...(task.metadata ?? {}) };
+  const existing = Array.isArray(metadata.comments) ? (metadata.comments as BoardComment[]) : [];
+  metadata.comments = [...existing, reply];
+  const url = `${base.replace(/\/$/, '')}/rest/v1/tasks?id=eq.${task.id}`;
+  try {
+    const res = await fetchImpl(url, {
+      method: 'PATCH',
+      headers: {
+        ...trackerHeaders(key),
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({ metadata }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn('[zoe/task-replies] post failed (nbd):', (err as Error).message);
+    return false;
+  }
+}
+
+export interface ReplyTickResult {
+  answered: number;
+  scanned: number;
+}
+
+/**
+ * One reply pass. Fetch candidates, answer each unanswered @zoe mention (capped),
+ * re-check freshness, and post. Best-effort; never throws.
+ * @param fetchImpl injectable for tests.
+ * @param call injectable model caller for tests.
+ */
+export async function runTaskCommentReplies(
+  fetchImpl: typeof fetch = fetch,
+  call: typeof callClaudeCli = callClaudeCli,
+): Promise<ReplyTickResult> {
+  if (!boardConfigured()) return { answered: 0, scanned: 0 };
+  const tasks = await fetchCandidateTasks(fetchImpl);
+  const pending = findUnansweredMentions(tasks).slice(0, MAX_REPLIES_PER_TICK);
+  let answered = 0;
+
+  for (const { task, comment } of pending) {
+    const ans = await answerMention(task, comment, call);
+    if (!ans) continue;
+    // Re-fetch just before writing to shrink the window where a concurrent app
+    // write clobbers our append or someone else already answered.
+    const fresh = (await fetchTaskById(task.id, fetchImpl)) ?? task;
+    const stillUnanswered = findUnansweredMentions([fresh]).some(
+      (m) => m.comment.id === comment.id,
+    );
+    if (!stillUnanswered) continue;
+    if (await postReply(fresh, ans, fetchImpl)) answered++;
+  }
+
+  if (answered > 0) {
+    console.log(`[zoe/task-replies] answered ${answered} @zoe task comment(s)`);
+  }
+  return { answered, scanned: tasks.length };
+}


### PR DESCRIPTION
## Summary
Tag @zoe in any task's comment on thezao.xyz/board and ZOE replies right in that thread. This is the missing 10% - the board already has per-task comment threads + @mentions (stored in `tasks.metadata.comments`); ZOE just wasn't noticing @zoe comments. No new table, no UI rebuild (a subagent started down that path; discarded).

## What it does
- Hourly tick fetches recent non-archived board tasks, finds @zoe-tagging comments with no ZOE reply after them, answers each with the task loaded as context (callClaudeCli, haiku, budget-capped $0.25), re-checks the task is still unanswered (concurrency guard), and appends ZOE's reply to `metadata.comments` via PostgREST PATCH.
- Reuses `COWORK_TRACKER_URL` / `COWORK_TRACKER_KEY`. Best-effort: no-op when unconfigured, capped at 5 replies/tick, never throws into the scheduler.

## Verification
- tsc: 0 errors in changed files (10 pre-existing zol/caster-template SDK errors remain).
- vitest: 10 tests pass (mention detection incl. answered/self-tag/plain skips + re-mention; the full answer+PATCH path; unconfigured + already-answered no-ops).
- esbuild bundle of src/index.ts succeeds - boot-safe.

## Notes
- Zaal approved act-freely on task edits (board writes are internal + reversible).
- Goes live on the next VPS deploy (currently pending).
- Optional Phase 3 follow-up: an \"Ask ZOE\" button in the UI that pre-fills @zoe (nicety - typing @zoe already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3