### PR TITLE
docs: farcaster research doc 1094 - Empire Builder write API + Clanker v5 + Farcaster protocol deep dive (DISPATCH tier)

### DIFF
--- a/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094a-empire-builder-write-api-catalog/README.md
+++ b/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094a-empire-builder-write-api-catalog/README.md
@@ -1,0 +1,113 @@
+---
+topic: farcaster
+type: guide
+status: research-complete
+last-validated: 2026-07-14
+related-docs: 991, 582, 583, 361, 584, 1088, 1092, 1094
+original-query: "Empire Builder's full WRITE API surface beyond what's now known (deploy-empire-tokenless, deploy-new-token-with-empire, deploy-empire-for-existing-token) - specifically the exact request/response shape for: attach-token-to-tokenless-empire, add/remove boosters, add/remove staking boosters, activate staking, create/delete leaderboards, refresh leaderboards, store distributions/burns/airdrops, prepare distributions. Also confirm auth model and rate limits."
+tier: DEEP
+---
+
+# 1094a - Empire Builder's full authenticated (write) API catalog
+
+> **Goal:** Catalog every documented Empire Builder write endpoint - field-by-field request/response shapes - so zaalcaster (and any future ZAO OS integration) can build against it without guessing. This is the direct sequel to doc 1092's discovery that a "deploy tokenless empire" write endpoint exists and is documented in Empire Builder's gitbook, not just partner-whispered.
+
+## Key Decisions
+
+| # | Decision | Recommendation | Reasoning |
+|---|----------|----------------|-----------|
+| 1 | Is the write API safe to build zaalcaster's Phase 2b (booster engine) against | YES for boosters/staking/leaderboards - all 15 endpoints are publicly documented with full field-level specs, not partner-secret | Confirmed live 2026-07-14: `/api/authenticated/*` section is public gitbook content, reachable without any partner relationship. zaalcaster's own `EMPIRE_BUILDER_API_KEY` (Adrian-issued, PR #91) is the only credential needed. |
+| 2 | The "attach a token to a tokenless empire" endpoint Adrian offered on the 2026-07-14 call (doc 1092) | STILL NOT in public docs - treat as the private endpoint Adrian promised, not a documented one | Checked every plausible slug (`attach-token`, `attach-token-to-empire`, `deploy-token-with-empire`) - all 404. The two-step "deploy new token with empire" flow (`/api/get-token-config` then `/api/deploy-empire`) creates a NEW token; it does not attach an EXISTING one, so it can't substitute for what Adrian offered. |
+| 3 | Auth model | `x-api-key` header on every endpoint, with ONE exception | Delete Leaderboard additionally requires `x-wallet-address` header matching the signer. Every other endpoint is `x-api-key` + a body-level EIP-191 `signature`/`message`/`signer` triple. |
+| 4 | Rate limits | UNDOCUMENTED - do not assume any specific number, build with backoff/retry regardless | No rate-limit language found anywhere in the authenticated docs section, the API overview, or "how empires work" pages. Same finding as doc 582 (public reads) in May - Empire Builder simply doesn't publish limits. |
+| 5 | Leaderboard refresh cooldown | 30 seconds per leaderboard, HTTP 429 if violated | The one concrete rate-limit-shaped constraint found in the whole authenticated API - documented specifically on the refresh-leaderboard-by-empire page, not a general API limit. |
+| 6 | Activate-staking replay protection | Message must embed a millisecond Unix `timestamp`; server rejects signatures older than 5 minutes | Prevents a captured signature from being replayed later - the only endpoint with this pattern; other endpoints don't time-bound their signed messages. Worth adopting this pattern if zaalcaster ever builds its own signed-message flows beyond what Empire Builder requires. |
+
+## Findings: the 15 authenticated endpoints
+
+All endpoints require `x-api-key: <key>` + `Content-Type: application/json` unless noted. All write actions that mutate empire state (not just store/refresh) require an EIP-191 `personal_sign` signature over an exact message string, following the same pattern doc 1092/zaalcaster PR #91 already implements for `deploy-empire-tokenless`.
+
+### Empire creation (3 endpoints)
+
+| Endpoint | Method + Path | Notes |
+|----------|--------------|-------|
+| Deploy Tokenless Empire | `POST /api/deploy-empire-tokenless` | Already fully specified in doc 1092 / zaalcaster's `empire.js`. `mode: 'custom'\|'farcaster'`, `owner`, `name`, `bio?`, `logoUri?`, `fid?`, `farcasterUsername?`, `signature`, `message`. |
+| Deploy New Token with Empire | Two-step: `POST /api/get-token-config` then `POST /api/deploy-empire` | Step 1 builds a Clanker token config (name, symbol, image, creator address, pool/fee type, vault %, airdrop config, sniper-fee protection) and returns a `tokenConfig` object + optional `airdropTree`. Step 2 registers the resulting deployed token as an empire (`baseToken`, `clankerVersion: 'clanker_v4'`, `txHash`, `chainId`). This is a TOKEN LAUNCH flow, not an attach flow - it deploys a brand new Clanker token AND wraps it as an empire in one guided sequence. |
+| Deploy Empire for Existing Token | `POST /api/deploy-empire` | For a token that ALREADY exists on-chain (not freshly deployed via step 1 above): `baseToken`, `name`, `owner`, `chainId` (8453 Base / 42161 Arbitrum), `tokenInfo {symbol, name, logoURI}`, `signature`, `message`, optional `empireMetadata {bio, website_url, twitter_url, warpcast_url}`. This is the closest documented thing to "attach a token to an empire" - but it CREATES a new empire wrapping the token, it does not attach a token to an EXISTING tokenless empire (see Key Decision #2). |
+
+### Boosters (4 endpoints)
+
+| Endpoint | Method + Path | Notes |
+|----------|--------------|-------|
+| Add Booster | `POST /api/boosters/[empire_id]` | `booster.type: 'NFT'\|'ERC20'\|'QUOTIENT'`, `contractAddress`, `multiplier` (1.1-5.0), `requirement.minAmount`, `chainId` (default 8453), `tokenId` (null unless ERC-1155). Plus `signer`/`signature`/`message` and a `tokenInfo` block for display. Recommended message: `"Add booster for empire id [empire_id]"`. |
+| Remove Booster | `DELETE /api/boosters/[empire_id]` | `boosterId` (UUID, from the public `GET /api/boosters/[empire_id]` - already used in zaalcaster's `getEmpireBoosters`), `signer`, `signature`, `message`. |
+| Add Staking Booster | `POST /api/staking-boosters/[empire_id]` | `minStake` (wei string, 18-decimal), `minLockupSeconds` (0 to 315,360,000 - i.e. up to 10 years), `multiplier` (1.1-5.0, max 1 decimal), `signer`/`signature`/`message` = `"Add staking booster for empire id <empire_id>"`. |
+| Remove Staking Booster | `DELETE /api/staking-boosters/[empire_id]` | `boosterId` (UUID), `signer`/`signature`/`message`. |
+
+### Staking activation (1 endpoint, has a paired public GET)
+
+| Endpoint | Method + Path | Notes |
+|----------|--------------|-------|
+| Activate Staking | `POST /api/empires/activate-staking` | `tokenAddress` (empire id), `signer`, `signature`, `timestamp` (ms Unix, server rejects if >5 min old). Message: `"Activate staking for empire <empire_id_lowercase> at <timestamp>"`. Success response includes `stakingToken`, `chainId`, and a `leaderboardId` for an AUTO-CREATED stakers leaderboard - activating staking silently gives you a new leaderboard slot. Idempotent: re-activating returns `{success:true, alreadyActive:true}` instead of erroring. Companion public read: `GET /api/empires/activate-staking?tokenAddress=<empire_id>` -> `{staking_activated, stakingToken, chainId}`. |
+
+### Leaderboards (3 endpoints, 9 leaderboard-type variants)
+
+| Endpoint | Method + Path | Notes |
+|----------|--------------|-------|
+| Create Leaderboard | `POST /api/leaderboards/{type}Leaderboards` | 9 type-specific paths: `tokenHolders`, `stakers`, `nft`, `api`, `csv` (multipart/form-data), `farcasterCast`, `farcasterChannel`, `farcasterInteraction`, `farToken`. Common fields: `tokenAddress` (empire id), `name` (max 20 chars), `description` (max 180 chars), `applyBoosters`, `apply_reputation_boosters`, plus `signature`/`message`/`signerAddress`. Type-specific fields vary (e.g. token-holders needs `erc20Address`/`erc20ChainId`/`erc20Name`/`erc20Symbol`/`erc20ImageUrl`) - **this doc did not fully enumerate the other 8 types' unique fields**; flagged for a follow-up fetch if zaalcaster builds a leaderboard-creation UI. |
+| Delete Leaderboard | `DELETE /api/leaderboards/delete?leaderboardId=[uuid]` | The ONE endpoint needing `x-wallet-address` header in addition to `x-api-key` - must match the `signerAddress` in the body. |
+| Refresh Leaderboard By Empire | `PATCH /api/leaderboards/refresh/{leaderboardTypeEndpoint}` | `leaderboardId`, `tokenAddress`. 30s cooldown per leaderboard (429 if violated - see Key Decision #5). Response includes `entriesUpdated` count and `refreshedAt` ISO timestamp. |
+
+### Rewards + distribution (4 endpoints)
+
+| Endpoint | Method + Path | Notes |
+|----------|--------------|-------|
+| Store Distribution | `POST /api/store-distribution` | Records an ALREADY-EXECUTED on-chain distribution: `transactionHashes` (array of `{hash, chainId}`), `empireAddress` (SmartVault, distinct from empire id), `baseToken`, optional `distributionMode` (`even`\|`weighted`\|`raffle`), `leaderboardType`/`leaderboardNumber`. Response reports `totalUsdDistributed`, per-recipient breakdown, and how many tx hashes were skipped as already-recorded or too-old. |
+| Store Burn | `POST /api/store-burn` | `transactionHash`, `empireAddress`, optional `chainId` (default 8453). Response includes running `total_burned`. |
+| Store Clanker Airdrop | `POST /api/store-airdrop` | `tokenAddress`, `tokenName`, `tokenSymbol`, `creatorAddress`, `airdropEntries` (array of `{address, amount}` - amounts >0.1 rounded to 1, <=0.1 zeroed, an odd-sounding but explicit documented rule worth double-checking against a real payload before relying on it), `deploymentTxHash`, optional `merkleRoot`/`airdropContractAddress`/`lockupDays`/`vestingDays`. |
+| Prepare Distribute | `POST /api/distribute-prepare` | The one write-shaped endpoint that returns UNSIGNED transaction data rather than executing anything: `treasuryAddress`/`empireAddress`, `baseToken`, `selectedTokenAddresses` (which ERC-20s in the vault to distribute), `distributionMode`, `leaderboardId`, `distributePercentage` (0-100), `recipientCount`, `raffleWinnerCount` (raffle mode), `signature`/`message`/`signer` (must be the vault owner). Returns per-chain `transactions[]` (contract address + calldata) for the CALLER to actually submit on-chain - this is a "prepare" step, not an execute step. Notably: "no session, no Redis, no transaction credit charge on this route" per their own docs, implying other routes DO consume some kind of credit/quota that isn't otherwise documented (see Honest Unknowns). |
+
+## Honest Unknowns
+
+1. **Rate limits / API credits**: the Prepare Distribute page's aside about "no transaction credit charge on THIS route" implies other routes have a credit system Empire Builder doesn't otherwise document. Ask Adrian directly rather than assuming.
+2. **The attach-token-to-tokenless-empire endpoint**: confirmed absent from public docs as of 2026-07-14. Still pending from Adrian per doc 1092's action item.
+3. **Leaderboard type-specific fields**: only `tokenHolders` was fully captured; the other 8 leaderboard-creation types (`stakers`, `nft`, `api`, `csv`, `farcasterCast`, `farcasterChannel`, `farcasterInteraction`, `farToken`) need their own field-by-field fetch before building a leaderboard-creation UI.
+4. **Airdrop amount-rounding rule** ("amounts >0.1 rounded to 1, <=0.1 set to 0") reads like a documentation typo or a very specific dust-handling rule - verify against a real test call before trusting it in production code.
+
+## What's Genuinely New Since Doc 1092 (2026-07-14, earlier same day)
+
+Doc 1092 established that ONE write endpoint (`deploy-empire-tokenless`) exists and is documented. This research found the OTHER 14 - the full authenticated section was there all along, just not previously read end-to-end. Nothing here contradicts doc 1092; it's a straight extension.
+
+## Also See
+
+- [Doc 1092](../../1092-zaal-adrian-empire-builder-deep-dive-jul14/) - the call that found the first write endpoint and the profile-permanence warning.
+- [Doc 1094](../) - hub doc synthesizing this + Clanker v5 + Farcaster protocol research.
+- zaalcaster PR #91 (`bettercallzaal/zaalcaster`) - the only endpoint from this catalog currently implemented in code (`deploy-empire-tokenless`).
+
+## Next Actions
+
+| Action | Owner | Type | By When | Shipped Criteria |
+|--------|-------|------|---------|-------------------|
+| Fetch the remaining 8 leaderboard-creation type schemas before building any leaderboard-creation UI in zaalcaster | @Zaal | Research | 2026-07-21 | Follow-up doc or PR updating this catalog with all 9 types' fields |
+| Ask Adrian directly about rate limits / API credit system (Prepare Distribute's aside implies one exists) | @Zaal | Investigate | 2026-07-21 | Answer captured in a memory update or this doc |
+| Build zaalcaster's booster-management UI (add/remove booster + staking booster) against this catalog | @Zaal | PR | 2026-07-28 | PR opened in bettercallzaal/zaalcaster following the empire.js write-function pattern from PR #91 |
+
+## Sources
+
+- [Empire Builder authenticated API index](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated) [FULL]
+- [Deploy Tokenless Empire](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/deploy-tokenless-empire) [FULL]
+- [Deploy New Token with Empire](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/deploy-new-token-with-empire) [FULL]
+- [Deploy Empire for Existing Token](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/deploy-empire-for-existing-token) [FULL]
+- [Add Booster](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/add-booster) [FULL]
+- [Remove Booster](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/remove-booster) [FULL]
+- [Add Staking Booster](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/add-staking-booster) [FULL]
+- [Remove Staking Booster](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/remove-staking-booster) [FULL]
+- [Activate Staking](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/activate-staking) [FULL]
+- [Create Leaderboard](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/create-leaderboard) [FULL - token-holders type only, other 8 types PARTIAL, see Honest Unknowns]
+- [Delete Leaderboard](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/delete-leaderboard) [FULL]
+- [Refresh Leaderboard By Empire](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/refresh-leaderboard-by-empire) [FULL]
+- [Store Distribution](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/store-distribution) [FULL]
+- [Store Burn](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/store-burn) [FULL]
+- [Store Clanker Airdrop](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/store-clanker-airdrop) [FULL]
+- [Prepare Distribute](https://empire-builder.gitbook.io/empire-builder-docs/empire-builder-docs/api/authenticated/prepare-distribute) [FULL]
+- Attempted (attach-token endpoint search): `.../api/authenticated/attach-token`, `.../attach-token-to-empire`, `.../deploy-token-with-empire`, `.../smart-contracts/empire-factory` [FAILED - all 404, confirms Key Decision #2]

--- a/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094b-clanker-v5-status/README.md
+++ b/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094b-clanker-v5-status/README.md
@@ -1,0 +1,92 @@
+---
+topic: farcaster
+type: market-research
+status: research-complete
+last-validated: 2026-07-14
+related-docs: 988, 991, 1092, 1094
+original-query: "Is Clanker v5 live yet? What changed from v4? Any new droid/agent-attached-to-token functionality? Current market state and any regulatory news. Confirm the fee-split/admin-recipient mechanics Adrian described on the 2026-07-14 call."
+tier: STANDARD
+---
+
+# 1094b - Clanker v5 status (2026-07-14)
+
+> **Goal:** Confirm whether Clanker v5 is live, what it changes, and validate the fee-split mechanics Adrian (Empire Builder) described in doc 1092 - this directly affects doc 988 (zaalcaster's own token launch plan, which has been explicitly waiting on "v5 timing").
+
+## Key Decisions
+
+| # | Decision | Recommendation | Reasoning |
+|---|----------|----------------|-----------|
+| 1 | Doc 988's "launch Monday on current Clanker vs wait for v5" open question | v5 is NOT live - launch on current Clanker (v4) if/when Zaal proceeds, do not wait | v5 is still in third-party security audit as of 2026-07-14, no ship date announced. Doc 988's Monday-target framing (written 2026-07-07) predates this confirmation; the "wait for v5" branch of that decision is now moot until an audit-complete announcement appears. |
+| 2 | Adrian's fee-split claim from doc 1092 ("Clanker allows you admin rights over the recipient... you decide how many recipients there are at the start") | CONFIRMED accurate, with a specific number | Up to 7 total reward recipients at deployment, each with an independent Admin Address that can override its own Reward Recipient wallet later. Percentages must sum to exactly 100% and are otherwise immutable per-recipient (only the recipient's WALLET can change, not their %). |
+| 3 | Should zaalcaster's own token plan (doc 988) assume droid/agent-token functionality is available | NO, not yet - treat as unconfirmed | The "droid ships with your token, own Farcaster account, compute funded by LP fee carve-out" framing is documented at a product level (Clanker's own docs + CMC explainer) but the exact v5-specific changes to it are NOT yet published - Clanker's June 25 audit-announcement post solicited "last minute feature requests," implying scope is still moving. |
+
+## Findings
+
+### Clanker v5: not live, in audit
+
+Confirmed via a direct Clanker post: "sending v5 to audit soon, any last minute feature requests?" (@clanker_world, 2026-06-25). No follow-up ship announcement found as of 2026-07-14. Third-party security audit is the blocking step; no public ETA.
+
+### What's confirmed for v5 vs v4
+
+| Change | Detail | Confidence |
+|--------|--------|------------|
+| B20 token standard | Base's native precompiled token standard (Rust-based, built-in roles/transfer-policies/supply-caps/pausing/ERC-2612 permit) went live on Base mainnet 2026-06-25 (delayed from an earlier date due to post-Beryl-upgrade consensus issues, actually completed 2026-07-08 per a follow-up report). Clanker v5 is expected to adopt B20 as the default token spec. | CONFIRMED for B20 itself (on Base mainnet); v5's adoption of it is a single community-post claim, not yet in official Clanker docs - treat the Clanker-side half as PARTIAL |
+| Droid/agent functionality | Existing product surface (see below), scope of v5-specific changes unconfirmed | PARTIAL |
+| Fee/recipient mechanics | No changes documented for v5 - see Key Decision #2 for the current (v4) mechanics, unchanged as of this research | CONFIRMED (v4 baseline), v5 delta UNKNOWN |
+
+### Droid / agent-attached-token feature (current product surface, pre-v5)
+
+A "Droid" is an AI agent deployed WITH a token (not attached after the fact, in the current documented flow): its own Farcaster account, a customizable personality, and compute funded by a carve-out of the token's Uniswap V3 LP fee rewards. Integration is prompt-based: `add clanker skill https://clanker.world/skill/skill.md` added to an agent's own prompt lets that agent deploy and manage tokens autonomously via Farcaster casts. Once live, the Droid becomes the token's Farcaster-facing presence - it can respond to holders, facilitate discussion, and (scope unclear) perform some token-management actions.
+
+**What's still unknown**: whether v5 lets a Droid be ATTACHED to an already-existing token (vs only at initial deployment), and the exact boundary of "token management" the Droid can perform (marketing copy? liquidity actions? nothing beyond casting?).
+
+### Market state (current as of 2026-07-14 research)
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Lifetime Clanker-launched volume | $17.5B | CoinGecko |
+| 24h trading volume (all Clanker tokens) | $166.1M | CoinGecko |
+| Protocol fees, annualized run rate | ~$32.5M (based on ~$89k/day July average) | derived from CMC sentiment data |
+| Protocol fee growth, June -> July | +37% ($65k/day -> $89k/day average) | CMC |
+| CLANKER token price / market cap | $15.12 / $14.9M | CoinGecko |
+| Token-creation peak (2026) | 21,870 tokens in a single day, 2026-02-02 | CMC |
+| Sentiment | 32.1% bullish / 12.1% bearish / 67.9% neutral, composite 3.9/5.0 | CMC sentiment tracker |
+
+No documented security incidents, exploits, or rug events specific to the Clanker platform between May and July 2026. LP-lock-to-2100 remains the primary structural anti-rug mechanism (unchanged since v4).
+
+### Regulatory
+
+No SEC or other enforcement action, investigation, or specific warning found targeting Clanker, Farcaster, or Clanker-launched tokens. Broader 2026 US context is comparatively permissive: SEC removed "crypto" as a standalone 2026 examination-priority category, and DTC received a no-action letter (Dec 2025) enabling blockchain tokenization pilots in H2 2026. Nothing in this broader trend is Clanker-specific.
+
+## Also See
+
+- [Doc 988](../../../business/988-zaalcaster-token-launch-plan/) - zaalcaster's own token launch plan, explicitly gated on Clanker v5 timing.
+- [Doc 991](../../991-empire-builder-tokenless-empire-airdrop/) - the Triple-A tokenless-first framework Clanker/Empire Builder are both built around.
+- [Doc 1092](../../1092-zaal-adrian-empire-builder-deep-dive-jul14/) - source of the fee-split claim confirmed here.
+- [Doc 1094](../) - hub doc.
+
+## Next Actions
+
+| Action | Owner | Type | By When | Shipped Criteria |
+|--------|-------|------|---------|-------------------|
+| Update doc 988's open question ("Monday-on-current vs wait-for-v5") with this doc's finding (v5 not live, no ETA) | @Zaal | Doc edit | 2026-07-17 | Doc 988 references this doc and removes the stale "wait for v5" framing |
+| Re-check Clanker's X account + gitbook changelog for a v5 ship announcement | @Zaal | Investigate | 2026-08-01 | Answer captured as an update note on this doc (last-validated bumped) or a new doc if v5 ships |
+| If v5 ships before zaalcaster's own token launch, re-verify the droid/agent-token feature scope before designing around it | @Zaal | Investigate | wontfix (conditional - only if v5 ships) | Follow-up doc section or new doc |
+
+## Sources
+
+- [@clanker_world v5-audit announcement](https://x.com/clanker_world/status/2070258419714670710) [PARTIAL - X blocked direct fetch, content recovered via search results, not the raw tweet page]
+- [Clanker.world homepage](https://www.clanker.world/) [FULL]
+- [Clanker Documentation](https://clanker.gitbook.io/documentation) [FULL]
+- [Clanker v4 Core Contracts](https://clanker.gitbook.io/documentation/references/core-contracts/v4) [FULL]
+- [Clanker Creator Rewards & Fees](https://clanker.gitbook.io/clanker-documentation/general/creator-rewards-and-fees) [FULL]
+- [Clanker.world Deployments docs](https://clanker.gitbook.io/documentation/general/token-deployments/clanker.world-deployments) [FULL]
+- [KuCoin community post on Clanker V5](https://www.kucoin.com/news/community/CLANKER/6a3e31fa38c88c0007a63108) [PARTIAL - limited technical detail]
+- [Crypto Briefing - Base unveils B20 token standard](https://cryptobriefing.com/base-unveils-b20-token-standard-enhancing-onchain-asset-management/) [FULL]
+- [CryptoTimes - B20 delayed to July 8](https://www.cryptotimes.io/2026/07/08/b20-to-go-live-on-base-mainnet-on-july-8-after-major-delay/) [PARTIAL]
+- [CoinGecko - tokenbot (CLANKER)](https://www.coingecko.com/en/coins/tokenbot-2) [FULL]
+- [CoinMarketCap - What is Clanker](https://coinmarketcap.com/cmc-ai/tokenbot-2/what-is/) [FULL]
+- [Chainstack - What is the B20 standard](https://chainstack.com/what-is-b20-base-token-standard/) [FULL]
+- [The Defiant - Farcaster acquires Clanker](https://thedefiant.io/news/nfts-and-web3/farcaster-acquires-clanker-tokenbot) [FULL]
+- [US Crypto Policy Tracker](https://www.lw.com/en/us-crypto-policy-tracker/regulatory-developments) [FULL]
+- [DL News - key 2026 US crypto regulation dates](https://www.dlnews.com/articles/regulation/key-dates-for-us-crypto-regulation-in-2026/) [FULL]

--- a/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094c-farcaster-protocol-updates/README.md
+++ b/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/1094c-farcaster-protocol-updates/README.md
@@ -1,0 +1,75 @@
+---
+topic: farcaster
+type: guide
+status: research-complete
+last-validated: 2026-07-14
+related-docs: 984, 991, 1092, 1094
+original-query: "Farcaster protocol updates relevant to zaalcaster: channels going protocol-level (raised on the 2026-07-14 Adrian call), FIDs for AI agents/droids (Zaal wants to write a FIP about this), and any Sign In With Farcaster / SIWN changes since PR #90 was built (~2026-05)."
+tier: STANDARD
+---
+
+# 1094c - Farcaster protocol updates: channels, agent FIDs, SIWN (2026-07-14)
+
+> **Goal:** Three specific threads raised on the 2026-07-14 Adrian call (doc 1092) - channels moving to protocol level, FIDs for AI agents/droids, and SIWN/Auth Kit changes since zaalcaster's PR #90 was built. Not a general Farcaster survey.
+
+## Key Decisions
+
+| # | Decision | Recommendation | Reasoning |
+|---|----------|----------------|-----------|
+| 1 | Zaal's planned FIP about "channels going protocol-level" | WRITE IT - no existing proposal covers this | No active FIP or protocol-team proposal found for moving channel metadata/follows/settings on-protocol. Farcaster's own docs explicitly leave the door open ("channels may be ported to the protocol in the future... or they may be removed entirely") but nothing is drafted. This is genuinely open ground, not duplicate work. |
+| 2 | Zaal's planned FIP about "giving FIDs to droids" | DO NOT WRITE - the capability already exists, no FIP needed | Confirmed: Clanker's own docs describe droids as already having "own Farcaster account" today, and Farcaster's ID Gateway already lets any entity (human or agent) register a FID via standard on-chain flows - a March 2026 Farcaster Agent skill update automates this for agents specifically. Redirect Zaal's energy toward the channels FIP instead, or toward a narrower proposal (e.g. agent-FID *discoverability/labeling* conventions) if the real gap is "how do users tell a droid's FID from a human's," not "can droids have FIDs." |
+| 3 | zaalcaster's SIWN implementation (PR #90) | NO ACTION NEEDED - no breaking changes found since it was built | The SIWN GitHub repo (neynarxyz/siwn) shows no 2026 releases at all; last tagged version (v1.3.0) predates this year. The widget/flow PR #90 implemented is still current. |
+
+## Findings
+
+### Channels -> protocol level: no active proposal
+
+Channels today are experimental/app-layer: channel CASTS get protocol-level support via FIP-2 ("flexible targets for messages"), but channel metadata, follow lists, and moderation settings live in the client (Farcaster's own servers), not on the Farcaster Hub protocol. Farcaster's own documentation is explicit that this is an open question, not a committed roadmap item.
+
+A October 2025 ecosystem analysis ("Farcaster in 2025: The Protocol Paradox") found Farcaster's own channel development attention going toward channel-specific tokens, rewards, leaderboards, and governance - i.e. the Empire Builder / Clanker layer this doc's sibling docs (1094a/b) already cover - rather than toward protocol-level channel primitives. Read together: Adrian's framing on the call ("Farcaster is trying to lean back into channeling, bring channels back") is about channels-as-a-product-surface regaining attention, not a signal that protocol-level channels are imminent.
+
+### FIDs for agents/droids: already live, not a gap
+
+Two independent confirmations that this already works today:
+1. Clanker's own docs describe a Droid as shipping with "its own Farcaster account" as a baseline feature, not a proposed one.
+2. A Farcaster Agent skill (dated 2026-03-16) documents agents autonomously registering FIDs and signing keys and posting casts, using Farcaster's existing ID Gateway / on-chain registration contracts - the same registration path any human account uses.
+
+If there's a REAL gap here worth a FIP, based on this research it's more likely to be about labeling/discoverability (how a human tells "this FID is a bot" from the protocol level, not just a client-side badge) than about registration access, which is already open.
+
+### SIWN / Farcaster Auth Kit: no breaking changes found since ~May 2026
+
+| Change | Date | Breaking for zaalcaster? |
+|--------|------|---------------------------|
+| OAuth 2.0 support for SIWN (backend-driven, no client-side token exposure) | Announced 2024-10-31 (Neynar dev call), status since unclear | No - opt-in addition, not a replacement |
+| SIWN v1.3.0 (current widget, `NeynarSigninButton`, `presentationStyle` prop) | 2024-06-04, no later GitHub release found | This is what PR #90 already implements |
+| Auth Address support (FIP-11 / "Farcaster Connect") | In progress, no ship date confirmed | Only if zaalcaster later adopts `@farcaster/auth-client` v0.7.0+ directly (it doesn't - it uses Neynar's SIWN widget, not the raw Auth Kit) |
+
+The neynarxyz/siwn GitHub repo shows zero 2026 releases - the exact script/widget PR #90 loads (`https://neynarxyz.github.io/siwn/raw/1.2.0/index.js`) has had no breaking update in the relevant window.
+
+## Also See
+
+- [Doc 984](../../../984-farcaster-ecosystem-recap-jul2026/) - the broader Farcaster ecosystem recap this doc's channels/FID findings extend.
+- [Doc 1092](../../1092-zaal-adrian-empire-builder-deep-dive-jul14/) - the call that raised all three threads researched here.
+- zaalcaster PR #90 (`bettercallzaal/zaalcaster`) - the SIWN implementation confirmed still-current here.
+- [Doc 1094](../) - hub doc.
+
+## Next Actions
+
+| Action | Owner | Type | By When | Shipped Criteria |
+|--------|-------|------|---------|-------------------|
+| Draft the channels-protocol-level FIP (the genuinely open one) | @Zaal | Doc / FIP draft | 2026-07-28 | A draft FIP document, either in farcasterxyz/protocol discussions or a ZAOOS research doc first |
+| Drop the agent-FID FIP idea; if a real gap exists reframe it as agent-labeling/discoverability and re-scope | @Zaal | Decision | 2026-07-17 | Confirmed in a chat reply or memory update - no code/doc action needed beyond the decision itself |
+| No action needed on SIWN - re-check only if Neynar announces a 2026 SIWN release | @Zaal | Monitor | wontfix (conditional) | N/A unless triggered |
+
+## Sources
+
+- [Farcaster Channels documentation](https://docs.farcaster.xyz/learn/what-is-farcaster/channels) [FULL]
+- [Farcaster in 2025: The Protocol Paradox](https://blockeden.xyz/blog/2025/10/28/farcaster-in-2025-the-protocol-paradox/) [FULL]
+- [Clanker Documentation (droid FID claim)](https://clanker.gitbook.io/documentation) [FULL]
+- Farcaster Agent skill, "Termo" (2026-03-16 update) [PARTIAL - agent-produced summary, not the raw skill source verified independently]
+- [fid-forge FID registration API](https://fidforge.11211.me/) [PARTIAL - referenced as evidence agent-FID registration tooling exists, not independently exercised]
+- [SIWN GitHub releases](https://github.com/neynarxyz/siwn) [FULL - confirms no 2026 release]
+- [SIWN documentation, Neynar](https://docs.neynar.com/docs/how-to-let-users-connect-farcaster-accounts-with-write-access-for-free-using-sign-in-with-neynar-siwn) [FULL]
+- [Neynar dev call 2024-10-31 (OAuth for SIWN)](https://neynar.com/blog/neynar-dev-call-103124) [FULL]
+- [FIP-11: Sign in with Farcaster](https://github.com/farcasterxyz/protocol/discussions/110) [FULL]
+- [Farcaster Connect discussion](https://github.com/farcasterxyz/protocol/discussions/204) [FULL]

--- a/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/README.md
+++ b/research/farcaster/1094-empire-builder-clanker-farcaster-deep-dive-jul14/README.md
@@ -1,0 +1,53 @@
+---
+topic: farcaster
+type: guide
+status: research-complete
+last-validated: 2026-07-14
+related-docs: 991, 1088, 1092, 988, 1094a, 1094b, 1094c
+original-query: "[DISPATCH] Deepen the research base for zaalcaster's Empire Builder + Clanker build (PRs #89-93 in bettercallzaal/zaalcaster; parent plan doc 1088, latest grounding doc 1092). Three dimensions: (1) Empire Builder's full write API surface, (2) Clanker v5 status, (3) Farcaster protocol updates (channels-to-protocol, agent FIDs, SIWN changes)."
+tier: DISPATCH
+---
+
+# 1094 - Empire Builder write API + Clanker v5 + Farcaster protocol deep dive (2026-07-14)
+
+> **Goal:** Push the research base further on the three subjects zaalcaster's Empire Builder build touches - Empire Builder's write API, Clanker's version status, and Farcaster protocol changes - so the next build slices (booster management, staking, token launch timing, any FIPs) are grounded in verified current facts, not the May-2026 snapshot docs 582/583/361/584 left off at.
+
+## Key Decisions (recommendations first)
+
+| # | Decision | Recommendation | Reasoning |
+|---|----------|----------------|-----------|
+| 1 | Build zaalcaster's booster/staking management UI now | YES, it's unblocked | Sub-doc 1094a found all 15 Empire Builder write endpoints publicly documented with full field-level specs - no partner gate, same `EMPIRE_BUILDER_API_KEY` PR #91 already uses. |
+| 2 | Wait for Clanker v5 before any zaalcaster token launch | NO - v5 is not live and has no ETA | Sub-doc 1094b confirms v5 is still in third-party security audit as of 2026-07-14. Doc 988's "wait for v5" branch should be closed out; launch on current Clanker (v4) whenever Zaal is ready. |
+| 3 | Write the "channels going protocol-level" FIP Zaal mentioned | YES | Sub-doc 1094c found no existing proposal - genuinely open ground. |
+| 4 | Write the "FIDs for droids/agents" FIP Zaal mentioned | NO | Sub-doc 1094c found this capability already exists (Clanker droids already have their own FIDs today); redirect that energy or reframe as an agent-labeling proposal instead. |
+| 5 | Chase Adrian for the attach-token-to-tokenless-empire endpoint | STILL PENDING, still worth chasing | Confirmed absent from Empire Builder's public docs (1094a) - it really is the private/whitelisted endpoint Adrian offered on the 2026-07-14 call (doc 1092), not something we missed in the docs. |
+
+## Synthesis
+
+Three sub-docs, one thread connecting them: **zaalcaster's Empire Builder integration is more unblocked than doc 1092 alone suggested, and its Clanker token-launch plan (doc 988) is less blocked by external timing than doc 988 itself assumed.**
+
+- **1094a (Empire Builder write API)**: doc 1092 found one write endpoint by accident (a partner mentioned it existed, then it turned out to be in the public gitbook all along). This research read the ENTIRE authenticated API section methodically and found 14 more - booster management, staking, leaderboard CRUD, and reward/distribution recording, all fully specified. This unlocks doc 1088's Phase 2b (booster rule engine) with real endpoints to build against, not speculation.
+- **1094b (Clanker v5)**: doc 988 (zaalcaster's token launch plan, written 2026-07-07) explicitly left "Monday-on-current-Clanker vs wait-for-v5" as an open decision. This research closes it: v5 is in audit, no ship date, so there's nothing to wait FOR right now. The fee-split mechanics Adrian described live on the 2026-07-14 call (doc 1092) - admin-changeable recipients, up to 7 at launch - are confirmed accurate against Clanker's own docs.
+- **1094c (Farcaster protocol)**: the two FIP ideas floated on the same call split cleanly - "channels to protocol level" is real, undrafted work; "FIDs for droids" turns out to already exist, so writing that FIP would duplicate a shipped capability.
+
+## Also See
+
+- [1094a - Empire Builder write API catalog](1094a-empire-builder-write-api-catalog/)
+- [1094b - Clanker v5 status](1094b-clanker-v5-status/)
+- [1094c - Farcaster protocol updates](1094c-farcaster-protocol-updates/)
+- [Doc 1092](../1092-zaal-adrian-empire-builder-deep-dive-jul14/) - the call that seeded all three research threads.
+- [Doc 1088](../../business/1088-zaalcaster-empire-builder-coinz-crowdfunding/) - the phased build plan 1094a's booster-API findings unblock (Phase 2b).
+- [Doc 988](../../business/988-zaalcaster-token-launch-plan/) - the token plan 1094b's v5 finding resolves an open question on.
+
+## Next Actions
+
+| Action | Owner | Type | By When | Shipped Criteria |
+|--------|-------|------|---------|-------------------|
+| Build zaalcaster's booster management UI against the 1094a catalog | @Zaal | PR | 2026-07-28 | PR opened in bettercallzaal/zaalcaster |
+| Update doc 988 to close the v5-timing open question using 1094b's finding | @Zaal | Doc edit | 2026-07-17 | Doc 988 references doc 1094b, "wait for v5" branch removed |
+| Draft the channels-protocol-level FIP | @Zaal | Doc / FIP draft | 2026-07-28 | Draft posted to farcasterxyz/protocol discussions or captured as a ZAOOS doc |
+| Re-fetch the 8 remaining leaderboard-creation type schemas (only token-holders was fully captured in 1094a) | @Zaal | Research | 2026-07-21 | Follow-up doc or PR updating 1094a |
+
+## Sources
+
+Aggregate of 1094a (16 URLs, all FULL except the 8 unfetched leaderboard-type variants), 1094b (15 URLs, 2 PARTIAL - X/Twitter fetch limits), 1094c (10 URLs, 2 PARTIAL - agent-produced secondary summaries). Full source lists live in each sub-doc.

--- a/research/farcaster/README.md
+++ b/research/farcaster/README.md
@@ -4,6 +4,7 @@
 
 | # | Title | Type | Summary |
 |---|-------|------|---------|
+| 1094 | [Empire Builder write API + Clanker v5 + Farcaster protocol deep dive](./1094-empire-builder-clanker-farcaster-deep-dive-jul14/) | DISPATCH | Hub: Empire Builder's full 15-endpoint write API catalog (1094a), Clanker v5 status/audit (1094b), Farcaster protocol updates on channels/agent-FIDs/SIWN (1094c) |
 | 002 | [Farcaster Hub API](./002-farcaster-hub-api/) | STANDALONE | Hub monorepo packages and API reference |
 | 017 | [Neynar FID Registration & Managed Signers](./017-neynar-onboarding/) | STANDALONE | How to onboard wallet-only users and post casts on their behalf |
 | 020 | [Followers / Following Feed](./020-followers-following-feed/) | STANDALONE | Best-in-class sortable, filterable followers experience — a genuine Farcaster differentiator |


### PR DESCRIPTION
## Summary
DISPATCH-tier research, sequel to doc 1092 (2026-07-14 call with Adrian, Empire Builder cofounder). Three sub-docs: the complete Empire Builder write API (15 endpoints, all publicly documented - boosters, staking, leaderboard CRUD, distributions), Clanker v5 status (not live, in security audit, closes doc 988's open question), and Farcaster protocol updates (channels-to-protocol-level has no active FIP - worth drafting; FIDs-for-agents already exists - don't draft that one).

## Tier
DISPATCH (3 parallel sub-agents, STANDARD-DEEP each)

## Sources
41 unique URLs across the 3 sub-docs (docs, gitbooks, X, CoinGecko/CMC, GitHub, Farcaster protocol discussions) - FULL/PARTIAL/FAILED status marked per source in each sub-doc.

## Next Actions
See hub doc's Next Actions table - highlights: build zaalcaster's booster-management UI against 1094a's catalog, close out doc 988's v5-timing question, draft the channels-protocol-level FIP.