### PR TITLE
docs+test(social/verifications): mark intentionally public + pin behavior

### DIFF
--- a/src/app/api/social/verifications/__tests__/route.test.ts
+++ b/src/app/api/social/verifications/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetVerifications } = vi.hoisted(() => ({
+  mockGetVerifications: vi.fn(),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getAccountVerifications: (fid: number) => mockGetVerifications(fid),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/social/verifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetVerifications.mockResolvedValue({ verified_addresses: ['0xabc'] });
+  });
+
+  it('returns 400 when fid is missing', async () => {
+    const res = await GET(makeGetRequest('/api/social/verifications'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid fid');
+  });
+
+  it('returns 400 when fid is not a positive integer', async () => {
+    const res = await GET(makeGetRequest('/api/social/verifications', { fid: '-3' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('coerces a numeric-string fid and returns verifications', async () => {
+    const res = await GET(makeGetRequest('/api/social/verifications', { fid: '123' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ verified_addresses: ['0xabc'] });
+    expect(mockGetVerifications).toHaveBeenCalledWith(123);
+  });
+
+  it('is intentionally public — succeeds with no session (see route doc comment)', async () => {
+    // This route has no session guard by design (public Farcaster data, public
+    // member-profile page). This test locks that in so a future guard-sweep does
+    // not "fix" it into a 401 and break logged-out profile viewing.
+    const res = await GET(makeGetRequest('/api/social/verifications', { fid: '123' }));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 500 when the neynar lookup throws', async () => {
+    mockGetVerifications.mockRejectedValue(new Error('neynar down'));
+    const res = await GET(makeGetRequest('/api/social/verifications', { fid: '123' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch verifications');
+  });
+});

--- a/src/app/api/social/verifications/route.ts
+++ b/src/app/api/social/verifications/route.ts
@@ -5,6 +5,16 @@ import { logger } from '@/lib/logger';
 
 const schema = z.object({ fid: z.coerce.number().int().positive() });
 
+/**
+ * GET /api/social/verifications?fid=123
+ *
+ * Intentionally PUBLIC (no session guard): returns a FID's on-chain account
+ * verifications, which are already public Farcaster protocol data. Consumed by
+ * the public member-profile page (src/app/members/[username]/page.tsx), whose
+ * data endpoints (friends, popular, verifications) are all public by design.
+ * Abuse is bounded by the `/api/social` rate limit in middleware.ts — so this
+ * is deliberately unguarded and should NOT be given a session guard.
+ */
 export async function GET(req: NextRequest) {
   const parsed = schema.safeParse({ fid: req.nextUrl.searchParams.get('fid') });
   if (!parsed.success) {


### PR DESCRIPTION
## What

Closes out the two "no auth guard" findings surfaced by PRs #1420 and #1421. **Investigation result: both are intentionally public — neither is a fixable bug, and adding guards would break features.**

### `admin/poll-config` GET — leave as-is
Code is explicitly commented `/** GET — public read of poll config */` and returns non-sensitive poll settings (choices/templates) to render the public poll widget. No change.

### `social/verifications` GET — document + pin (this PR)
- Returns **public Farcaster protocol data** (a FID's on-chain verifications) — not a data leak.
- Consumed by the **public** member-profile page (`src/app/members/[username]/page.tsx`), whose sibling endpoints (`friends`, `popular`) are **also public by design**.
- Abuse is already bounded by the `/api/social` rate limit in `middleware.ts`.
- **Adding a session guard would break logged-out profile viewing** → wrong fix.

The correct hardening is to make the intent explicit (it lacked the clarifying comment `poll-config` already has) and lock the behavior so a future guard-sweep — mine or another agent's — doesn't "fix" it into a 401.

## Changes
- Doc comment on `social/verifications` GET marking it intentionally public.
- New 5-test suite: 400 on missing/invalid fid, numeric-string coercion, **public success with no session**, 500 on neynar error.

## Verification
- `vitest run social/verifications` → **5/5 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

No behavior change (comment + tests only). 🤖 Generated with [Claude Code](https://claude.com/claude-code)
