### PR TITLE
feat(zoe): Telegram ping when @mentioned in a board task comment

### DIFF
--- a/bot/src/zoe/__tests__/task-mention-notify.test.ts
+++ b/bot/src/zoe/__tests__/task-mention-notify.test.ts
@@ -1,0 +1,114 @@
+import { test, beforeAll, beforeEach } from 'vitest';
+import assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const TMP = join(tmpdir(), `zoe-mention-test-${process.pid}-${Date.now()}`);
+process.env.ZOE_HOME = TMP;
+
+type Mod = typeof import('../task-mention-notify');
+let m: Mod;
+
+beforeAll(async () => {
+  await fs.mkdir(TMP, { recursive: true });
+  m = await import('../task-mention-notify');
+});
+
+beforeEach(async () => {
+  await fs.rm(join(TMP, 'mention_notify_seen.jsonl'), { force: true });
+  process.env.COWORK_TRACKER_URL = 'https://x.supabase.co';
+  process.env.COWORK_TRACKER_KEY = 'k';
+  delete process.env.MENTION_NOTIFY_MAP;
+});
+
+function task(id: string, legacy: string | null, comments: import('../task-mention-notify').BoardComment[]) {
+  return { id, legacy_id: legacy, title: `Task ${id}`, metadata: { comments } };
+}
+
+function fakeFetch(tasks: unknown[]): typeof fetch {
+  return (async () =>
+    ({ ok: true, status: 200, json: async () => tasks }) as unknown as Response) as unknown as typeof fetch;
+}
+
+test('parseMentions extracts handles, drops bots/broadcast + dups', () => {
+  assert.deepEqual(m.parseMentions('hey @iman and @zaal, cc @zoe @here @iman'), ['iman', 'zaal']);
+  assert.deepEqual(m.parseMentions('no mentions here'), []);
+});
+
+test('resolveDestinations parses env map + adds zaal default', () => {
+  process.env.MENTION_NOTIFY_MAP = JSON.stringify({ iman: { chatId: -100, topicId: 7 } });
+  const d = m.resolveDestinations(555);
+  assert.equal(d.iman.chatId, -100);
+  assert.equal(d.iman.topicId, 7);
+  assert.equal(d.zaal.chatId, 555);
+});
+
+test('resolveDestinations survives a malformed map', () => {
+  process.env.MENTION_NOTIFY_MAP = '{not json';
+  const d = m.resolveDestinations(9);
+  assert.deepEqual(d, { zaal: { chatId: 9 } });
+});
+
+test('findNewMentions: routes only mapped handles, skips self + seen', () => {
+  const dests = { iman: { chatId: 1 }, zaal: { chatId: 2 } };
+  const tasks = [
+    task('t1', '10', [
+      { id: 'c1', userId: 'zaal', content: '@iman can you check this?' },
+      { id: 'c2', userId: 'iman', content: '@iman note to self' }, // self-mention -> skip
+      { id: 'c3', userId: 'zaal', content: '@ghost unknown handle' }, // no route -> skip
+    ]),
+  ];
+  const found = m.findNewMentions(tasks, dests, new Set());
+  assert.equal(found.length, 1);
+  assert.equal(found[0].handle, 'iman');
+  assert.equal(found[0].comment.id, 'c1');
+
+  // Once seen, it's skipped.
+  const seen = new Set(['c1:iman']);
+  assert.equal(m.findNewMentions(tasks, dests, seen).length, 0);
+});
+
+test('runMentionNotify sends a ping and dedups on the next pass', async () => {
+  process.env.MENTION_NOTIFY_MAP = JSON.stringify({ iman: { chatId: -100, topicId: 5 } });
+  const sent: Array<{ chatId: number; text: string; threadId?: number }> = [];
+  const send = async (chatId: number, text: string, opts?: { threadId?: number }) => {
+    sent.push({ chatId, text, threadId: opts?.threadId });
+  };
+  const tasks = [task('t1', '11', [{ id: 'c1', userId: 'zaal', content: '@iman look here' }])];
+
+  const r1 = await m.runMentionNotify(send, 999, fakeFetch(tasks));
+  assert.equal(r1.notified, 1);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].chatId, -100);
+  assert.equal(sent[0].threadId, 5);
+  assert.match(sent[0].text, /mentioned you on task #11/);
+
+  const r2 = await m.runMentionNotify(send, 999, fakeFetch(tasks));
+  assert.equal(r2.notified, 0, 'deduped');
+  assert.equal(sent.length, 1);
+});
+
+test('runMentionNotify is a no-op with no board config', async () => {
+  delete process.env.COWORK_TRACKER_URL;
+  const r = await m.runMentionNotify(async () => {}, 1, fakeFetch([]));
+  assert.deepEqual(r, { notified: 0, scanned: 0 });
+});
+
+test('runMentionNotify does not mark seen when the send fails (retries next tick)', async () => {
+  process.env.MENTION_NOTIFY_MAP = JSON.stringify({ iman: { chatId: 1 } });
+  const failing = async () => {
+    throw new Error('telegram down');
+  };
+  const tasks = [task('t1', '12', [{ id: 'c9', userId: 'zaal', content: '@iman ping' }])];
+  const r1 = await m.runMentionNotify(failing, 1, fakeFetch(tasks));
+  assert.equal(r1.notified, 0);
+  // Next tick with a working sender should still find + send it.
+  const sent: number[] = [];
+  const ok = async (chatId: number) => {
+    sent.push(chatId);
+  };
+  const r2 = await m.runMentionNotify(ok, 1, fakeFetch(tasks));
+  assert.equal(r2.notified, 1);
+  assert.equal(sent.length, 1);
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -43,6 +43,7 @@ import { flushEmitQueue } from './thread-memory';
 import { checkAndResend, readLastUserReplyAt } from './escalation';
 import { reconcileUntaggedTasks } from './team-tracker';
 import { ingestInbox } from './inbox-ingest';
+import { runMentionNotify } from './task-mention-notify';
 
 /** await-reflection waits overnight for Zaal's reply, so a 14h TTL not 30m. */
 const AWAIT_REFLECTION_TTL_MS = 14 * 60 * 60 * 1000;
@@ -242,6 +243,22 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
           }
         } catch (err) {
           console.warn('[zoe/scheduler] inbox-ingest failed (nbd):', (err as Error).message);
+        }
+
+        // Ping people on Telegram when they're @mentioned in a board task
+        // comment (thezao.xyz/board), so they see it without opening the board.
+        // Best-effort - a no-op when the board or MENTION_NOTIFY_MAP is unset.
+        try {
+          const send = (chatId: number, text: string, o?: { threadId?: number }) =>
+            opts.bot.api
+              .sendMessage(chatId, text, o?.threadId ? { message_thread_id: o.threadId } : undefined)
+              .then(() => undefined);
+          const mn = await runMentionNotify(send, opts.zaalTgId);
+          if (mn.notified > 0) {
+            console.log(`[zoe/scheduler] mention-notify: pinged ${mn.notified}`);
+          }
+        } catch (err) {
+          console.warn('[zoe/scheduler] mention-notify failed (nbd):', (err as Error).message);
         }
 
         // Doc 983 Rec #4: hourly backfill of any task created untagged by a

--- a/bot/src/zoe/task-mention-notify.ts
+++ b/bot/src/zoe/task-mention-notify.ts
@@ -1,0 +1,211 @@
+/**
+ * task-mention-notify.ts - when someone @mentions a PERSON in a board task
+ * comment, ZOE pings that person on Telegram so they see it without opening the
+ * board. Companion to task-comment-replies.ts: that one answers @zoe; this one
+ * forwards @person mentions to the mentioned person's Telegram.
+ *
+ * Destinations come from MENTION_NOTIFY_MAP (JSON env), a handle -> {chatId,
+ * topicId?} map, so a mention of @iman lands in Iman's topic and @zaal in his
+ * DM. @zoe is never notified here (that path is task-comment-replies).
+ *
+ * Best-effort: no-op when the board or the map is unconfigured, deduped by
+ * (comment id + handle) so nobody is pinged twice, capped per tick, never
+ * throws into the scheduler.
+ */
+
+import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
+const SEEN_PATH = join(ZOE_HOME, 'mention_notify_seen.jsonl');
+const CANDIDATE_LIMIT = 200;
+const MAX_NOTIFY_PER_TICK = 20;
+const SNIPPET_LEN = 240;
+/** Handles that are bots / never get a person-notification. */
+const SKIP_HANDLES = new Set(['zoe', 'zaoclaw_bot', 'here', 'everyone', 'all']);
+
+export interface BoardComment {
+  id: string;
+  userId?: string;
+  displayName?: string;
+  content: string;
+  createdAt?: string;
+}
+
+export interface BoardTask {
+  id: string;
+  legacy_id: string | null;
+  title: string;
+  metadata?: (Record<string, unknown> & { comments?: BoardComment[] }) | null;
+}
+
+export interface Destination {
+  chatId: number;
+  topicId?: number;
+}
+
+/** send(chatId, text, {threadId}) -> resolves when sent. Injected by scheduler. */
+export type SendFn = (chatId: number, text: string, opts?: { threadId?: number }) => Promise<void>;
+
+export function boardConfigured(): boolean {
+  return Boolean(process.env.COWORK_TRACKER_URL && process.env.COWORK_TRACKER_KEY);
+}
+
+/**
+ * Resolve the handle -> Destination map from MENTION_NOTIFY_MAP (JSON), plus a
+ * default 'zaal' -> DM when zaalChatId is supplied and not already mapped.
+ * Handles are lowercased. Returns {} on parse failure (best-effort).
+ */
+export function resolveDestinations(zaalChatId?: number): Record<string, Destination> {
+  const out: Record<string, Destination> = {};
+  const raw = process.env.MENTION_NOTIFY_MAP;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, Destination>;
+      for (const [handle, dest] of Object.entries(parsed)) {
+        if (dest && typeof dest.chatId === 'number') out[handle.toLowerCase()] = dest;
+      }
+    } catch {
+      // ignore malformed map - fall through to the zaal default
+    }
+  }
+  if (zaalChatId && !out.zaal) out.zaal = { chatId: zaalChatId };
+  return out;
+}
+
+/** Lowercased @handles in a comment, excluding bot/broadcast handles. */
+export function parseMentions(content: string): string[] {
+  if (!content) return [];
+  const found = content.match(/@([a-z0-9_]{2,32})/gi) ?? [];
+  const handles = found.map((m) => m.slice(1).toLowerCase()).filter((h) => !SKIP_HANDLES.has(h));
+  return [...new Set(handles)];
+}
+
+function commentsOf(t: BoardTask): BoardComment[] {
+  const c = t.metadata?.comments;
+  return Array.isArray(c) ? c : [];
+}
+
+/** Dedup key for one (comment, mentioned-handle) pair. */
+function seenKey(commentId: string, handle: string): string {
+  return `${commentId}:${handle}`;
+}
+
+async function readSeen(): Promise<Set<string>> {
+  try {
+    const raw = await fs.readFile(SEEN_PATH, 'utf8');
+    return new Set(raw.trim().split('\n').filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
+async function markSeen(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  await fs.mkdir(ZOE_HOME, { recursive: true });
+  await fs.appendFile(SEEN_PATH, keys.map((k) => k).join('\n') + '\n', 'utf8');
+}
+
+export interface PendingMention {
+  task: BoardTask;
+  comment: BoardComment;
+  handle: string;
+}
+
+/**
+ * Every (comment, mentioned-handle) pair whose handle is in `destinations`,
+ * was not authored by the mentioned person, and is not already in `seen`.
+ * Pure + exported for unit testing.
+ */
+export function findNewMentions(
+  tasks: BoardTask[],
+  destinations: Record<string, Destination>,
+  seen: Set<string>,
+): PendingMention[] {
+  const out: PendingMention[] = [];
+  for (const task of tasks) {
+    for (const comment of commentsOf(task)) {
+      for (const handle of parseMentions(comment.content)) {
+        if (!destinations[handle]) continue; // no route -> skip silently
+        if (comment.userId && comment.userId.toLowerCase() === handle) continue; // self-mention
+        if (seen.has(seenKey(comment.id, handle))) continue;
+        out.push({ task, comment, handle });
+      }
+    }
+  }
+  return out;
+}
+
+async function fetchRecentBoardTasks(fetchImpl: typeof fetch): Promise<BoardTask[]> {
+  const base = process.env.COWORK_TRACKER_URL;
+  const key = process.env.COWORK_TRACKER_KEY;
+  if (!base || !key) return [];
+  const url =
+    `${base.replace(/\/$/, '')}/rest/v1/tasks` +
+    `?archived_at=is.null&metadata=not.is.null` +
+    `&select=id,legacy_id,title,metadata` +
+    `&order=updated_at.desc.nullslast&limit=${CANDIDATE_LIMIT}`;
+  try {
+    const res = await fetchImpl(url, {
+      headers: { apikey: key, Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(8000),
+      cache: 'no-store',
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as BoardTask[];
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+function notifyText(m: PendingMention): string {
+  const who = m.comment.displayName || m.comment.userId || 'Someone';
+  const snippet = m.comment.content.replace(/\s+/g, ' ').trim().slice(0, SNIPPET_LEN);
+  const label = m.task.legacy_id ? `#${m.task.legacy_id}` : m.task.title;
+  return `${who} mentioned you on task ${label} ("${m.task.title}"):\n${snippet}\n\nthezao.xyz/board?task=${m.task.legacy_id ?? m.task.id}`;
+}
+
+export interface NotifyResult {
+  notified: number;
+  scanned: number;
+}
+
+/**
+ * One notification pass. Best-effort; never throws.
+ * @param send injected Telegram sender.
+ * @param zaalChatId Zaal's DM chat id (default 'zaal' route).
+ * @param fetchImpl injectable for tests.
+ */
+export async function runMentionNotify(
+  send: SendFn,
+  zaalChatId?: number,
+  fetchImpl: typeof fetch = fetch,
+): Promise<NotifyResult> {
+  if (!boardConfigured()) return { notified: 0, scanned: 0 };
+  const destinations = resolveDestinations(zaalChatId);
+  if (Object.keys(destinations).length === 0) return { notified: 0, scanned: 0 };
+
+  const tasks = await fetchRecentBoardTasks(fetchImpl);
+  const seen = await readSeen();
+  const pending = findNewMentions(tasks, destinations, seen).slice(0, MAX_NOTIFY_PER_TICK);
+
+  const done: string[] = [];
+  let notified = 0;
+  for (const m of pending) {
+    const dest = destinations[m.handle];
+    try {
+      await send(dest.chatId, notifyText(m), dest.topicId ? { threadId: dest.topicId } : undefined);
+      notified++;
+      done.push(seenKey(m.comment.id, m.handle));
+    } catch (err) {
+      console.warn('[zoe/mention-notify] send failed (nbd):', (err as Error).message);
+      // Do NOT mark seen on failure - retry next tick.
+    }
+  }
+  await markSeen(done);
+
+  if (notified > 0) console.log(`[zoe/mention-notify] pinged ${notified} board mention(s)`);
+  return { notified, scanned: tasks.length };
+}


### PR DESCRIPTION
## Summary
When someone @mentions you in a task's comment on thezao.xyz/board, ZOE pings you on Telegram - so you (and Iman) see board comments without opening the board. The @person side of the comment system; the @zoe side (ZOE answers in-thread) is PR #1306.

## What it does
- Hourly tick fetches recent board tasks, finds new @person mentions (deduped by comment+handle), sends each to its destination from `MENTION_NOTIFY_MAP` (handle -> `{chatId, topicId}`). `@iman` -> Iman's topic, `@zaal` -> his DM. `@zoe` is never routed here.
- Best-effort: no-op when board or map unset, capped at 20/tick, a failed send is not marked seen (retries next tick).

## Iman onboarding
1. Add Iman to ZAAL BOTZ with his own topic.
2. Add to `MENTION_NOTIFY_MAP`: `{"iman":{"chatId":<group id>,"topicId":<his topic>}}`.

## Verification
- tsc: 0 errors in changed files (10 pre-existing zol SDK errors remain).
- vitest: 7 tests pass. esbuild bundle succeeds - boot-safe.
- Works for you now (@zaal -> DM); ready for Iman once his topic exists. Live on next VPS deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3