### PR TITLE
test(cron): daily-digest/weekly-reflection/follower-snapshot/engagement-collect (79 tests)

### DIFF
--- a/src/app/api/cron/daily-digest/__tests__/route.test.ts
+++ b/src/app/api/cron/daily-digest/__tests__/route.test.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+// FIFO chain: queries pop results from a queue in order.
+function queuedChain(results: Array<{ data?: unknown; error?: unknown; count?: number }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods — each returns the chain for further chaining
+  for (const m of ['select', 'from', 'gte', 'lte', 'eq', 'like', 'limit', 'order']) {
+    chain[m] = vi.fn(() => chain);
+  }
+
+  // Terminal method .single() returns a promise that resolves to the next queued result
+  chain.single = vi.fn(() => Promise.resolve(q.shift() ?? { data: null, error: null }));
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift() ?? { data: null, error: null });
+
+  return chain;
+}
+
+// Create a Supabase mock that returns new FIFO chains on each from() call
+function createSupabaseMock(results: Array<{ data?: unknown; error?: unknown; count?: number }>[]) {
+  let callIndex = 0;
+  return {
+    from: vi.fn(() => {
+      const chainResults = results[callIndex] || [];
+      callIndex++;
+      return queuedChain([...chainResults]);
+    }),
+  };
+}
+
+const { mockGetSupabaseAdmin } = vi.hoisted(() => ({
+  mockGetSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => mockGetSupabaseAdmin(),
+  supabaseAdmin: new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        const admin = mockGetSupabaseAdmin();
+        return (admin as Record<string | symbol, unknown>)[prop];
+      },
+    },
+  ),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/publish/auto-cast', () => ({
+  autoCastToZao: vi.fn(),
+}));
+
+import { autoCastToZao } from '@/lib/publish/auto-cast';
+import { GET } from '../route';
+
+describe('GET /api/cron/daily-digest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CRON_SECRET', 'test-secret');
+    vi.stubEnv('ZAO_OFFICIAL_SIGNER_UUID', 'signer-uuid-123');
+    vi.stubEnv('ZAO_OFFICIAL_NEYNAR_API_KEY', 'neynar-key-abc');
+  });
+
+  describe('environment configuration', () => {
+    it('returns 500 when CRON_SECRET is not configured', async () => {
+      vi.stubEnv('CRON_SECRET', '');
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('CRON_SECRET not configured');
+    });
+  });
+
+  describe('bearer token authentication', () => {
+    it('returns 401 when authorization header is missing', async () => {
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when authorization header has wrong token', async () => {
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer wrong-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when authorization header lacks Bearer prefix', async () => {
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('accepts correct Bearer token', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 2 }],
+          [{ data: null, error: null, count: 5 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(autoCastToZao as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+  });
+
+  describe('supabase stat queries', () => {
+    it('queries active users (last_login_at within EST day)', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 3 }],
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      await GET(req);
+
+      const mockFrom = mockGetSupabaseAdmin().from as ReturnType<typeof vi.fn>;
+      expect(mockFrom).toHaveBeenCalledWith('users');
+    });
+
+    it('queries play_history for tracks played', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 7 }],
+          [{ data: null, error: null, count: 0 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      await GET(req);
+
+      const mockFrom = mockGetSupabaseAdmin().from as ReturnType<typeof vi.fn>;
+      expect(mockFrom).toHaveBeenCalledWith('play_history');
+    });
+
+    it('queries rooms for rooms hosted', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 2 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      await GET(req);
+
+      const mockFrom = mockGetSupabaseAdmin().from as ReturnType<typeof vi.fn>;
+      expect(mockFrom).toHaveBeenCalledWith('rooms');
+    });
+
+    it('handles partial failures (one query fails, others succeed)', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: 'DB error', count: undefined }],
+          [{ data: null, error: null, count: 5 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-456');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      // activeMembers = 0 (due to error), tracksPlayed = 5, roomsHosted = 1
+      expect(res.status).toBe(200);
+      expect(body.stats.activeMembers).toBe(0);
+      expect(body.stats.tracksPlayed).toBe(5);
+      expect(body.stats.roomsHosted).toBe(1);
+      expect(body.posted).toBe(true);
+    });
+  });
+
+  describe('activity check and digest posting', () => {
+    it('returns early without posting when no activity', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+        ]),
+      );
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.posted).toBe(false);
+      expect(body.reason).toBe('No activity today');
+      expect(body.stats.activeMembers).toBe(0);
+      expect(body.stats.tracksPlayed).toBe(0);
+      expect(body.stats.roomsHosted).toBe(0);
+      expect(autoCastToZao).not.toHaveBeenCalled();
+    });
+
+    it('posts digest when there is active member activity', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 5 }],
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.posted).toBe(true);
+      expect(body.castHash).toBe('cast-hash-123');
+      expect(autoCastToZao).toHaveBeenCalled();
+    });
+
+    it('posts digest when there is track play activity', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 3 }],
+          [{ data: null, error: null, count: 0 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-456');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const _res = await GET(req);
+
+      expect(autoCastToZao as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+
+    it('posts digest when there is room hosting activity', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 0 }],
+          [{ data: null, error: null, count: 2 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-789');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const _res = await GET(req);
+
+      expect(autoCastToZao as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+
+    it('includes all stats in digest text', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 10 }],
+          [{ data: null, error: null, count: 42 }],
+          [{ data: null, error: null, count: 3 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-xyz');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.posted).toBe(true);
+      expect(body.stats.activeMembers).toBe(10);
+      expect(body.stats.tracksPlayed).toBe(42);
+      expect(body.stats.roomsHosted).toBe(3);
+
+      // Verify autoCastToZao was called with correct text
+      const callArgs = (autoCastToZao as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[0]).toContain('10 active members');
+      expect(callArgs[0]).toContain('42 tracks played');
+      expect(callArgs[0]).toContain('3 rooms hosted');
+    });
+
+    it('passes embed URL to autoCastToZao', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('cast-hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      await GET(req);
+
+      const callArgs = (autoCastToZao as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(callArgs[1]).toBe('https://zaoos.com');
+    });
+  });
+
+  describe('response format', () => {
+    it('returns 200 with posted=true when cast hash is returned', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('hash-abc123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.posted).toBe(true);
+      expect(body.castHash).toBe('hash-abc123');
+    });
+
+    it('returns 200 with posted=false when cast hash is null', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.posted).toBe(false);
+      expect(body.castHash).toBeNull();
+    });
+
+    it('includes stats in all responses', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 5 }],
+          [{ data: null, error: null, count: 10 }],
+          [{ data: null, error: null, count: 2 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockResolvedValueOnce('hash-123');
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.stats).toBeDefined();
+      expect(body.stats.activeMembers).toBe(5);
+      expect(body.stats.tracksPlayed).toBe(10);
+      expect(body.stats.roomsHosted).toBe(2);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when autoCastToZao throws', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+          [{ data: null, error: null, count: 1 }],
+        ]),
+      );
+      (autoCastToZao as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Farcaster API error'),
+      );
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+
+    it('returns 500 when supabase queries throw', async () => {
+      mockGetSupabaseAdmin.mockImplementationOnce(() => {
+        throw new Error('Connection failed');
+      });
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+
+    it('handles unknown error types gracefully', async () => {
+      mockGetSupabaseAdmin.mockImplementationOnce(() => {
+        // eslint-disable-next-line no-throw-literal
+        throw 'Unknown error type';
+      });
+
+      const req = makeRequest('/api/cron/daily-digest', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+  });
+});

--- a/src/app/api/cron/engagement-collect/__tests__/route.test.ts
+++ b/src/app/api/cron/engagement-collect/__tests__/route.test.ts
@@ -1,0 +1,733 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+const { mockIsThreadsConfigured } = vi.hoisted(() => ({
+  mockIsThreadsConfigured: vi.fn(),
+}));
+
+const { mockFetchThreadsInsights } = vi.hoisted(() => ({
+  mockFetchThreadsInsights: vi.fn(),
+}));
+
+const { mockGetXClient } = vi.hoisted(() => ({
+  mockGetXClient: vi.fn(),
+}));
+
+const { mockFetchXInsights } = vi.hoisted(() => ({
+  mockFetchXInsights: vi.fn(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/publish/threads', () => ({
+  isThreadsConfigured: mockIsThreadsConfigured,
+}));
+
+vi.mock('@/lib/publish/threads-insights', () => ({
+  fetchThreadsInsights: mockFetchThreadsInsights,
+}));
+
+vi.mock('@/lib/publish/x', () => ({
+  getXClient: mockGetXClient,
+}));
+
+vi.mock('@/lib/publish/x-insights', () => ({
+  fetchXInsights: mockFetchXInsights,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Helper: Build a queued chain for multiple sequential calls ──────────────
+
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, unknown> = {};
+
+  // Chainable methods — each returns the chain for further chaining
+  for (const m of ['select', 'insert', 'eq', 'gte', 'order']) {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (onFulfilled: unknown, _onRejected?: unknown) => {
+    const result = q.shift() ?? { data: null, error: null };
+    const callback = onFulfilled as (val: unknown) => unknown;
+    return Promise.resolve(callback ? callback(result) : result);
+  };
+
+  return chain;
+}
+
+// ── Helper: Create a Supabase mock with per-from-call result queues ────────
+
+function createSupabaseMock(resultQueues: Array<Array<{ data?: unknown; error?: unknown }>>) {
+  let callIndex = 0;
+  return () => {
+    const results = resultQueues[callIndex] || [];
+    callIndex++;
+    return queuedChain([...results]);
+  };
+}
+
+import { GET } from '../route';
+
+describe('GET /api/cron/engagement-collect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CRON_SECRET;
+  });
+
+  // ── Auth checks ──────────────────────────────────────────────────────────
+
+  describe('Authentication', () => {
+    it('returns 500 when CRON_SECRET is not configured', async () => {
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer some-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error?: unknown };
+      expect(body.error).toBe('CRON_SECRET not configured');
+    });
+
+    it('returns 401 when Authorization header is missing', async () => {
+      process.env.CRON_SECRET = 'secret-token';
+      const req = makeRequest('/api/cron/engagement-collect');
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error?: unknown };
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when Authorization header is incorrect', async () => {
+      process.env.CRON_SECRET = 'secret-token';
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer wrong-token' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error?: unknown };
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when Authorization header lacks Bearer prefix', async () => {
+      process.env.CRON_SECRET = 'secret-token';
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'secret-token' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+    });
+
+    it('passes auth when Bearer token matches CRON_SECRET', async () => {
+      process.env.CRON_SECRET = 'secret-token';
+      mockIsThreadsConfigured.mockReturnValue(false);
+      mockGetXClient.mockReturnValue(null);
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer secret-token' },
+      });
+
+      const res = await GET(req);
+
+      // Should pass auth and fail on "no platforms configured" check
+      expect(res.status).toBe(503);
+    });
+  });
+
+  // ── Platform configuration checks ────────────────────────────────────────
+
+  describe('Platform configuration', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('returns 503 when no platforms are configured', async () => {
+      mockIsThreadsConfigured.mockReturnValue(false);
+      mockGetXClient.mockReturnValue(null);
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error?: unknown; collected?: unknown };
+      expect(body.error).toBe('No platforms configured');
+      expect(body.collected).toBe(0);
+    });
+
+    it('skips Threads collection when Threads is not configured', async () => {
+      mockIsThreadsConfigured.mockReturnValue(false);
+      mockGetXClient.mockReturnValue({ v2: {} });
+      mockFrom.mockImplementation(createSupabaseMock([[{ data: [], error: null }]]));
+      mockFetchXInsights.mockResolvedValue({
+        views: 100,
+        likes: 10,
+        replies: 2,
+        reposts: 1,
+        quotes: 0,
+        bookmarks: 5,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFetchThreadsInsights).not.toHaveBeenCalled();
+    });
+
+    it('skips X collection when X client is not configured', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      mockFrom.mockImplementation(createSupabaseMock([[{ data: [], error: null }]]));
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 50,
+        likes: 5,
+        replies: 1,
+        reposts: 0,
+        quotes: 0,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFetchXInsights).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Successful collection ────────────────────────────────────────────────
+
+  describe('Successful engagement collection', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('collects Threads insights and returns aggregated result', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      const threadsPost = { id: 'post-1', platform_post_id: 'thread-123' };
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // First from() call: SELECT from publish_log for threads
+          [{ data: [threadsPost], error: null }],
+          // Second from() call: INSERT into engagement_metrics
+          [{ data: null, error: null }],
+        ]),
+      );
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        collected?: number;
+        failed?: number;
+        total?: number;
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.collected).toBe(1);
+      expect(body.failed).toBe(0);
+      expect(body.total).toBe(1);
+      expect(body.platforms).toHaveLength(1);
+      expect(body.platforms?.[0]?.platform).toBe('threads');
+    });
+
+    it('collects X insights and returns aggregated result', async () => {
+      mockIsThreadsConfigured.mockReturnValue(false);
+      mockGetXClient.mockReturnValue({ v2: {} });
+      const xPost = { id: 'post-2', platform_post_id: 'tweet-456' };
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // First from() call: SELECT from publish_log for x
+          [{ data: [xPost], error: null }],
+          // Second from() call: INSERT into engagement_metrics
+          [{ data: null, error: null }],
+        ]),
+      );
+      mockFetchXInsights.mockResolvedValue({
+        views: 2000,
+        likes: 100,
+        replies: 20,
+        reposts: 15,
+        quotes: 5,
+        bookmarks: 30,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        collected?: number;
+        failed?: number;
+        total?: number;
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.collected).toBe(1);
+      expect(body.failed).toBe(0);
+      expect(body.total).toBe(1);
+      expect(body.platforms?.[0]?.platform).toBe('x');
+    });
+
+    it('collects both Threads and X in same request', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue({ v2: {} });
+      const threadsPost = { id: 'post-1', platform_post_id: 'thread-123' };
+      const xPost = { id: 'post-2', platform_post_id: 'tweet-456' };
+
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // Threads SELECT
+          [{ data: [threadsPost], error: null }],
+          // Threads INSERT
+          [{ data: null, error: null }],
+          // X SELECT
+          [{ data: [xPost], error: null }],
+          // X INSERT
+          [{ data: null, error: null }],
+        ]),
+      );
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+      });
+      mockFetchXInsights.mockResolvedValue({
+        views: 2000,
+        likes: 100,
+        replies: 20,
+        reposts: 15,
+        quotes: 5,
+        bookmarks: 30,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        collected?: number;
+        failed?: number;
+        total?: number;
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.collected).toBe(2);
+      expect(body.failed).toBe(0);
+      expect(body.total).toBe(2);
+      expect(body.platforms).toHaveLength(2);
+    });
+
+    it('handles empty post lists gracefully', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      mockFrom.mockImplementation(createSupabaseMock([[{ data: [], error: null }]]));
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        collected?: number;
+        failed?: number;
+        total?: number;
+      };
+      expect(body.collected).toBe(0);
+      expect(body.failed).toBe(0);
+      expect(body.total).toBe(0);
+    });
+  });
+
+  // ── Error handling per platform ──────────────────────────────────────────
+
+  describe('Per-platform error handling', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('returns 0 collected/failed when DB fetch fails for a platform', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      mockFrom.mockImplementation(
+        createSupabaseMock([[{ data: null, error: 'DB connection error' }]]),
+      );
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.platforms?.[0]?.collected).toBe(0);
+      expect(body.platforms?.[0]?.failed).toBe(0);
+      expect(body.platforms?.[0]?.total).toBe(0);
+    });
+
+    it('increments failed count when insights fetch fails for a post', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      const threadsPost = { id: 'post-1', platform_post_id: 'thread-123' };
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // SELECT posts
+          [{ data: [threadsPost], error: null }],
+          // INSERT engagement_metrics (will not be called since fetchThreadsInsights throws)
+        ]),
+      );
+      mockFetchThreadsInsights.mockRejectedValue(new Error('API error'));
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.platforms?.[0]?.collected).toBe(0);
+      expect(body.platforms?.[0]?.failed).toBe(1);
+      expect(body.platforms?.[0]?.total).toBe(1);
+    });
+
+    it('increments failed count when insert fails for a post', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      const threadsPost = { id: 'post-1', platform_post_id: 'thread-123' };
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // SELECT posts
+          [{ data: [threadsPost], error: null }],
+          // INSERT engagement_metrics (fails)
+          [{ data: null, error: 'Insert failed' }],
+        ]),
+      );
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.platforms?.[0]?.collected).toBe(0);
+      expect(body.platforms?.[0]?.failed).toBe(1);
+      expect(body.platforms?.[0]?.total).toBe(1);
+    });
+
+    it('continues with second platform when first platform throws', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue({ v2: {} });
+      const xPost = { id: 'post-2', platform_post_id: 'tweet-456' };
+      let callIndex = 0;
+      mockFrom.mockImplementation(() => {
+        callIndex++;
+        if (callIndex === 1) {
+          // First platform (threads) SELECT throws
+          return queuedChain([{ data: null, error: 'DB error for threads' }]);
+        }
+        // Second platform (x) SELECT succeeds
+        return queuedChain([
+          { data: [xPost], error: null },
+          { data: null, error: null }, // X INSERT
+        ]);
+      });
+      mockFetchXInsights.mockResolvedValue({
+        views: 2000,
+        likes: 100,
+        replies: 20,
+        reposts: 15,
+        quotes: 5,
+        bookmarks: 30,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        collected?: number;
+        failed?: number;
+        total?: number;
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.platforms).toHaveLength(2);
+      // Threads had DB error
+      expect(body.platforms?.[0]?.collected).toBe(0);
+      // X succeeded
+      expect(body.platforms?.[1]?.collected).toBe(1);
+    });
+
+    it('partially collects when some posts fail and others succeed', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      const post1 = { id: 'post-1', platform_post_id: 'thread-123' };
+      const post2 = { id: 'post-2', platform_post_id: 'thread-456' };
+      mockFrom.mockImplementation(
+        createSupabaseMock([
+          // SELECT posts (returns 2 posts)
+          [{ data: [post1, post2], error: null }],
+          // INSERT for post1 (succeeds)
+          [{ data: null, error: null }],
+          // INSERT for post2 (fails)
+          [{ data: null, error: 'Insert failed' }],
+        ]),
+      );
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        platforms?: Array<{
+          platform?: string;
+          collected?: number;
+          failed?: number;
+          total?: number;
+        }>;
+      };
+      expect(body.platforms?.[0]?.collected).toBe(1);
+      expect(body.platforms?.[0]?.failed).toBe(1);
+      expect(body.platforms?.[0]?.total).toBe(2);
+    });
+  });
+
+  // ── Top-level error handling ────────────────────────────────────────────
+
+  describe('Top-level error handling', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('returns 500 when an unexpected error occurs', async () => {
+      mockIsThreadsConfigured.mockImplementation(() => {
+        throw new Error('Unexpected error in isThreadsConfigured');
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error?: unknown };
+      expect(body.error).toBe('Engagement collection failed');
+    });
+  });
+
+  // ── Insights fetcher behavior ────────────────────────────────────────────
+
+  describe('Insights fetcher behavior', () => {
+    beforeEach(() => {
+      process.env.CRON_SECRET = 'test-secret';
+    });
+
+    it('correctly transforms Threads insights into engagement_metrics insert', async () => {
+      mockIsThreadsConfigured.mockReturnValue(true);
+      mockGetXClient.mockReturnValue(null);
+      const threadsPost = { id: 'pub-123', platform_post_id: 'thread-xyz' };
+      let insertPayload: unknown;
+      let insertCalled = false;
+      mockFrom.mockImplementation(
+        createSupabaseMock([[{ data: [threadsPost], error: null }], [{ data: null, error: null }]]),
+      );
+      // Spy on the insert call to capture payload
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chain = queuedChain(
+          callCount === 0 ? [{ data: [threadsPost], error: null }] : [{ data: null, error: null }],
+        );
+        callCount++;
+        const originalChainInsert = chain.insert as ReturnType<typeof vi.fn>;
+        if (originalChainInsert) {
+          originalChainInsert.mockImplementation((_payload: unknown) => {
+            insertPayload = _payload;
+            insertCalled = true;
+            return chain;
+          });
+        }
+        return chain;
+      });
+      mockFetchThreadsInsights.mockResolvedValue({
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(insertCalled).toBe(true);
+      expect(insertPayload).toMatchObject({
+        publish_log_id: 'pub-123',
+        platform: 'threads',
+        platform_post_id: 'thread-xyz',
+        views: 1000,
+        likes: 50,
+        replies: 10,
+        reposts: 5,
+        quotes: 2,
+        clicks: 0,
+      });
+    });
+
+    it('correctly transforms X insights into engagement_metrics insert', async () => {
+      mockIsThreadsConfigured.mockReturnValue(false);
+      mockGetXClient.mockReturnValue({ v2: {} });
+      const xPost = { id: 'pub-456', platform_post_id: 'tweet-abc' };
+      let insertPayload: unknown;
+      let insertCalled = false;
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        const chain = queuedChain(
+          callCount === 0 ? [{ data: [xPost], error: null }] : [{ data: null, error: null }],
+        );
+        callCount++;
+        const originalChainInsert = chain.insert as ReturnType<typeof vi.fn>;
+        if (originalChainInsert) {
+          originalChainInsert.mockImplementation((_payload: unknown) => {
+            insertPayload = _payload;
+            insertCalled = true;
+            return chain;
+          });
+        }
+        return chain;
+      });
+      mockFetchXInsights.mockResolvedValue({
+        views: 2000,
+        likes: 100,
+        replies: 20,
+        reposts: 15,
+        quotes: 5,
+        bookmarks: 30,
+      });
+      const req = makeRequest('/api/cron/engagement-collect', {
+        headers: { Authorization: 'Bearer test-secret' },
+      });
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(insertCalled).toBe(true);
+      expect(insertPayload).toMatchObject({
+        publish_log_id: 'pub-456',
+        platform: 'x',
+        platform_post_id: 'tweet-abc',
+        views: 2000,
+        likes: 100,
+        replies: 20,
+        reposts: 15,
+        quotes: 5,
+        clicks: 0,
+      });
+    });
+  });
+});

--- a/src/app/api/cron/follower-snapshot/__tests__/route.test.ts
+++ b/src/app/api/cron/follower-snapshot/__tests__/route.test.ts
@@ -1,0 +1,644 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+// FIFO chain: queries pop results from a queue in order.
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods — each returns the chain for further chaining
+  for (const m of [
+    'select',
+    'insert',
+    'update',
+    'upsert',
+    'delete',
+    'eq',
+    'not',
+    'is',
+    'single',
+    'order',
+    'limit',
+    'like',
+    'maybeSingle',
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+
+  // Terminal method .single() returns a promise that resolves to the next queued result
+  chain.single = vi.fn(() => Promise.resolve(q.shift() ?? { data: null, error: null }));
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift() ?? { data: null, error: null });
+
+  return chain;
+}
+
+// Create a Supabase mock that returns new FIFO chains on each from() call
+function createSupabaseMock(results: Array<{ data?: unknown; error?: unknown }>[]) {
+  let callIndex = 0;
+  return {
+    from: () => {
+      const chainResults = results[callIndex] || [];
+      callIndex++;
+      return queuedChain([...chainResults]);
+    },
+  };
+}
+
+const { mockGetSupabaseAdmin, mockGetFollowers, mockGetUsersByFids, mockGetEngagementScores } =
+  vi.hoisted(() => ({
+    mockGetSupabaseAdmin: vi.fn(),
+    mockGetFollowers: vi.fn(),
+    mockGetUsersByFids: vi.fn(),
+    mockGetEngagementScores: vi.fn(),
+  }));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: vi.fn((...args: unknown[]) => {
+      const mock = mockGetSupabaseAdmin();
+      return mock.from?.(...args);
+    }),
+  },
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getFollowers: (...args: unknown[]) => mockGetFollowers(...args),
+  getUsersByFids: (...args: unknown[]) => mockGetUsersByFids(...args),
+}));
+
+vi.mock('@/lib/openrank/client', () => ({
+  getEngagementScores: (...args: unknown[]) => mockGetEngagementScores(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/cron/follower-snapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ---- AUTH TESTS ----
+
+  it('returns 500 when CRON_SECRET is not set', async () => {
+    const originalSecret = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+
+    try {
+      const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+      req.headers.set('authorization', 'Bearer any-value');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('CRON_SECRET not configured');
+    } finally {
+      if (originalSecret) process.env.CRON_SECRET = originalSecret;
+    }
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    // No authorization header
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when Authorization header value does not match CRON_SECRET', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer wrong-secret');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('accepts request with correct Bearer token', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [], error: null }], // members query
+      ]),
+    );
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    // Should proceed past auth and return 200 for empty members
+    expect(res.status).toBe(200);
+  });
+
+  // ---- MEMBERS QUERY TESTS ----
+
+  it('returns 500 when members query fails', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: null, error: { message: 'DB connection error' } }], // members query fails
+      ]),
+    );
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to fetch members');
+  });
+
+  it('returns 200 with zero members when members table is empty', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [], error: null }], // empty members
+      ]),
+    );
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(0);
+    expect(json.newUnfollows).toBe(0);
+    expect(json.errors).toEqual([]);
+  });
+
+  // ---- HAPPY PATH: SINGLE MEMBER ----
+
+  it('successfully snapshots a single member with no unfollows', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    // Mock getFollowers to return followers in one page
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 100 } }, { user: { fid: 101 } }, { user: { fid: 102 } }],
+      next: undefined,
+    });
+
+    // Mock getUsersByFids for member profile (following_count)
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    // Mock Supabase queries in order:
+    // 1. SELECT members
+    // 2. UPSERT follower_snapshots
+    // 3. UPSERT member_stats_history
+    // 4. SELECT yesterday's snapshot (none found)
+    // 5. POST engagement scores update (will fail gracefully)
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday's snapshot
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map()); // no scores
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+    expect(json.newUnfollows).toBe(0);
+    expect(json.errors).toEqual([]);
+
+    // Verify getFollowers was called with correct params
+    expect(mockGetFollowers).toHaveBeenCalledWith(
+      memberId,
+      undefined,
+      'desc_chron',
+      undefined,
+      100,
+    );
+
+    // Verify getUsersByFids was called to get member profile
+    expect(mockGetUsersByFids).toHaveBeenCalledWith([memberId]);
+  });
+
+  // ---- UNFOLLOW DETECTION ----
+
+  it('detects and records unfollows from previous snapshot', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+    const yesterdayFollowers = [100, 101, 102, 103]; // 103 will unfollow
+    const todayFollowers = [100, 101, 102]; // 103 is gone
+
+    mockGetFollowers.mockResolvedValue({
+      users: todayFollowers.map((fid) => ({ user: { fid } })),
+      next: undefined,
+    });
+
+    mockGetUsersByFids
+      .mockResolvedValueOnce([{ fid: memberId, following_count: 50 }]) // member profile
+      .mockResolvedValueOnce([
+        // unfollower batch
+        { fid: 103, username: 'unfollower', display_name: 'Unfollower User' },
+      ]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: { follower_fids: yesterdayFollowers }, error: null }], // select yesterday's snapshot
+        [{ data: null, error: null }], // insert unfollow_events
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+    expect(json.newUnfollows).toBe(1); // 1 unfollow detected
+    expect(json.errors).toEqual([]);
+  });
+
+  // ---- FOLLOWER PAGINATION ----
+
+  it('paginates through followers across multiple pages', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+    const page1Followers = [100, 101];
+    const page2Followers = [102, 103];
+
+    mockGetFollowers
+      .mockResolvedValueOnce({
+        users: page1Followers.map((fid) => ({ user: { fid } })),
+        next: { cursor: 'page2-cursor' },
+      })
+      .mockResolvedValueOnce({
+        users: page2Followers.map((fid) => ({ user: { fid } })),
+        next: undefined,
+      });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday's snapshot
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+
+    // Verify pagination calls
+    expect(mockGetFollowers).toHaveBeenCalledTimes(2);
+    expect(mockGetFollowers).toHaveBeenNthCalledWith(
+      1,
+      memberId,
+      undefined,
+      'desc_chron',
+      undefined,
+      100,
+    );
+    expect(mockGetFollowers).toHaveBeenNthCalledWith(
+      2,
+      memberId,
+      undefined,
+      'desc_chron',
+      'page2-cursor',
+      100,
+    );
+  });
+
+  // ---- ENGAGEMENT SCORES ----
+
+  it('updates engagement scores when available', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+    const engagementScore = 95.5;
+
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 100 } }],
+      next: undefined,
+    });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday's snapshot
+        [{ data: null, error: null }], // update member_stats_history with engagement score
+      ]),
+    );
+
+    const scoresMap = new Map([[memberId, engagementScore]]);
+    mockGetEngagementScores.mockResolvedValue(scoresMap);
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+
+    // Verify engagement scores were fetched for the member
+    expect(mockGetEngagementScores).toHaveBeenCalledWith([memberId]);
+  });
+
+  // ---- ERROR HANDLING ----
+
+  it('gracefully handles getFollowers error and continues', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    mockGetFollowers.mockRejectedValue(new Error('Neynar API error'));
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+      ]),
+    );
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(0); // Member processing failed
+    expect(json.errors.length).toBe(1);
+    expect(json.errors[0]).toContain('FID 12345');
+    expect(json.errors[0]).toContain('Neynar API error');
+  });
+
+  it('handles Supabase upsert errors gracefully', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 100 } }],
+      next: undefined,
+    });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: { message: 'Snapshot upsert failed' } }], // follower_snapshots upsert fails
+      ]),
+    );
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(0);
+    expect(json.errors.length).toBe(1);
+  });
+
+  it('handles OpenRank engagement scores fetch error gracefully (non-fatal)', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 100 } }],
+      next: undefined,
+    });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday's snapshot
+      ]),
+    );
+
+    mockGetEngagementScores.mockRejectedValue(new Error('OpenRank timeout'));
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    // Should still succeed despite engagement scores error
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+  });
+
+  // ---- MULTIPLE MEMBERS ----
+
+  it('processes multiple members sequentially', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const member1 = 100;
+    const member2 = 200;
+
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 999 } }],
+      next: undefined,
+    });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: 0, following_count: 50 }]);
+
+    // Each member needs: members query (shared), followers upsert, stats upsert, yesterday check
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: member1 }, { fid: member2 }], error: null }], // members query
+        [{ data: null, error: null }], // member1: upsert follower_snapshots
+        [{ data: null, error: null }], // member1: upsert member_stats_history
+        [{ data: null, error: null }], // member1: select yesterday
+        [{ data: null, error: null }], // member2: upsert follower_snapshots
+        [{ data: null, error: null }], // member2: upsert member_stats_history
+        [{ data: null, error: null }], // member2: select yesterday
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(2);
+  });
+
+  // ---- UNFOLLOW BATCHING (>100 unfollowers) ----
+
+  it('batches unfollower lookups in groups of 100', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+    // Create 150 yesterday followers, 50 today — 100 unfollows
+    const yesterdayFollowers = Array.from({ length: 150 }, (_, i) => i + 1);
+    const todayFollowers = Array.from({ length: 50 }, (_, i) => i + 1);
+
+    mockGetFollowers.mockResolvedValue({
+      users: todayFollowers.map((fid) => ({ user: { fid } })),
+      next: undefined,
+    });
+
+    mockGetUsersByFids
+      .mockResolvedValueOnce([{ fid: memberId, following_count: 50 }]) // member profile
+      .mockResolvedValueOnce(
+        // batch 1: unfollowers 51-150 (100 users)
+        Array.from({ length: 100 }, (_, i) => ({
+          fid: 51 + i,
+          username: `user${51 + i}`,
+          display_name: `User ${51 + i}`,
+        })),
+      );
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: { follower_fids: yesterdayFollowers }, error: null }], // select yesterday
+        [{ data: null, error: null }], // insert unfollow_events
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+    expect(json.newUnfollows).toBe(100);
+  });
+
+  // ---- EDGE CASE: empty following_count fallback ----
+
+  it('handles missing following_count from user profile', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    mockGetFollowers.mockResolvedValue({
+      users: [{ user: { fid: 100 } }],
+      next: undefined,
+    });
+
+    // Return user without following_count
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+  });
+
+  // ---- FOLLOWER FID EXTRACTION (Neynar response format) ----
+
+  it('extracts FID from both user.fid and direct fid fields', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    const memberId = 12345;
+
+    // Some entries have { user: { fid: X } }, others might have direct fid
+    mockGetFollowers.mockResolvedValue({
+      users: [
+        { user: { fid: 100 } }, // standard format
+        { fid: 101 }, // direct fid fallback
+      ],
+      next: undefined,
+    });
+
+    mockGetUsersByFids.mockResolvedValue([{ fid: memberId, following_count: 50 }]);
+
+    mockGetSupabaseAdmin.mockReturnValue(
+      createSupabaseMock([
+        [{ data: [{ fid: memberId }], error: null }], // members query
+        [{ data: null, error: null }], // upsert follower_snapshots
+        [{ data: null, error: null }], // upsert member_stats_history
+        [{ data: null, error: null }], // select yesterday
+      ]),
+    );
+
+    mockGetEngagementScores.mockResolvedValue(new Map());
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.membersProcessed).toBe(1);
+  });
+
+  it('handles caught errors in outer try-catch returning 500', async () => {
+    process.env.CRON_SECRET = 'test-secret-key';
+
+    // Mock members query to throw an unexpected error
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: () => {
+        throw new Error('Unexpected database error');
+      },
+    });
+
+    const req = makeRequest('/api/cron/follower-snapshot', { method: 'GET' });
+    req.headers.set('authorization', 'Bearer test-secret-key');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Internal server error');
+  });
+});

--- a/src/app/api/cron/weekly-reflection/__tests__/route.test.ts
+++ b/src/app/api/cron/weekly-reflection/__tests__/route.test.ts
@@ -1,0 +1,596 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, makeRequest } from '@/test-utils/api-helpers';
+
+const { mockRunWeeklyReflection } = vi.hoisted(() => ({
+  mockRunWeeklyReflection: vi.fn(),
+}));
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/memory-recall', () => ({
+  runWeeklyReflection: mockRunWeeklyReflection,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const CRON_SECRET = 'test-secret-key';
+
+describe('POST /api/cron/weekly-reflection', () => {
+  let POST: typeof import('../route').POST;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubEnv('CRON_SECRET', CRON_SECRET);
+    vi.resetModules();
+    const route = await import('../route');
+    POST = route.POST;
+  });
+
+  // ========================================================================
+  // Auth tests
+  // ========================================================================
+
+  it('returns 401 when authorization header is missing', async () => {
+    const membersChain = chainMock({
+      data: [
+        { fid: 1, username: 'user1' },
+        { fid: 2, username: 'user2' },
+      ],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: {},
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when authorization header is empty', async () => {
+    const membersChain = chainMock({
+      data: [{ fid: 1, username: 'user1' }],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: '' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when bearer token is incorrect', async () => {
+    const membersChain = chainMock({
+      data: [{ fid: 1, username: 'user1' }],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-secret' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when authorization scheme is not Bearer', async () => {
+    const membersChain = chainMock({
+      data: [{ fid: 1, username: 'user1' }],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Basic ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  // ========================================================================
+  // Supabase member fetch tests
+  // ========================================================================
+
+  it('returns 500 when supabase member fetch errors', async () => {
+    const membersChain = chainMock({
+      data: null,
+      error: new Error('Database error'),
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Failed to fetch members' });
+  });
+
+  it('queries members table with correct filters', async () => {
+    const membersChain = chainMock({
+      data: [{ fid: 1, username: 'user1' }],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+    mockRunWeeklyReflection.mockResolvedValue('reflection text');
+
+    const insertChain = chainMock({
+      data: { id: 1 },
+      error: null,
+    });
+    mockFrom.mockReturnValueOnce(membersChain.chain);
+    mockFrom.mockReturnValueOnce(insertChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    await POST(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('members');
+    expect(membersChain.chain.select).toHaveBeenCalledWith('fid, username');
+    expect(membersChain.chain.eq).toHaveBeenCalledWith('status', 'active');
+  });
+
+  // ========================================================================
+  // Success path tests
+  // ========================================================================
+
+  it('processes reflections for all active members successfully', async () => {
+    const members = [
+      { fid: 1, username: 'user1' },
+      { fid: 2, username: 'user2' },
+      { fid: 3, username: 'user3' },
+    ];
+
+    const membersChain = chainMock({
+      data: members,
+      error: null,
+    });
+
+    const insertChain = chainMock({
+      data: { id: 1 },
+      error: null,
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return membersChain.chain;
+      return insertChain.chain;
+    });
+
+    mockRunWeeklyReflection.mockResolvedValue('taste profile reflection');
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      processed: 3,
+      failed: 0,
+      errors: [],
+    });
+
+    expect(mockRunWeeklyReflection).toHaveBeenCalledTimes(3);
+    expect(mockRunWeeklyReflection).toHaveBeenCalledWith('1');
+    expect(mockRunWeeklyReflection).toHaveBeenCalledWith('2');
+    expect(mockRunWeeklyReflection).toHaveBeenCalledWith('3');
+  });
+
+  it('handles empty member list', async () => {
+    const membersChain = chainMock({
+      data: [],
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      processed: 0,
+      failed: 0,
+      errors: [],
+    });
+
+    expect(mockRunWeeklyReflection).not.toHaveBeenCalled();
+  });
+
+  it('handles null members array', async () => {
+    const membersChain = chainMock({
+      data: null,
+      error: null,
+    });
+    mockFrom.mockReturnValue(membersChain.chain);
+
+    // Need to re-mock since data is null not an array
+    const actualChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      // biome-ignore lint/suspicious/noThenProperty: Intentionally creating a thenable for await
+      then: vi.fn((_unknown_resolve: unknown) => {
+        const resolve = _unknown_resolve as (val: unknown) => void;
+        return resolve({ data: null, error: null });
+      }),
+    };
+    mockFrom.mockReturnValue(actualChain as unknown as Record<string, unknown>);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      processed: 0,
+      failed: 0,
+      errors: [],
+    });
+  });
+
+  it('stores reflection with correct user_fid and timestamp', async () => {
+    const members = [{ fid: 123, username: 'testuser' }];
+    const reflectionText = 'synthesized taste profile';
+
+    const membersChain = chainMock({
+      data: members,
+      error: null,
+    });
+
+    const insertChain = chainMock({
+      data: { id: 1 },
+      error: null,
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return membersChain.chain;
+      return insertChain.chain;
+    });
+
+    mockRunWeeklyReflection.mockResolvedValue(reflectionText);
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.processed).toBe(1);
+
+    expect(insertChain.chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_fid: 123,
+        reflection_text: reflectionText,
+        reflected_at: expect.any(String),
+      }),
+    );
+  });
+
+  // ========================================================================
+  // Partial failure tests
+  // ========================================================================
+
+  it('continues processing after reflection error for one member', async () => {
+    const members = [
+      { fid: 1, username: 'user1' },
+      { fid: 2, username: 'user2' },
+    ];
+
+    const membersChain = chainMock({
+      data: members,
+      error: null,
+    });
+
+    const insertChain = chainMock({
+      data: { id: 1 },
+      error: null,
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return membersChain.chain;
+      return insertChain.chain;
+    });
+
+    mockRunWeeklyReflection
+      .mockRejectedValueOnce(new Error('Hindsight unavailable'))
+      .mockResolvedValueOnce('reflection for user 2');
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.processed).toBe(1);
+    expect(body.failed).toBe(1);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain('User 1');
+    expect(body.errors[0]).toContain('Hindsight unavailable');
+  });
+
+  it('continues processing after insertion error for one member', async () => {
+    const members = [
+      { fid: 1, username: 'user1' },
+      { fid: 2, username: 'user2' },
+    ];
+
+    const membersChain = chainMock({
+      data: members,
+      error: null,
+    });
+
+    const insertChainError = chainMock({
+      data: null,
+      error: new Error('Unique constraint violation'),
+    });
+
+    const insertChainSuccess = chainMock({
+      data: { id: 2 },
+      error: null,
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return membersChain.chain;
+      if (callCount === 2) return insertChainError.chain;
+      return insertChainSuccess.chain;
+    });
+
+    mockRunWeeklyReflection
+      .mockResolvedValueOnce('reflection for user 1')
+      .mockResolvedValueOnce('reflection for user 2');
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.processed).toBe(1);
+    expect(body.failed).toBe(1);
+    expect(body.errors).toHaveLength(1);
+    expect(body.errors[0]).toContain('User 1');
+    expect(body.errors[0]).toContain('failed to store reflection');
+  });
+
+  it('increments failed and collects errors for all failing members', async () => {
+    const members = [
+      { fid: 1, username: 'user1' },
+      { fid: 2, username: 'user2' },
+      { fid: 3, username: 'user3' },
+    ];
+
+    const membersChain = chainMock({
+      data: members,
+      error: null,
+    });
+
+    const insertChain = chainMock({
+      data: null,
+      error: new Error('Insert failed'),
+    });
+
+    let callCount = 0;
+    mockFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return membersChain.chain;
+      return insertChain.chain;
+    });
+
+    mockRunWeeklyReflection.mockResolvedValue('reflection text');
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.processed).toBe(0);
+    expect(body.failed).toBe(3);
+    expect(body.errors).toHaveLength(3);
+  });
+
+  // ========================================================================
+  // Unexpected error tests
+  // ========================================================================
+
+  it('returns 500 and logs error when outer try/catch catches exception', async () => {
+    mockFrom.mockRejectedValue(new Error('Supabase connection error'));
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Weekly reflection cron failed' });
+  });
+
+  it('handles non-Error exception thrown during processing', async () => {
+    mockFrom.mockRejectedValue('string error');
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Weekly reflection cron failed' });
+  });
+
+  // ========================================================================
+  // Env var tests
+  // ========================================================================
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('CRON_SECRET', '');
+    vi.resetModules();
+    const route = await import('../route');
+    POST = route.POST;
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'POST',
+      headers: { authorization: 'Bearer some-secret' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'CRON_SECRET not configured' });
+  });
+});
+
+describe('GET /api/cron/weekly-reflection', () => {
+  let GET: typeof import('../route').GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubEnv('CRON_SECRET', CRON_SECRET);
+    vi.resetModules();
+    const route = await import('../route');
+    GET = route.GET;
+  });
+
+  it('returns 401 when authorization header is missing', async () => {
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'GET',
+      headers: {},
+    });
+
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when bearer token is incorrect', async () => {
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'GET',
+      headers: { authorization: 'Bearer wrong-secret' },
+    });
+
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 200 with status ok and schedule on success', async () => {
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'GET',
+      headers: { authorization: `Bearer ${CRON_SECRET}` },
+    });
+
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      status: 'ok',
+      schedule: 'Sunday 18:00 UTC',
+    });
+  });
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('CRON_SECRET', '');
+    vi.resetModules();
+    const route = await import('../route');
+    GET = route.GET;
+
+    const req = makeRequest('/api/cron/weekly-reflection', {
+      method: 'GET',
+      headers: { authorization: 'Bearer some-secret' },
+    });
+
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'CRON_SECRET not configured' });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested Vercel-cron API routes — **79 tests total**. All are Bearer `CRON_SECRET`-guarded; every external effect (casts, insights fetches, reflection runs) is mocked — **no real outbound**.

| Route | Tests | Covers |
|-------|-------|--------|
| `cron/daily-digest` | 21 | CRON_SECRET guard, Bearer auth, parallel stat queries, no-activity skip, autoCastToZao, errors |
| `cron/weekly-reflection` | 20 | module-load CRON_SECRET (dynamic-import test), Bearer, per-member reflection with partial-failure isolation, errors |
| `cron/follower-snapshot` | 18 | auth, member snapshot loop, unfollow detection vs prior snapshot, follower pagination, OpenRank scores, graceful degradation |
| `cron/engagement-collect` | 20 | auth, threads/x platform gating, per-platform failure isolation (Promise.allSettled), aggregate counts, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)