### PR TITLE
test(admin): backfill, respect-import, member-fix (task #591)

### DIFF
--- a/src/app/api/admin/backfill/__tests__/route.test.ts
+++ b/src/app/api/admin/backfill/__tests__/route.test.ts
@@ -1,0 +1,766 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger, mockFetch } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+  },
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    NEYNAR_API_KEY: 'test-neynar-key',
+  },
+}));
+
+// Mock global fetch before importing the route
+global.fetch = mockFetch;
+
+import { POST } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for further chaining.
+ * Terminal .then() resolves the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = ['select', 'update', 'eq'];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal — resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = vi.fn((resolve: (val: unknown) => void) =>
+    resolve(result),
+  );
+
+  return chain;
+}
+
+describe('POST /api/admin/backfill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication & Authorization ───────────────────────────────────────
+
+  it('returns 403 when not authenticated (no session)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Database read failure ────────────────────────────────────────────────
+
+  it('returns 500 when Supabase fetch fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: null, error: { message: 'permission denied' } });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to fetch allowlist');
+  });
+
+  // ── No entries needing backfill ──────────────────────────────────────────
+
+  it('returns success message when all entries have FID and profile', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entries = [
+      {
+        id: VALID_UUID,
+        fid: 12345,
+        wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+        ign: 'alice',
+        real_name: null,
+        username: 'alice_farcaster',
+        pfp_url: 'https://example.com/alice.jpg',
+      },
+    ];
+
+    const chain = chainMock({ data: entries, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain('All entries already have FIDs and profiles');
+    expect(body.updated).toBe(0);
+  });
+
+  it('returns 200 with updated=0 when no active entries exist', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(0);
+  });
+
+  // ── Single entry success ─────────────────────────────────────────────────
+
+  it('backfills missing FID for single entry from Neynar', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'alice',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 5678,
+          username: 'alice_farcaster',
+          display_name: 'Alice',
+          pfp_url: 'https://pfp.example.com/alice.jpg',
+          custody_address: '0x2222222222222222222222222222222222222222',
+          verified_addresses: {
+            eth_addresses: ['0x1111111111111111111111111111111111111111'],
+            sol_addresses: [],
+          },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(1);
+    expect(body.details[0].status).toBe('updated');
+    expect(body.details[0].fid).toBe(5678);
+  });
+
+  // ── Multiple entries with batch ──────────────────────────────────────────
+
+  it('processes multiple entries in batches of 50', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    // Create 75 entries to trigger 2 batches (50 + 25)
+    const entries = Array.from({ length: 75 }, (_, i) => ({
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: `0x${String(i).padStart(40, '0')}`,
+      ign: `user${i}`,
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    }));
+
+    const chain = chainMock({ data: entries, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const batch1Addresses = entries.slice(0, 50).map((e) => e.wallet_address.toLowerCase());
+    const batch2Addresses = entries.slice(50).map((e) => e.wallet_address.toLowerCase());
+
+    const neynarBatch1: Record<string, unknown> = {};
+    batch1Addresses.forEach((addr, idx) => {
+      neynarBatch1[addr] = [
+        {
+          fid: 1000 + idx,
+          username: `user${idx}`,
+          display_name: `User ${idx}`,
+          pfp_url: `https://pfp.example.com/user${idx}.jpg`,
+          custody_address: `0x${String(idx).padStart(40, '0')}`,
+          verified_addresses: { eth_addresses: [addr], sol_addresses: [] },
+        },
+      ];
+    });
+
+    const neynarBatch2: Record<string, unknown> = {};
+    batch2Addresses.forEach((addr, idx) => {
+      neynarBatch2[addr] = [
+        {
+          fid: 2000 + idx,
+          username: `user${50 + idx}`,
+          display_name: `User ${50 + idx}`,
+          pfp_url: `https://pfp.example.com/user${50 + idx}.jpg`,
+          custody_address: `0x${String(50 + idx).padStart(40, '0')}`,
+          verified_addresses: { eth_addresses: [addr], sol_addresses: [] },
+        },
+      ];
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(neynarBatch1),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue(neynarBatch2),
+      });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.updated).toBe(75);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  // ── No Farcaster account ─────────────────────────────────────────────────
+
+  it('marks entry as no_farcaster_account when Neynar returns empty', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'bob',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [], // Empty array: no FC account
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(body.noAccount).toBe(1);
+    expect(body.details[0].status).toBe('no_farcaster_account');
+  });
+
+  // ── Neynar API error ─────────────────────────────────────────────────────
+
+  it('marks entries as neynar_error when Neynar returns non-2xx status', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entries = [
+      {
+        id: VALID_UUID,
+        fid: null,
+        wallet_address: '0x1111111111111111111111111111111111111111',
+        ign: 'alice',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+    ];
+
+    const chain = chainMock({ data: entries, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: vi.fn().mockResolvedValue({ error: 'Rate limited' }),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(body.errors).toBe(1);
+    expect(body.details[0].status).toBe('neynar_error_429');
+  });
+
+  // ── Database update error ────────────────────────────────────────────────
+
+  it('marks entry as db_error when update fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'charlie',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: fetch allowlist
+        return chainMock({ data: [entry], error: null });
+      }
+      // Second call: update allowlist — fails
+      return chainMock({
+        data: null,
+        error: { message: 'unique constraint violation' },
+      });
+    });
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 9999,
+          username: 'charlie_farcaster',
+          display_name: 'Charlie',
+          pfp_url: 'https://pfp.example.com/charlie.jpg',
+          custody_address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          verified_addresses: {
+            eth_addresses: ['0x1111111111111111111111111111111111111111'],
+            sol_addresses: [],
+          },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(body.errors).toBe(1);
+    expect(body.details[0].status).toContain('db_error');
+    expect(body.details[0].status).toContain('unique constraint violation');
+  });
+
+  // ── Fetch exception (network error) ──────────────────────────────────────
+
+  it('marks entries as error when fetch throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entries = [
+      {
+        id: VALID_UUID,
+        fid: null,
+        wallet_address: '0x1111111111111111111111111111111111111111',
+        ign: 'dave',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+    ];
+
+    const chain = chainMock({ data: entries, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockFetch.mockRejectedValue(new Error('Network timeout'));
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(body.errors).toBe(1);
+    expect(body.details[0].status).toBe('error');
+  });
+
+  // ── Partial success / mixed results ──────────────────────────────────────
+
+  it('accumulates stats from mixed success/failure/no-account results', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entries = [
+      {
+        id: '550e8400-e29b-41d4-a716-446655440001',
+        fid: null,
+        wallet_address: '0x1111111111111111111111111111111111111111',
+        ign: 'success',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+      {
+        id: '550e8400-e29b-41d4-a716-446655440002',
+        fid: null,
+        wallet_address: '0x2222222222222222222222222222222222222222',
+        ign: 'no_account',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+      {
+        id: '550e8400-e29b-41d4-a716-446655440003',
+        fid: null,
+        wallet_address: '0x3333333333333333333333333333333333333333',
+        ign: 'error',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+    ];
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // Fetch allowlist
+        return chainMock({ data: entries, error: null });
+      }
+      // First update: success
+      if (callCount === 2) {
+        return chainMock({ data: null, error: null });
+      }
+      // Second update: db error
+      if (callCount === 3) {
+        return chainMock({ data: null, error: { message: 'db error' } });
+      }
+      throw new Error('Unexpected call');
+    });
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 100,
+          username: 'success_fc',
+          display_name: 'Success',
+          pfp_url: 'https://pfp.example.com/success.jpg',
+          custody_address: '0xaaaa',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+      '0x2222222222222222222222222222222222222222': [], // No account
+      '0x3333333333333333333333333333333333333333': [
+        {
+          fid: 300,
+          username: 'error_fc',
+          display_name: 'Error',
+          pfp_url: 'https://pfp.example.com/error.jpg',
+          custody_address: '0xcccc',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.updated).toBe(1);
+    expect(body.noAccount).toBe(1);
+    expect(body.errors).toBe(1);
+  });
+
+  // ── Selective field filling ──────────────────────────────────────────────
+
+  it('only fills in missing fields, does not overwrite existing data', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    // Entry has existing FID and username, but missing pfp_url
+    const entry = {
+      id: VALID_UUID,
+      fid: 5555,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'existing_user',
+      real_name: 'Real Name',
+      username: 'existing_username', // Existing, should not be overwritten
+      pfp_url: null, // Missing, should be filled
+    };
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return chainMock({ data: [entry], error: null });
+      }
+      // Verify the update call
+      const updateChain = chainMock({ data: null, error: null });
+      return updateChain;
+    });
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 9999, // Different FID, should not update existing
+          username: 'neynar_username',
+          display_name: 'Neynar Display',
+          pfp_url: 'https://pfp.example.com/neynar.jpg', // Should fill this
+          custody_address: '0xcccc',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    // Verify via details that update attempted
+    expect(body.updated).toBe(1);
+  });
+
+  // ── Handle entries without wallet_address ────────────────────────────────
+
+  it('filters out entries with missing wallet_address', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entries = [
+      {
+        id: VALID_UUID,
+        fid: null,
+        wallet_address: null, // Missing — should be filtered
+        ign: 'no_wallet',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+      {
+        id: '550e8400-e29b-41d4-a716-446655440002',
+        fid: null,
+        wallet_address: '0x1111111111111111111111111111111111111111',
+        ign: 'with_wallet',
+        real_name: null,
+        username: null,
+        pfp_url: null,
+      },
+    ];
+
+    const chain = chainMock({ data: entries, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 111,
+          username: 'with_wallet_fc',
+          display_name: 'With Wallet',
+          pfp_url: 'https://pfp.example.com/wallet.jpg',
+          custody_address: '0xaaaa',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+    // Only the entry with wallet_address should be processed
+    expect(body.updated).toBe(1);
+    expect(body.details).toHaveLength(1);
+  });
+
+  // ── Response shape validation ────────────────────────────────────────────
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const chain = chainMock({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(['message', 'updated'].sort());
+  });
+
+  it('returns response with detailed shape on backfill', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'test',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const neynarResponse = {
+      '0x1111111111111111111111111111111111111111': [
+        {
+          fid: 5678,
+          username: 'test_fc',
+          display_name: 'Test',
+          pfp_url: 'https://pfp.example.com/test.jpg',
+          custody_address: '0xbbbb',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    const res = await POST(makeRequest('/api/admin/backfill'));
+    const body = await res.json();
+
+    expect(Object.keys(body).sort()).toEqual(
+      ['message', 'updated', 'noAccount', 'errors', 'details'].sort(),
+    );
+    expect(Array.isArray(body.details)).toBe(true);
+  });
+
+  // ── Wallet address case normalization ────────────────────────────────────
+
+  it('normalizes wallet addresses to lowercase for Neynar lookup', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // Uppercase (40 chars)
+      ign: 'upper',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const neynarResponse = {
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa': [
+        {
+          fid: 1111,
+          username: 'upper_fc',
+          display_name: 'Upper',
+          pfp_url: 'https://pfp.example.com/upper.jpg',
+          custody_address: '0xdddd',
+          verified_addresses: { eth_addresses: [], sol_addresses: [] },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue(neynarResponse),
+    });
+
+    await POST(makeRequest('/api/admin/backfill'));
+    // Verify fetch was called with lowercase address
+    const fetchCall = mockFetch.mock.calls[0][0] as string;
+    expect(fetchCall).toContain('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+  });
+
+  // ── Logs errors ──────────────────────────────────────────────────────────
+
+  it('logs Neynar errors to logger.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'logged',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockResolvedValue({ error: 'Neynar server error' }),
+    });
+
+    await POST(makeRequest('/api/admin/backfill'));
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Neynar bulk-by-address error: 500');
+  });
+
+  it('logs batch errors to logger.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const entry = {
+      id: VALID_UUID,
+      fid: null,
+      wallet_address: '0x1111111111111111111111111111111111111111',
+      ign: 'error_batch',
+      real_name: null,
+      username: null,
+      pfp_url: null,
+    };
+
+    const chain = chainMock({ data: [entry], error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    await POST(makeRequest('/api/admin/backfill'));
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Backfill batch error:', expect.any(Error));
+  });
+});

--- a/src/app/api/admin/member-fix/__tests__/route.test.ts
+++ b/src/app/api/admin/member-fix/__tests__/route.test.ts
@@ -1,0 +1,1158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { POST } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for chaining.
+ * Terminal .then() and .maybeSingle() resolve the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = [
+    'select',
+    'update',
+    'eq',
+    'is',
+    'not',
+    'order',
+    'limit',
+    'gt',
+    'lt',
+    'gte',
+    'lte',
+    'like',
+    'ilike',
+    'in',
+    'insert',
+    'upsert',
+    'delete',
+    'range',
+    'or',
+  ];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal methods
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.maybeSingle = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Create a mock queue that returns chains in sequence.
+ * Useful for testing multiple queries that need different results.
+ */
+function createChainQueue(
+  results: Array<{ data?: unknown; error?: unknown; count?: number | null }>,
+) {
+  let callIndex = 0;
+  return {
+    mockFn: vi.fn(() => {
+      if (callIndex >= results.length) {
+        throw new Error(`Chain queue exhausted at call ${callIndex}`);
+      }
+      return chainMock(results[callIndex++]);
+    }),
+    getCallCount: () => callIndex,
+    reset: () => {
+      callIndex = 0;
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/member-fix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication guard ──────────────────────────────────────────────────
+
+  it('returns 403 when not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin required');
+  });
+
+  it('passes authentication when isAdmin is true', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const queue = createChainQueue([{ data: [], error: null }]);
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────
+
+  it('returns 400 for invalid action', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fix', { action: 'invalid-action' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid action');
+  });
+
+  it('returns 400 for missing action field', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const req = makePostRequest('/api/admin/member-fix', {});
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid action');
+  });
+
+  it('accepts all valid actions', async () => {
+    const validActions = [
+      'link-fids',
+      'enrich-profiles',
+      'import-socials',
+      'link-profiles',
+      'backfill-dates',
+    ];
+
+    for (const action of validActions) {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockFrom.mockImplementation(() => chainMock({ data: [], error: null }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results).toBeDefined();
+    }
+  });
+
+  // ── link-fids action ──────────────────────────────────────────────────────
+
+  describe('link-fids action', () => {
+    it('returns empty fixed count when no wallet-only users', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const queue = createChainQueue([{ data: [], error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].action).toBe('link-fids');
+      expect(body.results[0].fixed).toBe(0);
+      expect(body.results[0].errors).toBe(0);
+    });
+
+    it('skips users without primary_wallet', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const queue = createChainQueue([
+        { data: [{ id: VALID_UUID, primary_wallet: null, display_name: 'NoWallet' }], error: null },
+      ]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+      expect(body.results[0].errors).toBe(0);
+    });
+
+    it('accumulates errors for neynar fetch failures', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const userData = [
+        { id: VALID_UUID, primary_wallet: '0x123', display_name: 'User1' },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440001',
+          primary_wallet: '0x456',
+          display_name: 'User2',
+        },
+      ];
+      const queue = createChainQueue([{ data: userData, error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      // Mock global fetch to fail
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockRejectedValue(new Error('Network error'));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].errors).toBe(2);
+      fetchSpy.mockRestore();
+    });
+
+    it('links users when neynar returns valid fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const userData = [{ id: VALID_UUID, primary_wallet: '0x123', display_name: 'User1' }];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          // First call: fetch users without FID
+          fromCallIndex++;
+          return chainMock({ data: userData, error: null });
+        }
+        // Second call: update user with FID
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            '0x123': [
+              {
+                fid: 999,
+                username: 'testuser',
+                display_name: 'Test User',
+                pfp_url: 'http://pfp.jpg',
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      expect(body.results[0].details[0]).toContain('FID 999');
+      fetchSpy.mockRestore();
+    });
+
+    it('skips neynar response with no fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const userData = [{ id: VALID_UUID, primary_wallet: '0x123', display_name: 'User1' }];
+      const queue = createChainQueue([{ data: userData, error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+      fetchSpy.mockRestore();
+    });
+
+    it('skips neynar response with non-ok status', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const userData = [{ id: VALID_UUID, primary_wallet: '0x123', display_name: 'User1' }];
+      const queue = createChainQueue([{ data: userData, error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 }),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+      fetchSpy.mockRestore();
+    });
+  });
+
+  // ── enrich-profiles action ────────────────────────────────────────────────
+
+  describe('enrich-profiles action', () => {
+    it('returns zero enriched when no users with fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const queue = createChainQueue([{ data: [], error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'enrich-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].action).toBe('enrich-profiles');
+      expect(body.results[0].fixed).toBe(0);
+    });
+
+    it('batches users in groups of 100', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      // Create 150 users with FIDs
+      const users = Array.from({ length: 150 }, (_, i) => ({
+        id: `550e8400-e29b-41d4-a716-44665544000${i}`,
+        fid: 1000 + i,
+        display_name: `User${i}`,
+        pfp_url: null,
+        bio: null,
+        username: null,
+        custody_address: null,
+        verified_addresses: [],
+        real_name: null,
+        x_handle: null,
+        solana_wallet: null,
+      }));
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({ data: users, error: null }), // fetch users
+          chainMock({ error: null }), // batch 1 (100 users)
+          chainMock({ error: null }), // batch 2 (50 users)
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({ users: [] }), { status: 200 }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'enrich-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0); // No fields to update in this mock
+      fetchSpy.mockRestore();
+    });
+
+    it('only updates missing fields', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: 'ExistingName',
+          pfp_url: null,
+          bio: null,
+          username: null,
+          custody_address: null,
+          verified_addresses: [],
+          real_name: null,
+          x_handle: null,
+          solana_wallet: null,
+        },
+      ];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          fromCallIndex++;
+          return chainMock({ data: users, error: null });
+        }
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            users: [
+              {
+                fid: 123,
+                display_name: 'FromNeynar', // Should be ignored (display_name exists)
+                pfp_url: 'http://pfp.jpg', // Should be added (missing)
+                bio: 'New bio',
+                profile: { bio: { text: 'New bio' } },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'enrich-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      fetchSpy.mockRestore();
+    });
+
+    it('extracts real_name from display_name when matching pattern', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: null,
+          pfp_url: null,
+          bio: null,
+          username: null,
+          custody_address: null,
+          verified_addresses: [],
+          real_name: null,
+          x_handle: null,
+          solana_wallet: null,
+        },
+      ];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          fromCallIndex++;
+          return chainMock({ data: users, error: null });
+        }
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            users: [
+              {
+                fid: 123,
+                display_name: 'John Smith', // Matches "First Last" pattern
+                profile: {},
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'enrich-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      fetchSpy.mockRestore();
+    });
+
+    it('handles neynar fetch errors gracefully', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: 'User',
+          pfp_url: null,
+          bio: null,
+          username: null,
+          custody_address: null,
+          verified_addresses: [],
+          real_name: null,
+          x_handle: null,
+          solana_wallet: null,
+        },
+      ];
+      const queue = createChainQueue([{ data: users, error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockRejectedValueOnce(new Error('Network error'));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'enrich-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].errors).toBe(1);
+      fetchSpy.mockRestore();
+    });
+  });
+
+  // ── import-socials action ────────────────────────────────────────────────
+
+  describe('import-socials action', () => {
+    it('returns zero imported when no users with fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const queue = createChainQueue([{ data: [], error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'import-socials' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].action).toBe('import-socials');
+      expect(body.results[0].fixed).toBe(0);
+    });
+
+    it('imports x_handle from verified_accounts', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: 'User',
+          x_handle: null,
+          instagram_handle: null,
+          bio: null,
+        },
+      ];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          fromCallIndex++;
+          return chainMock({ data: users, error: null });
+        }
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            users: [
+              {
+                fid: 123,
+                display_name: 'User',
+                verified_accounts: [{ platform: 'x', username: 'twitterhandle' }],
+                profile: { bio: { text: 'My bio' } },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'import-socials' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      fetchSpy.mockRestore();
+    });
+
+    it('extracts x_handle from bio when verified_accounts missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: 'User',
+          x_handle: null,
+          instagram_handle: null,
+          bio: null,
+        },
+      ];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          fromCallIndex++;
+          return chainMock({ data: users, error: null });
+        }
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            users: [
+              {
+                fid: 123,
+                display_name: 'User',
+                verified_accounts: [],
+                profile: { bio: { text: 'Check me out at twitter.com/@biohandle' } },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'import-socials' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      fetchSpy.mockRestore();
+    });
+
+    it('skips importing if handle already set', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const users = [
+        {
+          id: VALID_UUID,
+          fid: 123,
+          display_name: 'User',
+          x_handle: 'existinghandle',
+          instagram_handle: null,
+          bio: null,
+        },
+      ];
+
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        if (fromCallIndex === 0) {
+          fromCallIndex++;
+          return chainMock({ data: users, error: null });
+        }
+        return chainMock({ error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            users: [
+              {
+                fid: 123,
+                display_name: 'User',
+                verified_accounts: [{ platform: 'x', username: 'newhandle' }],
+                profile: { bio: { text: '' } },
+              },
+            ],
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'import-socials' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+      fetchSpy.mockRestore();
+    });
+  });
+
+  // ── link-profiles action ──────────────────────────────────────────────────
+
+  describe('link-profiles action', () => {
+    it('links users by fid match', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: 123, display_name: 'User', community_profile_id: null }],
+            error: null,
+          }), // unlinked by fid
+          chainMock({ data: { id: 'profile-id', name: 'UserProfile' }, error: null }), // find profile
+          chainMock({ error: null }), // update user
+          chainMock({ data: [], error: null }), // still unlinked
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].action).toBe('link-profiles');
+      expect(body.results[0].fixed).toBe(1);
+      expect(body.results[0].details[0]).toContain('linked to profile');
+    });
+
+    it('links users by name match when fid fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({ data: [], error: null }), // no fid matches
+          chainMock({
+            data: [
+              { id: VALID_UUID, display_name: 'Alice', username: null, community_profile_id: null },
+            ],
+            error: null,
+          }), // still unlinked
+          chainMock({ data: { id: 'profile-id', name: 'Alice' }, error: null }), // name match
+          chainMock({ error: null }), // update user
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      expect(body.results[0].details[0]).toContain('name match');
+    });
+
+    it('skips users without fid or display_name', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      mockFrom.mockImplementation(() => {
+        return chainMock({ data: [], error: null });
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-profiles' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+    });
+  });
+
+  // ── backfill-dates action ────────────────────────────────────────────────
+
+  describe('backfill-dates action', () => {
+    it('returns zero fixed when all members have first_respect_at', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const queue = createChainQueue([{ data: [], error: null }]);
+      mockFrom.mockImplementation(queue.mockFn);
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'backfill-dates' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].action).toBe('backfill-dates');
+      expect(body.results[0].fixed).toBe(0);
+    });
+
+    it('backfills first_respect_at from earliest fractal score', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: 'member-id', name: 'Alice', wallet_address: '0x123' }],
+            error: null,
+          }), // members without date
+          chainMock({
+            data: [{ fractal_sessions: { session_date: '2026-01-15' } }],
+            error: null,
+          }), // find earliest score
+          chainMock({ error: null }), // update member
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'backfill-dates' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+      expect(body.results[0].details[0]).toContain('2026-01-15');
+    });
+
+    it('handles array of fractal_sessions', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: 'member-id', name: 'Bob', wallet_address: '0x456' }],
+            error: null,
+          }),
+          chainMock({
+            data: [
+              {
+                fractal_sessions: [{ session_date: '2026-02-01' }, { session_date: '2026-01-15' }],
+              },
+            ],
+            error: null,
+          }),
+          chainMock({ error: null }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'backfill-dates' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(1);
+    });
+
+    it('skips when no fractal score found', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: 'member-id', name: 'Charlie', wallet_address: null }],
+            error: null,
+          }),
+          chainMock({ data: [], error: null }), // no fractal scores
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'backfill-dates' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+    });
+  });
+
+  // ── sync-tiers action ────────────────────────────────────────────────────
+
+  describe('sync-tiers action', () => {
+    it('upgrades users to respect_holder when total_respect > 0', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: 123, primary_wallet: null, member_tier: null }],
+            error: null,
+          }), // users
+          chainMock({
+            data: [
+              {
+                id: 'rm-id',
+                fid: 123,
+                wallet_address: null,
+                total_respect: 50,
+                onchain_og: 0,
+                onchain_zor: 0,
+              },
+            ],
+            error: null,
+          }), // respect members
+          chainMock({ error: null }), // update user with tier
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results).toBeDefined();
+      expect(body.results.length).toBeGreaterThan(0);
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      expect(tierResult.fixed).toBe(1);
+      expect(tierResult.details[0]).toContain('respect_holder');
+    });
+
+    it('matches users by fid and wallet', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: null, primary_wallet: '0x123', member_tier: null }],
+            error: null,
+          }),
+          chainMock({
+            data: [
+              {
+                id: 'rm-id',
+                fid: null,
+                wallet_address: '0x123',
+                total_respect: 100,
+                onchain_og: 0,
+                onchain_zor: 0,
+              },
+            ],
+            error: null,
+          }),
+          chainMock({ error: null }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      expect(tierResult.fixed).toBe(1);
+    });
+
+    it('does not downgrade users already respect_holder', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [
+              { id: VALID_UUID, fid: 123, primary_wallet: null, member_tier: 'respect_holder' },
+            ],
+            error: null,
+          }),
+          chainMock({
+            data: [
+              {
+                id: 'rm-id',
+                fid: 123,
+                wallet_address: null,
+                total_respect: 50,
+                onchain_og: 0,
+                onchain_zor: 0,
+              },
+            ],
+            error: null,
+          }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      expect(tierResult.fixed).toBe(0); // Already correct tier
+    });
+
+    it('links respect_member_id to users', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: 123, primary_wallet: null, member_tier: null }],
+            error: null,
+          }),
+          chainMock({
+            data: [
+              {
+                id: 'rm-123',
+                fid: 123,
+                wallet_address: null,
+                total_respect: 0,
+                onchain_og: 1,
+                onchain_zor: 0,
+              },
+            ],
+            error: null,
+          }),
+          chainMock({ error: null }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      expect(tierResult.details.some((d: string) => d.includes('1 respect records linked'))).toBe(
+        true,
+      );
+    });
+
+    it('counts both upgraded and linked in details', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: 123, primary_wallet: null, member_tier: null }],
+            error: null,
+          }),
+          chainMock({
+            data: [
+              {
+                id: 'rm-123',
+                fid: 123,
+                wallet_address: null,
+                total_respect: 50,
+                onchain_og: 0,
+                onchain_zor: 0,
+              },
+            ],
+            error: null,
+          }),
+          chainMock({ error: null }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      // Should have 2 entries: the upgrade message + the linked count
+      expect(tierResult.details.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('handles zero respect members gracefully', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const chains = [
+          chainMock({
+            data: [{ id: VALID_UUID, fid: 123, primary_wallet: null, member_tier: null }],
+            error: null,
+          }),
+          chainMock({
+            data: [],
+            error: null,
+          }),
+        ];
+        return chains[Math.min(callIndex++, chains.length - 1)];
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'sync-tiers' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      const tierResult = body.results.find(
+        (r: Record<string, unknown>) => r.action === 'sync-tiers',
+      );
+      expect(tierResult.fixed).toBe(0);
+    });
+  });
+
+  // ── 'all' action (runs all fixes) ─────────────────────────────────────────
+
+  describe('all action', () => {
+    it('runs all fix actions sequentially', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      mockFrom.mockImplementation(() => {
+        return chainMock({ data: [], error: null });
+      });
+
+      const fetchSpy = vi.spyOn(global, 'fetch' as never);
+      fetchSpy.mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'all' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      // Should have results for all 6 actions
+      expect(body.results.length).toBe(6);
+      expect(body.results.map((r: Record<string, unknown>) => r.action).sort()).toEqual([
+        'backfill-dates',
+        'enrich-profiles',
+        'import-socials',
+        'link-fids',
+        'link-profiles',
+        'sync-tiers',
+      ]);
+
+      fetchSpy.mockRestore();
+    });
+  });
+
+  // ── Response shape ───────────────────────────────────────────────────────
+
+  describe('Response shape', () => {
+    it('returns results array with action, fixed, errors, details', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockFrom.mockImplementation(() => chainMock({ data: [], error: null }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results).toBeDefined();
+      expect(Array.isArray(body.results)).toBe(true);
+      expect(body.results[0]).toMatchObject({
+        action: expect.any(String),
+        fixed: expect.any(Number),
+        errors: expect.any(Number),
+        details: expect.any(Array),
+      });
+    });
+
+    it('includes fixed, errors and details even when all operations skip', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockFrom.mockImplementation(() => chainMock({ data: [], error: null }));
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.results[0].fixed).toBe(0);
+      expect(body.results[0].errors).toBe(0);
+      expect(Array.isArray(body.results[0].details)).toBe(true);
+    });
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────
+
+  describe('Error handling', () => {
+    it('returns 500 when req.json() throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      const mockReq = {
+        json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+      } as { json: () => Promise<never> };
+
+      const res = await POST(mockReq as never);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed');
+    });
+
+    it('logs errors to logger.error on exception', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      const mockReq = {
+        json: vi.fn().mockRejectedValue(new Error('JSON parse error')),
+      } as { json: () => Promise<never> };
+
+      await POST(mockReq as never);
+
+      expect(mockLogger.error).toHaveBeenCalledWith('[member-fix] error:', expect.any(Error));
+    });
+
+    it('returns 500 when supabase throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      mockFrom.mockImplementation(() => {
+        throw new Error('DB connection lost');
+      });
+
+      const req = makePostRequest('/api/admin/member-fix', { action: 'link-fids' });
+      const res = await POST(req);
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed');
+    });
+  });
+});

--- a/src/app/api/admin/respect-import/__tests__/route.test.ts
+++ b/src/app/api/admin/respect-import/__tests__/route.test.ts
@@ -1,0 +1,506 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockLogger, mockFetch } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+  mockFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// Mock global fetch
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { POST } from '../route';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+type AirtableRecord = { id: string; fields: Record<string, unknown> };
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ */
+function chainMock(result: { data?: unknown; error?: unknown; count?: number | null }) {
+  const chain: Record<string, unknown> = {};
+  const chainable = [
+    'select',
+    'insert',
+    'update',
+    'delete',
+    'eq',
+    'in',
+    'like',
+    'order',
+    'range',
+    'limit',
+  ];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void) => resolve(result));
+
+  return chain;
+}
+
+/**
+ * Create a FIFO queue of chains for sequential calls to mockFrom().
+ */
+function createChainQueue(
+  results: Array<{ data?: unknown; error?: unknown; count?: number | null }>,
+) {
+  let callIndex = 0;
+  return {
+    mockFn: vi.fn(() => {
+      if (callIndex >= results.length) {
+        throw new Error(`Chain queue exhausted at call ${callIndex}`);
+      }
+      return chainMock(results[callIndex++]);
+    }),
+    getCallCount: () => callIndex,
+  };
+}
+
+/**
+ * Mock a successful Airtable fetch response.
+ */
+function mockAirtableFetchSuccess(records: AirtableRecord[], hasMore = false) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: async () => '',
+    json: async () => ({
+      records,
+      offset: hasMore ? 'next-offset' : undefined,
+    }),
+  } as Response);
+}
+
+/**
+ * Mock a failed Airtable fetch response.
+ */
+function mockAirtableFetchError(status: number, message: string) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    text: async () => `Error: ${message}`,
+    json: async () => ({}),
+  } as Response);
+}
+
+/**
+ * Setup standard fetch mocks for all 6 Airtable tables.
+ */
+function setupFetchMocks(
+  wallets: AirtableRecord[] = [],
+  summary: AirtableRecord[] = [],
+  respect: AirtableRecord[] = [],
+  hosts: AirtableRecord[] = [],
+  festivals: AirtableRecord[] = [],
+  misc: AirtableRecord[] = [],
+) {
+  const responses = [
+    mockAirtableFetchSuccess(wallets),
+    mockAirtableFetchSuccess(summary),
+    mockAirtableFetchSuccess(respect),
+    mockAirtableFetchSuccess(hosts),
+    mockAirtableFetchSuccess(festivals),
+    mockAirtableFetchSuccess(misc),
+  ];
+
+  responses.forEach((r) => {
+    mockFetch.mockResolvedValueOnce(r as never);
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/respect-import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AIRTABLE_TOKEN = 'test-token-12345';
+  });
+
+  // ── Authentication & Authorization ────────────────────────────────────────
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await POST();
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when authenticated but not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await POST();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe('Admin access required');
+  });
+
+  // ── Environment Variable ───────────────────────────────────────────────────
+
+  it('returns 500 when AIRTABLE_TOKEN is not configured', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    delete process.env.AIRTABLE_TOKEN;
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('AIRTABLE_TOKEN not configured');
+  });
+
+  // ── Fetch Error Accumulation ───────────────────────────────────────────────
+
+  it('accumulates fetch errors and continues', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    // First table fails, rest succeed
+    mockFetch
+      .mockResolvedValueOnce(mockAirtableFetchError(403, 'Wallet forbidden') as never)
+      .mockResolvedValueOnce(mockAirtableFetchSuccess([]) as never)
+      .mockResolvedValueOnce(mockAirtableFetchSuccess([]) as never)
+      .mockResolvedValueOnce(mockAirtableFetchSuccess([]) as never)
+      .mockResolvedValueOnce(mockAirtableFetchSuccess([]) as never)
+      .mockResolvedValueOnce(mockAirtableFetchSuccess([]) as never);
+
+    const queue = createChainQueue([
+      { error: null }, // members upsert
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // sessions insert
+      { data: [], error: null }, // events delete
+      { data: [], error: null }, // scores select
+      { data: [], error: null }, // events select
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // members select
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.errors.length).toBeGreaterThan(0);
+  });
+
+  // ── Wallet Map Building ────────────────────────────────────────────────────
+
+  it('builds wallet map from Wallet Data table', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const walletRecords: AirtableRecord[] = [
+      { id: 'w1', fields: { Name: 'Alice', 'ETH WALLET': '0xaaaa' } },
+      { id: 'w2', fields: { Name: 'Bob', 'ETH WALLET': '0xbbbb' } },
+    ];
+
+    setupFetchMocks(walletRecords);
+
+    const queue = createChainQueue([
+      { error: null }, // members upsert
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // sessions insert
+      { data: [], error: null }, // events delete
+      { data: [], error: null }, // scores select
+      { data: [], error: null }, // events select
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // members select
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.wallets).toBe(2);
+  });
+
+  // ── Member Import ──────────────────────────────────────────────────────────
+
+  // ── Event Imports ──────────────────────────────────────────────────────────
+
+  it('imports hosting events from Fractal Hosts table', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const hostRecords: AirtableRecord[] = [
+      { id: 'h1', fields: { Name: 'Alice', Amount: 10 } },
+      { id: 'h2', fields: { Name: 'Bob', Amount: 5 } },
+    ];
+
+    setupFetchMocks([], [], [], hostRecords);
+
+    const queue = createChainQueue([
+      { error: null }, // members upsert
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // sessions insert
+      { data: [], error: null }, // events delete
+      { data: [], error: null }, // scores select
+      { data: [], error: null }, // events select
+      { data: [], error: null }, // sessions select
+      { data: [], error: null }, // members select
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.hosts).toBe(2);
+  });
+
+  it('imports festival events', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const festivalRecords: AirtableRecord[] = [
+      { id: 'f1', fields: { Name: 'Alice', Amount: 25, Festival: 'Fest 1' } },
+    ];
+
+    setupFetchMocks([], [], [], [], festivalRecords);
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.festivals).toBe(1);
+  });
+
+  it('imports misc events', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const miscRecords: AirtableRecord[] = [
+      { id: 'm1', fields: { Name: 'Alice', Amount: 15, Type: 'contribution' } },
+      { id: 'm2', fields: { Name: 'Bob', Amount: 8, Type: 'intro' } },
+    ];
+
+    setupFetchMocks([], [], [], [], [], miscRecords);
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.misc).toBe(2);
+  });
+
+  it('skips events with zero amount', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const hostRecords: AirtableRecord[] = [
+      { id: 'h1', fields: { Name: 'Alice', Amount: 10 } },
+      { id: 'h2', fields: { Name: 'Bob', Amount: 0 } },
+    ];
+
+    setupFetchMocks([], [], [], hostRecords);
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.hosts).toBe(1);
+  });
+
+  // ── Full Success Path & Response Shape ────────────────────────────────────
+
+  it('returns response with exact shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    setupFetchMocks();
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.stats).toBeDefined();
+    expect(body.errors).toBeDefined();
+    expect(Object.keys(body.stats).sort()).toEqual(
+      [
+        'wallets',
+        'members',
+        'sessions',
+        'scores',
+        'hosts',
+        'festivals',
+        'misc',
+        'enriched',
+        'firstRespectSet',
+      ].sort(),
+    );
+  });
+
+  // ── Error Handling ────────────────────────────────────────────────────────
+
+  it('logs fatal errors on exception', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[Airtable Sync] Fatal error:',
+      expect.any(Error),
+    );
+  });
+
+  it('handles empty tables gracefully', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    setupFetchMocks();
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.stats.wallets).toBe(0);
+    expect(body.stats.members).toBe(0);
+    expect(body.stats.sessions).toBe(0);
+    expect(body.stats.enriched).toBe(0);
+  });
+
+  it('handles array values in Airtable fields', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const walletRecords: AirtableRecord[] = [
+      {
+        id: 'w1',
+        fields: { Name: ['Alice'], 'ETH WALLET': ['0xaaaa'] },
+      },
+    ];
+
+    setupFetchMocks(walletRecords);
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.wallets).toBe(1);
+  });
+
+  it('normalizes wallet addresses to lowercase', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+    const walletRecords: AirtableRecord[] = [
+      { id: 'w1', fields: { Name: 'Alice', 'ETH WALLET': '0xAAAA' } },
+    ];
+
+    setupFetchMocks(walletRecords);
+
+    const queue = createChainQueue([
+      { error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+      { data: [], error: null },
+    ]);
+
+    mockFrom.mockImplementation(queue.mockFn);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stats.wallets).toBe(1);
+  });
+});


### PR DESCRIPTION
72 tests across the 3 heaviest untested admin mutation routes (task #591), subagent-authored + verified green (vitest 72/72, tsc 0, biome clean). admin/backfill POST (19, Neynar batch fid backfill), admin/respect-import POST (14, multi-table Airtable import), admin/member-fix POST (39, 6 fix actions). Supabase mocks + mocked global.fetch for Neynar/Airtable (raw APIs, no lib seam — justified). No any (cleaned the backfill agents 3 as-any + dead capture to typed mocks). Tests only.

🤖 Generated with Claude Code