### PR TITLE
test(fractals): matrix, analytics, sessions, member/[wallet] (task #591)

### DIFF
--- a/src/app/api/fractals/analytics/__tests__/route.test.ts
+++ b/src/app/api/fractals/analytics/__tests__/route.test.ts
@@ -1,0 +1,832 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { GET } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself.
+ * Terminal .then() resolves the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainable = [
+    'select',
+    'order',
+    'eq',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'limit',
+    'in',
+    'neq',
+    'like',
+    'ilike',
+    'not',
+  ];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+describe('GET /api/fractals/analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session exists but is null-like', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ── Success path tests ────────────────────────────────────────────────────
+
+  it('returns complete analytics structure on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const members = [
+      {
+        name: 'Alice',
+        wallet_address: '0x1111',
+        total_respect: 100,
+        fractal_respect: 50,
+        onchain_og: 10,
+        onchain_zor: 5,
+        event_respect: 20,
+        hosting_respect: 15,
+        bonus_respect: 5,
+        first_respect_at: '2026-01-01',
+        fractal_count: 5,
+      },
+      {
+        name: 'Bob',
+        wallet_address: '0x2222',
+        total_respect: 200,
+        fractal_respect: 100,
+        onchain_og: 20,
+        onchain_zor: 10,
+        event_respect: 40,
+        hosting_respect: 30,
+        bonus_respect: 10,
+        first_respect_at: '2026-01-02',
+        fractal_count: 10,
+      },
+    ];
+
+    const sessions = [
+      {
+        id: 'sess1',
+        name: 'Session 1',
+        session_date: '2026-01-01',
+        scoring_era: 'OG',
+        participant_count: 10,
+        notes: 'synced from Airtable',
+        created_at: '2026-01-01T10:00:00Z',
+      },
+      {
+        id: 'sess2',
+        name: 'Session 2',
+        session_date: '2026-01-02',
+        scoring_era: 'ORDAO',
+        participant_count: 15,
+        notes: '',
+        created_at: '2026-01-02T10:00:00Z',
+      },
+    ];
+
+    const scores = [
+      { score: 100, rank: 1, wallet_address: '0x1111' },
+      { score: 90, rank: 2, wallet_address: '0x2222' },
+      { score: 80, rank: 3, wallet_address: '0x1111' },
+    ];
+
+    const topByFractal = [
+      {
+        name: 'Alice',
+        wallet_address: '0x1111',
+        fractal_respect: 50,
+        fractal_count: 5,
+      },
+    ];
+
+    const recentSessions = [
+      {
+        id: 'sess2',
+        name: 'Session 2',
+        session_date: '2026-01-02',
+        scoring_era: 'ORDAO',
+        participant_count: 15,
+        notes: '',
+        fractal_scores: [
+          {
+            member_name: 'Bob',
+            wallet_address: '0x2222',
+            rank: 2,
+            score: 90,
+          },
+        ],
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: members }),
+      chainMock({ data: sessions }),
+      chainMock({ data: scores }),
+      chainMock({ data: topByFractal }),
+      chainMock({ data: recentSessions }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Verify response structure
+    expect(body).toHaveProperty('overview');
+    expect(body).toHaveProperty('participationTimeline');
+    expect(body).toHaveProperty('scoreDistribution');
+    expect(body).toHaveProperty('respectCurve');
+    expect(body).toHaveProperty('topByFractal');
+    expect(body).toHaveProperty('topHosters');
+    expect(body).toHaveProperty('recentSessions');
+
+    // Verify overview aggregation
+    expect(body.overview.totalRespect).toBe(300);
+    expect(body.overview.totalFractalRespect).toBe(150);
+    expect(body.overview.totalOGOnchain).toBe(30);
+    expect(body.overview.totalZOROnchain).toBe(15);
+    expect(body.overview.totalSessions).toBe(2);
+    expect(body.overview.totalParticipations).toBe(3);
+    expect(body.overview.uniqueParticipants).toBe(2);
+    expect(body.overview.membersWithRespect).toBe(2);
+    expect(body.overview.totalMembers).toBe(2);
+    expect(body.overview.ogSessions).toBe(1);
+    expect(body.overview.ordaoSessions).toBe(1);
+
+    // Verify participation timeline
+    expect(body.participationTimeline).toHaveLength(2);
+    expect(body.participationTimeline[0]).toEqual({
+      name: 'Session 1',
+      date: '2026-01-01',
+      era: 'OG',
+      participants: 10,
+    });
+
+    // Verify score distribution
+    expect(body.scoreDistribution['100']).toBe(1);
+    expect(body.scoreDistribution['90']).toBe(1);
+    expect(body.scoreDistribution['80']).toBe(1);
+
+    // Verify respect curve
+    expect(body.respectCurve).toHaveLength(2);
+    expect(body.respectCurve[0].name).toBe('Alice');
+    expect(body.respectCurve[0].total).toBe(100);
+    expect(body.respectCurve[0].fractal).toBe(50);
+    expect(body.respectCurve[0].sessions).toBe(5);
+
+    // Verify top by fractal
+    expect(body.topByFractal).toEqual(topByFractal);
+
+    // Verify top hosters
+    expect(body.topHosters).toHaveLength(2);
+    expect(body.topHosters[0].name).toBe('Bob');
+    expect(body.topHosters[0].value).toBe(30);
+
+    // Verify recent sessions
+    expect(body.recentSessions).toEqual(recentSessions);
+  });
+
+  it('returns empty collections when no data exists', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.overview.totalRespect).toBe(0);
+    expect(body.overview.totalSessions).toBe(0);
+    expect(body.overview.totalParticipations).toBe(0);
+    expect(body.participationTimeline).toEqual([]);
+    expect(body.scoreDistribution).toEqual({});
+    expect(body.respectCurve).toEqual([]);
+    expect(body.topByFractal).toEqual([]);
+    expect(body.topHosters).toEqual([]);
+    expect(body.recentSessions).toEqual([]);
+  });
+
+  it('filters members with zero respect from respectCurve and topHosters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const members = [
+      {
+        name: 'Alice',
+        wallet_address: '0x1111',
+        total_respect: 100,
+        fractal_respect: 50,
+        onchain_og: 0,
+        onchain_zor: 0,
+        event_respect: 0,
+        hosting_respect: 10,
+        bonus_respect: 0,
+        first_respect_at: '2026-01-01',
+        fractal_count: 5,
+      },
+      {
+        name: 'Bob',
+        wallet_address: '0x2222',
+        total_respect: 0,
+        fractal_respect: 0,
+        onchain_og: 0,
+        onchain_zor: 0,
+        event_respect: 0,
+        hosting_respect: 0,
+        bonus_respect: 0,
+        first_respect_at: null,
+        fractal_count: 0,
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: members }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Only Alice should appear (has > 0 total_respect)
+    expect(body.respectCurve).toHaveLength(1);
+    expect(body.respectCurve[0].name).toBe('Alice');
+
+    // Only Alice should appear (has > 0 hosting_respect)
+    expect(body.topHosters).toHaveLength(1);
+    expect(body.topHosters[0].name).toBe('Alice');
+  });
+
+  it('correctly identifies OG vs ORDAO sessions', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const sessions = [
+      {
+        id: 'og1',
+        name: 'OG Session 1',
+        session_date: '2026-01-01',
+        scoring_era: 'OG',
+        participant_count: 10,
+        notes: 'synced from Airtable',
+        created_at: '2026-01-01T10:00:00Z',
+      },
+      {
+        id: 'og2',
+        name: 'OG Session 2',
+        session_date: '2026-01-02',
+        scoring_era: 'OG',
+        participant_count: 12,
+        notes: 'imported from Airtable, synced from Airtable',
+        created_at: '2026-01-02T10:00:00Z',
+      },
+      {
+        id: 'ordao1',
+        name: 'ORDAO Session 1',
+        session_date: '2026-01-03',
+        scoring_era: 'ORDAO',
+        participant_count: 15,
+        notes: 'webhook event',
+        created_at: '2026-01-03T10:00:00Z',
+      },
+      {
+        id: 'ordao2',
+        name: 'ORDAO Session 2',
+        session_date: '2026-01-04',
+        scoring_era: 'ORDAO',
+        participant_count: 20,
+        notes: null,
+        created_at: '2026-01-04T10:00:00Z',
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: sessions }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.overview.totalSessions).toBe(4);
+    expect(body.overview.ogSessions).toBe(2);
+    expect(body.overview.ordaoSessions).toBe(2);
+  });
+
+  it('handles members with null fractal_count gracefully', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const members = [
+      {
+        name: 'Alice',
+        wallet_address: '0x1111',
+        total_respect: 100,
+        fractal_respect: 50,
+        onchain_og: 10,
+        onchain_zor: 5,
+        event_respect: 20,
+        hosting_respect: 15,
+        bonus_respect: 5,
+        first_respect_at: '2026-01-01',
+        fractal_count: null,
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: members }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // fractal_count should default to 0
+    expect(body.respectCurve[0].sessions).toBe(0);
+  });
+
+  it('correctly counts unique participants by wallet address', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const scores = [
+      { score: 100, rank: 1, wallet_address: '0x1111' },
+      { score: 90, rank: 2, wallet_address: '0x2222' },
+      { score: 80, rank: 3, wallet_address: '0x1111' }, // duplicate wallet
+      { score: 70, rank: 4, wallet_address: null }, // null address filtered out
+    ];
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: scores }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.overview.totalParticipations).toBe(4);
+    expect(body.overview.uniqueParticipants).toBe(2); // 0x1111 and 0x2222 only
+  });
+
+  it('builds correct score distribution histogram', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const scores = [
+      { score: 100, rank: 1, wallet_address: '0x1111' },
+      { score: 100, rank: 2, wallet_address: '0x2222' },
+      { score: 90, rank: 3, wallet_address: '0x3333' },
+      { score: 90, rank: 4, wallet_address: '0x4444' },
+      { score: 90, rank: 5, wallet_address: '0x5555' },
+      { score: 50, rank: 6, wallet_address: '0x6666' },
+    ];
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: scores }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.scoreDistribution['100']).toBe(2);
+    expect(body.scoreDistribution['90']).toBe(3);
+    expect(body.scoreDistribution['50']).toBe(1);
+  });
+
+  it('sorts topHosters by hosting_respect descending (top 10)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const members = Array.from({ length: 15 }, (_, i) => ({
+      name: `Member ${i}`,
+      wallet_address: `0x${i}`,
+      total_respect: 1000,
+      fractal_respect: 100,
+      onchain_og: 0,
+      onchain_zor: 0,
+      event_respect: 0,
+      hosting_respect: 1000 - i * 50, // descending from 1000 to 250
+      bonus_respect: 0,
+      first_respect_at: '2026-01-01',
+      fractal_count: 5,
+    }));
+
+    const mockChains = [
+      chainMock({ data: members }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.topHosters).toHaveLength(10);
+    expect(body.topHosters[0].name).toBe('Member 0');
+    expect(body.topHosters[0].value).toBe(1000);
+    expect(body.topHosters[9].name).toBe('Member 9');
+    expect(body.topHosters[9].value).toBe(550);
+  });
+
+  it('handles numeric string respect values correctly', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const members = [
+      {
+        name: 'Alice',
+        wallet_address: '0x1111',
+        total_respect: '100', // string instead of number
+        fractal_respect: '50',
+        onchain_og: '10',
+        onchain_zor: '5',
+        event_respect: '20',
+        hosting_respect: '15',
+        bonus_respect: '5',
+        first_respect_at: '2026-01-01',
+        fractal_count: 5,
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: members }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should coerce strings to numbers correctly
+    expect(body.overview.totalRespect).toBe(100);
+    expect(body.overview.totalFractalRespect).toBe(50);
+    expect(body.respectCurve[0].total).toBe(100);
+    expect(body.respectCurve[0].fractal).toBe(50);
+  });
+
+  // ── Error path tests ──────────────────────────────────────────────────────
+
+  it('returns 200 even when individual query results have error fields (route ignores them)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    // The route only checks .data (via ?? []), not .error—so a result with data: null, error: true still succeeds
+    const mockChains = [
+      chainMock({ data: null, error: new Error('db error') }), // error field ignored, data coerced to []
+      chainMock({ data: null, error: new Error('db error') }),
+      chainMock({ data: null, error: new Error('db error') }),
+      chainMock({ data: null, error: new Error('db error') }),
+      chainMock({ data: null, error: new Error('db error') }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200); // no exception, so 200
+    const body = await res.json();
+    expect(body.overview.totalRespect).toBe(0); // all data coerced to []
+  });
+
+  it('returns 500 when an unexpected exception is thrown', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error during query');
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load analytics');
+  });
+
+  it('calls correct supabase tables for all five queries', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation((_table) => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    await GET();
+
+    expect(mockFrom).toHaveBeenCalledTimes(5);
+    expect(mockFrom).toHaveBeenNthCalledWith(1, 'respect_members');
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'fractal_sessions');
+    expect(mockFrom).toHaveBeenNthCalledWith(3, 'fractal_scores');
+    expect(mockFrom).toHaveBeenNthCalledWith(4, 'respect_members');
+    expect(mockFrom).toHaveBeenNthCalledWith(5, 'fractal_sessions');
+  });
+
+  // ── Edge case tests ──────────────────────────────────────────────────────
+
+  it('handles deeply nested nested relations in recentSessions', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const recentSessions = [
+      {
+        id: 'sess1',
+        name: 'Session 1',
+        session_date: '2026-01-01',
+        scoring_era: 'OG',
+        participant_count: 5,
+        notes: 'test',
+        fractal_scores: [
+          {
+            member_name: 'Alice',
+            wallet_address: '0x1111',
+            rank: 1,
+            score: 100,
+          },
+          {
+            member_name: 'Bob',
+            wallet_address: '0x2222',
+            rank: 2,
+            score: 90,
+          },
+        ],
+      },
+    ];
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: recentSessions }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recentSessions).toHaveLength(1);
+    expect(body.recentSessions[0].fractal_scores).toHaveLength(2);
+    expect(body.recentSessions[0].fractal_scores[0].member_name).toBe('Alice');
+  });
+
+  it('only returns topByFractal limited to 20 entries from query', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const topByFractal = Array.from({ length: 25 }, (_, i) => ({
+      name: `Member ${i}`,
+      wallet_address: `0x${i}`,
+      fractal_respect: 100 - i,
+      fractal_count: i,
+    }));
+
+    // The query includes .limit(20), so only 20 come back from DB
+    const limitedTopByFractal = topByFractal.slice(0, 20);
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: limitedTopByFractal }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.topByFractal).toHaveLength(20);
+  });
+
+  it('only returns recentSessions limited to 10 entries from query', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const recentSessions = Array.from({ length: 15 }, (_, i) => ({
+      id: `sess${i}`,
+      name: `Session ${i}`,
+      session_date: '2026-01-01',
+      scoring_era: 'OG',
+      participant_count: i,
+      notes: '',
+      fractal_scores: [],
+    }));
+
+    // The query includes .limit(10), so only 10 come back from DB
+    const limitedRecentSessions = recentSessions.slice(0, 10);
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: limitedRecentSessions }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.recentSessions).toHaveLength(10);
+  });
+
+  it('handles score distribution with string keys correctly', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const scores = [
+      { score: 100, rank: 1, wallet_address: '0x1111' },
+      { score: '90', rank: 2, wallet_address: '0x2222' }, // string score
+      { score: 100, rank: 3, wallet_address: '0x3333' },
+    ];
+
+    const mockChains = [
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+      chainMock({ data: scores }),
+      chainMock({ data: [] }),
+      chainMock({ data: [] }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = mockChains[callIndex];
+      callIndex += 1;
+      return chain;
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should normalize string scores to numbers for histogram
+    expect(body.scoreDistribution['100']).toBe(2);
+    expect(body.scoreDistribution['90']).toBe(1);
+  });
+});

--- a/src/app/api/fractals/matrix/__tests__/route.test.ts
+++ b/src/app/api/fractals/matrix/__tests__/route.test.ts
@@ -1,0 +1,552 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * A Supabase query chain that supports .select(), .order(), and resolves
+ * (when awaited) to `result`. Lets tests inspect order/select calls without
+ * a live DB.
+ */
+function matrixChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'order']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // The route awaits the chain directly (no .single()).
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/fractals/matrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Authentication
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Empty data (all arrays null)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns empty matrix when all queries return null', async () => {
+    const sessionsCall = matrixChain({ data: null, error: null });
+    const membersCall = matrixChain({ data: null, error: null });
+    const scoresCall = matrixChain({ data: null, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+    expect(body.members).toEqual([]);
+    expect(body.cells).toEqual([]);
+    expect(body.stats).toEqual({
+      totalSessions: 0,
+      totalMembers: 0,
+      totalRespect: 0,
+    });
+  });
+
+  it('returns empty arrays when all queries return empty arrays', async () => {
+    const sessionsCall = matrixChain({ data: [], error: null });
+    const membersCall = matrixChain({ data: [], error: null });
+    const scoresCall = matrixChain({ data: [], error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+    expect(body.members).toEqual([]);
+    expect(body.cells).toEqual([]);
+    expect(body.stats.totalSessions).toBe(0);
+    expect(body.stats.totalMembers).toBe(0);
+    expect(body.stats.totalRespect).toBe(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Populated data
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns sessions in chronological order', async () => {
+    const sessions = [
+      { id: 's1', name: 'Session 1', session_date: '2026-01-01' },
+      { id: 's2', name: 'Session 2', session_date: '2026-01-02' },
+    ];
+
+    const sessionsCall = matrixChain({ data: sessions, error: null });
+    mockFrom.mockReturnValue(matrixChain({ data: [], error: null }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.sessions).toEqual(sessions);
+    expect(body.stats.totalSessions).toBe(2);
+  });
+
+  it('orders sessions chronologically (ascending) with nullsFirst false', async () => {
+    const sessions = [{ id: 's1', name: 'Session 1', session_date: '2026-01-01' }];
+    const chain = matrixChain({ data: sessions, error: null });
+    mockFrom.mockReturnValue(chain);
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return chain;
+      return matrixChain({ data: [], error: null });
+    });
+
+    await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(chain.order).toHaveBeenCalledWith('session_date', {
+      ascending: true,
+      nullsFirst: false,
+    });
+  });
+
+  it('returns members ranked by total_respect descending', async () => {
+    const members = [
+      { name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 },
+      { name: 'Bob', wallet_address: '0xbbb', fid: 2, total_respect: 50 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    mockFrom.mockReturnValue(matrixChain({ data: [], error: null }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0].name).toBe('Alice');
+    expect(body.members[0].totalRespect).toBe(100);
+    expect(body.members[1].name).toBe('Bob');
+    expect(body.members[1].totalRespect).toBe(50);
+  });
+
+  it('orders members by total_respect descending', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const chain = matrixChain({ data: members, error: null });
+    mockFrom.mockReturnValue(chain);
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return chain;
+      return matrixChain({ data: [], error: null });
+    });
+
+    await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(chain.order).toHaveBeenCalledWith('total_respect', { ascending: false });
+  });
+
+  it('transforms member fields correctly (snake_case to camelCase)', async () => {
+    const members = [
+      { name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 },
+      { name: 'Bob', wallet_address: null, fid: null, total_respect: 50 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    mockFrom.mockReturnValue(matrixChain({ data: [], error: null }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.members[0]).toEqual({
+      name: 'Alice',
+      wallet: '0xaaa',
+      fid: 1,
+      totalRespect: 100,
+    });
+    expect(body.members[1]).toEqual({
+      name: 'Bob',
+      wallet: null,
+      fid: null,
+      totalRespect: 50,
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Matrix cell construction and matching
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('builds matrix cells by matching member_name (case-insensitive)', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [{ session_id: 's1', member_name: 'ALICE', wallet_address: '0xaaa', score: 10 }];
+
+    const sessionsCall = matrixChain({ data: [], error: null });
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.cells).toHaveLength(1);
+    expect(body.cells[0]).toEqual({
+      memberId: 'Alice',
+      sessionId: 's1',
+      score: 10,
+    });
+  });
+
+  it('skips cells with null or undefined member_name', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [
+      { session_id: 's1', member_name: null, wallet_address: '0xaaa', score: 10 },
+      { session_id: 's1', member_name: undefined, wallet_address: '0xaaa', score: 10 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.cells).toEqual([]);
+  });
+
+  it('skips cells with null or missing session_id', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [
+      { session_id: null, member_name: 'Alice', wallet_address: '0xaaa', score: 10 },
+      { session_id: undefined, member_name: 'Alice', wallet_address: '0xaaa', score: 10 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.cells).toEqual([]);
+  });
+
+  it('skips cells with null or missing score', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [
+      { session_id: 's1', member_name: 'Alice', wallet_address: '0xaaa', score: null },
+      { session_id: 's1', member_name: 'Alice', wallet_address: '0xaaa', score: undefined },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.cells).toEqual([]);
+  });
+
+  it('skips cells when member_name does not match any member (case-insensitive)', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [
+      { session_id: 's1', member_name: 'Unknown', wallet_address: '0xaaa', score: 10 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.cells).toEqual([]);
+  });
+
+  it('converts score to number', async () => {
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+    const scores = [
+      { session_id: 's1', member_name: 'Alice', wallet_address: '0xaaa', score: '42' },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.cells[0].score).toBe(42);
+    expect(typeof body.cells[0].score).toBe('number');
+  });
+
+  it('builds matrix with multiple members and sessions', async () => {
+    const sessions = [
+      { id: 's1', name: 'Session 1', session_date: '2026-01-01' },
+      { id: 's2', name: 'Session 2', session_date: '2026-01-02' },
+    ];
+    const members = [
+      { name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 },
+      { name: 'Bob', wallet_address: '0xbbb', fid: 2, total_respect: 50 },
+    ];
+    const scores = [
+      { session_id: 's1', member_name: 'Alice', wallet_address: '0xaaa', score: 10 },
+      { session_id: 's1', member_name: 'Bob', wallet_address: '0xbbb', score: 5 },
+      { session_id: 's2', member_name: 'Alice', wallet_address: '0xaaa', score: 8 },
+    ];
+
+    const sessionsCall = matrixChain({ data: sessions, error: null });
+    const membersCall = matrixChain({ data: members, error: null });
+    const scoresCall = matrixChain({ data: scores, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.cells).toHaveLength(3);
+    expect(body.cells[0]).toEqual({ memberId: 'Alice', sessionId: 's1', score: 10 });
+    expect(body.cells[1]).toEqual({ memberId: 'Bob', sessionId: 's1', score: 5 });
+    expect(body.cells[2]).toEqual({ memberId: 'Alice', sessionId: 's2', score: 8 });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Statistics computation
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('computes totalRespect as sum of all member totalRespect', async () => {
+    const members = [
+      { name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 },
+      { name: 'Bob', wallet_address: '0xbbb', fid: 2, total_respect: 50 },
+      { name: 'Charlie', wallet_address: '0xccc', fid: 3, total_respect: 30 },
+    ];
+
+    const membersCall = matrixChain({ data: members, error: null });
+    mockFrom.mockReturnValue(matrixChain({ data: [], error: null }));
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'respect_members') return membersCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.stats.totalRespect).toBe(180);
+  });
+
+  it('returns correct stats structure', async () => {
+    const sessions = [{ id: 's1', name: 'Session 1', session_date: '2026-01-01' }];
+    const members = [{ name: 'Alice', wallet_address: '0xaaa', fid: 1, total_respect: 100 }];
+
+    const sessionsCall = matrixChain({ data: sessions, error: null });
+    const membersCall = matrixChain({ data: members, error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      return matrixChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    const body = await res.json();
+    expect(body.stats).toEqual({
+      totalSessions: 1,
+      totalMembers: 1,
+      totalRespect: 100,
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Error handling: Supabase query failures
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when sessions query errors', async () => {
+    mockFrom.mockReturnValue(matrixChain({ data: null, error: new Error('db down') }));
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load matrix data');
+  });
+
+  it('returns 500 when members query errors', async () => {
+    const sessionsCall = matrixChain({ data: [], error: null });
+    const membersCall = matrixChain({ data: null, error: new Error('members query failed') });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load matrix data');
+  });
+
+  it('returns 500 when scores query errors', async () => {
+    const sessionsCall = matrixChain({ data: [], error: null });
+    const membersCall = matrixChain({ data: [], error: null });
+    const scoresCall = matrixChain({ data: null, error: new Error('scores query failed') });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load matrix data');
+  });
+
+  it('logs error when queries fail', async () => {
+    const { logger } = await import('@/lib/logger');
+
+    mockFrom.mockReturnValue(matrixChain({ data: null, error: new Error('db error') }));
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(res.status).toBe(500);
+    expect(logger.error).toHaveBeenCalledWith('Fractals matrix error:', expect.any(Error));
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Error handling: Unexpected runtime errors
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 and logs error when an unexpected error is thrown', async () => {
+    const { logger } = await import('@/lib/logger');
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected runtime error');
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load matrix data');
+    expect(logger.error).toHaveBeenCalledWith('Fractals matrix error:', expect.any(Error));
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Response shape and types
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns MatrixResponse with all required fields', async () => {
+    const sessionsCall = matrixChain({ data: [], error: null });
+    const membersCall = matrixChain({ data: [], error: null });
+    const scoresCall = matrixChain({ data: [], error: null });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'fractal_sessions') return sessionsCall;
+      if (table === 'respect_members') return membersCall;
+      if (table === 'fractal_scores') return scoresCall;
+      return sessionsCall;
+    });
+
+    const res = await GET(makeGetRequest('/api/fractals/matrix'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveProperty('sessions');
+    expect(body).toHaveProperty('members');
+    expect(body).toHaveProperty('cells');
+    expect(body).toHaveProperty('stats');
+  });
+});

--- a/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
+++ b/src/app/api/fractals/member/[wallet]/__tests__/route.test.ts
@@ -1,0 +1,980 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a Supabase-like chain that returns a real Promise (for Promise.all).
+ * All chainable methods return the chain; awaiting resolves to result.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  const chainableMethods = [
+    'select',
+    'insert',
+    'update',
+    'upsert',
+    'delete',
+    'eq',
+    'neq',
+    'in',
+    'not',
+    'is',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'like',
+    'ilike',
+    'order',
+    'range',
+    'limit',
+    'maybeSingle',
+    'or',
+  ];
+
+  for (const method of chainableMethods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Implement both then (for thenable) and Symbol.toStringTag for Promise.all
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((onResolve?: (val: unknown) => void, onReject?: (err: unknown) => void) => {
+    const promise = Promise.resolve(result);
+    if (onResolve) return promise.then(onResolve, onReject);
+    return promise;
+  });
+
+  // Make it Promise.all compatible by returning a real Promise
+  chain[Symbol.toStringTag] = 'Promise';
+
+  return chain;
+}
+
+describe('GET /api/fractals/member/[wallet]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET(makeRequest('/api/fractals/member/0x123'), {
+        params: Promise.resolve({ wallet: VALID_WALLET }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when authenticated with a valid member', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const memberChain = chainMock({
+        data: {
+          name: 'Alice',
+          wallet_address: VALID_WALLET.toLowerCase(),
+          total_respect: 100,
+          fractal_respect: 50,
+          onchain_og: true,
+          onchain_zor: false,
+          fractal_count: 3,
+          event_respect: 20,
+          hosting_respect: 10,
+          bonus_respect: 5,
+          first_respect_at: '2024-01-01',
+        },
+      });
+
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected from() call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/0x123'), {
+        params: Promise.resolve({ wallet: VALID_WALLET }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.member.name).toBe('Alice');
+    });
+  });
+
+  describe('wallet parameter validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 for empty wallet string', async () => {
+      const res = await GET(makeRequest('/api/fractals/member/'), {
+        params: Promise.resolve({ wallet: '' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid lookup value');
+    });
+
+    it('returns 400 when wallet exceeds 100 characters', async () => {
+      const longWallet = 'x'.repeat(101);
+      const res = await GET(makeRequest('/api/fractals/member/x'), {
+        params: Promise.resolve({ wallet: longWallet }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid lookup value');
+    });
+  });
+
+  describe('member lookup behavior', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('converts wallet to lowercase before querying', async () => {
+      const upperWallet = '0xABCD1234567890ABCDEF1234567890abcdef1234';
+      const member = {
+        name: 'Carol',
+        wallet_address: upperWallet.toLowerCase(),
+        total_respect: 200,
+        fractal_respect: 100,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 5,
+        event_respect: 30,
+        hosting_respect: 20,
+        bonus_respect: 10,
+        first_respect_at: '2023-01-01',
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      await GET(makeRequest('/api/fractals/member/0x1234'), {
+        params: Promise.resolve({ wallet: upperWallet }),
+      });
+
+      expect(memberChain.eq).toHaveBeenCalledWith('wallet_address', upperWallet.toLowerCase());
+    });
+
+    it('returns 404 when member not found by wallet or name', async () => {
+      const memberChain = chainMock({ data: null });
+      const nameChain = chainMock({ data: null });
+
+      mockFrom.mockReturnValueOnce(memberChain).mockReturnValueOnce(nameChain);
+
+      const res = await GET(makeRequest('/api/fractals/member/0x999'), {
+        params: Promise.resolve({ wallet: 'nonexistent' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toBe('Member not found');
+    });
+
+    it('falls back to name search (ilike) if wallet lookup returns null', async () => {
+      const memberChain = chainMock({ data: null });
+      const member = {
+        name: 'David',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 75,
+        fractal_respect: 40,
+        onchain_og: false,
+        onchain_zor: false,
+        fractal_count: 1,
+        event_respect: 15,
+        hosting_respect: 5,
+        bonus_respect: 0,
+        first_respect_at: '2024-06-01',
+      };
+      const nameChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2) return nameChain;
+        if (callCount === 3 || callCount === 4) return scoresChain;
+        if (callCount === 5) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/david'), {
+        params: Promise.resolve({ wallet: 'david' }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(nameChain.ilike).toHaveBeenCalledWith('name', 'david');
+    });
+  });
+
+  describe('fractal scores aggregation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('deduplicates scores by session id and rank', async () => {
+      const member = {
+        name: 'Frank',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 120,
+        fractal_respect: 70,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 3,
+        event_respect: 20,
+        hosting_respect: 10,
+        bonus_respect: 5,
+        first_respect_at: '2024-01-15',
+      };
+
+      const score = {
+        rank: 1,
+        score: 50,
+        wallet_address: member.wallet_address,
+        member_name: member.name,
+        fractal_sessions: {
+          id: 'session-1',
+          name: 'Session A',
+          session_date: '2024-01-20',
+          scoring_era: '2x',
+          participant_count: 10,
+          notes: 'Test session',
+        },
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresDupChain = chainMock({ data: [score, score] }); // Duplicate
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresDupChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/frank'), {
+        params: Promise.resolve({ wallet: 'frank' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.history).toHaveLength(1); // Deduplicated to 1
+    });
+
+    it('handles fractal_sessions as array or single object', async () => {
+      const member = {
+        name: 'Grace',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 90,
+        fractal_respect: 60,
+        onchain_og: false,
+        onchain_zor: true,
+        fractal_count: 2,
+        event_respect: 15,
+        hosting_respect: 5,
+        bonus_respect: 0,
+        first_respect_at: '2024-04-01',
+      };
+
+      const scoreWithArray = {
+        rank: 2,
+        score: 35,
+        wallet_address: member.wallet_address,
+        member_name: member.name,
+        fractal_sessions: [
+          {
+            id: 'session-2',
+            name: 'Session B',
+            session_date: '2024-04-05',
+            scoring_era: '1x',
+            participant_count: 8,
+            notes: 'Array session',
+          },
+        ],
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [scoreWithArray] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/grace'), {
+        params: Promise.resolve({ wallet: 'grace' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.history).toHaveLength(1);
+      expect(body.history[0].sessionName).toBe('Session B');
+    });
+
+    it('detects ORDAO sessions from notes', async () => {
+      const member = {
+        name: 'Henry',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 110,
+        fractal_respect: 65,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 2,
+        event_respect: 22,
+        hosting_respect: 12,
+        bonus_respect: 3,
+        first_respect_at: '2024-03-01',
+      };
+
+      const scores = [
+        {
+          rank: 3,
+          score: 40,
+          wallet_address: member.wallet_address,
+          member_name: member.name,
+          fractal_sessions: {
+            id: 's1',
+            name: 'ORDAO',
+            session_date: '2024-03-10',
+            scoring_era: '3x',
+            participant_count: 12,
+            notes: 'ORDAO test',
+          },
+        },
+        {
+          rank: 2,
+          score: 25,
+          wallet_address: member.wallet_address,
+          member_name: member.name,
+          fractal_sessions: {
+            id: 's2',
+            name: 'On-Chain',
+            session_date: '2024-03-15',
+            scoring_era: '2x',
+            participant_count: 6,
+            notes: 'on-chain deployment',
+          },
+        },
+      ];
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: scores });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/henry'), {
+        params: Promise.resolve({ wallet: 'henry' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.history[0].source).toBe('ordao');
+      expect(body.history[1].source).toBe('ordao');
+    });
+
+    it('extracts Tx hash from notes', async () => {
+      const member = {
+        name: 'Iris',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 95,
+        fractal_respect: 55,
+        onchain_og: false,
+        onchain_zor: true,
+        fractal_count: 1,
+        event_respect: 20,
+        hosting_respect: 10,
+        bonus_respect: 2,
+        first_respect_at: '2024-05-01',
+      };
+
+      const score = {
+        rank: 1,
+        score: 55,
+        wallet_address: member.wallet_address,
+        member_name: member.name,
+        fractal_sessions: {
+          id: 'session-5',
+          name: 'TX Session',
+          session_date: '2024-05-20',
+          scoring_era: '1x',
+          participant_count: 5,
+          notes: 'ORDAO Tx: 0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        },
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [score] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/iris'), {
+        params: Promise.resolve({ wallet: 'iris' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.history[0].txHash).toBe(
+        '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+      );
+    });
+  });
+
+  describe('stats calculation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calculates stats including first place, avgRank, and session counts', async () => {
+      const member = {
+        name: 'Jack',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 200,
+        fractal_respect: 120,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 4,
+        event_respect: 40,
+        hosting_respect: 30,
+        bonus_respect: 10,
+        first_respect_at: '2023-12-01',
+      };
+
+      const scores = [
+        {
+          rank: 1,
+          score: 50,
+          wallet_address: member.wallet_address,
+          member_name: member.name,
+          fractal_sessions: {
+            id: 's1',
+            name: 'Session 1',
+            session_date: '2024-01-01',
+            scoring_era: '2x',
+            participant_count: 10,
+            notes: 'og',
+          },
+        },
+        {
+          rank: 1,
+          score: 40,
+          wallet_address: member.wallet_address,
+          member_name: member.name,
+          fractal_sessions: {
+            id: 's2',
+            name: 'Session 2',
+            session_date: '2024-02-01',
+            scoring_era: '2x',
+            participant_count: 12,
+            notes: 'ORDAO',
+          },
+        },
+        {
+          rank: 2,
+          score: 30,
+          wallet_address: member.wallet_address,
+          member_name: member.name,
+          fractal_sessions: {
+            id: 's3',
+            name: 'Session 3',
+            session_date: '2024-03-01',
+            scoring_era: '1x',
+            participant_count: 8,
+            notes: 'og',
+          },
+        },
+      ];
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: scores });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/jack'), {
+        params: Promise.resolve({ wallet: 'jack' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.stats.totalSessions).toBe(3);
+      expect(body.stats.totalFractalRespect).toBe(120);
+      expect(body.stats.firstPlace).toBe(2);
+      expect(body.stats.avgRank).toBeCloseTo((1 + 1 + 2) / 3, 1);
+      expect(body.stats.ogSessions).toBe(2);
+      expect(body.stats.ordaoSessions).toBe(1);
+    });
+
+    it('clamps rank to 1-6 range in stats but keeps original in history', async () => {
+      const member = {
+        name: 'Karen',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 50,
+        fractal_respect: 30,
+        onchain_og: false,
+        onchain_zor: false,
+        fractal_count: 1,
+        event_respect: 10,
+        hosting_respect: 5,
+        bonus_respect: 0,
+        first_respect_at: '2024-06-01',
+      };
+
+      const score = {
+        rank: 99,
+        score: 30,
+        wallet_address: member.wallet_address,
+        member_name: member.name,
+        fractal_sessions: {
+          id: 's-bad',
+          name: 'Bad Rank',
+          session_date: '2024-06-01',
+          scoring_era: '1x',
+          participant_count: 3,
+          notes: 'bad data',
+        },
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [score] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/karen'), {
+        params: Promise.resolve({ wallet: 'karen' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      // Route returns history with original rank, but clamped for stats calculations
+      expect(body.history[0].rank).toBe(99);
+    });
+  });
+
+  describe('respect events and ledger', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('includes respect events in response', async () => {
+      const member = {
+        name: 'Mary',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 110,
+        fractal_respect: 60,
+        onchain_og: true,
+        onchain_zor: false,
+        fractal_count: 2,
+        event_respect: 30,
+        hosting_respect: 15,
+        bonus_respect: 5,
+        first_respect_at: '2024-02-01',
+      };
+
+      const events = [
+        {
+          event_type: 'hosting',
+          amount: 15,
+          description: 'Hosted event X',
+          event_date: '2024-06-01',
+          created_at: '2024-06-01T12:00:00Z',
+        },
+        {
+          event_type: 'bonus',
+          amount: 5,
+          description: 'Referral bonus',
+          event_date: '2024-05-15',
+          created_at: '2024-05-15T08:00:00Z',
+        },
+      ];
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: events });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/mary'), {
+        params: Promise.resolve({ wallet: 'mary' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.events).toHaveLength(2);
+      expect(body.events[0].event_type).toBe('hosting');
+    });
+
+    it('builds ledger sorted by date descending', async () => {
+      const member = {
+        name: 'Noah',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 160,
+        fractal_respect: 100,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 3,
+        event_respect: 40,
+        hosting_respect: 15,
+        bonus_respect: 5,
+        first_respect_at: '2024-01-01',
+      };
+
+      const score = {
+        rank: 1,
+        score: 50,
+        wallet_address: member.wallet_address,
+        member_name: member.name,
+        fractal_sessions: {
+          id: 's1',
+          name: 'Session A',
+          session_date: '2024-05-01',
+          scoring_era: '2x',
+          participant_count: 10,
+          notes: 'test',
+        },
+      };
+
+      const event = {
+        event_type: 'hosting',
+        amount: 20,
+        description: 'Event hosting',
+        event_date: '2024-06-01',
+        created_at: '2024-06-01T10:00:00Z',
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [score] });
+      const eventsChain = chainMock({ data: [event] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/noah'), {
+        params: Promise.resolve({ wallet: 'noah' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ledger).toHaveLength(2);
+      expect(body.ledger[0].date).toBe('2024-06-01'); // Event first (later date)
+      expect(body.ledger[1].date).toBe('2024-05-01'); // Score second (earlier date)
+    });
+
+    it('handles null event_date by using created_at', async () => {
+      const member = {
+        name: 'Olivia',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 80,
+        fractal_respect: 50,
+        onchain_og: false,
+        onchain_zor: true,
+        fractal_count: 2,
+        event_respect: 20,
+        hosting_respect: 5,
+        bonus_respect: 0,
+        first_respect_at: '2024-04-01',
+      };
+
+      const event = {
+        event_type: 'bonus',
+        amount: 10,
+        description: 'Auto bonus',
+        event_date: null,
+        created_at: '2024-06-15T14:30:00Z',
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [event] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/olivia'), {
+        params: Promise.resolve({ wallet: 'olivia' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ledger[0].date).toBe('2024-06-15');
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when member lookup throws', async () => {
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('DB connection lost');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/error'), {
+        params: Promise.resolve({ wallet: 'error' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load member profile');
+    });
+
+    it('returns 500 when scores query throws', async () => {
+      const member = {
+        name: 'Quinn',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 60,
+        fractal_respect: 40,
+        onchain_og: false,
+        onchain_zor: false,
+        fractal_count: 1,
+        event_respect: 10,
+        hosting_respect: 5,
+        bonus_respect: 0,
+        first_respect_at: '2024-05-01',
+      };
+
+      const memberChain = chainMock({ data: member });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        callCount >= 2 && callCount <= 3
+          ? undefined
+          : (() => {
+              throw new Error('Scores table error');
+            })();
+      });
+
+      mockFrom.mockReturnValueOnce(memberChain).mockImplementationOnce(() => {
+        throw new Error('Scores table error');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/quinn'), {
+        params: Promise.resolve({ wallet: 'quinn' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load member profile');
+    });
+
+    it('logs errors with context', async () => {
+      const { logger } = await import('@/lib/logger');
+
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('Network timeout');
+      });
+
+      await GET(makeRequest('/api/fractals/member/error'), {
+        params: Promise.resolve({ wallet: 'error' }),
+      });
+
+      expect(logger.error).toHaveBeenCalledWith('Member profile error:', expect.any(Error));
+    });
+  });
+
+  describe('response structure', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns all expected fields in response', async () => {
+      const member = {
+        name: 'Rachel',
+        wallet_address: VALID_WALLET.toLowerCase(),
+        total_respect: 150,
+        fractal_respect: 90,
+        onchain_og: true,
+        onchain_zor: true,
+        fractal_count: 4,
+        event_respect: 35,
+        hosting_respect: 20,
+        bonus_respect: 5,
+        first_respect_at: '2024-01-01',
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/rachel'), {
+        params: Promise.resolve({ wallet: 'rachel' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toHaveProperty('member');
+      expect(body).toHaveProperty('history');
+      expect(body).toHaveProperty('events');
+      expect(body).toHaveProperty('ledger');
+      expect(body).toHaveProperty('stats');
+
+      // Verify member fields
+      expect(body.member.name).toBe('Rachel');
+      expect(body.member.wallet_address).toBe(member.wallet_address);
+      expect(body.member.total_respect).toBe(150);
+    });
+  });
+
+  describe('dynamic route parameters', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('correctly resolves wallet from params promise', async () => {
+      const testWallet = '0xTEST1234567890abcdef1234567890abcdefTEST';
+      const member = {
+        name: 'Sam',
+        wallet_address: testWallet.toLowerCase(),
+        total_respect: 85,
+        fractal_respect: 50,
+        onchain_og: true,
+        onchain_zor: false,
+        fractal_count: 2,
+        event_respect: 20,
+        hosting_respect: 10,
+        bonus_respect: 0,
+        first_respect_at: '2024-04-01',
+      };
+
+      const memberChain = chainMock({ data: member });
+      const scoresChain = chainMock({ data: [] });
+      const eventsChain = chainMock({ data: [] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return memberChain;
+        if (callCount === 2 || callCount === 3) return scoresChain;
+        if (callCount === 4) return eventsChain;
+        throw new Error('Unexpected call');
+      });
+
+      const res = await GET(makeRequest('/api/fractals/member/0x1234'), {
+        params: Promise.resolve({ wallet: testWallet }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(memberChain.eq).toHaveBeenCalledWith('wallet_address', testWallet.toLowerCase());
+    });
+  });
+});

--- a/src/app/api/fractals/sessions/__tests__/route.test.ts
+++ b/src/app/api/fractals/sessions/__tests__/route.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Chain for fractal_sessions queries: .select() -> .order() -> .range() -> resolve.
+ * Supports the full Supabase chain with count: 'exact' option.
+ */
+function sessionsChain(result: { data?: unknown; error?: unknown; count?: number }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'order', 'range']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/fractals/sessions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  // ===== Authentication =====
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  // ===== Query Validation =====
+  it('accepts default limit and offset (no query params)', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(200);
+    // Default limit=50, offset=0, so range should be (0, 49)
+    expect(chain.range).toHaveBeenCalledWith(0, 49);
+  });
+
+  it('applies custom limit when provided', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '25' }));
+    expect(res.status).toBe(200);
+    // offset=0 (default), limit=25, so range should be (0, 24)
+    expect(chain.range).toHaveBeenCalledWith(0, 24);
+  });
+
+  it('applies custom offset when provided', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { offset: '10' }));
+    expect(res.status).toBe(200);
+    // offset=10, limit=50 (default), so range should be (10, 59)
+    expect(chain.range).toHaveBeenCalledWith(10, 59);
+  });
+
+  it('applies both limit and offset when provided', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '100', offset: '5' }));
+    expect(res.status).toBe(200);
+    // offset=5, limit=100, so range should be (5, 104)
+    expect(chain.range).toHaveBeenCalledWith(5, 104);
+  });
+
+  it('rejects limit > 500', async () => {
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '501' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+    expect(body.details).toBeDefined();
+  });
+
+  it('rejects limit < 1', async () => {
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '0' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+  });
+
+  it('rejects offset < 0', async () => {
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { offset: '-1' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+  });
+
+  it('rejects non-integer limit', async () => {
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: 'abc' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+  });
+
+  it('rejects non-integer offset', async () => {
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { offset: '12.5' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+  });
+
+  it('rejects decimal limits (Zod int() validation fails)', async () => {
+    // Zod .int() rejects decimal values
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '25.9' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid query params');
+  });
+
+  // ===== Success Cases =====
+  it('returns empty list when no sessions exist', async () => {
+    mockFrom.mockReturnValue(sessionsChain({ data: null, error: null, count: 0 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  it('returns sessions list when data exists', async () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        session_date: '2026-07-15',
+        name: 'Fractal Alpha',
+        host_name: 'Alice',
+        scoring_era: 'era-1',
+        participant_count: 10,
+        notes: 'Great session',
+        created_at: '2026-07-15T10:00:00Z',
+        fractal_scores: [
+          {
+            id: 'score-1',
+            member_name: 'Bob',
+            wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+            rank: 1,
+            score: 100,
+          },
+        ],
+      },
+    ];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 1 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0]).toMatchObject({
+      id: 'session-1',
+      name: 'Fractal Alpha',
+      host_name: 'Alice',
+    });
+    expect(body.total).toBe(1);
+  });
+
+  it('returns sessions with nested fractal_scores', async () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        session_date: '2026-07-15',
+        name: 'Fractal Alpha',
+        host_name: 'Alice',
+        scoring_era: 'era-1',
+        participant_count: 3,
+        notes: 'Test session',
+        created_at: '2026-07-15T10:00:00Z',
+        fractal_scores: [
+          {
+            id: 'score-1',
+            member_name: 'Bob',
+            wallet_address: '0xaaaa',
+            rank: 1,
+            score: 100,
+          },
+          {
+            id: 'score-2',
+            member_name: 'Charlie',
+            wallet_address: '0xbbbb',
+            rank: 2,
+            score: 85,
+          },
+          {
+            id: 'score-3',
+            member_name: 'Diana',
+            wallet_address: '0xcccc',
+            rank: 3,
+            score: 70,
+          },
+        ],
+      },
+    ];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 1 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.sessions[0].fractal_scores).toHaveLength(3);
+    expect(body.sessions[0].fractal_scores[0].member_name).toBe('Bob');
+    expect(body.sessions[0].fractal_scores[0].rank).toBe(1);
+  });
+
+  it('returns multiple sessions', async () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        session_date: '2026-07-15',
+        name: 'Session 1',
+        host_name: 'Host 1',
+        scoring_era: 'era-1',
+        participant_count: 5,
+        notes: null,
+        created_at: '2026-07-15T10:00:00Z',
+        fractal_scores: [],
+      },
+      {
+        id: 'session-2',
+        session_date: '2026-07-14',
+        name: 'Session 2',
+        host_name: 'Host 2',
+        scoring_era: 'era-1',
+        participant_count: 8,
+        notes: 'Notes here',
+        created_at: '2026-07-14T10:00:00Z',
+        fractal_scores: [],
+      },
+    ];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 2 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.sessions).toHaveLength(2);
+    expect(body.total).toBe(2);
+  });
+
+  it('returns exact count from Supabase', async () => {
+    const mockSessions = [{ id: 'session-1' }];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 1234 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.total).toBe(1234);
+  });
+
+  // ===== Supabase Query Shape =====
+  it('calls supabase.from("fractal_sessions") with the correct select columns', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(mockFrom).toHaveBeenCalledWith('fractal_sessions');
+    expect(chain.select).toHaveBeenCalled();
+    // Verify the select argument contains the expected columns
+    const selectCall = chain.select.mock.calls[0][0];
+    expect(selectCall).toContain('id');
+    expect(selectCall).toContain('session_date');
+    expect(selectCall).toContain('name');
+    expect(selectCall).toContain('host_name');
+    expect(selectCall).toContain('scoring_era');
+    expect(selectCall).toContain('participant_count');
+    expect(selectCall).toContain('notes');
+    expect(selectCall).toContain('created_at');
+    expect(selectCall).toContain('fractal_scores');
+  });
+
+  it('orders by session_date descending', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(chain.order).toHaveBeenCalledWith('session_date', { ascending: false });
+  });
+
+  it('applies the range with correct offset and limit', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/fractals/sessions', { limit: '30', offset: '5' }));
+    // offset=5, limit=30 => range(5, 34)
+    expect(chain.range).toHaveBeenCalledWith(5, 34);
+  });
+
+  it('passes count option to select', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/fractals/sessions'));
+    // Check second argument to select
+    const selectCall = chain.select.mock.calls[0];
+    expect(selectCall[1]).toEqual({ count: 'exact' });
+  });
+
+  // ===== Error Handling =====
+  it('returns 500 when Supabase query returns an error', async () => {
+    mockFrom.mockReturnValue(
+      sessionsChain({ data: null, error: new Error('Database connection failed') }),
+    );
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load sessions');
+  });
+
+  it('catches thrown exceptions from Supabase and returns 500', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected runtime error');
+    });
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load sessions');
+  });
+
+  it('logs errors to logger.error', async () => {
+    const { logger } = await import('@/lib/logger');
+    mockFrom.mockReturnValue(sessionsChain({ data: null, error: new Error('Test error') }));
+    await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(logger.error).toHaveBeenCalledWith('Fractal sessions error:', expect.any(Error));
+  });
+
+  // ===== Response Headers =====
+  it('sets Cache-Control header with public, s-maxage, stale-while-revalidate', async () => {
+    mockFrom.mockReturnValue(sessionsChain({ data: [], error: null, count: 0 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const cacheControl = res.headers.get('Cache-Control');
+    expect(cacheControl).toBe('public, s-maxage=600, stale-while-revalidate=30');
+  });
+
+  // ===== Edge Cases =====
+  it('handles null data by coercing to empty array', async () => {
+    mockFrom.mockReturnValue(sessionsChain({ data: null, error: null, count: 0 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+  });
+
+  it('handles null count by coercing to 0', async () => {
+    mockFrom.mockReturnValue(sessionsChain({ data: [], error: null, count: null }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.total).toBe(0);
+  });
+
+  it('handles sessions with missing optional fields', async () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        session_date: '2026-07-15',
+        name: 'Minimal Session',
+        host_name: 'Host',
+        scoring_era: null,
+        participant_count: null,
+        notes: null,
+        created_at: '2026-07-15T10:00:00Z',
+        fractal_scores: [],
+      },
+    ];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 1 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessions[0]).toMatchObject({
+      id: 'session-1',
+      name: 'Minimal Session',
+      scoring_era: null,
+    });
+  });
+
+  it('handles sessions with empty fractal_scores array', async () => {
+    const mockSessions = [
+      {
+        id: 'session-1',
+        session_date: '2026-07-15',
+        name: 'No Scores Session',
+        host_name: 'Host',
+        scoring_era: 'era-1',
+        participant_count: 0,
+        notes: null,
+        created_at: '2026-07-15T10:00:00Z',
+        fractal_scores: [],
+      },
+    ];
+    mockFrom.mockReturnValue(sessionsChain({ data: mockSessions, error: null, count: 1 }));
+    const res = await GET(makeGetRequest('/api/fractals/sessions'));
+    const body = await res.json();
+    expect(body.sessions[0].fractal_scores).toEqual([]);
+  });
+
+  it('respects max limit boundary (exactly 500)', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '500' }));
+    expect(res.status).toBe(200);
+    // limit=500, offset=0 => range(0, 499)
+    expect(chain.range).toHaveBeenCalledWith(0, 499);
+  });
+
+  it('respects min limit boundary (exactly 1)', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { limit: '1' }));
+    expect(res.status).toBe(200);
+    // limit=1, offset=0 => range(0, 0)
+    expect(chain.range).toHaveBeenCalledWith(0, 0);
+  });
+
+  it('respects min offset boundary (exactly 0)', async () => {
+    const chain = sessionsChain({ data: [], error: null, count: 0 });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/fractals/sessions', { offset: '0' }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 49); // 0 + 50 - 1
+  });
+});


### PR DESCRIPTION
93 tests across 4 untested fractals/* routes (task #591), subagent-authored + verified green (vitest 93/93, tsc 0, biome clean). matrix (23, 3-query join), analytics (18, 5-table aggregation + histogram), sessions (31, pagination + nested scores), member/[wallet] (21, dynamic param + name-search fallback). All supabase module mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)