### PR TITLE
feat(zoe): curator github-digest - real merged-PR/ship data, clean prose

### DIFF
--- a/bot/src/zoe/__tests__/curator.test.ts
+++ b/bot/src/zoe/__tests__/curator.test.ts
@@ -3,6 +3,21 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+// Mock execSync before importing curator
+let mockExecSyncImpl = (cmd: string) => {
+  throw new Error('execSync not mocked');
+};
+
+vi.mock('node:child_process', () => ({
+  execSync: (cmd: string, opts: Record<string, unknown>) => {
+    return mockExecSyncImpl(cmd);
+  },
+}));
+
 import {
   readTopicThreadMap,
   writeTopicThreadMap,
@@ -16,9 +31,6 @@ import {
   type CuratorTickResult,
   runCuratorTick,
 } from '../curator';
-import { promises as fs } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
 
 const TEST_ZOE_HOME = join(homedir(), '.zao', 'zoe-test-curator');
 const TEST_TOPIC_MAP_PATH = join(TEST_ZOE_HOME, 'topic_thread_map.json');
@@ -43,6 +55,12 @@ describe('curator', () => {
       // OK
     }
     delete process.env.ZOE_HOME;
+    // Clean up all TG_TOPIC_* env vars
+    delete process.env.TG_TOPIC_NEWSLETTER;
+    delete process.env.TG_TOPIC_GITHUB;
+    delete process.env.TG_TOPIC_ARTIZEN;
+    delete process.env.TG_TOPIC_RECOMMENDATIONS;
+    delete process.env.TG_TOPIC_GENERAL;
   });
 
   describe('readTopicThreadMap / writeTopicThreadMap', () => {
@@ -180,11 +198,45 @@ describe('curator', () => {
   });
 
   describe('generateGithubDigest', () => {
-    it('returns a stub digest with timestamp', async () => {
+    it('returns a digest with timestamp when PRs are found', async () => {
+      // Mock execSync to return sample merged PRs
+      mockExecSyncImpl = (cmd: string) => {
+        if (cmd.includes('bettercallzaal/ZAOOS')) {
+          return JSON.stringify([
+            { number: 100, title: 'docs: research doc 1078' },
+            { number: 99, title: 'fix: bug in curator' },
+          ]);
+        }
+        if (cmd.includes('ZAODEVZ/ZAOcowork')) {
+          return JSON.stringify([{ number: 50, title: 'feat: new feature' }]);
+        }
+        throw new Error('Unexpected command');
+      };
+
       const digest = await generateGithubDigest();
       expect(digest).not.toBeNull();
       expect(digest?.text).toContain("Today's ships");
       expect(digest?.timestamp).toBeDefined();
+      expect(digest?.text).toContain('#100');
+      expect(digest?.text).toContain('#99');
+    });
+
+    it('returns null when no PRs are found', async () => {
+      // Mock execSync to return empty arrays
+      mockExecSyncImpl = () => JSON.stringify([]);
+
+      const digest = await generateGithubDigest();
+      expect(digest).toBeNull();
+    });
+
+    it('gracefully handles gh command failures', async () => {
+      // Mock execSync to throw an error
+      mockExecSyncImpl = () => {
+        throw new Error('gh: not found');
+      };
+
+      const digest = await generateGithubDigest();
+      expect(digest).toBeNull();
     });
   });
 

--- a/bot/src/zoe/curator.ts
+++ b/bot/src/zoe/curator.ts
@@ -46,6 +46,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { execSync } from 'node:child_process';
 
 const ZOE_HOME = process.env.ZOE_HOME ?? join(homedir(), '.zao', 'zoe');
 const TOPIC_THREAD_MAP_PATH = join(ZOE_HOME, 'topic_thread_map.json');
@@ -154,37 +155,93 @@ export async function postToTopic(
  * Example output:
  *   Today's ships (Jul 14):
  *
- *   PRs merged:
+ *   Merged PRs across ZAO repos:
  *   #1344: docs: research doc 1078 - individual operating system
  *   #1343: fix: insurance vendors sourcing
  *   #1342: fix: sound-system backup vendors
  *
- *   Commits landed:
- *   57f28c4 - docs: farcaster research doc
- *   8b3e1ad - docs: doc 1063 question 3
+ *   Today: 2 docs, 1 fix across the ecosystem.
  *
- * Stub implementation for MVP. Future: fetch from GitHub API + Bonfire recall.
+ * Fetches merged PRs from key repos (ZAOOS, ZAOcowork) in the last 24h.
+ * Gracefully no-ops if GitHub token is missing (runs without Telegram ping).
  */
 export async function generateGithubDigest(): Promise<{ text: string; timestamp: string } | null> {
   try {
     const now = new Date();
     const dateStr = now.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
-    // Stub: for MVP, return placeholder. Real impl would:
-    // - fetch recent merged PRs from GitHub API
-    // - fetch recent commits from git log
-    // - batch into prose narrative
-    // Disabled by default (curator OFF) so this won't fire until enabled.
+    // Fetch merged PRs from key repos
+    const repos = [
+      'bettercallzaal/ZAOOS',
+      'ZAODEVZ/ZAOcowork',
+    ];
 
-    const digestText = `Today's ships (${dateStr}):
+    interface PullRequest {
+      number: number;
+      title: string;
+      repository?: string;
+    }
 
-PRs merged:
-(fetching from GitHub API - not yet wired)
+    const allPrs: PullRequest[] = [];
 
-Commits landed:
-(fetching from git log - not yet wired)
+    for (const repo of repos) {
+      try {
+        const json = execSync(
+          `gh pr list --repo ${repo} --state merged --limit 8 --json number,title --search "merged:>24-hours-ago"`,
+          {
+            encoding: 'utf8',
+            timeout: 8000,
+          },
+        );
+        const prs = JSON.parse(json) as Array<{ number: number; title: string }>;
+        allPrs.push(...prs.map((pr) => ({ ...pr, repository: repo })));
+      } catch (err) {
+        // Graceful no-op: if a repo fetch fails, continue with others
+        console.warn(`[zoe/curator] failed to fetch merged PRs from ${repo}:`, (err as Error).message);
+      }
+    }
 
-If this appears, curator is enabled. Wire the GitHub API fetcher in curator.ts.`;
+    // If no PRs were found across all repos, return null (nothing to report)
+    if (allPrs.length === 0) {
+      return null;
+    }
+
+    // Sort by PR number (newest first) and cap at 8 items total
+    allPrs.sort((a, b) => b.number - a.number);
+    const topPrs = allPrs.slice(0, 8);
+
+    // Format as clean prose (not a raw list)
+    let digestText = `Today's ships (${dateStr}):\n\nMerged PRs across ZAO repos:`;
+
+    for (const pr of topPrs) {
+      const repoLabel = pr.repository?.includes('ZAOcowork') ? '[ZAOcowork]' : '';
+      digestText += `\n#${pr.number}: ${pr.title}${repoLabel ? ` ${repoLabel}` : ''}`;
+    }
+
+    // Add a closing note summarizing what shipped (keeps it high-signal, not spammy)
+    const categories = topPrs
+      .map((pr) => {
+        const title = pr.title.toLowerCase();
+        if (title.includes('docs')) return 'docs';
+        if (title.includes('fix')) return 'fix';
+        if (title.includes('feat')) return 'feature';
+        if (title.includes('refactor')) return 'refactor';
+        return null;
+      })
+      .filter(Boolean);
+
+    const categoryCount: { [key: string]: number } = {};
+    for (const cat of categories) {
+      if (cat) categoryCount[cat] = (categoryCount[cat] ?? 0) + 1;
+    }
+
+    const categorySummary = Object.entries(categoryCount)
+      .map(([cat, count]) => `${count} ${cat}${count > 1 ? 's' : ''}`)
+      .join(', ');
+
+    if (categorySummary) {
+      digestText += `\n\nToday: ${categorySummary} across the ecosystem.`;
+    }
 
     return {
       text: digestText,


### PR DESCRIPTION
Wire generateGithubDigest() to fetch actual last-24h merged PRs from key ZAO repos (ZAOOS, ZAOcowork). Output is clean prose digest (not raw logs), batched up to 8 items with category summary.

Uses existing gh CLI pattern for GitHub auth, gracefully no-ops when token missing. Routes via postToTopic('github') which is disabled by default.

Tested: 3 new tests for generateGithubDigest all passing (digest format, null return, error handling).

Verified: `npm run typecheck` (0 errors), `npm run build` (esbuild passes), `npm run test` (generateGithubDigest tests green).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3