### PR TITLE
feat(zoe): calendar-aware - watch the ZAO Luma calendar for briefs + reminders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,3 +160,17 @@ SENTRY_PROJECT=
 JUKE_API_KEY=
 JUKE_USER_TOKEN=
 JUKE_CREATE_PASSWORD=
+
+# ── Calendar Integration (ZOE) ─────────────────────────────────
+# ZOE watches a public calendar (ICS format) and includes upcoming events in
+# the morning brief + sends day-before reminders. Inform-only: ZOE tells Zaal
+# about events but never creates/modifies/RSVPs.
+#
+# CALENDAR_ICS_URL — defaults to ZAO Luma calendar at luma.com/zao
+# (cal-jPH4al7AMlXzdNN). Leave unset to use the default. Set to a custom
+# ICS feed URL (e.g., your own Luma event, Google Calendar export, Outlook
+# ICS feed) to override.
+#
+# The calendar reader caches events (~/.zao/zoe/calendar/cache.json) and
+# refreshes every 6 hours. No-op gracefully if the URL is unset or unreachable.
+CALENDAR_ICS_URL=

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -20,6 +20,7 @@ import { listOpenTasks } from './tasks';
 import { getOpenTeamTasks, summarizeTeamForBrief, zaalFocusForBrief } from './team-tracker';
 import { fleetConsensus } from './fleet-health';
 import { graphTopicAgeDays } from './recall';
+import { getCalendarEvents, formatEventForBrief } from './calendar';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -32,6 +33,9 @@ Morning brief - {Day} {Mon DD} 5am
 
 TOP PRIORITIES ({P0 count} P0, {P1 count} P1)
 - P0/P1 priority items, one per line. Group by priority.
+
+UPCOMING EVENTS
+- ZAO calendar events for the next week. Skip this section entirely if no upcoming events.
 
 LAST 24H COMMITS
 - List of commit subjects from last 24h. (none) if nothing.
@@ -67,6 +71,7 @@ interface BriefContext {
   focus: string | null;
   fleet: string | null;
   zol: string | null;
+  upcomingEvents: Array<{ title: string; start: string; location?: string }>;
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -234,6 +239,19 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     zol = null;
   }
 
+  // Upcoming calendar events — next 7 days. Best-effort; gracefully degrade.
+  let upcomingEvents: Array<{ title: string; start: string; location?: string }> = [];
+  try {
+    const events = await getCalendarEvents(7); // 7-day lookahead for the brief
+    upcomingEvents = events.map((e) => ({
+      title: e.title,
+      start: e.start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
+      location: e.location,
+    }));
+  } catch {
+    upcomingEvents = [];
+  }
+
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
@@ -245,6 +263,7 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     focus,
     fleet,
     zol,
+    upcomingEvents,
   };
 }
 
@@ -258,10 +277,15 @@ export async function generateMorningBrief(opts: { repoDir: string; model?: stri
       : `INBOX: ${ctx.inbox.unreadCount} unread. Recent subjects: ${ctx.inbox.recentSubjects.join(' | ')}`
     : 'INBOX: (api unavailable - skip the INBOX section)';
 
+  const eventsLine = ctx.upcomingEvents.length === 0
+    ? 'UPCOMING EVENTS: none in the next week'
+    : `UPCOMING EVENTS: ${ctx.upcomingEvents.map((e) => `${e.title} (${e.start}${e.location ? ' @ ' + e.location : ''})`).join(' | ')}`;
+
   const userPrompt = `Generate the morning brief for ${day} ${date}.
 
 CONTEXT:
 - Open tasks: ${JSON.stringify(ctx.open_tasks, null, 2)}
+- Upcoming events (next 7 days): ${eventsLine}
 - Last 24h commits (ZAOOS): ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
 - Recent activity across ALL Zaal's repos: ${ctx.cross_repo_24h.length === 0 ? '(none)' : ctx.cross_repo_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}

--- a/bot/src/zoe/calendar.ts
+++ b/bot/src/zoe/calendar.ts
@@ -1,0 +1,295 @@
+/**
+ * Calendar reader — fetches and caches the ZAO Luma calendar (ICS format).
+ *
+ * Source: ZAO Luma calendar at luma.com/zao (public ICS feed, no auth).
+ *
+ * Design:
+ * - Fetches ICS from CALENDAR_ICS_URL env var (defaults to ZAO Luma public feed)
+ * - Lightweight custom ICS parser (no heavy dep)
+ * - Caches parsed events to ~/.zao/zoe/calendar.json
+ * - Refreshes a few times/day; returns upcoming events (next 7-14 days)
+ * - No-op gracefully if URL unset or unreachable
+ *
+ * This is INFORM-ONLY: ZOE tells Zaal about events but does NOT create/modify/RSVP.
+ */
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { ZOE_PATHS } from './memory';
+
+/**
+ * Parsed calendar event.
+ */
+export interface CalendarEvent {
+  id: string;           // uid from ICS
+  title: string;        // SUMMARY
+  start: Date;          // DTSTART parsed
+  end: Date;            // DTEND parsed
+  location?: string;    // LOCATION (optional)
+  url?: string;         // URL (optional)
+  description?: string; // DESCRIPTION (optional)
+}
+
+/**
+ * Cached calendar state: metadata + events.
+ */
+interface CacheData {
+  fetchedAt: string;    // ISO 8601 timestamp
+  expiresAt: string;    // When to refresh next
+  events: Array<{
+    id: string;
+    title: string;
+    start: string;      // ISO 8601
+    end: string;        // ISO 8601
+    location?: string;
+    url?: string;
+    description?: string;
+  }>;
+}
+
+const CACHE_DIR = join(ZOE_PATHS.home, 'calendar');
+const CACHE_FILE = join(CACHE_DIR, 'cache.json');
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // refresh every 6 hours
+
+/**
+ * Get the configured calendar ICS URL.
+ * Default: ZAO Luma public feed.
+ * Unset: returns null (calendar feature disabled).
+ */
+function getCalendarUrl(): string | null {
+  const configured = process.env.CALENDAR_ICS_URL;
+  if (configured) return configured;
+
+  // Default to ZAO Luma public ICS feed.
+  // luma.com/zao has cal id cal-jPH4al7AMlXzdNN.
+  // The public ICS endpoint is: https://lu.ma/event/cal-<ID>/ics
+  return 'https://lu.ma/event/cal-jPH4al7AMlXzdNN/ics';
+}
+
+/**
+ * Lightweight ICS parser. Extracts VEVENT blocks and parses key fields.
+ * No external deps. Returns an array of events or [] on parse error.
+ */
+function parseIcs(icsText: string): Omit<CalendarEvent, 'start' | 'end'>[] {
+  const events: Omit<CalendarEvent, 'start' | 'end'>[] = [];
+
+  // Split by VEVENT blocks (simple regex split)
+  const veventMatches = icsText.match(/BEGIN:VEVENT[\s\S]*?END:VEVENT/g) || [];
+
+  for (const vevent of veventMatches) {
+    const event: Omit<CalendarEvent, 'start' | 'end'> = {
+      id: '',
+      title: '',
+    };
+
+    // Extract UID
+    const uidMatch = vevent.match(/^UID:(.+?)$/m);
+    if (uidMatch) event.id = uidMatch[1].trim();
+
+    // Extract SUMMARY (title)
+    const summaryMatch = vevent.match(/^SUMMARY:(.+?)$/m);
+    if (summaryMatch) event.title = summaryMatch[1].trim();
+
+    // Extract LOCATION
+    const locMatch = vevent.match(/^LOCATION:(.+?)$/m);
+    if (locMatch) event.location = locMatch[1].trim();
+
+    // Extract URL
+    const urlMatch = vevent.match(/^URL:(.+?)$/m);
+    if (urlMatch) event.url = urlMatch[1].trim();
+
+    // Extract DESCRIPTION
+    const descMatch = vevent.match(/^DESCRIPTION:(.+?)$/m);
+    if (descMatch) event.description = descMatch[1].trim();
+
+    // Only include if we got at least a title
+    if (event.title && event.id) {
+      events.push(event);
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Parse an ICS datetime (DTSTART / DTEND).
+ * Handles: 20250714T100000Z, 20250714T100000, 20250714 (all-day).
+ */
+function parseIcsDate(dtStr: string): Date | null {
+  if (!dtStr) return null;
+
+  // Try to parse ISO 8601-ish format
+  if (dtStr.includes('T')) {
+    // DateTime: 20250714T100000Z or 20250714T100000
+    const m = dtStr.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(Z?)$/);
+    if (m) {
+      const [, year, month, day, hour, min, sec, isUTC] = m;
+      const dateStr = `${year}-${month}-${day}T${hour}:${min}:${sec}${isUTC ? 'Z' : ''}`;
+      const d = new Date(dateStr);
+      return Number.isFinite(d.getTime()) ? d : null;
+    }
+  } else {
+    // All-day: 20250714 -> treat as midnight UTC
+    const m = dtStr.match(/^(\d{4})(\d{2})(\d{2})$/);
+    if (m) {
+      const [, year, month, day] = m;
+      const dateStr = `${year}-${month}-${day}T00:00:00Z`;
+      const d = new Date(dateStr);
+      return Number.isFinite(d.getTime()) ? d : null;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Fetch and parse the ICS feed. Caches result. Returns upcoming events.
+ * Best-effort: returns [] on any error (network, parse, cache).
+ */
+export async function getCalendarEvents(
+  lookaheadDays: number = 14,
+  now: number = Date.now(),
+): Promise<CalendarEvent[]> {
+  const url = getCalendarUrl();
+  if (!url) {
+    // Calendar feature disabled
+    return [];
+  }
+
+  try {
+    // Check cache first
+    const cached = await readCache();
+    if (cached && new Date(cached.expiresAt).getTime() > now) {
+      // Cache valid
+      return eventsFromCache(cached, lookaheadDays, now);
+    }
+
+    // Fetch fresh ICS
+    const icsText = await fetchIcs(url);
+    const events = parseIcs(icsText);
+
+    // Extract start/end datetimes
+    const fullEvents: CalendarEvent[] = [];
+    const veventMatches = icsText.match(/BEGIN:VEVENT[\s\S]*?END:VEVENT/g) || [];
+    for (let i = 0; i < events.length; i++) {
+      const vevent = veventMatches[i] || '';
+      const ev = events[i];
+
+      // Extract DTSTART and DTEND from the raw vevent block
+      const startMatch = vevent.match(/^DTSTART(?:;[^:]*)?:(.+?)$/m);
+      const endMatch = vevent.match(/^DTEND(?:;[^:]*)?:(.+?)$/m);
+
+      const start = startMatch ? parseIcsDate(startMatch[1].trim()) : null;
+      const end = endMatch ? parseIcsDate(endMatch[1].trim()) : null;
+
+      if (start && end) {
+        fullEvents.push({
+          ...ev,
+          start,
+          end,
+        });
+      }
+    }
+
+    // Cache the fetched events
+    await writeCache({
+      fetchedAt: new Date(now).toISOString(),
+      expiresAt: new Date(now + CACHE_TTL_MS).toISOString(),
+      events: fullEvents.map((e) => ({
+        id: e.id,
+        title: e.title,
+        start: e.start.toISOString(),
+        end: e.end.toISOString(),
+        location: e.location,
+        url: e.url,
+        description: e.description,
+      })),
+    });
+
+    // Return upcoming events
+    return filterUpcoming(fullEvents, lookaheadDays, now);
+  } catch (err) {
+    // Best-effort: log and return empty
+    console.warn('[zoe/calendar] fetch/parse failed:', (err as Error).message);
+    return [];
+  }
+}
+
+/**
+ * Fetch ICS from the given URL with a timeout.
+ */
+async function fetchIcs(url: string): Promise<string> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(15000),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching calendar ICS`);
+  }
+  const text = await response.text();
+  if (!text.includes('BEGIN:VCALENDAR')) {
+    throw new Error('Response is not valid ICS (no VCALENDAR)');
+  }
+  return text;
+}
+
+/**
+ * Read cached events from disk.
+ */
+async function readCache(): Promise<CacheData | null> {
+  try {
+    const data = await fs.readFile(CACHE_FILE, 'utf8');
+    const parsed = JSON.parse(data) as CacheData;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write cached events to disk.
+ */
+async function writeCache(data: CacheData): Promise<void> {
+  try {
+    await fs.mkdir(CACHE_DIR, { recursive: true });
+    await fs.writeFile(CACHE_FILE, JSON.stringify(data, null, 2), 'utf8');
+  } catch (err) {
+    console.warn('[zoe/calendar] cache write failed:', (err as Error).message);
+    // Non-fatal; cache misses just mean re-fetch next time
+  }
+}
+
+/**
+ * Extract upcoming events from cached data.
+ */
+function eventsFromCache(cache: CacheData, lookaheadDays: number, now: number): CalendarEvent[] {
+  const events: CalendarEvent[] = cache.events.map((e) => ({
+    ...e,
+    start: new Date(e.start),
+    end: new Date(e.end),
+  }));
+  return filterUpcoming(events, lookaheadDays, now);
+}
+
+/**
+ * Filter events to only those starting within the next N days.
+ */
+function filterUpcoming(events: CalendarEvent[], lookaheadDays: number, now: number): CalendarEvent[] {
+  const window = now + lookaheadDays * 24 * 60 * 60 * 1000;
+  return events
+    .filter((e) => e.start.getTime() >= now && e.start.getTime() <= window)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+/**
+ * Format an event for display in briefs/messages.
+ */
+export function formatEventForBrief(event: CalendarEvent): string {
+  const date = event.start.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  const loc = event.location ? ` @ ${event.location}` : '';
+  return `${date}: ${event.title}${loc}`;
+}

--- a/bot/src/zoe/events.ts
+++ b/bot/src/zoe/events.ts
@@ -271,59 +271,88 @@ interface GCalEvent {
 }
 
 /**
- * Surface calendar events starting within 2 hours, read from the most recent
- * gcal-*.json dump in ~/.zao/private/. Skips stale files (>24h). Scores at
- * 0.72 (time-sensitive: outranks stale PR, beaten by overdue commitment thread).
- * Best-effort: never throws.
+ * Surface calendar events starting within 2 hours. Reads from:
+ * 1. Most recent gcal-*.json dump in ~/.zao/private/ (Google Calendar exports)
+ * 2. ZOE's calendar reader (ZAO Luma ICS feed via calendar.ts)
+ *
+ * Skips stale files (>24h). Scores at 0.72 (time-sensitive: outranks stale PR,
+ * beaten by overdue commitment thread). Best-effort: never throws.
  */
 export async function gatherCalendarCandidates(now: number = Date.now()): Promise<Candidate[]> {
-  let files: string[] = [];
-  try {
-    const entries = await fs.readdir(ZAO_PRIVATE_DIR);
-    files = entries.filter((f) => f.startsWith('gcal-') && f.endsWith('.json')).sort();
-  } catch {
-    return []; // no private dir yet
-  }
-  if (files.length === 0) return [];
-
-  const latestPath = join(ZAO_PRIVATE_DIR, files[files.length - 1]);
-  try {
-    const stat = await fs.stat(latestPath);
-    if (now - stat.mtimeMs > GCAL_FILE_MAX_AGE_MS) return []; // stale
-  } catch {
-    return [];
-  }
-
-  let events: GCalEvent[] = [];
-  try {
-    const raw = await fs.readFile(latestPath, 'utf8');
-    const data = JSON.parse(raw) as GCalEvent[] | { items?: GCalEvent[]; events?: GCalEvent[] };
-    events = Array.isArray(data) ? data : (data.items ?? data.events ?? []);
-  } catch {
-    return [];
-  }
-
   const seen = await readSeen();
   const windowEnd = now + CALENDAR_LOOKAHEAD_MS;
   const out: Candidate[] = [];
 
-  for (const ev of events) {
-    const startStr = ev.start?.dateTime ?? ev.start?.date;
-    if (!startStr) continue;
-    const start = Date.parse(startStr);
-    if (!Number.isFinite(start) || start < now || start > windowEnd) continue;
+  // Check Google Calendar exports (from ~/.zao/private/gcal-*.json)
+  let gcalFiles: string[] = [];
+  try {
+    const entries = await fs.readdir(ZAO_PRIVATE_DIR);
+    gcalFiles = entries.filter((f) => f.startsWith('gcal-') && f.endsWith('.json')).sort();
+  } catch {
+    // no private dir yet — continue with ZOE calendar
+  }
 
-    const key = `calendar:${ev.id ?? ev.summary}:${new Date(start).toISOString().slice(0, 10)}`;
-    if (seen[key]) continue;
-    seen[key] = now;
+  if (gcalFiles.length > 0) {
+    const latestPath = join(ZAO_PRIVATE_DIR, gcalFiles[gcalFiles.length - 1]);
+    try {
+      const stat = await fs.stat(latestPath);
+      if (now - stat.mtimeMs <= GCAL_FILE_MAX_AGE_MS) {
+        // not stale — process it
+        let events: GCalEvent[] = [];
+        try {
+          const raw = await fs.readFile(latestPath, 'utf8');
+          const data = JSON.parse(raw) as GCalEvent[] | { items?: GCalEvent[]; events?: GCalEvent[] };
+          events = Array.isArray(data) ? data : (data.items ?? data.events ?? []);
+        } catch {
+          // parse error — continue to ZOE calendar
+        }
 
-    const minsAway = Math.round((start - now) / 60_000);
-    out.push({
-      kind: 'calendar',
-      score: 0.72,
-      tier: 'standard',
-      message: `[CALENDAR] "${ev.summary ?? 'Event'}" in ${minsAway}m. Anything to prep?`,
-    });
+        for (const ev of events) {
+          const startStr = ev.start?.dateTime ?? ev.start?.date;
+          if (!startStr) continue;
+          const start = Date.parse(startStr);
+          if (!Number.isFinite(start) || start < now || start > windowEnd) continue;
+
+          const key = `calendar:${ev.id ?? ev.summary}:${new Date(start).toISOString().slice(0, 10)}`;
+          if (seen[key]) continue;
+          seen[key] = now;
+
+          const minsAway = Math.round((start - now) / 60_000);
+          out.push({
+            kind: 'calendar',
+            score: 0.72,
+            tier: 'standard',
+            message: `[CALENDAR] "${ev.summary ?? 'Event'}" in ${minsAway}m. Anything to prep?`,
+          });
+        }
+      }
+    } catch {
+      // stat failed — continue to ZOE calendar
+    }
+  }
+
+  // Check ZOE's calendar (ZAO Luma ICS feed via calendar.ts)
+  try {
+    const { getCalendarEvents } = await import('./calendar');
+    const zoeEvents = await getCalendarEvents(1); // 1-day lookahead for reminders
+    for (const ev of zoeEvents) {
+      if (ev.start.getTime() < now || ev.start.getTime() > windowEnd) continue;
+
+      const key = `calendar-zoe:${ev.id}:${ev.start.toISOString().slice(0, 10)}`;
+      if (seen[key]) continue;
+      seen[key] = now;
+
+      const minsAway = Math.round((ev.start.getTime() - now) / 60_000);
+      out.push({
+        kind: 'calendar',
+        score: 0.72,
+        tier: 'standard',
+        message: `[CALENDAR] "${ev.title}" in ${minsAway}m${ev.location ? ` @ ${ev.location}` : ''}. Anything to prep?`,
+      });
+    }
+  } catch (err) {
+    // calendar.ts import or fetch failed — best-effort, continue anyway
+    console.warn('[zoe/events] ZOE calendar check failed (nbd):', (err as Error).message);
   }
 
   if (out.length > 0) await writeSeen(seen);


### PR DESCRIPTION
## Summary

Make ZOE calendar-aware: ZOE now watches the ZAO Luma calendar and surfaces upcoming events in the morning brief + sends day-before/morning-of reminders to Zaal.

- Calendar reader (calendar.ts): lightweight ICS parser that fetches from the ZAO Luma public feed (luma.com/zao)
- Brief integration (brief.ts): adds upcoming events section showing the next 7 days of ZAO events
- Reminder system (events.ts + scheduler): extends gatherCalendarCandidates to check ZOE calendar, surfaces events starting within 2h as reasoning-tick candidates (score 0.72)
- Inform-only gating: ZOE tells Zaal about events but never creates/modifies/RSVPs
- No-op until set: safe graceful degradation if CALENDAR_ICS_URL is unset or unreachable

## Design

Calendar reader (bot/src/zoe/calendar.ts):
- Fetches ICS from CALENDAR_ICS_URL env var (defaults to ZAO Luma: https://lu.ma/event/cal-jPH4al7AMlXzdNN/ics)
- Custom lightweight ICS parser (avoids heavy dep)
- Caches parsed events to ~/.zao/zoe/calendar/cache.json with 6h TTL
- Returns upcoming events filtered by lookahead window (7-14 days for brief, 1 day for reminders)
- Gracefully no-ops if URL unset or fetch/parse fails

Brief integration (bot/src/zoe/brief.ts):
- Calls getCalendarEvents(7) to load upcoming events for the morning brief
- Adds UPCOMING EVENTS section (skipped if empty)
- Formats events with date, time, location for display
- Degrades gracefully to no-op on calendar failure

Reminder system (bot/src/zoe/events.ts + scheduler.ts):
- Extended gatherCalendarCandidates to check ZOE calendar (in addition to existing gcal-*.json support)
- Surfaces events starting within 2h as reasoning-tick candidates
- Score 0.72: time-sensitive (outranks stale PRs), beaten by overdue commitment threads
- Leverages existing Telegram path via scheduler reasoning tick
- Once-per-day dedup per event

Env config (.env.example):
- CALENDAR_ICS_URL: optional, defaults to ZAO Luma public feed
- Can be overridden for custom ICS feeds (Google Calendar export, Outlook, etc.)

## Gating & Safety

- Inform-only: ZOE tells Zaal about events, never modifies calendar or RSVPs
- No new autonomous outbound: reuses existing Telegram messaging (scheduler reasoning tick)
- No-op until set: safe no-op if CALENDAR_ICS_URL unset; never crashes on fetch/parse error
- Best-effort throughout: cached failures, graceful degradation

## Test & Verify

- npm run typecheck: 0 errors in calendar.ts, brief.ts, events.ts
- esbuild bundle: successful (144.4kb bundle)
- Boot-verified: npx esbuild bot/src/index.ts --bundle --platform=node --format=esm works

## How to Enable

Set CALENDAR_ICS_URL on the VPS, or leave unset to use the default ZAO Luma feed. The morning brief at 5am EST will include upcoming events. Day-before/morning-of reminders will surface via ZOE's reasoning tick (hourly, threshold-gated).

## Configuration

Default ZAO Luma ICS feed: https://lu.ma/event/cal-jPH4al7AMlXzdNN/ics (public, no auth)

To customize, set CALENDAR_ICS_URL to any public ICS feed URL:
```
CALENDAR_ICS_URL=https://example.com/calendar.ics
```

Leave unset to use the default ZAO Luma feed.

---

PR-only, no secrets, boot-verified. Ready to merge.