### PR TITLE
docs(events): meeting recap 1087 - Restream + web3-musician strategy jam (2026-07-14)

### DIFF
--- a/research/events/1087-restream-strategy-jam-jul14/README.md
+++ b/research/events/1087-restream-strategy-jam-jul14/README.md
@@ -1,0 +1,77 @@
+---
+topic: events
+type: recap
+status: research-complete
+last-validated: 2026-07-14
+related-docs:
+original-query: "/meeting a call recording (Zaal x Dcoop x Candytoybox) - Restream setup + strategy jam"
+tier: n/a
+---
+
+# 1087 - Restream setup + web3-musician strategy jam
+
+> **Goal:** Overall recap of a 2026-07-14 call where Zaal walked Dcoop through Restream, then it turned into a strategy jam with Sam (Candytoybox) on the web3-musician onboarding workflow and a ZAO festivals tour shirt. Confidential / pre-launch detail redacted; raw transcript kept private.
+
+## Meeting
+
+| Field | Value |
+|-------|-------|
+| Date | 2026-07-14 |
+| Duration | ~33 min |
+| Attendees | Zaal, Dcoop (dcoopinthedmv), Sam (Candytoybox) |
+| Platform | Restream studio, recorded via Craig |
+
+## Decisions
+
+| # | Decision | Owner |
+|---|----------|-------|
+| 1 | Set up + test Dcoop's Restream this Sunday (2026-07-19), doubling as a social-media plan session | Zaal + Dcoop |
+| 2 | Sam designs a ZAO Festivals "tour shirt" - band-style, front + back listing every ZAO festival + date, print-on-demand on brand; target ZAO stock | Sam |
+| 3 | Continue developing the web3-musician onboarding workflow (vision below) as a ZABAL Games direction | Zaal |
+
+## Actions
+
+| Action | Owner | By When |
+|--------|-------|---------|
+| Sign up for Restream before the Sunday session | Dcoop | 2026-07-19 |
+| Put the Sunday Restream/social session in the calendar | Zaal | 2026-07-19 |
+| Explore a panel/roundtable livestream with a new vocalist joining the roster, leading into the events | Dcoop | 2026-07-20 |
+| Design + upload the ZAO Festivals tour shirt | Sam | no date set |
+| Turn this recording into a recap video for the group chat | Zaal | no date set |
+| Compile a list of community-member services members can tap | Zaal | no date set |
+
+## Recap
+
+**Restream.** Zaal walked Dcoop through the Restream studio: the host/guest model, how a guest adds their own channels before or mid-stream, and rebroadcasting to X, YouTube, Twitch, and Facebook. Caveats covered: YouTube and Instagram have no chat API (no incoming chat), and Restream caps channels (3 paid / 2 free), so the workaround is multiple accounts. Zaal's shareable link is stream2.thezao.com. Next step is to set up and test Dcoop's own Restream on Sunday.
+
+**Dcoop status.** Prepping for upcoming performances - new tracks in production with his producer, gear arriving, and a new vocalist joining the roster who they may feature in a panel/roundtable livestream leading into the events.
+
+**ZAO Festivals tour shirt (Zaal's idea).** A band-style tour shirt that lists every ZAO festival with its date on the back (ZAO-PALOOZA, ZAO-CHELLA, ZAOville, ZAO stock), adding each new festival over time. Sam will design it and set it up for print-on-demand on brand; target is ZAO stock (not enough time for ZAOville).
+
+**The web3-musician workflow (vision).** The through-line of the jam: give a musician a path where they build the energy behind an idea first and only tokenize when it makes sense, so the token adds to what they have built rather than extracting from it. The flow discussed: come in with an idea, build a following/leaderboard around it, add an AI agent, and only then launch, plugging into existing ZAO collaborations. (Pre-launch specifics and named collaborators redacted; captured privately.)
+
+**Sam's "musician decision tree."** A gamified yes/no flow (video-game-like, not a form) that routes a new musician to the right path - income, decentralized sync licensing, permanent Arweave storage, or a ZAO community/leaderboard. It hides the crypto, onboards in baby steps, and unlocks features by activity (e.g. enough songs -> leaderboard; active community -> merch). An AI asks natural-language questions and determines what the artist needs on the backend. Core principle, in her words: "gamified to improve the musician's career... instead of being gamified to sell you and make you come back."
+
+**ZAO artist profile (Zaal).** Should start basic and auto-populate, with turn-on plugins/integrations (merch store, leaderboard) that stay smooth for the artist rather than a wall of options.
+
+**Community services.** Zaal wants a list of services offered by people inside the community (e.g. an image consultant) that members can tap for quick consultations, free or paid.
+
+## Quotes
+
+- Zaal: "I want to create the workflow we've all been talking about for musicians on web3 - you come in with an idea, you can flush through that idea and then attack it."
+- Sam: "It's gamified to improve the musician's career... instead of being gamified to sell you and make you come back."
+- Zaal (on the tour shirt): "Every time we do a new festival, that's what the back looks like."
+
+## Transcript
+
+Raw transcript is kept private (not published) per PII hygiene. It lives in `~/.zao/private/`.
+
+## Next Actions
+
+| Action | Owner | Type | By When |
+|--------|-------|------|---------|
+| Set up + test Dcoop's Restream; run the social-media plan session | Zaal | Working session | 2026-07-19 |
+| Dcoop signs up for Restream before the session | Dcoop | Setup | 2026-07-19 |
+| Sam designs + uploads the ZAO Festivals tour shirt (print-on-demand live) | Sam | Design | no date set |
+| Zaal makes the recap video for the group chat | Zaal | Content | no date set |
+| Zaal compiles the community-services list | Zaal | Doc | no date set |

--- a/research/events/README.md
+++ b/research/events/README.md
@@ -4,6 +4,7 @@
 
 | # | Title | Type | Summary |
 |---|-------|------|---------|
+| 1087 | [Restream setup + web3-musician strategy jam](./1087-restream-strategy-jam-jul14/) | STANDALONE | Recap of the 2026-07-14 Restream + strategy call (Zaal, Dcoop, Sam): Restream setup, ZAO Festivals tour shirt, the web3-musician workflow vision, Sam musician decision tree. Confidential detail + raw transcript kept private. |
 | 1064 | [Iman Sync: ZaoZone refocus + board cleanup](./1064-iman-sync-zaozone-focus-2026-07-13/) | STANDALONE | Iman refocused to owning the ZAO Zone as the co-working front-end; board cleanup of auto-assigned tasks. |
 | 201 | [AI, Creator Economy & Web3 Landscape (March 2026)](./201-ai-creator-economy-landscape-march-2026/) | STANDALONE | 11 external signals — AI art DAOs, Suno 5.5, creator credentialing, NVIDIA agent tooling, AI filmmaking, Ethereum infra |
 | 207 | [ZAO VPS Agent Stack Session Log](./207-zao-vps-agent-stack-session-log/) | EVENT/LOG | Everything deployed on the ZAO VPS, how systems connect, roadmap to community-managed agent infra |

--- a/research/events/_meetings-index.md
+++ b/research/events/_meetings-index.md
@@ -4,6 +4,7 @@ Every meeting captured as a research recap, newest first. Maintained automatical
 
 | Date | Title | Project | Attendees | Doc | Actions |
 |------|-------|---------|-----------|-----|---------|
+| 2026-07-14 | Restream setup + web3-musician strategy jam | ZAO | Zaal, Dcoop, Sam | [1087](1087-restream-strategy-jam-jul14/) | 7 |
 | 2026-07-13 | Iman Sync: ZaoZone refocus + board cleanup | ZAO Devz | Zaal, Iman | [1064](1064-iman-sync-zaozone-focus-2026-07-13/) | 8 |
 | 2026-07-08 | ZABAL Gamez x POIDH fireside - Kenny, Thy Revolution, Mauro | ZABAL Games / POIDH | Zaal, Kenny, Thy Revolution, Mauro | [994](994-zabal-gamez-poidh-fireside-unlock-jul8/) | 11 |
 | 2026-06-29 | Deez x Zaal - Boardwalk token launcher | ZABAL Games / Tokenization | Zaal, Deez | [953](953-deez-boardwalk-token-launcher/) | n/a |


### PR DESCRIPTION
Redacted recap of the 2026-07-14 Restream + strategy call (Zaal, Dcoop, Sam). Full names, pre-launch token detail, and raw transcript kept private. 4 decisions, 7 actions now on the cowork board.