### PR TITLE
test(memory): recall, retain, reflect, community/recall (task #591)

### DIFF
--- a/src/app/api/memory/[userId]/recall/__tests__/route.test.ts
+++ b/src/app/api/memory/[userId]/recall/__tests__/route.test.ts
@@ -1,0 +1,452 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSession, mockGetHindsightClient } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetHindsightClient: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => mockGetSession(),
+}));
+
+vi.mock('@/lib/hindsight', () => ({
+  getHindsightClient: () => mockGetHindsightClient(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/memory/[userId]/recall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(mockUnauthenticatedSession());
+    mockGetHindsightClient.mockResolvedValue(null);
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockGetHindsightClient).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when session exists with valid fid', async () => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/456/recall?q=test'), {
+        params: Promise.resolve({ userId: '456' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetHindsightClient).toHaveBeenCalled();
+    });
+  });
+
+  describe('authorization (user can only access their own memories)', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 403 when session fid does not match userId', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/999/recall?q=test'), {
+        params: Promise.resolve({ userId: '999' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Forbidden');
+      expect(hindsightMock.recall).not.toHaveBeenCalled();
+    });
+
+    it('succeeds when session fid matches userId (numeric comparison)', async () => {
+      const hindsightMock = {
+        recall: vi
+          .fn()
+          .mockResolvedValue([{ content: 'test memory', score: 0.95, metadata: { type: 'note' } }]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(hindsightMock.recall).toHaveBeenCalled();
+    });
+  });
+
+  describe('query validation', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+    });
+
+    it('returns 400 when query (q) is missing', async () => {
+      const res = await GET(makeGetRequest('/api/memory/123/recall'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when query is empty string', async () => {
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q='), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when query exceeds max length (500 chars)', async () => {
+      const longQuery = 'x'.repeat(501);
+      const res = await GET(
+        makeGetRequest(`/api/memory/123/recall?q=${encodeURIComponent(longQuery)}`),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts query up to max length (500 chars)', async () => {
+      const query = 'x'.repeat(500);
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(
+        makeGetRequest(`/api/memory/123/recall?q=${encodeURIComponent(query)}`),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(hindsightMock.recall).toHaveBeenCalledWith('123', query, { limit: 10 });
+    });
+
+    it('returns 400 when limit is not a positive integer', async () => {
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test&limit=-5'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when limit exceeds max (100)', async () => {
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test&limit=101'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('uses default limit of 10 when not specified', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(hindsightMock.recall).toHaveBeenCalledWith('123', 'test', { limit: 10 });
+    });
+
+    it('coerces numeric-string limit to integer', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      await GET(makeGetRequest('/api/memory/123/recall?q=test&limit=25'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(hindsightMock.recall).toHaveBeenCalledWith('123', 'test', { limit: 25 });
+    });
+
+    it('accepts limit up to max (100)', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      await GET(makeGetRequest('/api/memory/123/recall?q=test&limit=100'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(hindsightMock.recall).toHaveBeenCalledWith('123', 'test', { limit: 100 });
+    });
+  });
+
+  describe('hindsight client errors', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 503 when hindsight client is not available', async () => {
+      mockGetHindsightClient.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toBe('Hindsight not available');
+    });
+
+    it('returns 500 when hindsight recall throws an error', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockRejectedValue(new Error('Hindsight service down')),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to recall memories');
+    });
+  });
+
+  describe('successful recall', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns recalled memories with all fields', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([
+          {
+            content: 'First memory about ZAO',
+            score: 0.95,
+            metadata: { type: 'note', date: '2026-01-01' },
+          },
+          {
+            content: 'Second memory about coworking',
+            score: 0.87,
+            metadata: { type: 'meeting' },
+          },
+        ]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=ZAO'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.memories).toHaveLength(2);
+      expect(body.memories[0]).toEqual({
+        content: 'First memory about ZAO',
+        score: 0.95,
+        metadata: { type: 'note', date: '2026-01-01' },
+      });
+      expect(body.memories[1]).toEqual({
+        content: 'Second memory about coworking',
+        score: 0.87,
+        metadata: { type: 'meeting' },
+      });
+    });
+
+    it('returns empty memories array when no matches found', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=nonexistent'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.memories).toEqual([]);
+    });
+
+    it('filters response to include only content, score, and metadata fields', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([
+          {
+            content: 'Test memory',
+            score: 0.9,
+            metadata: { key: 'value' },
+            extraField: 'should be excluded',
+            internalId: 'xyz',
+          },
+        ]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.memories[0]).not.toHaveProperty('extraField');
+      expect(body.memories[0]).not.toHaveProperty('internalId');
+      expect(body.memories[0]).toEqual({
+        content: 'Test memory',
+        score: 0.9,
+        metadata: { key: 'value' },
+      });
+    });
+
+    it('handles memories without metadata', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([
+          {
+            content: 'Memory without metadata',
+            score: 0.85,
+          },
+        ]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.memories[0]).toEqual({
+        content: 'Memory without metadata',
+        score: 0.85,
+        metadata: undefined,
+      });
+    });
+
+    it('respects the limit parameter passed to hindsight', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      await GET(makeGetRequest('/api/memory/123/recall?q=search&limit=50'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(hindsightMock.recall).toHaveBeenCalledWith('123', 'search', { limit: 50 });
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    it('reads userId from params promise', async () => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const testUserId = '789';
+      const res = await GET(makeGetRequest('/api/memory/789/recall?q=test'), {
+        params: Promise.resolve({ userId: testUserId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(hindsightMock.recall).toHaveBeenCalledWith(testUserId, 'test', { limit: 10 });
+    });
+
+    it('correctly handles userId as string even when fid is number', async () => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const hindsightMock = {
+        recall: vi.fn().mockResolvedValue([]),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/456/recall?q=test'), {
+        params: Promise.resolve({ userId: '456' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(hindsightMock.recall).toHaveBeenCalledWith('456', 'test', { limit: 10 });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('catches and logs errors in try/catch', async () => {
+      mockGetHindsightClient.mockImplementationOnce(() => {
+        throw new Error('Unexpected error during client initialization');
+      });
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to recall memories');
+    });
+
+    it('returns 500 with appropriate error message on internal server error', async () => {
+      const hindsightMock = {
+        recall: vi.fn().mockRejectedValue(new Error('Database connection lost')),
+      };
+      mockGetHindsightClient.mockResolvedValue(hindsightMock);
+
+      const res = await GET(makeGetRequest('/api/memory/123/recall?q=test'), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to recall memories');
+      expect(body).not.toHaveProperty('details');
+    });
+  });
+});

--- a/src/app/api/memory/[userId]/reflect/__tests__/route.test.ts
+++ b/src/app/api/memory/[userId]/reflect/__tests__/route.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSession, mockGetHindsightClient, mockLogger } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetHindsightClient: vi.fn(),
+  mockLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => mockGetSession(),
+}));
+
+vi.mock('@/lib/hindsight', () => ({
+  getHindsightClient: () => mockGetHindsightClient(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/memory/[userId]/reflect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ fid: undefined });
+    mockGetHindsightClient.mockResolvedValue(null);
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSession.mockResolvedValue({ fid: undefined });
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/reflect', { prompt: 'test prompt' }),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('proceeds when session exists with valid fid', async () => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+      const mockReflect = vi.fn().mockResolvedValue('Reflection result');
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/reflect', { prompt: 'test prompt' }),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockReflect).toHaveBeenCalled();
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns 403 when session fid does not match userId', async () => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+
+      const res = await POST(
+        makePostRequest('/api/memory/456/reflect', { prompt: 'test prompt' }),
+        {
+          params: Promise.resolve({ userId: '456' }),
+        },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Forbidden');
+    });
+
+    it('allows when session fid matches userId as string', async () => {
+      mockGetSession.mockResolvedValue({ fid: 789 });
+      const mockReflect = vi.fn().mockResolvedValue('Reflection');
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const res = await POST(
+        makePostRequest('/api/memory/789/reflect', { prompt: 'test prompt' }),
+        {
+          params: Promise.resolve({ userId: '789' }),
+        },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockReflect).toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 400 when prompt is empty string', async () => {
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: '' }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when prompt is missing', async () => {
+      const res = await POST(makePostRequest('/api/memory/123/reflect', {}), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when prompt exceeds 2000 characters', async () => {
+      const longPrompt = 'x'.repeat(2001);
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: longPrompt }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 500 when body is not JSON (caught in try/catch)', async () => {
+      const req = new Request(new URL('/api/memory/123/reflect', 'http://localhost:3000'), {
+        method: 'POST',
+        body: 'not json',
+      });
+
+      const res = await POST(req, {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to reflect on memories');
+    });
+
+    it('accepts prompt at exactly 2000 characters', async () => {
+      const promptAt2000 = 'x'.repeat(2000);
+      mockGetSession.mockResolvedValue({ fid: 123 });
+      const mockReflect = vi.fn().mockResolvedValue('Reflection');
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: promptAt2000 }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockReflect).toHaveBeenCalledWith('123', promptAt2000);
+    });
+  });
+
+  describe('hindsight integration', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 503 when hindsight client is not available', async () => {
+      mockGetHindsightClient.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/reflect', { prompt: 'test prompt' }),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toBe('Hindsight not available');
+    });
+
+    it('successfully calls hindsight reflect and returns result', async () => {
+      const reflectionText = 'You reflected on past experiences';
+      const mockReflect = vi.fn().mockResolvedValue(reflectionText);
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/reflect', { prompt: 'what did I learn?' }),
+        {
+          params: Promise.resolve({ userId: '123' }),
+        },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.reflection).toBe(reflectionText);
+      expect(mockReflect).toHaveBeenCalledWith('123', 'what did I learn?');
+    });
+
+    it('handles hindsight reflect promise rejection', async () => {
+      const mockReflect = vi.fn().mockRejectedValue(new Error('Hindsight service error'));
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to reflect on memories');
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 456 });
+    });
+
+    it('reads userId from params promise correctly', async () => {
+      const mockReflect = vi.fn().mockResolvedValue('Result');
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      const testUserId = '456';
+      const res = await POST(makePostRequest('/api/memory/456/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: testUserId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockReflect).toHaveBeenCalledWith(testUserId, expect.any(String));
+    });
+
+    it('passes string userId to hindsight, not numeric conversion', async () => {
+      const mockReflect = vi.fn().mockResolvedValue('Result');
+      mockGetHindsightClient.mockResolvedValue({ reflect: mockReflect });
+
+      mockGetSession.mockResolvedValue({ fid: 999 });
+
+      await POST(makePostRequest('/api/memory/999/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: '999' }),
+      });
+
+      expect(mockReflect).toHaveBeenCalledWith('999', expect.any(String));
+      const [passedUserId] = mockReflect.mock.calls[0];
+      expect(typeof passedUserId).toBe('string');
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 500 with generic message when unexpected error occurs', async () => {
+      mockGetHindsightClient.mockRejectedValue(new Error('Unexpected error'));
+
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to reflect on memories');
+    });
+
+    it('logs error to logger on exception', async () => {
+      mockGetHindsightClient.mockRejectedValue(new Error('Test error'));
+
+      await POST(makePostRequest('/api/memory/123/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+
+      expect(mockLogger.error).toHaveBeenCalled();
+      const [msg, err] = mockLogger.error.mock.calls[0];
+      expect(msg).toBe('Failed to reflect on memories:');
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('Test error');
+    });
+
+    it('does not expose error details to client', async () => {
+      mockGetHindsightClient.mockRejectedValue(new Error('Internal DB connection pooled out'));
+
+      const res = await POST(makePostRequest('/api/memory/123/reflect', { prompt: 'test' }), {
+        params: Promise.resolve({ userId: '123' }),
+      });
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to reflect on memories');
+      expect(body.details).toBeUndefined();
+    });
+  });
+});

--- a/src/app/api/memory/[userId]/retain/__tests__/route.test.ts
+++ b/src/app/api/memory/[userId]/retain/__tests__/route.test.ts
@@ -1,0 +1,423 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockGetHindsightClient } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetHindsightClient: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/hindsight', () => ({
+  getHindsightClient: () => mockGetHindsightClient(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * Mock hindsight client with a retain method that returns a result object.
+ */
+function mockHindsightClient(returnValue: unknown = { id: 'mem-123' }) {
+  return {
+    retain: vi.fn().mockResolvedValue(returnValue),
+  };
+}
+
+describe('POST /api/memory/[userId]/retain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockGetHindsightClient.mockResolvedValue(mockHindsightClient());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockGetHindsightClient).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const res = await POST(
+        makePostRequest('/api/memory/456/retain', {
+          content: 'test memory',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '456' }) },
+      );
+
+      expect(res.status).toBe(201);
+      expect(mockGetHindsightClient).toHaveBeenCalled();
+    });
+  });
+
+  describe('authorization', () => {
+    it('returns 403 when userId does not match session fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/memory/999/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '999' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Forbidden');
+      expect(mockGetHindsightClient).not.toHaveBeenCalled();
+    });
+
+    it('allows request when userId matches session fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+      const res = await POST(
+        makePostRequest('/api/memory/789/retain', {
+          content: 'my memory',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '789' }) },
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when content is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when content is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: '',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when content exceeds max length', async () => {
+      const longContent = 'x'.repeat(10001);
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: longContent,
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when eventType is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when eventType is invalid', async () => {
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'invalid_type',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid eventTypes', async () => {
+      const validEventTypes = [
+        'cast',
+        'track_share',
+        'respect',
+        'room_participation',
+        'profile_update',
+        'reaction',
+        'governance_vote',
+      ];
+
+      for (const eventType of validEventTypes) {
+        const res = await POST(
+          makePostRequest('/api/memory/123/retain', {
+            content: 'test',
+            eventType,
+          }),
+          { params: Promise.resolve({ userId: '123' }) },
+        );
+        expect(res.status).toBe(201);
+      }
+    });
+
+    it('returns 500 when request.json() throws', async () => {
+      const req = new (require('next/server').NextRequest)(
+        new URL('/api/memory/123/retain', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: 'not json',
+        },
+      );
+
+      const res = await POST(req, { params: Promise.resolve({ userId: '123' }) });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to retain memory');
+    });
+  });
+
+  describe('hindsight client handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 503 when hindsight client is not available', async () => {
+      mockGetHindsightClient.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.error).toBe('Hindsight client not available');
+    });
+
+    it('calls retain with correct parameters', async () => {
+      const hindsightClient = mockHindsightClient();
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'my memory content',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+
+      expect(hindsightClient.retain).toHaveBeenCalledWith('123', 'my memory content', {
+        metadata: {
+          eventType: 'cast',
+        },
+      });
+    });
+
+    it('includes metadata in retain call when provided', async () => {
+      const hindsightClient = mockHindsightClient();
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'my memory content',
+          eventType: 'cast',
+          metadata: {
+            roomId: 'room-123',
+            timestamp: 1234567890,
+          },
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+
+      expect(hindsightClient.retain).toHaveBeenCalledWith('123', 'my memory content', {
+        metadata: {
+          eventType: 'cast',
+          roomId: 'room-123',
+          timestamp: 1234567890,
+        },
+      });
+    });
+  });
+
+  describe('success response', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 201 with memoryId from result.id', async () => {
+      const hindsightClient = mockHindsightClient({ id: 'mem-abc123' });
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.memoryId).toBe('mem-abc123');
+    });
+
+    it('returns 201 with memoryId from result.memoryId when id is missing', async () => {
+      const hindsightClient = mockHindsightClient({ memoryId: 'mem-xyz789' });
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.memoryId).toBe('mem-xyz789');
+    });
+
+    it('returns 201 with entire result when neither id nor memoryId present', async () => {
+      const resultObject = { data: 'some result' };
+      const hindsightClient = mockHindsightClient(resultObject);
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.memoryId).toEqual(resultObject);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockGetHindsightClient.mockResolvedValue(mockHindsightClient());
+    });
+
+    it('returns 500 when hindsight retain throws', async () => {
+      const hindsightClient = mockHindsightClient();
+      hindsightClient.retain.mockRejectedValue(new Error('Network error'));
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      const res = await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to retain memory');
+    });
+
+    it('logs error on failure', async () => {
+      const { logger } = await import('@/lib/logger');
+      const hindsightClient = mockHindsightClient();
+      const testError = new Error('Test error');
+      hindsightClient.retain.mockRejectedValue(testError);
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      await POST(
+        makePostRequest('/api/memory/123/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '123' }) },
+      );
+
+      expect(logger.error).toHaveBeenCalledWith('Failed to retain memory:', testError);
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    it('reads userId from params promise', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+      const hindsightClient = mockHindsightClient();
+      mockGetHindsightClient.mockResolvedValue(hindsightClient);
+
+      const res = await POST(
+        makePostRequest('/api/memory/999/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '999' }) },
+      );
+
+      expect(res.status).toBe(201);
+      expect(hindsightClient.retain).toHaveBeenCalledWith('999', 'test', expect.any(Object));
+    });
+
+    it('compares userId as strings for authorization', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555 }));
+
+      const res = await POST(
+        makePostRequest('/api/memory/555/retain', {
+          content: 'test',
+          eventType: 'cast',
+        }),
+        { params: Promise.resolve({ userId: '555' }) },
+      );
+
+      expect(res.status).toBe(201);
+    });
+  });
+});

--- a/src/app/api/memory/community/recall/__tests__/route.test.ts
+++ b/src/app/api/memory/community/recall/__tests__/route.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSession, mockGetHindsightClient } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetHindsightClient: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => mockGetSession(),
+}));
+
+vi.mock('@/lib/hindsight', () => ({
+  getHindsightClient: () => mockGetHindsightClient(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/memory/community/recall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({ fid: 123 });
+  });
+
+  // =========================================================================
+  // Auth guard tests
+  // =========================================================================
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session has no fid', async () => {
+    mockGetSession.mockResolvedValue({});
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  // =========================================================================
+  // Query validation tests
+  // =========================================================================
+
+  it('returns 400 when q is missing', async () => {
+    const res = await GET(makeGetRequest('/api/memory/community/recall'));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid input');
+    expect(json.details).toBeDefined();
+  });
+
+  it('returns 400 when q is empty string', async () => {
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: '' }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when q exceeds 500 characters', async () => {
+    const longQuery = 'a'.repeat(501);
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: longQuery }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when limit is not a positive integer', async () => {
+    const res = await GET(
+      makeGetRequest('/api/memory/community/recall', { q: 'test', limit: '-5' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when limit exceeds 100', async () => {
+    const res = await GET(
+      makeGetRequest('/api/memory/community/recall', { q: 'test', limit: '101' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when limit is not a number', async () => {
+    const res = await GET(
+      makeGetRequest('/api/memory/community/recall', { q: 'test', limit: 'abc' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // =========================================================================
+  // Query parameter coercion tests
+  // =========================================================================
+
+  it('uses default limit of 10 when limit is omitted', async () => {
+    const mockRecall = vi.fn().mockResolvedValue([]);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    await GET(makeGetRequest('/api/memory/community/recall', { q: 'memory search' }));
+    expect(mockRecall).toHaveBeenCalledWith('zao-community', 'memory search', { limit: 10 });
+  });
+
+  it('coerces numeric-string limit to number', async () => {
+    const mockRecall = vi.fn().mockResolvedValue([]);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    await GET(makeGetRequest('/api/memory/community/recall', { q: 'test', limit: '25' }));
+    expect(mockRecall).toHaveBeenCalledWith('zao-community', 'test', { limit: 25 });
+  });
+
+  // =========================================================================
+  // Success tests
+  // =========================================================================
+
+  it('returns empty memories array when hindsight returns no results', async () => {
+    const mockRecall = vi.fn().mockResolvedValue([]);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'nonexistent' }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).memories).toEqual([]);
+  });
+
+  it('returns memories with content, score, and metadata', async () => {
+    const mockResults = [
+      {
+        content: 'ZAO ecosystem grants program details',
+        score: 0.95,
+        metadata: { source: 'doc_123', created_at: '2026-01-01' },
+      },
+      {
+        content: 'Community voting mechanism explanation',
+        score: 0.87,
+        metadata: { source: 'doc_456' },
+      },
+    ];
+    const mockRecall = vi.fn().mockResolvedValue(mockResults);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'grants' }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.memories).toHaveLength(2);
+    expect(json.memories[0]).toEqual({
+      content: 'ZAO ecosystem grants program details',
+      score: 0.95,
+      metadata: { source: 'doc_123', created_at: '2026-01-01' },
+    });
+    expect(json.memories[1]).toEqual({
+      content: 'Community voting mechanism explanation',
+      score: 0.87,
+      metadata: { source: 'doc_456' },
+    });
+  });
+
+  it('includes undefined metadata when hindsight result omits it', async () => {
+    const mockResults = [
+      {
+        content: 'Some memory',
+        score: 0.9,
+      },
+    ];
+    const mockRecall = vi.fn().mockResolvedValue(mockResults);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    const json = await res.json();
+    expect(json.memories[0].metadata).toBeUndefined();
+  });
+
+  it('passes correct bank ID and query to hindsight.recall()', async () => {
+    const mockRecall = vi.fn().mockResolvedValue([]);
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    await GET(
+      makeGetRequest('/api/memory/community/recall', { q: 'community history', limit: '5' }),
+    );
+    expect(mockRecall).toHaveBeenCalledWith('zao-community', 'community history', { limit: 5 });
+  });
+
+  // =========================================================================
+  // Hindsight availability tests
+  // =========================================================================
+
+  it('returns 503 when hindsight client is not available', async () => {
+    mockGetHindsightClient.mockResolvedValue(null);
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe('Hindsight not available');
+  });
+
+  // =========================================================================
+  // Error handling tests
+  // =========================================================================
+
+  it('returns 500 when hindsight.recall() throws an error', async () => {
+    const mockRecall = vi.fn().mockRejectedValue(new Error('hindsight service error'));
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to recall community memories');
+  });
+
+  it('returns 500 when getHindsightClient() throws an error', async () => {
+    mockGetHindsightClient.mockRejectedValue(new Error('client initialization failed'));
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to recall community memories');
+  });
+
+  it('returns 500 when session check throws unexpectedly', async () => {
+    mockGetSession.mockRejectedValue(new Error('session error'));
+    const res = await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to recall community memories');
+  });
+
+  it('logs errors to the logger on 500 response', async () => {
+    const { logger } = await import('@/lib/logger');
+    const mockRecall = vi.fn().mockRejectedValue(new Error('database timeout'));
+    mockGetHindsightClient.mockResolvedValue({ recall: mockRecall });
+
+    await GET(makeGetRequest('/api/memory/community/recall', { q: 'test' }));
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to recall community memories:',
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
81 tests across the 4 untested memory/* routes (task #591), subagent-authored + verified green (vitest 81/81, tsc 0, biome clean). memory/[userId]/recall GET (24), retain POST (21), reflect POST (17), community/recall GET (19). Covers auth + fid-authz, Zod validation, hindsight 503/500 paths, dynamic params. All hindsight/session module mocks (no fetch). Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)