### PR TITLE
test(users): wallet-visibility, messaging-prefs, storage (task #591)

### DIFF
--- a/src/app/api/users/messaging-prefs/__tests__/route.test.ts
+++ b/src/app/api/users/messaging-prefs/__tests__/route.test.ts
@@ -1,0 +1,533 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, makeRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Import route handlers after mocks ────────────────────────────────────────
+import { GET, PATCH } from '../route';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+const DEFAULTS = { autoJoinGroup: true, allowNonZaoDms: false };
+
+describe('/api/users/messaging-prefs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+  });
+
+  describe('GET', () => {
+    describe('auth guard', () => {
+      it('returns 401 when no session', async () => {
+        mockGetSessionData.mockResolvedValue(null);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+
+      it('returns 401 when session has no fid', async () => {
+        mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('success paths', () => {
+      it('returns defaults when no user record exists', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(DEFAULTS);
+        expect(mockFrom).toHaveBeenCalledWith('users');
+        expect(chain.select).toHaveBeenCalledWith('messaging_prefs');
+        expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+      });
+
+      it('returns user prefs merged with defaults', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const userPrefs = {
+          autoJoinGroup: false,
+          allowNonZaoDms: true,
+        };
+        const { chain } = chainMock({
+          data: { messaging_prefs: userPrefs },
+          error: null,
+        });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual(userPrefs);
+      });
+
+      it('merges partial prefs with defaults', async () => {
+        const session = mockAuthenticatedSession({ fid: 456 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const partialPrefs = { autoJoinGroup: false };
+        const { chain } = chainMock({
+          data: { messaging_prefs: partialPrefs },
+          error: null,
+        });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: false,
+        });
+      });
+
+      it('filters for is_active = true', async () => {
+        const session = mockAuthenticatedSession({ fid: 789 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const { chain } = chainMock({
+          data: { messaging_prefs: {} },
+          error: null,
+        });
+        mockFrom.mockReturnValue(chain);
+
+        await GET();
+
+        expect(chain.eq).toHaveBeenCalledWith('fid', 789);
+        expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+      });
+    });
+
+    describe('error handling', () => {
+      it('returns 500 when Supabase query fails', async () => {
+        const session = mockAuthenticatedSession({ fid: 999 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const supabaseError = new Error('Connection failed');
+        const { chain } = chainMock({
+          data: null,
+          error: supabaseError,
+        });
+        mockFrom.mockReturnValue(chain);
+
+        const res = await GET();
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Failed to load preferences');
+      });
+    });
+  });
+
+  describe('PATCH', () => {
+    describe('auth guard', () => {
+      it('returns 401 when no session', async () => {
+        mockGetSessionData.mockResolvedValue(null);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+
+      it('returns 401 when session has no fid', async () => {
+        mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('request validation', () => {
+      it('returns 400 for invalid JSON', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: '{not valid json}',
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid preferences');
+        expect(body.details).toBeDefined();
+      });
+
+      it('returns 400 for non-object body', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: '"string"',
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid preferences');
+        expect(body.details).toBeDefined();
+      });
+
+      it('returns 400 for invalid boolean values', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: 'not a boolean' }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid preferences');
+        expect(body.details).toBeDefined();
+      });
+
+      it('ignores unknown properties and updates valid ones', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const selectChain = chainMock({
+          data: { messaging_prefs: DEFAULTS },
+          error: null,
+        });
+        const updateChain = chainMock({
+          data: null,
+          error: null,
+        });
+
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: null }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false, unknownProperty: true }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: false,
+        });
+      });
+
+      it('allows empty object', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({}),
+        });
+        const res = await PATCH(req);
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('success paths', () => {
+      it('updates single preference', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const selectChain = chainMock({
+          data: { messaging_prefs: { autoJoinGroup: true, allowNonZaoDms: false } },
+          error: null,
+        });
+        const updateChain = chainMock({
+          data: null,
+          error: null,
+        });
+
+        mockFrom.mockImplementation((table) => {
+          if (table === 'users') {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: null }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: false,
+        });
+      });
+
+      it('updates multiple preferences at once', async () => {
+        const session = mockAuthenticatedSession({ fid: 456 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const selectChain = chainMock({
+          data: { messaging_prefs: DEFAULTS },
+          error: null,
+        });
+        const updateChain = chainMock({
+          data: null,
+          error: null,
+        });
+
+        mockFrom.mockImplementation(() => selectChain.chain);
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: null }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({
+            autoJoinGroup: false,
+            allowNonZaoDms: true,
+          }),
+        });
+
+        // Mock the second from() call for update
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: true,
+        });
+      });
+
+      it('merges with existing preferences', async () => {
+        const session = mockAuthenticatedSession({ fid: 789 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const existingPrefs = { autoJoinGroup: false };
+        const selectChain = chainMock({
+          data: { messaging_prefs: existingPrefs },
+          error: null,
+        });
+        const updateChain = chainMock({
+          data: null,
+          error: null,
+        });
+
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: null }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ allowNonZaoDms: true }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: true,
+        });
+      });
+
+      it('when no existing prefs, uses defaults then applies update', async () => {
+        const session = mockAuthenticatedSession({ fid: 999 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const selectChain = chainMock({
+          data: null,
+          error: null,
+        });
+        const updateChain = chainMock({
+          data: null,
+          error: null,
+        });
+
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: null }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body).toEqual({
+          autoJoinGroup: false,
+          allowNonZaoDms: false,
+        });
+      });
+    });
+
+    describe('error handling', () => {
+      it('returns 500 when select query fails', async () => {
+        const session = mockAuthenticatedSession({ fid: 123 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const supabaseError = new Error('Connection failed');
+        const { chain } = chainMock({
+          data: null,
+          error: supabaseError,
+        });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Failed to save preferences');
+      });
+
+      it('returns 500 when update query fails', async () => {
+        const session = mockAuthenticatedSession({ fid: 456 });
+        mockGetSessionData.mockResolvedValue(session);
+
+        const selectChain = chainMock({
+          data: { messaging_prefs: DEFAULTS },
+          error: null,
+        });
+        const updateError = new Error('Write failed');
+        const updateChain = chainMock({
+          data: null,
+          error: updateError,
+        });
+
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            return selectChain.chain;
+          }
+          return updateChain.chain;
+        });
+
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        updateChain.chain.then = vi.fn((resolve: (val: unknown) => void) =>
+          resolve({ error: updateError }),
+        );
+
+        const req = makeRequest('/api/users/messaging-prefs', {
+          method: 'PATCH',
+          body: JSON.stringify({ autoJoinGroup: false }),
+        });
+        const res = await PATCH(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Failed to save preferences');
+      });
+    });
+  });
+});

--- a/src/app/api/users/storage/__tests__/route.test.ts
+++ b/src/app/api/users/storage/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockGetStorageUsage, mockLoggerError } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetStorageUsage: vi.fn(),
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getStorageUsage: mockGetStorageUsage,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+  },
+}));
+
+// ── Route import ─────────────────────────────────────────────────────────────
+import { GET } from '@/app/api/users/storage/route';
+
+describe('GET /api/users/storage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 Unauthorized when no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 Unauthorized when session exists but has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+
+      const res = await GET();
+      expect(res.status).toBe(401);
+
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+  });
+
+  describe('success path', () => {
+    it('returns storage usage data when authenticated with valid fid', async () => {
+      const mockSessionData = {
+        fid: 12345,
+        username: 'testuser',
+      };
+      const mockStorageData = {
+        fid: 12345,
+        used_bytes: 1024000,
+        total_bytes: 104857600,
+      };
+
+      mockGetSessionData.mockResolvedValue(mockSessionData);
+      mockGetStorageUsage.mockResolvedValue(mockStorageData);
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toEqual(mockStorageData);
+    });
+
+    it('calls getStorageUsage with the fid from session', async () => {
+      const mockSessionData = { fid: 99999, username: 'testuser' };
+      const mockStorageData = { fid: 99999, used_bytes: 500, total_bytes: 1000 };
+
+      mockGetSessionData.mockResolvedValue(mockSessionData);
+      mockGetStorageUsage.mockResolvedValue(mockStorageData);
+
+      await GET();
+
+      expect(mockGetStorageUsage).toHaveBeenCalledWith(99999);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when getStorageUsage throws an error', async () => {
+      const mockSessionData = { fid: 12345, username: 'testuser' };
+      const testError = new Error('Network error from Neynar');
+
+      mockGetSessionData.mockResolvedValue(mockSessionData);
+      mockGetStorageUsage.mockRejectedValue(testError);
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to fetch storage usage' });
+    });
+
+    it('logs error when getStorageUsage fails', async () => {
+      const mockSessionData = { fid: 12345, username: 'testuser' };
+      const testError = new Error('API timeout');
+
+      mockGetSessionData.mockResolvedValue(mockSessionData);
+      mockGetStorageUsage.mockRejectedValue(testError);
+
+      await GET();
+
+      expect(mockLoggerError).toHaveBeenCalledWith('Storage usage fetch error:', testError);
+    });
+
+    it('returns 500 when getStorageUsage throws with unknown object', async () => {
+      const mockSessionData = { fid: 12345, username: 'testuser' };
+
+      mockGetSessionData.mockResolvedValue(mockSessionData);
+      mockGetStorageUsage.mockRejectedValue('Unknown error string');
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to fetch storage usage' });
+    });
+  });
+});

--- a/src/app/api/users/wallet-visibility/__tests__/route.test.ts
+++ b/src/app/api/users/wallet-visibility/__tests__/route.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PATCH } from '../route';
+
+describe('GET /api/users/wallet-visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 with no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({ fid: null });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful retrieval', () => {
+    it('returns hidden_wallets when user has some hidden', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 42 }));
+
+      const hiddenList = ['custody_address', 'solana_address'];
+      const { chain } = chainMock({ data: { hidden_wallets: hiddenList }, error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) =>
+        resolve({ data: { hidden_wallets: hiddenList }, error: null }),
+      );
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual(hiddenList);
+      expect(mockFrom).toHaveBeenCalledWith('users');
+    });
+
+    it('returns empty array when user has no hidden wallets', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 99 }));
+
+      const { chain } = chainMock({ data: null, error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ data: null, error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual([]);
+    });
+
+    it('filters by fid and is_active=true', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 77 }));
+
+      const { chain } = chainMock({ data: { hidden_wallets: [] }, error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) =>
+        resolve({ data: { hidden_wallets: [] }, error: null }),
+      );
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      expect(chain.select).toHaveBeenCalledWith('hidden_wallets');
+      expect(chain.eq).toHaveBeenCalledWith('fid', 77);
+      expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when Supabase query throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 55 }));
+
+      const { chain } = chainMock({ error: new Error('db connection lost') });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) =>
+        resolve({ error: new Error('db connection lost') }),
+      );
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load wallet visibility');
+    });
+
+    it('returns 500 when Supabase returns an error object', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 33 }));
+
+      const supabaseError = { message: 'Column does not exist' };
+      const { chain } = chainMock({ error: supabaseError });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: supabaseError }));
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load wallet visibility');
+    });
+  });
+});
+
+describe('PATCH /api/users/wallet-visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 with no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: [] });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({ fid: null });
+
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: [] });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when body is not valid JSON', async () => {
+      const req = makeRequest('/api/users/wallet-visibility', {
+        method: 'PATCH',
+        body: '{invalid json',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid wallet visibility data');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when hidden_wallets is not an array', async () => {
+      const req = makePostRequest('/api/users/wallet-visibility', {
+        hidden_wallets: 'not-an-array',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid wallet visibility data');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when hidden_wallets contains invalid wallet key', async () => {
+      const req = makePostRequest('/api/users/wallet-visibility', {
+        hidden_wallets: ['invalid_key'],
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid wallet visibility data');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when hidden_wallets exceeds max length of 10', async () => {
+      const tooMany = Array(11).fill('custody_address');
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: tooMany });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid wallet visibility data');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid wallet keys', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const validKeys = [
+        'custody_address',
+        'verified_addresses',
+        'solana_address',
+        'primary_wallet',
+      ];
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: validKeys });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual(validKeys);
+    });
+
+    it('defaults hidden_wallets to empty array when not provided', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', {});
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual([]);
+    });
+  });
+
+  describe('successful update', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 88 }));
+    });
+
+    it('updates and returns the hidden_wallets list', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const update = ['custody_address'];
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: update });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual(update);
+      expect(chain.update).toHaveBeenCalledWith({ hidden_wallets: update });
+    });
+
+    it('filters update by fid and is_active=true', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', {
+        hidden_wallets: ['solana_address'],
+      });
+      await PATCH(req);
+
+      expect(chain.eq).toHaveBeenCalledWith('fid', 88);
+      expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+    });
+
+    it('accepts empty hidden_wallets to clear all hidden', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', { hidden_wallets: [] });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual([]);
+      expect(chain.update).toHaveBeenCalledWith({ hidden_wallets: [] });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 66 }));
+    });
+
+    it('returns 500 when Supabase update throws', async () => {
+      const { chain } = chainMock({ error: new Error('constraint violation') });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) =>
+        resolve({ error: new Error('constraint violation') }),
+      );
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', {
+        hidden_wallets: ['custody_address'],
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update wallet visibility');
+    });
+
+    it('returns 500 when Supabase returns an error object', async () => {
+      const supabaseError = { message: 'Row not found' };
+      const { chain } = chainMock({ error: supabaseError });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: supabaseError }));
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', {
+        hidden_wallets: ['verified_addresses'],
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update wallet visibility');
+    });
+
+    it('returns 400 when hidden_wallets is not provided and body has unknown fields', async () => {
+      const { chain } = chainMock({ error: null });
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      chain.then = vi.fn((resolve: (val: unknown) => void) => resolve({ error: null }));
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/users/wallet-visibility', { unknown_field: 'value' });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.hidden_wallets).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Route tests for **3 untested `users/*` routes** (task **#591**), authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **48 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `users/wallet-visibility` | GET, PATCH | 21 |
| `users/messaging-prefs` | GET, PATCH | 20 |
| `users/storage` | GET | 7 |

All cover auth guards, Zod validation, success, and 500 paths. **Module mocks only** (no fetch stubbing).

## Verification
- `vitest run` (all 3) → **48/48 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
