### PR TITLE
docs(events): doc 1064 - Iman sync ZaoZone refocus (2026-07-13)

### DIFF
--- a/research/events/1064-iman-sync-zaozone-focus-2026-07-13/README.md
+++ b/research/events/1064-iman-sync-zaozone-focus-2026-07-13/README.md
@@ -1,0 +1,65 @@
+---
+topic: events
+type: incident-postmortem
+status: research-complete
+last-validated: 2026-07-13
+related-docs:
+original-query: "/meeting craig-rInoEEab0Sra-mix.wav - Iman working sync, board cleanup + refocus"
+tier: STANDARD
+---
+
+# 1064 - Iman Sync: ZaoZone Refocus + Board Cleanup (2026-07-13)
+
+> **Goal:** Capture the decision that refocused Iman onto one thing - owning the ZAO Zone as the front-end for the co-working board - and the workflow cleanup that produced it.
+
+**Date:** 2026-07-13
+**Duration:** ~18 min
+**Attendees:** Zaal, Iman
+**Platform:** Discord / Craig
+**Project:** ZAO Devz / general
+Full transcript: [transcript.md](transcript.md)
+
+## Headline
+
+Iman's focus collapsed from a scattered task pool to ONE thing: **own the [ZAO Zone](https://github.com/ZAODEVZ/theZAOZone) and turn it into the front-end for the [co-working board](https://thezao.xyz/board).** The board had auto-assigned Iman a firehose of PR-test / doc-review chores across every domain (the pr-test-task pipeline defaults owner to Iman); Zaal cleared almost all of them off live in this sync.
+
+## Decisions
+
+| # | Decision | Owner |
+|---|----------|-------|
+| 1 | Iman owns the [ZAO Zone](https://github.com/ZAODEVZ/theZAOZone); it becomes the front-end for the [co-working board](https://thezao.xyz/board). Ideal end state: only Zaal + Iman on the raw board, everyone else enters through the ZaoZone. | Iman |
+| 2 | ZaoZone home = choose-your-path: a 2x2 grid with two axes (e.g. decentralization x entrepreneurship), all ZAO projects plotted on the XY, pick your corner. | Iman |
+| 3 | Three types of people can join; Jose logs in and sees his ZaoZone tasks pulled from the board. Only builders get the raw board. | Both |
+| 4 | Onboarding = a ZAO course: vibe-coding instructions + ZAO instructions + integrate [ZAOlingo](https://github.com/bettercallzaal/zaolingo). | Both |
+| 5 | No duplicate repos - the [Zlank](https://github.com/bettercallzaal/zlank) templates went to a new GitHub; consolidate into the existing repo + delete the copy. Going forward, update the existing repo, never fork. | Zaal |
+| 6 | Daily-tasks process: each person gets a daily task; Iman logs all active to-dos + links into its comments as "working on this today". | Both |
+
+## Actions
+
+| Action | Owner | File / Link |
+|--------|-------|-------------|
+| Build the ZaoZone MVP - choose-your-path front-end for co-working | Iman | [task 857](https://thezao.xyz/board?task=857) - repo [ZAODEVZ/theZAOZone](https://github.com/ZAODEVZ/theZAOZone) |
+| Log all active to-dos into the daily task's comments (with links) | Iman | [task 858](https://thezao.xyz/board?task=858) |
+| Create the comms account; (optional) Anthropic Courses 101 | Iman | - |
+| Consolidate the Zlank templates repo + delete the duplicate | Zaal | [bettercallzaal/zlank](https://github.com/bettercallzaal/zlank) |
+| Build the per-person daily-view (one button per person) | Zaal | [board](https://thezao.xyz/board) |
+| Finish the POIDH bounty-deadline calendar (in progress, ASAP; talk to August re: Boyd) | Zaal | - |
+| WaveWarZ content week; [ZABAL Games](https://zabalgames.com) content that leads with WaveWarZ | Zaal | [zabalgames.com](https://zabalgames.com) |
+| Build "view board as any person" (Zaal view) | Zaal | [board](https://thezao.xyz/board) |
+
+## Also See
+
+- [[project_iman_role]] memory - updated with this ZaoZone refocus.
+- [[feedback_task_clarity_links]] - the "clear goal + GitHub file link" rule this sync produced.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Ship the ZaoZone MVP front-end (choose-your-path home, board-backed tasks) | Iman | PR to ZAODEVZ/theZAOZone | 2026-07-20 |
+| Fix the pr-test-task generator so it stops auto-assigning to Iman | Zaal (via ZOE) | PR to ZAOOS | 2026-07-16 |
+| Build the "view board as any person" Zaal-view | Zaal (via ZOE) | PR to ZAODEVZ/ZAOcowork | 2026-07-18 |
+
+## Sources
+
+- Meeting recording `craig-rInoEEab0Sra-mix.wav` (local transcription, mlx-whisper) `[FULL]` - transcript in [transcript.md](transcript.md).

--- a/research/events/1064-iman-sync-zaozone-focus-2026-07-13/transcript.md
+++ b/research/events/1064-iman-sync-zaozone-focus-2026-07-13/transcript.md
@@ -1,0 +1,220 @@
+# Transcript - Iman Sync (2026-07-13)
+
+Zaal + Iman, ~18 min, Discord/Craig. Local mlx-whisper transcription.
+
+but you shouldn't worry about that it's a little bit complicated so okay
+yeah tell me what you've been up to uh recording has started i have like 10 minutes total
+um i'll let you have the time i'll listen in i'll take note of everything you say i'll write it down
+i will start to work on it and then we'll relink in an hour or two if that's cool
+uh okay um we can relink later but i actually need you to help me with this
+assigned to me on this uh task okay let me just open it up yeah yeah so the 10 minutes now
+okay so we have this wait for that kind of stuff
+oh yeah yeah so i got 10 10 15 minutes now we'll rock through all of these
+right and knock them out so let's go talk okay number one we have the white paper
+version 1.0 publish three docs to permal web and mint manifesto what's uh what's that one
+i didn't change that to me click on it and change it to me assign yeah click on it and assign it to
+me though okay cool but I'm doing that right now then there's one next to it
+I'm sorry yeah just uncheck you perfect now if you refresh the page it shouldn't
+have that as the top one right okay let's do that I see yeah actually you
+don't even need to refresh the page perfect okay confirm novelty skill
+archive candidates cuts click on that actually 582 see this is where this is
+really good is now I can just go to 582 and do things so instead of like all
+right so I'm just gonna type in 582
+and this is novelty skill skill archive candidate cuts I don't even really know
+what this is so I'm gonna take you off of it and I'll look into it later what's
+the next thing uh reconciled for the devar agents global project skills
+okay and that is 584 584 and that shouldn't be tagged to you let me just tell my bot real quick
+I'm going through things with iman and zoll and there's lots of things that a don't have a lot of documentation or links to files use links instead so anyone can get to them especially github files which are hard to find and make sure that
+the things that we assign iman have a very clear and direct goal
+how is the za iman in the za bots category going can we ask him some questions
+on there like we have said
+Okay, cool.
+So I'm cleaning that up a little bit,
+but I just undid you off of 584.
+What's the next one, 585?
+585, yeah, then 586.
+Okay, and then this one,
+Claude Cowork, Lead Reengagement Skill.
+That's not you.
+So 586 is next.
+I should make a...
+I also want as a Zoll view to be able to view the board as any other person.
+So I can quickly see how the board would look to them.
+Okay, cool.
+So what's the next one?
+The next one is 589.
+yeah okay yeah most of these aren't going to be your things to be honest with you
+okay yeah let me pop that off is there a way i can filter by who owns it so my tax i want everyone
+owner i'm in and then i can quickly go through these besides stock spin out we can take you off
+this. Playboy's
+final bridge, take you off that.
+Parkcaster wiki,
+take you off that.
+Cord,
+comfy AI, yeah, a bunch of the
+such as should not have tagged you.
+I want you to just
+be locked in on your thing. I want you to take
+over the Zao zone. I want, like,
+I'm, like, I want when
+I share things, the Zao zone to be
+your thing, and, like, you
+sharing as the Zao devs. I would
+love for that to happen. So,
+like it'd be great if we could do a couple things and i'll download this right after i'm done and
+send you over a summary so just don't like stress too much about like writing it down
+but i would like for you to focus on the zhao zone being focused on getting more people on board
+like you and jose we need them to have uh vibe coding instructions if that's where they want to
+attack we need to have zhao instructions if that's where they want to attack we want to make it
+a course for the Zao. I created this thing called ZaoDL. It's like, sorry, ZaoLingo on my GitHub.
+And we can integrate that into there too, where it's just like very basic Duolingo style, but
+you learn about the Zao, right? So things like that, because it should be in different styles
+of learning, but you should be able to pick your way. Does that make sense? Yeah, it does. I get it.
+Okay. Cool, cool, cool. All right. So that's what I want you to lock in on is clean up the Zao
+zone and make it such that we can have three types of people join in jose can join in and can
+immediately see his zow zone tasks and we'll pull it from co-working board but in an ideal world we
+don't want anyone on this board we just want me and you right yeah so for that what we need to do
+is create the zow zone such that it's our front end for the co-working ah okay makes sense right
+But we want to right now, we have two people on the team, you and Jose.
+Those are the two people I'm teaching.
+I want to bring a lot of other people in that have skill sets, but I don't want them to come in and then be sitting here like you are sometimes, right?
+I want to be able to have them jump in, try things out, and immediately push stuff, right?
+Immediately watch stuff or immediately give feedback, immediately tag us in Farcaster.
+So that's what I want to do with the ZaoZone.
+That's what I'm thinking.
+I can take a look at it later today
+or whenever you're ready for me to take a look at it
+I can even look at it now
+because I know you updated it
+but I know we also looked at it as well
+so like I'm looking at the ZaoZone about
+this is super clean
+let's make the front page
+though like a click on what type of person
+what interests you
+and we could have like a
+like you can scroll like a grid
+like a 2x2 grid
+and we need to create two parameters.
+Like one might be decentralization
+and one might be entrepreneurship.
+So we have those two scales and you have an XY axis
+and we have all of our projects listed on that XY axis.
+If you want like a very high entrepreneurship,
+high decentralization, you go to the top left
+and you start looking from that corner down.
+does that make sense so that's where i want this home page to be this is that cool
+that makes sense bro that actually makes cool i'm gonna make a new to do i'm gonna call it the
+zow zone zow zone build out mvp i just made it it's gonna be 857 okay okay cool and i'll say
+iMan starting work on upgrading zone to be front end for co-work.
+Because I don't want to invite everyone to the co-working thing.
+I only want to invite people who are going to build on top of it.
+I want people that are actually going to do to-dos to just come in from one other angle.
+Cool?
+So is that good for you?
+You don't have any other big to-dos, right?
+So this test plan, let me remove you off of.
+Test plan, remove you off of.
+Tuesday tasks.
+So last week you said what's urgent.
+I said today's task is to make Zao templates with Zlank,
+confirm the templates work.
+You updated it in a new GitHub, right?
+So that is something we need to confirm and check.
+So I'm going to change this to at Zoll, look through the Slack updates and update the domain.
+To be honest with you, I probably won't update the domain and I'll just ask my bot to copy your updates from your thing and then delete yours.
+Because we have too many repos that are copies of each other.
+we can't do that right so i'm probably gonna do that but good work so like don't don't take that
+as you did wrong let's just think about how we can improve that process don't even have to have
+an answer right now we can do that again a couple more times it's okay but it's not the best way
+update the old repo to have the new updates and then share this week is gonna be a wave wars
+week, by the way. I'm just going to be sharing
+wave wars, stuff like crazy.
+Okay? Okay. Cool.
+Gotcha. Cool. I'm going to
+look at this later today.
+I'm going to take it off of your to-dos and
+put it as just Zoll.
+Okay. Cool, bro.
+And also, Zolli.
+Is it Zolli or Zoll?
+I just say Zoll, but yeah.
+Figured.
+Yeah. You need to create that account.
+Don't forget that you wanted us to
+try out for the communication.
+yeah i actually just figured it out i'm just gonna i just added you to a group chat
+and um i'm gonna make one specific topic for just you oh cool that'd be great and then i heard you
+mention it being wave wars week bro what can we what do we need from nemesis and wave wars africa
+content around the ball games i need the ball games and wave wars in the same content anywhere
+okay so content around the ball games with the wave wars topic so like push the ball games by
+sharing what wave wars is uh okay cool all right cool i don't know
+okay so that was the tuesday task one sec let me just review all of this um if i press refresh
+why are there so many more tasks now that's weird check board filters work
+did you check this oh you said should i build and
+okay so you said six days ago should i build and share a commit branch for a review
+this is for check board filters work so did it not work did you check it
+Oh, I was so that's okay. So are you assigning this to me?
+No, I actually created a new commit that I asked you to check.
+It should be there on the same day.
+So all I see on the 703 is you asking me should I build income and share a commit branch for review?
+Yeah, we spoke about it and you said I should I actually did check on the
+Yeah, it's
+Okay, so I'm just going to submit done by iVan.
+Close this out.
+Yeah, I don't need to know what happened.
+If it worked, I don't need to know.
+We can just exit out.
+Zoe self-check, new task auto-tagged correctly.
+So, Zoe verifies the task created from Zoe.
+Lance free tagged.
+Honestly, I think this is fine.
+I'm going to...
+Done, not needed, dash will fix if problem again.
+OK, mark that as done.
+And build the point bounty deadline calendar. Ooh, this is a
+good one. I'm going to take this off of your to do's, but I'm
+but I'm gonna put it in progress.
+Let's all complete this ASAP.
+I think it started.
+Let's talk to August about void.
+Okay.
+Papers, nav, make back to papers sticky.
+I don't know why it's assigning all these for you,
+to be honest with you.
+Why?
+Why were so many random things assigned to Iman?
+Can't we clean up our workflow process?
+I will share the meeting I had with him as a meeting here next.
+Okay, so we only have a few left.
+On your screen, if you press refresh, what does it do?
+You have nine assigned to you.
+Okay, perfect, perfect, perfect, perfect.
+Fix broken manifesto link.
+This does not need to be you.
+I'll take that off.
+Build deployed bounty debt.
+Okay, wait.
+We just need to take you off of that.
+And then Anthropic Courses 101.
+I wouldn't mind it if you spent some time on this as well.
+Okay.
+okay what's what's what is this i'm just gonna text it over to you okay you can put it in as a
+today assignment if you want make it okay yeah actually no no this is what i'll do real quick
+let me just tell you what i'm gonna do and how i want you to approach the daily to do's first off
+i'm gonna make a task a sideboard on the side that just says like daily to do's per person so i can
+click on one button. But I'm going to make a to-do today for you is going to be 7-13-26
+Monday iMan tasks. I actually didn't spell that right. Tasks. And then we will in here,
+I want you to put in the comments all of the to-dos you're working on.
+so what that means is in this comment i can say
+what is it to do i gave you at the very beginning of this
+conversation or oh zow zone yeah let me just search that real quick
+zone and there's nothing because it's on that man owner okay zaozone mvp build out i'm gonna put you
+as the owner for this but now i have this task 857 i can copy this link and i can paste it into
+the comments and i can say working on this today and that's what i want you to do so write everything
+in here. I'll text it to you.
+Write everything on 858 today.
+And I'll share you the skill jar here as well.
+Anthropic Courses 101.
+take a look at this
+hear anything you learn in this comment okay boom so you should be good to go okay cool

--- a/research/events/README.md
+++ b/research/events/README.md
@@ -4,6 +4,7 @@
 
 | # | Title | Type | Summary |
 |---|-------|------|---------|
+| 1064 | [Iman Sync: ZaoZone refocus + board cleanup](./1064-iman-sync-zaozone-focus-2026-07-13/) | STANDALONE | Iman refocused to owning the ZAO Zone as the co-working front-end; board cleanup of auto-assigned tasks. |
 | 201 | [AI, Creator Economy & Web3 Landscape (March 2026)](./201-ai-creator-economy-landscape-march-2026/) | STANDALONE | 11 external signals — AI art DAOs, Suno 5.5, creator credentialing, NVIDIA agent tooling, AI filmmaking, Ethereum infra |
 | 207 | [ZAO VPS Agent Stack Session Log](./207-zao-vps-agent-stack-session-log/) | EVENT/LOG | Everything deployed on the ZAO VPS, how systems connect, roadmap to community-managed agent infra |
 | 240 | [Farcaster Agentic Bootcamp (Builders Garden)](./240-farcaster-agentic-bootcamp-builders-garden/) | EVENT/LOG | Live coverage of the Builders Garden / urbe.eth Farcaster bootcamp series |

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-07-13 | Iman Sync: ZaoZone refocus + board cleanup | ZAO Devz | Zaal, Iman | [1064](1064-iman-sync-zaozone-focus-2026-07-13/) | 8 |
 | 2026-07-08 | ZABAL Gamez x POIDH fireside - Kenny, Thy Revolution, Mauro | ZABAL Games / POIDH | Zaal, Kenny, Thy Revolution, Mauro | [994](994-zabal-gamez-poidh-fireside-unlock-jul8/) | 11 |
 | 2026-06-29 | Deez x Zaal - Boardwalk token launcher | ZABAL Games / Tokenization | Zaal, Deez | [953](953-deez-boardwalk-token-launcher/) | n/a |
 | 2026-06-28 | ViniApp x Zaal - brainstorm session | ZABAL Games | Zaal, ViniApp team | [952](952-viniapp-brainstorm/) | n/a |


### PR DESCRIPTION
Recap of the 2026-07-13 Iman working sync. Headline: Iman refocused to owning the ZAO Zone (github.com/ZAODEVZ/theZAOZone) as the front-end for the co-working board. Includes the board-cleanup context (pr-test-task pipeline was auto-assigning Iman a firehose) + link-rich decisions/actions. Full transcript in transcript.md. Next-actions: ship ZaoZone MVP (Iman), fix the pr-test-task auto-assign (ZOE), build view-as-person (ZOE).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>