### PR TITLE
feat(geo): enrich root metadata for AI/search discoverability (task #724)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,13 +31,36 @@ const miniAppEmbed = JSON.stringify({
   },
 });
 
+const SITE_DESCRIPTION =
+  'The ZAO on Farcaster — a decentralized music community on Base with channel chat, encrypted XMTP DMs, shared listening, on-chain governance, reputation, and ZABAL tokens.';
+
 export const metadata: Metadata = {
   metadataBase: new URL('https://zaoos.com'),
-  title: 'ZAO OS',
-  description: 'The ZAO Community on Farcaster — gated chat for ZAO members',
+  title: { default: 'ZAO OS', template: '%s · ZAO OS' },
+  description: SITE_DESCRIPTION,
+  applicationName: 'ZAO OS',
+  authors: [{ name: 'The ZAO', url: 'https://thezao.xyz' }],
+  creator: 'The ZAO',
+  publisher: 'The ZAO',
+  category: 'social',
+  keywords: [
+    'The ZAO',
+    'ZAO OS',
+    'Farcaster',
+    'Base chain',
+    'decentralized music',
+    'music community',
+    'music DAO',
+    'XMTP',
+    'ZABAL token',
+    'onchain governance',
+    'Farcaster mini app',
+    'Web3 community',
+  ],
+  alternates: { canonical: '/' },
   openGraph: {
     title: 'ZAO OS',
-    description: 'The ZAO Community on Farcaster — gated chat for ZAO members',
+    description: SITE_DESCRIPTION,
     url: 'https://zaoos.com',
     siteName: 'ZAO OS',
     type: 'website',
@@ -45,7 +68,7 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'ZAO OS',
-    description: 'The ZAO Community on Farcaster — gated chat for ZAO members',
+    description: SITE_DESCRIPTION,
   },
   other: {
     'fc:miniapp': miniAppEmbed,


### PR DESCRIPTION
## What

Advances board task **#724 "GEO: make The ZAO AI-discoverable (TOP PRIORITY)."** The root metadata undersold the product ("gated chat for ZAO members") vs. what `llms.txt` and the app actually are. This enriches the Next.js Metadata API — **no `dangerouslySetInnerHTML`** (repo security rule), no new deps, no logic change.

- **Accurate description** across meta / OpenGraph / Twitter: a decentralized music community on Base — channel chat, encrypted XMTP DMs, shared listening, on-chain governance, reputation, ZABAL tokens.
- **`keywords[]`** for AI/search signals.
- **`applicationName`, `authors`/`creator`/`publisher` = The ZAO, `category: social`.**
- **Title template** `%s · ZAO OS` so child-page titles compose.
- **`alternates.canonical`.**

## Note on JSON-LD
The remaining high-value GEO gap is JSON-LD structured data — but its standard injection uses `dangerouslySetInnerHTML`, a hard **NEVER** in this repo. Intentionally **deferred to you** (needs a rule-compliant approach or an explicit exception).

## Verification
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Runtime metadata change → for your review/merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
