### PR TITLE
fix: clamp non-numeric/negative limit param (bluesky/feed, miniapp/discover, miniapp/search)

### DIFF
--- a/src/app/api/bluesky/feed/__tests__/route.test.ts
+++ b/src/app/api/bluesky/feed/__tests__/route.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetFeedSkeleton } = vi.hoisted(() => ({
+  mockGetFeedSkeleton: vi.fn(),
+}));
+
+vi.mock('@/lib/bluesky/feed', () => ({
+  getFeedSkeleton: mockGetFeedSkeleton,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/bluesky/feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------- 200 Success Cases ---------
+
+  it('returns 200 with feed and cursor on success', async () => {
+    const mockFeedData = {
+      feed: [
+        { post: 'at://did:plc:abc123/app.bsky.feed.post/xyz' },
+        { post: 'at://did:plc:abc123/app.bsky.feed.post/uvw' },
+      ],
+      cursor: '2026-07-16T10:00:00Z',
+    };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual(mockFeedData);
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 30);
+  });
+
+  it('passes cursor to getFeedSkeleton when valid (≤200 chars)', async () => {
+    const cursor = '2026-07-15T10:00:00Z'; // Valid cursor
+    const mockFeedData = { feed: [{ post: 'at://did:plc:abc123/app.bsky.feed.post/xyz' }] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { cursor }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(cursor, 30);
+  });
+
+  it('ignores cursor when over 200 chars', async () => {
+    const longCursor = 'x'.repeat(201); // Over 200 chars
+    const mockFeedData = { feed: [{ post: 'at://did:plc:abc123/app.bsky.feed.post/xyz' }] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { cursor: longCursor }));
+    expect(res.status).toBe(200);
+
+    // Cursor should be undefined (ignored)
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 30);
+  });
+
+  it('accepts exactly 200 char cursor', async () => {
+    const cursor200 = 'x'.repeat(200); // Exactly 200 chars
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { cursor: cursor200 }));
+    expect(res.status).toBe(200);
+
+    // Cursor should be passed through (≤200 is valid)
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(cursor200, 30);
+  });
+
+  it('uses default limit of 30 when not provided', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 30);
+  });
+
+  it('passes limit through when valid (≤100)', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: '50' }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 50);
+  });
+
+  it('clamps limit to 100 when higher', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: '500' }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 100);
+  });
+
+  it('clamps limit to 100 when at max boundary', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: '100' }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 100);
+  });
+
+  it('falls back to default 30 when limit is non-numeric (no NaN downstream)', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: 'notanumber' }));
+    expect(res.status).toBe(200);
+
+    // Regression guard: a non-numeric limit must clamp to the default 30, never
+    // pass NaN into getFeedSkeleton's DB .limit() (which would throw → 500).
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 30);
+  });
+
+  it('falls back to default 30 when limit is zero or negative', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const resZero = await GET(makeGetRequest('/api/bluesky/feed', { limit: '0' }));
+    expect(resZero.status).toBe(200);
+    expect(mockGetFeedSkeleton).toHaveBeenLastCalledWith(undefined, 30);
+
+    const resNeg = await GET(makeGetRequest('/api/bluesky/feed', { limit: '-5' }));
+    expect(resNeg.status).toBe(200);
+    expect(mockGetFeedSkeleton).toHaveBeenLastCalledWith(undefined, 30);
+  });
+
+  it('returns 200 with empty feed when no posts exist', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.feed).toEqual([]);
+  });
+
+  it('returns correct Cache-Control headers', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=60, s-maxage=300');
+  });
+
+  // --------- 500 Error Cases ---------
+
+  it('returns 500 with empty feed when getFeedSkeleton throws', async () => {
+    mockGetFeedSkeleton.mockRejectedValue(new Error('Database error'));
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ feed: [] });
+  });
+
+  it('returns 500 and logs error when getFeedSkeleton throws', async () => {
+    const _mockLogger = vi.mocked((await import('@/lib/logger')).logger);
+    const error = new Error('Network timeout');
+    mockGetFeedSkeleton.mockRejectedValue(error);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(500);
+  });
+
+  // --------- Defensive Clamping (No 400 status) ---------
+
+  it('does NOT return 400 for oversized cursor (defensive)', async () => {
+    const longCursor = 'x'.repeat(1000);
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { cursor: longCursor }));
+    // Should NOT be 400; should clamp and return 200
+    expect(res.status).toBe(200);
+  });
+
+  it('does NOT return 400 for oversized limit (defensive)', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: '10000' }));
+    // Should NOT be 400; should clamp to 100 and return 200
+    expect(res.status).toBe(200);
+  });
+
+  it('does NOT return 400 for invalid limit param (defensive)', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { limit: 'garbage' }));
+    // Should NOT be 400; should fall back to default and return 200
+    expect(res.status).toBe(200);
+  });
+
+  // --------- Edge Cases ---------
+
+  it('passes both valid cursor and limit through', async () => {
+    const cursor = '2026-07-15T10:00:00Z';
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed', { cursor, limit: '25' }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(cursor, 25);
+  });
+
+  it('clamps limit and ignores long cursor simultaneously', async () => {
+    const longCursor = 'x'.repeat(300);
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(
+      makeGetRequest('/api/bluesky/feed', { cursor: longCursor, limit: '200' }),
+    );
+    expect(res.status).toBe(200);
+
+    // Cursor ignored (>200), limit clamped to 100
+    expect(mockGetFeedSkeleton).toHaveBeenCalledWith(undefined, 100);
+  });
+
+  it('is publicly accessible (no session required)', async () => {
+    const mockFeedData = { feed: [] };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    // No auth headers or session
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(200);
+  });
+
+  it('returns feed without cursor when pagination ends', async () => {
+    const mockFeedData = {
+      feed: [{ post: 'at://did:plc:abc123/app.bsky.feed.post/xyz' }],
+      // No cursor property (pagination ended)
+    };
+    mockGetFeedSkeleton.mockResolvedValue(mockFeedData);
+
+    const res = await GET(makeGetRequest('/api/bluesky/feed'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.cursor).toBeUndefined();
+    expect(body.feed).toBeDefined();
+  });
+});

--- a/src/app/api/bluesky/feed/route.ts
+++ b/src/app/api/bluesky/feed/route.ts
@@ -16,7 +16,10 @@ export async function GET(req: NextRequest) {
     // clamp/ignore bad input so the feed keeps rendering. Ignore an over-long cursor.
     const rawCursor = req.nextUrl.searchParams.get('cursor') || undefined;
     const cursor = rawCursor && rawCursor.length <= 200 ? rawCursor : undefined;
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '30', 10), 100);
+    // Defensively clamp: a non-numeric/negative limit must fall back to the
+    // default 30 (not pass NaN/0 downstream into the DB .limit()), and cap at 100.
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '30', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 30 : rawLimit, 100);
 
     const result = await getFeedSkeleton(cursor, limit);
 

--- a/src/app/api/miniapp/discover/__tests__/route.test.ts
+++ b/src/app/api/miniapp/discover/__tests__/route.test.ts
@@ -1,0 +1,416 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+import { GET } from '../route';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockGetFrameCatalog, mockGetRelevantFrames } = vi.hoisted(() => ({
+  mockGetFrameCatalog: vi.fn(),
+  mockGetRelevantFrames: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getFrameCatalog: mockGetFrameCatalog,
+  getRelevantFrames: mockGetRelevantFrames,
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/miniapp/discover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when session is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('mode: catalog (default)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('calls getFrameCatalog with default limit when no params', async () => {
+      const mockData = { frames: [{ id: 'frame1' }] };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(mockData);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+      expect(mockGetRelevantFrames).not.toHaveBeenCalled();
+    });
+
+    it('uses default limit (20) when mode is not provided', async () => {
+      const mockData = { frames: [] };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {});
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+    });
+
+    it('uses explicit mode=catalog with custom limit', async () => {
+      const mockData = { frames: [{ id: 'frame2' }] };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'catalog',
+        limit: '35',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(mockData);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(35, undefined);
+    });
+
+    it('passes cursor to getFrameCatalog', async () => {
+      const mockData = { frames: [], cursor: 'next123' };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '25',
+        cursor: 'abc123def',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(25, 'abc123def');
+    });
+
+    it('returns empty results when getFrameCatalog returns no frames', async () => {
+      const mockData = { frames: [] };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.frames).toEqual([]);
+    });
+  });
+
+  describe('mode: relevant', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('calls getRelevantFrames with fid and default limit', async () => {
+      const mockData = { frames: [{ id: 'relevant1' }] };
+      mockGetRelevantFrames.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual(mockData);
+      expect(mockGetRelevantFrames).toHaveBeenCalledWith(456, 20);
+      expect(mockGetFrameCatalog).not.toHaveBeenCalled();
+    });
+
+    it('passes custom limit to getRelevantFrames', async () => {
+      const mockData = { frames: [] };
+      mockGetRelevantFrames.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+        limit: '40',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetRelevantFrames).toHaveBeenCalledWith(456, 40);
+    });
+
+    it('does not use cursor param for relevant mode', async () => {
+      const mockData = { frames: [] };
+      mockGetRelevantFrames.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+        cursor: 'ignored',
+      });
+      const _res = await GET(req);
+
+      // getRelevantFrames signature: (fid, limit) — no cursor param
+      expect(mockGetRelevantFrames).toHaveBeenCalledWith(456, 20);
+    });
+
+    it('returns results from getRelevantFrames', async () => {
+      const mockData = {
+        frames: [
+          { id: 'rel1', title: 'Frame 1' },
+          { id: 'rel2', title: 'Frame 2' },
+        ],
+      };
+      mockGetRelevantFrames.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.frames).toHaveLength(2);
+      expect(body.frames[0].id).toBe('rel1');
+    });
+  });
+
+  describe('limit clamping', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockGetFrameCatalog.mockResolvedValue({ frames: [] });
+    });
+
+    it('clamps limit to 50 when limit > 50', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '100',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(50, undefined);
+    });
+
+    it('allows limit exactly at 50', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '50',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(50, undefined);
+    });
+
+    it('allows limit below 50', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '10',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(10, undefined);
+    });
+
+    it('falls back to default limit (20) for a non-numeric limit string', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: 'notanumber',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Regression guard: a non-numeric limit must clamp to the default 20, never
+      // pass NaN downstream to getFrameCatalog (String(NaN) → ?limit=NaN → Neynar 400 → 500).
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+    });
+
+    it('falls back to default limit (20) for a negative limit', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '-10',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // A negative limit is invalid → clamp to default 20 (not passed through).
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when getFrameCatalog throws', async () => {
+      mockGetFrameCatalog.mockRejectedValue(new Error('Neynar API error'));
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to fetch mini apps');
+    });
+
+    it('returns 500 when getRelevantFrames throws', async () => {
+      mockGetRelevantFrames.mockRejectedValue(new Error('Network error'));
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to fetch mini apps');
+    });
+
+    it('returns 500 for non-Error thrown values', async () => {
+      mockGetFrameCatalog.mockRejectedValue('unexpected string error');
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to fetch mini apps');
+    });
+  });
+
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+      mockGetFrameCatalog.mockResolvedValue({ frames: [] });
+    });
+
+    it('ignores empty cursor string (treats as undefined)', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        cursor: '',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Empty string is falsy, so cursor should be undefined
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+    });
+
+    it('handles whitespace in limit parameter', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '  25  ',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // parseInt handles leading/trailing whitespace
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(25, undefined);
+    });
+
+    it('uses default limit when limit is 0', async () => {
+      const req = makeGetRequest('/api/miniapp/discover', {
+        limit: '0',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // 0 is not a valid page size → clamp to the default 20.
+      expect(mockGetFrameCatalog).toHaveBeenCalledWith(20, undefined);
+    });
+
+    it('preserves full session data beyond fid for relevant mode', async () => {
+      const session = mockAuthenticatedSession({
+        fid: 999,
+        username: 'testuser',
+        displayName: 'Test User',
+      });
+      mockGetSessionData.mockResolvedValue(session);
+      mockGetRelevantFrames.mockResolvedValue({ frames: [] });
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Only fid is used, but session should have other data
+      expect(mockGetRelevantFrames).toHaveBeenCalledWith(999, 20);
+    });
+
+    it('handles case-sensitive mode parameter', async () => {
+      mockGetRelevantFrames.mockResolvedValue({ frames: [] });
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'Relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // 'Relevant' !== 'relevant', so falls through to catalog
+      expect(mockGetFrameCatalog).toHaveBeenCalled();
+      expect(mockGetRelevantFrames).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns JSON response for catalog mode', async () => {
+      const mockData = {
+        frames: [{ id: '1' }],
+        cursor: 'next',
+        total: 100,
+      };
+      mockGetFrameCatalog.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual(mockData);
+    });
+
+    it('returns JSON response for relevant mode', async () => {
+      const mockData = {
+        frames: [{ id: '2' }],
+      };
+      mockGetRelevantFrames.mockResolvedValue(mockData);
+
+      const req = makeGetRequest('/api/miniapp/discover', {
+        mode: 'relevant',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual(mockData);
+    });
+
+    it('returns error JSON with proper status code on failure', async () => {
+      mockGetFrameCatalog.mockRejectedValue(new Error('API error'));
+
+      const req = makeGetRequest('/api/miniapp/discover');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to fetch mini apps' });
+    });
+  });
+});

--- a/src/app/api/miniapp/discover/route.ts
+++ b/src/app/api/miniapp/discover/route.ts
@@ -11,7 +11,10 @@ export async function GET(req: NextRequest) {
 
   try {
     const mode = req.nextUrl.searchParams.get('mode') || 'catalog';
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '20', 10), 50);
+    // Defensively clamp: a non-numeric/negative limit falls back to the default
+    // 20 (not NaN/negative passed downstream to Neynar), capped at 50.
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '20', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : rawLimit, 50);
     const cursor = req.nextUrl.searchParams.get('cursor') || undefined;
 
     if (mode === 'relevant') {

--- a/src/app/api/miniapp/search/__tests__/route.test.ts
+++ b/src/app/api/miniapp/search/__tests__/route.test.ts
@@ -1,0 +1,322 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockSearchFrames } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockSearchFrames: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  searchFrames: mockSearchFrames,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/miniapp/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========================================================================
+  // Auth tests (401)
+  // ========================================================================
+
+  it('returns 401 when session is not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'valid' }));
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  // ========================================================================
+  // Query validation tests (400)
+  // ========================================================================
+
+  it('returns 400 when q parameter is missing', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search'));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query required' });
+  });
+
+  it('returns 400 when q parameter is empty string', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: '' }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query required' });
+  });
+
+  it('returns 400 when q parameter exceeds 100 characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const longQuery = 'a'.repeat(101);
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: longQuery }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query required' });
+  });
+
+  it('accepts q parameter at exactly 100 characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const query100Chars = 'a'.repeat(100);
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: query100Chars }));
+    expect(res.status).toBe(200);
+  });
+
+  it('accepts q parameter at exactly 1 character', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'a' }));
+    expect(res.status).toBe(200);
+  });
+
+  // ========================================================================
+  // Limit parameter tests
+  // ========================================================================
+
+  it('uses default limit of 20 when limit parameter is not provided', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 20);
+  });
+
+  it('uses limit parameter when provided', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: '30' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 30);
+  });
+
+  it('caps limit at 50 when limit exceeds 50', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: '100' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 50);
+  });
+
+  it('falls back to default limit (20) when limit is not a valid number', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: 'invalid' }));
+
+    // Regression guard: a non-numeric limit clamps to 20, never passes NaN to
+    // searchFrames (String(NaN) → ?limit=NaN → Neynar 400 → 500).
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 20);
+  });
+
+  it('accepts limit of 1', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: '1' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 1);
+  });
+
+  // ========================================================================
+  // Success path tests (200)
+  // ========================================================================
+
+  it('returns 200 with data from searchFrames on success', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const mockData = {
+      frames: [
+        { id: 'frame-1', name: 'Frame 1' },
+        { id: 'frame-2', name: 'Frame 2' },
+      ],
+    };
+
+    mockSearchFrames.mockResolvedValue(mockData);
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'game' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual(mockData);
+  });
+
+  it('returns 200 with empty frames array', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'nonexistent' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ frames: [] });
+  });
+
+  it('passes correct query to searchFrames', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const testQuery = 'special search query';
+    await GET(makeGetRequest('/api/miniapp/search', { q: testQuery }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith(testQuery, 20);
+  });
+
+  it('calls searchFrames exactly once per request', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledTimes(1);
+  });
+
+  // ========================================================================
+  // Error handling tests (500)
+  // ========================================================================
+
+  it('returns 500 when searchFrames throws an error', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockRejectedValue(new Error('Neynar API error'));
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Failed to search mini apps' });
+  });
+
+  it('returns 500 when searchFrames throws a non-Error value', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockRejectedValue('Unknown error');
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Failed to search mini apps' });
+  });
+
+  it('logs error when searchFrames fails', async () => {
+    const { logger } = await vi.importMock('@/lib/logger');
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const testError = new Error('Test API failure');
+    mockSearchFrames.mockRejectedValue(testError);
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+
+    expect(logger.error).toHaveBeenCalledWith('[miniapp/search] GET error:', testError);
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  it('handles query with special characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const specialQuery = '@#$%^&*()';
+    await GET(makeGetRequest('/api/miniapp/search', { q: specialQuery }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith(specialQuery, 20);
+  });
+
+  it('handles query with unicode characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const unicodeQuery = '日本語';
+    await GET(makeGetRequest('/api/miniapp/search', { q: unicodeQuery }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith(unicodeQuery, 20);
+  });
+
+  it('handles query with whitespace', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const whitespaceQuery = '   multiple   spaces   ';
+    await GET(makeGetRequest('/api/miniapp/search', { q: whitespaceQuery }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith(whitespaceQuery, 20);
+  });
+
+  it('handles limit parameter with leading zeros', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: '0030' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 30);
+  });
+
+  it('falls back to default limit (20) for a negative limit parameter', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    await GET(makeGetRequest('/api/miniapp/search', { q: 'test', limit: '-5' }));
+
+    expect(mockSearchFrames).toHaveBeenCalledWith('test', 20);
+  });
+
+  it('returns authenticated user session data available during request', async () => {
+    mockGetSessionData.mockResolvedValue({
+      fid: 456,
+      username: 'anotheruser',
+      displayName: 'Another User',
+      isAdmin: true,
+    });
+
+    mockSearchFrames.mockResolvedValue({ frames: [] });
+
+    const res = await GET(makeGetRequest('/api/miniapp/search', { q: 'test' }));
+    expect(res.status).toBe(200);
+
+    expect(mockGetSessionData).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/miniapp/search/route.ts
+++ b/src/app/api/miniapp/search/route.ts
@@ -18,7 +18,10 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '20', 10), 50);
+    // Defensively clamp: a non-numeric/negative limit falls back to the default
+    // 20 (not NaN/negative passed downstream to Neynar), capped at 50.
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '20', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : rawLimit, 50);
     const data = await searchFrames(parsed.data.q, limit);
     return NextResponse.json(data);
   } catch (err) {


### PR DESCRIPTION
## Bug

`GET /api/bluesky/feed` (public Bluesky feed-generator, called by Bluesky's AppView) is documented to **defensively clamp/ignore bad input so the feed keeps rendering** — never 400/500. But:

```ts
const limit = Math.min(parseInt(searchParams.get('limit') || '30', 10), 100);
```

`parseInt('notanumber', 10)` → `NaN`, and `Math.min(NaN, 100)` → `NaN`. That `NaN` (and any zero/negative limit) was passed straight into `getFeedSkeleton` → supabase `.limit(NaN)`, which throws → the route returns **500 on garbage input**, violating its own stated contract. Since Bluesky's AppView controls the query string, a malformed `limit` breaks the whole feed.

## Fix

Clamp `NaN` / `< 1` to the default 30 (still capped at 100):

```ts
const rawLimit = parseInt(searchParams.get('limit') || '30', 10);
const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 30 : rawLimit, 100);
```

## Tests (21)

Success, cursor clamp (>200 chars ignored), limit cap at 100, and **NaN / zero / negative → 30** regression guards. Found while writing coverage for this route.

Runtime route change → **your review**. Low-risk defensive clamp, no behavior change for valid input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)