### PR TITLE
test(social): deep coverage — growth, spotlight, taste-match, unfollowers (task #591)

### DIFF
--- a/src/app/api/social/growth/__tests__/route.test.ts
+++ b/src/app/api/social/growth/__tests__/route.test.ts
@@ -1,0 +1,453 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { GET } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself.
+ * Terminal .then() resolves the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.gte = vi.fn().mockReturnValue(chain);
+  chain.order = vi.fn().mockReturnValue(chain);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+  return chain;
+}
+
+describe('GET /api/social/growth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ── FID parameter validation tests ────────────────────────────────────────
+
+  it('uses session fid when no fid param provided', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(123); // session fid
+  });
+
+  it('uses provided fid when param is valid', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '999' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(999);
+  });
+
+  it('returns 400 when fid is negative', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '-1' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when fid is zero', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '0' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when fid is not an integer', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '123.45' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when fid is non-numeric', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: 'abc' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when session has no fid and none provided', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' }); // no fid
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('No Farcaster account linked');
+  });
+
+  // ── Days parameter validation tests ──────────────────────────────────────
+
+  it('defaults to 30 days when no days param provided', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.days).toBe(30);
+  });
+
+  it('uses provided days when param is valid', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '90' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.days).toBe(90);
+  });
+
+  it('accepts max days value of 365', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '365' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.days).toBe(365);
+  });
+
+  it('returns 400 when days exceeds max of 365', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '366' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid days parameter (1-365)');
+  });
+
+  it('returns 400 when days is zero', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '0' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid days parameter (1-365)');
+  });
+
+  it('returns 400 when days is negative', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '-30' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid days parameter (1-365)');
+  });
+
+  it('returns 400 when days is not an integer', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { days: '30.5' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid days parameter (1-365)');
+  });
+
+  it('returns 400 when days is non-numeric', async () => {
+    const res = await GET(makeGetRequest('/api/social/growth', { days: 'abc' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid days parameter (1-365)');
+  });
+
+  // ── Supabase query tests ─────────────────────────────────────────────────
+
+  it('queries member_stats_history with correct select', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/social/growth'));
+    expect(mockFrom).toHaveBeenCalledWith('member_stats_history');
+    expect(chain.select).toHaveBeenCalledWith(
+      'snapshot_date, follower_count, following_count, engagement_score',
+    );
+  });
+
+  it('filters by fid', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/social/growth', { fid: '999' }));
+    expect(chain.eq).toHaveBeenCalledWith('fid', 999);
+  });
+
+  it('filters by start date using gte', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/social/growth', { days: '10' }));
+
+    // Verify gte was called with a date string
+    expect(chain.gte).toHaveBeenCalled();
+    const gteCall = (chain.gte as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    expect(gteCall[0]).toBe('snapshot_date');
+    expect(typeof gteCall[1]).toBe('string'); // ISO date string
+    expect(gteCall[1]).toMatch(/^\d{4}-\d{2}-\d{2}$/); // YYYY-MM-DD format
+  });
+
+  it('orders by snapshot_date ascending', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/social/growth'));
+    expect(chain.order).toHaveBeenCalledWith('snapshot_date', { ascending: true });
+  });
+
+  // ── Response data transformation tests ────────────────────────────────────
+
+  it('maps raw data to response history format', async () => {
+    const rawData = [
+      {
+        snapshot_date: '2026-07-01',
+        follower_count: 100,
+        following_count: 50,
+        engagement_score: 0.85,
+      },
+      {
+        snapshot_date: '2026-07-02',
+        follower_count: 105,
+        following_count: 52,
+        engagement_score: 0.87,
+      },
+    ];
+    const chain = chainMock({ data: rawData, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history).toEqual([
+      {
+        date: '2026-07-01',
+        followerCount: 100,
+        followingCount: 50,
+        engagementScore: 0.85,
+      },
+      {
+        date: '2026-07-02',
+        followerCount: 105,
+        followingCount: 52,
+        engagementScore: 0.87,
+      },
+    ]);
+  });
+
+  it('returns empty history when no data', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history).toEqual([]);
+  });
+
+  it('returns null data as empty history', async () => {
+    const chain = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history).toEqual([]);
+  });
+
+  it('includes fid and days in response', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '555', days: '60' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(555);
+    expect(body.days).toBe(60);
+  });
+
+  // ── Cache header tests ───────────────────────────────────────────────────
+
+  it('sets cache control headers on success', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=300, stale-while-revalidate=30',
+    );
+  });
+
+  // ── Error handling tests ─────────────────────────────────────────────────
+
+  it('returns 500 when supabase query errors', async () => {
+    const chain = chainMock({ data: null, error: new Error('db connection failed') });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch growth data');
+  });
+
+  it('logs error when supabase query fails', async () => {
+    const { logger } = await import('@/lib/logger');
+    const chain = chainMock({ data: null, error: { message: 'db error' } });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/social/growth'));
+    expect(logger.error).toHaveBeenCalledWith(
+      'Growth query error:',
+      expect.objectContaining({ message: 'db error' }),
+    );
+  });
+
+  it('returns 500 when an unexpected exception is thrown', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('logs exception when one is thrown', async () => {
+    const { logger } = await import('@/lib/logger');
+    const testError = new Error('Unexpected error');
+    mockFrom.mockImplementation(() => {
+      throw testError;
+    });
+    await GET(makeGetRequest('/api/social/growth'));
+    expect(logger.error).toHaveBeenCalledWith('Growth route error:', testError);
+  });
+
+  // ── Combined parameter tests ─────────────────────────────────────────────
+
+  it('accepts both fid and days parameters together', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '888', days: '180' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(888);
+    expect(body.days).toBe(180);
+  });
+
+  it('handles edge case of fid 1 (valid minimum)', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '1' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(1);
+  });
+
+  it('handles large fid values', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth', { fid: '999999999' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.fid).toBe(999999999);
+  });
+
+  it('date calculation is approximately correct', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const beforeCall = new Date();
+    beforeCall.setDate(beforeCall.getDate() - 10);
+    const beforeStr = beforeCall.toISOString().split('T')[0];
+
+    await GET(makeGetRequest('/api/social/growth', { days: '10' }));
+
+    const gteCall = (chain.gte as unknown as { mock: { calls: unknown[][] } }).mock.calls[0];
+    const queryDate = gteCall[1];
+
+    // Query date should be the date from 10 days ago
+    // Allow a 1-day margin for timing variations
+    expect(queryDate).toBe(beforeStr);
+  });
+
+  // ── Response structure tests ───────────────────────────────────────────────
+
+  it('response has required fields', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty('fid');
+    expect(body).toHaveProperty('days');
+    expect(body).toHaveProperty('history');
+  });
+
+  it('response does not include error field on success', async () => {
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    const body = await res.json();
+    expect(body).not.toHaveProperty('error');
+  });
+
+  it('history array contains properly mapped entries', async () => {
+    const rawData = [
+      {
+        snapshot_date: '2026-06-01',
+        follower_count: 50,
+        following_count: 25,
+        engagement_score: 0.5,
+      },
+      {
+        snapshot_date: '2026-06-02',
+        follower_count: 55,
+        following_count: 28,
+        engagement_score: 0.55,
+      },
+      {
+        snapshot_date: '2026-06-03',
+        follower_count: 60,
+        following_count: 30,
+        engagement_score: 0.6,
+      },
+    ];
+    const chain = chainMock({ data: rawData, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/social/growth'));
+    const body = await res.json();
+
+    expect(body.history).toHaveLength(3);
+    expect(body.history[0]).toEqual({
+      date: '2026-06-01',
+      followerCount: 50,
+      followingCount: 25,
+      engagementScore: 0.5,
+    });
+    expect(body.history[2]).toEqual({
+      date: '2026-06-03',
+      followerCount: 60,
+      followingCount: 30,
+      engagementScore: 0.6,
+    });
+  });
+});

--- a/src/app/api/social/spotlight/__tests__/route.test.ts
+++ b/src/app/api/social/spotlight/__tests__/route.test.ts
@@ -1,0 +1,640 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Chain whose chainable methods are inspectable spies. Supports .select(),
+ * .eq(), .not(), .order(), .limit() and resolves when awaited. Thenables
+ * queue results in FIFO order: first await gets results[0], second gets results[1].
+ */
+function spotlightChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'not', 'order', 'limit', 'in']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('GET /api/social/spotlight', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 401 guard
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session.fid is null', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: null });
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    expect(res.status).toBe(401);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Empty users
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns { member: null } when no active users exist', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockFrom.mockReturnValue(spotlightChain([{ data: [], error: null }]));
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.member).toBeNull();
+  });
+
+  it('returns { member: null } when users query data is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockFrom.mockReturnValue(spotlightChain([{ data: null, error: null }]));
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.member).toBeNull();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Single user selection
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns single user when only one active user exists', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 456,
+        username: 'alice',
+        display_name: 'Alice',
+        pfp_url: 'https://example.com/alice.png',
+        bio: 'Designer',
+        location: 'SF',
+        last_active_at: '2026-07-15T10:00:00Z',
+        respect_member_id: 1,
+      },
+    ];
+
+    const respect = [{ fid: 456, total_respect: 100 }];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.member).toBeDefined();
+    expect(body.member.fid).toBe(456);
+    expect(body.member.username).toBe('alice');
+    expect(body.member.displayName).toBe('Alice');
+    expect(body.member.respect).toEqual({ total: 100 });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Ranking by respect (sorting logic)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('selects user by deterministic day-of-year index from respect-sorted list', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 1,
+        username: 'alice',
+        display_name: 'Alice',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+      {
+        fid: 2,
+        username: 'bob',
+        display_name: 'Bob',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 2,
+      },
+      {
+        fid: 3,
+        username: 'charlie',
+        display_name: 'Charlie',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 3,
+      },
+    ];
+
+    const respect = [
+      { fid: 1, total_respect: 50 },
+      { fid: 2, total_respect: 200 },
+      { fid: 3, total_respect: 100 },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Sorted by respect desc: bob (200), charlie (100), alice (50)
+    // index = dayOfYear % 3
+    // The exact pick depends on today's dayOfYear, so we just verify
+    // the picked user is one of the three and has correct structure
+    expect([1, 2, 3]).toContain(body.member.fid);
+    expect(body.member).toHaveProperty('username');
+    expect(body.member).toHaveProperty('respect');
+  });
+
+  it('uses modulo to wrap selection when dayOfYear exceeds user count', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 1,
+        username: 'alice',
+        display_name: 'Alice',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+      {
+        fid: 2,
+        username: 'bob',
+        display_name: 'Bob',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 2,
+      },
+    ];
+
+    const respect = [
+      { fid: 1, total_respect: 100 },
+      { fid: 2, total_respect: 200 },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Pick should be deterministic and wrap correctly
+    expect([1, 2]).toContain(body.member.fid);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Enrichment (null fields, missing respect)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('includes all user fields in response', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 456,
+        username: 'alice',
+        display_name: 'Alice M',
+        pfp_url: 'https://example.com/alice.png',
+        bio: 'Musician',
+        location: 'NYC',
+        last_active_at: '2026-07-15T15:30:00Z',
+        respect_member_id: 1,
+      },
+    ];
+
+    const respect = [{ fid: 456, total_respect: 250 }];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    const body = await res.json();
+
+    expect(body.member.fid).toBe(456);
+    expect(body.member.username).toBe('alice');
+    expect(body.member.displayName).toBe('Alice M');
+    expect(body.member.pfpUrl).toBe('https://example.com/alice.png');
+    expect(body.member.bio).toBe('Musician');
+    expect(body.member.location).toBe('NYC');
+    expect(body.member.lastActiveAt).toBe('2026-07-15T15:30:00Z');
+  });
+
+  it('sets respect to null when no respect record found for user', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 789,
+        username: 'bob',
+        display_name: 'Bob',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+    ];
+
+    // No respect data for fid 789
+    const respect = [];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    const body = await res.json();
+
+    expect(body.member.respect).toBeNull();
+  });
+
+  it('converts respect.total_respect to number', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 999,
+        username: 'test',
+        display_name: 'Test',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+    ];
+
+    const respect = [{ fid: 999, total_respect: '500' }]; // String value
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    const body = await res.json();
+
+    expect(typeof body.member.respect.total).toBe('number');
+    expect(body.member.respect.total).toBe(500);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // SUCCESS: Query filter verification
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('queries users with is_active=true filter', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const chain = spotlightChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+
+    await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+  });
+
+  it('filters out users with null username (not() operator)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const chain = spotlightChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+
+    await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(chain.not).toHaveBeenCalledWith('username', 'is', null);
+  });
+
+  it('orders users by zid ascending', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const chain = spotlightChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+
+    await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(chain.order).toHaveBeenCalledWith('zid', { ascending: true, nullsFirst: false });
+  });
+
+  it('limits to 200 users', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const chain = spotlightChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+
+    await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(chain.limit).toHaveBeenCalledWith(200);
+  });
+
+  it('fetches respect_members for all user fids', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 111,
+        username: 'a',
+        display_name: '',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+      {
+        fid: 222,
+        username: 'b',
+        display_name: '',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 2,
+      },
+    ];
+
+    const respect = [
+      { fid: 111, total_respect: 10 },
+      { fid: 222, total_respect: 20 },
+    ];
+
+    const usersChain = spotlightChain([{ data: users, error: null }]);
+    const respectChain = spotlightChain([{ data: respect, error: null }]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return usersChain;
+      if (table === 'respect_members') return respectChain;
+      return usersChain;
+    });
+
+    await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(respectChain.in).toHaveBeenCalledWith('fid', [111, 222]);
+  });
+
+  it('returns empty respect query when no users have fids', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: null,
+        username: 'ghost',
+        display_name: '',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+    ];
+
+    const usersChain = spotlightChain([{ data: users, error: null }]);
+    mockFrom.mockReturnValue(usersChain);
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+    const body = await res.json();
+
+    // When no valid fids, respect should be empty and user selection still works
+    expect(body.member).toBeDefined();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // ERROR: users query errors
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when users query errors', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockFrom.mockReturnValue(
+      spotlightChain([{ data: null, error: new Error('db connection failed') }]),
+    );
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load spotlight');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // ERROR: respect query errors (continues, doesn't throw)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('continues when respect_members query errors (treats as no respect)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 456,
+        username: 'alice',
+        display_name: 'Alice',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+    ];
+
+    const usersChain = spotlightChain([{ data: users, error: null }]);
+    const respectChain = spotlightChain([{ data: null, error: new Error('respect query failed') }]);
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return usersChain;
+      if (table === 'respect_members') return respectChain;
+      return usersChain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.member).toBeDefined();
+    expect(body.member.respect).toBeNull();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // ERROR: Unexpected runtime errors (try/catch)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 and logs error on unexpected runtime exception', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected crash during query');
+    });
+
+    const { logger } = await import('@/lib/logger');
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load spotlight');
+    expect(logger.error).toHaveBeenCalledWith('[spotlight] error:', expect.any(Error));
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Response headers: Cache-Control
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('includes cache-control header on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 456,
+        username: 'alice',
+        display_name: 'Alice',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+    ];
+
+    const respect = [{ fid: 456, total_respect: 100 }];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    const cacheControl = res.headers.get('cache-control');
+    expect(cacheControl).toBe('public, s-maxage=3600, stale-while-revalidate=1800');
+  });
+
+  it('does not include cache-control header on error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockFrom.mockReturnValue(spotlightChain([{ data: null, error: new Error('db error') }]));
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    const cacheControl = res.headers.get('cache-control');
+    expect(cacheControl).toBeNull();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Edge case: Multiple users with same respect score
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('handles ties in respect scores deterministically', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const users = [
+      {
+        fid: 1,
+        username: 'a',
+        display_name: 'A',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 1,
+      },
+      {
+        fid: 2,
+        username: 'b',
+        display_name: 'B',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 2,
+      },
+      {
+        fid: 3,
+        username: 'c',
+        display_name: 'C',
+        pfp_url: '',
+        bio: '',
+        location: '',
+        last_active_at: '',
+        respect_member_id: 3,
+      },
+    ];
+
+    const respect = [
+      { fid: 1, total_respect: 100 },
+      { fid: 2, total_respect: 100 },
+      { fid: 3, total_respect: 100 },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'users') return spotlightChain([{ data: users, error: null }]);
+      if (table === 'respect_members') return spotlightChain([{ data: respect, error: null }]);
+      return spotlightChain([{ data: [], error: null }]);
+    });
+
+    const res = await GET(makeGetRequest('/api/social/spotlight'));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // All three have same respect; pick should be by dayOfYear % 3
+    expect([1, 2, 3]).toContain(body.member.fid);
+  });
+});

--- a/src/app/api/social/taste-match/__tests__/route.test.ts
+++ b/src/app/api/social/taste-match/__tests__/route.test.ts
@@ -1,0 +1,564 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a chain that resolves to result when awaited (via .then).
+ * All chainable methods return the chain itself for further chaining.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'limit', 'in']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/social/taste-match', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Auth guard
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Input validation (targetFid)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when targetFid is missing', async () => {
+    const res = await GET(makeGetRequest('/api/social/taste-match'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid params');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when targetFid is not a number', async () => {
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: 'abc' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid params');
+  });
+
+  it('returns 400 when targetFid is not positive', async () => {
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '0' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid params');
+  });
+
+  it('returns 400 when targetFid is negative', async () => {
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '-123' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid params');
+  });
+
+  it('returns 400 when targetFid is a float', async () => {
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '123.5' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid params');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Same-user case (targetFid === session.fid)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 100% match when comparing user to themselves', async () => {
+    // Session fid is 123 (from mockAuthenticatedSession default)
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '123' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(100);
+    expect(body.sharedTracks).toEqual([]);
+    expect(body.totalYours).toBe(0);
+    expect(body.totalTheirs).toBe(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Happy path: both users have likes, compute overlap
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('computes Jaccard similarity (shared / union) with both users having likes', async () => {
+    // Session user (fid 123): likes songs s1, s2, s3
+    // Target user (fid 456): likes songs s2, s3, s4
+    // Union: s1, s2, s3, s4 (size 4)
+    // Shared: s2, s3 (size 2)
+    // Match: 2/4 = 50%
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }, { song_id: 's2' }, { song_id: 's3' }]
+            : callCount === 1
+              ? [{ song_id: 's2' }, { song_id: 's3' }, { song_id: 's4' }]
+              : [],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(50);
+    expect(body.totalYours).toBe(3);
+    expect(body.totalTheirs).toBe(3);
+    expect(body.sharedCount).toBe(2);
+  });
+
+  it('fetches shared track details (up to 10)', async () => {
+    // My likes: s1, s2
+    // Their likes: s1, s2, s3
+    // Shared: s1, s2
+    const songs = [
+      {
+        id: 's1',
+        title: 'Song 1',
+        artist: 'Artist A',
+        url: 'https://example.com/s1',
+        artwork_url: 'https://example.com/s1.jpg',
+      },
+      {
+        id: 's2',
+        title: 'Song 2',
+        artist: 'Artist B',
+        url: 'https://example.com/s2',
+        artwork_url: 'https://example.com/s2.jpg',
+      },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }, { song_id: 's2' }]
+            : callCount === 1
+              ? [{ song_id: 's1' }, { song_id: 's2' }, { song_id: 's3' }]
+              : songs,
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sharedTracks).toHaveLength(2);
+    expect(body.sharedTracks[0]).toEqual({
+      id: 's1',
+      title: 'Song 1',
+      artist: 'Artist A',
+      url: 'https://example.com/s1',
+      artworkUrl: 'https://example.com/s1.jpg',
+    });
+    expect(body.sharedTracks[1]).toEqual({
+      id: 's2',
+      title: 'Song 2',
+      artist: 'Artist B',
+      url: 'https://example.com/s2',
+      artworkUrl: 'https://example.com/s2.jpg',
+    });
+  });
+
+  it('limits shared track details to 10 songs', async () => {
+    // Create 15 shared song IDs
+    const myLikes = Array.from({ length: 15 }, (_, i) => `s${i + 1}`);
+    const theirLikes = Array.from({ length: 15 }, (_, i) => `s${i + 1}`);
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? myLikes.map((id) => ({ song_id: id }))
+            : callCount === 1
+              ? theirLikes.map((id) => ({ song_id: id }))
+              : Array.from({ length: 10 }, (_, i) => ({
+                  id: `s${i + 1}`,
+                  title: `Song ${i + 1}`,
+                  artist: null,
+                  url: `https://example.com/s${i + 1}`,
+                  artwork_url: null,
+                })),
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sharedTracks).toHaveLength(10);
+    expect(body.sharedCount).toBe(15); // But we count all 15 shared
+  });
+
+  it('handles missing song title and artwork_url gracefully', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }]
+            : callCount === 1
+              ? [{ song_id: 's1' }]
+              : [
+                  {
+                    id: 's1',
+                    title: null,
+                    artist: 'Artist A',
+                    url: 'https://example.com/s1',
+                    artwork_url: null,
+                  },
+                ],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sharedTracks[0]).toEqual({
+      id: 's1',
+      title: 'Untitled',
+      artist: 'Artist A',
+      url: 'https://example.com/s1',
+      artworkUrl: null,
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // No overlap cases
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 0% match when users have no shared likes', async () => {
+    // Session user: s1, s2
+    // Target user: s3, s4
+    // Union: 4, Shared: 0, Match: 0%
+    mockFrom.mockReturnValue(
+      makeChain({ data: [{ song_id: 's1' }, { song_id: 's2' }], error: null }),
+    );
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }, { song_id: 's2' }]
+            : [{ song_id: 's3' }, { song_id: 's4' }],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.sharedCount).toBe(0);
+    expect(body.sharedTracks).toEqual([]);
+    expect(body.totalYours).toBe(2);
+    expect(body.totalTheirs).toBe(2);
+  });
+
+  it('returns 0% match when target user has no likes', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data: callCount === 0 ? [{ song_id: 's1' }, { song_id: 's2' }] : [],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.sharedCount).toBe(0);
+    expect(body.totalYours).toBe(2);
+    expect(body.totalTheirs).toBe(0);
+  });
+
+  it('returns 0% match when current user has no likes', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data: callCount === 0 ? [] : [{ song_id: 's1' }, { song_id: 's2' }],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.sharedCount).toBe(0);
+    expect(body.totalYours).toBe(0);
+    expect(body.totalTheirs).toBe(2);
+  });
+
+  it('returns 0% when both users have no likes (empty union)', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.sharedCount).toBe(0);
+    expect(body.totalYours).toBe(0);
+    expect(body.totalTheirs).toBe(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Promise.allSettled failure cases
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('continues with empty likes if current user query fails', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+      for (const m of ['select', 'eq', 'limit', 'in']) {
+        chain[m] = vi.fn(() => chain);
+      }
+
+      if (callCount === 0) {
+        // First call (myLikes) throws
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = () => {
+          throw new Error('Query failed');
+        };
+      } else if (callCount === 1) {
+        // Second call (theirLikes) succeeds
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [{ song_id: 's1' }, { song_id: 's2' }], error: null });
+      } else {
+        // songs query
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [], error: null });
+      }
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.totalYours).toBe(0);
+    expect(body.totalTheirs).toBe(2);
+  });
+
+  it('continues with empty likes if target user query fails', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+      for (const m of ['select', 'eq', 'limit', 'in']) {
+        chain[m] = vi.fn(() => chain);
+      }
+
+      if (callCount === 0) {
+        // First call (myLikes) succeeds
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [{ song_id: 's1' }, { song_id: 's2' }], error: null });
+      } else if (callCount === 1) {
+        // Second call (theirLikes) throws
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = () => {
+          throw new Error('Query failed');
+        };
+      } else {
+        // songs query
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [], error: null });
+      }
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.totalYours).toBe(2);
+    expect(body.totalTheirs).toBe(0);
+  });
+
+  it('both likes queries fail, treated as no likes', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+      for (const m of ['select', 'eq', 'limit', 'in']) {
+        chain[m] = vi.fn(() => chain);
+      }
+
+      if (callCount < 2) {
+        // Both throw
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = () => {
+          throw new Error('Query failed');
+        };
+      }
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(0);
+    expect(body.totalYours).toBe(0);
+    expect(body.totalTheirs).toBe(0);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Query error during songs fetch (third query)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when songs detail query fails', async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+      for (const m of ['select', 'eq', 'limit', 'in']) {
+        chain[m] = vi.fn(() => chain);
+      }
+
+      if (callCount === 0) {
+        // myLikes
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [{ song_id: 's1' }, { song_id: 's2' }], error: null });
+      } else if (callCount === 1) {
+        // theirLikes
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+          resolve({ data: [{ song_id: 's1' }], error: null });
+      } else {
+        // songs — throws
+        // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+        (chain as unknown as { then: unknown }).then = () => {
+          throw new Error('Songs query failed');
+        };
+      }
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to compute taste match');
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Rounding and edge cases for Jaccard similarity
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('rounds Jaccard percentage to nearest integer', async () => {
+    // 1 shared out of 3 union = 33.33% → rounds to 33
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }, { song_id: 's2' }]
+            : callCount === 1
+              ? [{ song_id: 's1' }, { song_id: 's3' }]
+              : [],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(33); // 1/3 = 0.333... → 33
+  });
+
+  it('rounds Jaccard percentage up on .5 boundary', async () => {
+    // 1 shared out of 2 union = 50%
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chain = makeChain({
+        data:
+          callCount === 0
+            ? [{ song_id: 's1' }]
+            : callCount === 1
+              ? [{ song_id: 's1' }, { song_id: 's2' }]
+              : [],
+        error: null,
+      });
+      callCount++;
+      return chain;
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.matchPercent).toBe(50);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Unexpected thrown error (not from Supabase)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when an unexpected error is thrown', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error outside of Promise.allSettled');
+    });
+
+    const res = await GET(makeGetRequest('/api/social/taste-match', { targetFid: '456' }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to compute taste match');
+  });
+});

--- a/src/app/api/social/unfollowers/__tests__/route.test.ts
+++ b/src/app/api/social/unfollowers/__tests__/route.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Chain whose chainable methods return the chain for further chaining.
+ * Terminal await (`then`) resolves to the provided result.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'order', 'limit']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/social/unfollowers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('Authentication & Authorization', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await GET();
+      expect(res.status).toBe(401);
+      expect((await res.json()).error).toBe('Unauthorized');
+    });
+
+    it('returns 400 when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+      const res = await GET();
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('No Farcaster account linked');
+    });
+
+    it('returns 400 when session fid is null', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: null as unknown as number }),
+      );
+      const res = await GET();
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('No Farcaster account linked');
+    });
+  });
+
+  describe('Query Construction', () => {
+    it('queries unfollow_events with the correct columns', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      await GET();
+      expect(chain.select).toHaveBeenCalledWith(
+        'id, unfollower_fid, unfollower_username, unfollower_display_name, detected_at',
+      );
+    });
+
+    it('filters by the session user fid', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+      await GET();
+      expect(chain.eq).toHaveBeenCalledWith('member_fid', 456);
+    });
+
+    it('orders by detected_at descending', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      await GET();
+      expect(chain.order).toHaveBeenCalledWith('detected_at', { ascending: false });
+    });
+
+    it('limits results to 50', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      await GET();
+      expect(chain.limit).toHaveBeenCalledWith(50);
+    });
+
+    it('queries the unfollow_events table', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      await GET();
+      expect(mockFrom).toHaveBeenCalledWith('unfollow_events');
+    });
+  });
+
+  describe('Response Structure', () => {
+    it('returns 200 with empty unfollowers list', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        unfollowers: [],
+        total: 0,
+      });
+    });
+
+    it('returns unfollowers with all expected fields', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-1',
+          unfollower_fid: 111,
+          unfollower_username: 'alice',
+          unfollower_display_name: 'Alice',
+          detected_at: '2026-07-15T10:00:00Z',
+        },
+        {
+          id: 'uf-2',
+          unfollower_fid: 222,
+          unfollower_username: 'bob',
+          unfollower_display_name: 'Bob',
+          detected_at: '2026-07-15T09:00:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.unfollowers).toEqual(unfollowerData);
+      expect(body.total).toBe(2);
+    });
+
+    it('returns correct count for multiple unfollowers', async () => {
+      const unfollowerData = Array.from({ length: 25 }, (_, i) => ({
+        id: `uf-${i}`,
+        unfollower_fid: 1000 + i,
+        unfollower_username: `user${i}`,
+        unfollower_display_name: `User ${i}`,
+        detected_at: new Date(Date.now() - i * 3600000).toISOString(),
+      }));
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.total).toBe(25);
+      expect(body.unfollowers.length).toBe(25);
+    });
+
+    it('returns total as 0 when data is null', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.total).toBe(0);
+      expect(body.unfollowers).toEqual([]);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('returns 500 when the query errors', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: null, error: new Error('db connection failed') }));
+      const res = await GET();
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('Failed to fetch unfollowers');
+    });
+
+    it('logs the database error when query fails', async () => {
+      const dbError = new Error('network timeout');
+      mockFrom.mockReturnValue(makeChain({ data: null, error: dbError }));
+      const { logger } = await import('@/lib/logger');
+      await GET();
+      expect(logger.error).toHaveBeenCalledWith('Unfollowers query error:', dbError);
+    });
+
+    it('returns 500 on unexpected exception during query', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('unexpected exception');
+      });
+      const res = await GET();
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('Internal server error');
+    });
+
+    it('logs the exception when query throws', async () => {
+      const error = new Error('async operation failed');
+      mockFrom.mockImplementation(() => {
+        throw error;
+      });
+      const { logger } = await import('@/lib/logger');
+      await GET();
+      expect(logger.error).toHaveBeenCalledWith('Unfollowers route error:', error);
+    });
+
+    it('returns 500 when getSessionData throws', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('session error'));
+      const res = await GET();
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('Internal server error');
+    });
+  });
+
+  describe('Unfollower Data Integrity', () => {
+    it('preserves all unfollower fields in response', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-complete',
+          unfollower_fid: 999,
+          unfollower_username: 'charlie',
+          unfollower_display_name: 'Charlie Brown',
+          detected_at: '2026-07-15T08:30:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.unfollowers[0]).toHaveProperty('id');
+      expect(body.unfollowers[0]).toHaveProperty('unfollower_fid');
+      expect(body.unfollowers[0]).toHaveProperty('unfollower_username');
+      expect(body.unfollowers[0]).toHaveProperty('unfollower_display_name');
+      expect(body.unfollowers[0]).toHaveProperty('detected_at');
+    });
+
+    it('maintains order from database (descending by detected_at)', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-1',
+          unfollower_fid: 100,
+          unfollower_username: 'first',
+          unfollower_display_name: 'First',
+          detected_at: '2026-07-15T12:00:00Z',
+        },
+        {
+          id: 'uf-2',
+          unfollower_fid: 200,
+          unfollower_username: 'second',
+          unfollower_display_name: 'Second',
+          detected_at: '2026-07-15T11:00:00Z',
+        },
+        {
+          id: 'uf-3',
+          unfollower_fid: 300,
+          unfollower_username: 'third',
+          unfollower_display_name: 'Third',
+          detected_at: '2026-07-15T10:00:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.unfollowers[0].detected_at).toBe('2026-07-15T12:00:00Z');
+      expect(body.unfollowers[1].detected_at).toBe('2026-07-15T11:00:00Z');
+      expect(body.unfollowers[2].detected_at).toBe('2026-07-15T10:00:00Z');
+    });
+  });
+
+  describe('Multi-User Isolation', () => {
+    it('queries only unfollowers for the authenticated user', async () => {
+      const chain = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain);
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+      await GET();
+      expect(chain.eq).toHaveBeenCalledWith('member_fid', 789);
+    });
+
+    it('uses different fid for different sessions', async () => {
+      const chain1 = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain1);
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 111 }));
+      await GET();
+      expect(chain1.eq).toHaveBeenCalledWith('member_fid', 111);
+
+      vi.clearAllMocks();
+      const chain2 = makeChain({ data: [], error: null });
+      mockFrom.mockReturnValue(chain2);
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 222 }));
+      await GET();
+      expect(chain2.eq).toHaveBeenCalledWith('member_fid', 222);
+    });
+  });
+
+  describe('Response Content-Type', () => {
+    it('returns JSON response', async () => {
+      mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+      const res = await GET();
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+  });
+
+  describe('Large Result Sets', () => {
+    it('handles limit of 50 unfollowers', async () => {
+      const unfollowerData = Array.from({ length: 50 }, (_, i) => ({
+        id: `uf-${i}`,
+        unfollower_fid: 2000 + i,
+        unfollower_username: `user${i}`,
+        unfollower_display_name: `User ${i}`,
+        detected_at: new Date(Date.now() - i * 3600000).toISOString(),
+      }));
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.unfollowers.length).toBe(50);
+      expect(body.total).toBe(50);
+    });
+
+    it('returns exact count even at limit boundary', async () => {
+      const unfollowerData = Array.from({ length: 50 }, (_, i) => ({
+        id: `uf-${i}`,
+        unfollower_fid: 3000 + i,
+        unfollower_username: `user${i}`,
+        unfollower_display_name: `User ${i}`,
+        detected_at: new Date(Date.now() - i * 60000).toISOString(),
+      }));
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.total).toBe(50);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles single unfollower', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-solo',
+          unfollower_fid: 5555,
+          unfollower_username: 'loner',
+          unfollower_display_name: 'Lone User',
+          detected_at: '2026-07-15T07:00:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.total).toBe(1);
+      expect(body.unfollowers.length).toBe(1);
+    });
+
+    it('handles empty string in optional fields gracefully', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-empty',
+          unfollower_fid: 6666,
+          unfollower_username: '',
+          unfollower_display_name: '',
+          detected_at: '2026-07-15T06:00:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      const body = await res.json();
+      expect(body.unfollowers[0].unfollower_username).toBe('');
+      expect(body.unfollowers[0].unfollower_display_name).toBe('');
+    });
+
+    it('returns 200 even if unfollower fields are partially populated', async () => {
+      const unfollowerData = [
+        {
+          id: 'uf-partial',
+          unfollower_fid: 7777,
+          unfollower_username: 'partial',
+          unfollower_display_name: null,
+          detected_at: '2026-07-15T05:00:00Z',
+        },
+      ];
+      mockFrom.mockReturnValue(makeChain({ data: unfollowerData, error: null }));
+      const res = await GET();
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.unfollowers[0].unfollower_display_name).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
107 tests across 4 social/* analytics routes that previously had only 401-guard coverage (task #591), subagent-authored + verified green (vitest 107/107, tsc 0, biome clean). growth (36, param validation + history), spotlight (22, day-of-year selection), taste-match (22, Jaccard similarity + Promise.allSettled), unfollowers (27). All supabase module mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)