### PR TITLE
test(auth,overlay,events,bots): status, np-update, rsvp, bots-status (task #591)

### DIFF
--- a/src/app/api/auth/listenbrainz/status/__tests__/route.test.ts
+++ b/src/app/api/auth/listenbrainz/status/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a mock Supabase query chain that resolves to the given result.
+ * Chainable methods (.select, .eq) return the chain for further chaining.
+ * Terminal method (.single) resolves to the result.
+ * The chain also implements .then so it resolves when awaited directly.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  for (const m of ['select', 'eq', 'order', 'limit']) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(result));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/auth/listenbrainz/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' });
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns connected:true when listenbrainz_token exists', async () => {
+    const chain = makeChain({ data: { listenbrainz_token: 'test-token-123' }, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(true);
+    expect(chain.select).toHaveBeenCalledWith('listenbrainz_token');
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+    expect(chain.single).toHaveBeenCalled();
+  });
+
+  it('returns connected:false when listenbrainz_token is null', async () => {
+    const chain = makeChain({ data: { listenbrainz_token: null }, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+  });
+
+  it('returns connected:false when data is null (no user row)', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+  });
+
+  it('queries the correct table and columns', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET();
+    expect(mockFrom).toHaveBeenCalledWith('user_settings');
+    expect(chain.select).toHaveBeenCalledWith('listenbrainz_token');
+    expect(chain.eq).toHaveBeenCalledWith('fid', 123);
+  });
+
+  it('returns connected:false on database error', async () => {
+    const chain = makeChain({ data: null, error: new Error('database connection lost') });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+  });
+
+  it('returns connected:false on unexpected exception', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('unexpected error');
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+  });
+
+  it('works with different authenticated session fids', async () => {
+    const chain = makeChain({ data: { listenbrainz_token: 'token-456' }, error: null });
+    mockFrom.mockReturnValue(chain);
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    await GET();
+    expect(chain.eq).toHaveBeenCalledWith('fid', 456);
+  });
+
+  it('returns connected:false when listenbrainz_token is empty string', async () => {
+    const chain = makeChain({ data: { listenbrainz_token: '' }, error: null });
+    mockFrom.mockReturnValue(chain);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(false);
+  });
+});

--- a/src/app/api/bots/status/__tests__/route.test.ts
+++ b/src/app/api/bots/status/__tests__/route.test.ts
@@ -1,0 +1,437 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAdminSession, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+import { GET } from '../route';
+
+describe('GET /api/bots/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.COWORK_API_URL;
+    delete process.env.COWORK_BOT_TOKEN;
+  });
+
+  describe('Authentication guard', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(401);
+      expect(body.configured).toBe(false);
+      expect(body.error).toBe('unauthorized');
+      expect(body.bots).toEqual([]);
+    });
+
+    it('returns 401 when user is authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(401);
+      expect(body.configured).toBe(false);
+      expect(body.error).toBe('unauthorized');
+    });
+
+    it('allows request when user is admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Configuration checks', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+    });
+
+    it('returns configured=false when COWORK_API_URL is missing', async () => {
+      delete process.env.COWORK_API_URL;
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.configured).toBe(false);
+      expect(body.bots).toEqual([]);
+    });
+
+    it('returns configured=false when COWORK_BOT_TOKEN is missing', async () => {
+      process.env.COWORK_API_URL = 'https://example.com';
+      delete process.env.COWORK_BOT_TOKEN;
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.configured).toBe(false);
+      expect(body.bots).toEqual([]);
+    });
+
+    it('returns configured=false when both env vars are missing', async () => {
+      delete process.env.COWORK_API_URL;
+      delete process.env.COWORK_BOT_TOKEN;
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.configured).toBe(false);
+      expect(body.bots).toEqual([]);
+    });
+  });
+
+  describe('Successful fetch from cowork board', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+    });
+
+    it('returns 200 with bots data on success', async () => {
+      const mockBots = [
+        {
+          bot: 'zoe',
+          status: 'up' as const,
+          ts: '2026-01-01T00:00:00Z',
+          online: true,
+          ageSeconds: 10,
+        },
+        {
+          bot: 'devz',
+          status: 'degraded' as const,
+          ts: '2026-01-01T00:00:05Z',
+          online: true,
+          ageSeconds: 5,
+        },
+      ];
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: mockBots }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.configured).toBe(true);
+      expect(body.bots).toEqual(mockBots);
+      expect(body.error).toBeUndefined();
+    });
+
+    it('coerces null bots to empty array', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: null }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.bots).toEqual([]);
+    });
+
+    it('coerces missing bots field to empty array', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({}), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.bots).toEqual([]);
+    });
+
+    it('strips trailing slash from COWORK_API_URL', async () => {
+      process.env.COWORK_API_URL = 'https://example.com/';
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      await GET();
+
+      const callUrl = vi.mocked(global.fetch).mock.calls[0]?.[0];
+      expect(callUrl).toBe('https://example.com/api/v1/bots');
+    });
+
+    it('includes Authorization header with bearer token', async () => {
+      process.env.COWORK_BOT_TOKEN = 'secret-bot-token';
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      await GET();
+
+      const callOptions = vi.mocked(global.fetch).mock.calls[0]?.[1];
+      expect((callOptions as Record<string, unknown>)?.headers).toEqual({
+        Authorization: 'Bearer secret-bot-token',
+      });
+    });
+
+    it('sets cache=no-store', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      await GET();
+
+      const callOptions = vi.mocked(global.fetch).mock.calls[0]?.[1];
+      expect((callOptions as Record<string, unknown>)?.cache).toBe('no-store');
+    });
+
+    it('sets a 6s timeout via AbortController', async () => {
+      // Verify that the fetch call receives an AbortSignal for timeout handling
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      await GET();
+
+      // The AbortController should have been passed to fetch
+      const callOptions = vi.mocked(global.fetch).mock.calls[0]?.[1];
+      expect((callOptions as Record<string, unknown>)?.signal).toBeDefined();
+      // Verify it's an AbortSignal
+      const signal = (callOptions as Record<string, unknown>)?.signal as AbortSignal;
+      expect(signal.constructor.name).toBe('AbortSignal');
+    });
+
+    it('returns fetchedAt timestamp in response', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.fetchedAt).toBeDefined();
+      expect(typeof body.fetchedAt).toBe('string');
+      // Should be a valid ISO date
+      expect(() => new Date(body.fetchedAt as string)).not.toThrow();
+    });
+  });
+
+  describe('Cowork board error responses', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+    });
+
+    it('returns 502 with error message when cowork board returns non-ok status', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Not found', { status: 404 }));
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.configured).toBe(true);
+      expect(body.bots).toEqual([]);
+      expect(body.error).toBe('cowork board returned 404');
+    });
+
+    it('returns 502 with error message on 500 from cowork board', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response('Internal Server Error', { status: 500 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('cowork board returned 500');
+    });
+
+    it('returns 502 with error message on 403 from cowork board', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Forbidden', { status: 403 }));
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('cowork board returned 403');
+    });
+  });
+
+  describe('Fetch failures and exceptions', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+    });
+
+    it('returns 502 with generic error message on fetch exception', async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new Error('Network timeout'));
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.configured).toBe(true);
+      expect(body.bots).toEqual([]);
+      expect(body.error).toBe('could not reach the cowork board');
+    });
+
+    it('returns 502 on unknown error type', async () => {
+      vi.mocked(global.fetch).mockRejectedValueOnce('some-string-error');
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('could not reach the cowork board');
+    });
+
+    it('returns 502 on AbortError (timeout)', async () => {
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      vi.mocked(global.fetch).mockRejectedValueOnce(abortError);
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('could not reach the cowork board');
+    });
+  });
+
+  describe('Response format', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+    });
+
+    it('always includes configured, fetchedAt, and bots fields', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body).toHaveProperty('configured');
+      expect(body).toHaveProperty('fetchedAt');
+      expect(body).toHaveProperty('bots');
+    });
+
+    it('includes error field only when there is an error', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.error).toBeUndefined();
+    });
+
+    it('includes error field when there is an error', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.error).toBeDefined();
+      expect(typeof body.error).toBe('string');
+    });
+
+    it('returns NextResponse with JSON content-type', async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: [] }), { status: 200 }),
+      );
+
+      const res = await GET();
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+  });
+
+  describe('Multiple bots in response', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      process.env.COWORK_API_URL = 'https://example.com';
+      process.env.COWORK_BOT_TOKEN = 'test-token';
+    });
+
+    it('handles multiple bots with different statuses', async () => {
+      const mockBots = [
+        {
+          bot: 'zoe',
+          status: 'up' as const,
+          ts: '2026-01-01T00:00:00Z',
+          online: true,
+          ageSeconds: 10,
+        },
+        {
+          bot: 'devz',
+          status: 'degraded' as const,
+          ts: '2026-01-01T00:00:05Z',
+          online: false,
+          ageSeconds: 300,
+        },
+        {
+          bot: 'bonfire',
+          status: 'down' as const,
+          ts: '2026-01-01T00:00:10Z',
+          online: false,
+          ageSeconds: 3600,
+        },
+      ];
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: mockBots }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect((body.bots as unknown[]).length).toBe(3);
+      expect(body.bots).toEqual(mockBots);
+    });
+
+    it('preserves bot metadata if present', async () => {
+      const mockBots = [
+        {
+          bot: 'zoe',
+          status: 'up' as const,
+          ts: '2026-01-01T00:00:00Z',
+          online: true,
+          ageSeconds: 10,
+          meta: { version: '1.2.3', uptime: 86400 },
+        },
+      ];
+      vi.mocked(global.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ bots: mockBots }), { status: 200 }),
+      );
+
+      const res = await GET();
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect((body.bots as unknown[])[0]).toEqual(mockBots[0]);
+    });
+  });
+});

--- a/src/app/api/events/rsvp/__tests__/route.test.ts
+++ b/src/app/api/events/rsvp/__tests__/route.test.ts
@@ -1,0 +1,551 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({ from: mockFrom }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * FIFO chain for sequential database calls in events/rsvp.
+ * Each request does: (1) select/maybeSingle for duplicate check, (2) insert.
+ * Queue one result per call.
+ */
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainMethods = [
+    'from',
+    'select',
+    'insert',
+    'update',
+    'delete',
+    'eq',
+    'neq',
+    'in',
+    'order',
+    'limit',
+  ];
+  for (const m of chainMethods) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.maybeSingle = vi.fn(() => Promise.resolve(q.shift()));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift());
+  return chain;
+}
+
+describe('POST /api/events/rsvp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when name is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          email: 'test@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when email is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when eventSlug is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'test@example.com',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when name is empty string', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: '',
+          email: 'test@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when name exceeds 200 chars', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const longName = 'a'.repeat(201);
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: longName,
+          email: 'test@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when email is invalid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'not-an-email',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when email exceeds 320 chars', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const longEmail = `${'a'.repeat(310)}@example.com`;
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: longEmail,
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when eventSlug is empty', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'test@example.com',
+          eventSlug: '',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when eventSlug exceeds 100 chars', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const longSlug = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'test@example.com',
+          eventSlug: longSlug,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('successful RSVP', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('successfully adds an RSVP with valid input', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check: no existing RSVP
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify duplicate check was performed
+      expect(chain.select).toHaveBeenCalledWith('id');
+      expect(chain.eq).toHaveBeenCalledWith('email', 'john@example.com');
+      expect(chain.eq).toHaveBeenCalledWith('event_slug', 'conference-2026');
+
+      // Verify insert was called
+      expect(chain.insert).toHaveBeenCalledWith({
+        name: 'John Doe',
+        email: 'john@example.com',
+        event_slug: 'conference-2026',
+        fid: 123,
+      });
+    });
+
+    it('successfully adds RSVP with null fid when session has no fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'Guest User',
+          email: 'guest@example.com',
+          eventSlug: 'public-event',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify insert includes fid: null
+      expect(chain.insert).toHaveBeenCalledWith({
+        name: 'Guest User',
+        email: 'guest@example.com',
+        event_slug: 'public-event',
+        fid: null,
+      });
+    });
+
+    it('accepts valid emails at boundary length (320 chars)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const longEmail = `${'a'.repeat(305)}@example.com`;
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'Test User',
+          email: longEmail,
+          eventSlug: 'event',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+
+    it('accepts valid names at boundary length (200 chars)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const longName = 'a'.repeat(200);
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: longName,
+          email: 'test@example.com',
+          eventSlug: 'event',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+  });
+
+  describe('duplicate RSVP handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('returns 409 when RSVP already exists for same email and event', async () => {
+      const chain = queuedChain([
+        { data: { id: 'existing-rsvp-id' }, error: null }, // duplicate found
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toBe('You have already RSVPed for this event');
+
+      // Verify insert was never called (only select was queued)
+      expect(chain.insert).not.toHaveBeenCalled();
+    });
+
+    it('allows duplicate name but different email for same event', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check: no existing
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john2@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+
+    it('allows same email for different events', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check: no existing
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'different-event',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+  });
+
+  describe('database errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+    });
+
+    it('returns 500 when duplicate check query fails', async () => {
+      const chain = queuedChain([
+        { data: null, error: new Error('Database connection error') }, // duplicate check errors
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Server error');
+    });
+
+    it('returns 500 when insert fails', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check: ok
+        { error: new Error('Unique constraint violation') }, // insert fails
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to save RSVP');
+    });
+
+    it('returns 500 when Supabase throws during duplicate check', async () => {
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error('Network timeout');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Server error');
+    });
+
+    it('returns 500 when Supabase throws during insert', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check: ok
+      ]);
+
+      mockFrom.mockReturnValueOnce(chain).mockImplementationOnce(() => {
+        throw new Error('Network timeout');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Server error');
+    });
+  });
+
+  describe('maybeSingle chain behavior', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    });
+
+    it('correctly uses maybeSingle for duplicate check', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+
+      // Verify the chain has maybeSingle called
+      expect(chain.maybeSingle).toHaveBeenCalled();
+    });
+  });
+
+  describe('case sensitivity', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 111 }));
+    });
+
+    it('preserves email case in insert', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'John Doe',
+          email: 'John.Doe@Example.COM',
+          eventSlug: 'conference-2026',
+        }),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'John.Doe@Example.COM',
+        }),
+      );
+    });
+
+    it('preserves name case in insert', async () => {
+      const chain = queuedChain([
+        { data: null, error: null }, // duplicate check
+        { error: null }, // insert
+      ]);
+
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/events/rsvp', {
+          name: 'JOHN DOE',
+          email: 'john@example.com',
+          eventSlug: 'conference-2026',
+        }),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'JOHN DOE',
+        }),
+      );
+    });
+  });
+});

--- a/src/app/api/overlay/now-playing/update/__tests__/route.test.ts
+++ b/src/app/api/overlay/now-playing/update/__tests__/route.test.ts
@@ -1,0 +1,693 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => ({
+    from: mockFrom,
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+/**
+ * Chain mock for upsert queries. The `upsert` method chains and resolves
+ * to { data, error } when awaited via `.then`.
+ */
+function upsertChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  chain.upsert = vi.fn().mockImplementation(() => {
+    // Return a thenable that resolves to the result
+    return {
+      // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+      then: (resolve: (v: unknown) => void) => resolve(result),
+    };
+  });
+
+  return chain;
+}
+
+describe('POST /api/overlay/now-playing/update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  // ---------- Authentication ----------
+
+  it('returns 401 when unauthenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session exists but fid is missing', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'testuser' }); // No fid
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ---------- Input Validation: Required Fields ----------
+
+  it('returns 400 when trackName is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when artistName is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when platform is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when isPlaying is missing', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  // ---------- Input Validation: Field Types ----------
+
+  it('returns 400 when trackName is not a string', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 123,
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when isPlaying is not a boolean', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: 'true',
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  // ---------- Input Validation: String Length Constraints ----------
+
+  it('returns 400 when trackName is empty string', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: '',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when trackName exceeds 300 characters', async () => {
+    const longName = 'a'.repeat(301);
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: longName,
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts trackName at exactly 300 characters', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const exactName = 'a'.repeat(300);
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: exactName,
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when artistName is empty string', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: '',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when artistName exceeds 300 characters', async () => {
+    const longName = 'a'.repeat(301);
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: longName,
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when platform is empty string', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: '',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when platform exceeds 50 characters', async () => {
+    const longPlatform = 'a'.repeat(51);
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: longPlatform,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ---------- Input Validation: Optional Fields ----------
+
+  it('returns 400 when artworkUrl is not a valid URL', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        artworkUrl: 'not-a-url',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts artworkUrl as valid URL', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        artworkUrl: 'https://example.com/art.jpg',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts omitted artworkUrl', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when position is negative', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        position: -1,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts position as 0', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        position: 0,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts position as positive number', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        position: 45000,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when duration is negative', async () => {
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        duration: -1,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('accepts omitted url', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 400 when url exceeds 1000 characters', async () => {
+    const longUrl = `https://example.com/${'a'.repeat(981)}`;
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        url: longUrl,
+        isPlaying: true,
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // ---------- Upsert Success ----------
+
+  it('upserts record with all required fields', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Midnight Dream',
+        artistName: 'Cosmic Echo',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify upsert was called with correct payload structure
+    expect(chain.upsert).toHaveBeenCalled();
+    const [upsertPayload, upsertOptions] = vi.mocked(chain.upsert).mock.calls[0];
+
+    expect(upsertPayload.fid).toBe(123); // From session
+    expect(upsertPayload.track_name).toBe('Midnight Dream');
+    expect(upsertPayload.artist_name).toBe('Cosmic Echo');
+    expect(upsertPayload.platform).toBe('spotify');
+    expect(upsertPayload.is_playing).toBe(true);
+    expect(upsertPayload.position).toBe(0);
+    expect(upsertPayload.duration).toBe(0);
+    expect(upsertPayload.artwork_url).toBeNull();
+    expect(upsertPayload.track_url).toBeNull();
+    expect(upsertPayload.updated_at).toBeDefined();
+    expect(typeof upsertPayload.updated_at).toBe('string');
+
+    // Verify onConflict strategy
+    expect(upsertOptions.onConflict).toBe('fid');
+  });
+
+  it('upserts with all optional fields populated', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        artworkUrl: 'https://example.com/art.jpg',
+        platform: 'apple_music',
+        position: 45000,
+        duration: 240000,
+        url: 'https://apple.com/track/123',
+        isPlaying: false,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    expect(upsertPayload.artwork_url).toBe('https://example.com/art.jpg');
+    expect(upsertPayload.position).toBe(45000);
+    expect(upsertPayload.duration).toBe(240000);
+    expect(upsertPayload.track_url).toBe('https://apple.com/track/123');
+    expect(upsertPayload.is_playing).toBe(false);
+  });
+
+  it('treats optional fields as null when omitted', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    expect(upsertPayload.artwork_url).toBeNull();
+    expect(upsertPayload.track_url).toBeNull();
+  });
+
+  it('defaults position to 0 when not provided', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    expect(upsertPayload.position).toBe(0);
+  });
+
+  it('defaults duration to 0 when not provided', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    expect(upsertPayload.duration).toBe(0);
+  });
+
+  it('includes updated_at timestamp in ISO format', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const beforeTime = new Date();
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+    const afterTime = new Date();
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    const updatedAt = new Date(upsertPayload.updated_at);
+
+    expect(updatedAt.getTime()).toBeGreaterThanOrEqual(beforeTime.getTime());
+    expect(updatedAt.getTime()).toBeLessThanOrEqual(afterTime.getTime());
+  });
+
+  // ---------- Error Handling ----------
+
+  it('returns 500 when supabase upsert error occurs', async () => {
+    const chain = upsertChain({ data: null, error: new Error('db connection failed') });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update now playing');
+  });
+
+  it('returns 500 when upsert throws exception', async () => {
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockImplementation(() => {
+        throw new Error('unexpected error');
+      }),
+    });
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update now playing');
+  });
+
+  it('returns 500 when getSupabaseAdmin throws', async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error('supabase initialization failed');
+    });
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to update now playing');
+  });
+
+  it('logs error when supabase operation fails', async () => {
+    const { logger } = await import('@/lib/logger');
+    const chain = upsertChain({ data: null, error: new Error('db error') });
+    mockFrom.mockReturnValue(chain);
+
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  // ---------- Response Format ----------
+
+  it('returns success: true on successful upsert', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+  });
+
+  // ---------- Multiple Users (FID Isolation) ----------
+
+  it('scopes upsert to the authenticated user fid', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song',
+        artistName: 'Artist',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    const [upsertPayload] = vi.mocked(chain.upsert).mock.calls[0];
+    expect(upsertPayload.fid).toBe(999);
+  });
+
+  it('correctly updates an existing user record via upsert', async () => {
+    const chain = upsertChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    // First update
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song A',
+        artistName: 'Artist A',
+        platform: 'spotify',
+        isPlaying: true,
+      }),
+    );
+
+    // Second update (same FID, different track)
+    await POST(
+      makePostRequest('/api/overlay/now-playing/update', {
+        trackName: 'Song B',
+        artistName: 'Artist B',
+        platform: 'spotify',
+        isPlaying: false,
+      }),
+    );
+
+    // Both calls should have used the same FID and onConflict strategy
+    expect(chain.upsert).toHaveBeenCalledTimes(2);
+    const [firstPayload, firstOptions] = vi.mocked(chain.upsert).mock.calls[0];
+    const [secondPayload, secondOptions] = vi.mocked(chain.upsert).mock.calls[1];
+
+    expect(firstPayload.fid).toBe(123);
+    expect(secondPayload.fid).toBe(123);
+    expect(firstOptions.onConflict).toBe('fid');
+    expect(secondOptions.onConflict).toBe('fid');
+  });
+});


### PR DESCRIPTION
96 tests across 4 untested routes (task #591), subagent-authored + verified green (vitest 96/96, tsc 0, biome clean). auth/listenbrainz/status (10), overlay/now-playing/update POST (37), events/rsvp POST (23, duplicate 409), bots/status GET (26). bots/status mocks global.fetch (raw cowork-board API, no lib seam — justified); others supabase mocks. Cleaned the overlay agents 9  mock accesses to vi.mocked() (no any / no lint suppressions). Tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)