### PR TITLE
test(spaces): chat, tips, scheduled/[id]/rsvp (task #591)

### DIFF
--- a/src/app/api/spaces/chat/__tests__/route.test.ts
+++ b/src/app/api/spaces/chat/__tests__/route.test.ts
@@ -1,0 +1,530 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+describe('/api/spaces/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── GET /api/spaces/chat ──────────────────────────────────────────────────
+
+  describe('GET /api/spaces/chat', () => {
+    describe('authentication', () => {
+      it('returns 401 when no session exists', async () => {
+        mockGetSessionData.mockResolvedValue(null);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+
+      it('accepts a valid session', async () => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('roomId validation', () => {
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      });
+
+      it('returns 400 when roomId is missing', async () => {
+        const req = makeGetRequest('/api/spaces/chat');
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Valid roomId (UUID) required');
+      });
+
+      it('returns 400 when roomId is not a valid UUID', async () => {
+        const req = makeGetRequest('/api/spaces/chat', { roomId: 'not-a-uuid' });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Valid roomId (UUID) required');
+      });
+
+      it('returns 400 when roomId is empty string', async () => {
+        const req = makeGetRequest('/api/spaces/chat', { roomId: '' });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Valid roomId (UUID) required');
+      });
+
+      it('accepts a valid UUID roomId', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+
+        expect(res.status).toBe(200);
+        expect(mockFrom).toHaveBeenCalledWith('room_messages');
+      });
+    });
+
+    describe('database query', () => {
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      });
+
+      it('selects all fields from room_messages', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        await GET(req);
+
+        expect(chain.select).toHaveBeenCalledWith('*');
+      });
+
+      it('filters by room_id', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        await GET(req);
+
+        expect(chain.eq).toHaveBeenCalledWith('room_id', VALID_UUID);
+      });
+
+      it('orders by created_at ascending', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        await GET(req);
+
+        expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: true });
+      });
+
+      it('limits results to 100', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        await GET(req);
+
+        expect(chain.limit).toHaveBeenCalledWith(100);
+      });
+
+      it('returns messages when query succeeds', async () => {
+        const messages = [
+          {
+            id: '1',
+            room_id: VALID_UUID,
+            fid: 123,
+            username: 'alice',
+            pfp_url: 'https://example.com/1.jpg',
+            message: 'hello',
+            created_at: '2026-07-15T10:00:00Z',
+          },
+          {
+            id: '2',
+            room_id: VALID_UUID,
+            fid: 124,
+            username: 'bob',
+            pfp_url: 'https://example.com/2.jpg',
+            message: 'hi alice',
+            created_at: '2026-07-15T10:01:00Z',
+          },
+        ];
+        const { chain } = chainMock({ data: messages, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.messages).toEqual(messages);
+      });
+
+      it('returns empty array when no messages exist', async () => {
+        const { chain } = chainMock({ data: [], error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.messages).toEqual([]);
+      });
+
+      it('returns 500 on database error', async () => {
+        const { chain } = chainMock({ data: null, error: { message: 'db error' } });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Database error');
+      });
+    });
+
+    describe('error handling', () => {
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      });
+
+      it('returns 500 when an unexpected error is thrown', async () => {
+        mockFrom.mockImplementation(() => {
+          throw new Error('unexpected error');
+        });
+
+        const req = makeGetRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await GET(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Internal server error');
+      });
+    });
+  });
+
+  // ── POST /api/spaces/chat ─────────────────────────────────────────────────
+
+  describe('POST /api/spaces/chat', () => {
+    describe('authentication', () => {
+      it('returns 401 when no session exists', async () => {
+        mockGetSessionData.mockResolvedValue(null);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(401);
+        expect(body.error).toBe('Unauthorized');
+      });
+
+      it('accepts a valid session', async () => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('body validation', () => {
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      });
+
+      it('returns 500 when body is not valid JSON (caught by try-catch)', async () => {
+        const url = new URL('/api/spaces/chat', 'http://localhost:3000');
+        const invalidReq = new Request(url, {
+          method: 'POST',
+          body: '{not json',
+          // biome-ignore lint/suspicious/noExplicitAny: NextRequest constructor requires any cast
+        }) as any;
+        const res = await POST(invalidReq);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Internal server error');
+      });
+
+      it('returns 400 when roomId is missing', async () => {
+        const req = makePostRequest('/api/spaces/chat', { message: 'hello' });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid input');
+        expect(body.details).toBeDefined();
+      });
+
+      it('returns 400 when roomId is not a UUID', async () => {
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: 'not-a-uuid',
+          message: 'hello',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid input');
+      });
+
+      it('returns 400 when message is missing', async () => {
+        const req = makePostRequest('/api/spaces/chat', { roomId: VALID_UUID });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid input');
+      });
+
+      it('returns 400 when message is empty string', async () => {
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: '',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid input');
+      });
+
+      it('returns 400 when message exceeds 500 chars', async () => {
+        const longMessage = 'x'.repeat(501);
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: longMessage,
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(body.error).toBe('Invalid input');
+      });
+
+      it('accepts message exactly 1 character', async () => {
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'x',
+        });
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+      });
+
+      it('accepts message exactly 500 characters', async () => {
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'x'.repeat(500),
+        });
+        const res = await POST(req);
+
+        expect(res.status).toBe(200);
+      });
+    });
+
+    describe('database insert', () => {
+      const session = mockAuthenticatedSession({
+        fid: 456,
+        username: 'testuser',
+        pfpUrl: 'https://example.com/pfp.jpg',
+      });
+
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(session);
+      });
+
+      it('inserts message with correct fields', async () => {
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const messageText = 'hello world';
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: messageText,
+        });
+        await POST(req);
+
+        expect(chain.insert).toHaveBeenCalledWith({
+          room_id: VALID_UUID,
+          fid: 456,
+          username: 'testuser',
+          pfp_url: 'https://example.com/pfp.jpg',
+          message: messageText,
+        });
+      });
+
+      it('inserts into room_messages table', async () => {
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        await POST(req);
+
+        expect(mockFrom).toHaveBeenCalledWith('room_messages');
+      });
+
+      it('returns 200 with ok: true on success', async () => {
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.ok).toBe(true);
+      });
+
+      it('returns 500 on database error', async () => {
+        const { chain } = chainMock({ data: null, error: { message: 'insert failed' } });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Database error');
+      });
+    });
+
+    describe('error handling', () => {
+      beforeEach(() => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      });
+
+      it('returns 500 when an unexpected error is thrown', async () => {
+        mockFrom.mockImplementation(() => {
+          throw new Error('unexpected error');
+        });
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'hello',
+        });
+        const res = await POST(req);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Internal server error');
+      });
+
+      it('returns 500 when req.json() throws (caught by try-catch)', async () => {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+        const url = new URL('/api/spaces/chat', 'http://localhost:3000');
+        const invalidReq = new Request(url, {
+          method: 'POST',
+          body: '{not json',
+          // biome-ignore lint/suspicious/noExplicitAny: NextRequest constructor requires any cast
+        }) as any;
+        const res = await POST(invalidReq);
+        const body = await res.json();
+
+        expect(res.status).toBe(500);
+        expect(body.error).toBe('Internal server error');
+      });
+    });
+
+    describe('session data integration', () => {
+      it('uses fid from session when inserting', async () => {
+        mockGetSessionData.mockResolvedValue(
+          mockAuthenticatedSession({ fid: 999, username: 'alice' }),
+        );
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'test',
+        });
+        await POST(req);
+
+        expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ fid: 999 }));
+      });
+
+      it('uses username from session when inserting', async () => {
+        mockGetSessionData.mockResolvedValue(
+          mockAuthenticatedSession({ username: 'bob', fid: 888 }),
+        );
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'test',
+        });
+        await POST(req);
+
+        expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ username: 'bob' }));
+      });
+
+      it('uses pfpUrl from session when inserting', async () => {
+        mockGetSessionData.mockResolvedValue(
+          mockAuthenticatedSession({ pfpUrl: 'https://example.com/custom.jpg' }),
+        );
+        const { chain } = chainMock({ data: null, error: null });
+        mockFrom.mockReturnValue(chain);
+
+        const req = makePostRequest('/api/spaces/chat', {
+          roomId: VALID_UUID,
+          message: 'test',
+        });
+        await POST(req);
+
+        expect(chain.insert).toHaveBeenCalledWith(
+          expect.objectContaining({ pfp_url: 'https://example.com/custom.jpg' }),
+        );
+      });
+    });
+  });
+});

--- a/src/app/api/spaces/scheduled/[id]/rsvp/__tests__/route.test.ts
+++ b/src/app/api/spaces/scheduled/[id]/rsvp/__tests__/route.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, POST } from '../route';
+
+describe('POST /api/spaces/scheduled/[id]/rsvp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const insertChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 5 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(insertChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('RSVP insertion', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+    });
+
+    it('successfully adds an RSVP', async () => {
+      const insertChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 3 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(insertChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify insert was called with correct table and data
+      expect(insertChain.chain.insert).toHaveBeenCalledWith({
+        scheduled_room_id: VALID_UUID,
+        fid: 789,
+      });
+
+      // Verify count was called
+      expect(countChain.chain.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      });
+      expect(countChain.chain.eq).toHaveBeenCalledWith('scheduled_room_id', VALID_UUID);
+
+      // Verify update was called with new count
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ rsvp_count: 3 });
+      expect(updateChain.chain.eq).toHaveBeenCalledWith('id', VALID_UUID);
+    });
+
+    it('returns 409 when already RSVPed (duplicate key)', async () => {
+      const insertChain = chainMock({ error: { code: '23505' } });
+
+      mockFrom.mockReturnValueOnce(insertChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toBe('Already RSVPed');
+      // Should not proceed to count/update
+      expect(mockFrom).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 500 when Supabase insert fails with other error', async () => {
+      const insertChain = chainMock({ error: { code: 'PGSQL_ERROR', message: 'DB error' } });
+
+      mockFrom.mockReturnValueOnce(insertChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to RSVP');
+    });
+
+    it('returns 500 when Supabase throws an exception during insert', async () => {
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('Network error');
+      });
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to RSVP');
+    });
+
+    it('updates RSVP count even when count is null', async () => {
+      const insertChain = chainMock({ error: null });
+      const countChain = chainMock({ count: null });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(insertChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ rsvp_count: 0 });
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('reads id from params promise', async () => {
+      const testId = '123e4567-e89b-12d3-a456-426614174000';
+      const insertChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 1 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(insertChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await POST(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(insertChain.chain.insert).toHaveBeenCalledWith({
+        scheduled_room_id: testId,
+        fid: expect.any(Number),
+      });
+    });
+  });
+});
+
+describe('DELETE /api/spaces/scheduled/[id]/rsvp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+
+      const deleteChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 2 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(deleteChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('RSVP deletion', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555 }));
+    });
+
+    it('successfully removes an RSVP', async () => {
+      const deleteChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 2 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(deleteChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify delete was called with correct table and conditions
+      expect(deleteChain.chain.eq).toHaveBeenNthCalledWith(1, 'scheduled_room_id', VALID_UUID);
+      expect(deleteChain.chain.eq).toHaveBeenNthCalledWith(2, 'fid', 555);
+
+      // Verify count was called
+      expect(countChain.chain.select).toHaveBeenCalledWith('*', {
+        count: 'exact',
+        head: true,
+      });
+      expect(countChain.chain.eq).toHaveBeenCalledWith('scheduled_room_id', VALID_UUID);
+
+      // Verify update was called with new count
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ rsvp_count: 2 });
+      expect(updateChain.chain.eq).toHaveBeenCalledWith('id', VALID_UUID);
+    });
+
+    it('returns 500 when Supabase delete fails', async () => {
+      const deleteChain = chainMock({ error: { code: 'PGSQL_ERROR' } });
+
+      mockFrom.mockReturnValueOnce(deleteChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to cancel RSVP');
+    });
+
+    it('returns 500 when Supabase throws an exception during delete', async () => {
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('Network error');
+      });
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to cancel RSVP');
+    });
+
+    it('updates RSVP count even when count is null', async () => {
+      const deleteChain = chainMock({ error: null });
+      const countChain = chainMock({ count: null });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(deleteChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ rsvp_count: 0 });
+    });
+
+    it('only deletes RSVPs for the current user', async () => {
+      const deleteChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 5 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(deleteChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+
+      expect(res.status).toBe(200);
+      // Verify fid filter ensures only current user's RSVP is deleted
+      expect(deleteChain.chain.eq).toHaveBeenNthCalledWith(2, 'fid', 555);
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('reads id from params promise', async () => {
+      const testId = '550e8400-e29b-41d4-a716-446655440001';
+      const deleteChain = chainMock({ error: null });
+      const countChain = chainMock({ count: 4 });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(deleteChain.chain)
+        .mockReturnValueOnce(countChain.chain)
+        .mockReturnValueOnce(updateChain.chain);
+
+      const res = await DELETE(makePostRequest('/api/spaces/scheduled/test-id/rsvp', {}), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(deleteChain.chain.eq).toHaveBeenNthCalledWith(1, 'scheduled_room_id', testId);
+    });
+  });
+});

--- a/src/app/api/spaces/tips/__tests__/route.test.ts
+++ b/src/app/api/spaces/tips/__tests__/route.test.ts
@@ -1,0 +1,696 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, POST } from '../route';
+
+describe('POST /api/spaces/tips', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts a request with a valid authenticated session', async () => {
+      const session = mockAuthenticatedSession({ fid: 456 });
+      mockGetSessionData.mockResolvedValue(session);
+
+      const tipChain = chainMock({
+        data: { id: 1, sender_fid: 456, amount: '1.0', tx_hash: `0x${'a'.repeat(64)}` },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when amount is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when amount is not a numeric string', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: 'not-a-number',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when txHash is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when txHash is not a valid transaction hash format', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: 'invalid-hash',
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when txHash is 0x but wrong length', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(63)}`, // 63 chars instead of 64
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts mixed case hex in txHash', async () => {
+      const tipChain = chainMock({
+        data: {
+          id: 1,
+          tx_hash: '0xAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBb',
+        },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: '0xAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBbCcDdEeFfAaBb', // 64 hex chars, mixed case
+          chain: 'base',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when roomId is not a valid UUID', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          roomId: 'not-a-uuid',
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts optional roomId when it is a valid UUID', async () => {
+      const tipChain = chainMock({
+        data: { id: 1, room_id: VALID_UUID, amount: '1.0' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          roomId: VALID_UUID,
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts optional recipientFid as an integer', async () => {
+      const tipChain = chainMock({
+        data: { id: 1, recipient_fid: 789 },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          recipientFid: 789,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when recipientFid is not an integer', async () => {
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          recipientFid: 12.5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('allows amount as a decimal string', async () => {
+      const tipChain = chainMock({
+        data: { id: 1, amount: '0.5' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '0.5',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('allows amount as an integer string', async () => {
+      const tipChain = chainMock({
+        data: { id: 1, amount: '1' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('defaults chain to base when not provided', async () => {
+      const tipChain = chainMock({
+        data: { id: 1, chain: 'base' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const insertCall = tipChain.chain.insert.mock.calls[0][0] as Record<string, unknown>;
+      expect(insertCall.chain).toBe('base');
+    });
+  });
+
+  describe('Supabase persistence', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('inserts tip with correct payload shape', async () => {
+      const tipChain = chainMock({
+        data: {
+          id: 1,
+          sender_fid: 123,
+          recipient_fid: 0,
+          amount: '1.0',
+          currency: 'ETH',
+          chain: 'base',
+          tx_hash: `0x${'a'.repeat(64)}`,
+          room_id: null,
+        },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+          chain: 'base',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalledWith('tips');
+      expect(tipChain.chain.insert).toHaveBeenCalledTimes(1);
+
+      const insertPayload = tipChain.chain.insert.mock.calls[0][0];
+      expect(insertPayload).toEqual({
+        room_id: null,
+        sender_fid: 123,
+        recipient_fid: 0,
+        amount: '1.0',
+        currency: 'ETH',
+        chain: 'base',
+        tx_hash: `0x${'a'.repeat(64)}`,
+      });
+    });
+
+    it('inserts tip with all optional fields when provided', async () => {
+      const tipChain = chainMock({
+        data: {
+          id: 1,
+          room_id: VALID_UUID,
+          sender_fid: 123,
+          recipient_fid: 789,
+          amount: '2.5',
+          currency: 'ETH',
+          chain: 'optimism',
+          tx_hash: `0x${'b'.repeat(64)}`,
+        },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          roomId: VALID_UUID,
+          amount: '2.5',
+          txHash: `0x${'b'.repeat(64)}`,
+          chain: 'optimism',
+          recipientFid: 789,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const insertPayload = tipChain.chain.insert.mock.calls[0][0];
+      expect(insertPayload).toEqual({
+        room_id: VALID_UUID,
+        sender_fid: 123,
+        recipient_fid: 789,
+        amount: '2.5',
+        currency: 'ETH',
+        chain: 'optimism',
+        tx_hash: `0x${'b'.repeat(64)}`,
+      });
+    });
+
+    it('calls .select() and .single() on the insert chain', async () => {
+      const tipChain = chainMock({
+        data: { id: 1 },
+        error: null,
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+
+      expect(tipChain.chain.select).toHaveBeenCalledWith();
+      expect(tipChain.chain.single).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 500 when Supabase insert returns an error', async () => {
+      const tipChain = chainMock({
+        data: null,
+        error: new Error('Unique constraint violation'),
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to log tip');
+    });
+
+    it('returns the inserted tip data in response on success', async () => {
+      const tipData = {
+        id: 42,
+        sender_fid: 123,
+        recipient_fid: 0,
+        amount: '1.5',
+        currency: 'ETH',
+        chain: 'base',
+        tx_hash: `0x${'c'.repeat(64)}`,
+        room_id: null,
+        created_at: '2026-07-15T10:30:00Z',
+      };
+      const tipChain = chainMock({ data: tipData, error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.5',
+          txHash: `0x${'c'.repeat(64)}`,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.tip).toEqual(tipData);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when req.json() throws', async () => {
+      const req = makePostRequest('/api/spaces/tips', {});
+      // Sabotage the request to make json() fail
+      Object.defineProperty(req, 'json', {
+        value: () => Promise.reject(new Error('Invalid JSON')),
+      });
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal error');
+    });
+
+    it('returns 500 when getSessionData throws unexpectedly', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('Session service down'));
+
+      const res = await POST(
+        makePostRequest('/api/spaces/tips', {
+          amount: '1.0',
+          txHash: `0x${'a'.repeat(64)}`,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal error');
+    });
+  });
+});
+
+describe('GET /api/spaces/tips', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts a request with a valid authenticated session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('query parameter validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when roomId query param is missing', async () => {
+      const res = await GET(makeGetRequest('/api/spaces/tips', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('roomId required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts a valid roomId and queries tips', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalledWith('tips');
+      expect(tipChain.chain.eq).toHaveBeenCalledWith('room_id', VALID_UUID);
+    });
+  });
+
+  describe('Supabase query', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('queries tips table with select all', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(tipChain.chain.select).toHaveBeenCalledWith('*');
+    });
+
+    it('filters by room_id equality', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const roomId = '550e8400-e29b-41d4-a716-446655440001';
+      await GET(makeGetRequest('/api/spaces/tips', { roomId }));
+
+      expect(tipChain.chain.eq).toHaveBeenCalledWith('room_id', roomId);
+    });
+
+    it('orders by created_at descending', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(tipChain.chain.order).toHaveBeenCalledWith('created_at', {
+        ascending: false,
+      });
+    });
+
+    it('limits results to 50', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(tipChain.chain.limit).toHaveBeenCalledWith(50);
+    });
+
+    it('returns empty array when no tips exist', async () => {
+      const tipChain = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.tips).toEqual([]);
+    });
+
+    it('returns list of tips when results exist', async () => {
+      const tipsData = [
+        {
+          id: 1,
+          room_id: VALID_UUID,
+          sender_fid: 100,
+          recipient_fid: 200,
+          amount: '1.0',
+          currency: 'ETH',
+          chain: 'base',
+          tx_hash: `0x${'a'.repeat(64)}`,
+          created_at: '2026-07-15T10:00:00Z',
+        },
+        {
+          id: 2,
+          room_id: VALID_UUID,
+          sender_fid: 300,
+          recipient_fid: 400,
+          amount: '0.5',
+          currency: 'ETH',
+          chain: 'base',
+          tx_hash: `0x${'b'.repeat(64)}`,
+          created_at: '2026-07-15T09:00:00Z',
+        },
+      ];
+      const tipChain = chainMock({ data: tipsData, error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.tips).toEqual(tipsData);
+      expect(body.tips).toHaveLength(2);
+    });
+
+    it('returns 500 when Supabase query returns an error', async () => {
+      const tipChain = chainMock({
+        data: null,
+        error: new Error('Database connection failed'),
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch tips');
+    });
+
+    it('respects the query chain order (select -> eq -> order -> limit)', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const callOrder: string[] = [];
+      tipChain.chain.select.mockImplementation(() => {
+        callOrder.push('select');
+        return tipChain.chain;
+      });
+      tipChain.chain.eq.mockImplementation(() => {
+        callOrder.push('eq');
+        return tipChain.chain;
+      });
+      tipChain.chain.order.mockImplementation(() => {
+        callOrder.push('order');
+        return tipChain.chain;
+      });
+      tipChain.chain.limit.mockImplementation(() => {
+        callOrder.push('limit');
+        return tipChain.chain;
+      });
+
+      await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+
+      expect(callOrder).toEqual(['select', 'eq', 'order', 'limit']);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when getSessionData throws unexpectedly', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('Session service down'));
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal error');
+    });
+
+    it('returns 500 on unexpected error in try/catch', async () => {
+      const tipChain = chainMock({ data: [], error: null });
+      tipChain.chain.then.mockImplementation(() => {
+        throw new Error('Unexpected chain error');
+      });
+      mockFrom.mockReturnValue(tipChain.chain);
+
+      const res = await GET(makeGetRequest('/api/spaces/tips', { roomId: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal error');
+    });
+  });
+});


### PR DESCRIPTION
## What

Route tests for **3 more untested `spaces/*` routes** (task **#591**), authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **85 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `spaces/chat` | GET, POST | 33 |
| `spaces/tips` | POST, GET | 36 |
| `spaces/scheduled/[id]/rsvp` | POST, DELETE | 16 |

The `rsvp` route is **dynamic** (`[id]`) — tests pass the `{ params: Promise.resolve({ id }) }` argument and cover 409-duplicate-RSVP handling + user-scoped delete. **Module mocks only.**

## Verification
- `vitest run` (all 3) → **85/85 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
