### PR TITLE
test(proposals,twitch,upload): test-publish, prediction, chat, upload (task #591)

### DIFF
--- a/src/app/api/proposals/test-publish/__tests__/route.test.ts
+++ b/src/app/api/proposals/test-publish/__tests__/route.test.ts
@@ -1,0 +1,677 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom, mockPostToBluesky } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockPostToBluesky: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/bluesky/client', () => ({
+  postToBluesky: mockPostToBluesky,
+}));
+
+// Mock ENV module for dynamic import
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    ZAO_OFFICIAL_SIGNER_UUID: 'mock-signer-uuid',
+    ZAO_OFFICIAL_FID: 12345,
+  },
+}));
+
+// Mock process.env for Bluesky check
+vi.stubGlobal('process', {
+  ...process,
+  env: {
+    ...process.env,
+    BLUESKY_HANDLE: 'test.bsky.social',
+    BLUESKY_APP_PASSWORD: 'test-password',
+  },
+});
+
+import { GET } from '../route';
+
+/**
+ * Build a Supabase chain mock that resolves to `result`.
+ * Each chainable method returns the chain, terminal methods resolve.
+ */
+function makeChain(result: { data?: unknown; error?: unknown; count?: number }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainableMethods = ['select', 'update', 'eq', 'order', 'limit'];
+  for (const m of chainableMethods) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.single = vi.fn(() => Promise.resolve(result));
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+/**
+ * Build a queued "from" implementation that returns a new chain for each call,
+ * drawing results sequentially from a queue.
+ */
+function queuedFromChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const queue = [...results];
+  return () => {
+    const result = queue.shift() || { data: null, error: new Error('Out of queued results') };
+    return makeChain(result);
+  };
+}
+
+describe('GET /api/proposals/test-publish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockPostToBluesky.mockResolvedValue(null);
+  });
+
+  // ================================================================
+  // Auth guard tests
+  // ================================================================
+
+  it('returns 403 when user is not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await GET(makeGetRequest('/api/proposals/test-publish'));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin only');
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await GET(makeGetRequest('/api/proposals/test-publish'));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin only');
+  });
+
+  // ================================================================
+  // List mode (no proposalId param)
+  // ================================================================
+
+  it('lists all proposals when no proposalId is provided', async () => {
+    const proposals = [
+      {
+        id: 'prop1',
+        title: 'Proposal 1',
+        status: 'active',
+        publish_text: 'Text 1',
+        published_cast_hash: null,
+        respect_threshold: 1000,
+      },
+      {
+        id: 'prop2',
+        title: 'Proposal 2',
+        status: 'active',
+        publish_text: 'Text 2',
+        published_cast_hash: 'hash2',
+        respect_threshold: 1000,
+      },
+    ];
+    mockFrom.mockReturnValue(makeChain({ data: proposals, error: null }));
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.proposals).toEqual(proposals);
+    expect(body.error).toBeNull();
+  });
+
+  it('includes error in list response if query fails', async () => {
+    const error = new Error('db connection failed');
+    mockFrom.mockReturnValue(makeChain({ data: null, error }));
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.error).toBeDefined();
+  });
+
+  // ================================================================
+  // Proposal lookup with ID
+  // ================================================================
+
+  it('returns error when proposal is not found', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'nonexistent' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.error).toBe('Proposal not found');
+    expect(body.steps.proposal).toBeNull();
+  });
+
+  it('returns 200 with steps when proposal lookup errors', async () => {
+    const error = new Error('proposal lookup failed');
+    mockFrom.mockReturnValue(makeChain({ data: null, error }));
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-123' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    // When proposal is not found, error is at top level and steps contains the details
+    expect(body.error).toBe('Proposal not found');
+    expect(body.steps.proposalError).toBeDefined();
+  });
+
+  // ================================================================
+  // Threshold check and action determination
+  // ================================================================
+
+  it('shows BELOW THRESHOLD when votes do not meet threshold', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [
+      { vote: 'for', respect_weight: 300 },
+      { vote: 'for', respect_weight: 200 },
+      { vote: 'against', respect_weight: 500 },
+    ];
+
+    // First call: get proposal, Second call: get votes
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.totalRespectFor).toBe(500);
+    expect(body.threshold).toBe(1000);
+    expect(body.thresholdMet).toBe(false);
+    expect(body.action).toBe('BELOW THRESHOLD');
+  });
+
+  it('shows ALREADY PUBLISHED when proposal has published_cast_hash', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'published',
+      publish_text: 'Test text',
+      published_cast_hash: 'some-hash',
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.action).toBe('ALREADY PUBLISHED');
+    expect(body.alreadyPublished).toBe(true);
+  });
+
+  it('shows WOULD PUBLISH when threshold is met and not yet published', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [
+      { vote: 'for', respect_weight: 600 },
+      { vote: 'for', respect_weight: 500 },
+    ];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    mockPostToBluesky.mockResolvedValue(null); // No Bluesky publish
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.totalRespectFor).toBe(1100);
+    expect(body.thresholdMet).toBe(true);
+    expect(body.action).toBe('WOULD PUBLISH');
+  });
+
+  // ================================================================
+  // Publishing capability detection
+  // ================================================================
+
+  it('detects Farcaster publish readiness from ENV', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes: unknown[] = [];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.farcasterPublishReady).toBe(true);
+  });
+
+  it('detects Bluesky publish readiness from env vars', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes: unknown[] = [];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.blueskyPublishReady).toBe(true);
+  });
+
+  // ================================================================
+  // Bluesky publish success
+  // ================================================================
+
+  it('successfully publishes to Bluesky when threshold met', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text for Bluesky',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+        { data: null, error: null }, // update call
+      ]),
+    );
+
+    const blueskyUri = 'at://did:plc:example/app.bsky.feed.post/abc123';
+    mockPostToBluesky.mockResolvedValue(blueskyUri);
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.action).toBe('WOULD PUBLISH');
+    expect(body.blueskySuccess).toBe(true);
+    expect(body.blueskyResult).toBe(blueskyUri);
+    expect(body.dbUpdate).toBe('Published!');
+
+    // Verify postToBluesky was called with correct arguments
+    expect(mockPostToBluesky).toHaveBeenCalledWith(
+      'Test text for Bluesky\n\n— Approved by ZAO governance',
+      'https://zaoos.com/governance',
+    );
+  });
+
+  it('marks proposal as published with Bluesky URI after successful post', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    const updateChain = makeChain({ data: null, error: null });
+    const queue = [
+      { data: proposal, error: null },
+      { data: votes, error: null },
+    ];
+    let updateCalled = false;
+
+    mockFrom.mockImplementation(() => {
+      if (updateCalled) {
+        return updateChain;
+      }
+      const result = queue.shift();
+      if (!result) {
+        updateCalled = true;
+        return updateChain;
+      }
+      return makeChain(result);
+    });
+
+    const blueskyUri = 'at://did:plc:example/app.bsky.feed.post/xyz789';
+    mockPostToBluesky.mockResolvedValue(blueskyUri);
+
+    await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+
+    // Verify update was called
+    expect(updateChain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        published_cast_hash: 'bluesky-only',
+        published_bluesky_uri: blueskyUri,
+        status: 'published',
+      }),
+    );
+  });
+
+  it('uses publish_text if available, otherwise falls back to title', async () => {
+    const proposalWithText = {
+      id: 'prop-1',
+      title: 'Proposal Title',
+      status: 'active',
+      publish_text: 'Custom publish text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposalWithText, error: null },
+        { data: votes, error: null },
+        { data: null, error: null },
+      ]),
+    );
+
+    mockPostToBluesky.mockResolvedValue('at://uri');
+
+    await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+
+    expect(mockPostToBluesky).toHaveBeenCalledWith(
+      expect.stringContaining('Custom publish text'),
+      expect.any(String),
+    );
+  });
+
+  it('falls back to title when publish_text is null', async () => {
+    const proposalNoText = {
+      id: 'prop-1',
+      title: 'Fallback Title',
+      status: 'active',
+      publish_text: null,
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposalNoText, error: null },
+        { data: votes, error: null },
+        { data: null, error: null },
+      ]),
+    );
+
+    mockPostToBluesky.mockResolvedValue('at://uri');
+
+    await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+
+    expect(mockPostToBluesky).toHaveBeenCalledWith(
+      expect.stringContaining('Fallback Title'),
+      expect.any(String),
+    );
+  });
+
+  // ================================================================
+  // Bluesky publish error handling
+  // ================================================================
+
+  it('captures Bluesky error and continues', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const bskyError = new Error('Rate limited');
+    mockPostToBluesky.mockRejectedValue(bskyError);
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.blueskyError).toBe('Rate limited');
+    // blueskySuccess is only set on success, not on error
+    expect(body.blueskySuccess).toBeUndefined();
+    // Should NOT have updated the database
+    expect(body.dbUpdate).toBeUndefined();
+  });
+
+  it('handles non-Error Bluesky exceptions', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [{ vote: 'for', respect_weight: 1200 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    mockPostToBluesky.mockRejectedValue('string error');
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.blueskyError).toBe('string error');
+    expect(body.blueskySuccess).toBeUndefined();
+  });
+
+  // ================================================================
+  // Votes query error handling
+  // ================================================================
+
+  it('includes votes error in steps when votes query fails', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: null, error: new Error('votes query failed') },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.votesError).toBeDefined();
+    expect(body.votes).toBeNull();
+  });
+
+  // ================================================================
+  // Respect weight calculations
+  // ================================================================
+
+  it('correctly sums respect_weight for votes with "for" vote', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 2000,
+    };
+    const votes = [
+      { vote: 'for', respect_weight: 500 },
+      { vote: 'for', respect_weight: 300 },
+      { vote: 'against', respect_weight: 1000 },
+      { vote: 'for', respect_weight: 200 },
+    ];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.totalRespectFor).toBe(1000); // 500 + 300 + 200
+  });
+
+  it('handles null respect_weight by treating as 0', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes = [
+      { vote: 'for', respect_weight: null },
+      { vote: 'for', respect_weight: 500 },
+    ];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.totalRespectFor).toBe(500);
+  });
+
+  it('uses default threshold of 1000 when respect_threshold is null', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: null,
+    };
+    const votes = [{ vote: 'for', respect_weight: 500 }];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.threshold).toBe(1000);
+  });
+
+  it('handles empty votes array', async () => {
+    const proposal = {
+      id: 'prop-1',
+      title: 'Test Proposal',
+      status: 'active',
+      publish_text: 'Test text',
+      published_cast_hash: null,
+      respect_threshold: 1000,
+    };
+    const votes: unknown[] = [];
+
+    mockFrom.mockImplementation(
+      queuedFromChain([
+        { data: proposal, error: null },
+        { data: votes, error: null },
+      ]),
+    );
+
+    const res = await GET(makeGetRequest('/api/proposals/test-publish', { id: 'prop-1' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.totalRespectFor).toBe(0);
+    expect(body.thresholdMet).toBe(false);
+  });
+});

--- a/src/app/api/twitch/chat/__tests__/route.test.ts
+++ b/src/app/api/twitch/chat/__tests__/route.test.ts
@@ -1,0 +1,519 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.stubGlobal('fetch', vi.fn());
+
+// Mock environment variables
+process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'test-twitch-client-id-12345';
+
+import { GET, POST } from '../route';
+
+describe('GET /api/twitch/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await GET(makeGetRequest('/api/twitch/chat'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('missing channel parameter', () => {
+    it('returns 400 when channel parameter is missing', async () => {
+      const res = await GET(makeGetRequest('/api/twitch/chat'));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Missing channel parameter');
+    });
+  });
+
+  describe('Twitch connection lookup', () => {
+    it('returns connection info with chat scopes', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        platform_username: 'teststreamer',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/twitch/chat', { channel: 'testchannel' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.channel).toBe('testchannel');
+      expect(body.connected).toBe(true);
+      expect(body.canRead).toBe(true);
+      expect(body.canSend).toBe(true);
+      expect(body.platformUserId).toBe('twitch-user-123');
+      expect(body.popoutUrl).toBe('https://www.twitch.tv/popout/testchannel/chat');
+
+      // Verify Supabase query chain
+      expect(chain.select).toHaveBeenCalledWith(
+        'platform_user_id, platform_username, scopes, access_token',
+      );
+      expect(chain.eq).toHaveBeenCalledWith('user_fid', 123);
+      expect(chain.eq).toHaveBeenCalledWith('platform', 'twitch');
+      expect(chain.single).toHaveBeenCalled();
+    });
+
+    it('returns connected: false when user has no Twitch connection', async () => {
+      const { chain } = chainMock({ data: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/twitch/chat', { channel: 'testchannel' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.channel).toBe('testchannel');
+      expect(body.connected).toBe(false);
+      expect(body.canRead).toBe(false);
+      expect(body.canSend).toBe(false);
+      expect(body.platformUserId).toBe(null);
+    });
+
+    it('returns correct scope flags when user has only chat:read', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        platform_username: 'teststreamer',
+        scopes: 'chat:read',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/twitch/chat', { channel: 'testchannel' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.connected).toBe(true);
+      expect(body.canRead).toBe(true);
+      expect(body.canSend).toBe(false);
+    });
+
+    it('URL-encodes channel name in popoutUrl', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        platform_username: 'teststreamer',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET(makeGetRequest('/api/twitch/chat', { channel: 'test channel' }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.popoutUrl).toContain(encodeURIComponent('test channel'));
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('database connection failed');
+      });
+
+      const res = await GET(makeGetRequest('/api/twitch/chat', { channel: 'test' }));
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to check Twitch chat');
+    });
+  });
+});
+
+describe('POST /api/twitch/chat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        data: [{ id: 'broadcaster-123' }],
+      }),
+    });
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('Zod validation', () => {
+    it('returns 400 when message is empty', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: '', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when message exceeds 500 characters', async () => {
+      const longMessage = 'a'.repeat(501);
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: longMessage, channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when channel is empty', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: '' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when channel exceeds 100 characters', async () => {
+      const longChannel = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: longChannel }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      const res = await POST(makePostRequest('/api/twitch/chat', { message: 'Hello' }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('Twitch connection check', () => {
+    it('returns 400 when user has no Twitch connection', async () => {
+      const { chain } = chainMock({ data: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Twitch account not connected');
+    });
+
+    it('returns 400 when Twitch connection has no access_token', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: null,
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Twitch account not connected');
+    });
+  });
+
+  describe('scope validation', () => {
+    it('returns 400 with needsReauth flag when chat:edit scope is missing', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Missing chat:edit scope');
+      expect(body.needsReauth).toBe(true);
+    });
+  });
+
+  describe('Twitch API integration', () => {
+    it('resolves broadcaster ID from channel username', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [{ id: 'broadcaster-456' }],
+        }),
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(200);
+
+      // Verify fetch was called to get broadcaster ID
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://api.twitch.tv/helix/users?login=testchannel',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer valid-access-token',
+            'Client-Id': 'test-twitch-client-id-12345',
+          }),
+        }),
+      );
+    });
+
+    it('returns 404 when channel username is not found', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [],
+        }),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'nonexistentchannel' }),
+      );
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Channel not found');
+    });
+
+    it('sends message to Twitch chat via Helix API', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [{ id: 'broadcaster-456' }],
+        }),
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({}),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello Twitch!', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.sent).toBe(true);
+
+      // Verify second fetch call sends the chat message
+      const secondFetchCall = vi.mocked(global.fetch).mock.calls[1];
+      expect(secondFetchCall[0]).toBe('https://api.twitch.tv/helix/chat/messages');
+      expect(secondFetchCall[1]).toEqual({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer valid-access-token',
+          'Client-Id': 'test-twitch-client-id-12345',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          broadcaster_id: 'broadcaster-456',
+          sender_id: 'twitch-user-123',
+          message: 'Hello Twitch!',
+        }),
+      });
+    });
+
+    it('returns error status from Twitch API when send fails', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [{ id: 'broadcaster-456' }],
+        }),
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: vi.fn().mockResolvedValue({
+          error: 'Forbidden',
+          message: 'User does not have permission to send messages',
+        }),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to send message to Twitch');
+    });
+
+    it('handles Twitch API error response gracefully', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          data: [{ id: 'broadcaster-456' }],
+        }),
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        json: vi.fn().mockRejectedValue(new SyntaxError('Invalid JSON')),
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(429);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to send message to Twitch');
+    });
+  });
+
+  describe('environment configuration', () => {
+    it('returns 500 when NEXT_PUBLIC_TWITCH_CLIENT_ID is not set', async () => {
+      const originalClientId = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID;
+      delete process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID;
+
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Twitch not configured');
+
+      process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = originalClientId;
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception during Supabase query', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('database connection failed');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to send chat message');
+    });
+
+    it('returns 500 when fetch throws during broadcaster lookup', async () => {
+      const platformData = {
+        platform_user_id: 'twitch-user-123',
+        scopes: 'chat:read chat:edit',
+        access_token: 'valid-access-token',
+      };
+      const { chain } = chainMock({ data: platformData });
+      mockFrom.mockReturnValue(chain);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+      const res = await POST(
+        makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'testchannel' }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to send chat message');
+    });
+
+    it('returns 500 when req.json() throws', async () => {
+      const req = makePostRequest('/api/twitch/chat', { message: 'Hello', channel: 'test' });
+      vi.spyOn(req, 'json').mockRejectedValue(new SyntaxError('Unexpected token'));
+
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to send chat message');
+    });
+  });
+});

--- a/src/app/api/twitch/prediction/__tests__/route.test.ts
+++ b/src/app/api/twitch/prediction/__tests__/route.test.ts
@@ -1,0 +1,592 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/twitch/client', () => ({
+  getValidTwitchToken: vi.fn(),
+  createTwitchPrediction: vi.fn(),
+  endTwitchPrediction: vi.fn(),
+}));
+
+import {
+  createTwitchPrediction,
+  endTwitchPrediction,
+  getValidTwitchToken,
+} from '@/lib/twitch/client';
+import { PATCH, POST } from '../route';
+
+describe('POST /api/twitch/prediction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST(makePostRequest('/api/twitch/prediction', { title: 'Test' }));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when title is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', { outcomes: ['Yes', 'No'] }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when title is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: '',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when title exceeds 45 chars', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'a'.repeat(46),
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when outcomes is missing', async () => {
+      const res = await POST(makePostRequest('/api/twitch/prediction', { title: 'Test' }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when outcomes array has less than 2 items', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes'],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when outcomes array exceeds 10 items', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: Array.from({ length: 11 }, (_, i) => `Option ${i + 1}`),
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when outcome item is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', ''],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when outcome item exceeds 25 chars', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'a'.repeat(26)],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when duration is below 30', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+          duration: 29,
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when duration exceeds 1800', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+          duration: 1801,
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when duration is not an integer', async () => {
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+          duration: 60.5,
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when request body is malformed JSON', async () => {
+      const req = new Request(new URL('http://localhost:3000/api/twitch/prediction'), {
+        method: 'POST',
+        body: 'not json',
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid duration within range', async () => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-123',
+        userId: 'user-456',
+      });
+      vi.mocked(createTwitchPrediction).mockResolvedValue({
+        id: 'pred-123',
+        outcomes: [{ id: 'out-1', title: 'Yes' }],
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+          duration: 120,
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(vi.mocked(createTwitchPrediction)).toHaveBeenCalledWith(
+        'token-123',
+        'user-456',
+        expect.objectContaining({ duration: 120 }),
+      );
+    });
+
+    it('omits duration from call when not provided', async () => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-123',
+        userId: 'user-456',
+      });
+      vi.mocked(createTwitchPrediction).mockResolvedValue({
+        id: 'pred-123',
+        outcomes: [{ id: 'out-1', title: 'Yes' }],
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(vi.mocked(createTwitchPrediction)).toHaveBeenCalledWith(
+        'token-123',
+        'user-456',
+        expect.objectContaining({ title: 'Test', outcomes: ['Yes', 'No'] }),
+      );
+    });
+  });
+
+  describe('Twitch connection', () => {
+    it('returns 400 when Twitch is not connected', async () => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Twitch not connected');
+    });
+
+    it('fetches valid token for the session user', async () => {
+      const sessionWithFid = mockAuthenticatedSession({ fid: 999 });
+      mockGetSessionData.mockResolvedValue(sessionWithFid);
+
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-abc',
+        userId: 'user-xyz',
+      });
+      vi.mocked(createTwitchPrediction).mockResolvedValue({
+        id: 'pred-123',
+        outcomes: [{ id: 'out-1', title: 'Yes' }],
+      });
+
+      await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+
+      expect(vi.mocked(getValidTwitchToken)).toHaveBeenCalledWith(999);
+    });
+  });
+
+  describe('Twitch API call', () => {
+    beforeEach(() => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-123',
+        userId: 'user-456',
+      });
+    });
+
+    it('calls createTwitchPrediction with correct parameters', async () => {
+      vi.mocked(createTwitchPrediction).mockResolvedValue({
+        id: 'pred-123',
+        outcomes: [
+          { id: 'out-1', title: 'Yes' },
+          { id: 'out-2', title: 'No' },
+        ],
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Will it work?',
+          outcomes: ['Yes', 'No'],
+          duration: 300,
+        }),
+      );
+
+      expect(vi.mocked(createTwitchPrediction)).toHaveBeenCalledWith('token-123', 'user-456', {
+        title: 'Will it work?',
+        outcomes: ['Yes', 'No'],
+        duration: 300,
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 500 when createTwitchPrediction returns null (stream not live)', async () => {
+      vi.mocked(createTwitchPrediction).mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to create prediction — stream must be live');
+    });
+
+    it('returns successful prediction creation response', async () => {
+      vi.mocked(createTwitchPrediction).mockResolvedValue({
+        id: 'pred-abc-123',
+        outcomes: [
+          { id: 'out-1', title: 'Yes' },
+          { id: 'out-2', title: 'No' },
+        ],
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Will it work?',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        success: true,
+        predictionId: 'pred-abc-123',
+        outcomes: [
+          { id: 'out-1', title: 'Yes' },
+          { id: 'out-2', title: 'No' },
+        ],
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception', async () => {
+      mockGetSessionData.mockImplementation(() => {
+        throw new Error('session check failed');
+      });
+
+      const res = await POST(
+        makePostRequest('/api/twitch/prediction', {
+          title: 'Test',
+          outcomes: ['Yes', 'No'],
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to create prediction');
+    });
+  });
+});
+
+describe('PATCH /api/twitch/prediction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+  });
+
+  describe('authentication guard', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when predictionId is missing', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when predictionId is empty string', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: '',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when winningOutcomeId is missing', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when winningOutcomeId is empty string', async () => {
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: '',
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when request body is malformed JSON', async () => {
+      const req = new Request(new URL('http://localhost:3000/api/twitch/prediction'), {
+        method: 'PATCH',
+        body: 'not json',
+      });
+      const res = await PATCH(req as unknown as Parameters<typeof PATCH>[0]);
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid predictionId and winningOutcomeId', async () => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-123',
+        userId: 'user-456',
+      });
+      vi.mocked(endTwitchPrediction).mockResolvedValue(true);
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-abc-123',
+          winningOutcomeId: 'out-xyz-789',
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(vi.mocked(endTwitchPrediction)).toHaveBeenCalledWith(
+        'token-123',
+        'user-456',
+        'pred-abc-123',
+        'out-xyz-789',
+      );
+    });
+  });
+
+  describe('Twitch connection', () => {
+    it('returns 400 when Twitch is not connected', async () => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue(null);
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Twitch not connected');
+    });
+
+    it('fetches valid token for the session user', async () => {
+      const sessionWithFid = mockAuthenticatedSession({ fid: 888 });
+      mockGetSessionData.mockResolvedValue(sessionWithFid);
+
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-abc',
+        userId: 'user-xyz',
+      });
+      vi.mocked(endTwitchPrediction).mockResolvedValue(true);
+
+      await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+
+      expect(vi.mocked(getValidTwitchToken)).toHaveBeenCalledWith(888);
+    });
+  });
+
+  describe('Twitch API call', () => {
+    beforeEach(() => {
+      vi.mocked(getValidTwitchToken).mockResolvedValue({
+        accessToken: 'token-123',
+        userId: 'user-456',
+      });
+    });
+
+    it('calls endTwitchPrediction with correct parameters', async () => {
+      vi.mocked(endTwitchPrediction).mockResolvedValue(true);
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-abc-123',
+          winningOutcomeId: 'out-xyz-789',
+        }),
+      );
+
+      expect(vi.mocked(endTwitchPrediction)).toHaveBeenCalledWith(
+        'token-123',
+        'user-456',
+        'pred-abc-123',
+        'out-xyz-789',
+      );
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 500 when endTwitchPrediction returns false', async () => {
+      vi.mocked(endTwitchPrediction).mockResolvedValue(false);
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to resolve prediction');
+    });
+
+    it('returns successful resolution response', async () => {
+      vi.mocked(endTwitchPrediction).mockResolvedValue(true);
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-abc-123',
+          winningOutcomeId: 'out-xyz-789',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 on unexpected exception', async () => {
+      mockGetSessionData.mockImplementation(() => {
+        throw new Error('session check failed');
+      });
+
+      const res = await PATCH(
+        makePostRequest('/api/twitch/prediction', {
+          predictionId: 'pred-123',
+          winningOutcomeId: 'out-123',
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to resolve prediction');
+    });
+  });
+});

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockUpload, mockGetPublicUrl, mockStorageFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockUpload: vi.fn(),
+  mockGetPublicUrl: vi.fn(),
+  mockStorageFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    storage: {
+      from: mockStorageFrom,
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { POST } from '../route';
+
+// Setup mockStorageFrom to return storage methods
+mockStorageFrom.mockReturnValue({
+  upload: mockUpload,
+  getPublicUrl: mockGetPublicUrl,
+});
+
+interface MockRequest {
+  formData: () => Promise<FormData>;
+}
+
+/**
+ * Helper to mock a NextRequest with formData().
+ */
+function createMockRequest(file: File | null): MockRequest {
+  const formData = new FormData();
+  if (file) {
+    formData.append('file', file);
+  }
+
+  return {
+    formData: vi.fn().mockResolvedValue(formData),
+  };
+}
+
+/**
+ * Helper to create a File object for testing.
+ * @param filename - The filename
+ * @param mimeType - The MIME type
+ * @param size - The file size in bytes
+ */
+function createFile(filename: string, mimeType: string, size: number = 1024): File {
+  const buffer = new ArrayBuffer(size);
+  const view = new Uint8Array(buffer);
+  view[0] = 0xff; // Simple byte pattern
+  return new File([buffer], filename, { type: mimeType });
+}
+
+describe('POST /api/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockUpload.mockResolvedValue({ error: null });
+    mockGetPublicUrl.mockReturnValue({
+      data: { publicUrl: 'https://storage.example.com/uploads/123/1720000000.png' },
+    });
+  });
+
+  // =========================================================================
+  // Auth guard tests
+  // =========================================================================
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // =========================================================================
+  // Validation tests (missing file, invalid type, oversized)
+  // =========================================================================
+
+  it('returns 400 when no file is provided', async () => {
+    const req = createMockRequest(null);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('No file provided');
+  });
+
+  it('returns 400 when file type is not allowed (e.g. PDF)', async () => {
+    const file = createFile('test.pdf', 'application/pdf');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Only JPEG, PNG, GIF, and WebP images are allowed');
+  });
+
+  it('returns 400 when file type is not allowed (e.g. text)', async () => {
+    const file = createFile('test.txt', 'text/plain');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when file size exceeds 5 MB limit', async () => {
+    const file = createFile('large.png', 'image/png', 6 * 1024 * 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('File must be under 5 MB');
+  });
+
+  it('allows JPEG files', async () => {
+    const file = createFile('test.jpg', 'image/jpeg', 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows PNG files', async () => {
+    const file = createFile('test.png', 'image/png', 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows GIF files', async () => {
+    const file = createFile('test.gif', 'image/gif', 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('allows WebP files', async () => {
+    const file = createFile('test.webp', 'image/webp', 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  // =========================================================================
+  // Successful upload tests
+  // =========================================================================
+
+  it('uploads a valid PNG file and returns public URL', async () => {
+    const file = createFile('test.png', 'image/png', 2048);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe('https://storage.example.com/uploads/123/1720000000.png');
+    expect(body.filename).toMatch(/^123\/\d+\.png$/);
+  });
+
+  it('uploads a JPEG file with correct extension', async () => {
+    const file = createFile('photo.jpg', 'image/jpeg');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filename).toMatch(/^123\/\d+\.jpg$/);
+  });
+
+  it('uploads a GIF file with correct extension', async () => {
+    const file = createFile('animation.gif', 'image/gif');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filename).toMatch(/^123\/\d+\.gif$/);
+  });
+
+  it('uploads a WebP file with correct extension', async () => {
+    const file = createFile('modern.webp', 'image/webp');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filename).toMatch(/^123\/\d+\.webp$/);
+  });
+
+  it('uses session fid in the filename path', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.filename).toMatch(/^999\/\d+\.png$/);
+  });
+
+  it('includes timestamp in filename format', async () => {
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    const body = await res.json();
+
+    // Filename format is fid/timestamp.ext
+    expect(body.filename).toMatch(/^\d+\/\d+\.png$/);
+    // Extract timestamp part
+    const [, timestampPart] = body.filename.split('/');
+    const timestamp = Number.parseInt(timestampPart.replace('.png', ''), 10);
+    // Verify it's a reasonable Unix timestamp (milliseconds)
+    expect(timestamp).toBeGreaterThan(1700000000000);
+  });
+
+  it('calls supabaseAdmin.storage.from with "uploads" bucket', async () => {
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    await POST(req);
+    expect(mockStorageFrom).toHaveBeenCalledWith('uploads');
+  });
+
+  it('calls upload with correct contentType and upsert false', async () => {
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    await POST(req);
+
+    expect(mockUpload).toHaveBeenCalledWith(
+      expect.stringMatching(/^123\/\d+\.png$/),
+      expect.any(Buffer),
+      {
+        contentType: 'image/png',
+        upsert: false,
+      },
+    );
+  });
+
+  // =========================================================================
+  // Upload failure (error returned from Supabase) tests
+  // =========================================================================
+
+  it('returns 500 when Supabase upload fails', async () => {
+    mockUpload.mockResolvedValue({ error: new Error('Storage quota exceeded') });
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Upload failed');
+  });
+
+  it('logs Supabase storage error when upload fails', async () => {
+    const storageError = new Error('Storage error');
+    mockUpload.mockResolvedValue({ error: storageError });
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    await POST(req);
+  });
+
+  // =========================================================================
+  // Exception handling (try/catch) tests
+  // =========================================================================
+
+  it('returns 500 when formData parsing throws', async () => {
+    const mockFormData = vi.fn().mockRejectedValue(new Error('formData parse error'));
+    const req = { formData: mockFormData } as unknown as Parameters<typeof POST>[0];
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Upload failed');
+  });
+
+  it('returns 500 and logs when file.arrayBuffer() throws', async () => {
+    const file = createFile('test.png', 'image/png');
+
+    // Mock arrayBuffer to throw
+    const originalArrayBuffer = file.arrayBuffer;
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: () => Promise.reject(new Error('Buffer read failed')),
+      writable: true,
+    });
+
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Upload failed');
+
+    // Restore
+    Object.defineProperty(file, 'arrayBuffer', {
+      value: originalArrayBuffer,
+      writable: true,
+    });
+  });
+
+  // =========================================================================
+  // Edge case tests
+  // =========================================================================
+
+  it('accepts a file exactly at the 5 MB limit', async () => {
+    const file = createFile('large.png', 'image/png', 5 * 1024 * 1024);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a file just over the 5 MB limit', async () => {
+    const file = createFile('toolarge.png', 'image/png', 5 * 1024 * 1024 + 1);
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('File must be under 5 MB');
+  });
+
+  it('getPublicUrl is called with the uploaded filename', async () => {
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    await POST(req);
+
+    expect(mockGetPublicUrl).toHaveBeenCalledWith(expect.stringMatching(/^123\/\d+\.png$/));
+  });
+
+  it('returns the full response object with url and filename', async () => {
+    const file = createFile('test.png', 'image/png');
+    const req = createMockRequest(file);
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(body).toHaveProperty('url');
+    expect(body).toHaveProperty('filename');
+    expect(typeof body.url).toBe('string');
+    expect(typeof body.filename).toBe('string');
+  });
+});


### PR DESCRIPTION
106 tests across 4 untested routes (task #591), subagent-authored + verified green (vitest 106/106, tsc 0, biome clean). proposals/test-publish GET (22, threshold/publish logic), twitch/prediction POST+PATCH (34), twitch/chat GET+POST (25), upload POST (25, Supabase Storage). twitch/chat mocks global.fetch (raw Twitch API); prediction mocks the twitch client lib; upload mocks Supabase Storage. Cleaned one as-any to as-unknown-as-Parameters (no any). Tests only.

Generated with Claude Code