### PR TITLE
test(juke): agent-join, register-webhook, partner-token, status (task #591)

### DIFF
--- a/src/app/api/juke/admin/agent-join/__tests__/route.test.ts
+++ b/src/app/api/juke/admin/agent-join/__tests__/route.test.ts
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const mockEnv = vi.hoisted(() => ({
+  JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+}));
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+import { POST } from '../route';
+
+describe('POST /api/juke/admin/agent-join', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    vi.mocked(global.fetch).mockClear();
+  });
+
+  describe('authorization', () => {
+    it('returns 401 when not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Admin only');
+    });
+
+    it('returns 401 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue({
+        fid: 123,
+        username: 'regularuser',
+        displayName: 'Regular User',
+        isAdmin: false,
+      });
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Admin only');
+      expect(vi.mocked(global.fetch)).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('configuration', () => {
+    it('returns 503 when JUKE_API_KEY is not configured', async () => {
+      mockEnv.JUKE_API_KEY = undefined;
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toContain('JUKE_API_KEY not configured on the server');
+    });
+  });
+
+  describe('request validation', () => {
+    it('returns 400 when body is not valid JSON', async () => {
+      const res = await POST(
+        new (await import('next/server')).NextRequest(
+          new URL('/api/juke/admin/agent-join', 'http://localhost:3000'),
+          {
+            method: 'POST',
+            body: '{not json',
+          },
+        ),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Request body must be valid JSON');
+    });
+
+    it('returns 400 when spaceId is missing', async () => {
+      const res = await POST(makePostRequest('/api/juke/admin/agent-join', { agentName: 'ZOE' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid body');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when spaceId is empty', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: '', agentName: 'ZOE' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid body');
+    });
+
+    it('returns 400 when spaceId exceeds max length', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'a'.repeat(129),
+          agentName: 'ZOE',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid body');
+    });
+
+    it('returns 400 when agentName exceeds max length', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'test-space',
+          agentName: 'a'.repeat(65),
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid body');
+    });
+
+    it('returns 400 when agentPfpUrl is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'test-space',
+          agentPfpUrl: 'not-a-url',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid body');
+    });
+
+    it('accepts valid inputs with agentName defaulting to ZOE', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            session_token: 'st_test_abc123',
+            agent_id: 'agent_123',
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.agentName).toBe('ZOE');
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        'https://api.juke.audio/v1/developer/rooms/test-space/agent-join',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'X-Juke-Api-Key': 'jk_sec_live_test',
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({
+            agent_name: 'ZOE',
+            agent_pfp_url: undefined,
+          }),
+        }),
+      );
+    });
+
+    it('trims whitespace from agentName', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ session_token: 'st_test' }), { status: 200 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'test-space',
+          agentName: '  CUSTOM  ',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.agentName).toBe('CUSTOM');
+    });
+  });
+
+  describe('Juke API interaction', () => {
+    it('encodes spaceId in the URL', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ session_token: 'st_test' }), { status: 200 }),
+      );
+
+      await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'space with spaces',
+          agentName: 'ZOE',
+        }),
+      );
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        'https://api.juke.audio/v1/developer/rooms/space%20with%20spaces/agent-join',
+        expect.any(Object),
+      );
+    });
+
+    it('includes optional agentPfpUrl when provided', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ session_token: 'st_test' }), { status: 200 }),
+      );
+
+      await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'test-space',
+          agentName: 'ZOE',
+          agentPfpUrl: 'https://example.com/pfp.png',
+        }),
+      );
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            agent_name: 'ZOE',
+            agent_pfp_url: 'https://example.com/pfp.png',
+          }),
+        }),
+      );
+    });
+
+    it('returns 201 with juke response on success', async () => {
+      const jukeResponse = {
+        session_token: 'st_live_secret123',
+        agent_id: 'agent_001',
+        room_id: 'test-space',
+      };
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify(jukeResponse), { status: 200 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', {
+          spaceId: 'test-space',
+          agentName: 'ZOE',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.spaceId).toBe('test-space');
+      expect(body.agentName).toBe('ZOE');
+      expect(body.juke).toEqual(jukeResponse);
+      expect(body.action_required).toContain('session_token');
+    });
+  });
+
+  describe('Juke API error handling', () => {
+    it('returns 404 when Juke returns 404', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Room not found' }), { status: 404 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'nonexistent' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Juke returned 404');
+    });
+
+    it('returns 429 when Juke returns 429 (rate limit or per-room cap)', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Rate limit exceeded' }), { status: 429 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(429);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Juke returned 429');
+    });
+
+    it('returns 502 when Juke returns 5xx', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Internal server error' }), { status: 500 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Juke returned 500');
+    });
+
+    it('handles non-JSON response from Juke gracefully', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response('Internal Server Error', { status: 502 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.juke).toBe('Internal Server Error');
+    });
+
+    it('returns 502 when fetch times out', async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new Error('AbortError: Request timeout'));
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('Juke agent-join API unreachable');
+    });
+
+    it('returns 502 when fetch fails for other reasons', async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network error'));
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/agent-join', { spaceId: 'test-space' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('Juke agent-join API unreachable');
+    });
+  });
+});

--- a/src/app/api/juke/admin/register-webhook/__tests__/route.test.ts
+++ b/src/app/api/juke/admin/register-webhook/__tests__/route.test.ts
@@ -1,0 +1,450 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  makeRequest,
+  mockAdminSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const mockEnv = vi.hoisted(() => ({
+  JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+}));
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+import { GET, POST } from '../route';
+
+const JUKE_SUCCESS_RESPONSE = {
+  id: 'webhook_xyz',
+  url: 'https://zaoos.com/api/juke/webhooks',
+  events: [
+    'room.started',
+    'room.finished',
+    'participant.joined',
+    'participant.left',
+    'recording.ready',
+  ],
+  secret: 'whsec_generated_by_juke_xyz123',
+  created_at: '2026-07-15T12:00:00Z',
+};
+
+describe('POST /api/juke/admin/register-webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    vi.resetAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Admin only');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue({ fid: 123, username: 'user', isAdmin: false });
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Admin only');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('accepts an admin session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+
+      expect(res.status).toBe(201);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('environment configuration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('returns 503 when JUKE_API_KEY is missing', async () => {
+      mockEnv.JUKE_API_KEY = undefined;
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Missing JUKE_API_KEY');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 503 when JUKE_API_KEY is empty string', async () => {
+      mockEnv.JUKE_API_KEY = '';
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toContain('Missing JUKE_API_KEY');
+    });
+  });
+
+  describe('request body validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('handles empty body gracefully', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(makeRequest('/api/juke/admin/register-webhook', { method: 'POST' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      // Should use default URL
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const fetchBody = JSON.parse(fetchCall[1].body);
+      expect(fetchBody.url).toBe('https://zaoos.com/api/juke/webhooks');
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/juke/admin/register-webhook', { url: 'not-a-url' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Invalid body');
+      expect(body.details).toBeDefined();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when extra fields are sent', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/register-webhook', {
+          url: 'https://example.com',
+          extraField: 'ignored',
+        }),
+      );
+      const body = await res.json();
+
+      // Zod strips unknown fields but accepts valid URL
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+    });
+
+    it('accepts a valid custom URL', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const customUrl = 'https://example.com/webhook';
+      const res = await POST(
+        makePostRequest('/api/juke/admin/register-webhook', { url: customUrl }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.url).toBe(customUrl);
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const fetchBody = JSON.parse(fetchCall[1].body);
+      expect(fetchBody.url).toBe(customUrl);
+    });
+
+    it('uses default URL when url is omitted', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/juke/admin/register-webhook', { someOtherField: 'ignored' }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.url).toBe('https://zaoos.com/api/juke/webhooks');
+    });
+  });
+
+  describe('successful webhook registration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('returns 201 with webhook details on success', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.ok).toBe(true);
+      expect(body.juke).toEqual(JUKE_SUCCESS_RESPONSE);
+      expect(body.action_required).toBeDefined();
+      expect(body.action_required).toContain('JUKE_WEBHOOK_SECRET');
+      expect(body.events).toEqual([
+        'room.started',
+        'room.finished',
+        'participant.joined',
+        'participant.left',
+        'recording.ready',
+      ]);
+    });
+
+    it('sends correct headers to Juke API', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(fetchCall[0]).toBe('https://api.juke.audio/v1/developer/webhooks');
+      expect(fetchCall[1].method).toBe('POST');
+      expect(fetchCall[1].headers['X-Juke-Api-Key']).toBe('jk_sec_live_test');
+      expect(fetchCall[1].headers['Content-Type']).toBe('application/json');
+    });
+
+    it('sends correct events list to Juke API', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const fetchBody = JSON.parse(fetchCall[1].body);
+      expect(fetchBody.events).toEqual([
+        'room.started',
+        'room.finished',
+        'participant.joined',
+        'participant.left',
+        'recording.ready',
+      ]);
+    });
+
+    it('includes URL in the request body to Juke', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const customUrl = 'https://custom.example.com/hook';
+      await POST(makePostRequest('/api/juke/admin/register-webhook', { url: customUrl }));
+
+      const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      const fetchBody = JSON.parse(fetchCall[1].body);
+      expect(fetchBody.url).toBe(customUrl);
+    });
+  });
+
+  describe('Juke API errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('returns 502 when Juke returns non-ok status', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => JSON.stringify({ error: 'Invalid API key' }),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Juke returned 401');
+      expect(body.juke).toEqual({ error: 'Invalid API key' });
+    });
+
+    it('returns 502 when Juke returns 429 (rate limit)', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => JSON.stringify({ error: 'Rate limited' }),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toContain('429');
+    });
+
+    it('handles non-JSON response body from Juke', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.juke).toBe('Internal Server Error');
+    });
+
+    it('handles invalid JSON response body from Juke', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        text: async () => 'not valid json {',
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.juke).toBe('not valid json {');
+    });
+  });
+
+  describe('unexpected errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('returns 500 when fetch throws unexpectedly', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network error'));
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Network error');
+    });
+
+    it('returns 500 when response.text() throws', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: vi.fn().mockRejectedValueOnce(new Error('Stream error')),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Stream error');
+    });
+
+    it('returns 500 for unknown error with message', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Unknown error'));
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Unknown error');
+    });
+
+    it('returns 500 for non-Error exception', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce('raw string error');
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Unknown error');
+    });
+  });
+
+  describe('response secrecy', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('includes the secret in the success response body', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.juke.secret).toBe('whsec_generated_by_juke_xyz123');
+    });
+
+    it('includes action_required instructions in response', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify(JUKE_SUCCESS_RESPONSE),
+      });
+
+      const res = await POST(makePostRequest('/api/juke/admin/register-webhook', {}));
+      const body = await res.json();
+
+      expect(body.action_required).toContain('COPY');
+      expect(body.action_required).toContain('JUKE_WEBHOOK_SECRET');
+      expect(body.action_required).toContain('Vercel');
+      expect(body.action_required).toContain('redeploy');
+    });
+  });
+});
+
+describe('GET /api/juke/admin/register-webhook', () => {
+  it('returns 405 Method Not Allowed', async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(405);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('POST only');
+  });
+
+  it('includes endpoint description in error', async () => {
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.error).toContain('one-shot admin registration endpoint');
+  });
+});

--- a/src/app/api/juke/partner-token/__tests__/route.test.ts
+++ b/src/app/api/juke/partner-token/__tests__/route.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const mockEnv = vi.hoisted(() => ({
+  JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+}));
+
+const { mockGetSessionData, mockMintPartnerToken } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockMintPartnerToken: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+vi.mock('@/lib/spaces/juke-partner-token', () => ({
+  mintPartnerToken: mockMintPartnerToken,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/juke/partner-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Sign in to mint a partner token');
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(mockMintPartnerToken).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Sign in to mint a partner token');
+      expect(mockMintPartnerToken).not.toHaveBeenCalled();
+    });
+
+    it('succeeds for an authenticated user with a valid fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 12345 }));
+      mockMintPartnerToken.mockResolvedValue({
+        ok: true,
+        data: {
+          token: 'jwt_test_token_abc123',
+          fid: 12345,
+          expires_at: '2026-07-16T01:30:00Z',
+          partner_app_id: 'zao',
+        },
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.token).toBe('jwt_test_token_abc123');
+      expect(body.fid).toBe(12345);
+      expect(body.expires_at).toBe('2026-07-16T01:30:00Z');
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(res.headers.get('x-zao-juke-partner-token')).toBe('v1');
+      expect(mockMintPartnerToken).toHaveBeenCalledWith('jk_sec_live_test', {
+        fid: 12345,
+        ttlSeconds: 300,
+      });
+    });
+  });
+
+  describe('configuration', () => {
+    it('returns 503 when JUKE_API_KEY is not configured', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      mockEnv.JUKE_API_KEY = undefined;
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('JUKE_API_KEY');
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      expect(mockMintPartnerToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upstream failures', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 12345 }));
+    });
+
+    it('returns 502 when mintPartnerToken returns a 5xx error', async () => {
+      mockMintPartnerToken.mockResolvedValue({
+        ok: false,
+        status: 502,
+        error: 'Juke API returned 502',
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('Juke API returned 502');
+      expect(res.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('returns 400 when mintPartnerToken returns a 4xx error', async () => {
+      mockMintPartnerToken.mockResolvedValue({
+        ok: false,
+        status: 400,
+        error: 'fid must be a positive integer',
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe('fid must be a positive integer');
+      expect(res.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('returns 429 when rate limited by Juke', async () => {
+      mockMintPartnerToken.mockResolvedValue({
+        ok: false,
+        status: 429,
+        error: 'Juke returned 429: Rate limit exceeded',
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(429);
+      expect(body.ok).toBe(false);
+      expect(body.error).toContain('Rate limit exceeded');
+    });
+
+    it('throws when mintPartnerToken throws an uncaught error', async () => {
+      mockMintPartnerToken.mockRejectedValue(new Error('Network timeout'));
+
+      // The route does not catch exceptions from mintPartnerToken, so it propagates
+      // and Next.js will return a 500 error page. We verify the mock was called.
+      try {
+        await GET();
+        // If we get here, the test should fail because an error should have been thrown
+        expect(true).toBe(false);
+      } catch (err: unknown) {
+        expect(err instanceof Error).toBe(true);
+        if (err instanceof Error) {
+          expect(err.message).toBe('Network timeout');
+        }
+        expect(mockMintPartnerToken).toHaveBeenCalled();
+      }
+    });
+
+    it('logs warnings when mintPartnerToken fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockMintPartnerToken.mockResolvedValue({
+        ok: false,
+        status: 500,
+        error: 'Internal server error',
+      });
+
+      await GET();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[juke/partner-token] mint failed',
+        500,
+        'Internal server error',
+      );
+    });
+  });
+
+  describe('success cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 98765 }));
+    });
+
+    it('passes ttlSeconds=300 to mintPartnerToken', async () => {
+      mockMintPartnerToken.mockResolvedValue({
+        ok: true,
+        data: {
+          token: 'jwt_token',
+          fid: 98765,
+          expires_at: '2026-07-16T01:35:00Z',
+          partner_app_id: 'zao',
+        },
+      });
+
+      await GET();
+
+      expect(mockMintPartnerToken).toHaveBeenCalledWith('jk_sec_live_test', {
+        fid: 98765,
+        ttlSeconds: 300,
+      });
+    });
+
+    it('includes partner_app_id in the response even though it is not returned to the client', async () => {
+      mockMintPartnerToken.mockResolvedValue({
+        ok: true,
+        data: {
+          token: 'jwt_token',
+          fid: 98765,
+          expires_at: '2026-07-16T01:35:00Z',
+          partner_app_id: 'zao',
+        },
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      // Note: partner_app_id is in the upstream response but not returned to the client
+      expect(body).toHaveProperty('token');
+      expect(body).toHaveProperty('fid');
+      expect(body).toHaveProperty('expires_at');
+      expect(body).not.toHaveProperty('partner_app_id');
+    });
+  });
+
+  describe('response headers', () => {
+    it('always sets cache-control: no-store for security', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET();
+
+      expect(res.headers.get('cache-control')).toBe('no-store');
+    });
+
+    it('sets x-zao-juke-partner-token header on success', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      mockMintPartnerToken.mockResolvedValue({
+        ok: true,
+        data: {
+          token: 'jwt_token',
+          fid: 123,
+          expires_at: '2026-07-16T01:35:00Z',
+          partner_app_id: 'zao',
+        },
+      });
+
+      const res = await GET();
+
+      expect(res.headers.get('x-zao-juke-partner-token')).toBe('v1');
+    });
+  });
+});

--- a/src/app/api/juke/status/__tests__/route.test.ts
+++ b/src/app/api/juke/status/__tests__/route.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+const mockEnv = vi.hoisted(() => ({
+  JUKE_API_KEY: 'jk_sec_live_test' as string | undefined,
+}));
+
+const {
+  mockGetJukeIntegrationManifest,
+  mockFetchJukeChangelog,
+  mockBuildResolutionIndex,
+  mockGetJukeIntegrationStats,
+  mockListRecentJukeSpaces,
+  mockListRecentWebhookEvents,
+} = vi.hoisted(() => ({
+  mockGetJukeIntegrationManifest: vi.fn(),
+  mockFetchJukeChangelog: vi.fn(),
+  mockBuildResolutionIndex: vi.fn(),
+  mockGetJukeIntegrationStats: vi.fn(),
+  mockListRecentJukeSpaces: vi.fn(),
+  mockListRecentWebhookEvents: vi.fn(),
+}));
+
+vi.mock('@/lib/env', () => ({ ENV: mockEnv }));
+
+vi.mock('@/lib/spaces/jukeIntegrationManifest', () => ({
+  getJukeIntegrationManifest: mockGetJukeIntegrationManifest,
+}));
+
+vi.mock('@/lib/spaces/jukeChangelog', () => ({
+  fetchJukeChangelog: mockFetchJukeChangelog,
+  buildResolutionIndex: mockBuildResolutionIndex,
+}));
+
+vi.mock('@/lib/spaces/jukeSpacesDb', () => ({
+  getJukeIntegrationStats: mockGetJukeIntegrationStats,
+  listRecentJukeSpaces: mockListRecentJukeSpaces,
+  listRecentWebhookEvents: mockListRecentWebhookEvents,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/** A minimal valid manifest from getJukeIntegrationManifest. */
+const SAMPLE_MANIFEST = {
+  version: '1.5',
+  generated_at: '2026-07-16T12:00:00Z',
+  about: {
+    name: 'The ZAO',
+    pitch: 'Decentralized impact network.',
+    farcaster: 'https://warpcast.com/~/channel/zao',
+    site: 'https://www.thezao.com',
+    juke_path_a_route: '/live/{spaceId}',
+    juke_path_b_route: '/api/juke/space',
+    public_status_route: 'https://zaoos.com/juke-status',
+  },
+  shipped: [
+    {
+      id: 'path-a-iframe',
+      title: 'Path A — keyless iframe',
+      description: 'Embedded Juke',
+      shippedAt: '2026-05-20',
+      files: ['src/lib/spaces/juke.ts'],
+    },
+  ],
+  open_asks: [
+    {
+      id: 'agents',
+      title: 'Agent join surface',
+      reason: 'ZOE in Juke rooms',
+      blocks: 'ZOE-in-Juke',
+      priority: 'p0' as const,
+    },
+  ],
+  conventions: ['All Juke calls server-side'],
+  contact: {
+    zao_dev: '@zaal (Farcaster)',
+    general: 'https://www.thezao.com',
+    partnership: 'See /juke-status',
+  },
+  juke_release_feed: 'https://juke.audio/changelog.json',
+};
+
+/** A minimal changelog to test resolution index building. */
+const SAMPLE_CHANGELOG = {
+  version: 1,
+  generated_at: '2026-07-16T12:00:00Z',
+  canonical_spec: 'https://juke.audio/spec.json',
+  skill_md: 'https://juke.audio/SKILL.md',
+  entries: [
+    {
+      id: 'agents',
+      shipped_at: '2026-07-15T10:00:00Z',
+      category: 'core',
+      title: 'Agent join',
+      summary: 'Agents can join rooms',
+      resolves: ['agents'],
+    },
+  ],
+};
+
+/** Sample stats from the database. */
+const SAMPLE_STATS = {
+  total_spaces: 42,
+  active_rooms: 3,
+  total_participants: 156,
+};
+
+/** Sample recent spaces. */
+const SAMPLE_RECENT_SPACES = [
+  {
+    id: 'space-1',
+    title: 'Fractal Call',
+    status: 'active' as const,
+    participant_count: 12,
+    scheduled_at: null,
+    started_at: '2026-07-16T11:00:00Z',
+    ended_at: null,
+    recording_url: null,
+    updated_at: '2026-07-16T12:00:00Z',
+  },
+];
+
+/** Sample recent webhook events. */
+const SAMPLE_RECENT_EVENTS = [
+  {
+    id: 'evt-1',
+    space_id: 'space-1',
+    event_type: 'room.started',
+    status: 'processed',
+    created_at: '2026-07-16T11:00:00Z',
+  },
+];
+
+describe('GET /api/juke/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv.JUKE_API_KEY = 'jk_sec_live_test';
+  });
+
+  it('returns 200 with manifest and decorated open_asks on success', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(SAMPLE_CHANGELOG);
+    mockBuildResolutionIndex.mockReturnValue(new Map([['agents', SAMPLE_CHANGELOG.entries[0]]]));
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue(SAMPLE_RECENT_SPACES);
+    mockListRecentWebhookEvents.mockResolvedValue(SAMPLE_RECENT_EVENTS);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveProperty('version', '1.5');
+    expect(body).toHaveProperty('about');
+    expect(body).toHaveProperty('shipped');
+    expect(body).toHaveProperty('open_asks');
+    expect(body).toHaveProperty('stats', SAMPLE_STATS);
+    expect(body).toHaveProperty('recent_spaces', SAMPLE_RECENT_SPACES);
+    expect(body).toHaveProperty('recent_events', SAMPLE_RECENT_EVENTS);
+    expect(body).toHaveProperty('release_feed', 'https://juke.audio/changelog.json');
+  });
+
+  it('decorates open_asks with juke_resolved when changelog resolves them', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(SAMPLE_CHANGELOG);
+    mockBuildResolutionIndex.mockReturnValue(new Map([['agents', SAMPLE_CHANGELOG.entries[0]]]));
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    const body = await res.json();
+
+    const agentsAsk = body.open_asks.find(
+      (ask: unknown) => (ask as Record<string, unknown>).id === 'agents',
+    );
+    expect(agentsAsk).toBeDefined();
+    expect((agentsAsk as Record<string, unknown>).juke_resolved).toEqual(
+      SAMPLE_CHANGELOG.entries[0],
+    );
+  });
+
+  it('leaves open_asks unchanged when not resolved by changelog', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(SAMPLE_CHANGELOG);
+    mockBuildResolutionIndex.mockReturnValue(new Map()); // Empty — no resolutions
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    const body = await res.json();
+
+    const agentsAsk = body.open_asks.find(
+      (ask: unknown) => (ask as Record<string, unknown>).id === 'agents',
+    );
+    expect(agentsAsk).toBeDefined();
+    expect((agentsAsk as Record<string, unknown>).juke_resolved).toBeUndefined();
+  });
+
+  it('handles changelog fetch returning null', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null); // Changelog unavailable
+    mockBuildResolutionIndex.mockReturnValue(new Map()); // Empty on null input
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // open_asks should be unchanged (no juke_resolved decorations)
+    expect(body.open_asks).toBeDefined();
+  });
+
+  it('handles getJukeIntegrationStats error gracefully', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockRejectedValue(new Error('db error'));
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats).toBeNull(); // Caught by .catch(() => null)
+  });
+
+  it('handles listRecentJukeSpaces error gracefully', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockRejectedValue(new Error('db error'));
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recent_spaces).toEqual([]); // Caught by .catch(() => [])
+  });
+
+  it('handles listRecentWebhookEvents error gracefully', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue(SAMPLE_RECENT_SPACES);
+    mockListRecentWebhookEvents.mockRejectedValue(new Error('db error'));
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.recent_events).toEqual([]); // Caught by .catch(() => [])
+  });
+
+  it('returns correct Cache-Control headers', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, max-age=30, s-maxage=60, stale-while-revalidate=120',
+    );
+  });
+
+  it('returns CORS open with Access-Control-Allow-Origin: *', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  it('returns X-ZAO-Juke-Status header v3', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+
+    expect(res.headers.get('X-ZAO-Juke-Status')).toBe('v3');
+  });
+
+  it('is publicly accessible (no auth check)', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(SAMPLE_STATS);
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    // No session is passed or checked — route should return 200
+    const res = await GET(makeRequest('/api/juke/status'));
+
+    expect(res.status).toBe(200);
+  });
+
+  it('always includes release_feed in response', async () => {
+    mockGetJukeIntegrationManifest.mockReturnValue(SAMPLE_MANIFEST);
+    mockFetchJukeChangelog.mockResolvedValue(null);
+    mockBuildResolutionIndex.mockReturnValue(new Map());
+    mockGetJukeIntegrationStats.mockResolvedValue(null); // All errors
+    mockListRecentJukeSpaces.mockResolvedValue([]);
+    mockListRecentWebhookEvents.mockResolvedValue([]);
+
+    const res = await GET(makeRequest('/api/juke/status'));
+    const body = await res.json();
+
+    expect(body.release_feed).toBe('https://juke.audio/changelog.json');
+  });
+});


### PR DESCRIPTION
## What

Route tests for **4 untested `juke/*` routes** (task **#591**), authored via parallel subagents, orchestrator-verified green (vitest + biome + `tsc --noEmit` 0). **71 tests.**

| Route | Methods | Tests |
|-------|---------|-------|
| `juke/admin/agent-join` | POST | 20 |
| `juke/admin/register-webhook` | POST | 26 |
| `juke/partner-token` | GET | 13 |
| `juke/status` | GET | 12 |

Covers admin/auth guards, config (JUKE_API_KEY), Zod validation, Juke-API success + upstream error paths (404/429/5xx/non-JSON/network), header assertions, and public-access on status.

## Note on the fetch rule
`agent-join` + `register-webhook` mock `global.fetch` — both call the **Juke API via raw `fetch`** with no lib seam, the one case the "mock modules, not fetch" rule can't apply (same justified exception as `members/nfts`). `partner-token` + `status` use **module mocks only**.

## Verification
- `vitest run` (all 4) → **71/71 pass**
- `tsc --noEmit` → **0 errors** · `biome check` → **clean**

Tests only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
