### PR TITLE
test(directory,artists,profile,admin): [slug], featured, platforms, member-fid (task #591)

### DIFF
--- a/src/app/api/admin/member-fid/__tests__/route.test.ts
+++ b/src/app/api/admin/member-fid/__tests__/route.test.ts
@@ -1,0 +1,850 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { GET, PATCH } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for chaining.
+ * Terminal .then() resolves the query (for awaited direct chains).
+ * Includes all methods used by member-fid route: select, update, eq, is, order, not
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = ['select', 'update', 'eq', 'is', 'order', 'not', 'gt', 'lt'];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal — resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Create a mock queue that returns chains in sequence for parallel queries.
+ * Useful for testing multiple parallel queries that need different results.
+ */
+function createChainQueue(
+  results: Array<{ data?: unknown; error?: unknown; count?: number | null }>,
+) {
+  let callIndex = 0;
+  return {
+    mockFn: vi.fn(() => {
+      if (callIndex >= results.length) {
+        throw new Error(`Chain queue exhausted at call ${callIndex}`);
+      }
+      return chainMock(results[callIndex++]);
+    }),
+    getCallCount: () => callIndex,
+  };
+}
+
+describe('GET /api/admin/member-fid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  it('passes authentication when isAdmin is true', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // members without FID
+      { count: 50, error: null }, // totalWithFid
+      { count: 100, error: null }, // totalMembers
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(queue.getCallCount()).toBe(3);
+  });
+
+  // ── Success path: member groups by priority ───────────────────────────────
+
+  it('returns members grouped by priority (active, onchainOnly, inactive)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        id: VALID_UUID,
+        name: 'Alice',
+        wallet_address: '0x1',
+        fid: null,
+        total_respect: 100,
+        fractal_count: 2,
+        onchain_og: 1,
+      },
+      {
+        id: VALID_UUID,
+        name: 'Bob',
+        wallet_address: '0x2',
+        fid: null,
+        total_respect: 80,
+        fractal_count: 0,
+        onchain_og: 1,
+      },
+      {
+        id: VALID_UUID,
+        name: 'Charlie',
+        wallet_address: '0x3',
+        fid: null,
+        total_respect: 50,
+        fractal_count: 0,
+        onchain_og: 0,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null }, // members without FID
+      { count: 80, error: null }, // totalWithFid
+      { count: 100, error: null }, // totalMembers
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Alice has fractal_count > 0 → active
+    expect(body.active).toHaveLength(1);
+    expect(body.active[0].name).toBe('Alice');
+
+    // Bob has fractal_count = 0 but onchain_og > 0 → onchainOnly
+    expect(body.onchainOnly).toHaveLength(1);
+    expect(body.onchainOnly[0].name).toBe('Bob');
+
+    // Charlie has fractal_count = 0 and onchain_og = 0 → inactive
+    expect(body.inactive).toHaveLength(1);
+    expect(body.inactive[0].name).toBe('Charlie');
+  });
+
+  it('returns correct stats: totalMembers, withFid, missingFid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        id: VALID_UUID,
+        name: 'Alice',
+        wallet_address: '0x1',
+        fid: null,
+        total_respect: 100,
+        fractal_count: 2,
+        onchain_og: 1,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null }, // members without FID
+      { count: 75, error: null }, // totalWithFid
+      { count: 100, error: null }, // totalMembers
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.stats).toEqual({
+      totalMembers: 100,
+      withFid: 75,
+      missingFid: 1, // length of membersData
+    });
+  });
+
+  it('handles empty members list (all have FID)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // no members without FID
+      { count: 100, error: null }, // totalWithFid
+      { count: 100, error: null }, // totalMembers
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.active).toEqual([]);
+    expect(body.onchainOnly).toEqual([]);
+    expect(body.inactive).toEqual([]);
+    expect(body.stats.missingFid).toBe(0);
+  });
+
+  it('calls supabase with correct filters (.is and .order)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain1 = chainMock({ data: [], error: null });
+    const chain2 = chainMock({ count: 50, error: null });
+    const chain3 = chainMock({ count: 100, error: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [chain1, chain2, chain3];
+      return chains[callIndex++];
+    });
+
+    await GET();
+
+    // First call: from('respect_members').select(...).is('fid', null).order(...)
+    expect(chain1.is).toHaveBeenCalledWith('fid', null);
+    expect(chain1.order).toHaveBeenCalledWith('total_respect', { ascending: false });
+
+    // Subsequent calls should be from() calls with select and count options
+    expect(mockFrom).toHaveBeenNthCalledWith(1, 'respect_members');
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'respect_members');
+    expect(mockFrom).toHaveBeenNthCalledWith(3, 'respect_members');
+  });
+
+  it('handles null counts as 0 in stats', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null },
+      { count: null, error: null }, // totalWithFid null
+      { count: null, error: null }, // totalMembers null
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.stats.totalMembers).toBe(0);
+    expect(body.stats.withFid).toBe(0);
+  });
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null },
+      { count: 50, error: null },
+      { count: 100, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(['active', 'inactive', 'onchainOnly', 'stats'].sort());
+    expect(Object.keys(body.stats).sort()).toEqual(
+      ['missingFid', 'totalMembers', 'withFid'].sort(),
+    );
+  });
+
+  // ── Error path: exception thrown ──────────────────────────────────────────
+
+  it('returns 500 when DB query throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('DB connection lost');
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to load members');
+  });
+
+  it('logs errors to logger.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('DB error');
+    });
+
+    await GET();
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Member FID list error:', expect.any(Error));
+  });
+
+  it('handles data.error from Supabase', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: null, error: { message: 'permission denied' } }, // Supabase error
+      { count: 50, error: null },
+      { count: 100, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    // Route doesn't explicitly check error field, but || fallback handles null data
+    const res = await GET();
+    expect(res.status).toBe(200); // Trusts the structure; relies on || [] fallback
+    const body = await res.json();
+    expect(body.active).toEqual([]);
+  });
+
+  // ── Grouping logic edge cases ────────────────────────────────────────────
+
+  it('prioritizes fractal_count over onchain_og (active > onchainOnly)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        id: VALID_UUID,
+        name: 'OnchainAndFractal',
+        wallet_address: '0x1',
+        fid: null,
+        total_respect: 100,
+        fractal_count: 1,
+        onchain_og: 5,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { count: 50, error: null },
+      { count: 100, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    // fractal_count > 0 means active, even if onchain_og is high
+    expect(body.active).toHaveLength(1);
+    expect(body.onchainOnly).toHaveLength(0);
+  });
+
+  it('filters onchainOnly members correctly (fractal_count=0 AND onchain_og>0)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        id: VALID_UUID,
+        name: 'OnchainOnly',
+        wallet_address: '0x1',
+        fid: null,
+        total_respect: 100,
+        fractal_count: 0,
+        onchain_og: 1,
+      },
+      {
+        id: VALID_UUID,
+        name: 'Inactive',
+        wallet_address: '0x2',
+        fid: null,
+        total_respect: 50,
+        fractal_count: 0,
+        onchain_og: 0,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { count: 50, error: null },
+      { count: 100, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.onchainOnly).toHaveLength(1);
+    expect(body.onchainOnly[0].name).toBe('OnchainOnly');
+    expect(body.inactive).toHaveLength(1);
+    expect(body.inactive[0].name).toBe('Inactive');
+  });
+
+  it('handles numeric coercion (string fractal_count from DB)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    // Supabase may return numeric fields as strings in some contexts
+    const membersData = [
+      {
+        id: VALID_UUID,
+        name: 'Member',
+        wallet_address: '0x1',
+        fid: null,
+        total_respect: 100,
+        fractal_count: '5',
+        onchain_og: '1',
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { count: 50, error: null },
+      { count: 100, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    // Number('5') = 5 > 0 → active
+    expect(body.active).toHaveLength(1);
+  });
+});
+
+describe('PATCH /api/admin/member-fid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/admin/member-fid', { updates: [] });
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const req = makePostRequest('/api/admin/member-fid', { updates: [] });
+    const res = await PATCH(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Input validation tests ────────────────────────────────────────────────
+
+  it('returns 400 for missing updates field', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {});
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 for updates not an array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', { updates: 'not-an-array' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for empty updates array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', { updates: [] });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for updates array exceeding max length (100)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const tooManyUpdates = Array.from({ length: 101 }, (_, i) => ({
+      memberId: VALID_UUID,
+      fid: 1000 + i,
+    }));
+
+    const req = makePostRequest('/api/admin/member-fid', { updates: tooManyUpdates });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for missing memberId in update object', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ fid: 1234 }], // missing memberId
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for memberId not a UUID', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: 'not-a-uuid', fid: 1234 }],
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for missing fid in update object', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID }], // missing fid
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for fid not a number', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 'not-a-number' }],
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for fid not an integer', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 1234.56 }],
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for fid not positive', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 0 }],
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for negative fid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: -123 }],
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('includes flattened error details in 400 response', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fid', { updates: [] });
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(body.details).toBeDefined();
+    expect(body.details.fieldErrors || body.details.formErrors).toBeDefined();
+  });
+
+  // ── Success path: batch updates ───────────────────────────────────────────
+
+  it('updates single member and returns success count', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 1234 }],
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.updated).toBe(1);
+    expect(body.errors).toEqual([]);
+  });
+
+  it('updates multiple members in a batch', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const uuid1 = VALID_UUID;
+    const uuid2 = '550e8400-e29b-41d4-a716-446655440001';
+    const uuid3 = '550e8400-e29b-41d4-a716-446655440002';
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [
+        { memberId: uuid1, fid: 1001 },
+        { memberId: uuid2, fid: 1002 },
+        { memberId: uuid3, fid: 1003 },
+      ],
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.updated).toBe(3);
+    expect(body.errors).toEqual([]);
+  });
+
+  it('calls update with fid and updated_at ISO string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 5678 }],
+    });
+
+    await PATCH(req);
+
+    // Verify update was called with fid and updated_at ISO string
+    expect(chain.update).toHaveBeenCalledWith({
+      fid: 5678,
+      updated_at: expect.stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+    });
+  });
+
+  it('calls eq with memberId to scope update', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const testUuid = VALID_UUID;
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: testUuid, fid: 9999 }],
+    });
+
+    await PATCH(req);
+
+    expect(chain.eq).toHaveBeenCalledWith('id', testUuid);
+  });
+
+  // ── Partial failure: mixed successes and errors ──────────────────────────
+
+  it('accumulates errors for members that fail and continues', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [
+        chainMock({ error: null }), // First update succeeds
+        chainMock({ error: { message: 'member not found' } }), // Second fails
+        chainMock({ error: null }), // Third succeeds
+      ];
+      return chains[callCount++];
+    });
+
+    const uuid1 = VALID_UUID;
+    const uuid2 = '550e8400-e29b-41d4-a716-446655440001';
+    const uuid3 = '550e8400-e29b-41d4-a716-446655440002';
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [
+        { memberId: uuid1, fid: 1001 },
+        { memberId: uuid2, fid: 1002 },
+        { memberId: uuid3, fid: 1003 },
+      ],
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.updated).toBe(2);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain(uuid2);
+    expect(body.errors[0]).toContain('member not found');
+  });
+
+  it('includes full error message in errors array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      return chainMock({ error: { message: 'unique constraint violation' } });
+    });
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 9999 }],
+    });
+
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(body.updated).toBe(0);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain(VALID_UUID);
+    expect(body.errors[0]).toContain('unique constraint violation');
+  });
+
+  it('handles all updates failing gracefully', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      return chainMock({ error: { message: 'db error' } });
+    });
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 1001 }],
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200); // Returns 200 even with partial failures
+    const body = await res.json();
+
+    expect(body.updated).toBe(0);
+    expect(body.errors).toHaveLength(1);
+  });
+
+  // ── Error path: exception thrown ──────────────────────────────────────────
+
+  it('returns 500 when req.json() throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const mockReq = {
+      json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+    } as { json: () => Promise<never> };
+
+    const res = await PATCH(mockReq as never);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update FIDs');
+  });
+
+  it('logs errors to logger.error on exception', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const mockReq = {
+      json: vi.fn().mockRejectedValue(new Error('JSON parse failed')),
+    } as { json: () => Promise<never> };
+
+    await PATCH(mockReq as never);
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Member FID update error:', expect.any(Error));
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+
+  it('handles max batch size (100 updates)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const updates = Array.from({ length: 100 }, (_, i) => ({
+      memberId: VALID_UUID,
+      fid: 2000 + i,
+    }));
+
+    const req = makePostRequest('/api/admin/member-fid', { updates });
+    const res = await PATCH(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(100);
+  });
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [{ memberId: VALID_UUID, fid: 5555 }],
+    });
+
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(['errors', 'updated'].sort());
+    expect(Array.isArray(body.errors)).toBe(true);
+    expect(typeof body.updated).toBe('number');
+  });
+
+  it('processes updates sequentially and tolerates errors in the middle', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chains = [
+      chainMock({ error: null }),
+      chainMock({ error: { message: 'fail' } }),
+      chainMock({ error: null }),
+    ];
+
+    let chainIndex = 0;
+    mockFrom.mockImplementation(() => chains[chainIndex++]);
+
+    const req = makePostRequest('/api/admin/member-fid', {
+      updates: [
+        { memberId: VALID_UUID, fid: 1 },
+        { memberId: VALID_UUID, fid: 2 },
+        { memberId: VALID_UUID, fid: 3 },
+      ],
+    });
+
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(body.updated).toBe(2);
+    expect(body.errors).toHaveLength(1);
+  });
+});

--- a/src/app/api/artists/featured/__tests__/route.test.ts
+++ b/src/app/api/artists/featured/__tests__/route.test.ts
@@ -1,0 +1,451 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a Supabase query chain that resolves to `result` when awaited.
+ * Each chainable method returns the chain for further chaining.
+ * The terminal `.then` property allows the chain to be awaited directly.
+ */
+function artistsChain(result: { data?: unknown; error?: unknown; count?: number }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'order', 'limit', 'in']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/artists/featured', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns empty artists list when no featured profiles exist', async () => {
+    mockFrom.mockReturnValue(artistsChain({ data: [], error: null }));
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).artists).toEqual([]);
+    // Only one call (the profiles query).
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty artists list when profiles have no valid FIDs', async () => {
+    const profiles = [{ fid: null }, { fid: undefined }];
+    mockFrom.mockReturnValue(artistsChain({ data: profiles, error: null }));
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).artists).toEqual([]);
+  });
+
+  it('fetches profiles, users, and song counts', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    // Queue: profiles query, users query, and one count query (for fid 111).
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 5 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artists).toHaveLength(1);
+    expect(body.artists[0]).toMatchObject({
+      fid: 111,
+      username: 'beatmaker',
+      displayName: 'Beat Maker',
+      pfpUrl: 'pfp.jpg',
+      coverImageUrl: 'cover.jpg',
+      category: 'producer',
+      trackCount: 5,
+    });
+  });
+
+  it('filters out profiles with no matching user', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb1.jpg',
+        cover_image_url: 'cover1.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+      {
+        fid: 222,
+        category: 'artist',
+        thumbnail_url: 'thumb2.jpg',
+        cover_image_url: 'cover2.jpg',
+        is_featured: true,
+        created_at: '2026-01-02',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp1.jpg' },
+    ];
+    // User 222 is missing, so it should be filtered out.
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 3 }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artists).toHaveLength(1);
+    expect(body.artists[0].fid).toBe(111);
+  });
+
+  it('uses a track count of 0 when count query fails', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    // Count query fails but is caught in allSettled.
+    mockFrom.mockReturnValueOnce(
+      artistsChain({ data: undefined, error: new Error('count failed'), count: undefined }),
+    );
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artists[0].trackCount).toBe(0);
+  });
+
+  it('handles partial count query failures with allSettled', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb1.jpg',
+        cover_image_url: 'cover1.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+      {
+        fid: 222,
+        category: 'artist',
+        thumbnail_url: 'thumb2.jpg',
+        cover_image_url: 'cover2.jpg',
+        is_featured: true,
+        created_at: '2026-01-02',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp1.jpg' },
+      { fid: 222, username: 'artist', display_name: 'The Artist', pfp_url: 'pfp2.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    // First count succeeds, second fails.
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 7 }));
+    mockFrom.mockReturnValueOnce(
+      artistsChain({ data: undefined, error: new Error('count failed'), count: undefined }),
+    );
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artists).toHaveLength(2);
+    expect(body.artists[0].trackCount).toBe(7);
+    expect(body.artists[1].trackCount).toBe(0);
+  });
+
+  it('limits featured profiles to 20', async () => {
+    const profiles = Array.from({ length: 25 }, (_, i) => ({
+      fid: 100 + i,
+      category: 'producer',
+      thumbnail_url: `thumb${i}.jpg`,
+      cover_image_url: `cover${i}.jpg`,
+      is_featured: true,
+      created_at: new Date(2026, 0, i + 1).toISOString(),
+    }));
+
+    mockFrom.mockReturnValue(artistsChain({ data: profiles.slice(0, 20), error: null }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    const body = await res.json();
+    // The route queries limit(20), so profiles will already be limited by the DB.
+    expect(body.artists.length).toBeLessThanOrEqual(20);
+  });
+
+  it('orders profiles by created_at descending', async () => {
+    const chain = artistsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/artists/featured'));
+    expect(chain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('queries for profiles with is_featured=true', async () => {
+    const chain = artistsChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/artists/featured'));
+    expect(chain.eq).toHaveBeenCalledWith('is_featured', true);
+  });
+
+  it('queries users with is_active=true', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    const usersChain = artistsChain({ data: users, error: null });
+    mockFrom.mockReturnValueOnce(usersChain);
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 0 }));
+
+    await GET(makeGetRequest('/api/artists/featured'));
+    expect(usersChain.eq).toHaveBeenCalledWith('is_active', true);
+  });
+
+  it('queries song counts using count=exact and head=true', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    const countChain = artistsChain({ data: undefined, error: null, count: 5 });
+    mockFrom.mockReturnValueOnce(countChain);
+
+    await GET(makeGetRequest('/api/artists/featured'));
+    expect(countChain.select).toHaveBeenCalledWith('submitted_by_fid', {
+      count: 'exact',
+      head: true,
+    });
+  });
+
+  it('handles profiles where category is null', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: null,
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    const body = await res.json();
+    expect(body.artists[0].category).toBeNull();
+  });
+
+  it('handles profiles where cover_image_url is null', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: null,
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    const body = await res.json();
+    expect(body.artists[0].coverImageUrl).toBeNull();
+  });
+
+  it('returns 500 when the profiles query errors', async () => {
+    mockFrom.mockReturnValue(
+      artistsChain({ data: null, error: new Error('db connection failed') }),
+    );
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to load featured artists');
+  });
+
+  it('returns empty artists when the users query returns null', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: null, error: null }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // No users found, so the profile is filtered out (no matching user entry).
+    expect(body.artists).toEqual([]);
+  });
+
+  it('sets cache headers on success', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb.jpg',
+        cover_image_url: 'cover.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 0 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.headers.get('Cache-Control')).toBe(
+      'public, s-maxage=300, stale-while-revalidate=120',
+    );
+  });
+
+  it('does not set cache headers on error', async () => {
+    mockFrom.mockReturnValue(artistsChain({ data: null, error: new Error('db error') }));
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.headers.get('Cache-Control')).toBeNull();
+  });
+
+  it('maps multiple artists with different track counts', async () => {
+    const profiles = [
+      {
+        fid: 111,
+        category: 'producer',
+        thumbnail_url: 'thumb1.jpg',
+        cover_image_url: 'cover1.jpg',
+        is_featured: true,
+        created_at: '2026-01-01',
+      },
+      {
+        fid: 222,
+        category: 'artist',
+        thumbnail_url: 'thumb2.jpg',
+        cover_image_url: 'cover2.jpg',
+        is_featured: true,
+        created_at: '2026-01-02',
+      },
+      {
+        fid: 333,
+        category: 'engineer',
+        thumbnail_url: 'thumb3.jpg',
+        cover_image_url: 'cover3.jpg',
+        is_featured: true,
+        created_at: '2026-01-03',
+      },
+    ];
+    const users = [
+      { fid: 111, username: 'beatmaker', display_name: 'Beat Maker', pfp_url: 'pfp1.jpg' },
+      { fid: 222, username: 'artist', display_name: 'The Artist', pfp_url: 'pfp2.jpg' },
+      { fid: 333, username: 'engineer', display_name: 'Sound Engineer', pfp_url: 'pfp3.jpg' },
+    ];
+
+    mockFrom.mockReturnValueOnce(artistsChain({ data: profiles, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: users, error: null }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 12 }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 8 }));
+    mockFrom.mockReturnValueOnce(artistsChain({ data: undefined, error: null, count: 3 }));
+
+    const res = await GET(makeGetRequest('/api/artists/featured'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.artists).toHaveLength(3);
+    expect(body.artists[0].trackCount).toBe(12);
+    expect(body.artists[1].trackCount).toBe(8);
+    expect(body.artists[2].trackCount).toBe(3);
+  });
+});

--- a/src/app/api/directory/[slug]/__tests__/route.test.ts
+++ b/src/app/api/directory/[slug]/__tests__/route.test.ts
@@ -1,0 +1,689 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a Supabase query-chain mock for community_profiles lookup.
+ * Supports chaining (.select, .eq, .maybeSingle) and resolves on await.
+ */
+function profileChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  const chainableMethods = ['select', 'eq', 'maybeSingle', 'order', 'limit', 'not', 'is'];
+
+  for (const method of chainableMethods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal thenable for await
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve?: (val: unknown) => void) => {
+    if (resolve) resolve(result);
+    return Promise.resolve(result);
+  });
+
+  return chain;
+}
+
+describe('GET /api/directory/[slug]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET(makeRequest('/api/directory/test'), {
+        params: Promise.resolve({ slug: 'test-slug' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when authenticated with valid session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const profile = {
+        id: 'p1',
+        slug: 'test-slug',
+        name: 'Test User',
+        fid: 123,
+        bio: 'A test profile',
+        created_at: '2024-01-01T00:00:00Z',
+      };
+
+      const profileMock = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(profileMock);
+
+      const res = await GET(makeRequest('/api/directory/test'), {
+        params: Promise.resolve({ slug: 'test-slug' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.profile).toEqual(profile);
+    });
+  });
+
+  describe('slug parameter and profile lookup', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('queries community_profiles by slug', async () => {
+      const profile = {
+        id: 'p1',
+        slug: 'alice-dev',
+        name: 'Alice Developer',
+        fid: 100,
+        bio: 'I build things',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await GET(makeRequest('/api/directory/alice-dev'), {
+        params: Promise.resolve({ slug: 'alice-dev' }),
+      });
+
+      expect(mockFrom).toHaveBeenCalledWith('community_profiles');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('slug', 'alice-dev');
+      expect(chain.maybeSingle).toHaveBeenCalled();
+    });
+
+    it('returns 404 when profile not found', async () => {
+      const chain = profileChain({ data: null, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/nonexistent'), {
+        params: Promise.resolve({ slug: 'nonexistent-slug' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toBe('Not found');
+    });
+
+    it('returns found profile with exact slug match', async () => {
+      const profile = {
+        id: 'p123',
+        slug: 'bob-artist',
+        name: 'Bob Artist',
+        fid: 200,
+        bio: 'Creative person',
+        category: 'artist',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/bob-artist'), {
+        params: Promise.resolve({ slug: 'bob-artist' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.profile).toEqual(profile);
+      expect(body.profile.slug).toBe('bob-artist');
+    });
+  });
+
+  describe('WaveWarZ stats enrichment', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('enriches profile with WaveWarZ stats when fid exists and solana_wallet is linked', async () => {
+      const profile = {
+        id: 'p1',
+        slug: 'musician-pro',
+        name: 'Musician Pro',
+        fid: 123,
+        bio: 'Music artist',
+      };
+
+      const userData = {
+        fid: 123,
+        solana_wallet: '9B5X4z6Y7A8B9C0D1E2F3G4H5I6J7K8L9M0N1O',
+      };
+
+      const warzStats = {
+        wins: 5,
+        losses: 2,
+        total_volume_sol: 1.5,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+      const warzChainMock = profileChain({ data: warzStats, error: null });
+
+      const _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/musician-pro'), {
+        params: Promise.resolve({ slug: 'musician-pro' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.wavewarzStats).toEqual(warzStats);
+    });
+
+    it('returns null wavewarzStats when profile has no fid', async () => {
+      const profile = {
+        id: 'p2',
+        slug: 'no-fid-user',
+        name: 'No FID User',
+        fid: null,
+        bio: 'User without farcaster',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/no-fid-user'), {
+        params: Promise.resolve({ slug: 'no-fid-user' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.profile.fid).toBeNull();
+      expect(body.wavewarzStats).toBeNull();
+    });
+
+    it('returns null wavewarzStats when user has no solana_wallet linked', async () => {
+      const profile = {
+        id: 'p3',
+        slug: 'dev-no-sol',
+        name: 'Dev No Sol',
+        fid: 456,
+        bio: 'Developer without Solana',
+      };
+
+      const userData = {
+        fid: 456,
+        solana_wallet: null,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        throw new Error(`Unexpected table call ${callCount}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/dev-no-sol'), {
+        params: Promise.resolve({ slug: 'dev-no-sol' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.wavewarzStats).toBeNull();
+    });
+
+    it('returns null wavewarzStats when user exists but not in wavewarz_artists', async () => {
+      const profile = {
+        id: 'p4',
+        slug: 'user-no-warz',
+        name: 'User No Warz',
+        fid: 789,
+        bio: 'User not in WaveWarZ',
+      };
+
+      const userData = {
+        fid: 789,
+        solana_wallet: '9B5X4z6Y7A8B9C0D1E2F3G4H5I6J7K8L9M0N1O',
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+      const warzChainMock = profileChain({ data: null, error: null }); // No record
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/user-no-warz'), {
+        params: Promise.resolve({ slug: 'user-no-warz' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.wavewarzStats).toBeNull();
+    });
+
+    it('queries users table with profile fid for solana_wallet', async () => {
+      const profile = {
+        id: 'p5',
+        slug: 'check-fid-lookup',
+        name: 'Check FID Lookup',
+        fid: 999,
+        bio: 'Testing FID lookup',
+      };
+
+      const userData = {
+        fid: 999,
+        solana_wallet: '9B5X4z6Y7A8B9C0D1E2F3G4H5I6J7K8L9M0N1O',
+      };
+
+      const warzStats = {
+        wins: 10,
+        losses: 3,
+        total_volume_sol: 5.2,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+      const warzChainMock = profileChain({ data: warzStats, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      await GET(makeRequest('/api/directory/check-fid-lookup'), {
+        params: Promise.resolve({ slug: 'check-fid-lookup' }),
+      });
+
+      expect(usersChainMock.eq).toHaveBeenCalledWith('fid', 999);
+    });
+
+    it('queries wavewarz_artists with solana_wallet from users lookup', async () => {
+      const profile = {
+        id: 'p6',
+        slug: 'artist-wallet-check',
+        name: 'Artist Wallet Check',
+        fid: 111,
+        bio: 'Artist with WaveWarZ',
+      };
+
+      const userData = {
+        fid: 111,
+        solana_wallet: 'SOL_WALLET_123456789ABCDEFGHIJKLMNOPQRST',
+      };
+
+      const warzStats = {
+        wins: 3,
+        losses: 1,
+        total_volume_sol: 0.8,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+      const warzChainMock = profileChain({ data: warzStats, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      await GET(makeRequest('/api/directory/artist-wallet-check'), {
+        params: Promise.resolve({ slug: 'artist-wallet-check' }),
+      });
+
+      expect(warzChainMock.eq).toHaveBeenCalledWith('solana_wallet', userData.solana_wallet);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when community_profiles query returns error', async () => {
+      const chain = profileChain({ data: null, error: new Error('DB connection failed') });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/error-slug'), {
+        params: Promise.resolve({ slug: 'error-slug' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch profile');
+    });
+
+    it('returns 500 when users table query throws', async () => {
+      const profile = {
+        id: 'p7',
+        slug: 'user-lookup-error',
+        name: 'User Lookup Error',
+        fid: 222,
+        bio: 'Error on user lookup',
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') {
+          throw new Error('Users table connection lost');
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/user-lookup-error'), {
+        params: Promise.resolve({ slug: 'user-lookup-error' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch profile');
+    });
+
+    it('returns 500 when wavewarz_artists query throws', async () => {
+      const profile = {
+        id: 'p8',
+        slug: 'warz-lookup-error',
+        name: 'Warz Lookup Error',
+        fid: 333,
+        bio: 'Error on warz lookup',
+      };
+
+      const userData = {
+        fid: 333,
+        solana_wallet: 'SOLANA_WALLET_ABC123',
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') {
+          throw new Error('WaveWarZ table unavailable');
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/warz-lookup-error'), {
+        params: Promise.resolve({ slug: 'warz-lookup-error' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch profile');
+    });
+
+    it('logs errors with context', async () => {
+      const { logger } = await import('@/lib/logger');
+
+      const chain = profileChain({ data: null, error: new Error('Test error') });
+      mockFrom.mockReturnValue(chain);
+
+      await GET(makeRequest('/api/directory/logged-error'), {
+        params: Promise.resolve({ slug: 'logged-error' }),
+      });
+
+      expect(logger.error).toHaveBeenCalledWith('[directory/slug] GET error:', expect.any(Error));
+    });
+  });
+
+  describe('response structure', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns profile and wavewarzStats in response', async () => {
+      const profile = {
+        id: 'p9',
+        slug: 'response-test',
+        name: 'Response Test',
+        fid: 444,
+        bio: 'Testing response structure',
+      };
+
+      const warzStats = {
+        wins: 7,
+        losses: 4,
+        total_volume_sol: 2.3,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({
+        data: { fid: 444, solana_wallet: 'WALLET_XYZ' },
+        error: null,
+      });
+      const warzChainMock = profileChain({ data: warzStats, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/response-test'), {
+        params: Promise.resolve({ slug: 'response-test' }),
+      });
+      const body = await res.json();
+
+      expect(body).toHaveProperty('profile');
+      expect(body).toHaveProperty('wavewarzStats');
+      expect(body.profile).toEqual(profile);
+      expect(body.wavewarzStats).toEqual(warzStats);
+    });
+
+    it('returns profile with null wavewarzStats when no stats available', async () => {
+      const profile = {
+        id: 'p10',
+        slug: 'no-stats-test',
+        name: 'No Stats Test',
+        fid: null,
+        bio: 'No WaveWarZ stats',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/no-stats-test'), {
+        params: Promise.resolve({ slug: 'no-stats-test' }),
+      });
+      const body = await res.json();
+
+      expect(body).toHaveProperty('profile');
+      expect(body).toHaveProperty('wavewarzStats');
+      expect(body.profile).toEqual(profile);
+      expect(body.wavewarzStats).toBeNull();
+    });
+  });
+
+  describe('dynamic route parameter handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('correctly resolves slug from params promise', async () => {
+      const testSlug = 'dynamic-param-test';
+      const profile = {
+        id: 'p11',
+        slug: testSlug,
+        name: 'Dynamic Param Test',
+        fid: 555,
+        bio: 'Testing dynamic params',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await GET(makeRequest('/api/directory/test-path'), {
+        params: Promise.resolve({ slug: testSlug }),
+      });
+
+      expect(chain.eq).toHaveBeenCalledWith('slug', testSlug);
+    });
+
+    it('awaits params promise before using slug', async () => {
+      const profile = {
+        id: 'p12',
+        slug: 'awaited-slug',
+        name: 'Awaited Slug',
+        fid: 666,
+        bio: 'Promise was awaited',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const paramsPromise = Promise.resolve({ slug: 'awaited-slug' });
+
+      const res = await GET(makeRequest('/api/directory/test'), {
+        params: paramsPromise,
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.profile.slug).toBe('awaited-slug');
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('handles profile with all null optional fields', async () => {
+      const profile = {
+        id: 'p13',
+        slug: 'sparse-profile',
+        name: 'Sparse Profile',
+        fid: null,
+        bio: null,
+        category: null,
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeRequest('/api/directory/sparse-profile'), {
+        params: Promise.resolve({ slug: 'sparse-profile' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.profile).toEqual(profile);
+      expect(body.wavewarzStats).toBeNull();
+    });
+
+    it('handles slug with special characters', async () => {
+      const specialSlug = 'user-2024-special-chars-_';
+      const profile = {
+        id: 'p14',
+        slug: specialSlug,
+        name: 'Special Slug',
+        fid: 777,
+        bio: 'Special characters in slug',
+      };
+
+      const chain = profileChain({ data: profile, error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await GET(makeRequest('/api/directory/special'), {
+        params: Promise.resolve({ slug: specialSlug }),
+      });
+
+      expect(chain.eq).toHaveBeenCalledWith('slug', specialSlug);
+    });
+
+    it('handles WaveWarZ stats with zero values', async () => {
+      const profile = {
+        id: 'p15',
+        slug: 'zero-warz-stats',
+        name: 'Zero Warz Stats',
+        fid: 888,
+        bio: 'Zero WaveWarZ stats',
+      };
+
+      const userData = {
+        fid: 888,
+        solana_wallet: 'ZERO_WALLET',
+      };
+
+      const warzStats = {
+        wins: 0,
+        losses: 0,
+        total_volume_sol: 0,
+      };
+
+      const profileChainMock = profileChain({ data: profile, error: null });
+      const usersChainMock = profileChain({ data: userData, error: null });
+      const warzChainMock = profileChain({ data: warzStats, error: null });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        _callCount++;
+        if (table === 'community_profiles') return profileChainMock;
+        if (table === 'users') return usersChainMock;
+        if (table === 'wavewarz_artists') return warzChainMock;
+        throw new Error(`Unexpected table: ${table}`);
+      });
+
+      const res = await GET(makeRequest('/api/directory/zero-warz-stats'), {
+        params: Promise.resolve({ slug: 'zero-warz-stats' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.wavewarzStats.wins).toBe(0);
+      expect(body.wavewarzStats.losses).toBe(0);
+      expect(body.wavewarzStats.total_volume_sol).toBe(0);
+    });
+  });
+});

--- a/src/app/api/profile/platforms/__tests__/route.test.ts
+++ b/src/app/api/profile/platforms/__tests__/route.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Chain for profile/platforms route tests.
+ * Supports .select().eq().single() for user platform queries.
+ */
+function platformsChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/profile/platforms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns all platforms as null when user has no connected platforms', async () => {
+    mockFrom.mockReturnValue(
+      platformsChain({
+        data: {
+          bluesky_handle: null,
+          lens_profile_id: null,
+          hive_username: null,
+          x_handle: null,
+        },
+        error: null,
+      }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      bluesky_handle: null,
+      lens_profile_id: null,
+      hive_username: null,
+      x_handle: null,
+    });
+  });
+
+  it('returns connected platform details on success', async () => {
+    const userData = {
+      bluesky_handle: 'user.bsky.social',
+      lens_profile_id: 'lens/0x1234',
+      hive_username: 'hiveuser',
+      x_handle: 'x_user',
+    };
+    mockFrom.mockReturnValue(platformsChain({ data: userData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(userData);
+  });
+
+  it('returns a mix of null and connected platforms', async () => {
+    const userData = {
+      bluesky_handle: null,
+      lens_profile_id: 'lens/0xabcd',
+      hive_username: null,
+      x_handle: 'twitter_handle',
+    };
+    mockFrom.mockReturnValue(platformsChain({ data: userData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(userData);
+  });
+
+  it('queries the users table', async () => {
+    const chain = platformsChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(mockFrom).toHaveBeenCalledWith('users');
+  });
+
+  it('selects the correct platform fields', async () => {
+    const chain = platformsChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.select).toHaveBeenCalledWith(
+      'bluesky_handle, lens_profile_id, hive_username, x_handle',
+    );
+  });
+
+  it('filters by session fid', async () => {
+    const chain = platformsChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('calls single() to retrieve a single row', async () => {
+    const chain = platformsChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.single).toHaveBeenCalled();
+  });
+
+  it('returns 500 when the query returns an error', async () => {
+    mockFrom.mockReturnValue(
+      platformsChain({ data: null, error: new Error('database connection lost') }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch platform status');
+  });
+
+  it('returns 500 when an exception is thrown', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected crash in supabase client');
+    });
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Internal server error');
+  });
+
+  it('returns user data even when some fields are missing from the row', async () => {
+    // Simulates a row where only bluesky and x are set
+    const userData = {
+      bluesky_handle: 'user.bsky.social',
+      lens_profile_id: null,
+      hive_username: null,
+      x_handle: 'x_user',
+    };
+    mockFrom.mockReturnValue(platformsChain({ data: userData, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.bluesky_handle).toBe('user.bsky.social');
+    expect(body.x_handle).toBe('x_user');
+    expect(body.lens_profile_id).toBeNull();
+    expect(body.hive_username).toBeNull();
+  });
+
+  it('uses session fid from authenticated session', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const chain = platformsChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(chain.eq).toHaveBeenCalledWith('fid', 999);
+  });
+
+  it('returns status 200 even when the user record returns null', async () => {
+    mockFrom.mockReturnValue(platformsChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Nullish coalescing converts undefined to null
+    expect(body.bluesky_handle).toBeNull();
+    expect(body.lens_profile_id).toBeNull();
+    expect(body.hive_username).toBeNull();
+    expect(body.x_handle).toBeNull();
+  });
+});


### PR DESCRIPTION
95 tests across 4 untested routes (task #591), subagent-authored + verified green (vitest 95/95, tsc 0, biome clean). directory/[slug] GET (22, dynamic + WaveWarZ enrichment), artists/featured GET (19), profile/platforms GET (13), admin/member-fid GET+PATCH (41, batch updates + partial-failure). All supabase module mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)