### PR TITLE
test(spaces): scheduled, stats, hand-raise, song-request (task #591)

### DIFF
--- a/src/app/api/spaces/hand-raise/__tests__/route.test.ts
+++ b/src/app/api/spaces/hand-raise/__tests__/route.test.ts
@@ -1,0 +1,493 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// ── Route imports ────────────────────────────────────────────────────────────
+import { GET, POST } from '@/app/api/spaces/hand-raise/route';
+
+// ── Test constants ───────────────────────────────────────────────────────────
+const TEST_ROOM_ID = VALID_UUID;
+const TEST_USER_FID = 123;
+const TEST_TARGET_FID = 456;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET TESTS
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/spaces/hand-raise', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makeGetRequest('/api/spaces/hand-raise', { roomId: TEST_ROOM_ID });
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when roomId query param is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    const req = makeGetRequest('/api/spaces/hand-raise', {});
+
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('roomId required');
+  });
+
+  it('returns raised hands when query succeeds', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const mockRaises = [
+      {
+        room_id: TEST_ROOM_ID,
+        fid: TEST_USER_FID,
+        username: 'testuser',
+        status: 'raised',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    const mock = chainMock({ data: mockRaises, error: null });
+    mockFrom.mockReturnValue(mock.chain);
+
+    const req = makeGetRequest('/api/spaces/hand-raise', { roomId: TEST_ROOM_ID });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.raises).toEqual(mockRaises);
+    expect(mockFrom).toHaveBeenCalledWith('room_hand_raises');
+  });
+
+  it('filters to raised and invited statuses', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const mock = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(mock.chain);
+
+    const req = makeGetRequest('/api/spaces/hand-raise', { roomId: TEST_ROOM_ID });
+    await GET(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('room_hand_raises');
+    // Verify the chain calls for filtering
+    expect(mock.chain.select).toHaveBeenCalledWith('*');
+    expect(mock.chain.eq).toHaveBeenCalledWith('room_id', TEST_ROOM_ID);
+    expect(mock.chain.in).toHaveBeenCalledWith('status', ['raised', 'invited']);
+    expect(mock.chain.order).toHaveBeenCalledWith('created_at', { ascending: true });
+  });
+
+  it('returns 500 when database error occurs', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const dbError = new Error('Connection failed');
+    const mock = chainMock({ data: null, error: dbError });
+    mockFrom.mockReturnValue(mock.chain);
+
+    const req = makeGetRequest('/api/spaces/hand-raise', { roomId: TEST_ROOM_ID });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Database error');
+    expect(mockLogger.error).toHaveBeenCalledWith('GET hand-raise error:', dbError);
+  });
+
+  it('returns 500 when unexpected error is thrown', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('Session error'));
+
+    const req = makeGetRequest('/api/spaces/hand-raise', { roomId: TEST_ROOM_ID });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Internal server error');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// POST TESTS
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/spaces/hand-raise', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Auth guard tests ──────────────────────────────────────────────────────
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/spaces/hand-raise', {
+      roomId: TEST_ROOM_ID,
+      action: 'raise',
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ── Zod validation tests ──────────────────────────────────────────────────
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when roomId is invalid', async () => {
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: 'not-a-uuid',
+        action: 'raise',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when action is invalid', async () => {
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'invalid',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 500 when body is not valid JSON (caught by try/catch)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      // Manually create request with invalid JSON
+      const invalidReq = new (require('next/server').NextRequest)(
+        new URL('/api/spaces/hand-raise', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: 'not json',
+        },
+      );
+
+      const res = await POST(invalidReq);
+      expect(res.status).toBe(500);
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  // ── Raise action tests ────────────────────────────────────────────────────
+  describe('action: raise', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: TEST_USER_FID,
+          username: 'testuser',
+          pfpUrl: 'https://example.com/pfp.jpg',
+        }),
+      );
+    });
+
+    it('successfully raises hand', async () => {
+      const mock = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'raise',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('room_hand_raises');
+      expect(mock.chain.upsert).toHaveBeenCalledWith(
+        {
+          room_id: TEST_ROOM_ID,
+          fid: TEST_USER_FID,
+          username: 'testuser',
+          pfp_url: 'https://example.com/pfp.jpg',
+          status: 'raised',
+        },
+        { onConflict: 'room_id,fid' },
+      );
+    });
+
+    it('returns 500 when upsert fails', async () => {
+      const dbError = new Error('Upsert failed');
+      const mock = chainMock({ data: null, error: dbError });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'raise',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Database error');
+      expect(mockLogger.error).toHaveBeenCalledWith('raise error:', dbError);
+    });
+  });
+
+  // ── Lower action tests ────────────────────────────────────────────────────
+  describe('action: lower', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: TEST_USER_FID }));
+    });
+
+    it('successfully lowers hand', async () => {
+      const mock = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'lower',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('room_hand_raises');
+      expect(mock.chain.update).toHaveBeenCalledWith({ status: 'lowered' });
+      expect(mock.chain.eq).toHaveBeenCalledWith('fid', TEST_USER_FID);
+    });
+
+    it('targets the correct room and user in lower', async () => {
+      const mock = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'lower',
+      });
+
+      await POST(req);
+
+      const eqCalls = mock.chain.eq.mock.calls;
+      expect(eqCalls).toContainEqual(['room_id', TEST_ROOM_ID]);
+      expect(eqCalls).toContainEqual(['fid', TEST_USER_FID]);
+    });
+  });
+
+  // ── Invite action tests ───────────────────────────────────────────────────
+  describe('action: invite', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: TEST_USER_FID }));
+    });
+
+    it('returns 400 when targetFid is missing', async () => {
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'invite',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('targetFid required');
+    });
+
+    it('returns 403 when user is not room host', async () => {
+      const mock = chainMock({
+        data: { host_fid: TEST_TARGET_FID },
+        error: null,
+      });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'invite',
+        targetFid: TEST_TARGET_FID,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Only the host can invite or dismiss');
+    });
+
+    it('returns 403 when room does not exist', async () => {
+      const mock = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'invite',
+        targetFid: TEST_TARGET_FID,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Only the host can invite or dismiss');
+    });
+
+    it('successfully invites when user is host', async () => {
+      const mockChainForRoom = chainMock({
+        data: { host_fid: TEST_USER_FID },
+        error: null,
+      });
+
+      const mockChainForUpdate = chainMock({ data: null, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? mockChainForRoom.chain : mockChainForUpdate.chain;
+      });
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'invite',
+        targetFid: TEST_TARGET_FID,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(mockChainForUpdate.chain.update).toHaveBeenCalledWith({
+        status: 'invited',
+      });
+    });
+  });
+
+  // ── Dismiss action tests ──────────────────────────────────────────────────
+  describe('action: dismiss', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: TEST_USER_FID }));
+    });
+
+    it('returns 400 when targetFid is missing', async () => {
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'dismiss',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('targetFid required');
+    });
+
+    it('returns 403 when user is not room host', async () => {
+      const mock = chainMock({
+        data: { host_fid: TEST_TARGET_FID },
+        error: null,
+      });
+      mockFrom.mockReturnValue(mock.chain);
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'dismiss',
+        targetFid: TEST_TARGET_FID,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Only the host can invite or dismiss');
+    });
+
+    it('successfully dismisses when user is host', async () => {
+      const mockChainForRoom = chainMock({
+        data: { host_fid: TEST_USER_FID },
+        error: null,
+      });
+
+      const mockChainForUpdate = chainMock({ data: null, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        return callCount === 1 ? mockChainForRoom.chain : mockChainForUpdate.chain;
+      });
+
+      const req = makePostRequest('/api/spaces/hand-raise', {
+        roomId: TEST_ROOM_ID,
+        action: 'dismiss',
+        targetFid: TEST_TARGET_FID,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(mockChainForUpdate.chain.update).toHaveBeenCalledWith({
+        status: 'dismissed',
+      });
+    });
+  });
+
+  // ── General error handling ────────────────────────────────────────────────
+  it('returns 500 on unexpected error', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('Unknown error'));
+
+    const req = makePostRequest('/api/spaces/hand-raise', {
+      roomId: TEST_ROOM_ID,
+      action: 'raise',
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Internal server error');
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/spaces/scheduled/__tests__/route.test.ts
+++ b/src/app/api/spaces/scheduled/__tests__/route.test.ts
@@ -1,0 +1,641 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+// ── Test constants ───────────────────────────────────────────────────────────
+
+/** A valid future ISO datetime for scheduled_at. */
+const FUTURE_TIME = new Date(Date.now() + 3600000).toISOString(); // 1 hour from now
+
+/** A past ISO datetime — should fail validation. */
+const PAST_TIME = new Date(Date.now() - 3600000).toISOString(); // 1 hour ago
+
+/** Sample scheduled room from DB. */
+const SAMPLE_ROOM = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  title: 'Morning Standup',
+  description: 'Daily team sync',
+  host_fid: 123,
+  host_name: 'Test User',
+  host_pfp: 'https://pfp.example.com/123.jpg',
+  scheduled_at: FUTURE_TIME,
+  category: 'general',
+  theme: 'default',
+  state: 'scheduled',
+  created_at: new Date().toISOString(),
+};
+
+const SAMPLE_ROOM_2 = {
+  ...SAMPLE_ROOM,
+  id: '660e8400-e29b-41d4-a716-446655440001',
+  title: 'Music Session',
+  category: 'music',
+  state: 'live',
+};
+
+// ── GET tests ────────────────────────────────────────────────────────────────
+
+describe('GET /api/spaces/scheduled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successful fetch', () => {
+    it('returns empty list when no rooms exist', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const { chain } = chainMock({ data: [] });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.rooms).toEqual([]);
+      expect(mockFrom).toHaveBeenCalledWith('scheduled_rooms');
+    });
+
+    it('returns scheduled rooms filtered by state and future time', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const { chain } = chainMock({ data: [SAMPLE_ROOM, SAMPLE_ROOM_2] });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.rooms).toHaveLength(2);
+      expect(body.rooms[0].id).toBe(SAMPLE_ROOM.id);
+      expect(body.rooms[1].id).toBe(SAMPLE_ROOM_2.id);
+
+      // Verify chain calls
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.in).toHaveBeenCalledWith('state', ['scheduled', 'live']);
+      expect(chain.gte).toHaveBeenCalledWith('scheduled_at', expect.any(String));
+      expect(chain.order).toHaveBeenCalledWith('scheduled_at', { ascending: true });
+    });
+
+    it('returns rooms sorted by scheduled_at ascending', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const room1 = { ...SAMPLE_ROOM, scheduled_at: FUTURE_TIME };
+      const room2 = {
+        ...SAMPLE_ROOM_2,
+        scheduled_at: new Date(Date.now() + 7200000).toISOString(),
+      };
+
+      const { chain } = chainMock({ data: [room1, room2] });
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      expect(chain.order).toHaveBeenCalledWith('scheduled_at', { ascending: true });
+    });
+  });
+
+  describe('database errors', () => {
+    it('returns 500 when Supabase query fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const { chain } = chainMock({ error: new Error('Connection failed') });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch scheduled rooms');
+    });
+
+    it('returns 500 when supabaseAdmin.from throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch scheduled rooms');
+    });
+  });
+});
+
+// ── POST tests ───────────────────────────────────────────────────────────────
+
+describe('POST /api/spaces/scheduled', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request body validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when body is not valid JSON (req.json throws)', async () => {
+      const req = makeRequest('/api/spaces/scheduled', {
+        method: 'POST',
+        body: '{not json}',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to schedule room');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when title is empty string', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: '',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when title exceeds 100 characters', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'a'.repeat(101),
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when scheduledAt is missing', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when scheduledAt is in the past', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Past Event',
+        scheduledAt: PAST_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when scheduledAt is not an ISO datetime', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: 'not-a-date',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when description exceeds 500 characters', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+        description: 'a'.repeat(501),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when category is invalid', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+        category: 'invalid-category',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when theme exceeds 50 characters', async () => {
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+        theme: 'a'.repeat(51),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('schema defaults', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('applies default category when omitted', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      await POST(req);
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'general',
+        }),
+      );
+    });
+
+    it('applies default theme when omitted', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      await POST(req);
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          theme: 'default',
+        }),
+      );
+    });
+
+    it('applies default empty description when omitted', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      await POST(req);
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: null,
+        }),
+      );
+    });
+  });
+
+  describe('successful creation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: 123,
+          displayName: 'Test User',
+          pfpUrl: 'https://pfp.example.com/123.jpg',
+        }),
+      );
+    });
+
+    it('creates a room with minimal fields', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.room).toEqual(SAMPLE_ROOM);
+    });
+
+    it('creates a room with all fields', async () => {
+      const fullRoom = { ...SAMPLE_ROOM, description: 'Team sync' };
+      const { chain } = chainMock({ data: fullRoom });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        description: 'Team sync',
+        scheduledAt: FUTURE_TIME,
+        category: 'music',
+        theme: 'dark',
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.room).toEqual(fullRoom);
+    });
+
+    it('correctly formats insert payload with session data', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        description: 'Team sync',
+        scheduledAt: FUTURE_TIME,
+        category: 'podcast',
+        theme: 'custom',
+      });
+
+      await POST(req);
+
+      expect(chain.insert).toHaveBeenCalledWith({
+        title: 'Standup',
+        description: 'Team sync',
+        host_fid: 123,
+        host_name: 'Test User',
+        host_pfp: 'https://pfp.example.com/123.jpg',
+        scheduled_at: FUTURE_TIME,
+        category: 'podcast',
+        theme: 'custom',
+      });
+    });
+
+    it('handles null pfpUrl from session', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: 456,
+          displayName: 'No PFP User',
+          pfpUrl: null,
+        }),
+      );
+
+      const { chain } = chainMock({ data: { ...SAMPLE_ROOM, host_fid: 456, host_pfp: null } });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      await POST(req);
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host_fid: 456,
+          host_pfp: null,
+        }),
+      );
+    });
+
+    it('chains select and single for insert query', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      await POST(req);
+
+      expect(chain.select).toHaveBeenCalledWith();
+      expect(chain.single).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('database errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when Supabase insert fails', async () => {
+      const { chain } = chainMock({ error: new Error('Unique constraint violated') });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to schedule room');
+    });
+
+    it('returns 500 when supabaseAdmin.from throws', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Connection failed');
+      });
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to schedule room');
+    });
+
+    it('returns 500 when chain methods throw', async () => {
+      mockFrom.mockReturnValue({
+        insert: vi.fn().mockImplementation(() => {
+          throw new Error('Insert failed');
+        }),
+      });
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to schedule room');
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('accepts title with exactly 100 characters', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const title100 = 'a'.repeat(100);
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: title100,
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts description with exactly 500 characters', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const desc500 = 'a'.repeat(500);
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        description: desc500,
+        scheduledAt: FUTURE_TIME,
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts theme with exactly 50 characters', async () => {
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const theme50 = 'a'.repeat(50);
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Standup',
+        scheduledAt: FUTURE_TIME,
+        theme: theme50,
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts all valid categories', async () => {
+      const categories = ['general', 'music', 'podcast', 'ama', 'chill', 'dj-set'];
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      for (const category of categories) {
+        const req = makePostRequest('/api/spaces/scheduled', {
+          title: 'Standup',
+          scheduledAt: FUTURE_TIME,
+          category,
+        });
+
+        const res = await POST(req);
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('schedules a room far in the future', async () => {
+      const farFuture = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days
+      const { chain } = chainMock({ data: SAMPLE_ROOM });
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/spaces/scheduled', {
+        title: 'Future Event',
+        scheduledAt: farFuture,
+      });
+
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/src/app/api/spaces/song-request/__tests__/route.test.ts
+++ b/src/app/api/spaces/song-request/__tests__/route.test.ts
@@ -1,0 +1,764 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { GET, PATCH, POST } from '../route';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+const ROOM_ID = VALID_UUID;
+const REQUEST_ID = VALID_UUID;
+const HOST_FID = 999;
+const REQUESTER_FID = 456;
+
+const MOCK_SONG_REQUEST = {
+  id: REQUEST_ID,
+  room_id: ROOM_ID,
+  requester_fid: REQUESTER_FID,
+  requester_name: 'Test Requester',
+  song_url: 'https://open.spotify.com/track/123',
+  song_title: 'Test Song',
+  song_artist: 'Test Artist',
+  song_artwork: 'https://example.com/artwork.jpg',
+  status: 'pending',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+// ── Test Suites ──────────────────────────────────────────────────────────────
+describe('GET /api/spaces/song-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await GET(makeGetRequest('/api/spaces/song-request', { roomId: ROOM_ID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when roomId query param is missing', async () => {
+      const res = await GET(makeGetRequest('/api/spaces/song-request'));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('roomId required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 200 with list of pending and accepted requests', async () => {
+      const { chain } = chainMock({
+        data: [MOCK_SONG_REQUEST],
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/song-request', { roomId: ROOM_ID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.requests).toEqual([MOCK_SONG_REQUEST]);
+      // Verify chain was constructed correctly
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('room_id', ROOM_ID);
+      expect(chain.in).toHaveBeenCalledWith('status', ['pending', 'accepted']);
+      expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: true });
+      expect(chain.limit).toHaveBeenCalledWith(50);
+    });
+
+    it('returns empty array when no requests exist', async () => {
+      const { chain } = chainMock({
+        data: [],
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/song-request', { roomId: ROOM_ID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.requests).toEqual([]);
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when Supabase returns an error', async () => {
+      const { chain } = chainMock({
+        data: null,
+        error: { message: 'Database connection failed' },
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/song-request', { roomId: ROOM_ID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Database error');
+    });
+  });
+});
+
+describe('POST /api/spaces/song-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when roomId is not a valid UUID', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: 'not-a-uuid',
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when songUrl is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'not-a-url',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when roomId is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when songUrl is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when songTitle exceeds 200 chars', async () => {
+      const longTitle = 'a'.repeat(201);
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+          songTitle: longTitle,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when songArtist exceeds 200 chars', async () => {
+      const longArtist = 'a'.repeat(201);
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+          songArtist: longArtist,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when songArtwork is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+          songArtwork: 'not-a-url',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 500 when body is invalid JSON', async () => {
+      const res = await POST(
+        makeRequest('/api/spaces/song-request', {
+          method: 'POST',
+          body: '{not valid json',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+  });
+
+  describe('success', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: REQUESTER_FID,
+          username: 'testuser',
+          displayName: 'Test User',
+        }),
+      );
+    });
+
+    it('creates a song request with required fields only', async () => {
+      const { chain } = chainMock({
+        data: {
+          ...MOCK_SONG_REQUEST,
+          song_title: null,
+          song_artist: null,
+          song_artwork: null,
+        },
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.request).toBeDefined();
+      // Verify insert was called with correct data
+      expect(chain.insert).toHaveBeenCalledWith({
+        room_id: ROOM_ID,
+        requester_fid: REQUESTER_FID,
+        requester_name: 'Test User',
+        song_url: 'https://open.spotify.com/track/123',
+        song_title: null,
+        song_artist: null,
+        song_artwork: null,
+      });
+    });
+
+    it('creates a song request with all optional fields', async () => {
+      const { chain } = chainMock({
+        data: MOCK_SONG_REQUEST,
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+          songTitle: 'Test Song',
+          songArtist: 'Test Artist',
+          songArtwork: 'https://example.com/artwork.jpg',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.request).toEqual(MOCK_SONG_REQUEST);
+      expect(chain.insert).toHaveBeenCalledWith({
+        room_id: ROOM_ID,
+        requester_fid: REQUESTER_FID,
+        requester_name: 'Test User',
+        song_url: 'https://open.spotify.com/track/123',
+        song_title: 'Test Song',
+        song_artist: 'Test Artist',
+        song_artwork: 'https://example.com/artwork.jpg',
+      });
+    });
+
+    it('falls back to username when displayName is not available', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: REQUESTER_FID,
+          username: 'testuser',
+          displayName: null,
+        }),
+      );
+
+      const { chain } = chainMock({
+        data: MOCK_SONG_REQUEST,
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const _body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requester_name: 'testuser',
+        }),
+      );
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when Supabase insert fails', async () => {
+      const { chain } = chainMock({
+        data: null,
+        error: { message: 'Constraint violation' },
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Database error');
+    });
+
+    it('returns 500 when an unexpected error is thrown', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Connection lost');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/spaces/song-request', {
+          roomId: ROOM_ID,
+          songUrl: 'https://open.spotify.com/track/123',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+  });
+});
+
+describe('PATCH /api/spaces/song-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when requestId is not a valid UUID', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: 'not-a-uuid',
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when status is not a valid enum', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'invalid',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when requestId is missing', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when status is missing', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 500 when body is invalid JSON', async () => {
+      const res = await PATCH(
+        makeRequest('/api/spaces/song-request', {
+          method: 'PATCH',
+          body: '{not valid json',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+  });
+
+  describe('authorization', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: REQUESTER_FID }));
+    });
+
+    it('returns 404 when song request does not exist', async () => {
+      const selectChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValueOnce(selectChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toBe('Song request not found');
+    });
+
+    it('returns 403 when caller is not the host', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: { host_fid: HOST_FID },
+        error: null,
+      });
+      mockFrom.mockReturnValueOnce(selectReqChain.chain).mockReturnValueOnce(selectRoomChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Only the host can accept or reject requests');
+    });
+
+    it('returns 403 when room is not found', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValueOnce(selectReqChain.chain).mockReturnValueOnce(selectRoomChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Only the host can accept or reject requests');
+    });
+  });
+
+  describe('success', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: HOST_FID }));
+    });
+
+    it('accepts a song request', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: { host_fid: HOST_FID },
+        error: null,
+      });
+      const updateChain = chainMock({
+        data: { ...MOCK_SONG_REQUEST, status: 'accepted' },
+        error: null,
+      });
+      mockFrom
+        .mockReturnValueOnce(selectReqChain.chain)
+        .mockReturnValueOnce(selectRoomChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.request.status).toBe('accepted');
+      // Verify update was called with correct status
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ status: 'accepted' });
+    });
+
+    it('rejects a song request', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: { host_fid: HOST_FID },
+        error: null,
+      });
+      const updateChain = chainMock({
+        data: { ...MOCK_SONG_REQUEST, status: 'rejected' },
+        error: null,
+      });
+      mockFrom
+        .mockReturnValueOnce(selectReqChain.chain)
+        .mockReturnValueOnce(selectRoomChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'rejected',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.request.status).toBe('rejected');
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ status: 'rejected' });
+    });
+
+    it('marks a song request as played', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: { host_fid: HOST_FID },
+        error: null,
+      });
+      const updateChain = chainMock({
+        data: { ...MOCK_SONG_REQUEST, status: 'played' },
+        error: null,
+      });
+      mockFrom
+        .mockReturnValueOnce(selectReqChain.chain)
+        .mockReturnValueOnce(selectRoomChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'played',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.request.status).toBe('played');
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ status: 'played' });
+    });
+  });
+
+  describe('errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: HOST_FID }));
+    });
+
+    it('returns 500 when Supabase update fails', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      const selectRoomChain = chainMock({
+        data: { host_fid: HOST_FID },
+        error: null,
+      });
+      const updateChain = chainMock({
+        data: null,
+        error: { message: 'Constraint violation' },
+      });
+      mockFrom
+        .mockReturnValueOnce(selectReqChain.chain)
+        .mockReturnValueOnce(selectRoomChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Database error');
+    });
+
+    it('returns 500 when an unexpected error is thrown', async () => {
+      const selectReqChain = chainMock({
+        data: { room_id: ROOM_ID },
+        error: null,
+      });
+      mockFrom.mockReturnValueOnce(selectReqChain.chain).mockImplementationOnce(() => {
+        throw new Error('Connection lost');
+      });
+
+      const res = await PATCH(
+        makePostRequest('/api/spaces/song-request', {
+          requestId: REQUEST_ID,
+          status: 'accepted',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+  });
+});

--- a/src/app/api/spaces/stats/__tests__/route.test.ts
+++ b/src/app/api/spaces/stats/__tests__/route.test.ts
@@ -1,0 +1,438 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { GET } from '@/app/api/spaces/stats/route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself.
+ * Terminal .then() resolves the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.not = vi.fn().mockReturnValue(chain);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+  return chain;
+}
+
+describe('GET /api/spaces/stats', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session exists but has no fid', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ── Success path tests ────────────────────────────────────────────────────
+
+  it('returns empty stats when user has no sessions', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const emptyChain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(emptyChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      totalMinutes: 0,
+      totalSessions: 0,
+      favoriteRoom: null,
+      thisWeek: 0,
+      lastWeek: 0,
+      currentStreak: 0,
+    });
+  });
+
+  it('calculates stats correctly with multiple sessions', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    // Now minus 2 days (within this week)
+    const twoAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    // Now minus 10 days (within last week)
+    const tenAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+    // Now minus 20 days (before last week)
+    const twentyAgo = new Date(Date.now() - 20 * 24 * 60 * 60 * 1000);
+
+    const sessions = [
+      {
+        room_name: 'Room A',
+        duration_seconds: 600, // 10 min
+        joined_at: twoAgo.toISOString(),
+      },
+      {
+        room_name: 'Room A',
+        duration_seconds: 300, // 5 min
+        joined_at: twoAgo.toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: 1200, // 20 min
+        joined_at: tenAgo.toISOString(),
+      },
+      {
+        room_name: 'Room C',
+        duration_seconds: 240, // 4 min
+        joined_at: twentyAgo.toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Total: 10 + 5 + 20 + 4 = 39 min
+    expect(body.totalMinutes).toBe(39);
+    expect(body.totalSessions).toBe(4);
+
+    // Favorite room: Room A has 2 sessions, Room B has 1, Room C has 1
+    expect(body.favoriteRoom).toBe('Room A');
+
+    // This week: 10 + 5 = 15 min
+    expect(body.thisWeek).toBe(15);
+
+    // Last week: 20 min
+    expect(body.lastWeek).toBe(20);
+
+    // Streak: depends on today and actual dates—test loosely
+    expect(typeof body.currentStreak).toBe('number');
+    expect(body.currentStreak).toBeGreaterThanOrEqual(0);
+  });
+
+  it('rounds minutes correctly', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const sessions = [
+      {
+        room_name: 'Room A',
+        duration_seconds: 119, // 1.98 min → 2 min
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: 89, // 1.48 min → 1 min
+        joined_at: new Date().toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // 119 + 89 = 208 sec = 3.47 min → 3 min
+    expect(body.totalMinutes).toBe(3);
+  });
+
+  it('identifies favorite room correctly with ties', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const sessions = [
+      {
+        room_name: 'Room A',
+        duration_seconds: 600,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'Room A',
+        duration_seconds: 300,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: 500,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: 400,
+        joined_at: new Date().toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Both rooms have 2 sessions; first one in iteration order wins
+    expect(['Room A', 'Room B']).toContain(body.favoriteRoom);
+    expect(body.totalSessions).toBe(4);
+  });
+
+  it('calculates current streak correctly', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    // Create sessions for today and the last 2 days (3-day streak)
+    const today = new Date();
+    today.setHours(12, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const twoDaysAgo = new Date(today);
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+    // 3 days ago—no session, so streak should break
+    const threeDaysAgo = new Date(today);
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+
+    const sessions = [
+      {
+        room_name: 'Room A',
+        duration_seconds: 300,
+        joined_at: today.toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: 300,
+        joined_at: yesterday.toISOString(),
+      },
+      {
+        room_name: 'Room C',
+        duration_seconds: 300,
+        joined_at: twoDaysAgo.toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Streak should be 3 (today, yesterday, 2 days ago)
+    expect(body.currentStreak).toBe(3);
+  });
+
+  it('handles sessions with null duration_seconds gracefully', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const sessions = [
+      {
+        room_name: 'Room A',
+        duration_seconds: 600,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'Room B',
+        duration_seconds: null,
+        joined_at: new Date().toISOString(),
+      },
+    ];
+
+    // The query itself filters out nulls with .not('duration_seconds', 'is', null)
+    // so this tests the runtime behavior if that somehow fails
+    const sessionsChain = chainMock({ data: [sessions[0]], error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMinutes).toBe(10);
+    expect(body.totalSessions).toBe(1);
+  });
+
+  // ── Error path tests ──────────────────────────────────────────────────────
+
+  it('returns 500 when supabase query fails', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const errorChain = chainMock({ data: null, error: { message: 'db error' } });
+    mockFrom.mockReturnValue(errorChain);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch stats');
+  });
+
+  it('returns 500 when an exception is thrown', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch stats');
+  });
+
+  it('calls the correct supabase query chain methods', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await GET();
+
+    expect(mockFrom).toHaveBeenCalledWith('space_sessions');
+    expect(chain.select).toHaveBeenCalledWith('room_name, duration_seconds, joined_at');
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+    expect(chain.not).toHaveBeenCalledWith('duration_seconds', 'is', null);
+  });
+
+  // ── Edge case tests ──────────────────────────────────────────────────────
+
+  it('handles a single long session', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const sessions = [
+      {
+        room_name: 'Marathon Room',
+        duration_seconds: 3600, // 60 min
+        joined_at: new Date().toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMinutes).toBe(60);
+    expect(body.totalSessions).toBe(1);
+    expect(body.favoriteRoom).toBe('Marathon Room');
+    expect(body.currentStreak).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not include sessions older than 14 days in time windows', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const fortyDaysAgo = new Date(Date.now() - 40 * 24 * 60 * 60 * 1000);
+
+    const sessions = [
+      {
+        room_name: 'Old Room',
+        duration_seconds: 600,
+        joined_at: fortyDaysAgo.toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.totalMinutes).toBe(10);
+    expect(body.thisWeek).toBe(0);
+    expect(body.lastWeek).toBe(0);
+  });
+
+  it('handles mixed case room names', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const sessions = [
+      {
+        room_name: 'Room-A',
+        duration_seconds: 300,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'room-a',
+        duration_seconds: 300,
+        joined_at: new Date().toISOString(),
+      },
+      {
+        room_name: 'ROOM-A',
+        duration_seconds: 300,
+        joined_at: new Date().toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Room names are treated as case-sensitive, so these are 3 different rooms
+    expect(body.totalSessions).toBe(3);
+    expect(body.totalMinutes).toBe(15);
+    // Each room has 1 session, so favorite could be any of them
+    expect(['Room-A', 'room-a', 'ROOM-A']).toContain(body.favoriteRoom);
+  });
+
+  it('calculates streak that starts in the past (no sessions today)', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const twoDaysAgo = new Date(today);
+    twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+
+    const sessions = [
+      {
+        room_name: 'Room B',
+        duration_seconds: 300,
+        joined_at: yesterday.toISOString(),
+      },
+      {
+        room_name: 'Room C',
+        duration_seconds: 300,
+        joined_at: twoDaysAgo.toISOString(),
+      },
+    ];
+
+    const sessionsChain = chainMock({ data: sessions, error: null });
+    mockFrom.mockReturnValue(sessionsChain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // No session today, so streak should be 0
+    expect(body.currentStreak).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Route tests for **4 untested `spaces/*` routes** (task **#591**), authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **103 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `spaces/scheduled` | GET, POST | 33 |
| `spaces/stats` | GET | 15 |
| `spaces/hand-raise` | GET, POST | 22 |
| `spaces/song-request` | GET, POST, PATCH | 33 |

Covers auth guards, Zod validation, per-action authorization (host-only 403 on hand-raise invite/dismiss), session-stats aggregation, success, and 500 paths. **Module mocks only** (no fetch stubbing).

## Verification
- `vitest run` (all 4) → **103/103 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
