### PR TITLE
test(platforms): twitch, facebook/broadcast, youtube/broadcast (task #591)

### DIFF
--- a/src/app/api/platforms/facebook/broadcast/__tests__/route.test.ts
+++ b/src/app/api/platforms/facebook/broadcast/__tests__/route.test.ts
@@ -1,0 +1,649 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch for Facebook API calls
+global.fetch = vi.fn();
+
+import { POST } from '../route';
+
+/**
+ * Chain mock for Supabase query: select → eq → eq → single.
+ * Both chainable methods (.select, .eq) return the chain.
+ * Terminal method (.single) resolves to the provided result.
+ * The chain also implements .then so it can be awaited directly.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'insert', 'update', 'upsert', 'delete', 'order', 'limit']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('POST /api/platforms/facebook/broadcast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  // --- Auth Guard Tests ---
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // --- Input Validation Tests ---
+
+  it('returns 400 when title is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        description: 'Missing title',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when title is empty', async () => {
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: '',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when title exceeds 255 characters', async () => {
+    const longTitle = 'a'.repeat(256);
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: longTitle,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts optional description (defaults to empty string)', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+        primary_page_id: 'page-1',
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  // --- Facebook Connection Tests ---
+
+  it('returns 400 when Facebook is not connected', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Facebook not connected');
+  });
+
+  it('returns 400 when Facebook query errors', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db down') }));
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Facebook not connected');
+  });
+
+  // --- Page Selection Tests ---
+
+  it('returns 400 when no Facebook pages are available', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe(
+      'No Facebook Page found. You must manage at least one Facebook Page to go live.',
+    );
+  });
+
+  it('uses primary_page_id when pageId is not specified', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Primary Page',
+            access_token: 'token-1',
+          },
+          {
+            id: 'page-2',
+            name: 'Secondary Page',
+            access_token: 'token-2',
+          },
+        ],
+        primary_page_id: 'page-1',
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pageId).toBe('page-1');
+    expect(body.pageName).toBe('Primary Page');
+  });
+
+  it('uses explicitly specified pageId when provided', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Primary Page',
+            access_token: 'token-1',
+          },
+          {
+            id: 'page-2',
+            name: 'Secondary Page',
+            access_token: 'token-2',
+          },
+        ],
+        primary_page_id: 'page-1',
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+        pageId: 'page-2',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pageId).toBe('page-2');
+    expect(body.pageName).toBe('Secondary Page');
+  });
+
+  it('falls back to first page when primary_page_id is not set', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'First Page',
+            access_token: 'token-1',
+          },
+          {
+            id: 'page-2',
+            name: 'Second Page',
+            access_token: 'token-2',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pageId).toBe('page-1');
+  });
+
+  // --- Facebook API Call Tests ---
+
+  it('calls Facebook Graph API with correct parameters', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'page-access-token',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'My Broadcast',
+        description: 'Broadcasting live',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://graph.facebook.com/v19.0/page-1/live_videos',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'My Broadcast',
+          description: 'Broadcasting live',
+          status: 'LIVE_NOW',
+          access_token: 'page-access-token',
+        }),
+      }),
+    );
+  });
+
+  // --- Success Response Tests ---
+
+  it('returns 200 with success payload on successful broadcast creation', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-123',
+            name: 'My Page',
+            access_token: 'token-abc',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/path/streamkey',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+        description: 'Testing',
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.liveVideoId).toBe('live-1');
+    expect(body.streamUrl).toBe('rtmp://host/path/streamkey');
+    expect(body.pageId).toBe('page-123');
+    expect(body.pageName).toBe('My Page');
+    expect(body.watchUrl).toBe('https://www.facebook.com/live/producer/live-1');
+  });
+
+  // --- RTMP URL Parsing Tests ---
+
+  it('correctly parses rtmp_url into rtmpUrl and streamKey', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://live-api-s.facebook.com:80/rtmp/abc123def456ghi789',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.rtmpUrl).toBe('rtmp://live-api-s.facebook.com:80/rtmp');
+    expect(body.streamKey).toBe('abc123def456ghi789');
+  });
+
+  it('handles stream_url without slash gracefully', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://simple',
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+
+    const body = await res.json();
+    expect(body.rtmpUrl).toBe('rtmp://simple');
+    expect(body.streamKey).toBe('');
+  });
+
+  // --- Error Response Tests ---
+
+  it('returns 500 when Facebook API response lacks id', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          stream_url: 'rtmp://host/path/streamkey',
+          error: { message: 'Invalid page' },
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create Facebook live video');
+  });
+
+  it('returns 500 when Facebook API response lacks stream_url', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          error: { message: 'No stream URL available' },
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create Facebook live video');
+    expect(body.details).toBe('No stream URL available');
+  });
+
+  it('returns 500 when Facebook API returns an error message', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: {
+        pages: [
+          {
+            id: 'page-1',
+            name: 'Test Page',
+            access_token: 'token-123',
+          },
+        ],
+      },
+    };
+    mockFrom.mockReturnValue(makeChain({ data: platform, error: null }));
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          error: {
+            message: 'Invalid access token',
+          },
+        }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test Stream',
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create Facebook live video');
+    expect(body.details).toBe('Invalid access token');
+  });
+
+  // --- Exception Handling Tests ---
+
+  it('returns 500 when request body is not valid JSON', async () => {
+    const req = new (await import('next/server')).NextRequest(
+      new URL('/api/platforms/facebook/broadcast', 'http://localhost:3000'),
+      {
+        method: 'POST',
+        body: 'not json',
+      },
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create broadcast');
+  });
+
+  it('logs errors via logger on exception', async () => {
+    const { logger } = await import('@/lib/logger');
+    mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db error') }));
+
+    await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test',
+      }),
+    );
+
+    // The error is logged in the catch block, not here. This test verifies
+    // that the route handles errors gracefully without throwing.
+    expect(logger.error).not.toHaveBeenCalled(); // Not called in this path
+  });
+
+  // --- Supabase Query Verification ---
+
+  it('queries Supabase with correct user fid and platform filter', async () => {
+    const platform = {
+      user_fid: 123,
+      platform: 'facebook',
+      metadata: { pages: [{ id: 'p1', name: 'Page', access_token: 'token' }] },
+    };
+    const chain = makeChain({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          id: 'live-1',
+          stream_url: 'rtmp://host/streamkey',
+        }),
+    });
+
+    await POST(
+      makePostRequest('/api/platforms/facebook/broadcast', {
+        title: 'Test',
+      }),
+    );
+
+    expect(mockFrom).toHaveBeenCalledWith('connected_platforms');
+    expect(chain.select).toHaveBeenCalledWith('*');
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'facebook');
+    expect(chain.single).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/platforms/twitch/__tests__/route.test.ts
+++ b/src/app/api/platforms/twitch/__tests__/route.test.ts
@@ -1,0 +1,208 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET } from '../route';
+
+/**
+ * Build a Supabase query-chain mock that resolves to the given result.
+ * Supports both .single() terminal and direct await.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const method of ['select', 'eq', 'delete', 'order', 'limit']) {
+    chain[method] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(result));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/platforms/twitch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await GET(makeGetRequest('/api/platforms/twitch'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('public lookup by fid', () => {
+    it('queries connected_platforms with the provided fid', async () => {
+      const chain = makeChain({
+        data: {
+          platform_username: 'teststreamer',
+          platform_display_name: 'Test Streamer',
+        },
+      });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch', { fid: '999' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(true);
+      expect(body.username).toBe('teststreamer');
+      expect(body.displayName).toBe('Test Streamer');
+
+      expect(chain.select).toHaveBeenCalledWith('platform_username, platform_display_name');
+      expect(chain.eq).toHaveBeenCalledWith('user_fid', 999);
+      expect(chain.eq).toHaveBeenCalledWith('platform', 'twitch');
+      expect(chain.single).toHaveBeenCalled();
+    });
+
+    it('returns connected: false when public lookup finds no data', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch', { fid: '999' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+    });
+  });
+
+  describe('authenticated user own connection', () => {
+    it('returns connected: false when user has no Twitch connection', async () => {
+      const chain = makeChain({ data: null, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+
+      expect(chain.select).toHaveBeenCalledWith(
+        'platform_username, platform_display_name, platform_user_id, stream_key, rtmp_url',
+      );
+      expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+      expect(chain.eq).toHaveBeenCalledWith('platform', 'twitch');
+      expect(chain.single).toHaveBeenCalled();
+    });
+
+    it('returns full Twitch connection data on success', async () => {
+      const twitchData = {
+        platform_username: 'streamerlive',
+        platform_display_name: 'StreamerLive',
+        platform_user_id: 'twitch-123',
+        stream_key: 'live_secret_key_123',
+        rtmp_url: 'rtmp://live-fra.twitch.tv/app/',
+      };
+      mockFrom.mockReturnValue(makeChain({ data: twitchData, error: null }));
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        connected: true,
+        username: 'streamerlive',
+        displayName: 'StreamerLive',
+        streamKey: 'live_secret_key_123',
+        rtmpUrl: 'rtmp://live-fra.twitch.tv/app/',
+      });
+    });
+
+    it('handles database error gracefully', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db connection failed') }));
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('unexpected exception');
+      });
+
+      const res = await GET(makeGetRequest('/api/platforms/twitch'));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to get Twitch info');
+    });
+  });
+});
+
+describe('DELETE /api/platforms/twitch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await DELETE();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('deletes the Twitch connection for the session user', async () => {
+      const chain = makeChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await DELETE();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+
+      expect(chain.delete).toHaveBeenCalled();
+      expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+      expect(chain.eq).toHaveBeenCalledWith('platform', 'twitch');
+    });
+
+    it('returns error message when delete fails', async () => {
+      mockFrom.mockReturnValue(makeChain({ error: new Error('permission denied') }));
+
+      const res = await DELETE();
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to disconnect');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('connection timeout');
+      });
+
+      const res = await DELETE();
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to disconnect');
+    });
+  });
+});

--- a/src/app/api/platforms/youtube/broadcast/__tests__/route.test.ts
+++ b/src/app/api/platforms/youtube/broadcast/__tests__/route.test.ts
@@ -1,0 +1,352 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+import { POST } from '../route';
+
+describe('POST /api/platforms/youtube/broadcast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when title is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/platforms/youtube/broadcast', { description: 'test' }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when title exceeds 100 characters', async () => {
+    const longTitle = 'x'.repeat(101);
+    const res = await POST(
+      makePostRequest('/api/platforms/youtube/broadcast', { title: longTitle }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when YouTube is not connected', async () => {
+    const { chain } = chainMock({ data: null, error: new Error('not found') });
+    mockFrom.mockReturnValue(chain);
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('YouTube not connected');
+  });
+
+  it('returns 401 when YouTube token is expired and no refresh token exists', async () => {
+    const platform = {
+      access_token: 'old_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('YouTube token expired — please reconnect');
+  });
+
+  it('returns 401 when token refresh fails', async () => {
+    const platform = {
+      access_token: 'old_token',
+      refresh_token: 'refresh_token',
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: () => Promise.resolve({ error: 'invalid_grant' }),
+    });
+
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('YouTube token refresh failed — please reconnect');
+  });
+
+  it('returns 500 when broadcast creation fails', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      json: () => Promise.resolve({ error: 'invalid_broadcast' }),
+    });
+
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create YouTube broadcast');
+  });
+
+  it('returns 500 when stream creation fails', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const broadcast = { id: 'broadcast_123' };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(broadcast),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ error: 'invalid_stream' }),
+      });
+
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create YouTube stream');
+  });
+
+  it('returns 500 when bind stream fails', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const broadcast = { id: 'broadcast_123' };
+    const stream = {
+      id: 'stream_456',
+      cdn: { ingestionInfo: { ingestionAddress: 'rtmp://...', streamName: 'key' } },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(broadcast),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(stream),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ error: 'bind_failed' }),
+      });
+
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to bind YouTube stream to broadcast');
+  });
+
+  it('returns 500 on uncaught exception', async () => {
+    mockGetSessionData.mockRejectedValueOnce(new Error('session error'));
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to create broadcast');
+  });
+
+  it('succeeds when all YouTube API calls succeed', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const broadcast = { id: 'broadcast_123' };
+    const stream = {
+      id: 'stream_456',
+      cdn: {
+        ingestionInfo: {
+          ingestionAddress: 'rtmp://example.com/live',
+          streamName: 'stream_key_789',
+        },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(broadcast),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(stream),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'broadcast_123' }),
+      });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/youtube/broadcast', {
+        title: 'Live Stream Test',
+        description: 'Test description',
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.broadcastId).toBe('broadcast_123');
+    expect(body.streamId).toBe('stream_456');
+    expect(body.rtmpUrl).toBe('rtmp://example.com/live');
+    expect(body.streamKey).toBe('stream_key_789');
+    expect(body.watchUrl).toBe('https://youtube.com/watch?v=broadcast_123');
+  });
+
+  it('refreshes token when expired and includes new token in subsequent API calls', async () => {
+    const platform = {
+      access_token: 'old_token',
+      refresh_token: 'refresh_token_123',
+      expires_at: new Date(Date.now() - 1000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const refreshResponse = { access_token: 'new_token', expires_in: 3600 };
+    const broadcast = { id: 'broadcast_123' };
+    const stream = {
+      id: 'stream_456',
+      cdn: {
+        ingestionInfo: { ingestionAddress: 'rtmp://example.com/live', streamName: 'stream_key' },
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(refreshResponse),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(broadcast),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(stream),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'broadcast_123' }),
+      });
+
+    const res = await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+    expect(res.status).toBe(200);
+
+    // Verify token refresh was called
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }),
+    );
+
+    // Verify the broadcast creation used the new token
+    const broadcastCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(broadcastCall[0]).toContain('liveBroadcasts');
+    expect(broadcastCall[1].headers.Authorization).toBe('Bearer new_token');
+  });
+
+  it('allows optional description field', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const broadcast = { id: 'broadcast_123' };
+    const stream = {
+      id: 'stream_456',
+      cdn: { ingestionInfo: { ingestionAddress: 'rtmp://example.com/live', streamName: 'key' } },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(broadcast),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve(stream),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'broadcast_123' }),
+      });
+
+    const res = await POST(
+      makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test Only' }),
+    );
+    expect(res.status).toBe(200);
+
+    // Verify broadcast was created with empty description default
+    const broadcastCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const bodyStr = broadcastCall[1].body;
+    const bodyObj = JSON.parse(bodyStr);
+    expect(bodyObj.snippet.description).toBe('');
+  });
+
+  it('scopes platform lookup to session fid', async () => {
+    const platform = {
+      access_token: 'valid_token',
+      refresh_token: null,
+      expires_at: new Date(Date.now() + 3600000).toISOString(),
+    };
+    const { chain } = chainMock({ data: platform, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'broadcast_123' }),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'stream_456', cdn: { ingestionInfo: {} } }),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ id: 'broadcast_123' }),
+      });
+
+    await POST(makePostRequest('/api/platforms/youtube/broadcast', { title: 'Test' }));
+
+    // Verify the query scoped to user's fid
+    expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+    expect(chain.eq).toHaveBeenCalledWith('platform', 'youtube');
+  });
+});


### PR DESCRIPTION
46 tests across 3 untested platform routes (task #591), subagent-authored + verified green (vitest 46/46, tsc 0, biome clean). twitch GET+DELETE (11), facebook/broadcast POST (21, Facebook Graph live-video + RTMP), youtube/broadcast POST (14, token-refresh + liveBroadcasts/liveStreams/bind). The two broadcast routes mock fetch (raw external-API calls, no lib seam — justified exception); twitch uses supabase module mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)