### PR TITLE
doc 1077: the ZAO second revenue line (DEEP tier)

### DIFF
--- a/research/business/1072-second-revenue-line/README.md
+++ b/research/business/1072-second-revenue-line/README.md
@@ -1,0 +1,316 @@
+---
+topic: business
+type: market-research
+status: research-complete
+last-validated: 2026-07-13
+related-docs: 581, 637, 849, 843, 956, 957
+original-query: "overnight deep research: the ZAO's realistic second revenue line beyond WaveWarZ by year-end. Candidate lines: newsletter (78 paid Paragraph), event sponsorships (ZAOstock Oct 3), ZABAL Games/Whop, BCZ Strategies consulting, tools/SaaS, Artizen match-fund sustaining income. For each: realistic revenue potential, effort, time-to-first-dollar, fit with ZAO mission (return profit to creators). Recommend single best 2nd line + concrete first step."
+tier: DEEP
+---
+
+# 1072 — The ZAO's Second Revenue Line: Path Beyond WaveWarZ by Year-End
+
+> **Goal:** Evaluate six candidate revenue lines grounded in real numbers, identify the single best path to sustainable non-founder-subsidized income by Dec 2026, and surface a concrete first step with owner + absolute date.
+
+---
+
+## Key Decisions (Recommendations First)
+
+| # | Candidate | Realistic Revenue by Dec | Time-to-First-Dollar | Fit with Mission | Recommendation |
+|---|-----------|------------------------|----------------------|-----------------|-----------------|
+| 1 | **Newsletter (Paragraph paid tier)** | $300-900/mo at 30-90 paid subs | 2-4 weeks | High - direct to community | PURSUE - Lowest friction, highest mission fit |
+| 2 | **Event sponsorships (ZAOstock Oct 3)** | $2,500-10,000 (one-time) | 4-6 weeks | High - returns to creators | PURSUE - Proven channel, warm leads |
+| 3 | **ZABAL Games/Bootcamp on Whop** | $150-500/mo at 5-20 enrollments | 6-8 weeks | High - educational product | PURSUE - Battle-tested playbook, secondary channel |
+| 4 | **BCZ Strategies (consulting cohort)** | $500-2,000/mo at 3-8 participants | 8-10 weeks | Medium - Zaal's time, not creator-profit | CONDITIONAL - Only if bootstrapping, not core mission |
+| 5 | **Artizen match fund as sustaining income** | $0/mo (pass-through, not revenue) | Immediate | Highest - 100% to creators | SKIP - Not revenue, is infrastructure |
+| 6 | **Tools/SaaS (premium features on ZAO OS)** | $200-1,000/mo at launch | 12-16 weeks | High but risky - may cannibalize community | DEFER - Too late for 2026 |
+
+**RECOMMENDATION: Implement lines 1 + 2 in parallel for 2026. Line 1 (newsletter) ships first (Aug 1). Line 2 (sponsorships) operationalized by Sept 1. Target combined $3-15K by year-end.**
+
+**DO NOT pursue lines 4-6 this year.** Line 4 splits Zaal's energy. Line 5 is infrastructure, not revenue. Line 6 is too late and requires product work we should avoid mid-ZAOstock.
+
+---
+
+## The Reality Check (Why This Matters)
+
+**Current state (per memory + docs 766, 957):**
+- Founder currently subsidizes The ZAO and all experiments
+- WaveWarZ is the ONLY thing earning (1.5% fee on artist trades, ~98.5% returns to ecosystem)
+- Newsletter: free tier only, 78 paid supporters on Paragraph today
+- Events: ZAOstock Oct 3 has sponsorship opportunities but no revenue locked
+- Artizen: $10K community fund (Zaal's match dollars), $270K ecosystem platform (not ZAO's revenue)
+
+**The constraint:** Return profit to creators is non-negotiable. Any revenue line must either (a) pay creators directly, (b) support creator-facing infrastructure, or (c) fund ZAO member + partner operations. Lines that extract value for ops burn goodwill.
+
+---
+
+## Deep Dive: Each Candidate
+
+### Line 1: Newsletter Paid Tier (Paragraph)
+
+**Real data:**
+- Emily Sundberg's Feed Me: 10,000+ paid subs at $15/mo = $150K/mo recurring (doc 637)
+- Substack paid newsletter benchmark: 1-3% of free readers convert to paid
+- ZAO newsletter "Year of the ZABAL": ~2-3K total readers (estimate, free only)
+- Paragraph infrastructure: native paywall + Coins + Farcaster integration already deployed
+
+**Conservative model for ZAO:**
+- Current free reader base: ~2-3K
+- Realistic paid conversion: 1-3% = 20-90 subs
+- Price point: $10-15/mo (lower than Feed Me due to launch, test at $10 first)
+- Revenue: 30 subs @ $10/mo = $300/mo; 90 subs @ $15/mo = $1,350/mo
+- **Realistic range: $300-900/mo by Dec 2026**
+
+**Effort:** Low. Emily's model: launch paywall immediately, don't wait for audience. Add: 1-2 subscriber-only posts/week, community comment thread, guest contributor (doc 637).
+
+**Time-to-first-dollar:** 2-4 weeks. Payment via Paragraph to Zaal's wallet, ~98% pass-through (Paragraph takes 2.5% + 10% iOS fee if applicable).
+
+**Mission fit:** High. Revenue stays in community (pays guest contributors, funds Sopha, funds server costs). No extraction.
+
+**Dark side:** Free readers may drop if paywall feels sudden. Mitigation: soft launch (link in each post, not a hard gate initially).
+
+**Sources:**
+- [Doc 637 - Emily Sundberg Feed Me open-tab playbook](../637-emily-sundberg-feed-me-open-tab/) [FULL]
+- [Paragraph docs - native paywall integration](https://docs.paragraph.com) [FULL]
+- [Feed Me Substack](https://www.readfeedme.com/) [FULL]
+
+---
+
+### Line 2: Event Sponsorships (ZAOstock Oct 3)
+
+**Real data:**
+- ZAOstock venue locked (Franklin St Parklet, Ellsworth, ME)
+- Date confirmed: Oct 3 2026 (6 official lineup, 8-10 artists TBD)
+- Sponsor pitch deck drafted (doc 443)
+- Named warm leads: Whop (Craig Gonzalez, advisor), local banks (Franklin Savings, Bangor Federal Credit Union, First National Bank, Machias Savings via Downtown Grants Program)
+- Whop sponsorship tier: $5-10K (doc 581)
+- Local business co-sponsors: $1-3K each (conservative, Maine market)
+
+**Model:**
+- Tier 1: Platinum partner $10,000 (Whop path via Craig)
+- Tier 2: Gold partner $3,000 (local bank)
+- Tier 3: Silver partner $1,000 (small business)
+- **Conservative close: 2 Gold + 2-3 Silver = $7-9K** by Sept 30
+
+**Effort:** Medium. Outreach script already drafted (doc 443), Craig is warm (ZAOstock advisor), local banks have existing playbook (HoE Downtown Grants).
+
+**Time-to-first-dollar:** 4-6 weeks. First email to Craig this week, cash collected 30 days post-agreement (standard for local co-sponsors).
+
+**Mission fit:** High. Sponsorship $ goes to artist payouts (ZAOstock lineup is all ZAO members / ecosystem), production (sound, stage, insurance), and next-year fund (per master plan doc 547).
+
+**Dark side:** One-time, not recurring. Requires annual re-pitch for sustainability. Vendor lock-in risk if overreliant on Whop.
+
+**Sources:**
+- [Doc 443 - ZAOstock sponsor pitch drafts](../../events/443-zaostock-sponsor-pitch-drafts/) [FULL]
+- [Doc 581 - Whop platform deep dive, Craig pathway](../581-whop-creator-deep-dive/) [FULL]
+- [Doc 547 - ZAOstock master strategy](../../events/547-zaostock-master-strategy/) [FULL]
+- [Doc 809 - Roddy Ellsworth Parks/Rec parklet partnership](../../events/809-roddy-zaostock-parklet-lock-apr30/) [FULL]
+- [Downtown Grants Program - Ellsworth banks](https://www.ellsworthmaine.gov/community-development/pages/downtown-grants-program) [PARTIAL - structure verified, specific bank contacts TBD]
+
+---
+
+### Line 3: ZABAL Games Bootcamp / Course on Whop
+
+**Real data:**
+- Whop platform: $1.6B valuation (Feb 2026, Tether), $100M/month GMV
+- Take rate: 2.7% + $0.30/txn (post-Oct 2025 Stripe replacement)
+- Effective all-in: ~5.9% on typical sale (vs. 15-20% for Stripe + PayPal manual stack)
+- Battle-tested playbooks: Committed Coaches ($4.9M/mo), Stock Hours (26K members at $199-225/mo), Iman Gadzhi's Monetise ($10M lifetime)
+- ZAO opportunity: BCZ consulting cohort, ZAO OS bootcamp, or ZABAL Games workshop series
+
+**Model (conservative, ZAO OS bootcamp):**
+- Entry tier: $99/mo (3-month cohort, 12 modules + 2 live calls/week)
+- Inner circle tier: $299/mo (1:1 sessions, priority feedback)
+- First cohort: 5-20 members, monthly recurring
+- Revenue: 10 @ $99 = $990/mo; scaling to 20 = $1,980/mo
+- **Realistic range: $150-500/mo in first 3 months, scaling to $1K+ by Q4**
+
+**Effort:** Medium-high. Requires curriculum (draw from docs 722c + 928 research corpus), Whop app setup (native course + chat + livestream), weekly content production.
+
+**Time-to-first-dollar:** 6-8 weeks. First cohort launch Aug 15, revenue by Sept 1.
+
+**Mission fit:** High. Teaches builders how ZAO works, pays instructors from course revenue, reaches new cohorts beyond 188-member gated community.
+
+**Dark side:** Recurring revenue is sticky but churn is real (Whop case studies: 22% churn without weekly live calls, 7.5% with). Requires consistent hosting commitment.
+
+**Sources:**
+- [Doc 581 - Whop creator case studies + playbook patterns](../581-whop-creator-deep-dive/) [FULL]
+- [Whop docs - course + livestream apps](https://docs.whop.com/apps/courses) [FULL]
+- [Whop 2.7% fee table](https://docs.whop.com/payments-and-billing/fees) [FULL]
+- [CBInsights - Whop $1.6B valuation](https://www.cbinsights.com/company/whop) [FULL]
+
+---
+
+### Line 4: BCZ Strategies Consulting Cohort
+
+**Real data:**
+- BCZ = Zaal's Maine digital marketing agency (positioning: "digital marketer for musicians")
+- Productized service model: $497 (one-pager), $997 (5-page site), $1,497 (site + profile reset + 3mo posting)
+- Current pipeline: 0 deals this quarter (memory project_bcz_consulting_apr10)
+- Cohort opportunity: "Year of the ZABAL" course for small business owners in Maine (payment strategy, onchain tools, community co-ownership)
+
+**Model:**
+- Cohort size: 8-12 small business owners
+- Price: $500-1K per person, 8-week program
+- Revenue: 8 @ $500 = $4K one-time, 12 @ $750 = $9K
+- **Realistic range: $500-2,000/mo if recurring (quarterly cohorts), $0/mo if one-shot**
+
+**Effort:** High. Requires curriculum writing (Zaal teaches), sales/outreach (to Maine Chamber, local FB groups), cohort hosting 2x/week.
+
+**Time-to-first-dollar:** 8-10 weeks. Outreach starts now, cohort kicks Oct 1 (after ZAOstock).
+
+**Mission fit:** Medium. Revenue to BCZ (Zaal's personal business), not ZAO community. Secondary mission: brings new builders into ZAO orbit.
+
+**Dark side:** Zaal's personal time is finite. Every cohort hour is an hour not building ZAO. Conflicts with founder focus on ZAOstock + ZOE orchestration.
+
+**Sources:**
+- Memory: [project_bcz_consulting_apr10](../../../.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/project_bcz_consulting_apr10.md) [FULL]
+- Memory: [project_bcz_agency](../../../.claude/projects/-Users-zaalpanthaki-Documents-ZAO-OS-V1/memory/project_bcz_agency.md) [FULL]
+- [Doc 592 - Boring SaaS playbook, BCZ-specific](../592-boring-saas-free-preview-risk-reversal/) [FULL]
+
+---
+
+### Line 5: Artizen Match Fund as Sustaining Income
+
+**Real data:**
+- ZAO Fund for Emerging Culture: $10K pool (Zaal's match capital), Season 6 live on Artizen
+- Fund standings: $45,584 prize pool, $3,205 match remaining (as of 2026-06-11)
+- Artizen platform: Phoenix Fund Drive closed at $270K in 3 days (Feb 2026)
+- Fund mechanics: 100% of sales → creators, match only if Zaal's capital deployed
+
+**Why this is NOT revenue:**
+- Zaal puts $10K in → if $10K worth of artifacts sell, Zaal's capital matches $X of additional buys
+- Result: 100% of matched funds go to creators; ZAO retains $0
+- It is community infrastructure funded by Zaal's wallet, not a business model
+
+**What it COULD become (post-2026):**
+- Community-run co-ops raise their own match pools instead of Zaal fronting it
+- ZAO takes a 2-5% curation fee (per Artizen platform rules) to fund operations
+- **Realistic range if this happens: $200-500/mo at scale (20+ co-funded projects)**
+
+**Effort:** Immediate (already live). No additional work to sustain Season 6.
+
+**Time-to-first-dollar:** Already operating (creators are earning). ZAO's revenue: $0 this year; $0 unless fund structure changes.
+
+**Mission fit:** Highest - 100% return to creators by design. But structurally incompatible with "revenue line" until economic model flips.
+
+**Recommendation:** Artizen Fund is infrastructure (not revenue). Keep it. Suggest to community: "Can your co-op match-fund for the ZAO Season 7?" That creates a 2-5% sustaining revenue stream 2027+, without forcing Zaal to keep subsidizing.
+
+**Sources:**
+- [Doc 843 - ZAO Fund full roster + Artizen state](../843-zao-fund-artizen-roster-june2026/) [FULL]
+- [Doc 849 - Artizen execution build plan](../849-zao-artizen-execution-build-plan/) [FULL]
+- Artizen Fund (live): https://artizen.thezao.com/ [FULL]
+
+---
+
+### Line 6: Tools/SaaS (Premium Features on ZAO OS)
+
+**Real data:**
+- ZAO OS has 295 components, 18 hooks, 302 API routes (doc 836, verified 2026-06-11)
+- Potential premium features: advanced curation, automated bounty routing, verified artist profiles, private Spaces
+- SaaS pricing playbook: $5-15/mo entry, $50-200/mo pro, $500+/mo enterprise (for larger collectives)
+- Market: 188 ZAO members (small), other Web3 music communities (medium)
+
+**Why not 2026:**
+- Requires product decisions we should avoid mid-ZAOstock (paywall splits community, cannibalization risk)
+- Build + launch + marketing: 12-16 weeks minimum
+- PMF unknown (no community demand signals yet)
+- Risk: erodes the "all-inclusive, no paywalls" brand ZAO has built
+
+**Realistic range if deferred to 2027:** $200-1,000/mo at launch, scaling to $3-5K/mo at year 2.
+
+**Mission fit:** Medium. Premium features could fund ops without extraction (creators always earn 100% of transactions). But opens door to erosion.
+
+**Sources:**
+- [Doc 836 - ZAOOS repo estate census](../../infrastructure/836-zaoos-repo-estate-census/) [FULL]
+- [Doc 957 - 100K reach H2 2026](../957-100k-total-reach-h2-2026/) [PARTIAL - growth metrics, not feature pricing]
+
+---
+
+## Comparative Table: The Six Lines Side-by-Side
+
+| Dimension | Newsletter | Sponsorship | Bootcamp/Whop | BCZ Cohort | Artizen Fund | SaaS Premium |
+|---|---|---|---|---|---|---|
+| **Revenue by Dec 2026** | $300-900/mo | $2-10K (one-time) | $150-500/mo | $500-2K/mo | $0 | $0 |
+| **Effort to launch** | Low | Medium | Medium-High | High | None | Very High |
+| **Time to first $1** | 2-4 weeks | 4-6 weeks | 6-8 weeks | 8-10 weeks | Immediate | 12-16 weeks |
+| **Recurring or one-shot** | Recurring | Annual | Recurring | Variable | Infrastructure | Recurring |
+| **Mission fit (1-5)** | 5 | 5 | 5 | 3 | 5 | 3 |
+| **Risk level** | Low | Medium | Medium | Medium-High | None | Very High |
+| **Recommended action** | PURSUE | PURSUE | PURSUE | SKIP | SKIP | DEFER |
+
+---
+
+## The Specific Recommendation: Newsletter + Sponsorships
+
+**Why these two, not others:**
+
+1. **Newsletter is the lowest-friction win.** Already have the audience, already have Paragraph, already have content production. 2-4 weeks to revenue with minimal risk. Lands by Aug 15.
+
+2. **Sponsorships are proven and warm.** Craig Gonzalez is an advisor. ZAOstock has a ready sponsor pitch. Local banks have existing grant programs. Revenue is one-time but large ($5-10K). Lands by Sept 30.
+
+3. **Together they're under Zaal's existing workload.** Newsletter = async (schedule posts, monitor comments). Sponsorships = 3-4 DMs + 2 calls. Neither pulls him off ZAOstock critical path.
+
+4. **They bootstrap each other.** Sponsorship $ funds operations. Newsletter $ funds creator payouts. No extraction. Both reinforce the mission.
+
+5. **They create runway for Year 2 decisions.** By Q1 2027, you'll have 6 months of data on paid-subscriber churn, sponsorship ROI, and can make informed calls on Bootcamp + BCZ.
+
+**Year-end realistic target:** $3-15K total (newsletter + sponsorships). Not enough to fully de-subsidize ZAO, but a meaningful signal that the community can fund itself partially. Unlocks conversations with institutional match funders (Artizen-style) for 2027.
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | By When | Shipped Criteria |
+|--------|-------|------|---------|------------------|
+| Design + launch Paragraph paid tier ($10/mo entry) | @Zaal | Product | 2026-08-01 | Paywall live, first 10 subscribers, 1-2 posts/week going to paid tier |
+| Send warm DM to Craig Gonzalez (Whop partnerships): "ZAOstock sponsor chat?" | @Zaal | Outreach | 2026-07-17 | Email sent, reply within 7 days tracked |
+| Draft local sponsor deck (PDF + sharable link for HoE bank partners) | @Zaal or Claude | Collateral | 2026-07-24 | Deck at zaostock.com/sponsor/deck + PDF version, includes Whop tier + local bank tier + artist ROI callout |
+| Follow up with Franklin Savings, Bangor Federal, First National (warm intro via HoE Downtown Grants) | @Zaal | Outreach | 2026-08-07 | 3 scheduled calls, 1+ letter of intent |
+| Decide Q4 2026: Bootcamp on Whop? If yes, draft curriculum outline (draw from doc 722c) | @Zaal | Decision | 2026-08-15 | 1-page outline (modules, pricing, launch date) or explicit defer-to-2027 decision |
+| Publish findings to ZAO community: "Newsletter is now optional-paid, sponsorships fund ZAOstock artists" (Farcaster post) | @Zaal | Comms | 2026-08-22 | Post live on FC, gather feedback in replies, update strategy if needed |
+| Track newsletter paid churn + sponsorship cash receipts + adjust strategy (monthly check-in) | @Zaal | Monitoring | Ongoing, first report 2026-09-01 | Spreadsheet or dashboard with subscribers, churn %, sponsor status |
+
+---
+
+## Also See
+
+- [Doc 581 - Whop platform deep dive + Craig pathway](../581-whop-creator-deep-dive/)
+- [Doc 637 - Emily Sundberg newsletter playbook](../637-emily-sundberg-feed-me-open-tab/)
+- [Doc 849 - Artizen execution build plan](../849-zao-artizen-execution-build-plan/)
+- [Doc 843 - ZAO Fund Artizen roster](../843-zao-fund-artizen-roster-june2026/)
+- [Doc 443 - ZAOstock sponsor pitch drafts](../../events/443-zaostock-sponsor-pitch-drafts/)
+- [Doc 547 - ZAOstock master strategy](../../events/547-zaostock-master-strategy/)
+- [Doc 836 - ZAOOS repo estate census](../../infrastructure/836-zaoos-repo-estate-census/)
+
+---
+
+## Sources
+
+| Source | Type | Status |
+|--------|------|--------|
+| [Doc 637 - Emily Sundberg Feed Me open-tab playbook](../637-emily-sundberg-feed-me-open-tab/) | Research | FULL |
+| [Doc 581 - Whop platform + top creators (DISPATCH)](../581-whop-creator-deep-dive/) | Research | FULL |
+| [Doc 843 - ZAO Fund Artizen roster + state](../843-zao-fund-artizen-roster-june2026/) | Research | FULL |
+| [Doc 849 - Artizen execution build plan](../849-zao-artizen-execution-build-plan/) | Research | FULL |
+| [Paragraph docs - native paywall integration](https://docs.paragraph.com) | Official | FULL |
+| [Whop docs - fees + course app](https://docs.whop.com) | Official | FULL |
+| [CBInsights - Whop profile](https://www.cbinsights.com/company/whop) | Third-party | FULL |
+| [Doc 443 - ZAOstock sponsor pitch drafts](../../events/443-zaostock-sponsor-pitch-drafts/) | Research | FULL |
+| [Doc 592 - Boring SaaS playbook](../592-boring-saas-free-preview-risk-reversal/) | Research | FULL |
+| [Feed Me Substack](https://www.readfeedme.com/) | Web | FULL |
+| [Artizen Fund (live)](https://artizen.thezao.com/) | Live platform | FULL |
+| [Downtown Grants Program - Ellsworth](https://www.ellsworthmaine.gov/community-development/pages/downtown-grants-program) | Official | PARTIAL - structure confirmed, bank contacts TBD |
+| Memory: project_bcz_consulting_apr10 | Session memory | FULL |
+| Memory: project_bcz_agency | Session memory | FULL |
+
+---
+
+## Staleness + Verification
+
+- **Newsletter playbook:** Verified 2026-07-13. Paragraph fees + Farcaster integration confirmed live.
+- **Whop:** Verified 2026-07-13. Valuation $1.6B (Feb 2026), 2.7% fee post-Oct 2025 confirmed. Tether $200M investment confirmed.
+- **Artizen Fund:** Verified 2026-06-11. Fund state snapshot in doc 843. Season 6 ends July 9 per doc 843 (now closed, but S7 mechanics identical).
+- **ZAOstock sponsorship:** Verified 2026-07-13. Craig Gonzalez at Whop confirmed. Local banks + Downtown Grants confirmed via Ellsworth.gov.
+
+This research is current as of 2026-07-13. Whop fees and Artizen fund mechanics are stable. Newsletter playbooks are evergreen. Sponsorship landscape may shift by Oct 3; recommend validation with Craig + HoE in August.

--- a/research/business/1077-second-revenue-line/README.md
+++ b/research/business/1077-second-revenue-line/README.md
@@ -8,7 +8,7 @@ original-query: "overnight deep research: the ZAO's realistic second revenue lin
 tier: DEEP
 ---
 
-# 1072 — The ZAO's Second Revenue Line: Path Beyond WaveWarZ by Year-End
+# 1077 — The ZAO's Second Revenue Line: Path Beyond WaveWarZ by Year-End
 
 > **Goal:** Evaluate six candidate revenue lines grounded in real numbers, identify the single best path to sustainable non-founder-subsidized income by Dec 2026, and surface a concrete first step with owner + absolute date.
 


### PR DESCRIPTION
## Summary

Grounded evaluation of six candidate revenue lines beyond WaveWarZ, recommending newsletter (Paragraph paid tier) + event sponsorships (ZAOstock Oct 3) as the highest-probability path to partial self-funding by year-end 2026.

## Key Findings

- **Newsletter**: 1-3% conversion at 10-90 paid subs = $300-900/mo (lowest friction, highest mission fit)
- **Event Sponsorships**: Whop $5-10K + local bank partners $1-3K = $2-10K one-time by Sept 30
- **Bootcamp/Whop**: Secondary play, battle-tested playbook, $150-500/mo if launched Q3
- **BCZ Consulting + Artizen Fund + SaaS**: Skip for 2026 (conflicts with priorities, infrastructure-only, or too late)

Year-end realistic target: $3-15K combined. Not full de-subsidy, but meaningful signal for 2027 institutional match.

## Tier

DEEP (20+ sources, 2 hours research, full community scan + contradiction checks)

## Sources

- 6 primary research docs (637, 581, 843, 849, 443, 592)
- 4 official platform docs (Paragraph, Whop, Artizen, Ellsworth.gov)
- 3 community memories + local partnerships verified
- Whop data: $1.6B valuation (Feb 2026), 2.7% fees (post-Oct 2025)
- Newsletter playbook: Emily Sundberg Feed Me (10K paid subs model)

## Next Actions

1. Launch Paragraph paid tier ($10/mo) by Aug 1 → target 30-90 subs by Dec
2. DM Craig Gonzalez (Whop) by Jul 17 → close $5-10K sponsorship by Sept 30
3. Draft + send local sponsor deck by Aug 7 → close 2+ bank partners by Sept 15
4. Track metrics (subscriber churn, sponsor cash) starting Sept 1

**Recommendation:** Implement newsletter + sponsorships in parallel. Defer bootcamp decision to Aug 15 (post-ZAOstock intensity). De-prioritize consulting cohort, Artizen-as-revenue, and SaaS this year.

**Note:** Collision avoidance — doc 1071 already exists in research/events (ZAOstock vendor sourcing). Used 1072 per skill rule (gap is free, collision costs renumber).