### PR TITLE
test(following,music,events): online/feed/verify-ticket (82 tests)

### DIFF
--- a/src/app/api/events/verify-ticket/__tests__/route.test.ts
+++ b/src/app/api/events/verify-ticket/__tests__/route.test.ts
@@ -1,0 +1,516 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockGetEventBySlug, mockFindKeyHolder, mockGetUserByFid, mockLogger } = vi.hoisted(() => ({
+  mockGetEventBySlug: vi.fn(),
+  mockFindKeyHolder: vi.fn(),
+  mockGetUserByFid: vi.fn(),
+  mockLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/unlock/events', () => ({
+  getEventBySlug: mockGetEventBySlug,
+}));
+
+vi.mock('@/lib/unlock/lock', () => ({
+  findKeyHolder: mockFindKeyHolder,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getUserByFid: mockGetUserByFid,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { POST } from '../route';
+
+/** A valid event with a lock address. */
+const SAMPLE_EVENT = {
+  id: 'evt-1',
+  slug: 'community-gathering-2026',
+  title: 'Community Gathering 2026',
+  description: 'A gathering of the ZAO community.',
+  lock_address: '0x1234567890abcdef1234567890abcdef12345678',
+  unlock_event_url: 'https://unlock-protocol.com/event/1',
+  chain_id: 8453, // Base
+  starts_at: '2026-07-20T10:00:00Z',
+  ends_at: '2026-07-20T15:00:00Z',
+  location: 'Virtual',
+  is_published: true,
+};
+
+/** A valid Farcaster user with verified addresses and custody. */
+const SAMPLE_NEYNAR_USER = {
+  fid: 123,
+  username: 'testuser',
+  verified_addresses: {
+    eth_addresses: ['0xabcd1234567890abcd1234567890abcd12345678'],
+  },
+  custody_address: '0xdeff1234567890deff1234567890deff12345678',
+};
+
+/** A Farcaster user with no verified addresses. */
+const SAMPLE_NEYNAR_USER_NO_VERIFIED = {
+  fid: 456,
+  username: 'noaddruser',
+  verified_addresses: null,
+  custody_address: '0x1111111111111111111111111111111111111111',
+};
+
+describe('POST /api/events/verify-ticket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========== Validation Tests ==========
+
+  it('returns 400 when eventSlug is missing', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+    expect(body).toHaveProperty('details');
+  });
+
+  it('returns 400 when eventSlug is empty string', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: '',
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+  });
+
+  it('returns 400 when eventSlug exceeds max length', async () => {
+    const longSlug = 'a'.repeat(101);
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: longSlug,
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+  });
+
+  it('returns 400 when neither fid nor wallet is provided', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+    expect(body).toHaveProperty('details');
+  });
+
+  it('returns 400 when wallet is malformed (not 0x...)', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: 'not-a-wallet',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+  });
+
+  it('returns 400 when wallet is valid format but wrong length', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0x1234567890abcdef1234567890abcdef123456', // 39 chars instead of 40
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+  });
+
+  it('returns 400 when fid is not a positive integer', async () => {
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: -5,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid input');
+  });
+
+  // ========== Event Not Found ==========
+
+  it('returns 404 when event is not found', async () => {
+    mockGetEventBySlug.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'nonexistent-event',
+      wallet: '0x1234567890abcdef1234567890abcdef12345678',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Event not found');
+  });
+
+  // ========== Event Has No Lock ==========
+
+  it('returns 409 when event has no lock_address', async () => {
+    const eventNoLock = { ...SAMPLE_EVENT, lock_address: null };
+    mockGetEventBySlug.mockResolvedValue(eventNoLock);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0x1234567890abcdef1234567890abcdef12345678',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Event has no ticket lock yet');
+    expect(body).toHaveProperty('holdsTicket', false);
+  });
+
+  // ========== Wallet Mode: Holder Found ==========
+
+  it('returns 200 with holdsTicket=true when wallet holds key', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockFindKeyHolder.mockResolvedValue('0xabcd1234567890abcd1234567890abcd12345678');
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0xabcd1234567890abcd1234567890abcd12345678',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', true);
+    expect(body).toHaveProperty('matchedAddress', '0xabcd1234567890abcd1234567890abcd12345678');
+    expect(body).toHaveProperty('eventSlug', 'community-gathering-2026');
+    expect(body).toHaveProperty('lockAddress', SAMPLE_EVENT.lock_address);
+    expect(body).toHaveProperty('chainId', 8453);
+  });
+
+  // ========== Wallet Mode: No Holder ==========
+
+  it('returns 200 with holdsTicket=false when wallet does not hold key', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockFindKeyHolder.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0xdead000000000000000000000000000000000000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', false);
+    expect(body).toHaveProperty('matchedAddress', null);
+    expect(body).toHaveProperty('eventSlug', 'community-gathering-2026');
+  });
+
+  // ========== FID Mode: Holder Found ==========
+
+  it('resolves fid to addresses and returns holdsTicket=true when holder found', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(SAMPLE_NEYNAR_USER);
+    mockFindKeyHolder.mockResolvedValue('0xabcd1234567890abcd1234567890abcd12345678');
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', true);
+    expect(body).toHaveProperty('matchedAddress', '0xabcd1234567890abcd1234567890abcd12345678');
+
+    // Verify that findKeyHolder was called with both verified + custody addresses
+    expect(mockFindKeyHolder).toHaveBeenCalledWith(
+      SAMPLE_EVENT.lock_address,
+      expect.arrayContaining([
+        '0xabcd1234567890abcd1234567890abcd12345678',
+        '0xdeff1234567890deff1234567890deff12345678',
+      ]),
+    );
+  });
+
+  // ========== FID Mode: No Holder ==========
+
+  it('resolves fid and returns holdsTicket=false when no holder found', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(SAMPLE_NEYNAR_USER);
+    mockFindKeyHolder.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', false);
+    expect(body).toHaveProperty('matchedAddress', null);
+  });
+
+  // ========== FID Mode: Neynar Returns Null ==========
+
+  it('handles fid lookup returning null gracefully', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(null);
+    mockFindKeyHolder.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 999,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', false);
+    expect(body).toHaveProperty('matchedAddress', null);
+
+    // findKeyHolder should be called with empty array (no addresses for missing user)
+    expect(mockFindKeyHolder).toHaveBeenCalledWith(SAMPLE_EVENT.lock_address, []);
+  });
+
+  // ========== FID Mode: Neynar Error ==========
+
+  it('catches Neynar error and returns holdsTicket=false', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockRejectedValue(new Error('Neynar API error'));
+    mockFindKeyHolder.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', false);
+    expect(body).toHaveProperty('matchedAddress', null);
+
+    // Logger should have been called with the error
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[events/verify-ticket] Neynar lookup failed:',
+      expect.any(Error),
+    );
+  });
+
+  // ========== FID Mode: No Verified Addresses ==========
+
+  it('includes custody address when verified_addresses is null', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(SAMPLE_NEYNAR_USER_NO_VERIFIED);
+    mockFindKeyHolder.mockResolvedValue('0x1111111111111111111111111111111111111111');
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 456,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', true);
+
+    // findKeyHolder should be called with only custody address
+    expect(mockFindKeyHolder).toHaveBeenCalledWith(SAMPLE_EVENT.lock_address, [
+      '0x1111111111111111111111111111111111111111',
+    ]);
+  });
+
+  // ========== Combined Mode: Wallet + FID ==========
+
+  it('checks both wallet and fid-resolved addresses when both provided', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(SAMPLE_NEYNAR_USER);
+    mockFindKeyHolder.mockResolvedValue('0xabcd1234567890abcd1234567890abcd12345678');
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0xdead000000000000000000000000000000000000',
+      fid: 123,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', true);
+
+    // findKeyHolder should be called with wallet first, then fid addresses
+    expect(mockFindKeyHolder).toHaveBeenCalledWith(
+      SAMPLE_EVENT.lock_address,
+      expect.arrayContaining([
+        '0xdead000000000000000000000000000000000000', // The direct wallet
+        '0xabcd1234567890abcd1234567890abcd12345678', // FID verified
+        '0xdeff1234567890deff1234567890deff12345678', // FID custody
+      ]),
+    );
+  });
+
+  // ========== Error Handling ==========
+
+  it('returns 500 on unexpected error during processing', async () => {
+    mockGetEventBySlug.mockRejectedValue(new Error('Database error'));
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0x1234567890abcdef1234567890abcdef12345678',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Server error');
+
+    // Logger should have been called with the error
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[events/verify-ticket] Unexpected error:',
+      expect.any(Error),
+    );
+  });
+
+  it('returns 500 when findKeyHolder throws', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockFindKeyHolder.mockRejectedValue(new Error('Contract read failed'));
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0x1234567890abcdef1234567890abcdef12345678',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Server error');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[events/verify-ticket] Unexpected error:',
+      expect.any(Error),
+    );
+  });
+
+  // ========== Response Shape Validation ==========
+
+  it('always includes all required response fields on success', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockFindKeyHolder.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      wallet: '0x1234567890abcdef1234567890abcdef12345678',
+    });
+
+    const res = await POST(req);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toHaveProperty('holdsTicket');
+    expect(body).toHaveProperty('matchedAddress');
+    expect(body).toHaveProperty('eventSlug');
+    expect(body).toHaveProperty('lockAddress');
+    expect(body).toHaveProperty('chainId');
+  });
+
+  // ========== Edge Case: Invalid JSON ==========
+
+  it('returns 500 when request body is not valid JSON (caught by try/catch)', async () => {
+    const req = new (await import('next/server')).NextRequest(
+      new URL('/api/events/verify-ticket', 'http://localhost:3000'),
+      {
+        method: 'POST',
+        body: 'not-json',
+      },
+    );
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Server error');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[events/verify-ticket] Unexpected error:',
+      expect.any(Error),
+    );
+  });
+
+  // ========== Edge Case: Multiple Addresses Candidate Check ==========
+
+  it('calls findKeyHolder with all candidate addresses including both verified and custody', async () => {
+    const userWithMultiple = {
+      fid: 789,
+      username: 'multiaddr',
+      verified_addresses: {
+        eth_addresses: [
+          '0xaaaa000000000000000000000000000000000000',
+          '0xbbbb000000000000000000000000000000000000',
+        ],
+      },
+      custody_address: '0xcccc000000000000000000000000000000000000',
+    };
+
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    mockGetUserByFid.mockResolvedValue(userWithMultiple);
+    mockFindKeyHolder.mockResolvedValue('0xbbbb000000000000000000000000000000000000');
+
+    const req = makePostRequest('/api/events/verify-ticket', {
+      eventSlug: 'community-gathering-2026',
+      fid: 789,
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('holdsTicket', true);
+    expect(body).toHaveProperty('matchedAddress', '0xbbbb000000000000000000000000000000000000');
+
+    expect(mockFindKeyHolder).toHaveBeenCalledWith(SAMPLE_EVENT.lock_address, [
+      '0xaaaa000000000000000000000000000000000000',
+      '0xbbbb000000000000000000000000000000000000',
+      '0xcccc000000000000000000000000000000000000',
+    ]);
+  });
+});

--- a/src/app/api/following/online/__tests__/route.test.ts
+++ b/src/app/api/following/online/__tests__/route.test.ts
@@ -1,0 +1,584 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockGetFollowing } = vi.hoisted(() => ({
+  mockGetFollowing: vi.fn(),
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getFollowing: (...args: unknown[]) => mockGetFollowing(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+  },
+}));
+
+// ── Route import (after mocks) ───────────────────────────────────────────────
+import { GET } from '@/app/api/following/online/route';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+describe('GET /api/following/online', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Unauthenticated requests (no session)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    });
+
+    it('returns 401 Unauthorized', async () => {
+      const _req = makeGetRequest('/api/following/online');
+      const res = await GET();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('does not call getFollowing', async () => {
+      const _req = makeGetRequest('/api/following/online');
+      await GET();
+      expect(mockGetFollowing).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Authenticated requests with valid session', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'currentuser' }),
+      );
+    });
+
+    it('returns 200 with members and currentFid', async () => {
+      const mockData = {
+        users: [
+          {
+            user: {
+              fid: 456,
+              username: 'alice',
+              display_name: 'Alice',
+              pfp_url: 'https://example.com/alice.jpg',
+              custody_address: '0xaaa',
+              verified_addresses: {
+                eth_addresses: ['0xbbb', '0xccc'],
+              },
+            },
+          },
+          {
+            fid: 789,
+            username: 'bob',
+            display_name: 'Bob Smith',
+            pfp_url: 'https://example.com/bob.jpg',
+            custody_address: '0xddd',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body).toHaveProperty('members');
+      expect(body).toHaveProperty('currentFid', 123);
+      expect(body.members).toHaveLength(2);
+    });
+
+    it('maps users correctly from nested user prop', async () => {
+      const mockData = {
+        users: [
+          {
+            user: {
+              fid: 456,
+              username: 'alice',
+              display_name: 'Alice',
+              pfp_url: 'https://example.com/alice.jpg',
+              custody_address: '0xaaa',
+              verified_addresses: {
+                eth_addresses: ['0xbbb'],
+              },
+            },
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0]).toEqual({
+        fid: 456,
+        username: 'alice',
+        displayName: 'Alice',
+        pfpUrl: 'https://example.com/alice.jpg',
+        addresses: ['0xaaa', '0xbbb'],
+      });
+    });
+
+    it('maps users correctly from flat structure (item.user missing)', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 789,
+            username: 'bob',
+            display_name: 'Bob Smith',
+            pfp_url: 'https://example.com/bob.jpg',
+            custody_address: '0xddd',
+            verified_addresses: {
+              eth_addresses: ['0xeee'],
+            },
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0]).toEqual({
+        fid: 789,
+        username: 'bob',
+        displayName: 'Bob Smith',
+        pfpUrl: 'https://example.com/bob.jpg',
+        addresses: ['0xddd', '0xeee'],
+      });
+    });
+
+    it('excludes self from members (filters by fid === session.fid)', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 123, // same as session.fid
+            username: 'currentuser',
+            display_name: 'Current User',
+            pfp_url: 'https://example.com/current.jpg',
+          },
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members).toHaveLength(1);
+      expect(body.members[0].fid).toBe(456);
+    });
+
+    it('handles empty following list', async () => {
+      const mockData = {
+        users: [],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members).toHaveLength(0);
+      expect(body.currentFid).toBe(123);
+    });
+
+    it('handles missing username with fallback', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            display_name: 'Alice Only Display',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].username).toBeNull();
+      expect(body.members[0].displayName).toBe('Alice Only Display');
+    });
+
+    it('uses FID as displayName fallback when display_name is missing', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].displayName).toBe('alice');
+    });
+
+    it('falls back to `FID {fid}` when both display_name and username are missing', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].displayName).toBe('FID 456');
+    });
+
+    it('handles missing pfpUrl with null', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].pfpUrl).toBeNull();
+    });
+
+    it('collects addresses from custody_address and verified_addresses.eth_addresses', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+            custody_address: '0xaaa',
+            verified_addresses: {
+              eth_addresses: ['0xbbb', '0xccc'],
+            },
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].addresses).toEqual(['0xaaa', '0xbbb', '0xccc']);
+    });
+
+    it('handles addresses with only custody_address', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+            custody_address: '0xaaa',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].addresses).toEqual(['0xaaa']);
+    });
+
+    it('handles addresses with only verified eth_addresses', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+            verified_addresses: {
+              eth_addresses: ['0xbbb', '0xccc'],
+            },
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].addresses).toEqual(['0xbbb', '0xccc']);
+    });
+
+    it('handles empty addresses array', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members[0].addresses).toEqual([]);
+    });
+
+    it('paginates through multiple pages (MAX_PAGES = 2)', async () => {
+      const mockDataPage1 = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: 'page1_cursor' },
+      };
+      const mockDataPage2 = {
+        users: [
+          {
+            fid: 789,
+            username: 'bob',
+            display_name: 'Bob',
+            pfp_url: 'https://example.com/bob.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+
+      mockGetFollowing.mockResolvedValueOnce(mockDataPage1).mockResolvedValueOnce(mockDataPage2);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.members).toHaveLength(2);
+      expect(mockGetFollowing).toHaveBeenCalledTimes(2);
+      expect(mockGetFollowing).toHaveBeenNthCalledWith(1, 123, 123, 'desc_chron', undefined, 100);
+      expect(mockGetFollowing).toHaveBeenNthCalledWith(
+        2,
+        123,
+        123,
+        'desc_chron',
+        'page1_cursor',
+        100,
+      );
+    });
+
+    it('stops pagination after MAX_PAGES (2) even if cursor is present', async () => {
+      const mockDataPage1 = {
+        users: [{ fid: 456, username: 'alice', display_name: 'Alice' }],
+        next: { cursor: 'page1_cursor' },
+      };
+      const mockDataPage2 = {
+        users: [{ fid: 789, username: 'bob', display_name: 'Bob' }],
+        next: { cursor: 'page2_cursor' }, // Would paginate further but capped at MAX_PAGES=2
+      };
+
+      mockGetFollowing.mockResolvedValueOnce(mockDataPage1).mockResolvedValueOnce(mockDataPage2);
+
+      const res = await GET();
+      const _body = await res.json();
+
+      expect(mockGetFollowing).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops pagination when cursor is undefined mid-loop', async () => {
+      const mockDataPage1 = {
+        users: [{ fid: 456, username: 'alice', display_name: 'Alice' }],
+        next: { cursor: undefined }, // Stop early
+      };
+
+      mockGetFollowing.mockResolvedValueOnce(mockDataPage1);
+
+      const res = await GET();
+      const _body = await res.json();
+
+      expect(mockGetFollowing).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets cache-control header to private, max-age=15', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+
+      expect(res.headers.get('Cache-Control')).toBe('private, max-age=15');
+    });
+
+    it('calls getFollowing with correct parameters (desc_chron sort)', async () => {
+      const mockData = {
+        users: [],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      await GET();
+
+      expect(mockGetFollowing).toHaveBeenCalledWith(123, 123, 'desc_chron', undefined, 100);
+    });
+  });
+
+  describe('Error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 and logs error when getFollowing throws', async () => {
+      const testError = new Error('Neynar API error');
+      mockGetFollowing.mockRejectedValue(testError);
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to fetch following' });
+      expect(mockLoggerError).toHaveBeenCalledWith('Following online error:', testError);
+    });
+
+    it('does not expose error details in response', async () => {
+      const sensitiveError = new Error('Neynar API key invalid');
+      mockGetFollowing.mockRejectedValue(sensitiveError);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to fetch following');
+      expect(body.error).not.toContain('API key');
+      expect(body.error).not.toContain('Neynar');
+    });
+
+    it('handles error during pagination (first page succeeds, second fails)', async () => {
+      const mockDataPage1 = {
+        users: [{ fid: 456, username: 'alice', display_name: 'Alice' }],
+        next: { cursor: 'page1_cursor' },
+      };
+
+      mockGetFollowing
+        .mockResolvedValueOnce(mockDataPage1)
+        .mockRejectedValueOnce(new Error('Second page failed'));
+
+      const res = await GET();
+      expect(res.status).toBe(500);
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Response structure validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('response contains all required member fields', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+            custody_address: '0xaaa',
+            verified_addresses: { eth_addresses: ['0xbbb'] },
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      const member = body.members[0];
+      expect(member).toHaveProperty('fid');
+      expect(member).toHaveProperty('username');
+      expect(member).toHaveProperty('displayName');
+      expect(member).toHaveProperty('pfpUrl');
+      expect(member).toHaveProperty('addresses');
+    });
+
+    it('response does not contain unwanted fields from source', async () => {
+      const mockData = {
+        users: [
+          {
+            fid: 456,
+            username: 'alice',
+            display_name: 'Alice',
+            pfp_url: 'https://example.com/alice.jpg',
+            custody_address: '0xaaa',
+            verified_addresses: { eth_addresses: ['0xbbb'] },
+            power_user: true, // should not appear in response
+            verified: true, // should not appear in response
+          },
+        ],
+        next: { cursor: undefined },
+      };
+      mockGetFollowing.mockResolvedValue(mockData);
+
+      const res = await GET();
+      const body = await res.json();
+
+      const member = body.members[0];
+      expect(member).not.toHaveProperty('power_user');
+      expect(member).not.toHaveProperty('verified');
+      expect(member).not.toHaveProperty('display_name');
+      expect(member).not.toHaveProperty('custody_address');
+    });
+  });
+});

--- a/src/app/api/music/feed/__tests__/route.test.ts
+++ b/src/app/api/music/feed/__tests__/route.test.ts
@@ -1,0 +1,764 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockIsMusicUrl } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockIsMusicUrl: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    NEYNAR_API_KEY: 'test-api-key-12345',
+  },
+}));
+
+vi.mock('@/lib/music/isMusicUrl', () => ({
+  isMusicUrl: mockIsMusicUrl,
+}));
+
+// Mock global fetch
+global.fetch = vi.fn() as ReturnType<typeof vi.fn>;
+
+import { GET } from '../route';
+
+describe('/api/music/feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication ──────────────────────────────────────────────────────
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(401);
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('allows request with valid session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [], next: { cursor: undefined } } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Query Parameter Validation ──────────────────────────────────────────
+
+  describe('query parameter validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('uses default channel "all" when not provided', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      await GET(req);
+
+      // searchMusicCasts is called for channel="all"
+      const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      expect(fetchCalls.length).toBeGreaterThan(0);
+      expect(fetchCalls[0][0]).toContain('cast/search');
+    });
+
+    it('uses default limit 20 when not provided', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+
+      // The route should call searchMusicCasts with limit=20
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts custom limit parameter', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { limit: '10' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when limit is less than 1', async () => {
+      const req = makeGetRequest('/api/music/feed', { limit: '0' });
+      const res = await GET(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error', 'Invalid params');
+      expect(body).toHaveProperty('details');
+    });
+
+    it('returns 400 when limit exceeds 50', async () => {
+      const req = makeGetRequest('/api/music/feed', { limit: '51' });
+      const res = await GET(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error', 'Invalid params');
+    });
+
+    it('coerces limit to number from string', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { limit: '15' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts limit at boundary value 1', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { limit: '1' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts limit at boundary value 50', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { limit: '50' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts custom channel parameter', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ casts: [] }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Should call getChannelMusicCasts instead of searchMusicCasts
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(fetchUrl).toContain('feed/channels');
+    });
+
+    it('accepts cursor parameter', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { cursor: 'abc123' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Channel-specific Behavior ───────────────────────────────────────────
+
+  describe('channel behavior', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calls searchMusicCasts when channel is "all"', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'all' });
+      await GET(req);
+
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(fetchUrl).toContain('cast/search');
+    });
+
+    it('calls getChannelMusicCasts when channel is not "all"', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ casts: [] }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music' });
+      await GET(req);
+
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(fetchUrl).toContain('feed/channels');
+    });
+
+    it('passes channel_ids parameter to feed endpoint', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ casts: [] }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music' });
+      await GET(req);
+
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(fetchUrl).toContain('channel_ids=music');
+    });
+  });
+
+  // ── Music URL Filtering ─────────────────────────────────────────────────
+
+  describe('music URL filtering and extraction', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('filters casts with music URLs only', async () => {
+      const casts = [
+        {
+          hash: 'cast1',
+          author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+          text: 'Check this out',
+          timestamp: '2026-07-15T10:00:00Z',
+          embeds: [{ url: 'https://spotify.com/track/123' }],
+        },
+        {
+          hash: 'cast2',
+          author: { fid: 101, username: 'user2', pfp_url: 'https://example.com/2.jpg' },
+          text: 'No music here',
+          timestamp: '2026-07-15T10:01:00Z',
+        },
+      ];
+
+      mockIsMusicUrl.mockImplementation((url: string) => {
+        if (url.includes('spotify')) return 'spotify';
+        return null;
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: unknown[] };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks).toHaveLength(1);
+      expect(body.tracks[0]).toHaveProperty('castHash', 'cast1');
+    });
+
+    it('extracts music URL from embeds', async () => {
+      const casts = [
+        {
+          hash: 'cast1',
+          author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+          text: 'Check this',
+          timestamp: '2026-07-15T10:00:00Z',
+          embeds: [{ url: 'https://soundcloud.com/artist/track' }],
+        },
+      ];
+
+      mockIsMusicUrl.mockReturnValue('soundcloud');
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: Array<{ musicUrl: string; platform: string }> };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks[0].musicUrl).toBe('https://soundcloud.com/artist/track');
+      expect(body.tracks[0].platform).toBe('soundcloud');
+    });
+
+    it('extracts music URL from text when no embeds', async () => {
+      const casts = [
+        {
+          hash: 'cast1',
+          author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+          text: 'Check https://audius.co/artist/track',
+          timestamp: '2026-07-15T10:00:00Z',
+        },
+      ];
+
+      mockIsMusicUrl.mockImplementation((url: string) => {
+        if (url.includes('audius')) return 'audius';
+        return null;
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: Array<{ musicUrl: string; platform: string }> };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks[0].musicUrl).toBe('https://audius.co/artist/track');
+      expect(body.tracks[0].platform).toBe('audius');
+    });
+
+    it('maps platform to correct TrackType', async () => {
+      const casts = [
+        {
+          hash: 'cast1',
+          author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+          text: 'Music',
+          timestamp: '2026-07-15T10:00:00Z',
+          embeds: [{ url: 'https://youtube.com/watch?v=123' }],
+        },
+      ];
+
+      mockIsMusicUrl.mockReturnValue('youtube');
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: Array<{ platform: string }> };
+
+      expect(body.tracks[0].platform).toBe('youtube');
+    });
+  });
+
+  // ── Response Shape ──────────────────────────────────────────────────────
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns tracks array with correct fields', async () => {
+      const casts = [
+        {
+          hash: 'abc123',
+          author: { fid: 456, username: 'alice', pfp_url: 'https://example.com/alice.jpg' },
+          text: 'Great track',
+          timestamp: '2026-07-15T10:00:00Z',
+          embeds: [{ url: 'https://spotify.com/track/xyz' }],
+        },
+      ];
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as {
+        tracks: Array<{
+          castHash: string;
+          authorFid: number;
+          authorUsername: string;
+          authorPfp: string;
+          castText: string;
+          musicUrl: string;
+          platform: string;
+          timestamp: string;
+        }>;
+      };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks).toHaveLength(1);
+      const track = body.tracks[0];
+      expect(track.castHash).toBe('abc123');
+      expect(track.authorFid).toBe(456);
+      expect(track.authorUsername).toBe('alice');
+      expect(track.authorPfp).toBe('https://example.com/alice.jpg');
+      expect(track.castText).toBe('Great track');
+      expect(track.musicUrl).toBe('https://spotify.com/track/xyz');
+      expect(track.platform).toBe('spotify');
+      expect(track.timestamp).toBe('2026-07-15T10:00:00Z');
+    });
+
+    it('returns nextCursor from Neynar response', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { casts: [], next: { cursor: 'next-cursor-123' } },
+        }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { nextCursor: string | null };
+
+      expect(res.status).toBe(200);
+      expect(body.nextCursor).toBe('next-cursor-123');
+    });
+
+    it('returns null for nextCursor when not present', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { nextCursor: null };
+
+      expect(res.status).toBe(200);
+      expect(body.nextCursor).toBeNull();
+    });
+
+    it('includes Cache-Control header', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, s-maxage=300, stale-while-revalidate=60',
+      );
+    });
+  });
+
+  // ── Empty/Edge Cases ────────────────────────────────────────────────────
+
+  describe('empty feed', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns empty tracks array when no casts found', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: unknown[] };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks).toEqual([]);
+    });
+
+    it('returns empty tracks array when no casts have music URLs', async () => {
+      const casts = [
+        {
+          hash: 'cast1',
+          author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+          text: 'No music here',
+          timestamp: '2026-07-15T10:00:00Z',
+          embeds: [{ url: 'https://example.com' }],
+        },
+      ];
+
+      mockIsMusicUrl.mockReturnValue(null);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: unknown[] };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks).toEqual([]);
+    });
+  });
+
+  // ── Limit Enforcement ───────────────────────────────────────────────────
+
+  describe('limit enforcement', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('stops at limit even if more casts with music exist', async () => {
+      const casts = Array.from({ length: 30 }, (_, i) => ({
+        hash: `cast${i}`,
+        author: { fid: 100 + i, username: `user${i}`, pfp_url: 'https://example.com/pfp.jpg' },
+        text: `Track ${i}`,
+        timestamp: '2026-07-15T10:00:00Z',
+        embeds: [{ url: `https://spotify.com/track/${i}` }],
+      }));
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { limit: '10' });
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: unknown[] };
+
+      expect(res.status).toBe(200);
+      expect(body.tracks.length).toBeLessThanOrEqual(10);
+    });
+  });
+
+  // ── Cursor Passthrough ──────────────────────────────────────────────────
+
+  describe('cursor passthrough', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('passes cursor to searchMusicCasts', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { cursor: 'cursor-abc' });
+      await GET(req);
+
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(fetchUrl).toContain('cursor=cursor-abc');
+    });
+
+    it('passes cursor to getChannelMusicCasts', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ casts: [] }),
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music', cursor: 'next123' });
+      await GET(req);
+
+      const fetchUrl = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+      expect(fetchUrl).toContain('cursor=next123');
+    });
+  });
+
+  // ── Neynar API Error Handling ───────────────────────────────────────────
+
+  describe('Neynar API error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when Neynar returns error status', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Neynar server error',
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music' });
+      const res = await GET(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toHaveProperty('error', 'Failed to fetch music feed');
+    });
+
+    it('returns 200 with empty tracks when searchMusicCasts fetch rejects (allSettled tolerates)', async () => {
+      // searchMusicCasts uses Promise.allSettled, so rejections don't throw
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network error'));
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as { tracks: unknown[] };
+
+      // Promise.allSettled catches rejections, so this returns 200 with empty tracks
+      expect(res.status).toBe(200);
+      expect(body.tracks).toEqual([]);
+    });
+
+    it('tolerates partial failures in searchMusicCasts domains', async () => {
+      // First two calls fail, third succeeds
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          json: async () => ({}),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          json: async () => ({}),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            result: {
+              casts: [
+                {
+                  hash: 'cast1',
+                  author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+                  text: 'Music',
+                  timestamp: '2026-07-15T10:00:00Z',
+                  embeds: [{ url: 'https://spotify.com/track/123' }],
+                },
+              ],
+            },
+          }),
+        });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tracks: unknown[] };
+      expect(body.tracks.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Generic Error Handling ──────────────────────────────────────────────
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      mockIsMusicUrl.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            casts: [
+              {
+                hash: 'cast1',
+                author: { fid: 100, username: 'user1', pfp_url: 'https://example.com/1.jpg' },
+                text: 'Music',
+                timestamp: '2026-07-15T10:00:00Z',
+                embeds: [{ url: 'https://spotify.com/track/123' }],
+              },
+            ],
+          },
+        }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      const res = await GET(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toHaveProperty('error', 'Failed to fetch music feed');
+    });
+
+    it('returns 500 on getChannelMusicCasts error', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'Service unavailable',
+      });
+
+      const req = makeGetRequest('/api/music/feed', { channel: 'music' });
+      const res = await GET(req);
+      const body = (await res.json()) as { error: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch music feed');
+    });
+  });
+
+  // ── API Headers ─────────────────────────────────────────────────────────
+
+  describe('Neynar API headers', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('includes x-api-key header in Neynar requests', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      await GET(req);
+
+      const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const headers = fetchCalls[0][1] as { headers: Record<string, string> };
+      expect(headers.headers['x-api-key']).toBe('test-api-key-12345');
+    });
+
+    it('includes Content-Type header in Neynar requests', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { casts: [] } }),
+      });
+
+      const req = makeGetRequest('/api/music/feed');
+      await GET(req);
+
+      const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+      const headers = fetchCalls[0][1] as { headers: Record<string, string> };
+      expect(headers.headers['Content-Type']).toBe('application/json');
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 3 previously-untested API routes — **82 tests total**. External Neynar/Unlock fully mocked — no real API or on-chain calls.

| Route | Tests | Covers |
|-------|-------|--------|
| `following/online` | 25 | auth, getFollowing mapping/filtering (self-exclusion, address collection), pagination cap, cache header, errors |
| `music/feed` | 35 | auth, Zod (channel/limit coerce/cursor), Neynar fetch, isMusicUrl filtering + TrackType map, Promise.allSettled tolerance, errors |
| `events/verify-ticket` | 22 | Zod (eventSlug + at-least-one-of fid/wallet), event-not-found 404 / no-lock 409, Unlock findKeyHolder holder/non-holder, fid→addresses, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found in these 3.

_(Note: the 4th route from this batch, `miniapp/discover`, surfaced the same NaN-limit bug as bluesky/feed — its route fix + test are folded into runtime PR #1476, not here.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)