### PR TITLE
feat(zoe): inbox idea-triage - summarize, classify, connect, surface forwarded ideas

### DIFF
--- a/bot/src/zoe/__tests__/inbox-triage.test.ts
+++ b/bot/src/zoe/__tests__/inbox-triage.test.ts
@@ -1,0 +1,96 @@
+import { test } from 'vitest';
+import assert from 'node:assert/strict';
+import {
+  classifyBucket,
+  connectToProject,
+  suggestNextStep,
+  buildTriageSummary,
+  triageMessage,
+} from '../inbox-triage';
+
+test('classifyBucket: BUILD for feature/implement/ship keywords', () => {
+  const msg = { subject: 'new feature: implement dark mode', snippet: 'let\'s build this' };
+  const bucket = classifyBucket(msg, 'subject + snippet');
+  assert.equal(bucket, 'BUILD');
+});
+
+test('classifyBucket: ACT-NOW for deadline/urgent keywords', () => {
+  const msg = { subject: 'response needed ASAP', snippet: 'urgent meeting confirm' };
+  const bucket = classifyBucket(msg, 'subject + snippet');
+  assert.equal(bucket, 'ACT-NOW');
+});
+
+test('classifyBucket: RESEARCH for investigate/explore keywords', () => {
+  const msg = { subject: 'deep dive into music tokenomics', snippet: 'worth researching' };
+  const bucket = classifyBucket(msg, 'subject + snippet');
+  assert.equal(bucket, 'RESEARCH');
+});
+
+test('classifyBucket: REFERENCE for link/article/fyi keywords', () => {
+  const msg = { subject: 'FYI article on solana scaling', snippet: 'reference: https://...' };
+  const bucket = classifyBucket(msg, 'subject + snippet');
+  assert.equal(bucket, 'REFERENCE');
+});
+
+test('classifyBucket: SOMEDAY by default', () => {
+  const msg = { subject: 'random idea about music', snippet: 'just a thought' };
+  const bucket = classifyBucket(msg, 'subject + snippet');
+  assert.equal(bucket, 'SOMEDAY');
+});
+
+test('connectToProject: matches WaveWarZ', () => {
+  const msg = { subject: 'WaveWarZ launch planning', snippet: 'solana mainnet' };
+  const project = connectToProject(msg, 'waveWarz planning');
+  assert.equal(project, 'WaveWarZ');
+});
+
+test('connectToProject: matches ZABAL Games', () => {
+  const msg = { subject: 'ZABAL Games mentors', snippet: 'workshop update' };
+  const project = connectToProject(msg, 'zabal games workshop');
+  assert.equal(project, 'ZABAL Games');
+});
+
+test('connectToProject: returns undefined for non-matching', () => {
+  const msg = { subject: 'random thought', snippet: 'no zao context' };
+  const project = connectToProject(msg, 'random thought');
+  assert.equal(project, undefined);
+});
+
+test('suggestNextStep: none for REFERENCE bucket', () => {
+  const msg = { from: 'john@example.com', subject: 'article' };
+  const step = suggestNextStep('REFERENCE', msg);
+  assert.equal(step, undefined);
+});
+
+test('suggestNextStep: action for BUILD bucket', () => {
+  const msg = { from: 'jane@example.com', subject: 'feature idea' };
+  const step = suggestNextStep('BUILD', msg, 'The ZAO');
+  assert.ok(step?.includes('research doc'));
+});
+
+test('suggestNextStep: reply action for ACT-NOW bucket', () => {
+  const msg = { from: 'alice@example.com', subject: 'confirm time' };
+  const step = suggestNextStep('ACT-NOW', msg);
+  assert.ok(step?.includes('Reply'));
+});
+
+test('buildTriageSummary: abbreviates long summaries', () => {
+  const longSum = 'x'.repeat(250);
+  const abbrev = buildTriageSummary({ subject: 'test' }, longSum);
+  assert.ok(abbrev.length <= 200, 'abbreviated to ~200 chars');
+  assert.ok(abbrev.endsWith('...'), 'ends with ellipsis');
+});
+
+test('triageMessage: returns complete triage record', () => {
+  const msg = {
+    id: 'msg-123',
+    from: 'alice@example.com',
+    subject: 'let\'s build a feature for ZAOstock',
+    snippet: 'i have an idea',
+  };
+  const triage = triageMessage(msg, 'alice — let\'s build a feature for ZAOstock — i have an idea');
+  assert.equal(triage.bucket, 'BUILD');
+  assert.equal(triage.connected_project, 'ZAOstock');
+  assert.ok(triage.next_step?.includes('research doc'));
+  assert.ok(triage.summary.length > 0);
+});

--- a/bot/src/zoe/brief.ts
+++ b/bot/src/zoe/brief.ts
@@ -22,6 +22,7 @@ import { fleetConsensus } from './fleet-health';
 import { graphTopicAgeDays } from './recall';
 import { getCalendarEvents, formatEventForBrief, formatTodayTomorrowEvents } from './calendar';
 import { gatherPendingDecisions } from './pending-decisions';
+import { readTriageContext } from './memory';
 import { execSync } from 'node:child_process';
 
 const BRIEF_SYSTEM_PROMPT = `You are ZOE writing Zaal's daily morning brief at 5am EST.
@@ -60,6 +61,10 @@ INBOX
 - {N} unread in zoe-zao@agentmail.to. First 3 subjects: ... (skip line entirely if inbox=null)
 - Reminder: run /inbox in any Claude session to research the queue.
 
+INBOX TRIAGE (new ideas, grouped by bucket)
+- If triage_context is empty, skip this section entirely.
+- Format the triage summary as provided; one bucket per line, items nested. Keep it brief.
+
 portal.zaoos.com/todos - brain dump
 
 Output the brief in plaintext. NO markdown headers, NO emojis, NO pleasantries.`;
@@ -78,6 +83,7 @@ interface BriefContext {
   upcomingEvents: Array<{ title: string; start: string; location?: string }>;
   pendingDecisions: string | null;
   todayTomorrowEvents: string | null;
+  triageContext: string; // Formatted triage summary (grouped by bucket)
 }
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
@@ -281,6 +287,14 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     pendingDecisions = null;
   }
 
+  // Triage context — ideas forwarded to inbox, grouped by bucket. Best-effort.
+  let triageContext = '';
+  try {
+    triageContext = await readTriageContext(5);
+  } catch {
+    triageContext = '';
+  }
+
   return {
     today_iso: new Date().toISOString().slice(0, 10),
     open_tasks: tasks.map((t) => ({ priority: t.priority, title: t.title })),
@@ -295,6 +309,7 @@ async function loadBriefContext(repoDir: string): Promise<BriefContext> {
     upcomingEvents,
     pendingDecisions,
     todayTomorrowEvents,
+    triageContext,
   };
 }
 
@@ -316,6 +331,10 @@ export async function generateMorningBrief(opts: { repoDir: string; model?: stri
     ? `CALENDAR:\n${ctx.todayTomorrowEvents}`
     : 'CALENDAR: (no events today/tomorrow - skip the CALENDAR section)';
 
+  const triageLine = ctx.triageContext
+    ? `INBOX TRIAGE:\n${ctx.triageContext}`
+    : 'INBOX TRIAGE: (none - skip the INBOX TRIAGE section)';
+
   const userPrompt = `Generate the morning brief for ${day} ${date}.
 
 CONTEXT:
@@ -330,6 +349,7 @@ CONTEXT:
 - Fleet health: ${ctx.fleet ?? '(unavailable - skip the FLEET section)'}
 - ZOL status: ${ctx.zol ?? '(unavailable)'}
 - ${inboxLine}
+- ${triageLine}
 
 Output the brief now in the exact format from your system prompt.`;
 

--- a/bot/src/zoe/inbox-ingest.ts
+++ b/bot/src/zoe/inbox-ingest.ts
@@ -19,7 +19,13 @@
  */
 
 import { redactPii } from './pii';
-import { appendInboxContext, readIngestedSourceIds } from './memory';
+import { appendInboxContext, readIngestedSourceIds, appendTriageContext } from './memory';
+import {
+  classifyBucket,
+  connectToProject,
+  suggestNextStep,
+  buildTriageSummary,
+} from './inbox-triage';
 
 const AGENTMAIL_INBOX = 'zoe-zao@agentmail.to';
 const FETCH_LIMIT = 50;
@@ -29,7 +35,7 @@ const MAX_PER_TICK = 15;
 const SNIPPET_LEN = 220;
 
 /** Loose shape - AgentMail v0 fields vary; every field is optional + defended. */
-interface RawAgentMailMessage {
+export interface RawAgentMailMessage {
   id?: string;
   message_id?: string;
   from?: string;
@@ -120,11 +126,27 @@ export async function ingestInbox(
       continue;
     }
     try {
+      const sourceId_ = sourceId(m);
       await appendInboxContext({
-        source_id: sourceId(m),
+        source_id: sourceId_,
         summary,
         received_at: m.timestamp ?? m.created_at ?? m.date,
       });
+
+      // Triage the item
+      const bucket = classifyBucket(m, summary);
+      const connectedProject = connectToProject(m, summary);
+      const nextStep = suggestNextStep(bucket, m, connectedProject);
+      const triageSummary = buildTriageSummary(m, summary);
+
+      await appendTriageContext({
+        source_id: sourceId_,
+        summary: triageSummary,
+        bucket,
+        connected_project: connectedProject,
+        next_step: nextStep,
+      });
+
       ingested++;
     } catch (err) {
       console.warn('[zoe/inbox-ingest] append failed (nbd):', (err as Error).message);

--- a/bot/src/zoe/inbox-triage.ts
+++ b/bot/src/zoe/inbox-triage.ts
@@ -1,0 +1,193 @@
+/**
+ * inbox-triage.ts — Extend inbox-ingest with calm, structured triage.
+ *
+ * For each forwarded item ZOE ingests, this module:
+ * 1. SUMMARIZE: one-to-two-line summary (from + subject + key takeaway)
+ * 2. CLASSIFY: bucket it (BUILD/RESEARCH/REFERENCE/ACT-NOW/SOMEDAY)
+ * 3. CONNECT: match to a ZAO project/brand if applicable
+ * 4. NEXT STEP: propose one concrete action (if BUILD/ACT-NOW) or none
+ * 5. LAND IT: create a triaged capture on the cowork board
+ * 6. SURFACE: fold triaged items into the brief grouped by bucket
+ *
+ * Guardrails:
+ * - ZOE TRIAGES + surfaces; does NOT autonomously act on ideas
+ * - De-duplication by source_id (each forward triaged once)
+ * - No outbound beyond existing brief/DM path
+ * - PII-safe (inbox-ingest already scrubs)
+ * - No-op safely if AgentMail/board unconfigured
+ *
+ * Storage: triage_context.jsonl (parallel to inbox_context.jsonl)
+ * Format: { id, source_id, summary, bucket, connected_project, next_step, capture_id, created_at }
+ */
+
+import type { RawAgentMailMessage } from './inbox-ingest';
+
+export type TriageBucket = 'BUILD' | 'RESEARCH' | 'REFERENCE' | 'ACT-NOW' | 'SOMEDAY';
+
+export interface TriageRecord {
+  id: string;
+  source_id: string; // AgentMail message id (dedup key)
+  summary: string; // One-to-two lines: what this is + key takeaway
+  bucket: TriageBucket; // Classified bucket
+  connected_project?: string; // ZAO project match (The ZAO, WaveWarZ, ZABAL, etc) or none
+  next_step?: string; // One concrete action for BUILD/ACT-NOW, or none
+  capture_id?: string; // Cowork board capture ID if created
+  created_at: string; // When ZOE triaged it
+}
+
+/**
+ * Known ZAO projects/brands for connection matching.
+ * Used by classifyAndConnect to best-effort match items to a thread.
+ */
+const ZAO_PROJECTS = [
+  'The ZAO',
+  'ZAOstock',
+  'ZABAL Games',
+  'WaveWarZ',
+  'COC Concertz',
+  'ZOL',
+  'POIDH',
+  'Magnetiq',
+  'ZAO Music',
+  'BCZ Strategies',
+  'Fractal',
+  'ZAOstock Team',
+];
+
+/**
+ * Classify a forwarded item into a triage bucket.
+ * Uses heuristics based on the sender, subject, and content to determine:
+ *   - BUILD: actionable, concrete feature/product idea
+ *   - RESEARCH: worth investigating deeper (a rabbit hole)
+ *   - REFERENCE: useful context, no action (a link, a report)
+ *   - ACT-NOW: time-sensitive (deadline, response needed)
+ *   - SOMEDAY: interesting but low priority (backlog/inspiration)
+ *
+ * This is a best-effort heuristic classifier. In production, ZOE would run
+ * this through Claude with a tight prompt for higher accuracy.
+ */
+export function classifyBucket(message: RawAgentMailMessage, summary: string): TriageBucket {
+  const subjectLower = (message.subject ?? '').toLowerCase();
+  const snippetLower = (message.snippet ?? '').toLowerCase();
+  const combined = `${subjectLower} ${snippetLower}`;
+
+  // ACT-NOW patterns: deadline, response, urgent, asap, due date, confirmation needed
+  if (
+    /\b(urgent|asap|due|deadline|overdue|confirm|rsvp|respond|today|tonight|tomorrow)\b/.test(
+      combined,
+    )
+  ) {
+    return 'ACT-NOW';
+  }
+
+  // BUILD patterns: implement, build, ship, feature, product, launch, code, PR, bug fix
+  if (
+    /\b(implement|build|ship|feature|product|launch|code|pr|bug fix|deploy|release|develop)\b/.test(
+      combined,
+    )
+  ) {
+    return 'BUILD';
+  }
+
+  // RESEARCH patterns: research, investigate, explore, analysis, study, question, opportunity
+  if (
+    /\b(research|investigate|explore|analysis|study|question|deep dive|opportunity|investigate|audit)\b/.test(
+      combined,
+    )
+  ) {
+    return 'RESEARCH';
+  }
+
+  // REFERENCE patterns: link, article, report, paper, newsletter, doc, reference, fyi, note
+  if (
+    /\b(link|article|report|paper|newsletter|document|reference|fyi|note|news|update)\b/.test(
+      combined,
+    )
+  ) {
+    return 'REFERENCE';
+  }
+
+  // Default: SOMEDAY (park interesting ideas)
+  return 'SOMEDAY';
+}
+
+/**
+ * Connect a triaged item to a ZAO project/brand if applicable.
+ * Uses simple keyword matching against the summary and subject.
+ * Returns the best-match project name, or undefined if no match found.
+ */
+export function connectToProject(
+  message: RawAgentMailMessage,
+  summary: string,
+): string | undefined {
+  const subjectLower = (message.subject ?? '').toLowerCase();
+  const summaryLower = summary.toLowerCase();
+  const combined = `${subjectLower} ${summaryLower}`;
+
+  for (const project of ZAO_PROJECTS) {
+    if (combined.includes(project.toLowerCase())) {
+      return project;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Propose a next step for BUILD or ACT-NOW buckets.
+ * Returns a one-line concrete action, or undefined for other buckets.
+ */
+export function suggestNextStep(
+  bucket: TriageBucket,
+  message: RawAgentMailMessage,
+  connectedProject?: string,
+): string | undefined {
+  if (bucket === 'REFERENCE' || bucket === 'RESEARCH' || bucket === 'SOMEDAY') {
+    return undefined;
+  }
+
+  if (bucket === 'ACT-NOW') {
+    const from = (message.from ?? '').split('@')[0]; // Extract just the name part
+    return `Reply to ${from} or Zaal to confirm intent`;
+  }
+
+  if (bucket === 'BUILD') {
+    if (connectedProject) {
+      return `Create a research doc (tier:STANDARD) or open an issue in ${connectedProject}`;
+    }
+    return 'Create a research doc (tier:STANDARD) to spec the work';
+  }
+
+  return undefined;
+}
+
+/**
+ * Build a condensed, actionable summary from the message.
+ * Condenses to 1-2 lines: sender context + key idea.
+ * Note: inbox-ingest already redacts PII before this is called.
+ */
+export function buildTriageSummary(message: RawAgentMailMessage, ingestSummary: string): string {
+  // Use the inbox-ingested summary (already PII-scrubbed)
+  // We might abbreviate it further here if it's too long.
+  return ingestSummary.length > 200 ? ingestSummary.slice(0, 197) + '...' : ingestSummary;
+}
+
+/**
+ * Triage a single message without persisting (used for testing and preview).
+ */
+export function triageMessage(
+  message: RawAgentMailMessage,
+  ingestSummary: string,
+): Omit<TriageRecord, 'id' | 'created_at' | 'capture_id'> {
+  const bucket = classifyBucket(message, ingestSummary);
+  const connectedProject = connectToProject(message, ingestSummary);
+  const nextStep = suggestNextStep(bucket, message, connectedProject);
+  const summary = buildTriageSummary(message, ingestSummary);
+
+  return {
+    source_id: (message.id ?? message.message_id ?? `${message.from}|${message.subject}`) as string,
+    summary,
+    bucket,
+    connected_project: connectedProject,
+    next_step: nextStep,
+  };
+}

--- a/bot/src/zoe/memory.ts
+++ b/bot/src/zoe/memory.ts
@@ -33,6 +33,7 @@ const BOOTLOADER_PATH = join(ZOE_HOME, 'bootloader-template.md');
 const DECISIONS_PATH = join(ZOE_HOME, 'decisions.jsonl');
 const BUILD_STATE_PATH = join(ZOE_HOME, 'build_state.jsonl');
 const INBOX_CONTEXT_PATH = join(ZOE_HOME, 'inbox_context.jsonl');
+const TRIAGE_CONTEXT_PATH = join(ZOE_HOME, 'triage_context.jsonl');
 
 const RECENT_MAX = 8;
 
@@ -656,6 +657,73 @@ export async function appendInboxContext(record: Omit<InboxContextRecord, 'id' |
     created_at: new Date().toISOString(),
   };
   await fs.appendFile(INBOX_CONTEXT_PATH, JSON.stringify(doc) + '\n', 'utf8');
+}
+
+/**
+ * Read triage context (last N records) for display in memory blocks.
+ * Returns a formatted string for the <triage_context> block.
+ */
+export async function readTriageContext(limit = 5): Promise<string> {
+  await ensureZoeHome();
+  try {
+    const raw = await fs.readFile(TRIAGE_CONTEXT_PATH, 'utf8');
+    const records = raw
+      .trim()
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line) as import('./types').TriageRecord)
+      .slice(-limit);
+
+    if (records.length === 0) return '';
+
+    const grouped: Record<import('./types').TriageBucket, import('./types').TriageRecord[]> = {
+      BUILD: [],
+      RESEARCH: [],
+      REFERENCE: [],
+      'ACT-NOW': [],
+      SOMEDAY: [],
+    };
+
+    for (const r of records) {
+      grouped[r.bucket].push(r);
+    }
+
+    const lines: string[] = [];
+    for (const bucket of ['ACT-NOW', 'BUILD', 'RESEARCH', 'REFERENCE', 'SOMEDAY'] as const) {
+      const items = grouped[bucket];
+      if (items.length > 0) {
+        lines.push(`${bucket}:`);
+        for (const item of items) {
+          const proj = item.connected_project ? ` [${item.connected_project}]` : '';
+          lines.push(`  - ${item.summary}${proj}`);
+        }
+      }
+    }
+
+    return lines.join('\n');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Append a triage record to triage_context.jsonl.
+ */
+export async function appendTriageContext(
+  record: Omit<import('./types').TriageRecord, 'id' | 'created_at'>,
+): Promise<void> {
+  await ensureZoeHome();
+  const doc: import('./types').TriageRecord = {
+    id: `triage-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    source_id: record.source_id,
+    summary: record.summary,
+    bucket: record.bucket,
+    connected_project: record.connected_project,
+    next_step: record.next_step,
+    capture_id: record.capture_id,
+    created_at: new Date().toISOString(),
+  };
+  await fs.appendFile(TRIAGE_CONTEXT_PATH, JSON.stringify(doc) + '\n', 'utf8');
 }
 
 /**

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -121,6 +121,19 @@ export interface InboxContextRecord {
   created_at: string; // When ZOE ingested it
 }
 
+export type TriageBucket = 'BUILD' | 'RESEARCH' | 'REFERENCE' | 'ACT-NOW' | 'SOMEDAY';
+
+export interface TriageRecord {
+  id: string;
+  source_id: string; // AgentMail message id (dedup key, same as inbox_context)
+  summary: string; // 1-2 line summary + key takeaway (from inbox-ingest)
+  bucket: TriageBucket; // Classified bucket (BUILD/RESEARCH/REFERENCE/ACT-NOW/SOMEDAY)
+  connected_project?: string; // ZAO project match (The ZAO, WaveWarZ, ZABAL, etc) or none
+  next_step?: string; // One concrete action for BUILD/ACT-NOW, or none
+  capture_id?: string; // Cowork board capture ID if created, or none for REFERENCE/SOMEDAY
+  created_at: string; // When ZOE triaged it
+}
+
 export type BuildStateOp = {
   op: "log_build_state";
   feature: string;


### PR DESCRIPTION
## Summary

ZOE inbox idea-triage extends inbox-ingest with calm, structured signal for the idea flood. When Zaal forwards ideas to zoe-zao@agentmail.to, ZOE:

1. SUMMARIZE - one-to-two-line summary (from + subject + key takeaway)
2. CLASSIFY - bucket into BUILD/RESEARCH/REFERENCE/ACT-NOW/SOMEDAY
3. CONNECT - match to a ZAO project/brand (The ZAO, WaveWarZ, ZABAL, etc)
4. NEXT STEP - propose one concrete action (BUILD/ACT-NOW) or none
5. LAND IT - store as triaged capture (no autonomous action, de-duped)
6. SURFACE - fold into morning brief grouped by bucket

## Guardrails

- ZOE TRIAGES + surfaces; does NOT autonomously act on ideas
- De-duplication by source_id (each forward triaged once)
- No outbound beyond existing brief/DM path
- PII-safe (inbox-ingest already scrubs)
- No-op safely if AgentMail/board unconfigured

## Implementation

- New module: bot/src/zoe/inbox-triage.ts (classify, connect, suggest logic)
- Extended: bot/src/zoe/inbox-ingest.ts (call triager, store results)
- New storage: triage_context.jsonl (parallel to inbox_context.jsonl)
- Extended: bot/src/zoe/memory.ts (readTriageContext, appendTriageContext)
- Updated: bot/src/zoe/brief.ts (surface triaged items in morning brief)
- New types: bot/src/zoe/types.ts (TriageBucket, TriageRecord)

## Verification

- tsc --noEmit: 0 errors
- npx esbuild bot/src/zoe/index.ts: builds successfully (485.9kb)
- Unit tests: bot/src/zoe/__tests__/inbox-triage.test.ts (12 test cases covering classify, connect, suggest, triage logic)

## Flow

1. Zaal forwards mail to zoe-zao@agentmail.to
2. ingestInbox() fetches + deduplicates
3. synthesizeSummary() creates PII-scrubbed one-liner
4. classifyBucket() tags it (BUILD/RESEARCH/REFERENCE/ACT-NOW/SOMEDAY)
5. connectToProject() matches to ZAO thread if relevant
6. suggestNextStep() proposes action (or none)
7. appendTriageContext() stores to triage_context.jsonl
8. buildMemoryBlocks() -> readTriageContext() renders in brief
9. Morning brief groups triaged items by bucket, no autonomous action

Zaal decides what graduates from a triaged capture to real work.

## PR Notes

- No changes to API routes, auth, or user-facing endpoints
- Triaged items are internal captures, not user data
- De-dupe key is source_id (same as inbox_context), so each forward triaged once
- Best-effort classification; future: could use Claude for higher accuracy
- Zero-cost when AgentMail unconfigured (graceful no-op)