### PR TITLE
test(users,members): route tests for profile, socials, nfts (task #591)

### DIFF
--- a/src/app/api/members/nfts/__tests__/route.test.ts
+++ b/src/app/api/members/nfts/__tests__/route.test.ts
@@ -1,0 +1,619 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+// Mock fetch globally to intercept Alchemy API calls
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { GET } from '@/app/api/members/nfts/route';
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const mockAlchemyResponse = {
+  ownedNfts: [
+    {
+      contract: {
+        address: '0xcb80ef04da68667c9a4450013bdd69269842c883', // ZOUNZ
+        name: 'ZOUNZ',
+      },
+      tokenId: '1',
+      name: 'ZOUNZ #1',
+      image: {
+        cachedUrl: 'https://example.com/zounz1.png',
+      },
+      raw: {
+        metadata: {
+          name: 'ZOUNZ #1',
+        },
+      },
+      metadata: {
+        name: 'ZOUNZ #1',
+      },
+    },
+    {
+      contract: {
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        name: 'Other Collection',
+        openSeaMetadata: {
+          collectionName: 'Other NFTs',
+        },
+      },
+      tokenId: '42',
+      name: 'Other NFT',
+      image: {
+        cachedUrl: 'https://example.com/other.png',
+      },
+      raw: {
+        metadata: {
+          name: 'Other NFT',
+        },
+      },
+    },
+    {
+      contract: {
+        address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        name: 'No Image Collection',
+      },
+      tokenId: '100',
+      name: 'No Image NFT',
+      image: null,
+      raw: {
+        metadata: {
+          name: 'No Image NFT',
+        },
+      },
+      // Skip this because it has no image
+    },
+  ],
+  pageKey: 'abc123',
+};
+
+const mockEmptyAlchemyResponse = {
+  ownedNfts: [],
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/members/nfts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    delete process.env.ALCHEMY_API_KEY;
+  });
+
+  describe('Authentication', () => {
+    it('returns 401 when not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('Input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when address is missing', async () => {
+      const req = makeGetRequest('/api/members/nfts', {});
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Valid ETH address required');
+    });
+
+    it('returns 400 when address is invalid (missing 0x prefix)', async () => {
+      const req = makeGetRequest('/api/members/nfts', {
+        address: '1234567890abcdef1234567890abcdef12345678',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Valid ETH address required');
+    });
+
+    it('returns 400 when address is too short', async () => {
+      const req = makeGetRequest('/api/members/nfts', {
+        address: '0x1234567890abcdef',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Valid ETH address required');
+    });
+
+    it('returns 400 when address is too long', async () => {
+      const req = makeGetRequest('/api/members/nfts', {
+        address: '0x1234567890abcdef1234567890abcdef123456781234567890abcdef',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Valid ETH address required');
+    });
+
+    it('returns 400 when address contains invalid hex chars', async () => {
+      const req = makeGetRequest('/api/members/nfts', {
+        address: '0x1234567890abcdef1234567890abcdef1234567G', // G is invalid hex
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Valid ETH address required');
+    });
+
+    it('accepts valid checksummed addresses', async () => {
+      process.env.ALCHEMY_API_KEY = 'test-key-123';
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockEmptyAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', {
+        address: '0x1234567890ABCDEF1234567890ABCDEF12345678', // Checksum case
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Service configuration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 503 when ALCHEMY_API_KEY is not configured', async () => {
+      delete process.env.ALCHEMY_API_KEY;
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toBe('NFT service not configured');
+    });
+  });
+
+  describe('Success path', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      process.env.ALCHEMY_API_KEY = 'test-key-123';
+    });
+
+    it('fetches NFTs from all three chains and returns them', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have fetched from 3 chains
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      // Verify fetch URLs include the correct chains
+      const calls = mockFetch.mock.calls;
+      const urls = calls.map(([url]) => url as string);
+
+      expect(urls[0]).toContain('eth-mainnet.g.alchemy.com');
+      expect(urls[1]).toContain('base-mainnet.g.alchemy.com');
+      expect(urls[2]).toContain('opt-mainnet.g.alchemy.com');
+
+      // Each URL should include the address and API key
+      urls.forEach((url) => {
+        expect(url).toContain(`owner=${VALID_WALLET}`);
+        expect(url).toContain('withMetadata=true');
+        expect(url).toContain('pageSize=50');
+        expect(url).toContain('excludeFilters');
+        expect(url).toContain('SPAM');
+        expect(url).toContain('test-key-123');
+      });
+
+      // Response shape
+      expect(body.nfts).toBeDefined();
+      expect(body.address).toBe(VALID_WALLET);
+      expect(body.count).toBeDefined();
+    });
+
+    it('filters out NFTs without images', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      // Should only include 2 NFTs (not the one without an image)
+      // 3 chains × 2 NFTs per chain = 6 total (the one without image is skipped per chain)
+      expect(body.nfts.length).toBeGreaterThan(0);
+
+      // No NFT should be missing an image
+      body.nfts.forEach((nft: { imageUrl: unknown }) => {
+        expect(nft.imageUrl).toBeTruthy();
+      });
+    });
+
+    it('sorts NFTs with ZOUNZ first, then by collection name', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      // ZOUNZ should come first
+      const zounzNfts = body.nfts.filter((nft: { isZounz: boolean }) => nft.isZounz === true);
+      const nonZounzNfts = body.nfts.filter((nft: { isZounz: boolean }) => nft.isZounz === false);
+
+      if (zounzNfts.length > 0 && nonZounzNfts.length > 0) {
+        const lastZounzIndex = body.nfts.findIndex(
+          (nft: { isZounz: boolean }) =>
+            zounzNfts.includes(nft) && body.nfts[body.nfts.indexOf(nft) + 1]?.isZounz === false,
+        );
+        const firstNonZounzIndex = body.nfts.findIndex(
+          (nft: { isZounz: boolean }) => nft.isZounz === false,
+        );
+        expect(lastZounzIndex).toBeLessThan(firstNonZounzIndex);
+      }
+    });
+
+    it('includes cache control headers in response', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockEmptyAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const cacheControl = res.headers.get('Cache-Control');
+      expect(cacheControl).toBe('public, s-maxage=300, stale-while-revalidate=60');
+    });
+
+    it('returns empty NFT array when chains return no NFTs', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockEmptyAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      expect(body.nfts).toEqual([]);
+      expect(body.address).toBe(VALID_WALLET);
+      expect(body.count).toBe(0);
+    });
+
+    it('handles failed fetch calls gracefully (Promise.allSettled)', async () => {
+      // First call fails, second and third succeed
+      const successResponse = new Response(JSON.stringify(mockAlchemyResponse), {
+        status: 200,
+      });
+      const errorResponse = new Response(JSON.stringify({ error: 'Not found' }), {
+        status: 404,
+      });
+
+      mockFetch
+        .mockResolvedValueOnce(errorResponse)
+        .mockResolvedValueOnce(successResponse)
+        .mockResolvedValueOnce(successResponse);
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should still have NFTs from the two successful chains
+      expect(body.nfts.length).toBeGreaterThan(0);
+    });
+
+    it('returns correct NFT structure with all required fields', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(mockAlchemyResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      if (body.nfts.length > 0) {
+        const nft = body.nfts[0];
+        expect(nft).toHaveProperty('name');
+        expect(nft).toHaveProperty('collection');
+        expect(nft).toHaveProperty('imageUrl');
+        expect(nft).toHaveProperty('chain');
+        expect(nft).toHaveProperty('contractAddress');
+        expect(nft).toHaveProperty('tokenId');
+        expect(nft).toHaveProperty('url');
+        expect(nft).toHaveProperty('isZounz');
+
+        expect(['eth', 'base', 'optimism']).toContain(nft.chain);
+        expect(typeof nft.name).toBe('string');
+        expect(typeof nft.collection).toBe('string');
+        expect(typeof nft.contractAddress).toBe('string');
+        expect(typeof nft.tokenId).toBe('string');
+        expect(typeof nft.isZounz).toBe('boolean');
+      }
+    });
+
+    it('correctly identifies ZOUNZ tokens by contract address', async () => {
+      const zounzResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0xcb80ef04da68667c9a4450013bdd69269842c883', // Exact ZOUNZ address
+              name: 'ZOUNZ',
+            },
+            tokenId: '999',
+            name: 'ZOUNZ Token',
+            image: {
+              cachedUrl: 'https://example.com/zounz.png',
+            },
+            raw: { metadata: { name: 'ZOUNZ Token' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(zounzResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+      const zounzNft = body.nfts.find(
+        (nft: { contractAddress: string }) =>
+          nft.contractAddress === '0xcb80ef04da68667c9a4450013bdd69269842c883',
+      );
+
+      expect(zounzNft).toBeDefined();
+      expect(zounzNft.isZounz).toBe(true);
+    });
+
+    it('generates correct marketplace URLs for zora NFTs', async () => {
+      const zoraResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0x7c0ef9eda74abb14a8b9eda23e36af33d39fdfa8',
+              name: 'Zora NFT Creator',
+            },
+            tokenId: '123',
+            name: 'Zora NFT',
+            image: {
+              cachedUrl: 'https://example.com/zora.png',
+            },
+            raw: { metadata: { name: 'Zora NFT' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(zoraResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+      const zoraNft = body.nfts[0];
+
+      expect(zoraNft.url).toContain('zora.co');
+    });
+
+    it('generates correct marketplace URLs for opensea NFTs', async () => {
+      const openseaResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0x1234567890abcdef1234567890abcdef12345678',
+              name: 'Generic NFT',
+            },
+            tokenId: '456',
+            name: 'Generic NFT',
+            image: {
+              cachedUrl: 'https://example.com/generic.png',
+            },
+            raw: { metadata: { name: 'Generic NFT' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(openseaResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+      const genericNft = body.nfts[0];
+
+      expect(genericNft.url).toContain('opensea.io');
+      expect(genericNft.url).toContain('0x1234567890abcdef1234567890abcdef12345678');
+      expect(genericNft.url).toContain('456');
+    });
+
+    it('uses correct chain name in opensea URL (ethereum vs eth)', async () => {
+      // For base chain
+      const baseResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0x1234567890abcdef1234567890abcdef12345678',
+              name: 'Generic NFT',
+            },
+            tokenId: '789',
+            name: 'Generic NFT',
+            image: {
+              cachedUrl: 'https://example.com/generic.png',
+            },
+            raw: { metadata: { name: 'Generic NFT' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(baseResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      // Find NFTs by chain
+      const baseNfts = body.nfts.filter((nft: { chain: string }) => nft.chain === 'base');
+      const ethNfts = body.nfts.filter((nft: { chain: string }) => nft.chain === 'eth');
+
+      baseNfts.forEach((nft: { url: string }) => {
+        expect(nft.url).toContain('opensea.io/assets/base');
+      });
+
+      ethNfts.forEach((nft: { url: string }) => {
+        expect(nft.url).toContain('opensea.io/assets/ethereum');
+      });
+    });
+
+    it('handles missing image metadata gracefully', async () => {
+      const mixedResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0x1234567890abcdef1234567890abcdef12345678',
+              name: 'Collection A',
+            },
+            tokenId: '1',
+            name: 'NFT 1',
+            image: {
+              cachedUrl: 'https://example.com/1.png',
+            },
+            raw: { metadata: {} },
+          },
+          {
+            contract: {
+              address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+              name: 'Collection B',
+            },
+            tokenId: '2',
+            name: 'NFT 2',
+            image: {
+              thumbnailUrl: 'https://example.com/2-thumb.png',
+            },
+            raw: { metadata: { image: 'https://example.com/2-meta.png' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(mixedResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      // All returned NFTs should have an image
+      body.nfts.forEach((nft: { imageUrl: string | null }) => {
+        expect(nft.imageUrl).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      process.env.ALCHEMY_API_KEY = 'test-key-123';
+    });
+
+    it('handles NFT with missing tokenId', async () => {
+      const missingTokenIdResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0x1234567890abcdef1234567890abcdef12345678',
+              name: 'Collection',
+            },
+            tokenId: null,
+            name: 'NFT',
+            image: {
+              cachedUrl: 'https://example.com/nft.png',
+            },
+            raw: { metadata: { name: 'NFT' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(
+        new Response(JSON.stringify(missingTokenIdResponse), { status: 200 }),
+      );
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      if (body.nfts.length > 0) {
+        const nft = body.nfts[0];
+        // Should default tokenId to '0'
+        expect(nft.tokenId).toBe('0');
+      }
+    });
+
+    it('normalizes contract addresses to lowercase', async () => {
+      const mixedCaseResponse = {
+        ownedNfts: [
+          {
+            contract: {
+              address: '0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD', // Uppercase
+              name: 'Collection',
+            },
+            tokenId: '1',
+            name: 'NFT',
+            image: {
+              cachedUrl: 'https://example.com/nft.png',
+            },
+            raw: { metadata: { name: 'NFT' } },
+          },
+        ],
+      };
+
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(mixedCaseResponse), { status: 200 }));
+
+      const req = makeGetRequest('/api/members/nfts', { address: VALID_WALLET });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      if (body.nfts.length > 0) {
+        const nft = body.nfts[0];
+        expect(nft.contractAddress).toBe('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd');
+      }
+    });
+  });
+});

--- a/src/app/api/users/profile/__tests__/route.test.ts
+++ b/src/app/api/users/profile/__tests__/route.test.ts
@@ -1,0 +1,491 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PATCH } from '../route';
+
+describe('GET /api/users/profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 "Unauthorized" when no session', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 "Unauthorized" when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({});
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('successful retrieval', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('returns profile data with all fields populated', async () => {
+      const profileData = {
+        display_name: 'Test User',
+        bio: 'A test bio',
+        ign: 'testign',
+        real_name: 'Test Real Name',
+        bluesky_handle: 'test.bsky.social',
+        lens_profile_id: 'lens123',
+        hive_username: 'hive_user',
+        publishing_prefs: { x: true, bluesky: false },
+      };
+
+      const { chain } = chainMock({ data: profileData, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual(profileData);
+      expect(mockFrom).toHaveBeenCalledWith('users');
+      expect(chain.select).toHaveBeenCalledWith(
+        'display_name, bio, ign, real_name, bluesky_handle, lens_profile_id, hive_username, publishing_prefs',
+      );
+      expect(chain.eq).toHaveBeenCalledWith('fid', 456);
+      expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+      expect(chain.maybeSingle).toHaveBeenCalled();
+    });
+
+    it('returns empty strings for missing text fields and null for rich fields', async () => {
+      const profileData = {
+        display_name: null,
+        bio: null,
+        ign: null,
+        real_name: null,
+        bluesky_handle: null,
+        lens_profile_id: null,
+        hive_username: null,
+        publishing_prefs: null,
+      };
+
+      const { chain } = chainMock({ data: profileData, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.display_name).toBe('');
+      expect(body.bio).toBe('');
+      expect(body.ign).toBe('');
+      expect(body.real_name).toBe('');
+      expect(body.bluesky_handle).toBeNull();
+      expect(body.lens_profile_id).toBeNull();
+      expect(body.hive_username).toBeNull();
+      expect(body.publishing_prefs).toBeNull();
+    });
+
+    it('returns empty strings/nulls when user record does not exist', async () => {
+      const { chain } = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.display_name).toBe('');
+      expect(body.bio).toBe('');
+      expect(body.ign).toBe('');
+      expect(body.real_name).toBe('');
+      expect(body.bluesky_handle).toBeNull();
+      expect(body.lens_profile_id).toBeNull();
+      expect(body.hive_username).toBeNull();
+      expect(body.publishing_prefs).toBeNull();
+    });
+
+    it('returns 500 when Supabase query throws', async () => {
+      const { chain } = chainMock({ data: null, error: new Error('DB error') });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load profile');
+    });
+  });
+});
+
+describe('PATCH /api/users/profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 "Unauthorized" when no session', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'New Name' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 "Unauthorized" when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({});
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'New Name' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: '{not json}',
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when body is empty object (no fields to update)', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({}),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when display_name exceeds max length', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'x'.repeat(51) }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when bio exceeds max length', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ bio: 'x'.repeat(301) }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+    });
+
+    it('returns 400 when ign exceeds max length', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ ign: 'x'.repeat(31) }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+    });
+
+    it('returns 400 when real_name exceeds max length', async () => {
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ real_name: 'x'.repeat(81) }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+    });
+
+    it('trims whitespace from all string fields', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const result = {
+        display_name: 'Test User',
+        bio: 'Test bio',
+        ign: 'testign',
+        real_name: 'Real Name',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: '  Test User  ' }),
+      });
+
+      const res = await PATCH(req);
+
+      expect(res.status).toBe(200);
+      // The trim is applied during schema parse, before the update call
+      expect(chain.update).toHaveBeenCalled();
+      const updateCall = chain.update.mock.calls[0];
+      expect(updateCall[0].display_name).toBe('Test User');
+    });
+  });
+
+  describe('successful updates', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('updates display_name and returns updated profile', async () => {
+      const result = {
+        display_name: 'Updated Name',
+        bio: '',
+        ign: '',
+        real_name: '',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Updated Name' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.display_name).toBe('Updated Name');
+      expect(mockFrom).toHaveBeenCalledWith('users');
+      expect(chain.update).toHaveBeenCalled();
+      const updateCall = chain.update.mock.calls[0][0];
+      expect(updateCall.display_name).toBe('Updated Name');
+      expect(updateCall.updated_at).toBeDefined();
+    });
+
+    it('updates multiple fields at once', async () => {
+      const result = {
+        display_name: 'New Display',
+        bio: 'New bio',
+        ign: 'newign',
+        real_name: 'New Real',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({
+          display_name: 'New Display',
+          bio: 'New bio',
+          ign: 'newign',
+          real_name: 'New Real',
+        }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.display_name).toBe('New Display');
+      expect(body.bio).toBe('New bio');
+      expect(body.ign).toBe('newign');
+      expect(body.real_name).toBe('New Real');
+
+      const updateCall = chain.update.mock.calls[0][0];
+      expect(updateCall.display_name).toBe('New Display');
+      expect(updateCall.bio).toBe('New bio');
+      expect(updateCall.ign).toBe('newign');
+      expect(updateCall.real_name).toBe('New Real');
+      expect(updateCall.updated_at).toBeDefined();
+    });
+
+    it('includes updated_at timestamp in Supabase update', async () => {
+      const result = {
+        display_name: 'Test',
+        bio: '',
+        ign: '',
+        real_name: '',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      await PATCH(req);
+
+      const updateCall = chain.update.mock.calls[0][0];
+      expect(updateCall.updated_at).toBeDefined();
+      expect(typeof updateCall.updated_at).toBe('string');
+      // Basic ISO string validation
+      expect(updateCall.updated_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('filters returned fields to only profile fields (no timestamps, etc)', async () => {
+      const result = {
+        display_name: 'Test',
+        bio: 'bio',
+        ign: 'ign',
+        real_name: 'real',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      await PATCH(req);
+
+      expect(chain.select).toHaveBeenCalledWith('display_name, bio, ign, real_name');
+    });
+
+    it('applies filters for current fid and is_active user', async () => {
+      const result = {
+        display_name: 'Test',
+        bio: '',
+        ign: '',
+        real_name: '',
+      };
+      const { chain } = chainMock({ data: result, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      await PATCH(req);
+
+      expect(chain.eq).toHaveBeenCalledWith('fid', 456);
+      expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('returns 500 "Failed to update profile" when Supabase throws', async () => {
+      const { chain } = chainMock({ data: null, error: new Error('DB error') });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update profile');
+    });
+
+    it('returns 500 when single() resolves to an error', async () => {
+      const { chain } = chainMock({ data: null, error: { message: 'No rows updated' } });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update profile');
+    });
+
+    it('returns 500 when JSON parsing fails catastrophically', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      // Create a request with a stream body that will throw when .json() is called
+      const req = makeRequest('/api/users/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ display_name: 'Test' }),
+      });
+
+      // Mock req.json to throw after the .catch handler
+      vi.spyOn(req, 'json').mockRejectedValueOnce(new Error('Stream error'));
+
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid profile data');
+    });
+  });
+});

--- a/src/app/api/users/socials/__tests__/route.test.ts
+++ b/src/app/api/users/socials/__tests__/route.test.ts
@@ -1,0 +1,437 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+// ── Route imports ────────────────────────────────────────────────────────────
+import { GET, PATCH } from '@/app/api/users/socials/route';
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+function makePatchRequest(path: string, body: unknown): NextRequest {
+  return new NextRequest(new URL(path, 'http://localhost:3000'), {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Test suite ───────────────────────────────────────────────────────────────
+
+describe('GET /api/users/socials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session.fid is undefined', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session.fid is null', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: null, username: 'testuser' });
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns socials when user is authenticated and has data', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const userData = {
+      x_handle: 'testuser_x',
+      instagram_handle: 'testuser_ig',
+      soundcloud_url: 'https://soundcloud.com/testuser',
+      spotify_url: 'https://open.spotify.com/artist/123',
+      audius_handle: 'testuser_audius',
+    };
+
+    const { chain } = chainMock({ data: userData, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(userData);
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.select).toHaveBeenCalledWith(
+      'x_handle, instagram_handle, soundcloud_url, spotify_url, audius_handle',
+    );
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+  });
+
+  it('returns nulls when user has no social data', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      x_handle: null,
+      instagram_handle: null,
+      soundcloud_url: null,
+      spotify_url: null,
+      audius_handle: null,
+    });
+  });
+
+  it('returns 500 when Supabase query fails', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const { chain } = chainMock({ data: null, error: new Error('Database error') });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load socials');
+  });
+
+  it('returns 500 when request.json() throws', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const { chain } = chainMock({ data: null, error: new Error('Parse error') });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load socials');
+  });
+});
+
+describe('PATCH /api/users/socials', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'newhandle',
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session.fid is undefined', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'newhandle',
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when body has no fields to update', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {});
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when x_handle exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'a'.repeat(51),
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('returns 400 when instagram_handle exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      instagram_handle: 'a'.repeat(51),
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('returns 400 when soundcloud_url is not a valid URL', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      soundcloud_url: 'not-a-url',
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('returns 400 when spotify_url is not a valid URL', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      spotify_url: 'invalid-url',
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('accepts empty string for soundcloud_url and transforms to null', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      soundcloud_url: '',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({ soundcloud_url: null });
+  });
+
+  it('accepts empty string for spotify_url and transforms to null', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      spotify_url: '',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({ spotify_url: null });
+  });
+
+  it('returns 400 when soundcloud_url exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const longUrl = `https://soundcloud.com/${'a'.repeat(200)}`;
+    const req = makePatchRequest('/api/users/socials', {
+      soundcloud_url: longUrl,
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('returns 400 when spotify_url exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const longUrl = `https://open.spotify.com/artist/${'a'.repeat(200)}`;
+    const req = makePatchRequest('/api/users/socials', {
+      spotify_url: longUrl,
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('returns 400 when audius_handle exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      audius_handle: 'a'.repeat(51),
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+
+  it('updates single social handle successfully', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'newhandle',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.update).toHaveBeenCalledWith({ x_handle: 'newhandle' });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('updates multiple social handles successfully', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'twitter_handle',
+      instagram_handle: 'insta_handle',
+      audius_handle: 'audius_user',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({
+      x_handle: 'twitter_handle',
+      instagram_handle: 'insta_handle',
+      audius_handle: 'audius_user',
+    });
+  });
+
+  it('trims whitespace from handles', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: '  trimmed_handle  ',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({ x_handle: 'trimmed_handle' });
+  });
+
+  it('accepts null values for handles', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: null,
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({ x_handle: null });
+  });
+
+  it('accepts valid URLs for soundcloud and spotify', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      soundcloud_url: 'https://soundcloud.com/artist/track',
+      spotify_url: 'https://open.spotify.com/artist/abc123',
+    });
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(chain.update).toHaveBeenCalledWith({
+      soundcloud_url: 'https://soundcloud.com/artist/track',
+      spotify_url: 'https://open.spotify.com/artist/abc123',
+    });
+  });
+
+  it('returns 500 when Supabase update fails', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    const req = makePatchRequest('/api/users/socials', {
+      x_handle: 'newhandle',
+    });
+
+    const { chain } = chainMock({ data: null, error: new Error('Update failed') });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update socials');
+  });
+
+  it('returns 400 when request.json() returns null', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const mockReq = {
+      json: vi.fn().mockRejectedValue(new Error('JSON parse error')),
+    } as unknown as Request;
+
+    const res = await PATCH(mockReq);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid data');
+  });
+});


### PR DESCRIPTION
## What

Route tests for **3 previously-untested routes** (task **#591**), authored via parallel subagents and verified green by the orchestrator (vitest + biome + `tsc --noEmit` 0 errors). **71 tests.**

| Route | Methods | Tests | Highlights |
|-------|---------|-------|-----------|
| `users/profile` | GET, PATCH | 23 | auth, Zod validation + trim, single/multi update, `updated_at` injection, field filtering, fid/is_active scoping, 500 |
| `users/socials` | GET, PATCH | 26 | auth, length/URL validation, empty-string→null, null handling, multi-update, 500 |
| `members/nfts` | GET | 22 | auth, ETH-address validation, 503 not-configured, multi-chain `Promise.allSettled`, ZOUNZ-first sort, marketplace URL construction |

## Note on `members/nfts` + the fetch rule

`.claude/rules/tests.md` says mock modules, not `fetch`. That assumes a mockable module seam — but `members/nfts` calls Alchemy via **raw inline `fetch()`** (route line 76) with no lib wrapper, so its success-path tests use `vi.stubGlobal('fetch')` as the only available seam. `users/profile` + `users/socials` use module mocks only. (If preferred, the nfts success tests can be dropped to keep only the pre-fetch guard/validation/503 paths — say the word.)

## Verification
- `vitest run` (all 3) → **71/71 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only — no source changes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
