### PR TITLE
test(music): collaborative-playlist routes ([id], vote, join, tracks) (task #591)

### DIFF
--- a/src/app/api/music/playlists/collaborative/[id]/__tests__/route.test.ts
+++ b/src/app/api/music/playlists/collaborative/[id]/__tests__/route.test.ts
@@ -1,0 +1,486 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET, PATCH } from '../route';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+const ctx: RouteContext = { params: Promise.resolve({ id: VALID_UUID }) };
+
+const OWNER_FID = 123;
+const OTHER_FID = 999;
+
+const PLAYLIST = {
+  id: VALID_UUID,
+  name: 'ZAO Vibes',
+  description: 'Collaborative playlist',
+  created_by_fid: OWNER_FID,
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const TRACK_1 = {
+  id: 'track-1',
+  playlist_id: VALID_UUID,
+  votes: 5,
+  position: 1,
+};
+
+const TRACK_2 = {
+  id: 'track-2',
+  playlist_id: VALID_UUID,
+  votes: 3,
+  position: 2,
+};
+
+const MEMBER_1 = {
+  id: 'member-1',
+  playlist_id: VALID_UUID,
+  fid: OWNER_FID,
+};
+
+const MEMBER_2 = {
+  id: 'member-2',
+  playlist_id: VALID_UUID,
+  fid: OTHER_FID,
+};
+
+const USER_VOTE_1 = {
+  playlist_track_id: 'track-1',
+  vote: 1,
+};
+
+const USER_VOTE_2 = {
+  playlist_track_id: 'track-2',
+  vote: -1,
+};
+
+describe('GET /api/music/playlists/collaborative/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('fetches playlist, tracks, members, and user votes successfully', async () => {
+    const playlistMock = chainMock({ data: PLAYLIST, error: null });
+    const tracksMock = chainMock({ data: [TRACK_1, TRACK_2], error: null });
+    const membersMock = chainMock({ data: [MEMBER_1, MEMBER_2], error: null });
+    const votesMock = chainMock({ data: [USER_VOTE_1, USER_VOTE_2], error: null });
+
+    // Set up mockFrom to return different chains for each table
+    mockFrom
+      .mockReturnValueOnce(playlistMock.chain)
+      .mockReturnValueOnce(tracksMock.chain)
+      .mockReturnValueOnce(membersMock.chain)
+      .mockReturnValueOnce(votesMock.chain);
+
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.playlist).toEqual(PLAYLIST);
+    expect(body.members).toEqual([MEMBER_1, MEMBER_2]);
+    expect(body.tracks).toHaveLength(2);
+    expect(body.tracks[0]).toEqual({ ...TRACK_1, user_vote: 1 });
+    expect(body.tracks[1]).toEqual({ ...TRACK_2, user_vote: -1 });
+  });
+
+  it('returns 404 when playlist query has an error', async () => {
+    const playlistChain: Record<string, ReturnType<typeof vi.fn>> = {};
+    const chainable = [
+      'select',
+      'eq',
+      'order',
+      'limit',
+      'single',
+      'insert',
+      'update',
+      'delete',
+      'neq',
+      'in',
+      'not',
+      'is',
+      'gt',
+      'gte',
+      'lt',
+      'lte',
+      'like',
+      'ilike',
+      'range',
+      'upsert',
+      'maybeSingle',
+    ];
+    for (const method of chainable) {
+      playlistChain[method] = vi.fn().mockReturnValue(playlistChain);
+    }
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable
+    playlistChain.then = vi.fn((resolve: (val: unknown) => void) =>
+      resolve({ data: null, error: 'Not found' }),
+    );
+    playlistChain.single = vi.fn().mockResolvedValue({ data: null, error: 'Not found' });
+
+    const tracksMock = chainMock({ data: [], error: null });
+    const membersMock = chainMock({ data: [], error: null });
+    const votesMock = chainMock({ data: [], error: null });
+
+    mockFrom
+      .mockReturnValueOnce(playlistChain)
+      .mockReturnValueOnce(tracksMock.chain)
+      .mockReturnValueOnce(membersMock.chain)
+      .mockReturnValueOnce(votesMock.chain);
+
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe('Playlist not found');
+  });
+
+  it('handles missing tracks gracefully', async () => {
+    const playlistMock = chainMock({ data: PLAYLIST, error: null });
+    const tracksMock = chainMock({ data: null, error: null });
+    const membersMock = chainMock({ data: [MEMBER_1], error: null });
+    const votesMock = chainMock({ data: [], error: null });
+
+    mockFrom
+      .mockReturnValueOnce(playlistMock.chain)
+      .mockReturnValueOnce(tracksMock.chain)
+      .mockReturnValueOnce(membersMock.chain)
+      .mockReturnValueOnce(votesMock.chain);
+
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.tracks).toEqual([]);
+    expect(body.members).toEqual([MEMBER_1]);
+  });
+
+  it('filters user votes to only include tracks in the playlist', async () => {
+    const tracksWithOneTrack = [TRACK_1];
+    const allVotes = [
+      USER_VOTE_1,
+      USER_VOTE_2,
+      { playlist_track_id: 'track-999', vote: 1 }, // Vote for a track not in this playlist
+    ];
+
+    const playlistMock = chainMock({ data: PLAYLIST, error: null });
+    const tracksMock = chainMock({ data: tracksWithOneTrack, error: null });
+    const membersMock = chainMock({ data: [MEMBER_1], error: null });
+    const votesMock = chainMock({ data: allVotes, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(playlistMock.chain)
+      .mockReturnValueOnce(tracksMock.chain)
+      .mockReturnValueOnce(membersMock.chain)
+      .mockReturnValueOnce(votesMock.chain);
+
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // Only track-1 should have user_vote set
+    expect(body.tracks[0].user_vote).toBe(1);
+    expect(allVotes).toHaveLength(3); // Verify we had 3 votes in the raw data
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Database connection failed');
+    });
+
+    const res = await GET(makeRequest('/x'), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to fetch playlist');
+  });
+});
+
+describe('PATCH /api/music/playlists/collaborative/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: OWNER_FID }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 on invalid input', async () => {
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: '' }), // Empty string violates min(1)
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when description exceeds max length', async () => {
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ description: 'x'.repeat(501) }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 403 when user is not the owner', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: OTHER_FID }));
+
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    mockFrom.mockReturnValueOnce(checkMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Hijacked' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Only the owner can update this playlist');
+  });
+
+  it('returns 403 when playlist not found', async () => {
+    const checkMock = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(checkMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Only the owner can update this playlist');
+  });
+
+  it('updates name successfully', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const updateMock = chainMock({
+      data: { ...PLAYLIST, name: 'Updated Name', updated_at: '2026-01-02T00:00:00Z' },
+      error: null,
+    });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(updateMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Updated Name' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.playlist.name).toBe('Updated Name');
+  });
+
+  it('updates description successfully', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const updateMock = chainMock({
+      data: { ...PLAYLIST, description: 'Updated description', updated_at: '2026-01-02T00:00:00Z' },
+      error: null,
+    });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(updateMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ description: 'Updated description' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.playlist.description).toBe('Updated description');
+  });
+
+  it('updates both name and description together', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const updateMock = chainMock({
+      data: {
+        ...PLAYLIST,
+        name: 'New Name',
+        description: 'New desc',
+        updated_at: '2026-01-02T00:00:00Z',
+      },
+      error: null,
+    });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(updateMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'New Name', description: 'New desc' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.playlist.name).toBe('New Name');
+    expect(body.playlist.description).toBe('New desc');
+  });
+
+  it('returns 500 on update error', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const updateMock = chainMock({
+      data: null,
+      error: 'Database error',
+    });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(updateMock.chain);
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to update playlist');
+  });
+
+  it('returns 500 on unexpected error during check', async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error('Connection failed');
+    });
+
+    const req = makeRequest('/x', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'New Name' }),
+    });
+    const res = await PATCH(req, ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to update playlist');
+  });
+});
+
+describe('DELETE /api/music/playlists/collaborative/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: OWNER_FID }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when user is not the owner', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: OTHER_FID }));
+
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    mockFrom.mockReturnValueOnce(checkMock.chain);
+
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Only the owner can delete this playlist');
+  });
+
+  it('returns 403 when playlist not found', async () => {
+    const checkMock = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(checkMock.chain);
+
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('Only the owner can delete this playlist');
+  });
+
+  it('deletes playlist successfully', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const deleteMock = chainMock({ data: null, error: null });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(deleteMock.chain);
+
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 500 on delete error', async () => {
+    const checkMock = chainMock({ data: PLAYLIST, error: null });
+    const deleteMock = chainMock({ data: null, error: 'Database error' });
+
+    mockFrom.mockReturnValueOnce(checkMock.chain).mockReturnValueOnce(deleteMock.chain);
+
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to delete playlist');
+  });
+
+  it('returns 500 on unexpected error during check', async () => {
+    mockFrom.mockImplementationOnce(() => {
+      throw new Error('Connection failed');
+    });
+
+    const res = await DELETE(makeRequest('/x', { method: 'DELETE' }), ctx);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('Failed to delete playlist');
+  });
+});

--- a/src/app/api/music/playlists/collaborative/[id]/join/__tests__/route.test.ts
+++ b/src/app/api/music/playlists/collaborative/[id]/join/__tests__/route.test.ts
@@ -1,0 +1,481 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Route import ─────────────────────────────────────────────────────────────
+import { POST } from '@/app/api/music/playlists/collaborative/[id]/join/route';
+
+// ── Test constants ───────────────────────────────────────────────────────────
+const PLAYLIST_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a Supabase chain mock that resolves to `result`.
+ * Note: intentionally uses thenable pattern for mock.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods
+  const chainable = ['select', 'eq', 'from', 'upsert', 'order', 'limit', 'single', 'maybeSingle'];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal — .single() resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable for mock
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Build a mock authenticated session.
+ */
+function mockSession(overrides?: { fid?: number; username?: string }) {
+  return {
+    fid: overrides?.fid ?? 123,
+    username: overrides?.username ?? 'testuser',
+    displayName: 'Test User',
+    isAdmin: false,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/music/playlists/collaborative/[id]/join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Authentication tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 if session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Validation & Playlist existence tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 404 if playlist does not exist', async () => {
+    const session = mockSession();
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock playlist query returning null
+    const playlistChain = chainMock({ data: null });
+    mockFrom.mockReturnValue(playlistChain);
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Playlist not found');
+  });
+
+  it('returns 403 if playlist is not collaborative', async () => {
+    const session = mockSession();
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock playlist query returning non-collaborative playlist
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: false,
+      },
+    });
+    mockFrom.mockReturnValue(playlistChain);
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('This playlist is not collaborative');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Join operation tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('successfully joins an existing collaborative playlist (first join)', async () => {
+    const session = mockSession({ fid: 456 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock playlist query
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    // Mock membership upsert
+    const membershipChain = chainMock({ error: null });
+
+    // Set up mocks to return different chains for different .from() calls
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        // First .from('playlists')
+        return playlistChain;
+      }
+      // Second .from('playlist_members')
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.role).toBe('contributor');
+  });
+
+  it('successfully joins via upsert (idempotent when already a member)', async () => {
+    const session = mockSession({ fid: 789 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock playlist query
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    // Mock upsert (idempotent — no error even if row exists)
+    const membershipChain = chainMock({ error: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.role).toBe('contributor');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Error handling tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 if upsert fails with a database error', async () => {
+    const session = mockSession({ fid: 101 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock successful playlist query
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    // Mock membership upsert with error
+    const membershipChain = chainMock({
+      error: new Error('Unique constraint violation'),
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to join playlist');
+  });
+
+  it('returns 500 if playlist query throws an error', async () => {
+    const session = mockSession({ fid: 102 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    // Mock playlist query throwing an error
+    const playlistChain = chainMock({
+      data: null,
+      error: new Error('Network error'),
+    });
+
+    // Make .single() throw
+    playlistChain.single = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    mockFrom.mockReturnValue(playlistChain);
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to join playlist');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Context params resolution tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('correctly resolves the params Promise from RouteContext', async () => {
+    const session = mockSession();
+    mockGetSessionData.mockResolvedValue(session);
+
+    const customPlaylistId = '999e9999-e89b-12d3-a456-999999999999';
+
+    const playlistChain = chainMock({
+      data: {
+        id: customPlaylistId,
+        is_collaborative: true,
+      },
+    });
+
+    const membershipChain = chainMock({ error: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        // Verify .eq was called with the resolved ID
+        expect(playlistChain.eq).toBeDefined();
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request(
+      `http://localhost:3000/api/music/playlists/collaborative/${customPlaylistId}/join`,
+      { method: 'POST' },
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: customPlaylistId }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Supabase call verification tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('calls Supabase with correct playlist query parameters', async () => {
+    const session = mockSession();
+    mockGetSessionData.mockResolvedValue(session);
+
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    const membershipChain = chainMock({ error: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      if (callCount === 0) {
+        callCount++;
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    // Verify Supabase was called correctly
+    expect(mockFrom).toHaveBeenCalledWith('playlists');
+    expect(playlistChain.select).toHaveBeenCalledWith('id, is_collaborative');
+    expect(playlistChain.eq).toHaveBeenCalledWith('id', PLAYLIST_ID);
+    expect(res.status).toBe(200);
+  });
+
+  it('calls Supabase upsert with correct membership parameters', async () => {
+    const session = mockSession({ fid: 555 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    const membershipChain = chainMock({ error: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      if (callCount === 0) {
+        callCount++;
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    // Verify upsert was called with correct parameters
+    expect(membershipChain.upsert).toHaveBeenCalledWith(
+      { playlist_id: PLAYLIST_ID, fid: 555, role: 'contributor' },
+      { onConflict: 'playlist_id,fid' },
+    );
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Response shape tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns correct success response shape', async () => {
+    const session = mockSession();
+    mockGetSessionData.mockResolvedValue(session);
+
+    const playlistChain = chainMock({
+      data: {
+        id: PLAYLIST_ID,
+        is_collaborative: true,
+      },
+    });
+
+    const membershipChain = chainMock({ error: null });
+
+    let callCount = 0;
+    mockFrom.mockImplementation((_table: string) => {
+      callCount++;
+      if (callCount === 1) {
+        return playlistChain;
+      }
+      return membershipChain;
+    });
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      role: 'contributor',
+    });
+  });
+
+  it('returns error response for 404 with correct shape', async () => {
+    mockGetSessionData.mockResolvedValue(mockSession());
+
+    const playlistChain = chainMock({ data: null });
+    mockFrom.mockReturnValue(playlistChain);
+
+    const req = new Request('http://localhost:3000/api/music/playlists/collaborative/123/join', {
+      method: 'POST',
+    });
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: PLAYLIST_ID }),
+    });
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Playlist not found' });
+    expect(body.success).toBeUndefined();
+  });
+});

--- a/src/app/api/music/playlists/collaborative/[id]/tracks/__tests__/route.test.ts
+++ b/src/app/api/music/playlists/collaborative/[id]/tracks/__tests__/route.test.ts
@@ -1,0 +1,653 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, mockAuthenticatedSession, VALID_UUID } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// ── Route imports ────────────────────────────────────────────────────────────
+import { DELETE, POST } from '@/app/api/music/playlists/collaborative/[id]/tracks/route';
+
+// ── Test constants ───────────────────────────────────────────────────────────
+const playlistId = VALID_UUID;
+const trackId = VALID_UUID;
+const addedTrackId = '660f9400-e29b-41d4-a716-446655440001';
+const fid = 123;
+const otherFid = 456;
+
+// ── Helper: create RouteContext ──────────────────────────────────────────────
+function makeRouteContext(id: string = playlistId) {
+  return {
+    params: Promise.resolve({ id }),
+  };
+}
+
+// ── Helper: create POST request ──────────────────────────────────────────────
+function makeTrackAddRequest(body: Record<string, unknown>) {
+  return new NextRequest(
+    new URL('/api/music/playlists/collaborative/test/tracks', 'http://localhost:3000'),
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+    },
+  );
+}
+
+// ── Helper: create DELETE request ────────────────────────────────────────────
+function makeTrackDeleteRequest(body: Record<string, unknown>) {
+  return new NextRequest(
+    new URL('/api/music/playlists/collaborative/test/tracks', 'http://localhost:3000'),
+    {
+      method: 'DELETE',
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+      },
+    },
+  );
+}
+
+describe('POST /api/music/playlists/collaborative/[id]/tracks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('returns 400 when song_url is missing', async () => {
+      const req = makeTrackAddRequest({
+        song_title: 'Test Track',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when song_url is not a valid URL', async () => {
+      const req = makeTrackAddRequest({
+        song_url: 'not-a-url',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when song_url exceeds max length (500)', async () => {
+      const req = makeTrackAddRequest({
+        song_url: `https://example.com/${'x'.repeat(500)}`,
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when song_title exceeds max length (200)', async () => {
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+        song_title: 'x'.repeat(201),
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid input without optional fields', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 0 } });
+      const insertChain = chainMock({ data: { id: addedTrackId, position: 1 } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.track).toBeDefined();
+    });
+  });
+
+  describe('authorization', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('returns 403 when user is not a playlist member', async () => {
+      const memberChain = chainMock({ data: null });
+      mockFrom.mockReturnValue(memberChain.chain);
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('You must be a contributor to add tracks');
+    });
+
+    it('returns 403 when user is a viewer (read-only member)', async () => {
+      const memberChain = chainMock({ data: { role: 'viewer' } });
+      mockFrom.mockReturnValue(memberChain.chain);
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('You must be a contributor to add tracks');
+    });
+
+    it('allows request when user is a contributor', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 5 } });
+      const insertChain = chainMock({ data: { id: addedTrackId, position: 6 } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/123',
+        song_title: 'Test Track',
+        song_artist: 'Test Artist',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+    });
+
+    it('allows request when user is an editor', async () => {
+      const memberChain = chainMock({ data: { role: 'editor' } });
+      const lastTrackChain = chainMock({ data: { position: 2 } });
+      const insertChain = chainMock({ data: { id: addedTrackId, position: 3 } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/789',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('track insertion', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('successfully adds a track with minimal fields', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 10 } });
+      const insertChain = chainMock({ data: { id: addedTrackId, position: 11 } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/abc123',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.track).toBeDefined();
+      expect(body.track.id).toBe(addedTrackId);
+      expect(body.track.position).toBe(11);
+    });
+
+    it('successfully adds a track with all fields', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 0 } });
+      const insertChain = chainMock({
+        data: {
+          id: addedTrackId,
+          position: 1,
+          song_url: 'https://open.spotify.com/track/xyz',
+          song_title: 'Full Details Track',
+          song_artist: 'Artist Name',
+          song_artwork_url: 'https://example.com/artwork.jpg',
+          song_platform: 'spotify',
+          song_stream_url: 'https://open.spotify.com/track/xyz',
+          added_by_fid: fid,
+        },
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/xyz',
+        song_title: 'Full Details Track',
+        song_artist: 'Artist Name',
+        song_artwork_url: 'https://example.com/artwork.jpg',
+        song_platform: 'spotify',
+        song_stream_url: 'https://open.spotify.com/track/xyz',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.track.song_title).toBe('Full Details Track');
+      expect(body.track.song_artist).toBe('Artist Name');
+    });
+
+    it('correctly calculates next position when no tracks exist', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: null });
+      const insertChain = chainMock({ data: { id: addedTrackId, position: 0 } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/first',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.track.position).toBe(0);
+    });
+
+    it('returns 409 on duplicate track constraint violation', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 5 } });
+      const insertChain = chainMock({
+        error: { code: '23505', message: 'duplicate key' },
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/duplicate',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('Track already in playlist');
+    });
+
+    it('returns 500 on database error', async () => {
+      const memberChain = chainMock({ data: { role: 'contributor' } });
+      const lastTrackChain = chainMock({ data: { position: 3 } });
+      const insertChain = chainMock({
+        error: { code: '42P01', message: 'table does not exist' },
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [memberChain.chain, lastTrackChain.chain, insertChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackAddRequest({
+        song_url: 'https://open.spotify.com/track/error',
+      });
+
+      const res = await POST(req, makeRouteContext());
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to add track');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('DELETE /api/music/playlists/collaborative/[id]/tracks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('returns 400 when track_id is missing', async () => {
+      const req = makeTrackDeleteRequest({});
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when track_id is not a valid UUID', async () => {
+      const req = makeTrackDeleteRequest({
+        track_id: 'not-a-uuid',
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('authorization', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('returns 404 when track does not exist', async () => {
+      const trackChain = chainMock({ data: null });
+      const playlistChain = chainMock({ data: { created_by_fid: otherFid } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Track not found');
+    });
+
+    it('returns 403 when user is neither owner nor adder', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: otherFid } });
+      const playlistChain = chainMock({ data: { created_by_fid: otherFid } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe(
+        'Only the playlist owner or the person who added the track can remove it',
+      );
+    });
+
+    it('allows deletion when user is the track adder', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: fid } });
+      const playlistChain = chainMock({ data: { created_by_fid: otherFid } });
+      const deleteChain = chainMock({ error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('allows deletion when user is the playlist owner', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: otherFid } });
+      const playlistChain = chainMock({ data: { created_by_fid: fid } });
+      const deleteChain = chainMock({ error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('track deletion', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('successfully deletes a track when user is the adder', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: fid } });
+      const playlistChain = chainMock({ data: { created_by_fid: otherFid } });
+      const deleteChain = chainMock({ error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('successfully deletes a track when user is the owner', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: otherFid } });
+      const playlistChain = chainMock({ data: { created_by_fid: fid } });
+      const deleteChain = chainMock({ error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('returns 500 on database error during deletion', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: fid } });
+      const playlistChain = chainMock({ data: { created_by_fid: otherFid } });
+      const deleteChain = chainMock({
+        error: { code: '42P01', message: 'table does not exist' },
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to remove track');
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('parallel queries with Promise.allSettled', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+    });
+
+    it('handles track query rejection gracefully', async () => {
+      const trackChain = chainMock({ data: null });
+      const playlistChain = chainMock({ data: { created_by_fid: fid } });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Track not found');
+    });
+
+    it('proceeds with deletion authorization when playlist query fails', async () => {
+      const trackChain = chainMock({ data: { added_by_fid: fid } });
+      const playlistChain = chainMock({ data: null });
+      const deleteChain = chainMock({ error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [trackChain.chain, playlistChain.chain, deleteChain.chain];
+        const chain = chains[callCount++];
+        return chain;
+      });
+
+      const req = makeTrackDeleteRequest({
+        track_id: trackId,
+      });
+
+      const res = await DELETE(req, makeRouteContext());
+      // User is the adder, so should be allowed even if playlist query fails
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+  });
+});

--- a/src/app/api/music/playlists/collaborative/[id]/vote/__tests__/route.test.ts
+++ b/src/app/api/music/playlists/collaborative/[id]/vote/__tests__/route.test.ts
@@ -1,0 +1,466 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+const playlistId = 'playlist-1';
+const trackId = VALID_UUID;
+const userId = 123;
+
+const ctx = { params: Promise.resolve({ id: playlistId }) };
+
+describe('POST /api/music/playlists/collaborative/[id]/vote', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('proceeds when authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      mockFrom.mockReturnValue(trackChain.chain);
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('returns 400 when trackId is not a UUID', async () => {
+      const res = await POST(makePostRequest('/x', { trackId: 'not-a-uuid', vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when vote is not 1 or -1', async () => {
+      const res = await POST(makePostRequest('/x', { trackId, vote: 0 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when vote is missing', async () => {
+      const res = await POST(makePostRequest('/x', { trackId }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 500 when body is invalid JSON (falls through to catch)', async () => {
+      const req = new (require('next/server').NextRequest)(new URL('http://localhost:3000/x'), {
+        method: 'POST',
+        body: '{bad json',
+      });
+      const res = await POST(req, ctx);
+      const body = await res.json();
+
+      // Invalid JSON throws in req.json(), which is caught and returns 500
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to vote');
+    });
+  });
+
+  describe('track lookup', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('returns 404 when track not found in playlist', async () => {
+      const trackChain = chainMock({ data: null, error: null });
+      mockFrom.mockReturnValue(trackChain.chain);
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toBe('Track not found in this playlist');
+    });
+
+    it('queries playlist_tracks with trackId and playlist_id', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+      const finalChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return updateChain.chain;
+        return finalChain.chain;
+      });
+
+      await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+
+      expect(mockFrom).toHaveBeenCalledWith('playlist_tracks');
+      expect(trackChain.chain.select).toHaveBeenCalledWith('id, votes');
+      expect(trackChain.chain.eq).toHaveBeenCalledWith('id', trackId);
+      expect(trackChain.chain.eq).toHaveBeenCalledWith('playlist_id', playlistId);
+    });
+  });
+
+  describe('new vote (no existing vote)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('inserts a new vote with upvote', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(11); // 10 + 1
+      expect(body.user_vote).toBe(1);
+      expect(insertChain.chain.insert).toHaveBeenCalledWith({
+        playlist_track_id: trackId,
+        fid: userId,
+        vote: 1,
+      });
+    });
+
+    it('inserts a new vote with downvote', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: -1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(9); // 10 - 1
+      expect(body.user_vote).toBe(-1);
+    });
+
+    it('updates track votes after new vote', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 5 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ votes: 6 });
+      expect(updateChain.chain.eq).toHaveBeenCalledWith('id', trackId);
+    });
+  });
+
+  describe('existing vote - same vote (toggle off)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('deletes existing upvote when voting again on +1', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: { id: 'vote-1', vote: 1 }, error: null });
+      const deleteChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return deleteChain.chain;
+        return updateChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(9); // 10 - 1 (voteDelta = -1)
+      expect(body.user_vote).toBe(0); // Removed
+      expect(deleteChain.chain.delete).toHaveBeenCalled();
+      expect(deleteChain.chain.eq).toHaveBeenCalledWith('id', 'vote-1');
+    });
+
+    it('deletes existing downvote when voting again on -1', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 5 }, error: null });
+      const voteChain = chainMock({ data: { id: 'vote-1', vote: -1 }, error: null });
+      const deleteChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return deleteChain.chain;
+        return updateChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: -1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(6); // 5 + 1 (voteDelta = 1)
+      expect(body.user_vote).toBe(0);
+    });
+  });
+
+  describe('existing vote - different vote (flip)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('flips from upvote to downvote (swing -2)', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: { id: 'vote-1', vote: 1 }, error: null });
+      const updateVoteChain = chainMock({ data: {}, error: null });
+      const updateTrackChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return updateVoteChain.chain;
+        return updateTrackChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: -1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(8); // 10 - 2
+      expect(body.user_vote).toBe(-1);
+      expect(updateVoteChain.chain.update).toHaveBeenCalledWith({ vote: -1 });
+      expect(updateVoteChain.chain.eq).toHaveBeenCalledWith('id', 'vote-1');
+    });
+
+    it('flips from downvote to upvote (swing +2)', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 5 }, error: null });
+      const voteChain = chainMock({ data: { id: 'vote-1', vote: -1 }, error: null });
+      const updateVoteChain = chainMock({ data: {}, error: null });
+      const updateTrackChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return updateVoteChain.chain;
+        return updateTrackChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(7); // 5 + 2
+      expect(body.user_vote).toBe(1);
+    });
+  });
+
+  describe('track votes (null edge case)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('treats null votes as 0 when adding new vote', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: null }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.votes).toBe(1); // (null || 0) + 1
+      expect(updateChain.chain.update).toHaveBeenCalledWith({ votes: 1 });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('returns 500 when track query throws', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('DB error');
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to vote');
+    });
+
+    it('returns 500 when vote insert throws', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        throw new Error('Insert failed');
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to vote');
+    });
+
+    it('catches errors from any operation and returns 500', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        // Throw on second call (playlist_votes query)
+        throw new Error('Boom');
+      });
+
+      const res = await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to vote');
+    });
+  });
+
+  describe('supabase chain construction', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: userId }));
+    });
+
+    it('builds correct chain for playlist_votes query', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+
+      expect(mockFrom).toHaveBeenCalledWith('playlist_votes');
+      expect(voteChain.chain.select).toHaveBeenCalledWith('id, vote');
+      expect(voteChain.chain.eq).toHaveBeenCalledWith('playlist_track_id', trackId);
+      expect(voteChain.chain.eq).toHaveBeenCalledWith('fid', userId);
+    });
+
+    it('queries playlist_tracks with select and filters', async () => {
+      const trackChain = chainMock({ data: { id: trackId, votes: 10 }, error: null });
+      const voteChain = chainMock({ data: null, error: null });
+      const insertChain = chainMock({ data: {}, error: null });
+      const updateChain = chainMock({ data: {}, error: null });
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) return trackChain.chain;
+        if (callIndex === 2) return voteChain.chain;
+        if (callIndex === 3) return insertChain.chain;
+        return updateChain.chain;
+      });
+
+      await POST(makePostRequest('/x', { trackId, vote: 1 }), ctx);
+
+      expect(mockFrom).toHaveBeenCalledWith('playlist_tracks');
+      expect(trackChain.chain.single).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What

Route tests for the **4 untested collaborative-playlist routes** (task **#591**) — a coherent dynamic-`[id]` cluster. Authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **82 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `music/playlists/collaborative/[id]` | GET, PATCH, DELETE | 22 |
| `.../[id]/vote` | POST | 21 |
| `.../[id]/join` | POST | 12 |
| `.../[id]/tracks` | POST, DELETE | 27 |

Highlights: ownership guards, toggle/flip voting with denormalized count sync, idempotent join upsert (404 missing / 403 non-collaborative), **role-based track authorization** (viewer/contributor/editor/owner) + 409 duplicate handling. Dynamic-route `RouteContext { params: Promise }` passed to every handler. **Module mocks only.**

## Verification
- `vitest run` (all 4) → **82/82 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
