### PR TITLE
test(auth): OAuth-init redirects + lastfm disconnect (task #591)

### DIFF
--- a/src/app/api/auth/facebook/__tests__/route.test.ts
+++ b/src/app/api/auth/facebook/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/auth/facebook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 500 when NEXT_PUBLIC_FACEBOOK_APP_ID is not configured', async () => {
+    vi.stubEnv('NEXT_PUBLIC_FACEBOOK_APP_ID', '');
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Facebook app ID not configured');
+  });
+
+  it('returns 307 redirect with correct OAuth URL', async () => {
+    const appId = 'test-app-id-123';
+    const baseUrl = 'http://localhost:3000';
+    vi.stubEnv('NEXT_PUBLIC_FACEBOOK_APP_ID', appId);
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', baseUrl);
+
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+
+    const location = res.headers.get('location');
+    expect(location).toBeDefined();
+    if (!location) throw new Error('location should be defined');
+
+    const url = new URL(location);
+    expect(url.hostname).toBe('www.facebook.com');
+    expect(url.pathname).toBe('/v19.0/dialog/oauth');
+    expect(url.searchParams.get('client_id')).toBe(appId);
+    expect(url.searchParams.get('redirect_uri')).toBe(`${baseUrl}/api/auth/facebook/callback`);
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('scope')).toBe(
+      'publish_video,pages_manage_posts,pages_read_engagement',
+    );
+    expect(url.searchParams.get('state')).toBe('123'); // session.fid from mockAuthenticatedSession
+  });
+
+  it('falls back to request.nextUrl.origin when NEXT_PUBLIC_BASE_URL is not set', async () => {
+    const appId = 'test-app-id-456';
+    vi.stubEnv('NEXT_PUBLIC_FACEBOOK_APP_ID', appId);
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', '');
+
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    expect(res.status).toBe(307);
+
+    const location = res.headers.get('location');
+    if (!location) throw new Error('location should be defined');
+
+    const url = new URL(location);
+    // Should use the request origin (http://localhost:3000 in tests)
+    expect(url.searchParams.get('redirect_uri')).toContain('/api/auth/facebook/callback');
+  });
+
+  it('uses session.fid as the state parameter', async () => {
+    const customFid = 999;
+    vi.stubEnv('NEXT_PUBLIC_FACEBOOK_APP_ID', 'app-id');
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: customFid }));
+
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    const location = res.headers.get('location');
+    if (!location) throw new Error('location should be defined');
+
+    const url = new URL(location);
+
+    expect(url.searchParams.get('state')).toBe('999');
+  });
+
+  it('includes all required OAuth parameters in the redirect URL', async () => {
+    vi.stubEnv('NEXT_PUBLIC_FACEBOOK_APP_ID', 'app-id-789');
+    vi.stubEnv('NEXT_PUBLIC_BASE_URL', 'https://example.com');
+
+    const req = makeRequest('/api/auth/facebook');
+    const res = await GET(req);
+    const location = res.headers.get('location');
+    if (!location) throw new Error('location should be defined');
+
+    const url = new URL(location);
+
+    // Verify all required parameters are present
+    expect(url.searchParams.has('client_id')).toBe(true);
+    expect(url.searchParams.has('redirect_uri')).toBe(true);
+    expect(url.searchParams.has('response_type')).toBe(true);
+    expect(url.searchParams.has('scope')).toBe(true);
+    expect(url.searchParams.has('state')).toBe(true);
+  });
+});

--- a/src/app/api/auth/lastfm/disconnect/__tests__/route.test.ts
+++ b/src/app/api/auth/lastfm/disconnect/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * Build a chain that supports update→eq→await for the disconnect operation.
+ * Chainable methods return the chain for further chaining.
+ * The chain supports direct await (via .then) for awaited operations.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainable = ['update', 'eq'];
+  for (const m of chainable) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('POST /api/auth/lastfm/disconnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('clears lastfm_session_key on success', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    expect(chain.update).toHaveBeenCalledWith({ lastfm_session_key: null });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('scopes the update to the session fid', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await POST();
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('queries the user_settings table', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await POST();
+    expect(mockFrom).toHaveBeenCalledWith('user_settings');
+  });
+
+  it('returns 500 when supabase query throws', async () => {
+    const testError = new Error('db connection failed');
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockRejectedValue(testError),
+      }),
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to disconnect');
+  });
+
+  it('logs errors server-side on disconnect failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    const testError = new Error('unexpected db error');
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockRejectedValue(testError),
+      }),
+    });
+
+    await POST();
+    expect(logger.error).toHaveBeenCalledWith('[lastfm/disconnect] Error:', testError);
+  });
+
+  it('disconnects only the authenticated user via fid', async () => {
+    const chain = makeChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+
+    await POST();
+    expect(chain.eq).toHaveBeenCalledWith('fid', 999);
+    expect(chain.update).toHaveBeenCalledWith({ lastfm_session_key: null });
+  });
+
+  it('returns 401 when session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'user' });
+
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+});

--- a/src/app/api/auth/twitch/__tests__/route.test.ts
+++ b/src/app/api/auth/twitch/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/auth/twitch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear env to test missing config path
+    delete process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID;
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'test-client-id';
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 500 when Twitch client ID is not configured', async () => {
+    // Ensure env var is unset
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = '';
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Twitch client ID not configured');
+  });
+
+  it('redirects to Twitch OAuth authorize with correct parameters', async () => {
+    const testClientId = 'test-client-id-12345';
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = testClientId;
+    const session = mockAuthenticatedSession({ fid: 42 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const res = await GET();
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('location');
+    expect(location).toBeDefined();
+    if (!location) throw new Error('location should be defined');
+
+    const url = new URL(location);
+    expect(url.hostname).toBe('id.twitch.tv');
+    expect(url.pathname).toBe('/oauth2/authorize');
+    expect(url.searchParams.get('client_id')).toBe(testClientId);
+    expect(url.searchParams.get('redirect_uri')).toBe('https://zaoos.com/api/auth/twitch/callback');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('state')).toBe('42');
+
+    // Verify scopes are included
+    const scopes = url.searchParams.get('scope');
+    expect(scopes).toContain('channel:read:stream_key');
+    expect(scopes).toContain('channel:manage:broadcast');
+    expect(scopes).toContain('chat:read');
+    expect(scopes).toContain('chat:edit');
+    expect(scopes).toContain('channel:manage:polls');
+    expect(scopes).toContain('channel:manage:predictions');
+    expect(scopes).toContain('clips:edit');
+    expect(scopes).toContain('channel:read:subscriptions');
+    expect(scopes).toContain('moderator:read:followers');
+  });
+
+  it('encodes the session FID as state parameter', async () => {
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'test-client-id';
+    const session = mockAuthenticatedSession({ fid: 999 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const res = await GET();
+
+    const location = res.headers.get('location');
+    if (!location) throw new Error('location should be defined');
+    const url = new URL(location);
+    expect(url.searchParams.get('state')).toBe('999');
+  });
+
+  it('uses the hardcoded redirect URI', async () => {
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'test-client-id';
+    const res = await GET();
+
+    const location = res.headers.get('location');
+    if (!location) throw new Error('location should be defined');
+    const url = new URL(location);
+    expect(url.searchParams.get('redirect_uri')).toBe('https://zaoos.com/api/auth/twitch/callback');
+  });
+});

--- a/src/app/api/auth/youtube/__tests__/route.test.ts
+++ b/src/app/api/auth/youtube/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/auth/youtube', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear env overrides from previous tests
+    delete process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID;
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 500 when NEXT_PUBLIC_YOUTUBE_CLIENT_ID is not configured', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('YouTube client ID not configured');
+  });
+
+  it('redirects to Google OAuth with correct parameters', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://app.example.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+
+    expect(res.status).toBe(307); // redirect status
+    const location = res.headers.get('location');
+    expect(location).toBeDefined();
+    expect(location).toContain('https://accounts.google.com/o/oauth2/v2/auth');
+    expect(location).toContain('client_id=test-client-id.apps.googleusercontent.com');
+    expect(location).toContain(
+      'redirect_uri=https%3A%2F%2Fapp.example.com%2Fapi%2Fauth%2Fyoutube%2Fcallback',
+    );
+    expect(location).toContain('response_type=code');
+    expect(location).toContain('scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube');
+    expect(location).toContain('access_type=offline');
+    expect(location).toContain('prompt=consent');
+    expect(location).toContain('state=456');
+  });
+
+  it('uses request origin when NEXT_PUBLIC_BASE_URL is not set', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makeRequest('http://localhost:3000/api/auth/youtube');
+    const res = await GET(req);
+
+    const location = res.headers.get('location');
+    expect(location).toBeDefined();
+    expect(location).toContain(
+      'redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fyoutube%2Fcallback',
+    );
+  });
+
+  it('includes both YouTube scopes in the OAuth request', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+
+    const location = res.headers.get('location');
+    expect(location).toContain('https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube');
+    expect(location).toContain('https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fyoutube.force-ssl');
+  });
+
+  it('sets state parameter to session fid', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+
+    const location = res.headers.get('location');
+    expect(location).toContain('state=789');
+  });
+
+  it('constructs valid redirect_uri with callback path', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    process.env.NEXT_PUBLIC_BASE_URL = 'https://example.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+
+    const location = res.headers.get('location');
+    expect(location).toContain(
+      'redirect_uri=https%3A%2F%2Fexample.com%2Fapi%2Fauth%2Fyoutube%2Fcallback',
+    );
+  });
+
+  it('returns a proper NextResponse.redirect', async () => {
+    process.env.NEXT_PUBLIC_YOUTUBE_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makeRequest('/api/auth/youtube');
+    const res = await GET(req);
+
+    // NextResponse.redirect sets status 307
+    expect(res.status).toBe(307);
+    // Location header is set
+    expect(res.headers.has('location')).toBe(true);
+  });
+});


### PR DESCRIPTION
27 tests across 4 untested auth/* routes (task #591), subagent-authored + verified green (vitest 27/27, tsc 0, biome clean). auth/twitch GET (5), auth/youtube GET (8), auth/facebook GET (6) — OAuth-init redirect-URL correctness + config guards + state=fid; auth/lastfm/disconnect POST (8). All module mocks (env/supabase); redirects asserted via status + Location header. Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)