### PR TITLE
test(neynar): like, recast, follow, cast (task #591)

### DIFF
--- a/src/app/api/neynar/cast/__tests__/route.test.ts
+++ b/src/app/api/neynar/cast/__tests__/route.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+// Mock environment variables
+process.env.NEYNAR_API_KEY = 'test-neynar-key-12345';
+
+import { POST } from '../route';
+
+describe('POST /api/neynar/cast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: VALID_UUID }));
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        cast: {
+          hash: '0x123abc',
+          text: 'Hello Farcaster',
+          embeds: [],
+        },
+      }),
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: 'Hello' }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized — no signer');
+  });
+
+  it('returns 401 when session has no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: undefined }));
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: 'Hello' }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized — no signer');
+  });
+
+  it('returns 400 when text is empty', async () => {
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: '' }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 when text exceeds 1024 characters', async () => {
+    const longText = 'a'.repeat(1025);
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: longText }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('returns 400 when embeds contains an invalid URL', async () => {
+    const res = await POST(
+      makePostRequest('/api/neynar/cast', {
+        text: 'Check this out',
+        embeds: ['not-a-valid-url'],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid input');
+  });
+
+  it('publishes a cast with text only', async () => {
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: 'Hello Farcaster' }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.cast.text).toBe('Hello Farcaster');
+    expect(global.fetch).toHaveBeenCalledWith('https://api.neynar.com/v2/farcaster/cast', {
+      method: 'POST',
+      headers: {
+        'x-api-key': 'test-neynar-key-12345',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        signer_uuid: VALID_UUID,
+        text: 'Hello Farcaster',
+        embeds: [],
+      }),
+    });
+  });
+
+  it('publishes a cast with embeds', async () => {
+    const res = await POST(
+      makePostRequest('/api/neynar/cast', {
+        text: 'Check this out',
+        embeds: ['https://example.com/image.png', 'https://example.com/video.mp4'],
+      }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledWith('https://api.neynar.com/v2/farcaster/cast', {
+      method: 'POST',
+      headers: {
+        'x-api-key': 'test-neynar-key-12345',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        signer_uuid: VALID_UUID,
+        text: 'Check this out',
+        embeds: [
+          { url: 'https://example.com/image.png' },
+          { url: 'https://example.com/video.mp4' },
+        ],
+      }),
+    });
+  });
+
+  it('returns 500 when Neynar API responds with an error', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({ error: 'Signer not active' }),
+    });
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: 'Hello' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to publish cast');
+  });
+
+  it('returns 500 when fetch throws', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+    const res = await POST(makePostRequest('/api/neynar/cast', { text: 'Hello' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Internal server error');
+  });
+
+  it('handles missing body gracefully', async () => {
+    const req = makePostRequest('/api/neynar/cast', { text: 'Hello' });
+    // Simulate malformed JSON by mocking req.json to throw
+    vi.spyOn(req, 'json').mockRejectedValue(new SyntaxError('Unexpected token'));
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/neynar/follow/__tests__/route.test.ts
+++ b/src/app/api/neynar/follow/__tests__/route.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFetch } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+global.fetch = mockFetch;
+
+import { POST } from '../route';
+
+describe('POST /api/neynar/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(
+      mockAuthenticatedSession({ signerUuid: 'test-signer-uuid' }),
+    );
+    process.env.NEYNAR_API_KEY = 'test-neynar-key';
+  });
+
+  afterEach(() => {
+    delete process.env.NEYNAR_API_KEY;
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('returns 401 when session has no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: undefined }));
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('returns 400 for missing targetFid', async () => {
+    const res = await POST(makePostRequest('/api/neynar/follow', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 for non-positive targetFid', async () => {
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: -1 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for non-integer targetFid', async () => {
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 3.14 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for zero targetFid', async () => {
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 0 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('successfully follows a user when Neynar returns 2xx', async () => {
+    const neynarResponse = { result: { success: true } };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => neynarResponse,
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.result).toEqual(neynarResponse);
+
+    // Verify fetch was called
+    expect(mockFetch).toHaveBeenCalled();
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[0]).toBe('https://api.neynar.com/v2/farcaster/user/follow');
+    expect(callArgs[1].method).toBe('POST');
+    expect(callArgs[1].headers['content-type']).toBe('application/json');
+    expect(callArgs[1].headers['x-api-key']).toBe('test-neynar-key');
+    expect(callArgs[1].body).toBe(
+      JSON.stringify({
+        signer_uuid: 'test-signer-uuid',
+        target_fids: [456],
+      }),
+    );
+  });
+
+  it('returns 500 when Neynar returns non-2xx status', async () => {
+    const errorResponse = { error: 'User not found' };
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => errorResponse,
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to follow user');
+  });
+
+  it('returns 500 when Neynar API call throws', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('returns 500 when response.json() throws', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error('Invalid JSON');
+      },
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('sends correct signer_uuid and target_fids to Neynar', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: {} }),
+    });
+
+    await POST(makePostRequest('/api/neynar/follow', { targetFid: 789 }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          signer_uuid: 'test-signer-uuid',
+          target_fids: [789],
+        }),
+      }),
+    );
+  });
+
+  it('respects NEYNAR_API_KEY from environment', async () => {
+    const originalKey = process.env.NEYNAR_API_KEY;
+    process.env.NEYNAR_API_KEY = 'test-neynar-key-123';
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: {} }),
+    });
+
+    await POST(makePostRequest('/api/neynar/follow', { targetFid: 456 }));
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'test-neynar-key-123',
+        }),
+      }),
+    );
+
+    process.env.NEYNAR_API_KEY = originalKey;
+  });
+});

--- a/src/app/api/neynar/like/__tests__/route.test.ts
+++ b/src/app/api/neynar/like/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch for Neynar API calls
+global.fetch = vi.fn();
+
+import { POST } from '../route';
+
+describe('POST /api/neynar/like', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(
+      mockAuthenticatedSession({ signerUuid: '550e8400-e29b-41d4-a716-446655440000' }),
+    );
+    process.env.NEYNAR_API_KEY = 'test-neynar-key';
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'abc123' }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized — no signer' });
+  });
+
+  it('returns 401 when session has no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: undefined }));
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'abc123' }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'Unauthorized — no signer' });
+  });
+
+  it('returns 400 when castHash is missing', async () => {
+    const res = await POST(makePostRequest('/api/neynar/like', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when castHash is empty', async () => {
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: '' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when castHash is not a string', async () => {
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 123 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('calls Neynar API with correct payload on success', async () => {
+    const mockNeynarData = { id: 'like1' };
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockNeynarData), { status: 200 }),
+    );
+
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'hash0x123abc' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.result).toEqual(mockNeynarData);
+
+    // Verify fetch was called with correct parameters
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.neynar.com/v2/farcaster/reaction',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-api-key': 'test-neynar-key',
+          'content-type': 'application/json',
+        }),
+        body: JSON.stringify({
+          signer_uuid: '550e8400-e29b-41d4-a716-446655440000',
+          reaction_type: 'like',
+          target: 'hash0x123abc',
+        }),
+      }),
+    );
+  });
+
+  it('returns 500 when Neynar API returns an error response', async () => {
+    const mockErrorResponse = { error: 'Invalid signer' };
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockErrorResponse), { status: 400 }),
+    );
+
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'hash0x123abc' }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Failed to like cast' });
+  });
+
+  it('returns 500 when Neynar API is unreachable', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'hash0x123abc' }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Internal server error' });
+  });
+
+  it('returns 500 when response body cannot be parsed', async () => {
+    vi.mocked(global.fetch).mockResolvedValue(new Response('invalid json', { status: 200 }));
+
+    const res = await POST(makePostRequest('/api/neynar/like', { castHash: 'hash0x123abc' }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/src/app/api/neynar/recast/__tests__/route.test.ts
+++ b/src/app/api/neynar/recast/__tests__/route.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFetch } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch
+global.fetch = mockFetch;
+
+import { POST } from '../route';
+
+describe('POST /api/neynar/recast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to authenticated session with signerUuid
+    mockGetSessionData.mockResolvedValue(
+      mockAuthenticatedSession({ signerUuid: '550e8400-e29b-41d4-a716-446655440000' }),
+    );
+    // Default Neynar API key
+    process.env.NEYNAR_API_KEY = 'test-key-12345';
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'abc123' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized — no signer');
+  });
+
+  it('returns 401 when session has no signerUuid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: undefined }));
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'abc123' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized — no signer');
+  });
+
+  it('returns 400 for missing castHash', async () => {
+    const res = await POST(makePostRequest('/api/neynar/recast', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 for empty castHash string', async () => {
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: '' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for non-string castHash', async () => {
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 12345 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('successfully recasts when Neynar API returns ok', async () => {
+    const neynarResponse = { success: true, hash: 'recast-hash-123' };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'cast-abc123' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.result).toEqual(neynarResponse);
+
+    // Verify fetch was called with correct params
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.neynar.com/v2/farcaster/reaction',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'x-api-key': 'test-key-12345',
+          'content-type': 'application/json',
+        }),
+        body: JSON.stringify({
+          signer_uuid: '550e8400-e29b-41d4-a716-446655440000',
+          reaction_type: 'recast',
+          target: 'cast-abc123',
+        }),
+      }),
+    );
+  });
+
+  it('returns 500 when Neynar API returns not ok', async () => {
+    const errorResponse = { error: 'Invalid cast hash' };
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => errorResponse,
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'bad-hash' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to recast');
+  });
+
+  it('returns 500 when fetch throws an error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'cast-abc123' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('returns 500 when response.json() throws', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => {
+        throw new Error('Invalid JSON');
+      },
+    });
+
+    const res = await POST(makePostRequest('/api/neynar/recast', { castHash: 'cast-abc123' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('ignores extra fields in request body', async () => {
+    const neynarResponse = { success: true };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const res = await POST(
+      makePostRequest('/api/neynar/recast', {
+        castHash: 'cast-abc123',
+        extraField: 'ignored',
+        anotherExtra: 12345,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
41 tests across the 4 untested neynar/* Farcaster-action routes (task #591), subagent-authored + verified green (vitest 41/41, tsc 0, biome clean). like POST (9), recast POST (10), follow POST (12), cast POST (10). Covers auth + signer guard, Zod validation, Neynar-API success + error/network/parse paths. All 4 routes call the Neynar API via raw fetch (no lib seam) so tests mock global.fetch — the justified exception (confirmed each route uses raw fetch). Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)