### PR TITLE
test(music): listening-party, submissions/vote, collect, track-of-day/vote (task #591)

### DIFF
--- a/src/app/api/music/collect/__tests__/route.test.ts
+++ b/src/app/api/music/collect/__tests__/route.test.ts
@@ -1,0 +1,509 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+import { POST } from '@/app/api/music/collect/route';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+// ── Chainable Supabase mock helper ───────────────────────────────────────────
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+  return chain;
+}
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+const assetTxId = 'test_tx_12345';
+const assetId = 'asset_uuid_123';
+const collectorFid = 456;
+
+describe('POST /api/music/collect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Authentication', () => {
+    it('returns 401 when not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session exists but fid is missing', async () => {
+      mockGetSessionData.mockResolvedValue({ username: 'testuser' }); // no fid
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('Input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('returns 400 when assetTxId is missing', async () => {
+      const req = makePostRequest('/api/music/collect', {});
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when assetTxId is empty string', async () => {
+      const req = makePostRequest('/api/music/collect', { assetTxId: '' });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when assetTxId is not a string', async () => {
+      const req = makePostRequest('/api/music/collect', { assetTxId: 123 });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('ignores extra fields in request body', async () => {
+      const asset = { id: assetId, collected_count: 0 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', {
+        assetTxId,
+        extraField: 'should be ignored',
+        another: 'ignored too',
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('Asset lookup', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('returns 404 when asset not found', async () => {
+      const assetChain = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(assetChain);
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Asset not found');
+    });
+
+    it('queries arweave_assets by arweave_tx_id', async () => {
+      const asset = { id: assetId, collected_count: 5 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalledWith('arweave_assets');
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const selectCall = (assetChain.select as any).mock.calls[0];
+      expect(selectCall[0]).toBe('id, collected_count');
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const eqCall = (assetChain.eq as any).mock.calls[0];
+      expect(eqCall[0]).toBe('arweave_tx_id');
+      expect(eqCall[1]).toBe(assetTxId);
+    });
+  });
+
+  describe('Duplicate collection check', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('returns 409 when asset already collected by user', async () => {
+      const asset = { id: assetId, collected_count: 2 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: { id: 'existing_collection_id' }, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        return existingChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('Already collected');
+    });
+
+    it('checks arweave_collections with correct filters', async () => {
+      const asset = { id: assetId, collected_count: 0 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalledWith('arweave_collections');
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const firstEqCall = (existingChain.eq as any).mock.calls[0];
+      expect(firstEqCall[0]).toBe('asset_id');
+      expect(firstEqCall[1]).toBe(assetId);
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const secondEqCall = (existingChain.eq as any).mock.calls[1];
+      expect(secondEqCall[0]).toBe('collector_fid');
+      expect(secondEqCall[1]).toBe(collectorFid);
+    });
+  });
+
+  describe('Successful collection', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('creates collection record with correct data', async () => {
+      const asset = { id: assetId, collected_count: 3 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalledWith('arweave_collections');
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const insertCall = (insertChain.insert as any).mock.calls[0];
+      expect(insertCall[0]).toEqual({
+        asset_id: assetId,
+        collector_fid: collectorFid,
+        collector_address: '',
+      });
+    });
+
+    it('increments collected_count on asset', async () => {
+      const asset = { id: assetId, collected_count: 10 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      // Verify update was called on arweave_assets
+      const updateCalls = mockFrom.mock.calls.filter((call) => call[0] === 'arweave_assets');
+      expect(updateCalls.length).toBeGreaterThan(0);
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const updateCall = (updateChain.update as any).mock.calls[0];
+      expect(updateCall[0]).toEqual({ collected_count: 11 });
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const updateEqCall = (updateChain.eq as any).mock.calls[0];
+      expect(updateEqCall[0]).toBe('id');
+      expect(updateEqCall[1]).toBe(assetId);
+    });
+
+    it('handles collected_count as null/undefined with fallback to 0', async () => {
+      const asset = { id: assetId, collected_count: null };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.collectedCount).toBe(1);
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const updateCall = (updateChain.update as any).mock.calls[0];
+      expect(updateCall[0]).toEqual({ collected_count: 1 });
+    });
+
+    it('returns success response with incremented collected count', async () => {
+      const asset = { id: assetId, collected_count: 7 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.collectedCount).toBe(8);
+    });
+  });
+
+  describe('Error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('returns 500 when asset lookup throws', async () => {
+      const errorChain: Record<string, unknown> = {};
+      errorChain.select = vi.fn().mockReturnValue(errorChain);
+      errorChain.eq = vi.fn().mockReturnValue(errorChain);
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      errorChain.then = vi.fn().mockRejectedValue(new Error('DB connection failed'));
+      mockFrom.mockReturnValue(errorChain);
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Collection failed');
+    });
+
+    it('returns 500 when insert throws', async () => {
+      const asset = { id: assetId, collected_count: 0 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+
+      // insertChain for arweave_collections call
+      const insertChain: Record<string, unknown> = {};
+      insertChain.insert = vi.fn().mockImplementation(() => {
+        throw new Error('Insert failed');
+      });
+      const insertFromChain: Record<string, unknown> = {};
+      insertFromChain.from = vi.fn().mockReturnValue(insertChain);
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        // For the insert call, throw
+        throw new Error('Insert failed');
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Collection failed');
+    });
+
+    it('returns 500 when update throws', async () => {
+      const asset = { id: assetId, collected_count: 0 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        // For the 4th call (update), throw an error
+        throw new Error('Update failed');
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Collection failed');
+    });
+  });
+
+  describe('Edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: collectorFid });
+    });
+
+    it('works with very large collected_count', async () => {
+      const asset = { id: assetId, collected_count: 999999 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.collectedCount).toBe(1000000);
+    });
+
+    it('works with special characters in assetTxId', async () => {
+      const specialTxId = 'tx_!@#$%^&*()_+-={}[]|:;<>,.?/~`';
+      const asset = { id: assetId, collected_count: 0 };
+      const assetChain = chainMock({ data: asset, error: null });
+      const existingChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: { id: 'collection_id' }, error: null });
+      const updateChain = chainMock({ data: asset, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return assetChain;
+        if (callCount === 2) return existingChain;
+        if (callCount === 3) return insertChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/music/collect', { assetTxId: specialTxId });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      // biome-ignore lint/suspicious/noExplicitAny: accessing mock.calls in test
+      const eqCall = (assetChain.eq as any).mock.calls[0];
+      expect(eqCall[1]).toBe(specialTxId);
+    });
+  });
+});

--- a/src/app/api/music/listening-party/__tests__/route.test.ts
+++ b/src/app/api/music/listening-party/__tests__/route.test.ts
@@ -1,0 +1,706 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ───────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// ── Import routes after mocks ───────────────────────────────────────────────
+import { GET, POST } from '../route';
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+/** A sample listening party object as returned from Supabase */
+function sampleParty(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'party-123',
+    title: 'ZAO Sunday Listening',
+    description: 'Vibes only',
+    host_fid: 123,
+    host_name: 'Test User',
+    track_urls: ['https://example.com/track1.mp3', 'https://example.com/track2.mp3'],
+    scheduled_at: '2026-07-20T18:00:00Z',
+    state: 'scheduled',
+    started_at: null,
+    created_at: '2026-07-15T10:00:00Z',
+    updated_at: '2026-07-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ── GET /api/music/listening-party ──────────────────────────────────────────
+
+describe('GET /api/music/listening-party', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with parties when authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const parties = [
+        sampleParty({ id: 'party-1', state: 'live' }),
+        sampleParty({ id: 'party-2', state: 'scheduled' }),
+      ];
+      const { chain } = chainMock({ data: parties, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.parties).toEqual(parties);
+      expect(mockFrom).toHaveBeenCalledWith('listening_parties');
+    });
+  });
+
+  describe('query filtering', () => {
+    it('filters to only scheduled and live states', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const parties = [sampleParty({ state: 'live' })];
+      const { chain } = chainMock({ data: parties, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      // Verify the chain was called with the correct filter
+      expect(chain.in).toHaveBeenCalledWith('state', ['scheduled', 'live']);
+    });
+
+    it('orders by scheduled_at ascending', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const parties = [
+        sampleParty({ id: 'party-1', scheduled_at: '2026-07-20T10:00:00Z' }),
+        sampleParty({ id: 'party-2', scheduled_at: '2026-07-20T18:00:00Z' }),
+      ];
+      const { chain } = chainMock({ data: parties, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      // Verify ordering
+      expect(chain.order).toHaveBeenCalledWith('scheduled_at', { ascending: true });
+    });
+  });
+
+  describe('success response', () => {
+    it('returns empty array when no parties found', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const { chain } = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.parties).toEqual([]);
+    });
+
+    it('returns parties with all fields', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const party = sampleParty();
+      const { chain } = chainMock({ data: [party], error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.parties[0]).toMatchObject({
+        id: 'party-123',
+        title: 'ZAO Sunday Listening',
+        host_fid: 123,
+        state: 'scheduled',
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on Supabase error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const { chain } = chainMock({ data: null, error: new Error('DB connection failed') });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load listening parties');
+    });
+
+    it('returns 500 on query throw', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected query failure');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load listening parties');
+    });
+  });
+});
+
+// ── POST /api/music/listening-party ─────────────────────────────────────────
+
+describe('POST /api/music/listening-party', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 201 when authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const createdParty = sampleParty({ host_fid: 123 });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'ZAO Sunday Listening',
+          description: 'Vibes only',
+          trackUrls: ['https://example.com/track1.mp3', 'https://example.com/track2.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.party).toMatchObject({
+        id: 'party-123',
+        title: 'ZAO Sunday Listening',
+      });
+    });
+  });
+
+  describe('request validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when body is not valid JSON', async () => {
+      const res = await POST(
+        makeRequest('/api/music/listening-party', {
+          method: 'POST',
+          body: '{not json',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create listening party');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when title is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: '',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when title exceeds 200 chars', async () => {
+      const longTitle = 'a'.repeat(201);
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: longTitle,
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when description exceeds 1000 chars', async () => {
+      const longDescription = 'a'.repeat(1001);
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          description: longDescription,
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when trackUrls is empty', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: [],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when trackUrls contains invalid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: ['not-a-url'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when trackUrls exceeds 50 items', async () => {
+      const manyUrls = Array(51)
+        .fill(0)
+        .map((_, i) => `https://example.com/track${i}.mp3`);
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: manyUrls,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when URL exceeds 500 chars', async () => {
+      const longUrl = `https://example.com/${'.'.repeat(500)}`;
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: [longUrl],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when scheduledAt is not ISO datetime', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: ['https://example.com/track.mp3'],
+          scheduledAt: 'next friday',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid ISO datetime for scheduledAt', async () => {
+      const { chain } = chainMock({
+        data: sampleParty({ scheduled_at: '2026-07-20T18:00:00Z' }),
+        error: null,
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Valid Title',
+          trackUrls: ['https://example.com/track.mp3'],
+          scheduledAt: '2026-07-20T18:00:00Z',
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('insert behavior', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: 123,
+          username: 'testuser',
+          displayName: 'Test User',
+        }),
+      );
+    });
+
+    it('inserts with host_fid and host_name from session', async () => {
+      const createdParty = sampleParty({ host_fid: 123, host_name: 'Test User' });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      // Verify insert was called with session data
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host_fid: 123,
+          host_name: 'Test User',
+          title: 'Test Party',
+        }),
+      );
+    });
+
+    it('sets state to "live" when scheduledAt is omitted', async () => {
+      const createdParty = sampleParty({ state: 'live', started_at: expect.any(String) });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      // Verify state is 'live' and started_at is set
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'live',
+          started_at: expect.any(String),
+        }),
+      );
+    });
+
+    it('sets state to "scheduled" when scheduledAt is provided', async () => {
+      const createdParty = sampleParty({
+        state: 'scheduled',
+        started_at: null,
+        scheduled_at: '2026-07-20T18:00:00Z',
+      });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+          scheduledAt: '2026-07-20T18:00:00Z',
+        }),
+      );
+
+      // Verify state is 'scheduled' and started_at is null
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'scheduled',
+          started_at: null,
+          scheduled_at: '2026-07-20T18:00:00Z',
+        }),
+      );
+    });
+
+    it('sets description to null when omitted', async () => {
+      const createdParty = sampleParty({ description: null });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: null,
+        }),
+      );
+    });
+
+    it('preserves description when provided', async () => {
+      const createdParty = sampleParty({ description: 'Test description' });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          description: 'Test description',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'Test description',
+        }),
+      );
+    });
+
+    it('calls .select() and .single() on insert', async () => {
+      const createdParty = sampleParty();
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(chain.select).toHaveBeenCalled();
+      expect(chain.single).toHaveBeenCalled();
+    });
+  });
+
+  describe('success response', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 201 status', async () => {
+      const createdParty = sampleParty();
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('returns the created party in the response', async () => {
+      const createdParty = sampleParty({
+        id: 'party-xyz',
+        title: 'ZAO Sunday Listening',
+        description: 'Vibes only',
+      });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'ZAO Sunday Listening',
+          description: 'Vibes only',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.party).toEqual(createdParty);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 on Supabase insert error', async () => {
+      const { chain } = chainMock({ data: null, error: new Error('Duplicate key') });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create listening party');
+    });
+
+    it('returns 500 when insert throws unexpectedly', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create listening party');
+    });
+
+    it('logs error on Supabase failure', async () => {
+      const { logger } = await import('@/lib/logger');
+      const { chain } = chainMock({ data: null, error: new Error('DB error') });
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[listening-party] POST failed:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({
+          fid: 123,
+          username: 'testuser',
+          displayName: null,
+        }),
+      );
+    });
+
+    it('handles null displayName in session', async () => {
+      const createdParty = sampleParty({ host_name: null });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(res.status).toBe(201);
+      // Verify that host_name falls back to username when displayName is null
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host_name: expect.any(String),
+        }),
+      );
+    });
+
+    it('accepts description as empty string (treats as optional)', async () => {
+      const createdParty = sampleParty();
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          description: '',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts single track URL', async () => {
+      const createdParty = sampleParty({
+        track_urls: ['https://example.com/track.mp3'],
+      });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: ['https://example.com/track.mp3'],
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts maximum 50 track URLs', async () => {
+      const urls = Array(50)
+        .fill(0)
+        .map((_, i) => `https://example.com/track${i}.mp3`);
+      const createdParty = sampleParty({ track_urls: urls });
+      const { chain } = chainMock({ data: createdParty, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/music/listening-party', {
+          title: 'Test Party',
+          trackUrls: urls,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/src/app/api/music/submissions/vote/__tests__/route.test.ts
+++ b/src/app/api/music/submissions/vote/__tests__/route.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mockLogger,
+  },
+}));
+
+import { POST } from '@/app/api/music/submissions/vote/route';
+
+const SUBMISSION_ID = VALID_UUID;
+const VOTER_FID = 123;
+
+describe('POST /api/music/submissions/vote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('400 on missing submissionId', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    const req = makePostRequest('/api/music/submissions/vote', {});
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('400 on invalid UUID format', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: 'not-a-uuid' });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('adds a vote when none exists (toggle on)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    // Mock the chain sequence:
+    // 1. maybeSingle() for existing vote check -> null (no existing vote)
+    // 2. insert() for adding vote
+    // 3. then for count() query
+    const existingChain = chainMock({ data: null });
+    const insertChain = chainMock({ data: {} });
+    const countChain = chainMock({ data: null, count: 5 });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table !== 'song_votes') {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      callCount++;
+      if (callCount === 1) {
+        // First call: check existing vote
+        return existingChain.chain;
+      }
+      if (callCount === 2) {
+        // Second call: insert vote
+        return insertChain.chain;
+      }
+      // Third call: get vote count
+      return countChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voted).toBe(true);
+    expect(body.voteCount).toBe(5);
+  });
+
+  it('removes a vote when one exists (toggle off)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    // Mock the chain sequence:
+    // 1. maybeSingle() for existing vote check -> found with id 'v1'
+    // 2. delete() for removing vote
+    // 3. then for count() query
+    const existingChain = chainMock({ data: { id: 'v1' } });
+    const deleteChain = chainMock({ data: {} });
+    const countChain = chainMock({ data: null, count: 2 });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table !== 'song_votes') {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      callCount++;
+      if (callCount === 1) {
+        // First call: check existing vote
+        return existingChain.chain;
+      }
+      if (callCount === 2) {
+        // Second call: delete vote
+        return deleteChain.chain;
+      }
+      // Third call: get vote count
+      return countChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voted).toBe(false);
+    expect(body.voteCount).toBe(2);
+  });
+
+  it('returns 0 vote count when count is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    const existingChain = chainMock({ data: null });
+    const insertChain = chainMock({ data: {} });
+    const countChain = chainMock({ data: null, count: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) return existingChain.chain;
+      if (callCount === 2) return insertChain.chain;
+      return countChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.voteCount).toBe(0);
+  });
+
+  it('500 on error checking existing vote', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    const existingChain = chainMock({ error: new Error('DB connection failed') });
+    mockFrom.mockReturnValue(existingChain.chain);
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to process vote');
+    expect(mockLogger).toHaveBeenCalled();
+  });
+
+  it('500 on error inserting vote', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    const existingChain = chainMock({ data: null });
+    const insertChain = chainMock({ error: new Error('Insert failed') });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) return existingChain.chain;
+      return insertChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to process vote');
+    expect(mockLogger).toHaveBeenCalled();
+  });
+
+  it('500 on error deleting vote', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    const existingChain = chainMock({ data: { id: 'v1' } });
+    const deleteChain = chainMock({ error: new Error('Delete failed') });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) return existingChain.chain;
+      return deleteChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to process vote');
+    expect(mockLogger).toHaveBeenCalled();
+  });
+
+  it('500 on error fetching vote count', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: VOTER_FID }));
+
+    const existingChain = chainMock({ data: null });
+    const insertChain = chainMock({ data: {} });
+    const countChain = chainMock({ error: new Error('Count query failed') });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) return existingChain.chain;
+      if (callCount === 2) return insertChain.chain;
+      return countChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to process vote');
+    expect(mockLogger).toHaveBeenCalled();
+  });
+
+  it('uses voter FID from session', async () => {
+    const customFid = 999;
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: customFid }));
+
+    const existingChain = chainMock({ data: null });
+    const insertChain = chainMock({ data: {} });
+    const countChain = chainMock({ data: null, count: 1 });
+
+    const eqCalls: Array<[string, unknown]> = [];
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        existingChain.chain.eq = vi.fn((field: string, value: unknown) => {
+          eqCalls.push([field, value]);
+          return existingChain.chain;
+        });
+        return existingChain.chain;
+      }
+      if (callCount === 2) return insertChain.chain;
+      return countChain.chain;
+    });
+
+    const req = makePostRequest('/api/music/submissions/vote', { submissionId: SUBMISSION_ID });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    // Verify that voter_fid was passed to eq() in the first check
+    const voterFidCall = eqCalls.find(([field]) => field === 'voter_fid');
+    expect(voterFidCall).toBeDefined();
+    expect(voterFidCall?.[1]).toBe(customFid);
+  });
+});

--- a/src/app/api/music/track-of-day/vote/__tests__/route.test.ts
+++ b/src/app/api/music/track-of-day/vote/__tests__/route.test.ts
@@ -1,0 +1,529 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// ── Route import ─────────────────────────────────────────────────────────────
+import { POST } from '@/app/api/music/track-of-day/vote/route';
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/music/track-of-day/vote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Auth guard ───────────────────────────────────────────────────────────
+
+  describe('Authentication', () => {
+    it('returns 401 when no session', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  // ── Input validation ─────────────────────────────────────────────────────
+
+  describe('Input validation (Zod)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 with details when trackId is missing', async () => {
+      const req = makePostRequest('/api/music/track-of-day/vote', {});
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 with details when trackId is not a UUID', async () => {
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: 'not-a-uuid' });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 with details when trackId is an empty string', async () => {
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: '' });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+  });
+
+  // ── Track lookup errors ──────────────────────────────────────────────────
+
+  describe('Track lookup', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 404 when track does not exist', async () => {
+      const trackLookup = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(trackLookup.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Nomination not found');
+    });
+
+    it('throws on Supabase error during track lookup', async () => {
+      const trackLookup = chainMock({ data: null, error: new Error('Database error') });
+      mockFrom.mockReturnValue(trackLookup.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process vote');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('returns 400 when track has already been selected', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: '2026-07-15' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(trackLookup.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Cannot vote on an already-selected track');
+    });
+  });
+
+  // ── Vote toggle: add vote (success path) ──────────────────────────────────
+
+  describe('Vote toggle: add vote (success)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('adds a vote when no existing vote and returns voted=true', async () => {
+      // Chain 1: track lookup
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+
+      // Chain 2: existing vote check
+      const checkVote = chainMock({ data: null, error: null });
+
+      // Chain 3: insert vote
+      const insertVote = chainMock({ error: null });
+
+      // Chain 4: get vote count
+      const countVotes = chainMock({ data: [], count: 5, error: null });
+
+      // Chain 5: update denormalized count (no result expected)
+      const updateCount = chainMock({ error: null });
+
+      // Queue chains in FIFO order
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.voted).toBe(true);
+      expect(body.voteCount).toBe(5);
+    });
+
+    it('inserts vote with correct track_id and voter_fid', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 1, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      await POST(req);
+
+      // Verify insert was called with correct data
+      expect(insertVote.chain.insert).toHaveBeenCalledWith({
+        track_id: VALID_UUID,
+        voter_fid: 123,
+      });
+    });
+
+    it('throws on Supabase error during insert', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: new Error('Insert failed') });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process vote');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  // ── Vote toggle: remove vote (success path) ──────────────────────────────
+
+  describe('Vote toggle: remove vote (success)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('removes a vote when existing vote and returns voted=false', async () => {
+      // Chain 1: track lookup
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+
+      // Chain 2: existing vote check
+      const checkVote = chainMock({
+        data: { id: 'vote-id-456' },
+        error: null,
+      });
+
+      // Chain 3: delete vote
+      const deleteVote = chainMock({ error: null });
+
+      // Chain 4: get vote count
+      const countVotes = chainMock({ data: [], count: 3, error: null });
+
+      // Chain 5: update denormalized count
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(deleteVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.voted).toBe(false);
+      expect(body.voteCount).toBe(3);
+    });
+
+    it('deletes vote with correct vote id', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({
+        data: { id: 'vote-id-456' },
+        error: null,
+      });
+      const deleteVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 0, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(deleteVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      await POST(req);
+
+      // Verify delete was called with correct vote id
+      expect(deleteVote.chain.eq).toHaveBeenCalledWith('id', 'vote-id-456');
+    });
+
+    it('throws on Supabase error during delete', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({
+        data: { id: 'vote-id-456' },
+        error: null,
+      });
+      const deleteVote = chainMock({ error: new Error('Delete failed') });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(deleteVote.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process vote');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  // ── Vote count errors ────────────────────────────────────────────────────
+
+  describe('Vote count retrieval', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('throws on Supabase error during vote count', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ error: new Error('Count failed') });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process vote');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('handles null count gracefully (defaults to 0)', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: null, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.voteCount).toBe(0);
+    });
+  });
+
+  // ── Denormalized count update ────────────────────────────────────────────
+
+  describe('Denormalized vote count sync', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('updates votes_count on track_of_the_day after vote add', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 42, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      await POST(req);
+
+      // Verify update was called with correct count
+      expect(updateCount.chain.update).toHaveBeenCalledWith({ votes_count: 42 });
+      expect(updateCount.chain.eq).toHaveBeenCalledWith('id', VALID_UUID);
+    });
+
+    it('does not fail if denormalized count update returns error', async () => {
+      // Note: the route does NOT check for updateError, so errors here are swallowed.
+      // This test verifies that behavior.
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 1, error: null });
+      const updateCount = chainMock({ error: new Error('Update failed') });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      // Route succeeds anyway (no error check on updateError)
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.voted).toBe(true);
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    });
+
+    it('handles check existing vote error', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: new Error('Check failed') });
+
+      mockFrom.mockReturnValueOnce(trackLookup.chain).mockReturnValueOnce(checkVote.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process vote');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('correctly uses voter FID from session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 777 }));
+
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 1, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      await POST(req);
+
+      // Verify second eq call for voter_fid check
+      const checkVoteEqCalls = checkVote.chain.eq.mock.calls;
+      expect(checkVoteEqCalls).toContainEqual(['voter_fid', 777]);
+    });
+
+    it('responds with correct JSON shape', async () => {
+      const trackLookup = chainMock({
+        data: { id: VALID_UUID, selected_date: null },
+        error: null,
+      });
+      const checkVote = chainMock({ data: null, error: null });
+      const insertVote = chainMock({ error: null });
+      const countVotes = chainMock({ data: [], count: 10, error: null });
+      const updateCount = chainMock({ error: null });
+
+      mockFrom
+        .mockReturnValueOnce(trackLookup.chain)
+        .mockReturnValueOnce(checkVote.chain)
+        .mockReturnValueOnce(insertVote.chain)
+        .mockReturnValueOnce(countVotes.chain)
+        .mockReturnValueOnce(updateCount.chain);
+
+      const req = makePostRequest('/api/music/track-of-day/vote', { trackId: VALID_UUID });
+      const res = await POST(req);
+
+      const body = await res.json();
+      expect(body).toHaveProperty('voted');
+      expect(body).toHaveProperty('voteCount');
+      expect(typeof body.voted).toBe('boolean');
+      expect(typeof body.voteCount).toBe('number');
+    });
+  });
+});


### PR DESCRIPTION
## What

Route tests for **4 untested `music/*` action routes** (task **#591**), authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **86 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `music/listening-party` | GET, POST | 36 |
| `music/submissions/vote` | POST | 11 |
| `music/collect` | POST | 19 |
| `music/track-of-day/vote` | POST | 20 |

Covers auth guards, Zod validation, toggle-vote add/remove with denormalized count sync, collect dedup + count increment, listening-party scheduling. **Module mocks only.**

## Verification
- `vitest run` (all 4) → **86/86 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
