### PR TITLE
test(auth): expand auth-guard table + signer-gated mutations (task #591)

### DIFF
--- a/src/app/api/__tests__/auth-guards.test.ts
+++ b/src/app/api/__tests__/auth-guards.test.ts
@@ -43,6 +43,8 @@ vi.mock('@/lib/music/isMusicUrl', () => ({
 import { GET as chatMessagesGET } from '@/app/api/chat/messages/route';
 // ── Route imports ────────────────────────────────────────────────────────────
 import { POST as chatSendPOST } from '@/app/api/chat/send/route';
+import { GET as membersMeGET, POST as membersMePOST } from '@/app/api/members/me/route';
+import { GET as membersNftsGET } from '@/app/api/members/nfts/route';
 import { GET as musicCuratorsGET } from '@/app/api/music/curators/route';
 import { GET as musicDigestGET } from '@/app/api/music/digest/route';
 import { GET as musicLyricsGET } from '@/app/api/music/lyrics/route';
@@ -57,6 +59,11 @@ import {
   PATCH as notificationsPATCH,
 } from '@/app/api/notifications/route';
 import { GET as respectLeaderboardGET } from '@/app/api/respect/leaderboard/route';
+import { DELETE as usersBlockDELETE, POST as usersBlockPOST } from '@/app/api/users/block/route';
+import { POST as usersFollowBatchPOST } from '@/app/api/users/follow-batch/route';
+import { DELETE as usersMuteDELETE, POST as usersMutePOST } from '@/app/api/users/mute/route';
+import { GET as usersProfileGET, PATCH as usersProfilePATCH } from '@/app/api/users/profile/route';
+import { GET as usersSocialsGET, PATCH as usersSocialsPATCH } from '@/app/api/users/socials/route';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 function makeRequest(url: string, options?: RequestInit) {
@@ -99,6 +106,62 @@ const unauthRoutes: [string, string, RouteHandler, RequestInit?][] = [
   ['GET  /api/music/curators', '/api/music/curators', musicCuratorsGET],
   ['GET  /api/music/digest', '/api/music/digest', musicDigestGET],
   ['GET  /api/music/lyrics', '/api/music/lyrics?songId=1', musicLyricsGET],
+  ['GET  /api/members/me', '/api/members/me', membersMeGET],
+  [
+    'POST /api/members/me',
+    '/api/members/me',
+    membersMePOST,
+    { method: 'POST', body: JSON.stringify({ bio: 'hi' }) },
+  ],
+  ['GET  /api/members/nfts', '/api/members/nfts?address=0x1234', membersNftsGET],
+  ['GET  /api/users/socials', '/api/users/socials', usersSocialsGET],
+  [
+    'PATCH /api/users/socials',
+    '/api/users/socials',
+    usersSocialsPATCH,
+    { method: 'PATCH', body: JSON.stringify({}) },
+  ],
+  ['GET  /api/users/profile', '/api/users/profile', usersProfileGET],
+  [
+    'PATCH /api/users/profile',
+    '/api/users/profile',
+    usersProfilePATCH,
+    { method: 'PATCH', body: JSON.stringify({}) },
+  ],
+];
+
+// Mutation routes gated on a Neynar signer — no signer → 401 "Signer required".
+const signerRoutes: [string, string, RouteHandler, RequestInit?][] = [
+  [
+    'POST   /api/users/block',
+    '/api/users/block',
+    usersBlockPOST,
+    { method: 'POST', body: JSON.stringify({ targetFid: 1 }) },
+  ],
+  [
+    'DELETE /api/users/block',
+    '/api/users/block',
+    usersBlockDELETE,
+    { method: 'DELETE', body: JSON.stringify({ targetFid: 1 }) },
+  ],
+  [
+    'POST   /api/users/mute',
+    '/api/users/mute',
+    usersMutePOST,
+    { method: 'POST', body: JSON.stringify({ targetFid: 1 }) },
+  ],
+  [
+    'DELETE /api/users/mute',
+    '/api/users/mute',
+    usersMuteDELETE,
+    { method: 'DELETE', body: JSON.stringify({ targetFid: 1 }) },
+  ],
+  [
+    'POST   /api/users/follow-batch',
+    '/api/users/follow-batch',
+    usersFollowBatchPOST,
+    { method: 'POST', body: JSON.stringify({ fids: [1] }) },
+  ],
 ];
 
 describe('Auth guards — unauthenticated requests return 401', () => {
@@ -114,6 +177,23 @@ describe('Auth guards — unauthenticated requests return 401', () => {
       expect(res.status).toBe(401);
       const body = await res.json();
       expect(body.error).toBe('Unauthorized');
+    });
+  });
+});
+
+describe('Auth guards — signer-gated mutations return 401 without a signer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+  });
+
+  describe.each(signerRoutes)('%s', (_label, url, handler, init) => {
+    it('returns 401 with error "Signer required"', async () => {
+      const req = makeRequest(url, init);
+      const res = await handler(req);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Signer required');
     });
   });
 });


### PR DESCRIPTION
## What

Expands `auth-guards.test.ts` with more untested session-gated routes (task **#591**):

**Added to the 401/"Unauthorized" table (7 route/methods):** `members/me` GET+POST, `members/nfts` GET, `users/socials` GET+PATCH, `users/profile` GET+PATCH.

**New describe block — signer-gated mutations (5 route/methods):** `users/block` POST+DELETE, `users/mute` POST+DELETE, `users/follow-batch` POST. These gate on `session.signerUuid` and return 401 **"Signer required"** — a distinct guard worth its own assertion, and these are write/mutation routes where auth enforcement matters most.

## Verification (ground truth)

- `vitest run auth-guards.test.ts` → **24/24 pass** (was 12)
- `tsc --noEmit` → **0 errors**
- `biome check` → **clean**

Tests only — no source changes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
