### PR TITLE
test(casts,broadcast,empire-builder): route coverage (94 tests)

### DIFF
--- a/src/app/api/broadcast/targets/__tests__/route.test.ts
+++ b/src/app/api/broadcast/targets/__tests__/route.test.ts
@@ -1,0 +1,522 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+import { DELETE, GET, POST } from '../route';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockCreateTarget, mockGetUserTargets, mockDeleteTarget } = vi.hoisted(
+  () => ({
+    mockGetSessionData: vi.fn(),
+    mockCreateTarget: vi.fn(),
+    mockGetUserTargets: vi.fn(),
+    mockDeleteTarget: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/broadcast/targetsDb', () => ({
+  createTarget: (data: unknown) => mockCreateTarget(data),
+  deleteTarget: (id: unknown, fid: unknown) => mockDeleteTarget(id, fid),
+  getUserTargets: (fid: unknown) => mockGetUserTargets(fid),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+// ── Test data factories ──────────────────────────────────────────────────────
+function createMockTarget(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VALID_UUID,
+    user_fid: 123,
+    platform: 'youtube',
+    name: 'My YouTube Channel',
+    rtmp_url: 'rtmps://a.rtmp.youtube.com/live2',
+    stream_key: 'test-key-123',
+    provider: 'direct',
+    is_active: true,
+    created_at: '2026-07-01T10:00:00Z',
+    updated_at: '2026-07-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function createValidPostBody(overrides: Record<string, unknown> = {}) {
+  return {
+    platform: 'youtube',
+    name: 'My Stream',
+    rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+    streamKey: 'test-stream-key',
+    provider: 'direct',
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+describe('GET /api/broadcast/targets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns targets for authenticated user', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const targets = [
+      createMockTarget({ name: 'YouTube Stream' }),
+      createMockTarget({ id: 'uuid-2', name: 'Twitch Stream', platform: 'twitch' }),
+    ];
+    mockGetUserTargets.mockResolvedValue(targets);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { targets: unknown[] };
+    expect(body.targets).toEqual(targets);
+    expect(mockGetUserTargets).toHaveBeenCalledWith(123);
+  });
+
+  it('returns empty array when user has no targets', async () => {
+    const session = mockAuthenticatedSession({ fid: 456 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockGetUserTargets.mockResolvedValue([]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { targets: unknown[] };
+    expect(body.targets).toEqual([]);
+  });
+
+  it('returns 500 when getUserTargets throws', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockGetUserTargets.mockRejectedValue(new Error('Database error'));
+
+    const res = await GET();
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Failed to fetch targets');
+  });
+});
+
+describe('POST /api/broadcast/targets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const body = createValidPostBody();
+    const req = makePostRequest('/api/broadcast/targets', body);
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const responseBody = (await res.json()) as { error: string };
+    expect(responseBody.error).toBe('Unauthorized');
+  });
+
+  it('creates a target with required fields', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My YouTube Stream',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'test-key-123',
+    };
+    const createdTarget = createMockTarget(bodyData);
+    mockCreateTarget.mockResolvedValue(createdTarget);
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { target: unknown };
+    expect(body.target).toEqual(createdTarget);
+    expect(mockCreateTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userFid: 123,
+        platform: 'youtube',
+        name: 'My YouTube Stream',
+        rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+        streamKey: 'test-key-123',
+      }),
+    );
+  });
+
+  it('creates a target with optional provider field', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'twitch',
+      name: 'My Twitch Stream',
+      rtmpUrl: 'rtmps://live.twitch.tv/app',
+      streamKey: 'test-twitch-key',
+      provider: 'livepeer',
+    };
+    const createdTarget = createMockTarget(bodyData);
+    mockCreateTarget.mockResolvedValue(createdTarget);
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockCreateTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userFid: 123,
+        provider: 'livepeer',
+      }),
+    );
+  });
+
+  it('returns 400 when platform is invalid', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'invalid-platform',
+      name: 'My Stream',
+      rtmpUrl: 'rtmps://example.com/live',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; details?: unknown };
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when name is empty string', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: '',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when name exceeds max length', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'a'.repeat(101),
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when rtmpUrl is missing', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My Stream',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when rtmpUrl is empty string', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My Stream',
+      rtmpUrl: '',
+      streamKey: 'test-key',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when streamKey is missing', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My Stream',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when streamKey is empty string', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My Stream',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: '',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when provider is invalid enum', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = {
+      platform: 'youtube',
+      name: 'My Stream',
+      rtmpUrl: 'rtmps://a.rtmp.youtube.com/live2',
+      streamKey: 'test-key',
+      provider: 'invalid-provider',
+    };
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 500 when createTarget throws', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const bodyData = createValidPostBody();
+    mockCreateTarget.mockRejectedValue(new Error('Database error'));
+
+    const req = makePostRequest('/api/broadcast/targets', bodyData);
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Failed to create target');
+  });
+
+  it('supports all valid platform enums', async () => {
+    const platforms = ['youtube', 'twitch', 'tiktok', 'facebook', 'kick', 'custom'];
+
+    for (const platform of platforms) {
+      vi.clearAllMocks();
+      const session = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(session);
+
+      const bodyData = {
+        ...createValidPostBody(),
+        platform,
+      };
+      const createdTarget = createMockTarget(bodyData);
+      mockCreateTarget.mockResolvedValue(createdTarget);
+
+      const req = makePostRequest('/api/broadcast/targets', bodyData);
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateTarget).toHaveBeenCalled();
+    }
+  });
+
+  it('supports all valid provider enums', async () => {
+    const providers = ['direct', 'livepeer', 'restream'];
+
+    for (const provider of providers) {
+      vi.clearAllMocks();
+      const session = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(session);
+
+      const bodyData = {
+        ...createValidPostBody(),
+        provider,
+      };
+      const createdTarget = createMockTarget(bodyData);
+      mockCreateTarget.mockResolvedValue(createdTarget);
+
+      const req = makePostRequest('/api/broadcast/targets', bodyData);
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockCreateTarget).toHaveBeenCalledWith(expect.objectContaining({ provider }));
+    }
+  });
+});
+
+describe('DELETE /api/broadcast/targets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makeRequest(`/api/broadcast/targets?id=${VALID_UUID}`, {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('deletes a target when id is provided', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockDeleteTarget.mockResolvedValue(undefined);
+
+    const req = makeRequest(`/api/broadcast/targets?id=${VALID_UUID}`, {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean };
+    expect(body.success).toBe(true);
+    expect(mockDeleteTarget).toHaveBeenCalledWith(VALID_UUID, 123);
+  });
+
+  it('returns 400 when id is missing', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const req = makeRequest('/api/broadcast/targets', {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Target ID required');
+    expect(mockDeleteTarget).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when id is empty string', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const req = makeRequest('/api/broadcast/targets?id=', {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Target ID required');
+    expect(mockDeleteTarget).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when deleteTarget throws', async () => {
+    const session = mockAuthenticatedSession({ fid: 123 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockDeleteTarget.mockRejectedValue(new Error('Database error'));
+
+    const req = makeRequest(`/api/broadcast/targets?id=${VALID_UUID}`, {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Failed to delete target');
+  });
+
+  it('passes correct parameters to deleteTarget', async () => {
+    const session = mockAuthenticatedSession({ fid: 456 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockDeleteTarget.mockResolvedValue(undefined);
+
+    const targetId = 'some-target-uuid';
+    const req = makeRequest(`/api/broadcast/targets?id=${targetId}`, {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req);
+
+    expect(res.status).toBe(200);
+    expect(mockDeleteTarget).toHaveBeenCalledWith(targetId, 456);
+  });
+});

--- a/src/app/api/casts/summary/__tests__/route.test.ts
+++ b/src/app/api/casts/summary/__tests__/route.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockGetCastConversationSummary } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetCastConversationSummary: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getCastConversationSummary: mockGetCastConversationSummary,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/casts/summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(mockGetCastConversationSummary).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when session fid is missing', async () => {
+    mockGetSessionData.mockResolvedValue({
+      username: 'testuser',
+      displayName: 'Test User',
+    });
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 400 when castHash is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {});
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+    expect(Array.isArray(body.details)).toBe(true);
+  });
+
+  it('returns 400 when castHash does not start with 0x', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: 'abcdef123456',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+    expect(Array.isArray(body.details)).toBe(true);
+  });
+
+  it('returns 400 when castHash is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts castHash of just 0x (edge case but valid per Zod startsWith)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = { conversation: { total_replies: 0 } };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockGetCastConversationSummary).toHaveBeenCalledWith('0x');
+  });
+
+  it('returns 200 with summary data on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = {
+      cast: {
+        hash: '0x1234567890abcdef',
+        author: { fid: 456 },
+        text: 'Test cast',
+      },
+      conversation: {
+        total_replies: 5,
+        total_recasts: 2,
+      },
+    };
+
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual(summaryData);
+    expect(mockGetCastConversationSummary).toHaveBeenCalledWith('0x1234567890abcdef');
+  });
+
+  it('calls getCastConversationSummary with the provided castHash', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = { conversation: { total_replies: 10 } };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const castHash = '0xaabbccddee1122334455';
+    const req = makePostRequest('/api/casts/summary', { castHash });
+
+    await POST(req);
+
+    expect(mockGetCastConversationSummary).toHaveBeenCalledWith(castHash);
+  });
+
+  it('returns 500 when getCastConversationSummary throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockGetCastConversationSummary.mockRejectedValue(new Error('Neynar API error'));
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.error).toBe('Failed to get cast summary');
+  });
+
+  it('logs error when getCastConversationSummary throws', async () => {
+    const loggerMock = vi.mocked(await import('@/lib/logger')).logger;
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const testError = new Error('Neynar timeout');
+    mockGetCastConversationSummary.mockRejectedValue(testError);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    await POST(req);
+
+    expect(loggerMock.error).toHaveBeenCalledWith('Cast summary error:', testError);
+  });
+
+  it('accepts castHash with multiple 0x prefixed hex values', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = { conversation: { total_replies: 3 } };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const castHash = '0xdeadbeefcafebabe';
+    const req = makePostRequest('/api/casts/summary', { castHash });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockGetCastConversationSummary).toHaveBeenCalledWith(castHash);
+  });
+
+  it('rejects castHash with leading whitespace', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: ' 0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect(mockGetCastConversationSummary).not.toHaveBeenCalled();
+  });
+
+  it('rejects castHash that is not a string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: 12345,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('ignores extra properties in request body', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = { conversation: { total_replies: 1 } };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+      extraField: 'should be ignored',
+      anotherField: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockGetCastConversationSummary).toHaveBeenCalledWith('0x1234567890abcdef');
+  });
+
+  it('authenticates with a valid FID in session', async () => {
+    const session = mockAuthenticatedSession({ fid: 999 });
+    mockGetSessionData.mockResolvedValue(session);
+
+    const summaryData = { conversation: { total_replies: 0 } };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns NextResponse.json for all response types', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const summaryData = { test: 'data' };
+    mockGetCastConversationSummary.mockResolvedValue(summaryData);
+
+    const req = makePostRequest('/api/casts/summary', {
+      castHash: '0x1234567890abcdef',
+    });
+
+    const res = await POST(req);
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+});

--- a/src/app/api/empire-builder/leaderboard/__tests__/route.test.ts
+++ b/src/app/api/empire-builder/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,551 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ZABAL_TOKEN_ADDRESS } from '@/lib/empire-builder/config';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockSession, mockDiscoverLeaderboards, mockGetLeaderboard, mockWithCache } = vi.hoisted(
+  () => ({
+    mockSession: { fid: undefined as number | undefined },
+    mockDiscoverLeaderboards: vi.fn(),
+    mockGetLeaderboard: vi.fn(),
+    mockWithCache: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => Promise.resolve(mockSession),
+}));
+
+vi.mock('@/lib/empire-builder/client', () => ({
+  discoverLeaderboards: mockDiscoverLeaderboards,
+  getLeaderboard: mockGetLeaderboard,
+}));
+
+vi.mock('@/lib/empire-builder/cache', () => ({
+  withCache: mockWithCache,
+  DEFAULT_TTL_MS: 60000,
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/empire-builder/leaderboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.fid = undefined;
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when session.fid is falsy', async () => {
+      mockSession.fid = undefined;
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('unauthorized');
+      expect(mockDiscoverLeaderboards).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when session.fid is 0', async () => {
+      mockSession.fid = 0;
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('unauthorized');
+    });
+
+    it('accepts authenticated request with valid fid', async () => {
+      mockSession.fid = 123;
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockDiscoverLeaderboards).toHaveBeenCalled();
+    });
+  });
+
+  describe('query validation', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+    });
+
+    it('accepts valid optional slot parameter', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([
+        { id: 'slot1', name: 'Slot 1', leaderboard_type: 'global' },
+      ]);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '0' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts valid optional tokenAddress parameter', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const customTokenAddress = '0x1234567890abcdef1234567890abcdef12345678';
+      const req = makeGetRequest('/api/empire-builder/leaderboard', {
+        tokenAddress: customTokenAddress,
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 200 with valid optional parameters', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([
+        { id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' },
+      ]);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', {
+        slot: '0',
+        tokenAddress: 'valid_address',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('leaderboard discovery', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+    });
+
+    it('uses ZABAL_TOKEN_ADDRESS by default when tokenAddress not provided', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      await GET(req);
+
+      expect(mockDiscoverLeaderboards).toHaveBeenCalledWith(ZABAL_TOKEN_ADDRESS);
+    });
+
+    it('uses supplied tokenAddress when provided', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const customTokenAddress = '0xaabbccddaabbccddaabbccddaabbccddaabbccdd';
+      const req = makeGetRequest('/api/empire-builder/leaderboard', {
+        tokenAddress: customTokenAddress,
+      });
+      await GET(req);
+
+      expect(mockDiscoverLeaderboards).toHaveBeenCalledWith(customTokenAddress);
+    });
+
+    it('calls withCache with correct cache key and TTL', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      await GET(req);
+
+      const callArgs = mockWithCache.mock.calls[0];
+      expect(callArgs[0]).toBe(`eb:slots:${ZABAL_TOKEN_ADDRESS}`);
+      expect(callArgs[1]).toBe(60000 * 5); // DEFAULT_TTL_MS * 5
+    });
+
+    it('returns empty leaderboard when no slots discovered', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.slots).toEqual([]);
+      expect(body.data.leaderboard).toBeNull();
+      expect(mockGetLeaderboard).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('leaderboard selection', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+    });
+
+    it('selects slot by index when slot parameter provided', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Slot 1', leaderboard_type: 'personal' },
+      ];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '1' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.active.id).toBe('slot1');
+      expect(body.data.active.index).toBe(1);
+      expect(mockGetLeaderboard).toHaveBeenCalledWith('slot1');
+    });
+
+    it('defaults to first slot when slot parameter not provided', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Slot 1', leaderboard_type: 'personal' },
+      ];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.active.id).toBe('slot0');
+      expect(body.data.active.index).toBe(0);
+    });
+
+    it('defaults to first slot when slot index is out of bounds', async () => {
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '5' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.active.id).toBe('slot0');
+    });
+
+    it('defaults to first slot when slot is negative', async () => {
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '-1' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.active.id).toBe('slot0');
+    });
+
+    it('defaults to first slot when slot is not a number', async () => {
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: 'invalid' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.active.id).toBe('slot0');
+    });
+  });
+
+  describe('response structure', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+    });
+
+    it('returns correct response structure on success', async () => {
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      const leaderboard = { entries: [{ rank: 1, address: '0xabc', score: 100 }] };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body).toHaveProperty('success', true);
+      expect(body).toHaveProperty('data');
+      expect(body.data).toHaveProperty('slots');
+      expect(body.data).toHaveProperty('active');
+      expect(body.data).toHaveProperty('leaderboard');
+    });
+
+    it('transforms slots to include index and type', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Slot 1', leaderboard_type: 'personal' },
+      ];
+      const leaderboard = { entries: [] };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.data.slots).toEqual([
+        { index: 0, id: 'slot0', name: 'Slot 0', type: 'global' },
+        { index: 1, id: 'slot1', name: 'Slot 1', type: 'personal' },
+      ]);
+    });
+
+    it('includes leaderboard data in response', async () => {
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      const leaderboard = {
+        entries: [
+          { rank: 1, address: '0xabc', score: 100 },
+          { rank: 2, address: '0xdef', score: 90 },
+        ],
+      };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.data.leaderboard).toEqual(leaderboard);
+    });
+
+    it('sets correct active slot index when multiple slots exist', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Slot 1', leaderboard_type: 'personal' },
+        { id: 'slot2', name: 'Slot 2', leaderboard_type: 'daily' },
+      ];
+      const leaderboard = { entries: [] };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '2' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.data.active).toEqual({ index: 2, id: 'slot2' });
+    });
+  });
+
+  describe('caching', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+    });
+
+    it('uses withCache for leaderboards discovery', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce([]);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      await GET(req);
+
+      expect(mockWithCache).toHaveBeenCalledWith(
+        expect.stringContaining('eb:slots:'),
+        expect.any(Number),
+        expect.any(Function),
+      );
+    });
+
+    it('uses withCache for leaderboard fetch with correct TTL', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce({ entries: [] });
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      await GET(req);
+
+      // Second withCache call should be for the leaderboard
+      const secondCall = mockWithCache.mock.calls[1];
+      expect(secondCall[0]).toBe('eb:leaderboard:slot0');
+      expect(secondCall[1]).toBe(60000); // DEFAULT_TTL_MS without multiplier
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+    });
+
+    it('returns 502 when discoverLeaderboards throws', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockRejectedValueOnce(new Error('API error'));
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('leaderboard_unavailable');
+    });
+
+    it('returns 502 when getLeaderboard throws', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      const slots = [{ id: 'slot0', name: 'Slot 0', leaderboard_type: 'global' }];
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockRejectedValueOnce(new Error('Fetch failed'));
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('leaderboard_unavailable');
+    });
+
+    it('returns 502 when withCache throws', async () => {
+      mockWithCache.mockRejectedValueOnce(new Error('Cache error'));
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('leaderboard_unavailable');
+    });
+
+    it('handles non-Error thrown exceptions', async () => {
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockRejectedValueOnce('raw string error');
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('leaderboard_unavailable');
+    });
+  });
+
+  describe('integration scenarios', () => {
+    beforeEach(() => {
+      mockSession.fid = 123;
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+    });
+
+    it('handles full happy path with multiple slots', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Global', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Weekly', leaderboard_type: 'weekly' },
+      ];
+      const leaderboard = {
+        entries: [
+          { rank: 1, address: '0x111', score: 1000 },
+          { rank: 2, address: '0x222', score: 900 },
+          { rank: 3, address: '0x333', score: 800 },
+        ],
+      };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', { slot: '0' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.data.slots).toHaveLength(2);
+      expect(body.data.active.id).toBe('slot0');
+      expect(body.data.leaderboard.entries).toHaveLength(3);
+    });
+
+    it('handles switching between slots', async () => {
+      const slots = [
+        { id: 'slot0', name: 'Global', leaderboard_type: 'global' },
+        { id: 'slot1', name: 'Weekly', leaderboard_type: 'weekly' },
+      ];
+      const leaderboard1 = { entries: [{ rank: 1, address: '0x111', score: 1000 }] };
+      const leaderboard2 = { entries: [{ rank: 1, address: '0x222', score: 500 }] };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard1);
+
+      // First request with slot 0
+      const req1 = makeGetRequest('/api/empire-builder/leaderboard', { slot: '0' });
+      const res1 = await GET(req1);
+      const body1 = await res1.json();
+
+      expect(body1.data.active.id).toBe('slot0');
+      expect(body1.data.leaderboard).toEqual(leaderboard1);
+
+      // Reset mock for second request
+      vi.clearAllMocks();
+      mockWithCache.mockImplementation(async (_key: string, _ttl: number, fetcher: () => unknown) =>
+        fetcher(),
+      );
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard2);
+
+      // Second request with slot 1
+      const req2 = makeGetRequest('/api/empire-builder/leaderboard', { slot: '1' });
+      const res2 = await GET(req2);
+      const body2 = await res2.json();
+
+      expect(body2.data.active.id).toBe('slot1');
+      expect(body2.data.leaderboard).toEqual(leaderboard2);
+    });
+
+    it('handles custom tokenAddress parameter end-to-end', async () => {
+      const customTokenAddress = '0x9999999999999999999999999999999999999999';
+      const slots = [{ id: 'custom-slot', name: 'Custom', leaderboard_type: 'global' }];
+      const leaderboard = { entries: [] };
+
+      mockDiscoverLeaderboards.mockResolvedValueOnce(slots);
+      mockGetLeaderboard.mockResolvedValueOnce(leaderboard);
+
+      const req = makeGetRequest('/api/empire-builder/leaderboard', {
+        tokenAddress: customTokenAddress,
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(mockDiscoverLeaderboards).toHaveBeenCalledWith(customTokenAddress);
+    });
+  });
+});

--- a/src/app/api/empire-builder/me/__tests__/route.test.ts
+++ b/src/app/api/empire-builder/me/__tests__/route.test.ts
@@ -1,0 +1,613 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSession, mockWithCache, mockDiscoverLeaderboards, mockGetLeaderboardForAddress } =
+  vi.hoisted(() => ({
+    mockGetSession: vi.fn(),
+    mockWithCache: vi.fn(),
+    mockDiscoverLeaderboards: vi.fn(),
+    mockGetLeaderboardForAddress: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('@/lib/empire-builder/cache', () => ({
+  withCache: mockWithCache,
+  DEFAULT_TTL_MS: 60000,
+}));
+
+vi.mock('@/lib/empire-builder/client', () => ({
+  discoverLeaderboards: mockDiscoverLeaderboards,
+  getLeaderboardForAddress: mockGetLeaderboardForAddress,
+}));
+
+vi.mock('@/lib/empire-builder/config', () => ({
+  ZABAL_TOKEN_ADDRESS: '0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07',
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/empire-builder/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========================================================================
+  // Auth tests
+  // ========================================================================
+
+  it('returns 401 when session has no fid', async () => {
+    mockGetSession.mockResolvedValue({ fid: undefined, walletAddress: '0xabc' });
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'unauthorized' });
+  });
+
+  it('returns 502 when session is null (cannot read fid)', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'me_unavailable' });
+  });
+
+  // ========================================================================
+  // Query validation tests
+  // ========================================================================
+
+  it('accepts query params and does not 400 on valid strings', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123 });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const req = makeGetRequest('/api/empire-builder/me', {
+      wallet: '0xvalid',
+      slot: '0', // Optional string — schema allows
+    });
+
+    const res = await GET(req);
+    // The schema is minimal: just { wallet?: string, slot?: string }
+    // so these valid params will parse and return 200.
+    expect(res.status).toBe(200);
+  });
+
+  // ========================================================================
+  // No wallet tests (neither query nor session)
+  // ========================================================================
+
+  it('returns 200 with null wallet when neither query wallet nor session wallet provided', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: undefined });
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: { wallet: null, entry: null, boosters: [] },
+    });
+  });
+
+  it('returns 200 with null wallet when both query and session wallet are empty strings', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '' });
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { wallet: '  ' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: { wallet: null, entry: null, boosters: [] },
+    });
+  });
+
+  // ========================================================================
+  // Query wallet precedence tests
+  // ========================================================================
+
+  it('prefers query wallet over session wallet', async () => {
+    mockGetSession.mockResolvedValue({
+      fid: 123,
+      walletAddress: '0xsession_wallet',
+    });
+
+    const queryWallet = '0xquery_wallet';
+    const slotId = 'slot-1';
+    const mockSlot = { id: slotId, name: 'Slot 1' };
+    const mockStats = {
+      entry: { rank: 1, score: 1000 },
+      boosters: [{ id: 'b1', name: 'Booster 1' }],
+    };
+
+    // Mock withCache to call the fetcher and return the result
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { wallet: queryWallet }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.wallet).toBe(queryWallet);
+  });
+
+  it('uses session wallet when query wallet not provided', async () => {
+    const sessionWallet = '0xsession_wallet';
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: sessionWallet });
+
+    const slotId = 'slot-1';
+    const mockSlot = { id: slotId, name: 'Slot 1' };
+    const mockStats = {
+      entry: { rank: 1, score: 1000 },
+      boosters: [],
+    };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.wallet).toBe(sessionWallet);
+  });
+
+  // ========================================================================
+  // Leaderboard discovery and slot selection tests
+  // ========================================================================
+
+  it('returns 200 with entry null when no leaderboards exist', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([]);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: { wallet: '0xwallet', entry: null, boosters: [] },
+    });
+  });
+
+  it('uses slot index 0 by default', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 5 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot, { id: 'slot-1', name: 'Slot 1' }]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.slot.id).toBe('slot-0');
+  });
+
+  it('uses query slot parameter when provided and valid', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-2', name: 'Slot 2' };
+    const mockStats = { entry: { rank: 3 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([
+      { id: 'slot-0', name: 'Slot 0' },
+      { id: 'slot-1', name: 'Slot 1' },
+      mockSlot,
+    ]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { slot: '2' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.slot.id).toBe('slot-2');
+  });
+
+  it('falls back to slot 0 when query slot is out of bounds', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { slot: '999' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.slot.id).toBe('slot-0');
+  });
+
+  it('falls back to slot 0 when query slot is not a finite number', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { slot: 'abc' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.slot.id).toBe('slot-0');
+  });
+
+  // ========================================================================
+  // Cache integration tests
+  // ========================================================================
+
+  it('calls withCache for leaderboards discovery', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    await GET(makeGetRequest('/api/empire-builder/me'));
+
+    expect(mockWithCache).toHaveBeenCalledWith(
+      'eb:slots:0xbB48f19B0494Ff7C1fE5Dc2032aeEE14312f0b07',
+      expect.any(Number),
+      expect.any(Function),
+    );
+  });
+
+  it('calls withCache for address stats', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    await GET(makeGetRequest('/api/empire-builder/me'));
+
+    expect(mockWithCache).toHaveBeenCalledWith(
+      expect.stringContaining('eb:me:slot-0:'),
+      expect.any(Number),
+      expect.any(Function),
+    );
+  });
+
+  // ========================================================================
+  // Full success path tests
+  // ========================================================================
+
+  it('returns 200 with full stats on success', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = {
+      entry: { rank: 1, score: 5000 },
+      boosters: [
+        { id: 'b1', name: 'Booster 1', level: 2 },
+        { id: 'b2', name: 'Booster 2', level: 1 },
+      ],
+    };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toEqual({
+      wallet: '0xwallet',
+      slot: mockSlot,
+      entry: mockStats.entry,
+      boosters: mockStats.boosters,
+    });
+  });
+
+  it('returns 200 with empty boosters array when stats.boosters is undefined', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = {
+      entry: { rank: 1 },
+      boosters: undefined, // Explicitly undefined
+    };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(
+      mockStats as unknown as {
+        entry: { rank: number };
+        boosters?: unknown[];
+      },
+    );
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.boosters).toEqual([]);
+  });
+
+  it('returns 200 with entry null when getLeaderboardForAddress returns null', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      data: { wallet: '0xwallet', entry: null, boosters: [], slot: mockSlot },
+    });
+  });
+
+  // ========================================================================
+  // Error handling tests
+  // ========================================================================
+
+  it('returns 502 when getSession throws an error', async () => {
+    mockGetSession.mockRejectedValue(new Error('Session error'));
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'me_unavailable' });
+  });
+
+  it('returns 502 when discoverLeaderboards throws an error', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockRejectedValue(new Error('Leaderboards API error'));
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'me_unavailable' });
+  });
+
+  it('returns 502 when getLeaderboardForAddress throws an error', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockRejectedValue(new Error('Address stats API error'));
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: false, error: 'me_unavailable' });
+  });
+
+  it('logs error message when an unknown error is thrown', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockRejectedValue(new Error('Custom error'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await GET(makeGetRequest('/api/empire-builder/me'));
+
+    expect(consoleSpy).toHaveBeenCalledWith('[empire-builder] me error', expect.any(String));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles non-Error thrown values gracefully', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockRejectedValue('String error');
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(502);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: false,
+      error: 'me_unavailable',
+    });
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  it('handles wallet address with leading/trailing whitespace', async () => {
+    mockGetSession.mockResolvedValue({
+      fid: 123,
+      walletAddress: '  0xwallet  ',
+    });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.wallet).toBe('0xwallet');
+  });
+
+  it('converts wallet address to lowercase when calling getLeaderboardForAddress', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xABCDEF' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    await GET(makeGetRequest('/api/empire-builder/me'));
+
+    // The cache key includes the lowercase address
+    expect(mockWithCache).toHaveBeenCalledWith(
+      expect.stringContaining('0xabcdef'),
+      expect.any(Number),
+      expect.any(Function),
+    );
+  });
+
+  it('uses negative slot index to fall back to slot 0', async () => {
+    mockGetSession.mockResolvedValue({ fid: 123, walletAddress: '0xwallet' });
+
+    const mockSlot = { id: 'slot-0', name: 'Slot 0' };
+    const mockStats = { entry: { rank: 1 }, boosters: [] };
+
+    mockWithCache.mockImplementation(
+      async (_key: string, _ttl: number, fetcher: () => Promise<unknown>) => {
+        return fetcher();
+      },
+    );
+
+    mockDiscoverLeaderboards.mockResolvedValue([mockSlot]);
+    mockGetLeaderboardForAddress.mockResolvedValue(mockStats);
+
+    const res = await GET(makeGetRequest('/api/empire-builder/me', { slot: '-1' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data.slot.id).toBe('slot-0');
+  });
+});


### PR DESCRIPTION
## What

Adds test coverage for 4 previously-untested API routes — **94 tests total**.

| Route | Tests | Covers |
|-------|-------|--------|
| `casts/summary` | 16 | auth 401, castHash Zod validation (0x-prefix), summary success, 500 error |
| `broadcast/targets` | 25 | GET/POST/DELETE — auth, platform+provider enums, field validation, success + error |
| `empire-builder/leaderboard` | 28 | auth, query validation, slot selection/bounds, token-address default, cache, 502 paths |
| `empire-builder/me` | 25 | auth, wallet precedence (query vs session), slot bounds, cache, error paths |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md` (Vitest, `vi.mock`/`vi.hoisted`, shared `test-utils/api-helpers`, co-located `__tests__/`). No bugs found in any of the 4 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)