### PR TITLE
doc 1073: ZAOstock Oct 3 readiness (DEEP tier)

### DIFF
--- a/research/events/1073-zaostock-oct3-readiness/README.md
+++ b/research/events/1073-zaostock-oct3-readiness/README.md
@@ -1,0 +1,431 @@
+---
+topic: events
+type: decision
+status: research-complete
+last-validated: 2026-07-14
+superseded-by:
+related-docs: "1007, 1013, 1030, 1031, 1032, 1033, 1034, 1035, 1070, 1071"
+original-query: "ZAOstock Oct 3 readiness - what must happen to ship the event (overnight deep research: ZAOstock Oct 3 readiness plan)"
+tier: DEEP
+---
+
+# 1073 — ZAOstock Oct 3 Readiness: Dated Execution Plan Through Go-Live
+
+> **Goal:** With 82 days until ZAOstock (Oct 3, 2026), build a realistic, phase-based readiness checklist from now (2026-07-13) through launch. Ground every action in actual prior research (docs 1007-1071), confirm what exists vs. what's missing, map the critical path with real deadlines and owners, identify the single biggest bottleneck, and surface where $5-25K funding target creates unavoidable trade-offs.
+
+## Key Decisions
+
+| Recommendation | Why |
+|---|---|
+| **The critical path runs through PERMITS (Aug 19 deadline) and FUNDING (sponsor closes needed before Sept 1).** | If either misses their date window, the whole event either doesn't legally exist or runs with a broken budget. Artists, media gear, volunteers all sequence after these two. Priority order: (1) Permit decision by July 25 so surety bond can be lined up by Aug 10. (2) Sponsor pitch decks locked by July 18, closes by Aug 15. (3) Livestream gear secured by July 25 (doubles as ZAOville equipment). Everything else has 3-4 week buffers. |
+| **The $5K budget target creates a hard EITHER/OR on EMS standby and livestream production gear - plan for the cheaper option and escalate if required.** | Real numbers: standalone permit ($200-500 surety bond), possible EMS standby ($1,500-2,000 if mandated), livestream gear ($600 ideally, but rentable/software-based alternatives exist at $0-200), vendors/permits/operations ($176-730). If EMS is required, the team either cuts livestream production (software-only OBS + basic USB audio interface, ~$200 capital vs. $600) or scraps the $1.5K cash reserve and asks sponsors for a dedicated gear/ops budget line. Today's $ on hand is ~$1.5K; $5K target needs ~$3.5K more in closes. If permits signal EMS will be required, this becomes urgent to sponsor conversations NOW, not in August. |
+| **Name the First Aid Lead NOW (not mid-August), separately from the Site Lead.** | Doc 1032 explicitly called for a certified First Aid Lead, and both roles run full-day in parallel during the 12pm-6pm show. Zaal holding both is a liability and a single-point failure. Real candidate pool: ask the Ellsworth community first (HoE may know volunteer First Aid providers), then escalate to Hancock County EMS if needed. Not a blocker if a qualified volunteer surfaces in the next 2 weeks, but silence after August 1 means cost ($200-400 for a private first-aid contractor rental). |
+| **Lock the sponsor pitch decks (Artizen fund + HoE bank-partner deck) by July 18, not Aug 1.** | Two decks, shared content backbone: proof numbers ($5K target, Acadia 4M visits, 30K vehicles/day through Ellsworth, $391K HoE grant history), artist/volunteer model, Ellsworth positioning, media/social reach. The Artizen fund run closes dynamically - this is the time-sensitive gate. HoE bank-partner outreach can follow, but Artizen deadline is now (2-3 weeks). Zaal has drafts; they need polish and proof-read, not more research. |
+| **Assume the livestream/media lead is Ohnahji (confirmed 2026-07-12) and ground all media assumptions (gear, venue speed test, end-to-end test timeline) on his availability starting immediately.** | The role has been unowned/reassigned twice since May (Thy Revolution->Onaji->Ohnahji). Ohnahji is the confirmed owner as of doc 1035 update. Media production runs on its own 6-week critical path: gear by July 25 (dual-purpose for ZAOville), venue speed test by Aug 15, full end-to-end dress rehearsal by Sept 1. Each step depends on Ohnahji's time + the prior step's completion. If Ohnahji deprioritizes this thread, the entire media production fails - assign a backup, or make media async/recorded (clips uploaded post-event, not live). |
+| **Permit exemption almost certainly DOES NOT apply - call the City by July 20, file the standalone application by Aug 15, expect approval before Sept 1.** | Doc 1070 resolved the ambiguity: Chapter 14's exemption requires events "sponsored and under the direct supervision of the City." ZAOstock, as a sub-event of Art of Ellsworth (organized by Heart of Ellsworth, a nonprofit partner), likely doesn't meet that bar - needs a real call to confirm. If it doesn't apply: 45-day notice to Police Chief = Aug 19 deadline, plus $200-500 surety bond (apply by Aug 10, allow 5-7 day processing), plus possible EMS standby decision from the Fire Chief (answer in the same call). Real contact: City Clerk Suzanne McLean (207-667-2563, smclean@ellsworthmaine.gov) or Police Chief Troy Bires (207-667-2168, tbires@ellsworthmaine.gov). One call can resolve permit path AND EMS requirement. Do this week. |
+| **The single biggest risk is volunteer/team attrition between now and Oct 3 (82-day lead time for a volunteer event).** | Doc 1031's Finding 5 explicitly flagged this: volunteer-run organizations have higher failure rates in Year 1 specifically due to "weak succession planning" and key-organizer loss. ZAOstock already showed this pattern: livestream lead changed hands twice in 2.5 months (May-July), venue-lead confirmation is stale (doc 1007 flagged this in June, not re-checked yet). Mitigation: assign backup owners to all Tier 1 items NOW (permit, funding, media) before someone drops out mid-August, and confirm workstream owners weekly in a published check-in, not just memory. The cowork tracker is live for this - use it. |
+
+## Findings
+
+### 1. Permits & Legal: Mass Gathering License Path is Certain; EMS Standby Is a Maybe with Real Cost
+
+**Status as of doc 1070 (2026-07-13, FULL research):**
+
+The exemption question is resolved: ZAOstock likely DOES NOT qualify for the Chapter 14 city-sponsored exemption. The ordinance requires events "sponsored and under the direct supervision of the City of Ellsworth" - Art of Ellsworth is run by Heart of Ellsworth (independent 501(c)(3) nonprofit, City partner but not city-direct). A confirmation call is needed this week, but the working plan should be standalone Mass Gathering License.
+
+Real timeline and costs:
+- **July 20:** Call City Clerk or Police Chief (Suzanne McLean 207-667-2563 or Troy Bires 207-667-2168) to confirm exemption doesn't apply and get standalone application + EMS requirement answer
+- **July 25-Aug 10:** File Mass Gathering License application with Police Chief + obtain corporate surety bond from a Maine-authorized bonding company ($200-500, 5-7 day processing, apply by Aug 10)
+- **Aug 19:** Hard deadline - 45 days' notice to Police Chief (do not miss this)
+- **Aug 20-Sept 1:** City processes, expects approval before Labor Day
+- **EMS standby:** Fire Chief discretionary decision, asked in the same permit call. If required, real cost $1,500-2,000+ for 6-hour paramedic standby crew. Do not assume it's free.
+
+**Real contacts & sources (all FULL, verified 2026-07-13):**
+- City Clerk & Tax Collector: Suzanne McLean, (207) 667-2563, smclean@ellsworthmaine.gov
+- Police Chief (Mass Gathering applications): Troy Bires, (207) 667-2168, tbires@ellsworthmaine.gov
+- Fire Department (EMS requirement decision): (207) 667-8666
+- Ordinance: City of Ellsworth Chapter 14 (fetched directly, https://www.ellsworthmaine.gov/wp-content/uploads/2016/06/ord14_licenses_permits.pdf)
+- Maine Bonding Company Directory: www.maine.gov/professional_and_financial_regulation/bonding
+
+**Recommendation:** Schedule this call for July 17-20, not later. Document answers in writing (email follow-up asking for confirmation). If the exemption applies (unlikely), replan the timeline. If it doesn't (expected), immediately start surety-bond sourcing - a 45-day deadline can evaporate fast with one bonding company waiting 10 days to respond.
+
+---
+
+### 2. Funding Path: $5K Target Requires ~$3.5K in Closes; Fiscal Sponsorship Structure TBD; MaineCF Status Unknown
+
+**Current state (doc 1013, corrected 2026-07-12, doc 1035 update):**
+- Budget target: ~$5K
+- Cash on hand: ~$1.5K
+- Funding gap: ~$3.5K to target
+- Sponsors in-pocket or close: unconfirmed (last snapshot was May, doc 1013)
+- Fiscal sponsor: Status unconfirmed - is ZAOstock filed under Fractured Atlas yet? MaineCF? Neither? This gate-blocks everything else.
+
+**Sponsor pipeline (from doc 1031, HoE partnership angle - HIGH SIGNAL):**
+- Heart of Ellsworth partners with 4 community banks: Franklin Savings Bank, Bangor Federal Credit Union, First National Bank, Machias Savings Bank
+- These 4 run the Downtown Grants Program (2026 launch, $5K/$3K/$500 awards to local entrepreneurs)
+- ZAOstock isn't a Grants Program recipient, but HoE's own 2025 Annual Report shows HoE manages 50+ sponsor relationships and raised $391,670 in grant dollars - these are warm intros available NOW
+- Contact: Cara Romano, HoE Executive Director (via heartofellsworth.org)
+
+**Artizen Fund (time-sensitive gate):**
+- ZAO Fund is listed as eligible for the Artizen Daybreak Fund Drive (festival/arts category)
+- Fund runs on a rolling close (not a fixed deadline), but the real pressure is: every week a pitch isn't in, the fund pool shrinks as other orgs get funded. A completed pitch deck + application can potentially land $3-10K, but it needs to be in NOW or very soon
+- Status: Zaal has pitch deck drafts; needs polish + proof-read, not more research
+- **Action deadline: July 18** (give deck 3-5 days of circulation + feedback before final submission by July 25)
+
+**MaineCF status (NEEDS CONFIRMATION):**
+- No evidence in the research library that ZAOstock is currently in a MaineCF grant pipeline or applied
+- MaineCF is a real funder (Maine Community Foundation, legitimate 501(c)(3), awards $2-50K to community projects statewide)
+- Worth adding as a parallel track, but this is a "gather info and apply" task, not a "follow up on a prior application" task - assume 4-6 week lead time if pursuing
+
+**Fractured Atlas fiscal sponsorship (NEEDS CONFIRMATION):**
+- Fractured Atlas is mentioned as the target fiscal sponsor in various ZAO docs, but no doc confirms ZAOstock has an active account/project ID there
+- Fractured Atlas is the right choice (national fiscal sponsor for artist/culture projects, well-known, legitimate, 501(c)(3), $15K+ annual budget support available)
+- If ZAOstock is NOT yet sponsored by Fractured Atlas, setting that up takes 2-4 weeks (application + approval)
+- If it IS already set up, confirm the project ID and that donation page is live + social-media-shareable
+
+**Real recommendation:**
+By July 18, Zaal needs to confirm: (1) Is ZAOstock currently under Fractured Atlas fiscal sponsorship? If yes, get project ID + donation link and put it in every pitch deck + social media. If no, apply NOW - this is a 2-4 week gate and it blocks all formal grantmaking. (2) Is the Artizen pitch deck done? If not, block 2 hours today to finish it (it's a visual/story deck, not research-heavy). (3) Has anyone actually contacted the HoE bank partners yet? If not, that's a warm-intro call that takes 30 minutes and could unlock $3-5K in co-sponsorships.
+
+---
+
+### 3. Venue: Franklin Street Parklet - Confirmed, Availability and Logistics Still Need Confirmation
+
+**Status (doc 1031, Finding 3; docs 1032, 1046 - audience assumptions, accessibility audit):**
+- Venue: Franklin Street Parklet, Ellsworth, Maine (established, proven audience from Thursday summer concert series)
+- Confirmed: It exists, it's actively used for community events (Thursday concerts, Saturday farmers market)
+- Still unconfirmed: City/HoE permit for Oct 3 specifically (probably included in the Mass Gathering License, but needs explicit confirmation in that permit call); weather contingency plan (doc 1040 exists; status unconfirmed if it's actually filed/approved); accessibility/ADA compliance (doc 1046 - status unconfirmed on implementation)
+
+**Real numbers:**
+- Capacity: not explicitly stated in research, but Thursday concert attendance is implied to be 100-300 range based on context, ZAOstock target 200-400
+- Parking: doc 1031 found 30,000+ vehicles pass through Ellsworth daily, main parking is downtown lots (free, metered, municipal garage)
+- Sound/power/staging: none confirmed yet - this is part of the "sound system" decision that Zaal deliberately deferred to July 16 pending a check-in with the Town of Ellsworth on what they might provide
+
+**Recommendation:** The venue itself is locked. Logistics (parking signage, accessibility accommodations, weather contingency site identification) sequence after the July 16 town check-in and the permit confirmation call. Not a blocker today.
+
+---
+
+### 4. Artists & Lineup: 2 Confirmed (Tom Fellenz + 1), Rest of 8-12 Slot Open Call in Progress
+
+**Status (docs 1032, 1033 - operations and calendar framing; lineupowner Dcoop, unconfirmed since June):**
+- Confirmed: Tom Fellenz (1 artist, role/format unconfirmed)
+- Confirmed: 1 other artist (format unconfirmed from research)
+- Open: 8-12 artist slots via an open call (status: in-progress, timeline: most should be locked by Aug 15 per doc 472 earlier precedent, not yet re-confirmed)
+- Lineup lead: Dcoop (ownership unconfirmed since doc 1007, June 11; needs a direct check-in)
+
+**Real constraint:** Every artist added changes the run-of-show timeline (doc 428), the sound system needs (how many amps? wireless mics?), and the crew schedule (load-in, sound check, stage time). The lineup lock-in date isn't explicitly stated in current docs, but it's implicitly tied to: run-of-show finalization (Aug 15 per doc 1032), and photo/video content production starts (doc 1033, photo calendar needs artist videos/images starting mid-August). Working assumption: lineup should be locked by Aug 15.
+
+**Recommendation:** Confirm Dcoop is still lineup lead THIS WEEK. Ask for: (1) status of open-call applications, (2) expected lock-in date (assume Aug 15 unless told otherwise), (3) artist-materials collection process (video URLs, bios, images - this needs to start immediately for the photo calendar work).
+
+---
+
+### 5. Production & Media: Livestream Gear Critical Path (By July 25 for ZAOville, Oct 3 as secondary)
+
+**Status (doc 1030 - full media strategy; doc 1035 Tier 2 update 2026-07-13):**
+
+Media lead: Ohnahji (confirmed 2026-07-12; role reassigned twice before this, May->July)
+
+**Gear decision - URGENT (real deadline July 25 for ZAOville, not just Oct 3):**
+
+Option A: ATEM Mini Pro ($325) + audio DI/interface bundle ($250-300) = $600, one-time capital cost, owned, reusable
+- Pros: broadcast-quality output, can cover both ZAOville (July 25) and ZAOstock (Oct 3)
+- Cons: $600 spend against ~$1.5K cash on hand (40% of liquid reserves)
+- Payment: Zaal prefers crypto if a path exists; otherwise negotiation for cost-down or split with sponsors
+
+Option B: OBS (free, open-source) + basic USB audio interface ($100-150) + laptop capture = ~$200 total
+- Pros: minimal capital, open-source, sufficient for Twitch/YouTube streaming
+- Cons: less polished output, no built-in graphics/mixing, requires more technical skill from Ohnahji
+
+Option C: Rental (ATEM Mini Pro $80-120/weekend from a rental house, e.g. Borrowlenses or LensRentals) = ~$200 for both events
+- Pros: zero capital outlay, professional gear, insured
+- Cons: two separate rental cycles (July 20-28 for ZAOville, Sept 26-Oct 5 for ZAOstock), coordination overhead
+
+**Working plan (doc 1035 direction, 2026-07-13):** Buy Option A (ATEM + audio) if crypto payment can be arranged; otherwise pursue Option C (rent twice) or Option B (software). Decision deadline: July 18. Order deadline: July 20 (allow 5-7 day shipping if buying).
+
+**Media timeline:**
+- By July 25: Gear in hand (ZAOville dry run use)
+- By Aug 15: Venue connectivity speed test (Franklin St Parklet internet, backup cellular if needed)
+- By Sept 1: Full end-to-end test stream (all gear + graphics + test broadcast to a private Twitch channel)
+- By Sept 15: Graphics/lower-thirds/branding finalized (Firefly, fonts, ZAOstock color scheme)
+- Oct 3: Live stream at event
+
+**Photo/promo calendar (doc 1033):**
+- Needs artist images/videos collected by Aug 15 (depends on Dcoop's lineup lock-in + artist materials)
+- Needs photo scouting pass at Acadia locations by Aug 20 (Cadillac Mountain, Jordan Pond, Otter Cliffs, Bass Harbor, Schoodic)
+- Social posting cadence: Mon/Wed/Fri via Firefly (start immediately, template posts available in doc 1033)
+
+---
+
+### 6. Team & Roles: Confirmed = 3 (Zaal, Ohnahji, Jay/Duh); Gaps = First Aid Lead, Operations Crew, Volunteers
+
+**Confirmed:**
+- Site Lead: Zaal (dual-hatted with First Aid Lead, a liability - see below)
+- Livestream/Media Lead: Ohnahji (confirmed 2026-07-12)
+- Sponsors workstream: Jay/Duh (confirmed in doc 1007, last checked June 11)
+
+**Open/Stale:**
+- First Aid Lead: Needs a name separate from Zaal (doc 1032 called for certified First Aid person; both roles run full-day in parallel). Stale since June.
+- Venue/Operations Lead: Confirmation stale (doc 1007, June 11). Real work: parking coordination, vendor coordination, crew scheduling, day-of logistics.
+- Lineup Lead: Dcoop (unconfirmed since June 11, doc 1007). Real work: artist outreach, artist materials collection, run-of-show coordination.
+- Volunteer coordinator: Unconfirmed (doc 1043 exists as a recruitment plan; status unknown if it's been executed). Real work: volunteer onboarding, crew rosters, load-in/load-out scheduling.
+
+**Real constraint:** Each open role is a single point of failure. If Dcoop deprioritizes, artist lock-in slips and the photo calendar can't be seeded. If First Aid Lead is really Zaal, and Zaal gets sick or unavailable on Oct 3, there's no backup. The current state (3 confirmed, 5+ open/stale) is 3 weeks from dangerous.
+
+**Recommendation:** Weekly check-in on workstream ownership (already in doc 1035 as an action; no evidence it's been scheduled yet). Use the cowork tracker or a public calendar event, so silence = confirmed escalation, not silent gap.
+
+---
+
+### 7. Marketing & Comms Timeline: Social Cadence Scheduled; Event Listings TBD; Farcaster Angle Unconfirmed
+
+**Status (docs 1033, 1042):**
+
+Social media:
+- Cadence planned (Mon/Wed/Fri via Firefly)
+- Photo/promo calendar planned and seeded by doc 1033's hub content
+- Status: Not yet started (as of doc 1033 date 2026-07-11)
+
+Event listings:
+- Yodel calendar: Mentioned in docs 1034, 1042 as planned; status unknown if it's live
+- Facebook event: Planned, status unknown if live
+- Google Calendar: Planned, status unknown
+
+Press/outreach:
+- Doc 1042 (press outreach plan) exists; status unknown if executed
+- HoE partnership amplification: implicit, not yet explicit in social calendars
+
+Farcaster-native angle:
+- NO RESEARCH FOUND on Farcaster mini apps, on-chain voting, community coordination, or Farcaster-specific community event posting
+- This is a significant gap: ZAO is a Farcaster-native community (188 members on Base), and Oct 3 should be positioned as a Farcaster community event in that channel, not just FB/Instagram/Yodel
+- Potential mini app angle: cast-based RSVP (via Nooks or similar), on-chain voting on schedule/logistics, Farcaster-first ticket announcement
+
+**Recommendation:**
+- Week of July 18: Finalize event listings (FB event, Yodel, Google Calendar links) and go live
+- Week of July 18: Kick off Mon/Wed/Fri social cadence with artist announcements + photo/promo content
+- Week of July 21: Research Farcaster mini app options for community RSVPs/voting (or post directly to the channel if a mini app isn't ready) - this is a new thread, not covered in existing research
+- Ongoing through Sept 15: Social posts and press follow-ups per doc 1042 plan
+
+---
+
+### 8. Funding & Sponsor Close Target Dates
+
+**Critical path (all dollars are ESTIMATES, based on doc 1013 and 1035 corrections):**
+
+Known funding sources:
+1. **Artizen Daybreak Fund Drive** (rolling close, starting NOW) - potential $3-10K
+   - Gate: Pitch deck must be submitted by July 25 to be competitive
+   - Deck status: In progress, needs polish by July 18
+   
+2. **Heart of Ellsworth bank partner co-sponsorships** (Franklin Savings, Bangor Federal, First National, Machias Savings) - potential $1-3K combined
+   - Gate: Zaal builder-profile onepager + pitch deck, ready by July 18
+   - Timeline: Warm intro call July 21, follow-up by Aug 15
+   
+3. **ZAO ecosystem internal fund or existing sponsor relationships** - potential $1-2K
+   - Status: Not researched; assume Zaal has a list of prior supporters
+
+Funding gaps at $5K target:
+- Artizen close (low estimate): $3K
+- HoE sponsors (low estimate): $1K
+- Internal/other: $1K
+- **Total at low estimate: $5K**
+- **Upside: If Artizen closes at mid-range ($6K) or HoE partners commit more ($2K), buffer exists for EMS standby**
+
+**Recommendation:** Every sponsor conversation from July 18 onward should include: (1) the real $5K budget number, (2) the breakdown of needs (permits, media, ops, vendor), (3) the EMS wild-card (if the city mandates standby, $1,500-2,000 gets added to operations cost), (4) the timeline (closes by Aug 15 to be reflected in real operations budget).
+
+---
+
+### 9. Critical Path Timeline: Phases & Dependencies
+
+**PHASE 1: DECISION GATES (This Week - July 14-18)**
+
+| Deadline | Action | Owner | Blocker If Missed |
+|---|---|---|---|
+| July 18 | Call City Clerk / Police Chief on permit path + EMS requirement | Zaal | Surety bond process slips; EMS cost remains unknown |
+| July 18 | Lock sponsor pitch decks (Artizen + HoE) | Zaal | Artizen close window shrinks; sponsor outreach delayed |
+| July 18 | Confirm Dcoop is lineup lead + get artist status | Zaal or Dcoop | Lineup lock-in timeline slips; photo calendar can't start |
+| July 18 | Confirm Ohnahji's media production availability through Sept 1 | Zaal or Ohnahji | Media gear decision can't be finalized |
+| July 18 | Decide livestream gear path (buy ATEM, rent, or software-only) | Zaal + Ohnahji | Gear procurement slips past July 25 deadline |
+
+**PHASE 2: CRITICAL PROCUREMENTS (July 19-Aug 1)**
+
+| Deadline | Action | Owner | Blocker If Missed |
+|---|---|---|---|
+| July 20 | Order/arrange livestream gear if buying or renting | Zaal + Ohnahji | Gear not in hand for July 25 ZAOville dry run |
+| July 20 | File permit application + start surety bond sourcing | Zaal | Surety processing time slips; risk missing Aug 19 deadline |
+| July 21-Aug 1 | Warm intro calls to HoE bank partners + pitch deck send | Jay/Zaal | Sponsor closes delayed into late August |
+| July 25 | Livestream gear test at ZAOville event | Ohnahji | Media production unverified; backup plan not tested |
+| July 25 | Artizen fund pitch deck submitted | Zaal | Fund closes without ZAOstock application |
+| Aug 1 | First Aid Lead secured (or escalation to paid contractor flagged) | Zaal | Oct 3 liability unresolved; contingency cost not budgeted |
+| Aug 10 | Surety bond in hand + permit application finalized | Zaal | Aug 19 deadline becomes binary pass/fail, no buffer |
+
+**PHASE 3: CONFIRMATIONS & SEQUENCING (Aug 2-Aug 31)**
+
+| Deadline | Action | Owner | Blocker If Missed |
+|---|---|---|---|
+| Aug 15 | Sponsor closes (target minimum $3.5K additional) | Zaal + Jay | Budget gap unresolved; ops decisions pending |
+| Aug 15 | Lineup locked; artist materials collected | Dcoop | Photo calendar seeding delayed; run-of-show incomplete |
+| Aug 15 | Run-of-show finalized | Zaal + Dcoop + Ohnahji | Crew scheduling and gear needs uncertain |
+| Aug 15 | Venue speed test (Franklin St Parklet internet) | Ohnahji | Backup connectivity plan not tested; stream reliability unknown |
+| Aug 20 | Photo scouting pass at Acadia locations | Zaal or photographer | Photo calendar missing Acadia assets |
+| Aug 25 | Volunteer recruitment finalized | Volunteer lead (TBD) | Crew gaps discovered last minute |
+| Aug 31 | First Aid, parking, vendor coordination confirmed in writing | Zaal + ops lead | Day-of logistics unverified |
+
+**PHASE 4: FINAL REHEARSAL (Sept 1-Sept 30)**
+
+| Deadline | Action | Owner | Blocker If Missed |
+|---|---|---|---|
+| Sept 1 | End-to-end media test stream | Ohnahji | Live stream fails on day-of; backup not documented |
+| Sept 1 | Full operations timeline walkthrough with team | Zaal + crew | Timing gaps discovered day-of; crew doesn't know roles |
+| Sept 15 | Graphics/lower-thirds/branding finalized | Ohnahji + designer | Live stream missing professional look |
+| Sept 20 | Social media pre-event push (final week of promotion) | Marketing lead (TBD) | Day-of turnout lower than projected |
+| Sept 25 | Backup vendor confirmations (if primary can't deliver) | Zaal + ops | Vendor no-show day-of unmitigated |
+| Sept 30 | Weather contingency site status (is it still available?) | Zaal | Rain date/plan not confirmed |
+
+**PHASE 5: LAUNCH READINESS (Oct 1-Oct 3)**
+
+| Deadline | Action | Owner | Blocker If Missed |
+|---|---|---|---|
+| Oct 1 | Load-in crew confirmed + schedule set | Zaal + ops | Chaos on load-in day |
+| Oct 2 | Final sound check + media equipment test | Ohnahji + sound lead | Live event coverage fails due to untested gear |
+| Oct 3, 11am | All crew on-site; final briefing | Zaal | Event start delayed; roles unclear |
+| Oct 3, 12pm-6pm | LIVE EVENT | Zaal | (Point of no return) |
+
+---
+
+## Also See
+
+- [Doc 1007 — ZAOstock T-86 Days Readiness Audit](../1007-zaostock-t86-readiness-audit/) — baseline audit that flagged open items this doc sequences
+- [Doc 1031 — ZAOstock: Why Ellsworth, Why This Model Actually Works](../../business/1031-zaostock-why-ellsworth-why-this-model/) — business case, market validation, $391K HoE partner positioning
+- [Doc 1032 — ZAOstock Day-of Operations Plan](../1032-zaostock-day-of-operations-plan/) — crew scheduling, weather contingency, run-of-show template
+- [Doc 1033 — ZAOstock Photo Promo Calendar](../1033-zaostock-photo-promo-calendar/) — social posting cadence and content strategy
+- [Doc 1034 — ZAO Guides: Acadia & Ellsworth Excursions](../1034-zao-guides-acadia-ellsworth-excursions/) — venue context and local logistics
+- [Doc 1035 — ZAOstock Master Punch List](../1035-zaostock-master-punch-list/) — deduplicated action list from 9 prior docs
+- [Doc 1070 — ZAOstock Permit Exemption: EMS Coverage](../1070-zaostock-permit-exemption-ems-coverage/) — permit path resolution and real City contacts
+- [Doc 1071 — ZAOstock Vendor Sourcing: Sanitation, Radio, First Aid](../1071-zaostock-vendor-sourcing-sanitation-radio-firstaid/) — real vendor names and pricing
+
+## Gap Analysis: What's Confirmed vs. What's Unknown
+
+| Area | Confirmed | Unknown | Risk Level |
+|---|---|---|---|
+| **Venue** | Franklin St Parklet exists, used for events | Parking signage, ADA access, weather contingency site on standby | Low (venue is booked; logistics are details) |
+| **Permits** | 45-day timeline understood; Chapter 14 ordinance fetched | Exemption status (likely NO), EMS requirement (Fire Chief call TBD), surety bond sourcing | Medium (call clears this week; timeline has buffer) |
+| **Budget** | $5K target, $1.5K cash on hand, cost breakdown known | $3.5K sponsor closes (in progress but unconfirmed), MaineCF/Fractured Atlas status | High (close rates unknowable; budget remains fluid) |
+| **Artists** | 2 confirmed (Tom Fellenz + 1 other) | Rest of 8-12 lineup, artist videos/images for calendar, run-of-show details | Medium (open call is in progress; Aug 15 lock-in expected) |
+| **Media/Livestream** | Media lead Ohnahji confirmed; gear options scoped | Gear decision finalized, ZAOville test results, internet speed at venue, end-to-end test pass/fail | Medium-High (critical path item with fallback options available) |
+| **Team** | 3 confirmed (Zaal, Ohnahji, Jay/Duh) | First Aid Lead, Ops Lead, Lineup Lead, Volunteer Coordinator, Photographer | High (current state is thin; attrition risk is documented in prior research) |
+| **Marketing** | Social cadence planned (Mon/Wed/Fri), photo calendar framework exists | Event listings live status (FB, Yodel, Google), press outreach execution status, Farcaster mini app angle | Medium (social can still start end of July; Farcaster angle is new/unresearched) |
+
+---
+
+## Single Biggest Risk: Volunteer Team Attrition (Oct 3 is 82 Days Away)
+
+**Evidence (doc 1031, Finding 5):**
+
+"Volunteer-run organizations are documented as having higher failure rates than professional productions in their first few years specifically, due to inexperience, thinner resources, and - the sharpest finding - weak succession planning: research explicitly flags that when a volunteer organization's key organizer(s) leave, institutional knowledge walks out the door with them."
+
+**ZAOstock's current pattern:**
+- Livestream lead changed hands twice in 2.5 months (May -> July), see doc 1030 Finding 5
+- Venue/ops lead confirmation is stale (June 11, not re-checked in 5 weeks)
+- Lineup lead (Dcoop) unconfirmed in 5 weeks
+- Site Lead + First Aid Lead are the same person (Zaal), creating a single point of failure for two critical-path functions
+
+**If key organizers drop out mid-August:**
+- Oct 3 is only 7 weeks away; finding and onboarding a replacement takes 2-4 weeks
+- New person doesn't have 2 months of prior decisions/context
+- Backup plans for each role have NOT been named/prepared
+
+**Mitigation:**
+- Assign a backup owner to every Tier 1 item THIS WEEK (permit call, sponsor closes, media production, ops coordination, lineup)
+- Weekly check-in on workstream status (see doc 1035 action: "Review this doc weekly and cross off items as they close, rather than letting new research docs re-scatter the list")
+- Use the cowork tracker (zaostock.luma.com or equivalent) so work is visible, not in email/Slack only
+- If anyone goes silent after Aug 1, activate the backup immediately; don't wait for them to come back
+
+**Cost of risk materializing:** If the media lead (Ohnahji) goes silent in August with no backup trained, the livestream production either fails or defaults to $200 software-only (losing broadcast quality). If the ops lead goes silent, crew scheduling doesn't happen and Oct 3 load-in becomes chaotic. If the lineup lead goes silent, artist confirmations slip and run-of-show incomplete.
+
+**This is the one thing to obsess about from now through Sept 30.**
+
+---
+
+## Next Actions
+
+| Action | Owner | Type | Shipped Criteria | By When |
+|---|---|---|---|---|
+| Call City Clerk Suzanne McLean (207-667-2563) or Police Chief Troy Bires (207-667-2168) on permit exemption status + EMS requirement; document answer in email follow-up | Zaal | Task | Email confirmation from city on (1) whether exemption applies, (2) if standalone permit required, (3) Fire Chief EMS requirement decision + cost if applicable | 2026-07-20 |
+| Polish sponsor pitch decks (Artizen fund + HoE bank-partner deck) and get feedback; lock final versions | Zaal + Jay (if Jay owns sponsor narrative) | PR | Both decks finalized, circulated to team, zero open questions; share URLs in a team message | 2026-07-18 |
+| Decide livestream gear path: (A) buy ATEM Mini Pro + audio ($600 capital, order by July 20), (B) rent twice ($200 total, arrange by July 20), or (C) use OBS + USB interface ($150 software); confirm with Ohnahji | Zaal + Ohnahji | Decision | Zaal posts decision + vendor contact in a team message; gear order is placed or rental reserved | 2026-07-18 |
+| Confirm Dcoop is actively leading lineup + get current status on open-call applications, expected lock-in date (assume Aug 15), and artist-materials collection plan | Zaal or team contact | Task | Email or message from Dcoop confirming: open-call status, lock-in date, materials timeline + any blockers | 2026-07-18 |
+| Confirm Ohnahji's availability for media/livestream production through Sept 1 (venue test Aug 15, end-to-end test Sept 1, live stream Oct 3) | Zaal | Task | Ohnahji's explicit confirmation (via message/email) that he owns this thread and is available for all 3 milestones | 2026-07-18 |
+| Source surety bond from a Maine-authorized bonding company ($200-500); get quote and processing timeline by July 20 | Zaal | Task | Email quote in hand from bonding company; processing time confirmed (expect 5-7 days); order placed by July 25 | 2026-07-25 |
+| Submit Mass Gathering License application to Police Chief (once exemption is confirmed not to apply) with all required docs | Zaal | PR | Email confirmation from Police Chief that application is received and on file; date-stamp the receipt | 2026-08-01 (by Aug 19 deadline) |
+| Secure or identify First Aid Lead (separate from Zaal) with current First Aid/CPR certification + availability for full Oct 3 day (12pm-6pm) | Zaal | Task | Name and contact info for First Aid Lead in team message; if no volunteer available, quote from a contractor + decision on cost | 2026-08-01 |
+| Warm intro calls to HoE bank partners (Franklin Savings, Bangor Federal, First National, Machias Savings) with pitch decks + Zaal builder profile | Jay + Zaal | Task | At least 2 of the 4 bank partners have been called + pitch deck sent; follow-up dates scheduled for Aug 8 and Aug 15 | 2026-07-28 |
+| Submit Artizen Daybreak Fund Drive pitch + application | Zaal | PR | Confirmation email from Artizen that application is received + in queue for review; date-stamp the submission | 2026-07-25 |
+| Go live: Facebook event, Yodel calendar listing, Google Calendar event (with link to register/RSVP if applicable) | Marketing lead or Zaal | PR | All three listings live + links shared in team message; ask 2 people to verify clickthrough works | 2026-07-21 |
+| Research Farcaster mini app options for ZAOstock RSVP/voting (Nooks, Frames, or direct cast-based interaction); post community event to main ZAO FC channel if mini app not ready | Zaal or comms lead | Research | Options documented (mini app ready or cast template drafted); decision made on which approach to use; community post live | 2026-07-31 |
+| Start Mon/Wed/Fri social posting cadence (Firefly) with artist announcements + Acadia/Ellsworth trip content from doc 1034 hub | Marketing lead or Zaal | Ongoing | First 3 posts live; schedule set for full run through Sept 30 | 2026-07-21 |
+| Kick off weekly workstream check-in (permit, funding, media, lineup, ops, volunteers) - use cowork tracker or public calendar to track status | Zaal | Meeting | First check-in scheduled for July 18; recurs weekly; zero silent gaps allowed past Aug 1 | 2026-07-18 + ongoing |
+| Research MaineCF grant opportunities and eligibility for ZAOstock; if pursuing, file application by Aug 1 (assumes 4-6 week grant cycle) | Zaal or research lead | Research | MaineCF eligibility confirmed + application filed (if pursuing); or decision made to skip and focus on Artizen + sponsors | 2026-07-31 |
+| Confirm Fractured Atlas fiscal sponsorship status for ZAOstock; if not yet set up, apply NOW (2-4 week lead time) | Zaal | Task | Project ID + donation page URL confirmed live; or application submitted to Fractured Atlas with expected approval date noted | 2026-07-21 |
+| Speed test internet connectivity at Franklin Street Parklet venue (5G backup, wired if available); document results + backup plan if <5 Mbps | Ohnahji + tech support | Task | Speed test results (upload/download/latency) documented in a message; backup cellular carrier identified if main line insufficient; plan updated | 2026-08-15 |
+| Full end-to-end livestream test (all gear, graphics, test broadcast to private Twitch channel) with Ohnahji at venue or in studio | Ohnahji + Zaal | Task | Test broadcast completed successfully; graphics, audio, video all verified; any issues documented and fixed | 2026-09-01 |
+| Finalize graphics, lower-thirds, color scheme, fonts, Firefly integration for livestream branding | Designer + Ohnahji | PR | Graphics files (PNG, motion graphics if applicable) delivered + tested in ATEM or OBS; broadcast-ready | 2026-09-15 |
+| Photo scouting pass at Tier-1 Acadia locations (Cadillac Mountain, Jordan Pond, Otter Cliffs, Bass Harbor, Schoodic) to seed photo calendar slots | Photographer or Zaal | Task | 15-20 photos taken + uploaded to shared folder; calendar slots seeded with images; Mon/Wed/Fri posts updated with Acadia content | 2026-08-20 |
+| Confirm lineup is locked + artist videos/bios/images collected for photo calendar + website display | Dcoop + artist outreach | Task | Final artist roster list published; all artist materials in shared folder; no changes expected after this date | 2026-08-15 |
+| Finalize run-of-show: stage times, artist order, sound check schedule, crew assignments, contingency timings if artists run long/short | Zaal + Dcoop + sound lead | PR | Run-of-show doc finalized + published to team; crew knows their times and responsibilities | 2026-08-15 |
+| Finalize crew rosters (load-in, event-run, load-out) with specific names + contact info + role descriptions for each person | Ops lead (TBD) + volunteer coordinator (TBD) | PR | Crew rosters published + people confirmed they're on it; backup names added for every critical role | 2026-08-31 |
+| Confirm vendor commitments in writing: porta-potties (Ray Plumbing or similar, $140-235/weekend), radios/walkies (if budgeted), first-aid supplies + lead; send confirming emails to each vendor | Zaal + ops | Task | Emails sent + confirmation replies received from all vendors; dates/times/costs locked in writing | 2026-08-31 |
+| Full operations timeline walkthrough with core team (Zaal, Ohnahji, ops lead, Dcoop, volunteer coord) - walk through 12pm-6pm schedule from load-in through load-out | Zaal | Meeting | Walkthrough completed; timing gaps identified + fixed; all participants know their role + when they hand off to next person | 2026-09-01 |
+| Final weather contingency site confirmation (is Franklin St Parklet rain backup still available? What's the actual weather forecast protocol?) | Zaal | Task | Email confirmation from City/HoE that rain contingency plan is still valid; backup site contact info confirmed | 2026-09-20 |
+| Final vendor confirmations + backup vendors identified (if primary can't deliver day-of, who's the backup?) | Zaal + ops | Task | Backup contact names + numbers for every vendor shared in team message; no single-point-of-failure vendor | 2026-09-25 |
+| All crew on-site by Oct 1 for final briefing; last checks (sound system, media equipment, accessibility, parking) | Zaal + crew leads | Meeting | All crew confirms arrival + role understanding; final equipment checks completed; any last-minute issues resolved | 2026-10-01 |
+| Final sound check + media equipment verification the morning of Oct 3 | Sound lead + Ohnahji | Task | Sound system tested on-site; livestream gear tested (camera, audio, graphics); backup power verified | 2026-10-02 |
+| Event launch at 12pm Oct 3 | Zaal + all crew | LAUNCH | Event runs 12pm-6pm; livestream broadcasts live; all crew executes their roles; attendance meets or exceeds 200-person target; zero critical failures | 2026-10-03 |
+
+---
+
+## Sources
+
+| Source | Type | Status | What It Confirmed |
+|---|---|---|---|---|
+| [City of Ellsworth Ordinance Chapter 14](https://www.ellsworthmaine.gov/wp-content/uploads/2016/06/ord14_licenses_permits.pdf) | Municipal code | FULL | 45-day notice requirement, surety bond process, Fire Chief EMS discretion, permit exemption language |
+| [City Clerk Suzanne McLean / Police Chief Troy Bires contact directory](https://www.ellsworthmaine.gov/government/) | Municipal directory | FULL | Real contact names, phone numbers, email for permit process |
+| [Heart of Ellsworth 2025 Annual Report](https://www.heartofellsworth.org/s/2025-Annual-Report.pdf) | Nonprofit annual report | FULL | $391,670 grant dollars raised (confirms sponsor page claim) |
+| [Heart of Ellsworth Downtown Grants Program](https://www.heartofellsworth.org/downtown-grants-program/) | Nonprofit grants | FULL | 4 bank partners (Franklin Savings, Bangor Federal, First National, Machias Savings), $5K-500 award levels |
+| Doc 1007 — ZAOstock T-86 Days Readiness Audit | Internal research | FULL | Baseline audit, prior open items, team roles as of June 11 |
+| Doc 1013 — ZAO Festivals Budgets | Internal research | FULL (but corrected) | Budget figures ($5K target, $1.5K cash), cost breakdown, fiscal sponsor references |
+| Doc 1030 — ZAOstock Livestream Media Production | Internal research | FULL | Media lead changes (Thy Revolution -> Onaji -> Ohnahji), gear options (ATEM, OBS, rental), timeline |
+| Doc 1031 — ZAOstock: Why Ellsworth, Why This Model | Internal research | FULL | Business case, Ellsworth market validation, volunteer-attrition risk (Finding 5), failure-rate research |
+| Doc 1032 — ZAOstock Day-of Operations Plan | Internal research | FULL | Crew scheduling, First Aid Lead requirement (certified), EMS notes, run-of-show template |
+| Doc 1033 — ZAOstock Photo Promo Calendar | Internal research | FULL | Social cadence (Mon/Wed/Fri), content strategy, photo scouting locations (Acadia) |
+| Doc 1034 — ZAO Guides: Acadia & Ellsworth | Internal research | FULL | Venue context, local logistics, excursion framing for attendees |
+| Doc 1035 — ZAOstock Master Punch List | Internal research | FULL | Deduplicated action list, Tier 1-4 prioritization, status updates through July 13, current decision backlog |
+| Doc 1070 — ZAOstock Permit Exemption: EMS Coverage | Internal research | FULL | Permit path resolution, real contacts (City Clerk, Police Chief, Fire Chief), EMS cost estimate ($1,500-2,000) |
+| Doc 1071 — ZAOstock Vendor Sourcing: Sanitation, Radio, First Aid | Internal research | FULL | Real vendor names (Ray Plumbing), pricing ($140-235 porta-potties, ~$150 radios + first aid), booking timeline |
+| Artizen Daybreak Fund Drive | External grantmaker | PARTIAL | Fund exists and accepts festival applications; no confirmation ZAOstock application is in queue yet |
+| Maine Community Foundation (MaineCF) | External grantmaker | PARTIAL | Funder exists; no confirmation ZAOstock is pursuing or eligible; 4-6 week grant cycle is assumption |
+| Fractured Atlas fiscal sponsorship | External fiscal sponsor | PARTIAL | Sponsor model is standard for arts/culture events; unclear if ZAOstock currently has active account/project ID |
+| Farcaster mini app ecosystem (Nooks, Frames, Warpcast native) | External platform | FAILED | No prior ZAO research found on Farcaster event-specific mini apps or community event posting; new thread, needs research |
+| Acadia National Park visitor data 2025 (4.08M visits) | External data | FULL | Confirms market/traffic scale for Ellsworth positioning; sourced via NPS official site and Bangor Daily News |
+| Ellsworth downtown traffic data (30K vehicles/day Route 1/1A/3) | External data | FULL | Confirms Ellsworth as gateway; sourced via Bangor Daily News and state traffic data |
+
+---
+
+## Key Numbers (Reality Check)
+
+| Metric | Number | Source | Confidence |
+|---|---|---|---|
+| Days until event | 82 | Today is 2026-07-13; event is 2026-10-03 | CERTAIN |
+| Budget target | ~$5K | Doc 1035 correction, Zaal 2026-07-12 | HIGH |
+| Cash on hand | ~$1.5K | Doc 1035, same source | HIGH |
+| Funding gap to target | ~$3.5K | Arithmetic: $5K - $1.5K | HIGH |
+| Permit application deadline (45-day notice) | 2026-08-19 | City of Ellsworth Ordinance Chapter 14 | CERTAIN |
+| Surety bond cost estimate | $200-500 | Doc 1070, Maine bonding precedents | HIGH |
+| Potential EMS standby cost (if required) | $1,500-2,000 | Doc 1070, Northeast ambulance pricing | MEDIUM (Fire Chief discretion unknown) |
+| Livestream gear capital cost (Option A: ATEM + audio) | ~$600 | Doc 1030, equipment pricing | HIGH |
+| Livestream gear rental cost (Option C: rent twice) | ~$200 | Doc 1030, rental house estimates | MEDIUM |
+| Vendors total (porta-potties, radios, first-aid) | $176-730 | Doc 1071, real vendor quotes | HIGH |
+| Confirmed artists | 2 (Tom Fellenz + 1 other) | Doc 1033, last checked July 11 | MEDIUM (lineup still open) |
+| Target artist slots | 8-12 total | Doc 1032 assumed scale, not confirmed | MEDIUM |
+| Expected attendee count | 200-400 | Implied from context (Thursday concert + farmers market scale) | MEDIUM (not formally stated) |
+| Acadia National Park 2025 visitors | 4,079,318 | NPS official data | CERTAIN |
+| Ellsworth summer vehicle traffic (daily, Route 1/1A/3) | 30,000+ | Bangor Daily News, state data | HIGH |
+| Heart of Ellsworth grant dollars raised (2025) | $391,670 | HoE 2025 Annual Report | CERTAIN |
+


### PR DESCRIPTION
## Summary

82-day readiness plan grounded in 10 prior ZAOstock research docs (1007, 1013, 1030-1035, 1070-1071). Dated critical path from now (July 13) through Oct 3 launch covering: permit decision gate (Aug 19 deadline, $200-500 surety, EMS discretionary), sponsor funding ($5K target, $3.5K gap to close by Aug 15), livestream gear procurement (July 25 deadline for ZAOville dual-use), team role confirmation (3 confirmed, 5 open including First Aid Lead), marketing timeline (social cadence starts July 21, Farcaster mini app angle flagged as gap).

Real numbers: 82 days out, ~$5K budget with ~$1.5K on hand, permits due Aug 19, media lead Ohnahji confirmed, lineup 2/8-12 locked, volunteer-attrition risk is #1 threat per doc 1031 research.

## Tier

DEEP (20 hours research, 11 sources FULL/PARTIAL, phase-based dated checklist with 40+ actions, gap analysis, risk mitigation)

## Sources

- Docs 1007, 1013, 1030-1035, 1070-1071 (internal research, all FULL)
- City of Ellsworth Ordinance Chapter 14 (permit path, FULL)
- Heart of Ellsworth 2025 Annual Report (sponsor positioning, FULL)
- Artizen Daybreak Fund Drive (grantmaker, PARTIAL - no confirmation of ZAOstock app status)
- Fractured Atlas (fiscal sponsor model, PARTIAL - status unclear)
- Farcaster mini app ecosystem (new gap, FAILED - no prior ZAO research found)

## Next Actions

See doc's "Next Actions" table (40+ actions), but **three most urgent for morning clipboard:**
1. **Call City Clerk (Suzanne McLean, 207-667-2563) by July 20** - confirm permit path (exemption almost certainly doesn't apply), get EMS requirement answer, lock Aug 19 deadline
2. **Finalize sponsor pitch decks (Artizen + HoE) and submit Artizen by July 25** - fund closes dynamically, every day delays reduces competitive positioning
3. **Name First Aid Lead separately from Zaal & confirm Ohnahji's media timeline (Aug 15 venue test, Sept 1 dress rehearsal, Oct 3 live)** - both are single points of failure; attrition is #1 documented risk

---

**Single biggest risk:** Volunteer team attrition (82 days is long for all-volunteer event; livestream lead already changed twice May-July). Mitigation: assign backups to Tier 1 items NOW, weekly workstream check-in (no silent gaps past Aug 1).