### PR TITLE
test(library): route tests for all 6 /api/library endpoints (task #591)

### DIFF
--- a/src/app/api/library/comments/__tests__/route.test.ts
+++ b/src/app/api/library/comments/__tests__/route.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom, mockModerate } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockModerate: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/moderation/moderate', () => ({
+  moderateContent: (t: string) => mockModerate(t),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+/** FIFO chain: `.single()` and awaited `then` both draw from one result queue. */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'insert', 'update', 'eq', 'order']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(q.shift()));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('GET /api/library/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/library/comments', { entry_id: VALID_UUID }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when entry_id is missing', async () => {
+    const res = await GET(makeGetRequest('/api/library/comments'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Valid entry_id required');
+  });
+
+  it('returns 400 when entry_id is not a UUID', async () => {
+    const res = await GET(makeGetRequest('/api/library/comments', { entry_id: 'nope' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns comments for a valid entry_id', async () => {
+    const comments = [{ id: 'c1', body: 'hi' }];
+    mockFrom.mockReturnValue(queuedChain([{ data: comments, error: null }]));
+    const res = await GET(makeGetRequest('/api/library/comments', { entry_id: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).comments).toEqual(comments);
+  });
+
+  it('coerces a null comment list to []', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: null }]));
+    const res = await GET(makeGetRequest('/api/library/comments', { entry_id: VALID_UUID }));
+    expect((await res.json()).comments).toEqual([]);
+  });
+
+  it('returns 500 when the query errors', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db down') }]));
+    const res = await GET(makeGetRequest('/api/library/comments', { entry_id: VALID_UUID }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch comments');
+  });
+});
+
+describe('POST /api/library/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockModerate.mockResolvedValue({ action: 'allow' });
+  });
+
+  const validBody = { entry_id: VALID_UUID, body: 'Great research!' };
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/library/comments', validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+    const res = await POST(makePostRequest('/api/library/comments', validBody));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Farcaster account required to comment');
+  });
+
+  it('returns 400 for an empty comment body', async () => {
+    const res = await POST(
+      makePostRequest('/api/library/comments', { entry_id: VALID_UUID, body: '' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 for a non-UUID entry_id', async () => {
+    const res = await POST(makePostRequest('/api/library/comments', { entry_id: 'x', body: 'hi' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when moderation flags the comment', async () => {
+    mockModerate.mockResolvedValue({ action: 'hide' });
+    const res = await POST(makePostRequest('/api/library/comments', validBody));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Comment flagged by moderation');
+  });
+
+  it('inserts the comment and returns it on success', async () => {
+    const comment = { id: 'c1', body: 'Great research!', fid: 123 };
+    mockFrom.mockReturnValue(queuedChain([{ data: comment, error: null }, { count: 4 }, {}]));
+    const res = await POST(makePostRequest('/api/library/comments', validBody));
+    expect(res.status).toBe(200);
+    expect((await res.json()).comment).toEqual(comment);
+    expect(mockModerate).toHaveBeenCalledWith('Great research!');
+  });
+
+  it('returns 500 when the insert errors', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db down') }]));
+    const res = await POST(makePostRequest('/api/library/comments', validBody));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to post comment');
+  });
+});

--- a/src/app/api/library/delete/__tests__/route.test.ts
+++ b/src/app/api/library/delete/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE } from '../route';
+
+/** A delete chain: .delete().eq() is awaited and resolves to `result`. */
+function deleteChain(result: { error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.delete = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+function deleteReq(body: unknown) {
+  return makeRequest('/api/library/delete', { method: 'DELETE', body: JSON.stringify(body) });
+}
+
+describe('DELETE /api/library/delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockFrom.mockReturnValue(deleteChain({ error: null }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE(deleteReq({ entry_id: VALID_UUID }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 403 for a non-admin session', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await DELETE(deleteReq({ entry_id: VALID_UUID }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Admin access required');
+  });
+
+  it('returns 400 when entry_id is missing', async () => {
+    const res = await DELETE(deleteReq({}));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 when entry_id is not a UUID', async () => {
+    const res = await DELETE(deleteReq({ entry_id: 'not-a-uuid' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('deletes the entry for an admin and returns success', async () => {
+    const chain = deleteChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await DELETE(deleteReq({ entry_id: VALID_UUID }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith('research_entries');
+    expect(chain.eq).toHaveBeenCalledWith('id', VALID_UUID);
+  });
+
+  it('returns 500 when the delete errors', async () => {
+    mockFrom.mockReturnValue(deleteChain({ error: new Error('db down') }));
+    const res = await DELETE(deleteReq({ entry_id: VALID_UUID }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to delete entry');
+  });
+});

--- a/src/app/api/library/docs/__tests__/route.test.ts
+++ b/src/app/api/library/docs/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * A Supabase query chain that records the filter methods called on it and
+ * resolves (when awaited) to `result`. Lets tests assert search/category
+ * filters were applied without a live DB.
+ */
+function docsChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'order', 'ilike', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // The route awaits the chain directly (no .single()).
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/library/docs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/library/docs'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns docs on success (empty list coerced to [])', async () => {
+    mockFrom.mockReturnValue(docsChain({ data: null, error: null }));
+    const res = await GET(makeGetRequest('/api/library/docs'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).docs).toEqual([]);
+  });
+
+  it('returns docs when present', async () => {
+    const docs = [{ id: 1, title: 'Doc One', category: 'infra' }];
+    mockFrom.mockReturnValue(docsChain({ data: docs, error: null }));
+    const res = await GET(makeGetRequest('/api/library/docs'));
+    expect((await res.json()).docs).toEqual(docs);
+  });
+
+  it('applies an ilike title filter when search is provided', async () => {
+    const chain = docsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/docs', { search: 'staking' }));
+    expect(chain.ilike).toHaveBeenCalledWith('title', '%staking%');
+  });
+
+  it('strips PostgREST-unsafe characters from the search term', async () => {
+    const chain = docsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/docs', { search: 'a%b,c()' }));
+    expect(chain.ilike).toHaveBeenCalledWith('title', '%abc%');
+  });
+
+  it('does not filter when the sanitized search is empty', async () => {
+    const chain = docsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/docs', { search: '%,()' }));
+    expect(chain.ilike).not.toHaveBeenCalled();
+  });
+
+  it('applies a category equality filter when provided', async () => {
+    const chain = docsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/docs', { category: 'music' }));
+    expect(chain.eq).toHaveBeenCalledWith('category', 'music');
+  });
+
+  it('returns 500 when the query errors', async () => {
+    mockFrom.mockReturnValue(docsChain({ data: null, error: new Error('db down') }));
+    const res = await GET(makeGetRequest('/api/library/docs'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch docs');
+  });
+});

--- a/src/app/api/library/entries/__tests__/route.test.ts
+++ b/src/app/api/library/entries/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * A single chain object reused across every `.from()` call. Terminal awaits
+ * (`then`) resolve to results in FIFO order, so a test queues one result per
+ * DB round-trip the route makes (entries, then userVotes, then allVotes).
+ */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'or', 'contains', 'order', 'range', 'eq', 'in']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('GET /api/library/entries', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/library/entries'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns an empty entries list without querying votes', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: [], error: null }]));
+    const res = await GET(makeGetRequest('/api/library/entries'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.entries).toEqual([]);
+    expect(body.userVotes).toEqual({});
+    expect(body.entryVoters).toEqual({});
+    // Only the entries query runs when there are no entry ids.
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps the current user vote and all voters per entry', async () => {
+    const entries = [{ id: 'e1' }, { id: 'e2' }];
+    const userVotes = [{ entry_id: 'e1', vote_type: 'up' }];
+    const allVotes = [
+      { entry_id: 'e1', fid: 123, vote_type: 'up' },
+      { entry_id: 'e1', fid: 999, vote_type: 'down' },
+    ];
+    mockFrom.mockReturnValue(
+      queuedChain([
+        { data: entries, error: null },
+        { data: userVotes, error: null },
+        { data: allVotes, error: null },
+      ]),
+    );
+    const res = await GET(makeGetRequest('/api/library/entries'));
+    const body = await res.json();
+    expect(body.entries).toEqual(entries);
+    expect(body.userVotes).toEqual({ e1: 'up' });
+    expect(body.entryVoters.e1).toHaveLength(2);
+    expect(body.entryVoters.e1).toContainEqual({ fid: 999, vote_type: 'down' });
+    expect(mockFrom).toHaveBeenCalledTimes(3);
+  });
+
+  it('sorts by upvote_count when sort=upvoted', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/entries', { sort: 'upvoted' }));
+    expect(chain.order).toHaveBeenCalledWith('upvote_count', { ascending: false });
+  });
+
+  it('defaults to newest (created_at desc) sort', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/entries'));
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('applies a sanitized search filter', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/entries', { search: 'zao%,()' }));
+    expect(chain.or).toHaveBeenCalledWith(
+      'topic.ilike.%zao%,ai_summary.ilike.%zao%,note.ilike.%zao%',
+    );
+  });
+
+  it('applies a tag contains filter', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/library/entries', { tag: 'Music' }));
+    expect(chain.contains).toHaveBeenCalledWith('tags', ['Music']);
+  });
+
+  it('returns 500 when the entries query errors', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db down') }]));
+    const res = await GET(makeGetRequest('/api/library/entries'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch entries');
+  });
+});

--- a/src/app/api/library/submit/__tests__/route.test.ts
+++ b/src/app/api/library/submit/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom, mockModerate, mockSummary, mockIsUrl, mockExtractOG } =
+  vi.hoisted(() => ({
+    mockGetSessionData: vi.fn(),
+    mockFrom: vi.fn(),
+    mockModerate: vi.fn(),
+    mockSummary: vi.fn(),
+    mockIsUrl: vi.fn(),
+    mockExtractOG: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/library/minimax', () => ({
+  generateResearchSummary: (c: string) => mockSummary(c),
+}));
+
+vi.mock('@/lib/library/og-extract', () => ({
+  isUrl: (i: string) => mockIsUrl(i),
+  extractOGMetadata: (u: string) => mockExtractOG(u),
+}));
+
+vi.mock('@/lib/moderation/moderate', () => ({
+  moderateContent: (t: string) => mockModerate(t),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/** FIFO chain: insert→select→single, then a follow-up update await. */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['insert', 'update', 'select', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(q.shift()));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('POST /api/library/submit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockModerate.mockResolvedValue({ action: 'allow' });
+    mockSummary.mockResolvedValue({ summary: 'AI summary text' });
+    mockIsUrl.mockReturnValue(false);
+    mockExtractOG.mockResolvedValue({ ogTitle: null, ogDescription: null, ogImage: null });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'AI music' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'AI music' }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Farcaster account required to submit');
+  });
+
+  it('returns 400 for empty input', async () => {
+    const res = await POST(makePostRequest('/api/library/submit', { input: '' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 when more than 3 tags are supplied', async () => {
+    const res = await POST(
+      makePostRequest('/api/library/submit', {
+        input: 'topic',
+        tags: ['Music', 'Tech', 'AI', 'Business'],
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when moderation flags the content', async () => {
+    mockModerate.mockResolvedValue({ action: 'hide' });
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'bad topic' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Content flagged by moderation');
+  });
+
+  it('submits a freeform topic and attaches the AI summary', async () => {
+    const entry = { id: 'e1', topic: 'AI music', fid: 123 };
+    mockFrom.mockReturnValue(queuedChain([{ data: entry, error: null }, {}]));
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'AI music' }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.entry.ai_summary).toBe('AI summary text');
+    expect(body.entry.ai_status).toBe('complete');
+    // No OG extraction for a non-URL topic.
+    expect(mockExtractOG).not.toHaveBeenCalled();
+  });
+
+  it('extracts OG metadata for a URL submission and uses the OG title as topic', async () => {
+    mockIsUrl.mockReturnValue(true);
+    mockExtractOG.mockResolvedValue({
+      ogTitle: 'The Future of Onchain Music',
+      ogDescription: 'A deep dive',
+      ogImage: 'https://img/x.png',
+    });
+    const entry = { id: 'e2', topic: 'The Future of Onchain Music' };
+    mockFrom.mockReturnValue(queuedChain([{ data: entry, error: null }, {}]));
+    const res = await POST(
+      makePostRequest('/api/library/submit', { input: 'https://example.com/post' }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockExtractOG).toHaveBeenCalledWith('https://example.com/post');
+  });
+
+  it('marks ai_status failed when the summary is null', async () => {
+    mockSummary.mockResolvedValue({ summary: null, error: 'Minimax not configured' });
+    mockFrom.mockReturnValue(queuedChain([{ data: { id: 'e3' }, error: null }, {}]));
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'AI music' }));
+    const body = await res.json();
+    expect(body.entry.ai_status).toBe('failed');
+  });
+
+  it('returns 500 when the insert errors', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db down') }]));
+    const res = await POST(makePostRequest('/api/library/submit', { input: 'AI music' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to submit entry');
+  });
+});

--- a/src/app/api/library/vote/__tests__/route.test.ts
+++ b/src/app/api/library/vote/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * FIFO chain shared across every `.from()` call. The vote route makes several
+ * round-trips per request (existence lookup, the mutation, up-count, down-count,
+ * denormalized update) — a test queues one result per trip in call order.
+ * `.maybeSingle()` and awaited `then` both draw from the same queue.
+ */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'insert', 'update', 'delete', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.maybeSingle = vi.fn(() => Promise.resolve(q.shift()));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('POST /api/library/vote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'up' }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'up' }),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Farcaster account required to vote');
+  });
+
+  it('returns 400 for an invalid vote_type', async () => {
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'sideways' }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 for a non-UUID entry_id', async () => {
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: 'nope', vote_type: 'up' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('adds a new vote when none exists', async () => {
+    mockFrom.mockReturnValue(
+      queuedChain([
+        { data: null, error: null }, // existence lookup: no prior vote
+        { error: null }, // insert
+        { count: 3 }, // up count
+        { count: 1 }, // down count
+        {}, // denormalized update
+      ]),
+    );
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'up' }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      action: 'added',
+      vote_type: 'up',
+      upvote_count: 3,
+      downvote_count: 1,
+    });
+  });
+
+  it('removes the vote when the same type is submitted again', async () => {
+    mockFrom.mockReturnValue(
+      queuedChain([
+        { data: { id: 'v1', vote_type: 'up' }, error: null },
+        { error: null }, // delete
+        { count: 2 },
+        { count: 0 },
+        {},
+      ]),
+    );
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'up' }),
+    );
+    const body = await res.json();
+    expect(body.action).toBe('removed');
+    expect(body.vote_type).toBeNull();
+    expect(body.upvote_count).toBe(2);
+  });
+
+  it('changes the vote when a different type is submitted', async () => {
+    mockFrom.mockReturnValue(
+      queuedChain([
+        { data: { id: 'v1', vote_type: 'up' }, error: null },
+        { error: null }, // update
+        { count: 0 },
+        { count: 5 },
+        {},
+      ]),
+    );
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'down' }),
+    );
+    const body = await res.json();
+    expect(body.action).toBe('changed');
+    expect(body.vote_type).toBe('down');
+    expect(body.downvote_count).toBe(5);
+  });
+
+  it('returns 500 when the existence lookup errors', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db down') }]));
+    const res = await POST(
+      makePostRequest('/api/library/vote', { entry_id: VALID_UUID, vote_type: 'up' }),
+    );
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to process vote');
+  });
+});


### PR DESCRIPTION
## What

Adds Vitest route tests for **all 6 `/api/library` endpoints** — the research-library entry API (`submit`, `vote`, `comments`, `entries`, `delete`, `docs`). This surface was entirely untested.

Advances cowork task **#591** (test-coverage push: 79 tests vs 306 API routes) and roadmap doc 1115's quality theme. **52 tests** added.

## Coverage per route

| Route | Method | Tested |
|-------|--------|--------|
| `submit` | POST | 401/403 auth, Zod (empty input, >3 tags), moderation-hide 400, URL→OG-title path, freeform path, ai_status complete/failed, 500 |
| `vote` | POST | 401/403, invalid vote_type/uuid, add/remove/change vote actions + denormalized counts, 500 |
| `comments` | GET+POST | 401, uuid guard, list/empty coercion, 403 no-fid, moderation-hide, insert success, 500 |
| `entries` | GET | 401, empty (no vote queries), user-vote + all-voters mapping, sort=upvoted/newest, sanitized search, tag filter, 500 |
| `delete` | DELETE | 401, **403 non-admin**, uuid guard, admin delete success, 500 |
| `docs` | GET | 401, list/empty coercion, ilike search + sanitization, category filter, 500 |

## Conventions (per `.claude/rules/tests.md`)

- Vitest `describe`/`it`/`expect`, `vi.hoisted()` + `vi.mock()` — no MSW, no live DB.
- Shared `src/test-utils/api-helpers.ts` (`makeRequest`, session factories, `VALID_UUID`).
- Both success **and** error paths for every handler.
- A small FIFO `queuedChain` helper models multi-round-trip Supabase calls (existence lookup → mutation → counts → denormalized update) in call order. The `then` suppression mirrors the committed `chainMock` helper's thenable pattern.

## Verification (ground truth)

- `vitest run src/app/api/library` → **52/52 pass**
- `tsc --noEmit` → **0 errors**
- `biome check src/app/api/library` → **clean**

No source/behavior changes — tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
