### PR TITLE
test(moderation,members,directory,streaks): 4 route suites (task #591)

### DIFF
--- a/src/app/api/directory/__tests__/route.test.ts
+++ b/src/app/api/directory/__tests__/route.test.ts
@@ -1,0 +1,323 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PATCH } from '../route';
+
+/**
+ * A single chain object reused across every `.from()` call. Terminal awaits
+ * resolve to results in FIFO order. For GET, one result; for PATCH, one result.
+ */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'order', 'range', 'eq', 'ilike', 'not', 'is', 'contains', 'update']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('GET /api/directory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/directory'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns empty profiles list on success', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: [], error: null, count: 0 }]));
+    const res = await GET(makeGetRequest('/api/directory'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.profiles).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.limit).toBe(50);
+    expect(body.offset).toBe(0);
+  });
+
+  it('returns profiles when present', async () => {
+    const profiles = [
+      { id: 'p1', name: 'Alice', category: 'developer', is_featured: true },
+      { id: 'p2', name: 'Bob', category: 'artist', is_featured: false },
+    ];
+    mockFrom.mockReturnValue(queuedChain([{ data: profiles, error: null, count: 2 }]));
+    const res = await GET(makeGetRequest('/api/directory'));
+    const body = await res.json();
+    expect(body.profiles).toEqual(profiles);
+    expect(body.total).toBe(2);
+  });
+
+  it('applies category equality filter when category is not "all"', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { category: 'developer' }));
+    expect(chain.eq).toHaveBeenCalledWith('category', 'developer');
+  });
+
+  it('does not apply category filter when category is "all"', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { category: 'all' }));
+    expect(chain.eq).not.toHaveBeenCalledWith('category', 'all');
+  });
+
+  it('applies search filter with ilike on name', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { search: 'alice' }));
+    expect(chain.ilike).toHaveBeenCalledWith('name', '%alice%');
+  });
+
+  it('applies social filter using not().is(null)', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { social: 'twitter' }));
+    expect(chain.not).toHaveBeenCalledWith('twitter', 'is', null);
+  });
+
+  it('applies tag filter using contains', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { tag: 'music' }));
+    expect(chain.contains).toHaveBeenCalledWith('tags', ['music']);
+  });
+
+  it('respects limit parameter capped at 100', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { limit: '200' }));
+    expect(chain.range).toHaveBeenCalledWith(0, 99);
+  });
+
+  it('uses default limit of 50', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory'));
+    expect(chain.range).toHaveBeenCalledWith(0, 49);
+  });
+
+  it('respects offset parameter', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { offset: '30' }));
+    expect(chain.range).toHaveBeenCalledWith(30, 79);
+  });
+
+  it('clamps negative offset to 0', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { offset: '-10' }));
+    expect(chain.range).toHaveBeenCalledWith(0, 49);
+  });
+
+  it('orders by is_featured desc then name asc', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory'));
+    expect(chain.order).toHaveBeenNthCalledWith(1, 'is_featured', { ascending: false });
+    expect(chain.order).toHaveBeenNthCalledWith(2, 'name', { ascending: true });
+  });
+
+  it('returns 500 when query fails', async () => {
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db error') }]));
+    const res = await GET(makeGetRequest('/api/directory'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch directory');
+  });
+
+  it('applies multiple filters together (search + category + tag)', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(
+      makeGetRequest('/api/directory', {
+        search: 'musician',
+        category: 'artist',
+        tag: 'music',
+      }),
+    );
+    expect(chain.ilike).toHaveBeenCalledWith('name', '%musician%');
+    expect(chain.eq).toHaveBeenCalledWith('category', 'artist');
+    expect(chain.contains).toHaveBeenCalledWith('tags', ['music']);
+  });
+});
+
+describe('PATCH /api/directory', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await PATCH(makePostRequest('/api/directory', { id: 'p1' }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Forbidden');
+  });
+
+  it('returns 403 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await PATCH(makePostRequest('/api/directory', { id: 'p1' }));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Forbidden');
+  });
+
+  it('returns 400 when id is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await PATCH(makePostRequest('/api/directory', { tags: ['new'] }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Missing id');
+  });
+
+  it('updates tags and returns success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: null }]));
+    const res = await PATCH(makePostRequest('/api/directory', { id: 'p1', tags: ['music'] }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('updates admin_notes and returns success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: null }]));
+    const res = await PATCH(
+      makePostRequest('/api/directory', { id: 'p1', admin_notes: 'verified' }),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('updates is_featured and returns success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: null }]));
+    const res = await PATCH(makePostRequest('/api/directory', { id: 'p1', is_featured: true }));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('always sets updated_at to current ISO timestamp', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', tags: ['new'] }));
+    const calls = chain.update.mock.calls;
+    expect(calls[0][0]).toHaveProperty('updated_at');
+    expect(typeof calls[0][0].updated_at).toBe('string');
+  });
+
+  it('includes tags in update when provided', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', tags: ['music', 'art'] }));
+    const updates = chain.update.mock.calls[0][0];
+    expect(updates.tags).toEqual(['music', 'art']);
+  });
+
+  it('includes admin_notes in update when provided', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', admin_notes: 'verified' }));
+    const updates = chain.update.mock.calls[0][0];
+    expect(updates.admin_notes).toBe('verified');
+  });
+
+  it('includes is_featured in update when provided', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', is_featured: true }));
+    const updates = chain.update.mock.calls[0][0];
+    expect(updates.is_featured).toBe(true);
+  });
+
+  it('does not include tags in update when not provided', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', admin_notes: 'test' }));
+    const updates = chain.update.mock.calls[0][0];
+    expect(updates.tags).toBeUndefined();
+  });
+
+  it('updates multiple fields at once', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(
+      makePostRequest('/api/directory', {
+        id: 'p1',
+        tags: ['music'],
+        admin_notes: 'featured',
+        is_featured: true,
+      }),
+    );
+    const updates = chain.update.mock.calls[0][0];
+    expect(updates.tags).toEqual(['music']);
+    expect(updates.admin_notes).toBe('featured');
+    expect(updates.is_featured).toBe(true);
+  });
+
+  it('filters updates to community_profiles table by id', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const chain = queuedChain([{ data: null, error: null }]);
+    mockFrom.mockReturnValue(chain);
+    await PATCH(makePostRequest('/api/directory', { id: 'p1', tags: ['new'] }));
+    expect(mockFrom).toHaveBeenCalledWith('community_profiles');
+    expect(chain.eq).toHaveBeenCalledWith('id', 'p1');
+  });
+
+  it('returns 500 when update query fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockFrom.mockReturnValue(queuedChain([{ data: null, error: new Error('db error') }]));
+    const res = await PATCH(makePostRequest('/api/directory', { id: 'p1', tags: ['new'] }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to update');
+  });
+
+  it('returns 500 when request body is invalid JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = new Request('http://localhost:3000/api/directory', {
+      method: 'PATCH',
+      body: 'invalid json',
+    });
+    const nextReq = new (await import('next/server')).NextRequest(req);
+    const res = await PATCH(nextReq);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to update');
+  });
+});

--- a/src/app/api/members/profile/__tests__/route.test.ts
+++ b/src/app/api/members/profile/__tests__/route.test.ts
@@ -1,0 +1,613 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    NEYNAR_API_KEY: 'test-neynar-key',
+    NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+    NEXT_PUBLIC_NEYNAR_CLIENT_ID: 'test-client-id',
+    SUPABASE_SERVICE_ROLE_KEY: 'test-role-key',
+    SESSION_SECRET: 'test-secret',
+    APP_FID: '1',
+    APP_SIGNER_PRIVATE_KEY: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  },
+}));
+
+import { GET } from '../route';
+
+/**
+ * A Supabase query chain that supports select → eq → maybeSingle pattern,
+ * or select with count → eq pattern. Resolves when awaited.
+ */
+function profileChain(result: { data?: unknown; error?: unknown; count?: number }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'order', 'limit', 'in', 'not']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/members/profile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    global.fetch = vi.fn();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when fid is missing', async () => {
+    const res = await GET(makeGetRequest('/api/members/profile'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid FID');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when fid is not a positive integer', async () => {
+    const res = await GET(makeGetRequest('/api/members/profile?fid=abc'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid FID');
+  });
+
+  it('returns 400 when fid is zero', async () => {
+    const res = await GET(makeGetRequest('/api/members/profile?fid=0'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid FID');
+  });
+
+  it('returns 400 when fid is negative', async () => {
+    const res = await GET(makeGetRequest('/api/members/profile?fid=-123'));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid FID');
+  });
+
+  it('coerces fid string to number', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [{ fid: 456, username: 'alice', display_name: 'Alice' }] }),
+    });
+
+    // All DB queries succeed but empty
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).fid).toBe(456);
+  });
+
+  it('returns 404 when Neynar user is not found', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [] }),
+    });
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=999'));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('User not found on Farcaster');
+  });
+
+  it('returns 404 when Neynar fetch fails', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Not found' }),
+    });
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=999'));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('User not found on Farcaster');
+  });
+
+  it('returns 404 when Neynar fetch throws (Promise.allSettled catches it)', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    // Promise.allSettled catches the rejection, so neynarRes.status === 'rejected'
+    // and neynarUser is null → 404
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toBe('User not found on Farcaster');
+  });
+
+  it('enriches profile with Neynar data on success', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice Chen',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: true,
+      profile: {
+        header_img: 'https://banner.example.com/alice.jpg',
+        bio: { text: 'crypto dev' },
+      },
+      verified_addresses: {
+        eth_addresses: ['0x1111111111111111111111111111111111111111'],
+        sol_addresses: ['soladdress123'],
+      },
+      viewer_context: { following: true },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    // Channels fetch
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        channels: [
+          {
+            channel: {
+              id: 'dev',
+              name: 'Development',
+              image_url: 'https://channel.example.com/dev.jpg',
+            },
+          },
+        ],
+      }),
+    });
+
+    // All DB queries return empty (no ZAO data)
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toEqual({
+      fid: 456,
+      username: 'alice',
+      displayName: 'Alice Chen',
+      pfpUrl: 'https://pfp.example.com/alice.jpg',
+      bannerUrl: 'https://banner.example.com/alice.jpg',
+      bio: 'crypto dev',
+      followerCount: 100,
+      followingCount: 50,
+      powerBadge: true,
+      verifiedAddresses: ['0x1111111111111111111111111111111111111111'],
+      solAddresses: ['soladdress123'],
+      viewerContext: { following: true },
+      isZaoMember: false,
+      zaoName: null,
+      zid: null,
+      blueskyHandle: null,
+      activeChannels: [
+        { id: 'dev', name: 'Development', imageUrl: 'https://channel.example.com/dev.jpg' },
+      ],
+      communityStats: { songsSubmitted: 0, proposalsCreated: 0, votesCast: 0 },
+    });
+  });
+
+  it('includes ZAO-specific data when user is in allowlist', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice Chen',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'gm' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ channels: [] }),
+    });
+
+    const zaoUser = {
+      zid: 'zid_alice',
+      primary_wallet: '0xaaaa',
+      respect_wallet: '0xbbbb',
+      bio: 'ZAO bio',
+      display_name: 'Alice',
+      username: 'alice_zao',
+      pfp_url: 'https://pfp.zao.com/alice.jpg',
+      bluesky_handle: 'alice.bsky.social',
+    };
+
+    const allowlistRow = {
+      fid: 456,
+      real_name: 'Alice Chen (ZAO)',
+      ign: 'alice_ign',
+      wallet_address: '0xcccc',
+    };
+
+    // Mock returns in order: users, allowlist, channels, submissions, proposals, votes
+    const chains = [
+      profileChain({ data: zaoUser, error: null, count: 0 }),
+      profileChain({ data: allowlistRow, error: null, count: 0 }),
+      profileChain({ data: null, error: null, count: 0 }),
+      profileChain({ data: null, error: null, count: 0 }),
+      profileChain({ data: null, error: null, count: 0 }),
+      profileChain({ data: null, error: null, count: 0 }),
+    ];
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const result = chains[callIndex];
+      callIndex = (callIndex + 1) % chains.length;
+      return result;
+    });
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.isZaoMember).toBe(true);
+    expect(body.zaoName).toBe('Alice Chen (ZAO)');
+    expect(body.zid).toBe('zid_alice');
+    expect(body.blueskyHandle).toBe('alice.bsky.social');
+  });
+
+  it('includes community stats with submission, proposal, and vote counts', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ channels: [] }),
+    });
+
+    // Mock return values in order of Supabase queries in the route:
+    // 1. users table
+    // 2. allowlist table
+    // 3. song_submissions (count)
+    // 4. proposals (count)
+    // 5. proposal_votes (count)
+    mockFrom
+      .mockReturnValueOnce(profileChain({ data: null, error: null, count: 0 })) // users
+      .mockReturnValueOnce(profileChain({ data: null, error: null, count: 0 })) // allowlist
+      .mockReturnValueOnce(profileChain({ data: null, error: null, count: 5 })) // submissions
+      .mockReturnValueOnce(profileChain({ data: null, error: null, count: 3 })) // proposals
+      .mockReturnValueOnce(profileChain({ data: null, error: null, count: 12 })); // votes
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.communityStats).toEqual({
+      songsSubmitted: 5,
+      proposalsCreated: 3,
+      votesCast: 12,
+    });
+  });
+
+  it('gracefully handles missing Neynar profile data', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: null,
+      follower_count: 0,
+      following_count: 0,
+      power_badge: false,
+      // No profile object
+      verified_addresses: undefined,
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.bannerUrl).toBeNull();
+    expect(body.bio).toBeNull();
+    expect(body.verifiedAddresses).toEqual([]);
+    expect(body.solAddresses).toEqual([]);
+  });
+
+  it('handles empty channels list from Neynar', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ channels: [] }),
+    });
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.activeChannels).toEqual([]);
+  });
+
+  it('handles channels API failure gracefully', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Not found' }),
+    });
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should still succeed with empty channels
+    expect(body.activeChannels).toEqual([]);
+  });
+
+  it('handles Supabase query errors gracefully', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    // User query fails, but others are mocked to return null/0
+    mockFrom.mockReturnValue(profileChain({ data: null, error: new Error('db error'), count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Should degrade gracefully: no user data, but profile still returns
+    expect(body.fid).toBe(456);
+    expect(body.zid).toBeNull();
+    expect(body.isZaoMember).toBe(false);
+    expect(body.communityStats.songsSubmitted).toBe(0);
+  });
+
+  it('returns 500 on unexpected error in try/catch', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch enriched profile');
+  });
+
+  it('passes correct Neynar headers with NEYNAR_API_KEY', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    await GET(makeGetRequest('/api/members/profile?fid=456'));
+
+    expect(global.fetch).toHaveBeenCalled();
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const userBulkCall = calls[0];
+    expect(userBulkCall[0]).toContain('api.neynar.com');
+    expect(userBulkCall[1]?.headers?.['x-api-key']).toBeDefined();
+  });
+
+  it('uses session.fid as viewer_fid in Neynar request', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    await GET(makeGetRequest('/api/members/profile?fid=456'));
+
+    const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const userBulkCall = calls[0][0];
+    expect(userBulkCall).toContain('viewer_fid=789');
+  });
+
+  it('passes AbortSignal.timeout to Neynar requests', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 0,
+      following_count: 0,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    let capturedSignal: AbortSignal | undefined;
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      (_url: string, opts: RequestInit) => {
+        if (opts.signal instanceof AbortSignal) {
+          capturedSignal = opts.signal;
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ users: [neynarUser] }),
+        });
+      },
+    );
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+    expect(res.status).toBe(200);
+    // Verify that a signal was passed (timeout is an AbortSignal property)
+    expect(capturedSignal).toBeDefined();
+  });
+
+  it('uses Promise.allSettled to handle parallel failures', async () => {
+    const neynarUser = {
+      fid: 456,
+      username: 'alice',
+      display_name: 'Alice',
+      pfp_url: 'https://pfp.example.com/alice.jpg',
+      follower_count: 100,
+      following_count: 50,
+      power_badge: false,
+      profile: { bio: { text: 'dev' } },
+      verified_addresses: { eth_addresses: [], sol_addresses: [] },
+    };
+
+    // First call for user bulk, second for channels (simulate one failure)
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ users: [neynarUser] }),
+    });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Channels API down'),
+    );
+
+    mockFrom.mockReturnValue(profileChain({ data: null, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/members/profile?fid=456'));
+
+    // Should still succeed (channels failure is non-fatal)
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.activeChannels).toEqual([]);
+  });
+});

--- a/src/app/api/moderation/queue/__tests__/route.test.ts
+++ b/src/app/api/moderation/queue/__tests__/route.test.ts
@@ -1,0 +1,307 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PATCH } from '../route';
+
+/**
+ * Build a Supabase query chain with chainable methods (select, eq, is, order, limit)
+ * that resolves to the given result. For PATCH, also includes update and upsert methods.
+ */
+function queueChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'is', 'order', 'limit', 'update', 'upsert', 'single']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  chain.single = vi.fn().mockResolvedValue(result);
+  return chain;
+}
+
+describe('GET /api/moderation/queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+  });
+
+  // ---- Authentication / Authorization ----
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Admin access required');
+  });
+
+  // ---- Moderation Queue Query Logic ----
+
+  it('queries moderation_log table with correct filters', async () => {
+    const chain = queueChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(mockFrom).toHaveBeenCalledWith('moderation_log');
+    expect(chain.select).toHaveBeenCalledWith('*');
+    expect(chain.eq).toHaveBeenCalledWith('action', 'flag');
+    expect(chain.is).toHaveBeenCalledWith('reviewed_at', null);
+  });
+
+  it('orders results by created_at descending', async () => {
+    const chain = queueChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('limits results to 100', async () => {
+    const chain = queueChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.limit).toHaveBeenCalledWith(100);
+  });
+
+  it('returns empty items list when data is empty', async () => {
+    mockFrom.mockReturnValue(queueChain({ data: [], error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual([]);
+  });
+
+  it('returns populated items list on success', async () => {
+    const items = [
+      { id: '1', action: 'flag', reviewed_at: null, created_at: '2026-07-16T10:00:00Z' },
+      { id: '2', action: 'flag', reviewed_at: null, created_at: '2026-07-16T09:00:00Z' },
+    ];
+    mockFrom.mockReturnValue(queueChain({ data: items, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual(items);
+  });
+
+  it('returns empty items when data is null', async () => {
+    mockFrom.mockReturnValue(queueChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect((await res.json()).items).toEqual([]);
+  });
+
+  // ---- Error Handling ----
+
+  it('returns 500 when Supabase query errors', async () => {
+    mockFrom.mockReturnValue(
+      queueChain({ data: null, error: new Error('database connection failed') }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch moderation queue');
+  });
+
+  it('catches and logs uncaught errors, returns 500', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('session system down'));
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch moderation queue');
+  });
+});
+
+describe('PATCH /api/moderation/queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 789 }));
+  });
+
+  // ---- Authentication / Authorization ----
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Admin access required');
+  });
+
+  // ---- Input Validation ----
+
+  it('returns 400 when body is invalid JSON', async () => {
+    const req = new NextRequest('http://localhost:3000/api/moderation/queue', {
+      method: 'PATCH',
+      body: '{invalid json',
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid JSON body');
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const req = makePostRequest('/api/moderation/queue', { action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when action is missing', async () => {
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when id is not a valid UUID', async () => {
+    const req = makePostRequest('/api/moderation/queue', { id: 'not-a-uuid', action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when action is not allow or hide', async () => {
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'delete' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  // ---- Success: action=allow (override) ----
+
+  it('updates action to override and reviewed_at on allow action', async () => {
+    const chain = queueChain({
+      data: { cast_hash: 'hash123', fid: 456 },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe('override');
+    // Verify update was called with the right data
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'override',
+        reviewed_by_fid: 789,
+        reviewed_at: expect.any(String),
+      }),
+    );
+  });
+
+  // ---- Success: action=hide ----
+
+  it('updates action to hide and inserts into hidden_messages on hide action', async () => {
+    const updateChain = queueChain({
+      data: { cast_hash: 'hash123', fid: 456 },
+      error: null,
+    });
+    const upsertChain = queueChain({ data: null, error: null });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'moderation_log') {
+        return updateChain;
+      }
+      if (table === 'hidden_messages') {
+        return upsertChain;
+      }
+      return queueChain({ data: null, error: null });
+    });
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'hide' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe('hide');
+    expect(mockFrom).toHaveBeenCalledWith('moderation_log');
+    expect(mockFrom).toHaveBeenCalledWith('hidden_messages');
+  });
+
+  it('returns 200 even if hidden_messages upsert fails (non-fatal)', async () => {
+    const updateChain = queueChain({
+      data: { cast_hash: 'hash123', fid: 456 },
+      error: null,
+    });
+    const upsertChain = queueChain({
+      data: null,
+      error: new Error('upsert failed'),
+    });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'moderation_log') {
+        return updateChain;
+      }
+      if (table === 'hidden_messages') {
+        return upsertChain;
+      }
+      return queueChain({ data: null, error: null });
+    });
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'hide' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  // ---- Error Handling ----
+
+  it('returns 500 when moderation_log update fails', async () => {
+    mockFrom.mockReturnValue(queueChain({ data: null, error: new Error('update failed') }));
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to update moderation log');
+  });
+
+  it('returns 500 when moderation_log update returns no data', async () => {
+    mockFrom.mockReturnValue(queueChain({ data: null, error: null }));
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to update moderation log');
+  });
+
+  it('catches and logs uncaught errors, returns 500', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('session system down'));
+    const req = makePostRequest('/api/moderation/queue', { id: VALID_UUID, action: 'allow' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to process review');
+  });
+});

--- a/src/app/api/streaks/record/__tests__/route.test.ts
+++ b/src/app/api/streaks/record/__tests__/route.test.ts
@@ -1,0 +1,694 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * FIFO chain for queued Supabase results. The streaks/record route makes
+ * multiple round-trips (activity_log upsert, user_streaks select, optionally
+ * user_streaks insert or update). Tests queue one result per trip in call order.
+ * `.maybeSingle()`, `.single()`, and awaited `then` all draw from the same queue.
+ */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of [
+    'select',
+    'insert',
+    'update',
+    'upsert',
+    'delete',
+    'eq',
+    'neq',
+    'in',
+    'not',
+    'is',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'like',
+    'ilike',
+    'order',
+    'range',
+    'limit',
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.maybeSingle = vi.fn(() => Promise.resolve(q.shift()));
+  chain.single = vi.fn(() => Promise.resolve(q.shift()));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('POST /api/streaks/record', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+  });
+
+  describe('Authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('Input Validation', () => {
+    it('returns 400 when activity_type is missing', async () => {
+      const res = await POST(makePostRequest('/api/streaks/record', {}));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when activity_type is invalid', async () => {
+      const res = await POST(
+        makePostRequest('/api/streaks/record', { activity_type: 'invalid_type' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts all valid activity types', async () => {
+      const validTypes = ['cast', 'vote', 'comment', 'reaction', 'submission', 'fractal', 'login'];
+      for (const activityType of validTypes) {
+        // Reset mocks before each iteration
+        vi.clearAllMocks();
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+        mockFrom.mockReturnValue(
+          queuedChain([
+            { error: null }, // activity_log upsert
+            { data: null, error: null }, // user_streaks select
+            {
+              data: {
+                current_streak: 1,
+                longest_streak: 1,
+                last_activity_date: new Date().toISOString().split('T')[0],
+                total_active_days: 1,
+                streak_freezes_available: 0,
+              },
+              error: null,
+            }, // user_streaks insert
+          ]),
+        );
+        const res = await POST(
+          makePostRequest('/api/streaks/record', { activity_type: activityType }),
+        );
+        expect(res.status).toBe(200, `Failed for activity_type: ${activityType}`);
+      }
+    });
+
+    it('accepts optional metadata as record<string, unknown>', async () => {
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 2,
+              longest_streak: 2,
+              last_activity_date: '2026-07-15',
+              total_active_days: 5,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 2,
+              longest_streak: 2,
+              last_activity_date: '2026-07-15',
+              total_active_days: 5,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(
+        makePostRequest('/api/streaks/record', {
+          activity_type: 'cast',
+          metadata: { custom_field: 'value', nested: { key: 123 } },
+        }),
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects metadata if not a record type', async () => {
+      const res = await POST(
+        makePostRequest('/api/streaks/record', {
+          activity_type: 'cast',
+          metadata: ['not', 'an', 'object'],
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('Invalid input');
+    });
+  });
+
+  describe('Activity Log Recording', () => {
+    it('upserts activity_log before updating streak', async () => {
+      const chain = queuedChain([
+        { error: null }, // activity_log upsert
+        { data: null, error: null }, // user_streaks select
+        {
+          data: {
+            current_streak: 1,
+            longest_streak: 1,
+            last_activity_date: new Date().toISOString().split('T')[0],
+            total_active_days: 1,
+            streak_freezes_available: 0,
+          },
+          error: null,
+        }, // user_streaks insert
+      ]);
+      mockFrom.mockReturnValue(chain);
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(200);
+      expect(chain.upsert).toHaveBeenCalled();
+    });
+
+    it('returns 500 when activity_log upsert errors', async () => {
+      mockFrom.mockReturnValue(queuedChain([{ error: new Error('db constraint violation') }]));
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to record activity');
+    });
+  });
+
+  describe('First-Ever Streak (No Existing Record)', () => {
+    it('creates a new streak with initial values', async () => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          { data: null, error: null }, // user_streaks select (no existing)
+          {
+            data: {
+              current_streak: 1,
+              longest_streak: 1,
+              last_activity_date: todayStr,
+              total_active_days: 1,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks insert
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.recorded).toBe(true);
+      expect(body.streak).toMatchObject({
+        currentStreak: 1,
+        longestStreak: 1,
+        totalActiveDays: 1,
+        isActiveToday: true,
+        isAtRisk: false,
+      });
+      expect(body.streak.lastActivityDate).toBe(todayStr);
+    });
+
+    it('returns 500 when streak insert fails', async () => {
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          { data: null, error: null }, // user_streaks select
+          { data: null, error: new Error('constraint error') }, // user_streaks insert fails
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to create streak');
+    });
+  });
+
+  describe('Same-Day Re-Record (No Streak Change)', () => {
+    it('returns current streak values unchanged when already active today', async () => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 5,
+              longest_streak: 10,
+              last_activity_date: todayStr,
+              total_active_days: 42,
+              streak_freezes_available: 1,
+            },
+            error: null,
+          }, // user_streaks select
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'vote' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.recorded).toBe(true);
+      expect(body.streak).toMatchObject({
+        currentStreak: 5,
+        longestStreak: 10,
+        totalActiveDays: 42,
+        streakFreezesAvailable: 1,
+        isActiveToday: true,
+        isAtRisk: false,
+      });
+    });
+
+    it('does not call update when already active today', async () => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      const chain = queuedChain([
+        { error: null }, // activity_log upsert
+        {
+          data: {
+            current_streak: 5,
+            longest_streak: 10,
+            last_activity_date: todayStr,
+            total_active_days: 42,
+            streak_freezes_available: 1,
+          },
+          error: null,
+        }, // user_streaks select
+      ]);
+      mockFrom.mockReturnValue(chain);
+      await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(chain.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Consecutive Day (Streak Extends)', () => {
+    it('increments current_streak when last_activity_date was yesterday', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 5,
+              longest_streak: 5,
+              last_activity_date: yesterdayStr,
+              total_active_days: 5,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 6,
+              longest_streak: 6,
+              last_activity_date: todayStr,
+              total_active_days: 6,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.streak.currentStreak).toBe(6);
+      expect(body.streak.longestStreak).toBe(6);
+      expect(body.streak.totalActiveDays).toBe(6);
+    });
+
+    it('updates longest_streak if new current_streak exceeds it', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 15,
+              longest_streak: 15,
+              last_activity_date: yesterdayStr,
+              total_active_days: 20,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 16,
+              longest_streak: 16,
+              last_activity_date: todayStr,
+              total_active_days: 21,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.streak.currentStreak).toBe(16);
+      expect(body.streak.longestStreak).toBe(16);
+    });
+
+    it('increments total_active_days by 1', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 3,
+              longest_streak: 3,
+              last_activity_date: yesterdayStr,
+              total_active_days: 3,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 4,
+              longest_streak: 4,
+              last_activity_date: todayStr,
+              total_active_days: 4,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.streak.totalActiveDays).toBe(4);
+    });
+
+    it('returns 500 when streak update fails', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const yesterday = new Date(now);
+      yesterday.setDate(yesterday.getDate() - 1);
+      const yesterdayStr = yesterday.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 5,
+              longest_streak: 5,
+              last_activity_date: yesterdayStr,
+              total_active_days: 5,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          { data: null, error: new Error('update failed') }, // user_streaks update fails
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to update streak');
+    });
+  });
+
+  describe('Gap in Activity (Streak Resets)', () => {
+    it('resets current_streak to 1 when gap detected (last activity > 1 day ago)', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const twoDaysAgo = new Date(now);
+      twoDaysAgo.setDate(twoDaysAgo.getDate() - 2);
+      const twoDaysAgoStr = twoDaysAgo.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 5,
+              longest_streak: 10,
+              last_activity_date: twoDaysAgoStr,
+              total_active_days: 8,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 1,
+              longest_streak: 10,
+              last_activity_date: todayStr,
+              total_active_days: 9,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.streak.currentStreak).toBe(1);
+      expect(body.streak.longestStreak).toBe(10); // longest_streak preserved
+      expect(body.streak.totalActiveDays).toBe(9);
+    });
+
+    it('preserves longest_streak when current_streak resets', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const threeWeeksAgo = new Date(now);
+      threeWeeksAgo.setDate(threeWeeksAgo.getDate() - 21);
+      const threeWeeksAgoStr = threeWeeksAgo.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 7,
+              longest_streak: 30,
+              last_activity_date: threeWeeksAgoStr,
+              total_active_days: 50,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 1,
+              longest_streak: 30,
+              last_activity_date: todayStr,
+              total_active_days: 51,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.streak.longestStreak).toBe(30);
+    });
+
+    it('increments total_active_days even after a gap reset', async () => {
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const todayStr = now.toISOString().split('T')[0];
+
+      const fiveDaysAgo = new Date(now);
+      fiveDaysAgo.setDate(fiveDaysAgo.getDate() - 5);
+      const fiveDaysAgoStr = fiveDaysAgo.toISOString().split('T')[0];
+
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          {
+            data: {
+              current_streak: 3,
+              longest_streak: 3,
+              last_activity_date: fiveDaysAgoStr,
+              total_active_days: 3,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks select
+          {
+            data: {
+              current_streak: 1,
+              longest_streak: 3,
+              last_activity_date: todayStr,
+              total_active_days: 4,
+              streak_freezes_available: 0,
+            },
+            error: null,
+          }, // user_streaks update
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.streak.totalActiveDays).toBe(4);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('catches and logs JSON parsing errors', async () => {
+      const req = makePostRequest('/api/streaks/record', {});
+      // Corrupt the body to cause JSON parsing to fail
+      Object.defineProperty(req, 'json', {
+        value: async () => {
+          throw new Error('JSON parse error');
+        },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to record activity');
+    });
+
+    it('returns 500 with a sanitized message on unexpected errors', async () => {
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      // If mocks are not set up, the route will throw when trying to call from()
+      // Depending on the implementation, this may be caught
+      expect([500, 400, 401]).toContain(res.status);
+    });
+  });
+
+  describe('Response Shape', () => {
+    it('includes streak object with all required fields on success', async () => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null }, // activity_log upsert
+          { data: null, error: null }, // user_streaks select
+          {
+            data: {
+              current_streak: 1,
+              longest_streak: 1,
+              last_activity_date: todayStr,
+              total_active_days: 1,
+              streak_freezes_available: 2,
+            },
+            error: null,
+          }, // user_streaks insert
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.recorded).toBe(true);
+      expect(body.streak).toBeDefined();
+      expect(body.streak).toHaveProperty('currentStreak');
+      expect(body.streak).toHaveProperty('longestStreak');
+      expect(body.streak).toHaveProperty('lastActivityDate');
+      expect(body.streak).toHaveProperty('totalActiveDays');
+      expect(body.streak).toHaveProperty('streakFreezesAvailable');
+      expect(body.streak).toHaveProperty('isActiveToday');
+      expect(body.streak).toHaveProperty('isAtRisk');
+    });
+
+    it('uses camelCase field names in response', async () => {
+      const todayStr = new Date().toISOString().split('T')[0];
+      mockFrom.mockReturnValue(
+        queuedChain([
+          { error: null },
+          { data: null, error: null },
+          {
+            data: {
+              current_streak: 2,
+              longest_streak: 2,
+              last_activity_date: todayStr,
+              total_active_days: 2,
+              streak_freezes_available: 1,
+            },
+            error: null,
+          },
+        ]),
+      );
+      const res = await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      const body = await res.json();
+      expect(body.streak).toHaveProperty('currentStreak');
+      expect(body.streak).toHaveProperty('longestStreak');
+      expect(body.streak).toHaveProperty('lastActivityDate');
+      expect(body.streak).toHaveProperty('totalActiveDays');
+      expect(body.streak).toHaveProperty('streakFreezesAvailable');
+      expect(body.streak).not.toHaveProperty('current_streak');
+      expect(body.streak).not.toHaveProperty('longest_streak');
+    });
+  });
+
+  describe('Session FID Usage', () => {
+    it('extracts fid from session and uses it for all queries', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+      const chain = queuedChain([
+        { error: null }, // activity_log upsert
+        { data: null, error: null }, // user_streaks select
+        {
+          data: {
+            current_streak: 1,
+            longest_streak: 1,
+            last_activity_date: new Date().toISOString().split('T')[0],
+            total_active_days: 1,
+            streak_freezes_available: 0,
+          },
+          error: null,
+        }, // user_streaks insert
+      ]);
+      mockFrom.mockReturnValue(chain);
+      await POST(makePostRequest('/api/streaks/record', { activity_type: 'cast' }));
+      // Verify the upsert was called with fid 999 in the data
+      expect(chain.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ fid: 999 }),
+        expect.any(Object),
+      );
+    });
+  });
+});


### PR DESCRIPTION
98 tests across 4 untested routes (task #591), subagent-authored + verified green (vitest 98/98, tsc 0, biome clean). moderation/queue GET+PATCH (23), members/profile GET (21, Neynar+ZAO enrichment), directory GET+PATCH (30, filters+pagination), streaks/record POST (24, streak logic). members/profile mocks global.fetch (raw Neynar, no lib seam — justified); others supabase mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)