### PR TITLE
test(platforms): lens, kick, youtube, facebook (task #591)

### DIFF
--- a/src/app/api/platforms/facebook/__tests__/route.test.ts
+++ b/src/app/api/platforms/facebook/__tests__/route.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET } from '../route';
+
+/**
+ * Build a Supabase query chain mock for the Facebook route.
+ * Supports .select().eq().single() (GET), .delete().eq() (DELETE), and awaited chains.
+ */
+function facebookChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'delete', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/platforms/facebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns connected: false when no Facebook connection exists', async () => {
+    mockFrom.mockReturnValue(facebookChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns connected: false when Supabase returns an error', async () => {
+    mockFrom.mockReturnValue(facebookChain({ data: null, error: new Error('query error') }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns full Facebook connection details on success', async () => {
+    const facebookData = {
+      platform_username: 'john_doe_fb',
+      platform_display_name: 'John Doe',
+      platform_user_id: 'fb_12345',
+      metadata: {
+        primary_page_id: 'page_001',
+        primary_page_name: 'My Page',
+        pages: [
+          { id: 'page_001', name: 'My Page' },
+          { id: 'page_002', name: 'Another Page' },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(facebookChain({ data: facebookData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      connected: true,
+      userId: 'fb_12345',
+      username: 'john_doe_fb',
+      displayName: 'John Doe',
+      primaryPageId: 'page_001',
+      primaryPageName: 'My Page',
+      pages: [
+        { id: 'page_001', name: 'My Page' },
+        { id: 'page_002', name: 'Another Page' },
+      ],
+    });
+  });
+
+  it('handles missing metadata gracefully', async () => {
+    const facebookData = {
+      platform_username: 'user_fb',
+      platform_display_name: 'User Name',
+      platform_user_id: 'fb_999',
+      metadata: null,
+    };
+    mockFrom.mockReturnValue(facebookChain({ data: facebookData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryPageId).toBe(null);
+    expect(body.primaryPageName).toBe(null);
+    expect(body.pages).toEqual([]);
+  });
+
+  it('handles empty metadata object gracefully', async () => {
+    const facebookData = {
+      platform_username: 'user_fb',
+      platform_display_name: 'User Name',
+      platform_user_id: 'fb_999',
+      metadata: {},
+    };
+    mockFrom.mockReturnValue(facebookChain({ data: facebookData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.primaryPageId).toBe(null);
+    expect(body.primaryPageName).toBe(null);
+    expect(body.pages).toEqual([]);
+  });
+
+  it('queries connected_platforms with correct filters', async () => {
+    const chain = facebookChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(mockFrom).toHaveBeenCalledWith('connected_platforms');
+    expect(chain.select).toHaveBeenCalledWith(
+      'platform_username, platform_display_name, platform_user_id, metadata',
+    );
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'facebook');
+  });
+
+  it('returns 500 when a try/catch error occurs', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to get Facebook info');
+  });
+});
+
+describe('DELETE /api/platforms/facebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns success: true when disconnection succeeds', async () => {
+    mockFrom.mockReturnValue(facebookChain({ error: null }));
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it('deletes from connected_platforms with correct filters', async () => {
+    const chain = facebookChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    await DELETE();
+    expect(mockFrom).toHaveBeenCalledWith('connected_platforms');
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'facebook');
+  });
+
+  it('returns 500 when Supabase delete returns an error', async () => {
+    mockFrom.mockReturnValue(facebookChain({ error: new Error('delete failed') }));
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+
+  it('returns 500 when a try/catch error occurs', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error during delete');
+    });
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+
+  it('logs errors to logger.error on Supabase failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    mockFrom.mockReturnValue(facebookChain({ error: new Error('query error') }));
+    await DELETE();
+    expect(logger.error).toHaveBeenCalledWith('Facebook disconnect error:', expect.any(Error));
+  });
+
+  it('logs errors to logger.error on try/catch failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+    await DELETE();
+    expect(logger.error).toHaveBeenCalledWith('Facebook platform DELETE error:', expect.any(Error));
+  });
+});
+
+describe('GET /api/platforms/facebook - Error logging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('logs errors to logger.error on try/catch failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+    await GET();
+    expect(logger.error).toHaveBeenCalledWith('Facebook platform GET error:', expect.any(Error));
+  });
+});

--- a/src/app/api/platforms/kick/__tests__/route.test.ts
+++ b/src/app/api/platforms/kick/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET } from '../route';
+
+/**
+ * Supabase query chain for Kick route tests.
+ * Supports .select().eq().single() for GET queries
+ * and .delete().eq() for DELETE queries (awaitable directly).
+ */
+function kickChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'delete', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/platforms/kick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns connected: false when no Kick platform record exists', async () => {
+    mockFrom.mockReturnValue(kickChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns connected platform details on success', async () => {
+    const platformData = {
+      platform_username: 'kickuser123',
+      platform_display_name: 'Kick User',
+      platform_user_id: 'usr_kick_001',
+      stream_key: 'sk_test_abc123',
+      rtmp_url: 'rtmp://live.kick.com/stream',
+    };
+    mockFrom.mockReturnValue(kickChain({ data: platformData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(true);
+    expect(body.username).toBe('kickuser123');
+    expect(body.displayName).toBe('Kick User');
+    expect(body.streamKey).toBe('sk_test_abc123');
+    expect(body.rtmpUrl).toBe('rtmp://live.kick.com/stream');
+  });
+
+  it('queries the correct platform and user_fid', async () => {
+    const chain = kickChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'kick');
+  });
+
+  it('selects the correct fields', async () => {
+    const chain = kickChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.select).toHaveBeenCalledWith(
+      'platform_username, platform_display_name, platform_user_id, stream_key, rtmp_url',
+    );
+  });
+
+  it('returns connected: false when the query errors', async () => {
+    mockFrom.mockReturnValue(kickChain({ data: null, error: new Error('db connection lost') }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns connected: false when an error is returned even with data present', async () => {
+    // The route checks `if (error || !data)`, so error alone is enough to treat as not connected
+    mockFrom.mockReturnValue(
+      kickChain({
+        data: { platform_username: 'test' },
+        error: new Error('partial error'),
+      }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+});
+
+describe('DELETE /api/platforms/kick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('disconnects the platform on success', async () => {
+    mockFrom.mockReturnValue(kickChain({ error: null }));
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it('queries the correct platform and user_fid for deletion', async () => {
+    const chain = kickChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    await DELETE();
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'kick');
+  });
+
+  it('uses the delete method', async () => {
+    const chain = kickChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    await DELETE();
+    expect(chain.delete).toHaveBeenCalled();
+  });
+
+  it('queries the connected_platforms table', async () => {
+    mockFrom.mockReturnValue(kickChain({ error: null }));
+    await DELETE();
+    expect(mockFrom).toHaveBeenCalledWith('connected_platforms');
+  });
+
+  it('returns 500 when the delete query errors', async () => {
+    mockFrom.mockReturnValue(kickChain({ error: new Error('db constraint violation') }));
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+});
+
+describe('Kick route error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('GET catches exceptions and returns 500', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected crash');
+    });
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to get Kick info');
+  });
+
+  it('DELETE catches exceptions and returns 500', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected crash');
+    });
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+});

--- a/src/app/api/platforms/lens/__tests__/route.test.ts
+++ b/src/app/api/platforms/lens/__tests__/route.test.ts
@@ -1,0 +1,477 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock fetch at global scope
+global.fetch = vi.fn();
+
+import { DELETE, POST } from '../route';
+
+/**
+ * Build a chain that supports select→eq→await for user row fetches,
+ * and update→eq→await for the update operation.
+ * Also supports the direct await on the chain for Lens API fetch results.
+ */
+function makeChain(result: { data?: unknown; error?: unknown; count?: number }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainable = ['select', 'update', 'eq', 'from'];
+  for (const m of chainable) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('POST /api/platforms/lens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(
+      mockAuthenticatedSession({ fid: 123, walletAddress: VALID_WALLET }),
+    );
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/platforms/lens', { wallet: VALID_WALLET }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const req = makeRequest('/api/platforms/lens', { method: 'POST', body: '{invalid json}' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  it('returns 200 with no Lens profile found when user has no wallets', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ data: { accountsAvailable: { items: [] } } })),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.hasProfile).toBe(false);
+    expect(body.handle).toBeNull();
+    expect(body.walletsChecked).toBe(1); // session.walletAddress
+  });
+
+  it('finds a Lens profile with localName', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: null,
+        },
+        error: null,
+      }),
+    );
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: 'alice', value: 'alice.lens' },
+                metadata: { name: 'Alice' },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.hasProfile).toBe(true);
+    expect(body.handle).toBe('alice');
+    expect(body.accountAddress).toBe(VALID_WALLET);
+  });
+
+  it('falls back to username.value when localName is missing', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: null,
+        },
+        error: null,
+      }),
+    );
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: null, value: 'alice.lens' },
+                metadata: { name: null },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handle).toBe('alice.lens');
+  });
+
+  it('falls back to metadata.name when username is missing', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: null,
+        },
+        error: null,
+      }),
+    );
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: null, value: null },
+                metadata: { name: 'Alice Profile' },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handle).toBe('Alice Profile');
+  });
+
+  it('uses short address format when no name is available', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: null,
+        },
+        error: null,
+      }),
+    );
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: null, value: null },
+                metadata: { name: null },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handle).toMatch(/^@0x1234\.\.\./);
+  });
+
+  it('stores valid access and refresh tokens', async () => {
+    const chain = makeChain({
+      data: {
+        primary_wallet: null,
+        custody_address: null,
+        verified_addresses: null,
+      },
+      error: null,
+    });
+
+    mockFrom.mockReturnValue(chain);
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: 'alice', value: null },
+                metadata: { name: null },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(
+      makePostRequest('/api/platforms/lens', {
+        wallet: VALID_WALLET,
+        accessToken: `valid_token_with_good_length_${'x'.repeat(40)}`,
+        refreshToken: `refresh_token_with_good_length_${'x'.repeat(40)}`,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(chain.update).toHaveBeenCalledWith({
+      lens_profile_id: 'alice',
+      lens_access_token: `valid_token_with_good_length_${'x'.repeat(40)}`,
+      lens_refresh_token: `refresh_token_with_good_length_${'x'.repeat(40)}`,
+    });
+  });
+
+  it('rejects access tokens that are too short', async () => {
+    const chain = makeChain({
+      data: {
+        primary_wallet: null,
+        custody_address: null,
+        verified_addresses: null,
+      },
+      error: null,
+    });
+
+    mockFrom.mockReturnValue(chain);
+
+    const lensResponse = {
+      data: {
+        accountsAvailable: {
+          items: [
+            {
+              account: {
+                address: VALID_WALLET,
+                username: { localName: 'alice', value: null },
+                metadata: { name: null },
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensResponse)),
+    );
+
+    const res = await POST(
+      makePostRequest('/api/platforms/lens', {
+        wallet: VALID_WALLET,
+        accessToken: 'short',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // Token too short, should not be stored
+    expect(chain.update).toHaveBeenCalledWith({
+      lens_profile_id: 'alice',
+    });
+  });
+
+  it('checks multiple wallets when user has verified_addresses', async () => {
+    const chain = makeChain({
+      data: {
+        primary_wallet: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        custody_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        verified_addresses: ['0xcccccccccccccccccccccccccccccccccccccccc'],
+      },
+      error: null,
+    });
+
+    mockFrom.mockReturnValue(chain);
+
+    let callCount = 0;
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First wallet check: no profile
+        return Promise.resolve(
+          new Response(JSON.stringify({ data: { accountsAvailable: { items: [] } } })),
+        );
+      }
+      // Later wallet: found profile
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: {
+              accountsAvailable: {
+                items: [
+                  {
+                    account: {
+                      address: '0xcccccccccccccccccccccccccccccccccccccccc',
+                      username: { localName: 'charlie', value: null },
+                      metadata: { name: null },
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        ),
+      );
+    });
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.walletsChecked).toBe(4); // session wallet + primary + custody + 1 verified
+    expect(body.handle).toBe('charlie');
+  });
+
+  it('skips invalid addresses in verified_addresses array', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: ['not-an-address', '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
+        },
+        error: null,
+      }),
+    );
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ data: { accountsAvailable: { items: [] } } })),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Only valid addresses + session wallet
+    expect(body.walletsChecked).toBe(2);
+  });
+
+  it('returns 500 when supabase user query errors', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db connection failed') }));
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to check Lens profile');
+  });
+
+  it('handles Lens API errors gracefully', async () => {
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: {
+          primary_wallet: null,
+          custody_address: null,
+          verified_addresses: null,
+        },
+        error: null,
+      }),
+    );
+
+    const lensError = {
+      errors: [{ message: 'Invalid address' }],
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify(lensError)),
+    );
+
+    const res = await POST(makePostRequest('/api/platforms/lens', {}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.hasProfile).toBe(false);
+  });
+});
+
+describe('DELETE /api/platforms/lens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('clears lens profile and tokens on success', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    expect(chain.update).toHaveBeenCalledWith({
+      lens_profile_id: null,
+      lens_access_token: null,
+      lens_refresh_token: null,
+    });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+});

--- a/src/app/api/platforms/youtube/__tests__/route.test.ts
+++ b/src/app/api/platforms/youtube/__tests__/route.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET } from '../route';
+
+/**
+ * Chain whose chainable methods are inspectable spies. `.single()` awaits to
+ * `result`, and `.delete()` chain awaits directly, so a single chain serves
+ * both the GET (select→single) and DELETE (delete→eq→await) call shapes.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'delete', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(result));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/platforms/youtube', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns connected: false when no row is found', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns connected: false when the query errors', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db down') }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).connected).toBe(false);
+  });
+
+  it('returns platform details on success', async () => {
+    const platformData = {
+      platform_username: 'testchannel',
+      platform_display_name: 'Test Channel',
+      platform_user_id: 'UCxxxxx123',
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platformData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(true);
+    expect(body.username).toBe('testchannel');
+    expect(body.displayName).toBe('Test Channel');
+    expect(body.channelId).toBe('UCxxxxx123');
+  });
+
+  it('filters by user_fid and platform', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'youtube');
+  });
+
+  it('selects the correct fields', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.select).toHaveBeenCalledWith(
+      'platform_username, platform_display_name, platform_user_id',
+    );
+  });
+
+  it('returns 500 on exception', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to get YouTube info');
+  });
+});
+
+describe('DELETE /api/platforms/youtube', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns success: true on successful disconnect', async () => {
+    mockFrom.mockReturnValue(makeChain({ error: null }));
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+  });
+
+  it('returns 500 when the delete errors', async () => {
+    mockFrom.mockReturnValue(makeChain({ error: new Error('db down') }));
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+
+  it('filters by user_fid and platform', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    await DELETE();
+    expect(chain.delete).toHaveBeenCalled();
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'youtube');
+  });
+
+  it('deletes from the correct table', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    await DELETE();
+    expect(mockFrom).toHaveBeenCalledWith('connected_platforms');
+  });
+
+  it('returns 500 on exception', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to disconnect');
+  });
+});


### PR DESCRIPTION
59 tests across 4 untested platform-connection routes (task #591), subagent-authored + orchestrator-verified green (vitest 59/59, tsc 0, biome clean).

| Route | Methods | Tests |
|---|---|---|
| platforms/lens | POST, DELETE | 15 |
| platforms/kick | GET, DELETE | 15 |
| platforms/youtube | GET, DELETE | 13 |
| platforms/facebook | GET, DELETE | 16 |

lens mocks global.fetch (raw Lens API call, no lib seam — justified exception); the other 3 use supabase module mocks only. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)