### PR TITLE
test(autocliper,chat): drafts/approve/search/hide coverage (98 tests)

### DIFF
--- a/src/app/api/autocliper/approve/__tests__/route.test.ts
+++ b/src/app/api/autocliper/approve/__tests__/route.test.ts
@@ -1,0 +1,763 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClipMetadata } from '@/lib/autocliper';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockValidateRequest, mockGetClipDraft, mockApproveClipDraft } =
+  vi.hoisted(() => ({
+    mockGetSessionData: vi.fn(),
+    mockValidateRequest: vi.fn(),
+    mockGetClipDraft: vi.fn(),
+    mockApproveClipDraft: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/autocliper', () => ({
+  validateRequest: mockValidateRequest,
+  getClipDraft: mockGetClipDraft,
+  approveClipDraft: mockApproveClipDraft,
+  ApprovalRequestSchema: { parse: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/autocliper/approve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========================================================================
+  // Authentication tests
+  // ========================================================================
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/autocliper/approve', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session is undefined (safety check)', async () => {
+    mockGetSessionData.mockResolvedValue(undefined);
+
+    const req = makePostRequest('/api/autocliper/approve', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ========================================================================
+  // Validation tests
+  // ========================================================================
+
+  it('returns 400 when validation fails with error message', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = { clipId: 'not-a-uuid' };
+    const validationError = 'clipId: Invalid UUID format';
+
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: validationError,
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe(validationError);
+  });
+
+  it('returns 400 when clipId is missing from validation', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = {};
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: 'clipId: Required',
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('clipId: Required');
+  });
+
+  it('returns 400 when multiple validation errors occur', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = { clipId: 'bad', platforms: 'not-array' };
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: 'clipId: Invalid UUID; platforms: Expected array',
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('clipId: Invalid UUID');
+  });
+
+  // ========================================================================
+  // Clip not found tests
+  // ========================================================================
+
+  it('returns 404 when clip draft does not exist', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockReturnValue(undefined);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip not found');
+    expect(body.error).toContain(clipId);
+  });
+
+  it('returns 404 when getClipDraft returns null', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockReturnValue(null);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip not found');
+  });
+
+  // ========================================================================
+  // Clip stage validation tests
+  // ========================================================================
+
+  it('returns 400 when clip is not in draft stage', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('not a draft');
+    expect(body.error).toContain('approved');
+  });
+
+  it('returns 400 when clip is in published stage', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const publishedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'published',
+      stagedAt: new Date().toISOString(),
+      publishedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('not a draft');
+    expect(body.error).toContain('published');
+  });
+
+  it('returns 400 when clip is in rejected stage', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const rejectedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'rejected',
+      stagedAt: new Date().toISOString(),
+      rejectedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(rejectedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('not a draft');
+    expect(body.error).toContain('rejected');
+  });
+
+  // ========================================================================
+  // Success path tests
+  // ========================================================================
+
+  it('returns 200 and calls approveClipDraft on valid request', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'A test clip for approval',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean; clip: ClipMetadata; message: string };
+    expect(body.success).toBe(true);
+    expect(body.clip.stage).toBe('approved');
+    expect(body.message).toBe('Clip approved for publishing');
+    expect(mockApproveClipDraft).toHaveBeenCalledWith(clipId);
+  });
+
+  it('returns 200 with approved clip metadata including approvedAt timestamp', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    const approvedAtTime = new Date().toISOString();
+
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Premium Content',
+      description: 'High value clip',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: approvedAtTime,
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean; clip: ClipMetadata; message: string };
+    expect(body.clip.approvedAt).toBe(approvedAtTime);
+    expect(body.clip.title).toBe('Premium Content');
+    expect(body.clip.description).toBe('High value clip');
+  });
+
+  it('accepts optional platforms parameter in request body', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, platforms: ['warpcast', 'x'] },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', {
+      clipId,
+      platforms: ['warpcast', 'x'],
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean; clip: ClipMetadata };
+    expect(body.success).toBe(true);
+  });
+
+  it('accepts optional approvedBy parameter in request body', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, approvedBy: 'admin-user' },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', {
+      clipId,
+      approvedBy: 'admin-user',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean; clip: ClipMetadata };
+    expect(body.success).toBe(true);
+  });
+
+  // ========================================================================
+  // Error handling tests
+  // ========================================================================
+
+  it('returns 500 when getSessionData throws an error', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('Session error'));
+
+    const req = makePostRequest('/api/autocliper/approve', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Session error');
+  });
+
+  it('returns 500 when request.json() throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const badRequest = new Request('http://localhost:3000/api/autocliper/approve', {
+      method: 'POST',
+      body: 'invalid json',
+    });
+
+    const res = await POST(badRequest as unknown as Request);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 500 when getClipDraft throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw new Error('Database error on getClipDraft');
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Database error');
+  });
+
+  it('returns 500 when approveClipDraft throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    mockApproveClipDraft.mockImplementation(() => {
+      throw new Error('Failed to approve clip');
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Failed to approve clip');
+  });
+
+  it('logs error to console when exception occurs', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw new Error('Test error message');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    await POST(req);
+
+    expect(consoleSpy).toHaveBeenCalledWith('[api/autocliper/approve]', 'Test error message');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles non-Error thrown values gracefully', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw 'String error instead of Error object';
+    });
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unknown error');
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  it('extracts clipId correctly from validated data record', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, extraField: 'ignored' },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockGetClipDraft).toHaveBeenCalledWith(clipId);
+  });
+
+  it('handles clip with full metadata including highlights and generated clips', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+      highlights: [
+        {
+          id: 'h1',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          score: 0.95,
+          reason: 'High engagement moment',
+        },
+      ],
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Amazing moment',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { success: boolean; clip: ClipMetadata };
+    expect(body.clip.highlights).toHaveLength(1);
+    expect(body.clip.generatedClips).toHaveLength(1);
+  });
+
+  it('response includes correct ApiResponse structure', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const approvedClip: ClipMetadata = {
+      ...draftClip,
+      stage: 'approved',
+      approvedAt: new Date().toISOString(),
+    };
+
+    mockApproveClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/approve', { clipId });
+
+    const res = await POST(req);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('success');
+    expect(body).toHaveProperty('clip');
+    expect(body).toHaveProperty('message');
+    expect(typeof body.success).toBe('boolean');
+    expect(typeof body.message).toBe('string');
+  });
+});

--- a/src/app/api/autocliper/drafts/__tests__/route.test.ts
+++ b/src/app/api/autocliper/drafts/__tests__/route.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClipMetadata, ClipStage } from '@/lib/autocliper';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockListClipsByStage, mockGetDraftStats } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockListClipsByStage: vi.fn(),
+  mockGetDraftStats: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/autocliper', () => ({
+  listClipsByStage: (...args: unknown[]) => mockListClipsByStage(...args),
+  getDraftStats: () => mockGetDraftStats(),
+}));
+
+import { GET } from '../route';
+
+/** Factory for creating mock ClipMetadata objects */
+function createMockClip(overrides?: Partial<ClipMetadata>): ClipMetadata {
+  return {
+    id: 'clip-001',
+    sourceUrl: 'https://example.com/video',
+    sourceType: 'stream',
+    title: 'Test Clip',
+    description: 'A test clip',
+    createdAt: new Date().toISOString(),
+    stage: 'draft',
+    stagedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('GET /api/autocliper/drafts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockListClipsByStage.mockReturnValue([]);
+    mockGetDraftStats.mockReturnValue({
+      total: 0,
+      byStage: { draft: 0, approved: 0, published: 0, rejected: 0 },
+    });
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts'));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockListClipsByStage).not.toHaveBeenCalled();
+      expect(mockGetDraftStats).not.toHaveBeenCalled();
+    });
+
+    it('succeeds with an authenticated session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts'));
+
+      expect(res.status).toBe(200);
+      expect(mockListClipsByStage).toHaveBeenCalled();
+    });
+  });
+
+  describe('stage parameter handling', () => {
+    it('returns all clips when no stage parameter is provided', async () => {
+      const draftClip = createMockClip({ id: 'draft-1', stage: 'draft' });
+      const approvedClip = createMockClip({ id: 'approved-1', stage: 'approved' });
+      const publishedClip = createMockClip({ id: 'published-1', stage: 'published' });
+      const rejectedClip = createMockClip({ id: 'rejected-1', stage: 'rejected' });
+
+      mockListClipsByStage.mockImplementation((stage: ClipStage) => {
+        const stageMap: Record<ClipStage, ClipMetadata[]> = {
+          draft: [draftClip],
+          approved: [approvedClip],
+          published: [publishedClip],
+          rejected: [rejectedClip],
+        };
+        return stageMap[stage];
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts'));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.clips)).toBe(true);
+      expect((body.clips as unknown[]).length).toBe(4);
+      expect(mockListClipsByStage).toHaveBeenCalledTimes(4);
+      expect(mockListClipsByStage).toHaveBeenNthCalledWith(1, 'draft');
+      expect(mockListClipsByStage).toHaveBeenNthCalledWith(2, 'approved');
+      expect(mockListClipsByStage).toHaveBeenNthCalledWith(3, 'published');
+      expect(mockListClipsByStage).toHaveBeenNthCalledWith(4, 'rejected');
+    });
+
+    it('returns only draft stage clips when ?stage=draft', async () => {
+      const draftClip = createMockClip({ id: 'draft-1', stage: 'draft' });
+      mockListClipsByStage.mockReturnValue([draftClip]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.clips)).toBe(true);
+      expect((body.clips as unknown[]).length).toBe(1);
+      expect(mockListClipsByStage).toHaveBeenCalledTimes(1);
+      expect(mockListClipsByStage).toHaveBeenCalledWith('draft');
+    });
+
+    it('returns only approved stage clips when ?stage=approved', async () => {
+      const approvedClip = createMockClip({ id: 'approved-1', stage: 'approved' });
+      mockListClipsByStage.mockReturnValue([approvedClip]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'approved' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect((body.clips as unknown[]).length).toBe(1);
+      expect(mockListClipsByStage).toHaveBeenCalledWith('approved');
+    });
+
+    it('returns only published stage clips when ?stage=published', async () => {
+      const publishedClip = createMockClip({ id: 'published-1', stage: 'published' });
+      mockListClipsByStage.mockReturnValue([publishedClip]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'published' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect((body.clips as unknown[]).length).toBe(1);
+      expect(mockListClipsByStage).toHaveBeenCalledWith('published');
+    });
+
+    it('returns only rejected stage clips when ?stage=rejected', async () => {
+      const rejectedClip = createMockClip({ id: 'rejected-1', stage: 'rejected' });
+      mockListClipsByStage.mockReturnValue([rejectedClip]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'rejected' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect((body.clips as unknown[]).length).toBe(1);
+      expect(mockListClipsByStage).toHaveBeenCalledWith('rejected');
+    });
+
+    it('returns 400 when stage parameter is invalid', async () => {
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'invalid-stage' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(String(body.error)).toContain('Invalid stage: invalid-stage');
+      expect(mockListClipsByStage).not.toHaveBeenCalled();
+    });
+
+    it('treats empty string stage as no stage parameter (returns all clips)', async () => {
+      const draftClip = createMockClip({ id: 'draft-1', stage: 'draft' });
+      const approvedClip = createMockClip({ id: 'approved-1', stage: 'approved' });
+
+      mockListClipsByStage.mockImplementation((stage: ClipStage) => {
+        const stageMap: Record<ClipStage, ClipMetadata[]> = {
+          draft: [draftClip],
+          approved: [approvedClip],
+          published: [],
+          rejected: [],
+        };
+        return stageMap[stage];
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: '' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      // Should call listClipsByStage 4 times (once per stage)
+      expect(mockListClipsByStage).toHaveBeenCalledTimes(4);
+    });
+
+    it('rejects stage parameter with special characters', async () => {
+      const res = await GET(
+        makeGetRequest('/api/autocliper/drafts', { stage: 'draft; DROP TABLE' }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe('response shape', () => {
+    it('includes success, clips, stats, and count in response', async () => {
+      const clip1 = createMockClip({ id: 'clip-1', stage: 'draft' });
+      const clip2 = createMockClip({ id: 'clip-2', stage: 'draft' });
+
+      mockListClipsByStage.mockImplementation((stage: ClipStage) => {
+        if (stage === 'draft') return [clip1, clip2];
+        return [];
+      });
+
+      mockGetDraftStats.mockReturnValue({
+        total: 2,
+        byStage: { draft: 2, approved: 0, published: 0, rejected: 0 },
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.clips)).toBe(true);
+      expect(body.stats).toBeDefined();
+      expect(body.count).toBe(2);
+    });
+
+    it('includes accurate count of clips returned', async () => {
+      const clips = [
+        createMockClip({ id: 'clip-1', stage: 'draft' }),
+        createMockClip({ id: 'clip-2', stage: 'draft' }),
+        createMockClip({ id: 'clip-3', stage: 'draft' }),
+      ];
+
+      mockListClipsByStage.mockReturnValue(clips);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.count).toBe(3);
+      expect((body.clips as unknown[]).length).toBe(3);
+    });
+
+    it('returns stats with all stages when all stages requested', async () => {
+      const stats = {
+        total: 10,
+        byStage: { draft: 3, approved: 2, published: 4, rejected: 1 },
+      };
+
+      mockGetDraftStats.mockReturnValue(stats);
+      mockListClipsByStage.mockReturnValue([]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts'));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.stats).toEqual(stats);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when listClipsByStage throws', async () => {
+      mockListClipsByStage.mockImplementation(() => {
+        throw new Error('Database connection failed');
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(500);
+      expect(body.success).toBe(false);
+      expect(String(body.error)).toContain('Database connection failed');
+    });
+
+    it('returns 500 when getDraftStats throws', async () => {
+      mockListClipsByStage.mockReturnValue([]);
+      mockGetDraftStats.mockImplementation(() => {
+        throw new Error('Stats aggregation failed');
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(500);
+      expect(body.success).toBe(false);
+      expect(String(body.error)).toContain('Stats aggregation failed');
+    });
+
+    it('returns 500 with generic message for unknown errors', async () => {
+      mockListClipsByStage.mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/no-throw-literal
+        throw 'not an error object';
+      });
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'draft' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(500);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Unknown error');
+    });
+  });
+
+  describe('clip data preservation', () => {
+    it('preserves clip metadata in response', async () => {
+      const clip = createMockClip({
+        id: 'clip-123',
+        sourceUrl: 'https://example.com/video.mp4',
+        sourceType: 'stream',
+        title: 'Great Moment',
+        description: 'A great moment from the stream',
+        tags: ['important', 'viral'],
+        mentions: ['@user1', '@user2'],
+        stage: 'approved',
+      });
+
+      mockListClipsByStage.mockReturnValue([clip]);
+
+      const res = await GET(makeGetRequest('/api/autocliper/drafts', { stage: 'approved' }));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      const returnedClips = body.clips as unknown[];
+      expect(returnedClips.length).toBe(1);
+      const returnedClip = returnedClips[0] as Record<string, unknown>;
+      expect(returnedClip.id).toBe('clip-123');
+      expect(returnedClip.title).toBe('Great Moment');
+      expect(returnedClip.sourceType).toBe('stream');
+      expect(returnedClip.tags).toEqual(['important', 'viral']);
+    });
+  });
+});

--- a/src/app/api/chat/hide/__tests__/route.test.ts
+++ b/src/app/api/chat/hide/__tests__/route.test.ts
@@ -1,0 +1,500 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetClientIp, mockLogAuditEvent } = vi.hoisted(() => ({
+  mockGetClientIp: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  getClientIp: mockGetClientIp,
+  logAuditEvent: mockLogAuditEvent,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/chat/hide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+    mockFrom.mockReturnValue(chainMock({ error: null }).chain);
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when castHash is missing', async () => {
+      const res = await POST(makePostRequest('/api/chat/hide', { reason: 'spam' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when castHash is invalid format', async () => {
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: 'not-a-valid-hash',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when castHash is too short', async () => {
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when reason exceeds max length (500 chars)', async () => {
+      const longReason = 'a'.repeat(501);
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: longReason,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid 40-char hash (0x + 40 hex)', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0xabcdef1234567890abcdef1234567890abcdef12',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(mockFrom).toHaveBeenCalledWith('hidden_messages');
+    });
+
+    it('accepts valid 64-char hash (0x + 64 hex)', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts request without optional reason', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts reason with exactly 500 chars', async () => {
+      const maxReason = 'a'.repeat(500);
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: maxReason,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('calls supabaseAdmin.from with hidden_messages table', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('hidden_messages');
+    });
+
+    it('performs upsert with correct payload structure', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      expect(upsertCall).toHaveBeenCalled();
+      const [payload, options] = upsertCall.mock.calls[0] as unknown as Array<unknown>;
+
+      expect(payload).toEqual({
+        cast_hash: '0x1234567890abcdef1234567890abcdef12345678',
+        hidden_by_fid: 123,
+        reason: 'spam',
+      });
+      expect(options).toEqual({ onConflict: 'cast_hash' });
+    });
+
+    it('upserts with null reason when reason is not provided', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as Array<unknown>;
+
+      expect(payload).toEqual({
+        cast_hash: '0x1234567890abcdef1234567890abcdef12345678',
+        hidden_by_fid: 123,
+        reason: null,
+      });
+    });
+
+    it('uses admin session fid in hidden_by_fid field', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [{ hidden_by_fid: number }];
+
+      expect(payload.hidden_by_fid).toBe(999);
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event after successful upsert', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'message.hide',
+          targetType: 'cast',
+          targetId: '0x1234567890abcdef1234567890abcdef12345678',
+          details: { reason: 'spam' },
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('logs audit event with null reason when reason not provided', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'message.hide',
+          targetType: 'cast',
+          targetId: '0x1234567890abcdef1234567890abcdef12345678',
+          details: { reason: null },
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('calls getClientIp with the request object', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/chat/hide', {
+        castHash: '0x1234567890abcdef1234567890abcdef12345678',
+        reason: 'spam',
+      });
+
+      await POST(req);
+
+      expect(mockGetClientIp).toHaveBeenCalledWith(req);
+    });
+
+    it('includes correct client IP in audit event', async () => {
+      mockGetClientIp.mockReturnValue('203.0.113.42');
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ipAddress: '203.0.113.42',
+        }),
+      );
+    });
+
+    it('logs audit event with undefined ipAddress when getClientIp returns undefined', async () => {
+      mockGetClientIp.mockReturnValue(undefined);
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ipAddress: undefined,
+        }),
+      );
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with success true on valid request', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(Object.keys(body)).toEqual(['success']);
+    });
+
+    it('does not expose internal details in success response', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.data).toBeUndefined();
+      expect(body.details).toBeUndefined();
+      expect(body.fid).toBeUndefined();
+      expect(body.castHash).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when Supabase upsert returns an error', async () => {
+      const dbError = new Error('Unique constraint violation');
+      mockFrom.mockReturnValue(chainMock({ error: dbError }).chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to hide message');
+    });
+
+    it('returns 500 when request body is not valid JSON', async () => {
+      // Manually override the body to trigger JSON parsing error
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/chat/hide', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await POST(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to hide message');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = new Error('Database connection failed');
+      mockFrom.mockReturnValue(chainMock({ error: dbError }).chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Hide message error:',
+        expect.any(Error),
+      );
+    });
+
+    it('does not log audit event when Supabase upsert fails', async () => {
+      const dbError = new Error('Database error');
+      mockFrom.mockReturnValue(chainMock({ error: dbError }).chain);
+
+      await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Password: hunter2, connection to db.example.com failed');
+      mockFrom.mockReturnValue(chainMock({ error: dbError }).chain);
+
+      const res = await POST(
+        makePostRequest('/api/chat/hide', {
+          castHash: '0x1234567890abcdef1234567890abcdef12345678',
+          reason: 'spam',
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to hide message');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+  });
+});

--- a/src/app/api/chat/search/__tests__/route.test.ts
+++ b/src/app/api/chat/search/__tests__/route.test.ts
@@ -1,0 +1,917 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    NEYNAR_API_KEY: 'test-neynar-key-123',
+  },
+}));
+
+// Mock fetch globally for Neynar requests
+global.fetch = vi.fn();
+
+import { GET } from '../route';
+
+describe('GET /api/chat/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========================================================================
+  // Authentication tests
+  // ========================================================================
+
+  it('returns 401 when session is not authenticated', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test' }));
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  // ========================================================================
+  // Query validation tests
+  // ========================================================================
+
+  it('returns 400 when query is missing', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/chat/search'));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query must be at least 2 characters' });
+  });
+
+  it('returns 400 when query is less than 2 characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'a' }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query must be at least 2 characters' });
+  });
+
+  it('returns 400 when query is only whitespace', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: '   ' }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Query must be at least 2 characters' });
+  });
+
+  it('accepts query with exactly 2 characters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    // Mock Neynar fetch to fail (OK is enough for validation test)
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    // Mock supabase empty results
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'ab', channel: 'zao' }));
+    expect(res.status).toBe(200);
+  });
+
+  // ========================================================================
+  // Channel validation tests
+  // ========================================================================
+
+  it('returns 400 for invalid channel', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'invalid' }));
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Invalid channel' });
+  });
+
+  it('uses default channel "zao" when channel param is missing', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test' }));
+    expect(res.status).toBe(200);
+
+    // Verify supabase .eq was called with 'zao'
+    expect(mockFrom).toHaveBeenCalledWith('channel_casts');
+    const chain = mockFrom.mock.results[0].value;
+    expect(chain.eq).toHaveBeenCalledWith('channel_id', 'zao');
+  });
+
+  it('accepts valid channels', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    // Test each valid channel from community.config
+    const validChannels = ['zao', 'zabal', 'cocconcertz', 'wavewarz'];
+
+    for (const channel of validChannels) {
+      vi.clearAllMocks();
+      mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+      mockFrom.mockReturnValue(mockSupabaseChain({ data: [], error: null }));
+
+      const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel }));
+      expect(res.status).toBe(200);
+    }
+  });
+
+  // ========================================================================
+  // Wildcard escaping tests
+  // ========================================================================
+
+  it('escapes % wildcards in query for supabase search', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test%query', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    // Verify the ilike call has escaped the %
+    const chain = mockFrom.mock.results[0].value;
+    expect(chain.ilike).toHaveBeenCalledWith('text', expect.stringContaining('test\\%query'));
+  });
+
+  it('escapes _ wildcards in query for supabase search', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test_query', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const chain = mockFrom.mock.results[0].value;
+    expect(chain.ilike).toHaveBeenCalledWith('text', expect.stringContaining('test\\_query'));
+  });
+
+  it('escapes backslash in query for supabase search', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test\\query', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const chain = mockFrom.mock.results[0].value;
+    expect(chain.ilike).toHaveBeenCalledWith('text', expect.stringContaining('test\\\\query'));
+  });
+
+  it('escapes multiple special characters in query', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(
+      makeGetRequest('/api/chat/search', { q: '%test_query\\', channel: 'zao' }),
+    );
+    expect(res.status).toBe(200);
+
+    const chain = mockFrom.mock.results[0].value;
+    expect(chain.ilike).toHaveBeenCalledWith(
+      'text',
+      expect.stringContaining('\\%test\\_query\\\\'),
+    );
+  });
+
+  // ========================================================================
+  // Supabase search tests
+  // ========================================================================
+
+  it('queries supabase channel_casts table with correct parameters', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    await GET(makeGetRequest('/api/chat/search', { q: 'search term', channel: 'zao' }));
+
+    expect(mockFrom).toHaveBeenCalledWith('channel_casts');
+    const chain = mockFrom.mock.results[0].value;
+
+    expect(chain.select).toHaveBeenCalledWith('*');
+    expect(chain.eq).toHaveBeenCalledWith('channel_id', 'zao');
+    expect(chain.ilike).toHaveBeenCalledWith('text', expect.stringContaining('search term'));
+    expect(chain.order).toHaveBeenCalledWith('timestamp', { ascending: false });
+    expect(chain.limit).toHaveBeenCalledWith(20);
+  });
+
+  it('returns db results when supabase returns data', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const dbResults = [
+      {
+        hash: 'hash1',
+        fid: 456,
+        author_username: 'author1',
+        author_display: 'Author One',
+        author_pfp: 'pfp1.jpg',
+        text: 'This is a test message',
+        timestamp: '2026-07-16T10:00:00Z',
+        replies_count: 5,
+      },
+    ];
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toEqual({
+      hash: 'hash1',
+      author: {
+        fid: 456,
+        username: 'author1',
+        display_name: 'Author One',
+        pfp_url: 'pfp1.jpg',
+      },
+      text: 'This is a test message',
+      timestamp: '2026-07-16T10:00:00Z',
+      replies: { count: 5 },
+    });
+  });
+
+  // ========================================================================
+  // Neynar fetch tests
+  // ========================================================================
+
+  it('calls Neynar search API with correct headers and params', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    await GET(makeGetRequest('/api/chat/search', { q: 'search term', channel: 'zao' }));
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('https://api.neynar.com/v2/farcaster/cast/search'),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'test-neynar-key-123',
+        },
+      },
+    );
+
+    // Verify URL contains search params (URLSearchParams encodes spaces as +)
+    const callArgs = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(callArgs).toContain('q=search+term');
+    expect(callArgs).toContain('limit=20');
+    expect(callArgs).toContain('channel_id=zao');
+  });
+
+  it('returns Neynar results when search succeeds', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: 'neynar_hash1',
+            author: {
+              fid: 789,
+              username: 'neynar_author',
+              display_name: 'Neynar Author',
+              pfp_url: 'neynar_pfp.jpg',
+            },
+            text: 'Neynar cast message',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 3 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0]).toEqual({
+      hash: 'neynar_hash1',
+      author: {
+        fid: 789,
+        username: 'neynar_author',
+        display_name: 'Neynar Author',
+        pfp_url: 'neynar_pfp.jpg',
+      },
+      text: 'Neynar cast message',
+      timestamp: '2026-07-16T09:00:00Z',
+      replies: { count: 3 },
+    });
+  });
+
+  // ========================================================================
+  // Result merging and deduplication tests
+  // ========================================================================
+
+  it('deduplicates results by hash when both Neynar and DB return same cast', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const sharedHash = 'shared_hash';
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: sharedHash,
+            author: { fid: 789, username: 'author', display_name: 'Author', pfp_url: 'pfp.jpg' },
+            text: 'Same message',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 3 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const dbResults = [
+      {
+        hash: sharedHash,
+        fid: 789,
+        author_username: 'author',
+        author_display: 'Author',
+        author_pfp: 'pfp.jpg',
+        text: 'Same message',
+        timestamp: '2026-07-16T09:00:00Z',
+        replies_count: 3,
+      },
+    ];
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // Should only have 1 result despite both sources returning it
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].hash).toBe(sharedHash);
+  });
+
+  it('merges Neynar results first, then unique DB results', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: 'neynar1',
+            author: { fid: 1, username: 'author1', display_name: 'Author 1', pfp_url: 'pfp1.jpg' },
+            text: 'Neynar message',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 0 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const dbResults = [
+      {
+        hash: 'db1',
+        fid: 2,
+        author_username: 'author2',
+        author_display: 'Author 2',
+        author_pfp: 'pfp2.jpg',
+        text: 'DB message',
+        timestamp: '2026-07-16T08:00:00Z',
+        replies_count: 1,
+      },
+    ];
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(2);
+    expect(body.results[0].hash).toBe('neynar1');
+    expect(body.results[1].hash).toBe('db1');
+  });
+
+  // ========================================================================
+  // Hidden messages filtering tests
+  // ========================================================================
+
+  it('filters out hidden messages from results', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: 'visible_hash',
+            author: { fid: 1, username: 'author', display_name: 'Author', pfp_url: 'pfp.jpg' },
+            text: 'Visible message',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 0 },
+          },
+          {
+            hash: 'hidden_hash',
+            author: { fid: 2, username: 'author2', display_name: 'Author 2', pfp_url: 'pfp2.jpg' },
+            text: 'Should be hidden',
+            timestamp: '2026-07-16T08:00:00Z',
+            replies: { count: 0 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'channel_casts') {
+        return mockSupabaseChain({ data: [], error: null });
+      }
+      if (table === 'hidden_messages') {
+        return mockSupabaseChain(
+          { data: [{ cast_hash: 'hidden_hash' }], error: null },
+          true, // isHiddenTable
+        );
+      }
+      return mockSupabaseChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].hash).toBe('visible_hash');
+  });
+
+  it('handles empty hidden_messages table gracefully', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: 'hash1',
+            author: { fid: 1, username: 'author', display_name: 'Author', pfp_url: 'pfp.jpg' },
+            text: 'Message 1',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 0 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'hidden_messages') {
+        return mockSupabaseChain({ data: [], error: null }, true);
+      }
+      return mockSupabaseChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+  });
+
+  // ========================================================================
+  // Limit and slicing tests
+  // ========================================================================
+
+  it('limits results to SEARCH_LIMIT (20)', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    // Create 25 results
+    const casts = Array.from({ length: 25 }, (_, i) => ({
+      hash: `hash_${i}`,
+      author: { fid: i, username: `author${i}`, display_name: `Author ${i}`, pfp_url: 'pfp.jpg' },
+      text: `Message ${i}`,
+      timestamp: '2026-07-16T09:00:00Z',
+      replies: { count: 0 },
+    }));
+
+    const neynarResponse = { result: { casts } };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(20);
+  });
+
+  // ========================================================================
+  // Error handling tests
+  // ========================================================================
+
+  it('handles supabase channel_casts returning null gracefully', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    // Supabase returns { data: null, error: null } as a valid response
+    const mockChain = mockSupabaseChain({ data: null, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toEqual([]);
+  });
+
+  it('handles supabase hidden_messages returning null gracefully', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const neynarResponse = {
+      result: {
+        casts: [
+          {
+            hash: 'hash1',
+            author: { fid: 1, username: 'author', display_name: 'Author', pfp_url: 'pfp.jpg' },
+            text: 'Message',
+            timestamp: '2026-07-16T09:00:00Z',
+            replies: { count: 0 },
+          },
+        ],
+      },
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => neynarResponse,
+    });
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'hidden_messages') {
+        return mockSupabaseChain({ data: null, error: null }, true);
+      }
+      return mockSupabaseChain({ data: [], error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    // Should still have the Neynar result
+    expect(body.results).toHaveLength(1);
+  });
+
+  it('gracefully handles Neynar fetch failure and falls back to DB', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network error'));
+
+    const dbResults = [
+      {
+        hash: 'db_hash',
+        fid: 1,
+        author_username: 'author',
+        author_display: 'Author',
+        author_pfp: 'pfp.jpg',
+        text: 'DB result',
+        timestamp: '2026-07-16T09:00:00Z',
+        replies_count: 0,
+      },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'hidden_messages') {
+        return mockSupabaseChain({ data: [], error: null }, true);
+      }
+      return mockSupabaseChain({ data: dbResults, error: null });
+    });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].hash).toBe('db_hash');
+  });
+
+  it('returns 500 on unexpected error during search', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+    });
+
+    // Mock supabase to throw an unexpected error
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected database error');
+    });
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Search failed' });
+  });
+
+  // ========================================================================
+  // Response shape tests
+  // ========================================================================
+
+  it('returns results array in response', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveProperty('results');
+    expect(Array.isArray(body.results)).toBe(true);
+  });
+
+  it('formats author object correctly in results', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const dbResults = [
+      {
+        hash: 'hash1',
+        fid: 456,
+        author_username: 'test_author',
+        author_display: 'Test Author',
+        author_pfp: 'https://example.com/pfp.jpg',
+        text: 'Test message',
+        timestamp: '2026-07-16T10:00:00Z',
+        replies_count: 5,
+      },
+    ];
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results[0].author).toEqual({
+      fid: 456,
+      username: 'test_author',
+      display_name: 'Test Author',
+      pfp_url: 'https://example.com/pfp.jpg',
+    });
+  });
+
+  it('formats replies object correctly in results', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const dbResults = [
+      {
+        hash: 'hash1',
+        fid: 456,
+        author_username: 'author',
+        author_display: 'Author',
+        author_pfp: 'pfp.jpg',
+        text: 'Message',
+        timestamp: '2026-07-16T10:00:00Z',
+        replies_count: 12,
+      },
+    ];
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results[0].replies).toEqual({ count: 12 });
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  it('handles null/undefined author fields gracefully', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const dbResults = [
+      {
+        hash: 'hash1',
+        fid: 456,
+        author_username: null,
+        author_display: undefined,
+        author_pfp: null,
+        text: 'Message',
+        timestamp: '2026-07-16T10:00:00Z',
+        replies_count: 0,
+      },
+    ];
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const mockChain = mockSupabaseChain({ data: dbResults, error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results[0].author).toEqual({
+      fid: 456,
+      username: '',
+      display_name: '',
+      pfp_url: '',
+    });
+  });
+
+  it('handles Neynar response with missing result field', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const invalidResponse = {}; // Missing result field
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => invalidResponse,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toEqual([]);
+  });
+
+  it('handles Neynar response with missing casts field', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const invalidResponse = { result: {} }; // Missing casts field
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => invalidResponse,
+    });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    const res = await GET(makeGetRequest('/api/chat/search', { q: 'test', channel: 'zao' }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.results).toEqual([]);
+  });
+
+  it('trims whitespace from query parameter', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false });
+
+    const mockChain = mockSupabaseChain({ data: [], error: null });
+    mockFrom.mockReturnValue(mockChain);
+
+    await GET(makeGetRequest('/api/chat/search', { q: '   test query   ', channel: 'zao' }));
+
+    const chain = mockFrom.mock.results[0].value;
+    const ilikeCall = chain.ilike.mock.calls[0];
+    // Query should be trimmed to 'test query' (no leading/trailing spaces)
+    expect(ilikeCall[1]).toContain('test query');
+  });
+});
+
+// ============================================================================
+// Helper function to create a mock Supabase chain
+// ============================================================================
+
+interface SupabaseChainResult {
+  data: unknown;
+  error: unknown;
+}
+
+function mockSupabaseChain(
+  result: SupabaseChainResult,
+  _isHiddenTable: boolean = false,
+): Record<string, ReturnType<typeof vi.fn>> {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  const chainable = ['select', 'eq', 'ilike', 'order', 'limit', 'in', 'maybeSingle', 'single'];
+
+  for (const method of chainable) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Allow the chain to be awaited directly
+  // biome-ignore lint: reason
+  (chain as unknown as { then: unknown }).then = vi.fn((resolve: (val: unknown) => void) =>
+    resolve(result),
+  ) as unknown as undefined;
+
+  return chain;
+}


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **98 tests total**.

| Route | Tests | Covers |
|-------|-------|--------|
| `autocliper/drafts` | 17 | auth, stage filtering (draft/approved/published/rejected/invalid), stats, errors |
| `autocliper/approve` | 23 | auth, validateRequest 400, draft-not-found 404, stage guard, approve success, 500 |
| `chat/search` | 32 | auth, query min-length, channel allowlist, SQL wildcard escaping, supabase+Neynar merge/dedup, hidden filter, errors |
| `chat/hide` | 26 | auth + admin guards, Zod, supabase upsert, audit-log (client IP), success + error paths |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)