### PR TITLE
fix(zoe): cowork ack UX - contextual acknowledgment + notify asker on Zaal reply

### DIFF
--- a/bot/src/zoe/task-teammate-ack.ts
+++ b/bot/src/zoe/task-teammate-ack.ts
@@ -66,6 +66,8 @@ export interface PendingReply {
   commentId: string;
   taskTitle: string;
   createdAt: string;
+  originalAskerId?: string;
+  originalAskerName?: string;
 }
 
 export type SendTgFn = (chatId: number, text: string, opts?: { replyToMessageId?: number }) => Promise<number | null>;
@@ -201,15 +203,21 @@ async function fetchCandidateTasks(fetchImpl: typeof fetch): Promise<BoardTask[]
 }
 
 /** Append a "noted" ack to the task's metadata.comments. */
-async function postNotedAck(task: BoardTask, fetchImpl: typeof fetch): Promise<boolean> {
+async function postNotedAck(
+  task: BoardTask,
+  comment: BoardComment,
+  fetchImpl: typeof fetch,
+): Promise<boolean> {
   const base = process.env.COWORK_TRACKER_URL;
   const key = process.env.COWORK_TRACKER_KEY;
   if (!base || !key) return false;
+  const taskLabel = task.legacy_id ? `#${task.legacy_id}` : task.id;
+  const snippet = comment.content.replace(/\s+/g, ' ').trim().slice(0, 60);
   const ack: BoardComment = {
     id: `zoe-ack-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     userId: ZOE_USER_ID,
     displayName: ZOE_DISPLAY,
-    content: 'Noted - looping Zaal in.',
+    content: `Noted on ${taskLabel} - flagged to Zaal: "${snippet}". He will reply here.`,
     createdAt: new Date().toISOString(),
   };
   const metadata = { ...(task.metadata ?? {}) };
@@ -277,7 +285,7 @@ export async function runTaskTeammateAck(
     const comment = pend.comment;
 
     // Post the "noted" ack to the task.
-    const ackPosted = await postNotedAck(task, fetchImpl);
+    const ackPosted = await postNotedAck(task, comment, fetchImpl);
     if (!ackPosted) {
       console.warn('[zoe/teammate-ack] ack post failed, skipping telegram ask for', task.id);
       continue;
@@ -300,6 +308,8 @@ export async function runTaskTeammateAck(
         commentId: comment.id,
         taskTitle: task.title,
         createdAt: new Date().toISOString(),
+        originalAskerId: comment.userId,
+        originalAskerName: comment.displayName,
       };
       try {
         await writePendingReply(pending_);
@@ -308,6 +318,13 @@ export async function runTaskTeammateAck(
       } catch (err) {
         console.warn('[zoe/teammate-ack] failed to store pending reply (nbd):', (err as Error).message);
       }
+    } else {
+      // Log the TG send failure clearly (P3 reliability)
+      console.error(
+        '[zoe/teammate-ack] telegram send failed for',
+        task.id,
+        '- will retry next cycle',
+      );
     }
   }
 
@@ -359,11 +376,15 @@ export async function postZaalReplyToTask(
   if (!task) return false;
 
   // Append Zaal's reply as a comment (attributed to Zaal, not ZOE).
+  // Prefix with @mention of the original asker so they get notified.
+  const askerHandle = pending.originalAskerId ? `@${pending.originalAskerId}` : '';
+  const contentWithMention = askerHandle ? `${askerHandle} ${replyText.trim()}` : replyText.trim();
+
   const reply: BoardComment = {
     id: `zaal-reply-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
     userId: 'zaal',
     displayName: 'Zaal',
-    content: replyText.trim(),
+    content: contentWithMention,
     createdAt: new Date().toISOString(),
   };
   const metadata = { ...(task.metadata ?? {}) };


### PR DESCRIPTION
## Summary

Fixes three UX/reliability issues in the cowork-flow loop (from doc 1102 audit).

When Iman comments on a task, ZOE now:
1. Sends her an acknowledgment that includes the task ID and comment snippet (not just "Noted - looping Zaal in.")
2. When Zaal replies via Telegram, the reply posted to the board includes an @mention of the original asker so she gets notified

These changes make the flow feel less like theater and more like real acknowledgment.

## Changes

### 1. Contextual Acknowledgment (fixes audit P1)

Before:
```
Noted - looping Zaal in.
```

After:
```
Noted on #880 - flagged to Zaal: "any updates on direction...". He will reply here.
```

This tells Iman what was noted, which task it's about, and that she'll get a reply.

- Modified `postNotedAck()` to take the comment as a parameter
- Extract first 60 chars of comment as snippet
- Use task.legacy_id or task.id in the message

### 2. Notify Asker on Zaal's Reply (fixes audit P2)

When posting Zaal's reply to the task, prefix with @mention of the original asker:
```
@iman Thank you for the question. Here's the direction...
```

This triggers the board's mention-notification system so Iman knows to check the task.

- Extended `PendingReply` interface with `originalAskerId` and `originalAskerName`
- Store these fields when creating pending reply mapping
- Prefix Zaal's reply with `@${originalAskerId}` before posting to task

### 3. Improve Failure Logging (fixes audit P3)

When Telegram send fails:
- Already correct behavior: comment is NOT marked seen, so it retries next cycle
- Added explicit error log so failures are visible in ZOE logs
- Clarifies that the comment will retry rather than being silently dropped

## Boot Verification Results

All verification passed:
```
npm install --no-audit --no-fund       [ok]
npx tsc --noEmit                         [0 errors]
npx esbuild src/zoe/index.ts --bundle   [513.8kb, success]
```

## What Was Done vs Skipped

### Done:
- [x] Contextual ack message with task ID + snippet
- [x] @mention asker on Zaal's reply
- [x] Explicit logging for TG send failures
- [x] Extended PendingReply to store asker info
- [x] Updated postNotedAck() signature to take comment
- [x] Updated postZaalReplyToTask() to add @mention prefix

### Skipped:
- [ ] Supabase migration of pending-reply tracking (audit item P4/P5)
  - Rationale: Low risk to keep file-based JSONL for now; DB migration is larger scope
  - Can be done in follow-up PR if needed
  - Current approach works and retries properly
  - Recovery: clear `~/.zao/zoe/teammate_ack_pending.jsonl` manually if needed

## Deploy Notes

After merging, deploy requires:
1. `git pull origin main` on the VPS
2. `npm install --no-audit --no-fund` to ensure deps are fresh (bot/ directory)
3. Restart ZOE process: `pm2 restart zoe`

The changes are backward-compatible: old PendingReply entries in the JSONL file will work with optional fields.

## Next Steps

Recommend testing this live to confirm:
- Iman gets contextual ack message on task
- Zaal receives full TG ask with context
- When Zaal replies, Iman gets @mention notification
- Check ZOE logs to confirm TG send failures (if any) are logged