### PR TITLE
feat(zoe): DM research dedupe guard (task #931)

### DIFF
--- a/bot/src/zoe/__tests__/research-dedupe.test.ts
+++ b/bot/src/zoe/__tests__/research-dedupe.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractFirstUrl, normalizeUrl, wasResearched } from '../research-dedupe';
+
+describe('research-dedupe', () => {
+  describe('extractFirstUrl', () => {
+    it('extracts a URL from text', () => {
+      expect(extractFirstUrl('research this https://example.com/page')).toBe(
+        'https://example.com/page',
+      );
+    });
+
+    it('returns null if no URL present', () => {
+      expect(extractFirstUrl('just some text without a link')).toBeNull();
+    });
+
+    it('extracts http URLs', () => {
+      expect(extractFirstUrl('check out http://example.com')).toBe('http://example.com');
+    });
+
+    it('extracts only the first URL when multiple present', () => {
+      expect(extractFirstUrl('https://first.com and https://second.com')).toBe(
+        'https://first.com',
+      );
+    });
+
+    it('stops at whitespace', () => {
+      expect(extractFirstUrl('analyze https://example.com/path some other text')).toBe(
+        'https://example.com/path',
+      );
+    });
+  });
+
+  describe('normalizeUrl', () => {
+    it('normalizes https to same as http', () => {
+      expect(normalizeUrl('https://example.com/path')).toBe('example.com/path');
+      expect(normalizeUrl('http://example.com/path')).toBe('example.com/path');
+    });
+
+    it('lowercases the host', () => {
+      expect(normalizeUrl('https://EXAMPLE.COM/path')).toBe('example.com/path');
+      expect(normalizeUrl('https://Example.Com/Path')).toBe('example.com/path');
+    });
+
+    it('strips trailing slash from path', () => {
+      expect(normalizeUrl('https://example.com/path/')).toBe('example.com/path');
+    });
+
+    it('removes query strings', () => {
+      expect(normalizeUrl('https://example.com/path?query=value&other=1')).toBe(
+        'example.com/path',
+      );
+    });
+
+    it('removes fragments', () => {
+      expect(normalizeUrl('https://example.com/path#section')).toBe('example.com/path');
+    });
+
+    it('handles all together: protocol + host case + trailing slash + query + fragment', () => {
+      expect(normalizeUrl('HTTPS://EXAMPLE.COM/path/?q=1&x=2#section')).toBe(
+        'example.com/path',
+      );
+    });
+
+    it('handles malformed URLs by doing basic cleanup', () => {
+      // If URL parsing fails, it falls back to simple string manipulation
+      const result = normalizeUrl('not-a-real-url');
+      expect(result).toBe('not-a-real-url'); // No https:// to strip, just lowercased
+    });
+
+    it('preserves path structure', () => {
+      expect(normalizeUrl('https://example.com/a/b/c')).toBe('example.com/a/b/c');
+    });
+  });
+
+  describe('wasResearched', () => {
+    it('returns false if URL not found in any doc', async () => {
+      const mockReadFile = vi.fn().mockRejectedValue(new Error('not found'));
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business', 'dev-workflows'];
+        return []; // No docs in these categories
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns true when URL is found in a README', async () => {
+      const mockReadFile = vi.fn(async (path: string) => {
+        if (path.includes('123-test')) {
+          return `---\ntopic: business\n---\n\n# Test Doc\n\nFound the URL: https://example.com/test in this doc`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business'];
+        if (path.includes('/research/business')) return ['123-test'];
+        return [];
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('normalizes URLs before comparing (protocol difference)', async () => {
+      const mockReadFile = vi.fn(async (path: string) => {
+        if (path.includes('456-test')) {
+          return `---\n---\n\nFound http://example.com/path here`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business'];
+        if (path.includes('/research/business')) return ['456-test'];
+        return [];
+      });
+
+      // Query with https, doc has http - should still match
+      const result = await wasResearched(
+        'https://example.com/path',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('normalizes URLs before comparing (trailing slash difference)', async () => {
+      const mockReadFile = vi.fn(async (path: string) => {
+        if (path.includes('789-test')) {
+          return `---\n---\n\nResearched: https://EXAMPLE.COM/path/`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['infrastructure'];
+        if (path.includes('/research/infrastructure')) return ['789-test'];
+        return [];
+      });
+
+      // Query without trailing slash, doc has it - should still match
+      const result = await wasResearched(
+        'https://example.com/path',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('normalizes URLs before comparing (query string difference)', async () => {
+      const mockReadFile = vi.fn(async (path: string) => {
+        if (path.includes('111-test')) {
+          return `---\n---\n\nhttps://example.com/page?old=param&was=here`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['dev-workflows'];
+        if (path.includes('/research/dev-workflows')) return ['111-test'];
+        return [];
+      });
+
+      // Query with different params, same path - should match
+      const result = await wasResearched(
+        'https://example.com/page?new=param',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('skips archive and meta directories (_archive, .hidden)', async () => {
+      const mockReadFile = vi.fn();
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['_archive', '.hidden', 'business'];
+        return []; // Don't have docs in real categories
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+
+      // Should have tried to list _archive and .hidden but skipped them
+      expect(mockReaddir).toHaveBeenCalledWith('/fake/research');
+      // Should not have called readFile at all since no real docs exist
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('returns false if research directory does not exist', async () => {
+      const mockReadFile = vi.fn();
+      const mockReaddir = vi.fn(async () => {
+        throw new Error('ENOENT: directory does not exist');
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/nonexistent/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('returns false if a category directory cannot be read', async () => {
+      const mockReadFile = vi.fn();
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business', 'broken-category'];
+        // broken-category fails to list
+        throw new Error('permission denied');
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('continues checking other docs if one README read fails', async () => {
+      let callCount = 0;
+      const mockReadFile = vi.fn(async (path: string) => {
+        callCount++;
+        if (path.includes('111-fail')) {
+          throw new Error('cannot read');
+        }
+        if (path.includes('222-success')) {
+          return `---\n---\n\nFound https://example.com/found`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business'];
+        if (path.includes('/research/business')) return ['111-fail', '222-success'];
+        return [];
+      });
+
+      const result = await wasResearched(
+        'https://example.com/found',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+      // Should have tried to read both, despite the first failing
+      expect(mockReadFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('checks original-query frontmatter field for URL match', async () => {
+      const mockReadFile = vi.fn(async (path: string) => {
+        if (path.includes('333-test')) {
+          return `---\noriginal-query: "https://example.com/original"\n---\n\n# Doc\n\nContent here`;
+        }
+        throw new Error('not found');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business'];
+        if (path.includes('/research/business')) return ['333-test'];
+        return [];
+      });
+
+      const result = await wasResearched(
+        'https://example.com/original',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('fails-open (returns false) on unexpected errors', async () => {
+      const mockReadFile = vi.fn(async () => {
+        throw new Error('unexpected error');
+      });
+
+      const mockReaddir = vi.fn(async (path: string) => {
+        if (path.endsWith('research')) return ['business'];
+        throw new Error('unexpected error');
+      });
+
+      const result = await wasResearched(
+        'https://example.com/test',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(false);
+    });
+
+    it('handles empty normalized URL gracefully', async () => {
+      const mockReadFile = vi.fn();
+      const mockReaddir = vi.fn();
+
+      // A URL that normalizes to empty string
+      const result = await wasResearched(
+        'http://',
+        '/fake/research',
+        mockReadFile,
+        mockReaddir,
+      );
+      expect(result).toBe(false);
+      // Should not have called readdir if URL normalized to empty
+      expect(mockReaddir).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -79,6 +79,7 @@ import {
 } from './posts';
 import { dispatchPlan } from './dispatch';
 import { commitResearchDoc } from './research-doc';
+import { extractFirstUrl, wasResearched } from './research-dedupe';
 import { enqueueTurn } from './turn-queue';
 import {
   getPending,
@@ -971,6 +972,21 @@ bot.on('message:text', async (ctx) => {
     ).catch((e) => console.error('[zoe/index] zaalbotz bridge-log failed:', (e as Error)?.message));
 
     if (action.kind === 'research') {
+      // Dedupe guard: check if this URL was already researched
+      const url = extractFirstUrl(text);
+      if (url) {
+        const researched = await wasResearched(url, join(repoDir, 'research')).catch((e) => {
+          console.error('[zoe/index] dedupe check failed (fail-open):', (e as Error)?.message);
+          return false;
+        });
+        if (researched) {
+          await ctx
+            .reply('Already researched that link — see the Research topic.')
+            .catch(() => {});
+          return;
+        }
+      }
+
       await enqueueWork(text, { chatId, threadId }).catch((e) =>
         console.error('[zoe/index] research enqueue failed:', (e as Error)?.message),
       );

--- a/bot/src/zoe/research-dedupe.ts
+++ b/bot/src/zoe/research-dedupe.ts
@@ -1,0 +1,124 @@
+/**
+ * research-dedupe.ts — URL deduplication for research dispatch.
+ *
+ * Before enqueueing a research task, extract the URL and check if that link
+ * has already been researched. If found in any research doc, return true;
+ * if not found or on any IO error, return false (fail-open).
+ *
+ * Pure functions with injected fs for testability.
+ */
+
+/**
+ * Extract the first URL from text. Returns null if no URL found.
+ * Matches http:// or https://, stopping at whitespace.
+ */
+export function extractFirstUrl(text: string): string | null {
+  const match = /https?:\/\/\S+/.exec(text);
+  return match ? match[0] : null;
+}
+
+/**
+ * Normalize a URL for robust matching: lowercase host, strip protocol,
+ * trailing slash, query, and fragment.
+ *
+ * E.g. "https://example.com/path?q=1#section" -> "example.com/path"
+ *      "http://EXAMPLE.COM/path/" -> "example.com/path"
+ */
+export function normalizeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname?.toLowerCase() || '';
+    const path = parsed.pathname.toLowerCase().replace(/\/$/, ''); // strip trailing /, lowercase
+    return host + path;
+  } catch {
+    // If URL parsing fails, do basic cleanup: lowercase and remove protocol
+    return url.toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '');
+  }
+}
+
+/**
+ * Check if a URL has been researched by scanning research docs for README.md files.
+ * Normalizes both the target URL and any URLs found in the docs for robust matching.
+ *
+ * @param url - The URL to check
+ * @param researchDir - The root directory containing research/<category>/<num>-<slug>/README.md files
+ * @param readFileImpl - Optional fs.readFile override for testing (default: node:fs/promises)
+ * @param readdirImpl - Optional fs.readdir override for testing (default: node:fs/promises)
+ * @returns Promise<true> if URL found in any research doc, false otherwise (including on any error)
+ */
+export async function wasResearched(
+  url: string,
+  researchDir: string,
+  readFileImpl?: (path: string, encoding: string) => Promise<string>,
+  readdirImpl?: (path: string) => Promise<string[]>,
+): Promise<boolean> {
+  try {
+    const normalized = normalizeUrl(url);
+    if (!normalized) return false; // Empty normalized URL can't match
+
+    // Use injected or default fs functions
+    const readFile = readFileImpl || (async (p: string) => {
+      const { promises: fs } = await import('node:fs');
+      return fs.readFile(p, 'utf8');
+    });
+    const readdir = readdirImpl || (async (p: string) => {
+      const { promises: fs } = await import('node:fs');
+      return fs.readdir(p);
+    });
+
+    // List all category directories in research/
+    let categories: string[] = [];
+    try {
+      categories = await readdir(researchDir);
+    } catch {
+      return false; // research dir doesn't exist or can't be read
+    }
+
+    // Scan each category for numbered doc directories
+    for (const category of categories) {
+      if (category.startsWith('_') || category.startsWith('.')) continue; // Skip archive/meta dirs
+
+      let entries: string[] = [];
+      try {
+        entries = await readdir(`${researchDir}/${category}`);
+      } catch {
+        continue; // Skip if category can't be read
+      }
+
+      // Check each numbered doc directory
+      for (const entry of entries) {
+        if (!/^\d+-/.test(entry)) continue; // Skip non-numbered entries
+
+        const readmePath = `${researchDir}/${category}/${entry}/README.md`;
+        try {
+          const content = await readFile(readmePath, 'utf8');
+
+          // Search for any URL in the README that matches our normalized URL
+          const urlMatches = content.match(/https?:\/\/\S+/g) || [];
+          for (const foundUrl of urlMatches) {
+            if (normalizeUrl(foundUrl) === normalized) {
+              return true; // URL found in this doc
+            }
+          }
+
+          // Also check the frontmatter `original-query` field for the URL
+          const originalQueryMatch = /original-query:\s*"([^"]+)"/.exec(content);
+          if (originalQueryMatch) {
+            const originalQuery = originalQueryMatch[1];
+            if (normalizeUrl(originalQuery) === normalized) {
+              return true;
+            }
+          }
+        } catch {
+          // If we can't read this specific doc, continue to the next
+          continue;
+        }
+      }
+    }
+
+    return false; // URL not found in any doc
+  } catch {
+    // Fail-open: any unexpected error means we don't block research
+    return false;
+  }
+}


### PR DESCRIPTION
## What

Implements cowork task **#931** — DM intent-router dedupe. The "research this <link>" DM auto-dispatch already worked (`wantsLinkResearch` -> `enqueueWork` -> doc + PR -> Research topic); this adds the missing **dedupe guard** so the same link doesn't produce duplicate research.

## Changes

**New `bot/src/zoe/research-dedupe.ts`** (pure, IO-injected -> unit-testable without the bot):
- `extractFirstUrl(text)`, `normalizeUrl(url)` (protocol / trailing-slash / query / host-case insensitive), `wasResearched(url, researchDir, readFile?, readdir?)` scans `research/**/README.md`. **Fails open** on any IO error (never blocks research on a dedupe failure).

**`index.ts`** — 1 import + a 3-line guard in the `action.kind==='research'` branch: extract URL -> `wasResearched(url, join(repoDir,'research'))` -> if found, reply "Already researched that link — see the Research topic." and return.

## Verification (build-verified; boot is yours)
- **25 unit tests pass** (extract/normalize/dedupe incl. fail-open on IO throw).
- **Bot `tsc`: 0 new errors** — 8 pre-existing (unrelated `ctx.chatId`/`sendLongMessage` in a different handler), simply line-shifted by the insert. `research-dedupe.ts` itself: 0 errors.
- New module **transpile-loads under tsx**.
- Not boot-verified — the live ZOE bot can't run a second instance (one-instance rule). **Boot/deploy Zaal-gated**, same as the other open ZOE PRs (#1394/#1396/#1400).

Runtime bot change → for your review + boot-test. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
