### PR TITLE
test(admin,auth,overlay): agents, ens-subnames, listenbrainz, now-playing (task #591)

### DIFF
--- a/src/app/api/admin/agents/__tests__/route.test.ts
+++ b/src/app/api/admin/agents/__tests__/route.test.ts
@@ -1,0 +1,695 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { GET, PATCH } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for chaining.
+ * Terminal .single() resolves the query (for awaited direct chains).
+ * Includes all methods used by agents route: select, update, eq, order, limit.
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = ['select', 'update', 'eq', 'order', 'limit'];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal — resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Create a mock queue that returns chains in sequence for parallel queries.
+ * Useful for testing Promise.allSettled() with multiple queries that need different results.
+ */
+function createChainQueue(
+  results: Array<{ data?: unknown; error?: unknown; count?: number | null }>,
+) {
+  let callIndex = 0;
+  return {
+    mockFn: vi.fn(() => {
+      if (callIndex >= results.length) {
+        throw new Error(`Chain queue exhausted at call ${callIndex}`);
+      }
+      return chainMock(results[callIndex++]);
+    }),
+    getCallCount: () => callIndex,
+  };
+}
+
+describe('GET /api/admin/agents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Success path: list agents and recent events ──────────────────────────
+
+  it('passes authentication when isAdmin is true and fetches configs + events', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // agent_config
+      { data: [], error: null }, // agent_events
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(queue.getCallCount()).toBe(2);
+  });
+
+  it('returns agents and recentEvents on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const agentConfigs = [
+      {
+        name: 'VAULT',
+        trading_enabled: true,
+        max_daily_spend: 1000,
+        enabled: true,
+      },
+      {
+        name: 'BANKER',
+        trading_enabled: false,
+        max_daily_spend: 500,
+        enabled: true,
+      },
+    ];
+
+    const recentEvents = [
+      {
+        agent_name: 'VAULT',
+        event_type: 'trade_executed',
+        created_at: '2026-07-16T10:00:00Z',
+      },
+      {
+        agent_name: 'BANKER',
+        event_type: 'trade_failed',
+        created_at: '2026-07-16T09:55:00Z',
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: agentConfigs, error: null },
+      { data: recentEvents, error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.agents).toHaveLength(2);
+    expect(body.agents[0].name).toBe('VAULT');
+    expect(body.recentEvents).toHaveLength(2);
+    expect(body.recentEvents[0].event_type).toBe('trade_executed');
+  });
+
+  it('handles empty agents list', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // no agents
+      { data: [], error: null }, // no events
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.agents).toEqual([]);
+    expect(body.recentEvents).toEqual([]);
+  });
+
+  it('orders agent configs by name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain1 = chainMock({ data: [], error: null });
+    const chain2 = chainMock({ data: [], error: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [chain1, chain2];
+      return chains[callIndex++];
+    });
+
+    await GET();
+
+    // Verify order('name') was called on the first chain
+    expect(chain1.order).toHaveBeenCalledWith('name');
+  });
+
+  it('limits agent events to 50', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain1 = chainMock({ data: [], error: null });
+    const chain2 = chainMock({ data: [], error: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [chain1, chain2];
+      return chains[callIndex++];
+    });
+
+    await GET();
+
+    // Verify limit(50) was called on the second chain
+    expect(chain2.limit).toHaveBeenCalledWith(50);
+  });
+
+  // ── Error path: rejected Promise.allSettled ──────────────────────────────
+
+  it('returns 500 when agent_config query is rejected via Promise.allSettled', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain1 = chainMock({ data: [], error: null });
+    // Override .then to throw for agent_config
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+    chain1.then = vi.fn(() => {
+      throw new Error('DB connection lost');
+    });
+
+    const chain2 = chainMock({ data: [], error: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [chain1, chain2];
+      return chains[callIndex++];
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch agent configs');
+  });
+
+  it('returns 500 when agent_events query is rejected via Promise.allSettled', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain1 = chainMock({ data: [], error: null });
+    const chain2 = chainMock({ data: [], error: null });
+    // Override .then to throw for agent_events
+    // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+    chain2.then = vi.fn(() => {
+      throw new Error('DB connection lost');
+    });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      const chains = [chain1, chain2];
+      return chains[callIndex++];
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch agent events');
+  });
+
+  // ── Error path: Supabase error in value.error ────────────────────────────
+
+  it('returns 500 when agent_config returns error in value.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: null, error: { message: 'permission denied' } }, // agent_config error
+      { data: [], error: null }, // agent_events succeeds
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch agent configs');
+  });
+
+  it('returns 500 when agent_events returns error in value.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // agent_config succeeds
+      { data: null, error: { message: 'table not found' } }, // agent_events error
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch agent events');
+  });
+
+  it('logs error to logger.error on agent_config failure', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: null, error: { message: 'db error' } },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    await GET();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'GET /api/admin/agents: agent_config returned error:',
+      expect.any(Object),
+    );
+  });
+
+  it('logs error to logger.error on agent_events failure', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null },
+      { data: null, error: { message: 'db error' } },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    await GET();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'GET /api/admin/agents: agent_events returned error:',
+      expect.any(Object),
+    );
+  });
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(['agents', 'recentEvents'].sort());
+    expect(Array.isArray(body.agents)).toBe(true);
+    expect(Array.isArray(body.recentEvents)).toBe(true);
+  });
+});
+
+describe('PATCH /api/admin/agents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  it('returns 401 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Input validation tests ────────────────────────────────────────────────
+
+  it('returns 400 for missing name field', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', {});
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 for empty name string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', { name: '' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 for non-string name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', { name: 123 });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for non-boolean trading_enabled', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT', trading_enabled: 'yes' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for negative max_daily_spend', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'VAULT',
+      max_daily_spend: -100,
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for zero max_daily_spend (must be positive)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'VAULT',
+      max_daily_spend: 0,
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for non-number max_daily_spend', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'VAULT',
+      max_daily_spend: 'five-hundred',
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 for non-boolean enabled', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT', enabled: 'true' });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts valid optional fields (trading_enabled, max_daily_spend, enabled)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: { name: 'VAULT' }, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'VAULT',
+      trading_enabled: true,
+      max_daily_spend: 2000,
+      enabled: false,
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Success path: agent update ──────────────────────────────────────────
+
+  it('updates agent with only name and returns updated config', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const updatedAgent = {
+      name: 'VAULT',
+      trading_enabled: true,
+      max_daily_spend: 1000,
+      enabled: true,
+      updated_at: '2026-07-16T10:00:00Z',
+    };
+
+    const chain = chainMock({ data: updatedAgent, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT' });
+    const res = await PATCH(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent).toEqual(updatedAgent);
+  });
+
+  it('updates agent with trading_enabled flag', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({
+      data: {
+        name: 'BANKER',
+        trading_enabled: false,
+        updated_at: '2026-07-16T10:00:00Z',
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'BANKER',
+      trading_enabled: false,
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent.trading_enabled).toBe(false);
+  });
+
+  it('updates agent with max_daily_spend', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({
+      data: {
+        name: 'DEALER',
+        max_daily_spend: 5000,
+        updated_at: '2026-07-16T10:00:00Z',
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'DEALER',
+      max_daily_spend: 5000,
+    });
+
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent.max_daily_spend).toBe(5000);
+  });
+
+  it('includes updated_at timestamp in update call', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: { name: 'VAULT' }, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT', enabled: true });
+    await PATCH(req);
+
+    expect(chain.update).toHaveBeenCalledWith({
+      enabled: true,
+      updated_at: expect.stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/),
+    });
+  });
+
+  it('filters out name from update object (uses it for eq)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: { name: 'VAULT' }, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', {
+      name: 'VAULT',
+      trading_enabled: true,
+    });
+
+    await PATCH(req);
+
+    // Verify that update() does NOT contain 'name'
+    const updateCall = (chain.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(updateCall).not.toHaveProperty('name');
+    expect(updateCall).toHaveProperty('trading_enabled');
+  });
+
+  it('calls supabase eq with the agent name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: { name: 'VAULT' }, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT', enabled: true });
+    await PATCH(req);
+
+    expect(chain.eq).toHaveBeenCalledWith('name', 'VAULT');
+  });
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: { name: 'VAULT' }, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT' });
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(Object.keys(body)).toEqual(['agent']);
+    expect(body.agent).toBeDefined();
+  });
+
+  // ── Error path: Supabase error ──────────────────────────────────────────
+
+  it('returns 500 when update returns error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({
+      data: null,
+      error: { message: 'agent not found' },
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'NONEXISTENT' });
+    const res = await PATCH(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update agent config');
+  });
+
+  it('logs error when Supabase update fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({
+      data: null,
+      error: { message: 'unique constraint violation' },
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/agents', { name: 'VAULT' });
+    await PATCH(req);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to update agent config:',
+      expect.any(Object),
+    );
+  });
+
+  // ── Error path: exception thrown ────────────────────────────────────────
+
+  it('returns 500 when req.json() throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const mockReq = {
+      json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+    } as { json: () => Promise<never> };
+
+    const res = await PATCH(mockReq as never);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('logs error when exception is thrown', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const mockReq = {
+      json: vi.fn().mockRejectedValue(new Error('JSON parse error')),
+    } as { json: () => Promise<never> };
+
+    await PATCH(mockReq as never);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'PATCH /api/admin/agents error:',
+      expect.any(Error),
+    );
+  });
+
+  it('handles Zod parsing errors and returns flatten()', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/agents', {
+      name: '',
+      max_daily_spend: -50,
+    });
+    const res = await PATCH(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.details).toBeDefined();
+    expect(body.details.fieldErrors || body.details.formErrors).toBeDefined();
+  });
+});

--- a/src/app/api/admin/ens-subnames/__tests__/route.test.ts
+++ b/src/app/api/admin/ens-subnames/__tests__/route.test.ts
@@ -1,0 +1,1074 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const {
+  mockCreateSubnameWithFallback,
+  mockBatchCreateSubnames,
+  mockSanitizeSubname,
+  mockIsValidSubname,
+  mockBuildMemberTextRecords,
+} = vi.hoisted(() => ({
+  mockCreateSubnameWithFallback: vi.fn(),
+  mockBatchCreateSubnames: vi.fn(),
+  mockSanitizeSubname: vi.fn((name: string) => name.toLowerCase()),
+  mockIsValidSubname: vi.fn((name: string) => /^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$/.test(name)),
+  mockBuildMemberTextRecords: vi.fn((member) => ({
+    description: member.bio || 'ZAO Member',
+    ...(member.username && { url: `https://zaoos.com/members/${member.username}` }),
+    ...(member.pfpUrl && { avatar: member.pfpUrl }),
+  })),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+vi.mock('@/lib/ens/subnames', () => ({
+  createSubnameWithFallback: (
+    name: string,
+    addr: string,
+    zid: number | null,
+    records: Record<string, string>,
+  ) => mockCreateSubnameWithFallback(name, addr, zid, records),
+  batchCreateSubnames: (names) => mockBatchCreateSubnames(names),
+  sanitizeSubname: (name: string) => mockSanitizeSubname(name),
+  isValidSubname: (name: string) => mockIsValidSubname(name),
+  buildMemberTextRecords: (member) => mockBuildMemberTextRecords(member),
+}));
+
+import { DELETE, GET, POST } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for chaining.
+ * Terminal .then() resolves the query (for awaited direct chains).
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = [
+    'select',
+    'update',
+    'eq',
+    'is',
+    'order',
+    'not',
+    'gt',
+    'lt',
+    'insert',
+    'single',
+  ];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal — resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Create a mock queue that returns chains in sequence for parallel queries.
+ */
+function createChainQueue(
+  results: Array<{ data?: unknown; error?: unknown; count?: number | null }>,
+) {
+  let callIndex = 0;
+  return {
+    mockFn: vi.fn(() => {
+      if (callIndex >= results.length) {
+        throw new Error(`Chain queue exhausted at call ${callIndex}`);
+      }
+      return chainMock(results[callIndex++]);
+    }),
+    getCallCount: () => callIndex,
+  };
+}
+
+describe('GET /api/admin/ens-subnames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication & Authorization ────────────────────────────────────────
+
+  it('returns 403 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Success path: list all active users ───────────────────────────────────
+
+  it('returns 200 with members list on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const userData = [
+      {
+        fid: 123,
+        username: 'alice',
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zao_subname: 'alice.thezao.eth',
+        zid: '001',
+        pfp_url: 'https://example.com/alice.jpg',
+      },
+      {
+        fid: 124,
+        username: 'bob',
+        display_name: 'Bob',
+        primary_wallet: '0x2222',
+        zao_subname: null,
+        zid: null,
+        pfp_url: null,
+      },
+    ];
+
+    const chain = chainMock({ data: userData, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0]).toEqual({
+      fid: 123,
+      username: 'alice',
+      displayName: 'Alice',
+      wallet: '0x1111',
+      zaoSubname: 'alice.thezao.eth',
+      zid: '001',
+      pfpUrl: 'https://example.com/alice.jpg',
+    });
+  });
+
+  it('calls supabase with correct select fields and filters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await GET();
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.select).toHaveBeenCalledWith(
+      'fid, username, display_name, primary_wallet, zao_subname, zid, pfp_url',
+    );
+    expect(chain.eq).toHaveBeenCalledWith('is_active', true);
+    expect(chain.not).toHaveBeenCalledWith('primary_wallet', 'is', null);
+    expect(chain.order).toHaveBeenCalledWith('zid', { ascending: true, nullsFirst: false });
+  });
+
+  it('returns empty members array when no users found', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.members).toEqual([]);
+  });
+
+  it('transforms field names from snake_case to camelCase', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const userData = [
+      {
+        fid: 100,
+        username: 'test',
+        display_name: 'Test User',
+        primary_wallet: '0xabcd',
+        zao_subname: 'test.thezao.eth',
+        zid: '999',
+        pfp_url: 'https://example.com/test.jpg',
+      },
+    ];
+
+    const chain = chainMock({ data: userData, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    const body = await res.json();
+
+    const member = body.members[0];
+    expect(member).not.toHaveProperty('display_name');
+    expect(member).not.toHaveProperty('primary_wallet');
+    expect(member).not.toHaveProperty('zao_subname');
+    expect(member).not.toHaveProperty('pfp_url');
+    expect(member).toHaveProperty('displayName');
+    expect(member).toHaveProperty('wallet');
+    expect(member).toHaveProperty('zaoSubname');
+    expect(member).toHaveProperty('pfpUrl');
+  });
+
+  // ── Error path ────────────────────────────────────────────────────────────
+
+  it('returns 500 when DB query throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('Connection timeout');
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to list subnames');
+  });
+
+  it('logs error when query fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const testError = new Error('DB error');
+    mockFrom.mockImplementation(() => {
+      throw testError;
+    });
+
+    await GET();
+
+    expect(mockLogger.error).toHaveBeenCalledWith('[admin/ens-subnames] list error:', testError);
+  });
+});
+
+describe('POST /api/admin/ens-subnames (Single Create)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication & Authorization ────────────────────────────────────────
+
+  it('returns 403 when not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns 400 when body is not valid JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = new Request(new URL('/api/admin/ens-subnames', 'http://localhost:3000'), {
+      method: 'POST',
+      body: 'invalid json',
+    });
+    const res = await POST(req as never);
+    expect(res.status).toBe(500); // JSON parse error is caught in try/catch
+  });
+
+  it('returns 400 when fid is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when fid is not a number', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 'not-a-number', name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when fid is not a positive integer', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: -1, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when fid is 0', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 0, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when fid is a float', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 123.45, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100 });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: '' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name exceeds 63 characters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const longName = 'a'.repeat(64);
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: longName });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts a 63-character name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const name63 = 'a'.repeat(63);
+    mockSanitizeSubname.mockReturnValue(name63);
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({
+      data: {
+        primary_wallet: '0x1234',
+        zid: null,
+        username: 'test',
+        pfp_url: null,
+        bio: null,
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: `${name63}.thezao.eth`,
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: name63 });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Single create success ──────────────────────────────────────────────────
+
+  it('creates a single subname successfully', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const queue = createChainQueue([
+      {
+        data: {
+          primary_wallet: '0x1234',
+          zid: '001',
+          username: 'alice',
+          pfp_url: 'https://example.com/alice.jpg',
+          bio: 'My bio',
+        },
+        error: null,
+      },
+      { error: null }, // update user
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+      txHash: '0xabcd',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.subname).toBe('alice.thezao.eth');
+  });
+
+  it('sanitizes the name before validation', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({
+      data: { primary_wallet: '0x1234', zid: null, username: 'alice', pfp_url: null, bio: null },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'Alice' });
+    await POST(req);
+
+    expect(mockSanitizeSubname).toHaveBeenCalledWith('Alice');
+    expect(mockIsValidSubname).toHaveBeenCalledWith('alice');
+  });
+
+  it('returns 400 when sanitized name is invalid', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('-invalid-');
+    mockIsValidSubname.mockReturnValue(false);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'invalid' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid subname');
+  });
+
+  it('returns 404 when user not found', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 999, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Member not found or no wallet');
+  });
+
+  it('returns 404 when user has no primary_wallet', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({
+      data: {
+        primary_wallet: null,
+        zid: null,
+        username: 'alice',
+        pfp_url: null,
+        bio: null,
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Member not found or no wallet');
+  });
+
+  it('calls buildMemberTextRecords with member data', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const userData = {
+      primary_wallet: '0x1234',
+      zid: '001',
+      username: 'alice',
+      pfp_url: 'https://example.com/alice.jpg',
+      bio: 'My bio',
+    };
+
+    const queue = createChainQueue([{ data: userData, error: null }, { error: null }]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockBuildMemberTextRecords.mockReturnValue({ description: 'My bio' });
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await POST(req);
+
+    expect(mockBuildMemberTextRecords).toHaveBeenCalledWith({
+      username: 'alice',
+      pfpUrl: 'https://example.com/alice.jpg',
+      bio: 'My bio',
+    });
+  });
+
+  it('passes zid as number to createSubnameWithFallback', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const queue = createChainQueue([
+      {
+        data: {
+          primary_wallet: '0x1234',
+          zid: '999',
+          username: 'alice',
+          pfp_url: null,
+          bio: null,
+        },
+        error: null,
+      },
+      { error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await POST(req);
+
+    expect(mockCreateSubnameWithFallback).toHaveBeenCalledWith(
+      'alice',
+      '0x1234',
+      999,
+      expect.any(Object),
+    );
+  });
+
+  it('handles null zid correctly', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const queue = createChainQueue([
+      {
+        data: {
+          primary_wallet: '0x1234',
+          zid: null,
+          username: 'alice',
+          pfp_url: null,
+          bio: null,
+        },
+        error: null,
+      },
+      { error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await POST(req);
+
+    expect(mockCreateSubnameWithFallback).toHaveBeenCalledWith(
+      'alice',
+      '0x1234',
+      null,
+      expect.any(Object),
+    );
+  });
+
+  it('returns 500 when ENS lib creation fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({
+      data: { primary_wallet: '0x1234', zid: null, username: 'alice', pfp_url: null, bio: null },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: false,
+      fullName: 'alice.thezao.eth',
+      error: 'Name already registered',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Name already registered');
+  });
+
+  it('updates DB with created subname', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const chain = chainMock({
+      data: { primary_wallet: '0x1234', zid: null, username: 'alice', pfp_url: null, bio: null },
+      error: null,
+    });
+
+    let chainCallCount = 0;
+    mockFrom.mockImplementation(() => {
+      chainCallCount++;
+      if (chainCallCount === 1) {
+        return chain; // First call: select user
+      }
+      return chainMock({ error: null }); // Second call: update user
+    });
+
+    mockCreateSubnameWithFallback.mockResolvedValue({
+      success: true,
+      fullName: 'alice.thezao.eth',
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await POST(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+  });
+});
+
+describe('POST /api/admin/ens-subnames (Batch Create)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('recognizes batch mode with { batch: true }', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // members without subname
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockBatchCreateSubnames.mockResolvedValue({ created: [], failed: [] });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.message).toContain('All members already have subnames');
+    expect(body.created).toEqual([]);
+    expect(body.failed).toEqual([]);
+  });
+
+  it('recognizes batch: true even with extra fields in body', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    // batch schema only checks for batch: true, doesn't strictly validate extra fields
+    // so batch mode runs when batch: true is present
+    const queue = createChainQueue([{ data: [], error: null }]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockBatchCreateSubnames.mockResolvedValue({ created: [], failed: [] });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true, extra: 'field' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain('All members already have subnames');
+  });
+
+  it('queries members without subnames for batch mode', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    mockBatchCreateSubnames.mockResolvedValue({ created: [], failed: [] });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    await POST(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.select).toHaveBeenCalled();
+  });
+
+  it('returns 200 when all members already have subnames', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const queue = createChainQueue([
+      { data: [], error: null }, // no members without subname
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.message).toBe('All members already have subnames');
+    expect(body.created).toEqual([]);
+    expect(body.failed).toEqual([]);
+  });
+
+  it('processes multiple members in batch mode', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        fid: 100,
+        username: 'alice',
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zid: '001',
+        pfp_url: 'https://example.com/alice.jpg',
+        bio: 'Bio A',
+        zao_subname: null,
+      },
+      {
+        fid: 101,
+        username: 'bob',
+        display_name: 'Bob',
+        primary_wallet: '0x2222',
+        zid: '002',
+        pfp_url: null,
+        bio: null,
+        zao_subname: null,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { error: null }, // first update
+      { error: null }, // second update
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockSanitizeSubname.mockImplementation((n) => n.toLowerCase());
+    mockBatchCreateSubnames.mockResolvedValue({
+      created: [
+        { name: 'alice.thezao.eth', txHash: '0xabc' },
+        { name: 'bob.thezao.eth', txHash: '0xdef' },
+      ],
+      failed: [],
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.created).toHaveLength(2);
+    expect(body.failed).toHaveLength(0);
+    expect(mockBatchCreateSubnames).toHaveBeenCalled();
+  });
+
+  it('builds text records for each member in batch', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        fid: 100,
+        username: 'alice',
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zid: '001',
+        pfp_url: 'https://example.com/alice.jpg',
+        bio: 'My bio',
+        zao_subname: null,
+      },
+    ];
+
+    const queue = createChainQueue([{ data: membersData, error: null }, { error: null }]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockBuildMemberTextRecords.mockReturnValue({
+      description: 'My bio',
+      url: 'https://zaoos.com/members/alice',
+    });
+    mockBatchCreateSubnames.mockResolvedValue({
+      created: [{ name: 'alice.thezao.eth' }],
+      failed: [],
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    await POST(req);
+
+    expect(mockBuildMemberTextRecords).toHaveBeenCalledWith({
+      username: 'alice',
+      pfpUrl: 'https://example.com/alice.jpg',
+      bio: 'My bio',
+    });
+  });
+
+  it('uses fallback username when not present', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        fid: 100,
+        username: null,
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zid: '001',
+        pfp_url: null,
+        bio: null,
+        zao_subname: null,
+      },
+    ];
+
+    const queue = createChainQueue([{ data: membersData, error: null }, { error: null }]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockBatchCreateSubnames.mockResolvedValue({
+      created: [{ name: 'alice.thezao.eth' }],
+      failed: [],
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    await POST(req);
+
+    // Should use display_name or member-{fid} fallback
+    expect(mockBatchCreateSubnames).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+        }),
+      ]),
+    );
+  });
+
+  it('updates DB for successfully created subnames', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        fid: 100,
+        username: 'alice',
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zid: '001',
+        pfp_url: null,
+        bio: null,
+        zao_subname: null,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { error: null }, // update
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockBatchCreateSubnames.mockResolvedValue({
+      created: [{ name: 'alice.thezao.eth' }],
+      failed: [],
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    await POST(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+  });
+
+  it('returns summary of created and failed subnames', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const membersData = [
+      {
+        fid: 100,
+        username: 'alice',
+        display_name: 'Alice',
+        primary_wallet: '0x1111',
+        zid: '001',
+        pfp_url: null,
+        bio: null,
+        zao_subname: null,
+      },
+      {
+        fid: 101,
+        username: 'bob',
+        display_name: 'Bob',
+        primary_wallet: '0x2222',
+        zid: '002',
+        pfp_url: null,
+        bio: null,
+        zao_subname: null,
+      },
+    ];
+
+    const queue = createChainQueue([
+      { data: membersData, error: null },
+      { error: null },
+      { error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+    mockSanitizeSubname.mockImplementation((n) => n.toLowerCase());
+    mockBatchCreateSubnames.mockResolvedValue({
+      created: [{ name: 'alice.thezao.eth' }],
+      failed: [{ name: 'bob', error: 'Already registered' }],
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { batch: true });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body.message).toBe('Created 1/2 subnames');
+    expect(body.created).toHaveLength(1);
+    expect(body.failed).toHaveLength(1);
+  });
+});
+
+describe('DELETE /api/admin/ens-subnames', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication & Authorization ────────────────────────────────────────
+
+  it('returns 403 when not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns 400 when fid is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { name: 'alice' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when fid is not positive', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 0, name: 'alice' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100 });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when name exceeds 63 characters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const longName = 'a'.repeat(64);
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: longName });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+  });
+
+  // ── Success path ──────────────────────────────────────────────────────────
+
+  it('unlinks subname from member successfully', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.message).toBe('Subname unlinked from member profile');
+  });
+
+  it('updates DB to set zao_subname to null', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await DELETE(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.update).toHaveBeenCalledWith({ zao_subname: null });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 100);
+  });
+
+  it('returns correct response shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await DELETE(req);
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(['message', 'success'].sort());
+    expect(typeof body.success).toBe('boolean');
+    expect(typeof body.message).toBe('string');
+  });
+
+  // ── Error path ────────────────────────────────────────────────────────────
+
+  it('returns 500 when DB query throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFrom.mockImplementation(() => {
+      throw new Error('DB connection lost');
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    const res = await DELETE(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to revoke subname');
+  });
+
+  it('logs error when query fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const testError = new Error('DB error');
+    mockFrom.mockImplementation(() => {
+      throw testError;
+    });
+
+    const req = makePostRequest('/api/admin/ens-subnames', { fid: 100, name: 'alice' });
+    await DELETE(req);
+
+    expect(mockLogger.error).toHaveBeenCalledWith('[admin/ens-subnames] delete error:', testError);
+  });
+});

--- a/src/app/api/auth/listenbrainz/__tests__/route.test.ts
+++ b/src/app/api/auth/listenbrainz/__tests__/route.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock fetch at global scope
+global.fetch = vi.fn();
+
+import { DELETE, POST } from '../route';
+
+/**
+ * Build a chain that supports upsert→await and update→eq→await.
+ * The chain is thenable so it resolves when awaited directly.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainable = ['upsert', 'update', 'eq', 'from'];
+  for (const m of chainable) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('POST /api/auth/listenbrainz', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    (global.fetch as ReturnType<typeof vi.fn>).mockClear();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'test' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when token is missing', async () => {
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', {}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Token required');
+  });
+
+  it('returns 400 when token is empty string', async () => {
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: '' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Token required');
+  });
+
+  it('validates token against ListenBrainz API', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ valid: true, user_name: 'alice' })),
+    );
+
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'test_token' }));
+
+    expect(global.fetch).toHaveBeenCalledWith('https://api.listenbrainz.org/1/validate-token', {
+      headers: { Authorization: 'Token test_token' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.username).toBe('alice');
+  });
+
+  it('returns 400 when ListenBrainz token is invalid', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ valid: false })),
+    );
+
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'bad_token' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid ListenBrainz token');
+  });
+
+  it('stores valid token in user_settings via upsert', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ valid: true, user_name: 'alice' })),
+    );
+
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'test_token' }));
+
+    expect(res.status).toBe(200);
+    expect(chain.upsert).toHaveBeenCalledWith(
+      { fid: 123, listenbrainz_token: 'test_token' },
+      { onConflict: 'fid' },
+    );
+  });
+
+  it('returns 500 when supabase upsert throws', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('db error');
+    });
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ valid: true, user_name: 'alice' })),
+    );
+
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'test_token' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to save token');
+  });
+
+  it('returns 500 when fetch throws', async () => {
+    mockFrom.mockReturnValue(makeChain({ error: null }));
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
+
+    const res = await POST(makePostRequest('/api/auth/listenbrainz', { token: 'test_token' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to save token');
+  });
+});
+
+describe('DELETE /api/auth/listenbrainz', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await DELETE();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('clears listenbrainz_token on success', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    expect(chain.update).toHaveBeenCalledWith({ listenbrainz_token: null });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('returns 500 when supabase update throws', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('db error');
+    });
+
+    const res = await DELETE();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to disconnect');
+  });
+});

--- a/src/app/api/overlay/now-playing/__tests__/route.test.ts
+++ b/src/app/api/overlay/now-playing/__tests__/route.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a Supabase chain mock for overlay_now_playing queries.
+ * Implements .select().eq().single() -> resolved result.
+ */
+function nowPlayingChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods
+  chain.select = vi.fn(() => chain);
+  chain.eq = vi.fn(() => chain);
+
+  // Terminal: .single() resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  return chain;
+}
+
+describe('GET /api/overlay/now-playing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---------- Query Parameter Validation ----------
+
+  it('returns 400 when fid parameter is missing', async () => {
+    const res = await GET(makeGetRequest('/api/overlay/now-playing'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when fid is not a positive integer', async () => {
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '0' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when fid is a negative integer', async () => {
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '-1' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('returns 400 when fid is not numeric', async () => {
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: 'abc' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid fid parameter');
+  });
+
+  it('accepts fid as numeric string and coerces to number', async () => {
+    const chain = nowPlayingChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(200);
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  // ---------- Playing States ----------
+
+  it('returns playing=true with track details when actively playing and recent', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 10_000).toISOString(); // 10 sec ago
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Midnight Dream',
+      artist_name: 'Cosmic Echo',
+      artwork_url: 'https://example.com/art.jpg',
+      platform: 'spotify',
+      position: 45_000,
+      duration: 240_000,
+      track_url: 'https://spotify.com/track/123',
+      is_playing: true,
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.playing).toBe(true);
+    expect(body.trackName).toBe('Midnight Dream');
+    expect(body.artistName).toBe('Cosmic Echo');
+    expect(body.artworkUrl).toBe('https://example.com/art.jpg');
+    expect(body.platform).toBe('spotify');
+    expect(body.position).toBe(45_000);
+    expect(body.duration).toBe(240_000);
+    expect(body.url).toBe('https://spotify.com/track/123');
+  });
+
+  it('handles optional position/duration as 0 when null', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 10_000).toISOString();
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'apple_music',
+      position: null, // nullable
+      duration: null, // nullable
+      track_url: null,
+      is_playing: true,
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    const body = await res.json();
+    expect(body.position).toBe(0);
+    expect(body.duration).toBe(0);
+  });
+
+  it('returns playing=false when record exists but is_playing is false', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 10_000).toISOString();
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: false, // Paused
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playing).toBe(false);
+  });
+
+  it('returns playing=false when record is stale (>30 seconds old)', async () => {
+    const now = Date.now();
+    const staleUpdatedAt = new Date(now - 31_000).toISOString(); // 31 sec ago
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: true,
+      updated_at: staleUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playing).toBe(false);
+  });
+
+  it('returns playing=false when exactly 30 seconds old (boundary)', async () => {
+    const now = Date.now();
+    const boundaryUpdatedAt = new Date(now - 30_000).toISOString(); // Exactly 30 sec
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: true,
+      updated_at: boundaryUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    const body = await res.json();
+    // 30_000ms is NOT < 30_000, so not live
+    expect(body.playing).toBe(false);
+  });
+
+  it('returns playing=false when record has no track_name', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 10_000).toISOString();
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: null, // No track
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: true,
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    const body = await res.json();
+    expect(body.playing).toBe(false);
+  });
+
+  it('returns playing=false when no record exists (data is null)', async () => {
+    const chain = nowPlayingChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '456' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.playing).toBe(false);
+  });
+
+  // ---------- Response Headers ----------
+
+  it('includes Cache-Control header for playing response', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 5_000).toISOString();
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: true,
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=5, stale-while-revalidate=2');
+  });
+
+  it('includes Cache-Control header for not-playing response', async () => {
+    const chain = nowPlayingChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.headers.get('Cache-Control')).toBe('public, s-maxage=5, stale-while-revalidate=2');
+  });
+
+  it('includes CORS header Access-Control-Allow-Origin: * for playing', async () => {
+    const now = Date.now();
+    const recentUpdatedAt = new Date(now - 5_000).toISOString();
+    const nowPlayingRecord = {
+      fid: 123,
+      track_name: 'Song',
+      artist_name: 'Artist',
+      artwork_url: null,
+      platform: 'spotify',
+      position: 0,
+      duration: 180_000,
+      track_url: null,
+      is_playing: true,
+      updated_at: recentUpdatedAt,
+    };
+
+    const chain = nowPlayingChain({ data: nowPlayingRecord, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  it('includes CORS header Access-Control-Allow-Origin: * for not-playing', async () => {
+    const chain = nowPlayingChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  // ---------- Error Handling ----------
+
+  it('returns 500 when supabase query throws an exception', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn().mockRejectedValue(new Error('db connection failed')),
+        })),
+      })),
+    });
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  it('returns 500 when getSupabaseAdmin throws', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('supabase initialization failed');
+    });
+
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  // ---------- No Auth Required (Public) ----------
+
+  it('is publicly accessible without authentication', async () => {
+    const chain = nowPlayingChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    // No session/auth header provided — should still work
+    const res = await GET(makeGetRequest('/api/overlay/now-playing', { fid: '123' }));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
115 tests across 4 untested routes (task #591), subagent-authored + verified green (vitest 115/115, tsc 0, biome clean). admin/agents GET+PATCH (37), admin/ens-subnames GET+POST+DELETE (48, single+batch via mocked ENS lib), auth/listenbrainz POST+DELETE (11), overlay/now-playing GET (19, public + play-state). auth/listenbrainz mocks global.fetch (raw ListenBrainz API, no lib seam — justified); ens-subnames mocks the ENS lib; others supabase mocks. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)