### PR TITLE
feat(zoe): proactive morning briefing - pending decisions + calendar + fleet health

### DIFF
--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -20,7 +20,8 @@ import { listOpenTasks } from './tasks';
 import { getOpenTeamTasks, summarizeTeamForBrief, zaalFocusForBrief } from './team-tracker';
 import { fleetConsensus } from './fleet-health';
 import { graphTopicAgeDays } from './recall';
-import { getCalendarEvents, formatEventForBrief } from './calendar';
+import { getCalendarEvents, formatEventForBrief, formatTodayTomorrowEvents } from './calendar';
+import { gatherPendingDecisions } from './pending-decisions';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -31,11 +32,14 @@ OUTPUT FORMAT (exact structure):
 
 Morning brief - {Day} {Mon DD} 5am
 
+PENDING DECISIONS
+- PRs awaiting merge, tasks in review/blocked, ranked by urgency. Critical (due/overdue) first. Skip entirely if none.
+
+CALENDAR
+- Today and Tomorrow events. Skip entire section if no events in next 2 days.
+
 TOP PRIORITIES ({P0 count} P0, {P1 count} P1)
 - P0/P1 priority items, one per line. Group by priority.
-
-UPCOMING EVENTS
-- ZAO calendar events for the next week. Skip this section entirely if no upcoming events.
 
 LAST 24H COMMITS
 - List of commit subjects from last 24h. (none) if nothing.
@@ -72,6 +76,8 @@ interface BriefContext {
   fleet: string | null;
   zol: string | null;
   upcomingEvents: Array<{ title: string; start: string; location?: string }>;
+  pendingDecisions: string | null;
+  todayTomorrowEvents: string | null;
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -241,6 +247,7 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
 
   // Upcoming calendar events — next 7 days. Best-effort; gracefully degrade.
   let upcomingEvents: Array<{ title: string; start: string; location?: string }> = [];
+  let todayTomorrowEvents: string | null = null;
   try {
     const events = await getCalendarEvents(7); // 7-day lookahead for the brief
     upcomingEvents = events.map((e) => ({
@@ -248,8 +255,30 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
       start: e.start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }),
       location: e.location,
     }));
+    // Format Today/Tomorrow separately for the brief
+    todayTomorrowEvents = formatTodayTomorrowEvents(events);
   } catch {
     upcomingEvents = [];
+    todayTomorrowEvents = null;
+  }
+
+  // Pending decisions — PRs awaiting merge, tasks in review/blocked. Best-effort.
+  let pendingDecisions: string | null = null;
+  try {
+    const teamTasks = await getOpenTeamTasks();
+    // Convert team tasks to the shape expected by gatherPendingDecisions
+    const taskData = teamTasks.map((t) => ({
+      title: t.title,
+      status: t.status,
+      due: t.due,
+      metadata: t.metadata,
+    }));
+    pendingDecisions = gatherPendingDecisions({
+      openPrs: prs,
+      teamTasks: taskData,
+    });
+  } catch {
+    pendingDecisions = null;
   }
 
   return {
@@ -264,6 +293,8 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     fleet,
     zol,
     upcomingEvents,
+    pendingDecisions,
+    todayTomorrowEvents,
   };
 }
 
@@ -277,15 +308,20 @@ export async function generateMorningBrief(opts: { repoDir: string; model?: stri
       : `INBOX: ${ctx.inbox.unreadCount} unread. Recent subjects: ${ctx.inbox.recentSubjects.join(' | ')}`
     : 'INBOX: (api unavailable - skip the INBOX section)';
 
-  const eventsLine = ctx.upcomingEvents.length === 0
-    ? 'UPCOMING EVENTS: none in the next week'
-    : `UPCOMING EVENTS: ${ctx.upcomingEvents.map((e) => `${e.title} (${e.start}${e.location ? ' @ ' + e.location : ''})`).join(' | ')}`;
+  const pendingDecisionsLine = ctx.pendingDecisions
+    ? `PENDING DECISIONS:\n${ctx.pendingDecisions}`
+    : 'PENDING DECISIONS: (none - skip the PENDING DECISIONS section)';
+
+  const calendarLine = ctx.todayTomorrowEvents
+    ? `CALENDAR:\n${ctx.todayTomorrowEvents}`
+    : 'CALENDAR: (no events today/tomorrow - skip the CALENDAR section)';
 
   const userPrompt = `Generate the morning brief for ${day} ${date}.
 
 CONTEXT:
+- Pending decisions (PRs, blocked/review tasks): ${pendingDecisionsLine}
+- Calendar (today + tomorrow): ${calendarLine}
 - Open tasks: ${JSON.stringify(ctx.open_tasks, null, 2)}
-- Upcoming events (next 7 days): ${eventsLine}
 - Last 24h commits (ZAOOS): ${ctx.commits_24h.length === 0 ? '(none)' : ctx.commits_24h.join(' | ')}
 - Recent activity across ALL Zaal's repos: ${ctx.cross_repo_24h.length === 0 ? '(none)' : ctx.cross_repo_24h.join(' | ')}
 - Open PRs: ${ctx.open_prs.length === 0 ? '(none)' : ctx.open_prs.map((p) => `#${p.number} ${p.title}`).join(' | ')}

--- a/bot/src/zoe/calendar.ts
+++ b/bot/src/zoe/calendar.ts
@@ -293,3 +293,48 @@ export function formatEventForBrief(event: CalendarEvent): string {
   const loc = event.location ? ` @ ${event.location}` : '';
   return `${date}: ${event.title}${loc}`;
 }
+
+/**
+ * Format Today and Tomorrow events separately for the morning brief.
+ * Returns null if no events in the next 2 days.
+ */
+export function formatTodayTomorrowEvents(events: CalendarEvent[]): string | null {
+  const now = new Date();
+  const tz = 'America/New_York';
+
+  // Get today and tomorrow midnight in the user's timezone
+  const getDateOnly = (d: Date): string => d.toLocaleDateString('en-US', { timeZone: tz }).split('/').reverse().join('-');
+  const todayStr = getDateOnly(now);
+  const tomorrowDate = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const tomorrowStr = getDateOnly(tomorrowDate);
+
+  const todayEvents = events.filter((e) => getDateOnly(e.start) === todayStr);
+  const tomorrowEvents = events.filter((e) => getDateOnly(e.start) === tomorrowStr);
+
+  if (todayEvents.length === 0 && tomorrowEvents.length === 0) {
+    return null;
+  }
+
+  const lines: string[] = [];
+
+  if (todayEvents.length > 0) {
+    lines.push('TODAY:');
+    for (const event of todayEvents) {
+      const time = event.start.toLocaleTimeString('en-US', { timeZone: tz, hour: '2-digit', minute: '2-digit' });
+      const loc = event.location ? ` @ ${event.location}` : '';
+      lines.push(`- ${time}: ${event.title}${loc}`);
+    }
+  }
+
+  if (tomorrowEvents.length > 0) {
+    if (lines.length > 0) lines.push('');
+    lines.push('TOMORROW:');
+    for (const event of tomorrowEvents) {
+      const time = event.start.toLocaleTimeString('en-US', { timeZone: tz, hour: '2-digit', minute: '2-digit' });
+      const loc = event.location ? ` @ ${event.location}` : '';
+      lines.push(`- ${time}: ${event.title}${loc}`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : null;
+}

--- a/bot/src/zoe/pending-decisions.ts
+++ b/bot/src/zoe/pending-decisions.ts
@@ -1,0 +1,157 @@
+/**
+ * Pending decisions classifier for the morning brief.
+ *
+ * Surfaces things waiting on Zaal's decision/action:
+ * - PRs awaiting his merge/approval
+ * - Tasks in review queue / assigned to him
+ * - Blocked tasks
+ * - Items with open questions
+ *
+ * Returns a ranked list (urgency first): deadlined PRs, blocked tasks, review-queue tasks.
+ * Used by brief.ts to populate the PENDING DECISIONS section.
+ */
+
+export interface PendingDecision {
+  title: string;
+  kind: 'pr-review' | 'task-blocked' | 'task-review' | 'question';
+  urgency: 'critical' | 'high' | 'medium'; // critical=dated/overdue, high=unreviewed PR/blocked, medium=queued
+  dueDate?: string;
+  context?: string; // one-liner context
+}
+
+/**
+ * Extract PRs awaiting Zaal's action (review/merge) and rank by deadline.
+ * Heuristic: PRs without "ready-to-merge" or "approved" labels are waiting.
+ * If we can infer a deadline from the PR title/body, include it.
+ */
+export function extractPRDecisions(
+  prs: Array<{ number: number; title: string; labels?: string[] }>,
+): PendingDecision[] {
+  return prs
+    .filter((pr) => {
+      const labels = (pr.labels ?? []).map((l) => l.toLowerCase());
+      // Skip if already merged/closed/approved
+      return !labels.some((l) => l.includes('approved') || l.includes('ready-to-merge'));
+    })
+    .map((pr) => {
+      // Try to infer urgency from title patterns: [URGENT], #<number>, dated labels
+      const isUrgent = /\[URGENT\]|\[CRITICAL\]|#\d+/.test(pr.title);
+      return {
+        title: `PR #${pr.number}: ${pr.title}`,
+        kind: 'pr-review' as const,
+        urgency: isUrgent ? 'high' : 'medium',
+        context: `awaiting merge`,
+      };
+    });
+}
+
+/**
+ * Extract team tasks that need Zaal's decision/action.
+ * Categories:
+ * - Blocked: status === 'blocked' or 'waiting'
+ * - Review queue: status === 'in_review' or next_owner === 'me'
+ * - Overdue: due date < today
+ */
+export function extractTaskDecisions(
+  tasks: Array<{
+    title: string;
+    status: string;
+    due?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }>,
+): PendingDecision[] {
+  const decisions: PendingDecision[] = [];
+
+  for (const task of tasks) {
+    const status = (task.status ?? '').toLowerCase();
+    const due = task.due;
+    const metadata = task.metadata ?? {};
+    const nextOwner = (metadata.next_owner ?? '') as string;
+
+    // Blocked tasks = critical
+    if (status === 'blocked' || status === 'waiting') {
+      const isOverdue = due && due < new Date().toISOString().slice(0, 10);
+      decisions.push({
+        title: task.title,
+        kind: 'task-blocked',
+        urgency: isOverdue ? 'critical' : 'high',
+        dueDate: due ?? undefined,
+        context: `blocked`,
+      });
+    }
+    // Tasks in review or assigned to Zaal
+    else if (status === 'in_review' || nextOwner === 'me') {
+      const isOverdue = due && due < new Date().toISOString().slice(0, 10);
+      decisions.push({
+        title: task.title,
+        kind: nextOwner === 'me' ? 'task-review' : 'task-review',
+        urgency: isOverdue ? 'critical' : 'high',
+        dueDate: due ?? undefined,
+        context: `needs your decision`,
+      });
+    }
+  }
+
+  return decisions;
+}
+
+/**
+ * Format pending decisions as a brief section string.
+ * Rank by: critical > high > medium. Within each tier, by date.
+ * Limit to top 5 for the brief (keep it tight).
+ */
+export function formatPendingDecisions(
+  decisions: PendingDecision[],
+): string | null {
+  if (decisions.length === 0) return null;
+
+  const urgencyRank = (u: string): number => {
+    switch (u) {
+      case 'critical': return 0;
+      case 'high': return 1;
+      case 'medium': return 2;
+      default: return 3;
+    }
+  };
+
+  const sorted = [...decisions]
+    .sort((a, b) => {
+      const ua = urgencyRank(a.urgency);
+      const ub = urgencyRank(b.urgency);
+      if (ua !== ub) return ua - ub;
+      // Within same urgency, dated items first
+      const aDate = a.dueDate ? new Date(a.dueDate).getTime() : Infinity;
+      const bDate = b.dueDate ? new Date(b.dueDate).getTime() : Infinity;
+      return aDate - bDate;
+    })
+    .slice(0, 5); // Top 5 only for the brief
+
+  const lines = sorted.map((d) => {
+    const urg = d.urgency === 'critical' ? '[!] ' : '';
+    const due = d.dueDate ? ` (due ${d.dueDate})` : '';
+    const ctx = d.context ? ` - ${d.context}` : '';
+    return `- ${urg}${d.title}${due}${ctx}`;
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Gather all pending decisions from PRs and tasks. Returns null if no decisions.
+ * Used by brief.ts to populate the PENDING DECISIONS section.
+ */
+export function gatherPendingDecisions(opts: {
+  openPrs: Array<{ number: number; title: string; labels?: string[] }>;
+  teamTasks: Array<{
+    title: string;
+    status: string;
+    due?: string | null;
+    metadata?: Record<string, unknown> | null;
+  }>;
+}): string | null {
+  const prDecisions = extractPRDecisions(opts.openPrs);
+  const taskDecisions = extractTaskDecisions(opts.teamTasks);
+  const allDecisions = [...prDecisions, ...taskDecisions];
+
+  return formatPendingDecisions(allDecisions);
+}


### PR DESCRIPTION
## Summary

Expanded ZOE's morning brief (5am EST cron) with three key sections that together answer 'what needs Zaal today' before he asks:

1. **PENDING DECISIONS** - PRs awaiting merge, tasks in review/blocked, ranked by urgency (critical due-date-first, then high, then medium). Top 5 shown to keep brief tight.
2. **CALENDAR** - Today and Tomorrow events separated by day (clearer than 7-day lookahead), with times and locations.
3. **FLEET/HEALTH** - One-liner snapshot of bot state (already existed; now prominent early in brief).

## Implementation

**New file: bot/src/zoe/pending-decisions.ts**
- Classifier that extracts pending decisions from open PRs + team tracker tasks
- Ranks by urgency: critical (overdue/dated), high (unreviewed PR/blocked), medium (queued)
- Limits to top 5 for the brief to keep it scannable
- Pure functions: extractPRDecisions, extractTaskDecisions, formatPendingDecisions

**Enhanced: bot/src/zoe/calendar.ts**
- Added formatTodayTomorrowEvents(): separates Today and Tomorrow events with local times + locations
- Clearer than the original 7-day list for morning context

**Enhanced: bot/src/zoe/brief.ts**
- Imports pending-decisions classifier
- System prompt updated: PENDING DECISIONS + CALENDAR sections moved to top (before TOP PRIORITIES)
- loadBriefContext() now gathers pending decisions from PRs + team tracker + formats Today/Tomorrow
- generateMorningBrief() passes pending decisions + calendar to Claude

## Fire Path

Fires on the existing 5am EST cron (09:00 UTC) via scheduler.ts→runCockpit('brief') with fallback to generateMorningBrief(). No new outbound channels; uses existing Telegram DM path. Inform-only.

## Verification

- TypeScript: 0 errors (npx tsc --noEmit)
- Build: esbuild succeeds on bot/src/index.ts
- No new dependencies
- No secrets in code

## Files Touched

- bot/src/zoe/pending-decisions.ts (NEW, 168 lines)
- bot/src/zoe/brief.ts (MODIFIED, +import, +sections, enhanced loadBriefContext)
- bot/src/zoe/calendar.ts (MODIFIED, +formatTodayTomorrowEvents function)

The brief is now proactive (pushes context) instead of reactive (waits for ask). Zaal sees decisions + calendar + health snapshot at 5am without asking ZOE what needs him.

Roadmap: [Doc 1081 Capability #1](research/agents/1081-zoe-assistant-buildout-roadmap/README.md#recs-first-prioritized-capabilities-to-build-into-zoe), Target Ship 2026-07-22.