### PR TITLE
test(music,fractals): search/radio/proposals (82 tests)

### DIFF
--- a/src/app/api/fractals/proposals/__tests__/route.test.ts
+++ b/src/app/api/fractals/proposals/__tests__/route.test.ts
@@ -1,0 +1,775 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetSessionData, mockFetchProposalsOnChain } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFetchProposalsOnChain: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/ordao/client', () => ({
+  fetchProposalsOnChain: mockFetchProposalsOnChain,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock global fetch for the ornode fallback
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+import { GET } from '../route';
+
+describe('GET /api/fractals/proposals', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockClear();
+  });
+
+  // ========================================================================
+  // Authentication / Session tests
+  // ========================================================================
+
+  it('returns 401 when session is null (unauthenticated)', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when session is undefined (unauthenticated)', async () => {
+    mockGetSessionData.mockResolvedValue(undefined);
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('returns 401 when session is falsy object', async () => {
+    mockGetSessionData.mockResolvedValue({});
+
+    // Empty object is truthy in JS, so this should actually NOT return 401
+    // Let's test that authenticated requests pass through.
+    const mockProposals = [
+      {
+        id: '0x123',
+        proposer: '0xabc',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 1000,
+      },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  // ========================================================================
+  // Primary path: ornode success
+  // ========================================================================
+
+  it('returns 200 with proposals from ornode when successful', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+
+    const mockProposals = [
+      { id: '0x1', proposer: '0xaaa', title: 'Proposal 1' },
+      { id: '0x2', proposer: '0xbbb', title: 'Proposal 2' },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      proposals: mockProposals,
+      total: mockProposals.length,
+      source: 'ornode',
+    });
+  });
+
+  it('passes correct ornode URL and request options to fetch', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = [{ id: '0x1', proposer: '0xaaa' }];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    await GET();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ornode2.frapps.xyz/proposals?limit=20',
+      expect.objectContaining({
+        next: { revalidate: 60 },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('handles ornode response as array directly', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = [
+      { id: '0x1', proposer: '0xaaa' },
+      { id: '0x2', proposer: '0xbbb' },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals).toEqual(mockProposals);
+  });
+
+  it('handles ornode response as object with proposals field', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = [
+      { id: '0x1', proposer: '0xaaa' },
+      { id: '0x2', proposer: '0xbbb' },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        proposals: mockProposals,
+        meta: { total: 2 },
+      }),
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals).toEqual(mockProposals);
+    expect(body.total).toBe(mockProposals.length);
+  });
+
+  it('includes correct total count in response', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = Array.from({ length: 5 }, (_, i) => ({
+      id: `0x${i}`,
+      proposer: '0xaaa',
+    }));
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.total).toBe(5);
+  });
+
+  // ========================================================================
+  // Primary path: ornode failures and fallback to on-chain
+  // ========================================================================
+
+  it('falls back to on-chain when ornode returns non-ok status', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0x100',
+        proposer: '0xccc',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 5000,
+      },
+    ];
+
+    // ornode fails with 500
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    // on-chain succeeds
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      proposals: onChainProposals,
+      total: onChainProposals.length,
+      source: 'onchain',
+    });
+  });
+
+  it('falls back to on-chain when ornode throws error', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0x200',
+        proposer: '0xddd',
+        stage: 'Veto',
+        voteStatus: 'Failing',
+        isLive: false,
+        blockNumber: 6000,
+      },
+    ];
+
+    // ornode throws network error
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    // on-chain succeeds
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.source).toBe('onchain');
+  });
+
+  it('falls back to on-chain when ornode returns empty proposals', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0x300',
+        proposer: '0xeee',
+        stage: 'Execution',
+        voteStatus: 'Passed',
+        isLive: false,
+        blockNumber: 7000,
+      },
+    ];
+
+    // ornode returns empty array
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    // on-chain succeeds
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.source).toBe('onchain');
+  });
+
+  it('falls back to on-chain when ornode returns object with empty proposals field', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0x400',
+        proposer: '0xfff',
+        stage: 'Expired',
+        voteStatus: 'Failed',
+        isLive: false,
+        blockNumber: 8000,
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ proposals: [] }),
+    });
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.source).toBe('onchain');
+  });
+
+  it('falls back to on-chain when ornode JSON parsing fails', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0x500',
+        proposer: '0x999',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 9000,
+      },
+    ];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new Error('Invalid JSON');
+      },
+    });
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.source).toBe('onchain');
+  });
+
+  // ========================================================================
+  // Fallback path: on-chain success
+  // ========================================================================
+
+  it('returns 200 with proposals from on-chain fallback when successful', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const onChainProposals = [
+      {
+        id: '0xabc123',
+        proposer: '0xproposer1',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 12345,
+      },
+    ];
+
+    // ornode fails
+    mockFetch.mockRejectedValueOnce(new Error('ornode unavailable'));
+
+    // on-chain succeeds
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      proposals: onChainProposals,
+      total: 1,
+      source: 'onchain',
+    });
+  });
+
+  it('calls fetchProposalsOnChain with limit of 20', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode unavailable'));
+
+    const onChainProposals = [];
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    await GET();
+
+    expect(mockFetchProposalsOnChain).toHaveBeenCalledWith(20);
+  });
+
+  // ========================================================================
+  // Both paths fail
+  // ========================================================================
+
+  it('returns empty proposals with source unavailable when both paths fail', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    // ornode fails
+    mockFetch.mockRejectedValueOnce(new Error('ornode timeout'));
+
+    // on-chain also fails
+    mockFetchProposalsOnChain.mockRejectedValueOnce(new Error('on-chain read failed'));
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      proposals: [],
+      total: 0,
+      source: 'unavailable',
+    });
+  });
+
+  it('returns empty proposals when on-chain throws network error', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode network error'));
+    mockFetchProposalsOnChain.mockRejectedValueOnce(new Error('RPC connection failed'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals).toEqual([]);
+    expect(body.source).toBe('unavailable');
+  });
+
+  it('returns empty proposals when on-chain throws contract error', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode unavailable'));
+    mockFetchProposalsOnChain.mockRejectedValueOnce(new Error('Call exception'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals).toEqual([]);
+    expect(body.total).toBe(0);
+  });
+
+  // ========================================================================
+  // Response shape validation
+  // ========================================================================
+
+  it('response shape includes all required fields when ornode succeeds', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = [{ id: '0x1' }];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toHaveProperty('proposals');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('source');
+    expect(typeof body.proposals).toBe('object');
+    expect(typeof body.total).toBe('number');
+    expect(typeof body.source).toBe('string');
+  });
+
+  it('response shape includes all required fields when on-chain succeeds', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode failed'));
+
+    const onChainProposals = [
+      {
+        id: '0xdef456',
+        proposer: '0xprop',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 15000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toHaveProperty('proposals');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('source');
+  });
+
+  it('response shape includes all required fields when both paths fail', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode failed'));
+    mockFetchProposalsOnChain.mockRejectedValueOnce(new Error('on-chain failed'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body).toHaveProperty('proposals');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('source');
+    expect(Array.isArray(body.proposals)).toBe(true);
+  });
+
+  // ========================================================================
+  // Source field validation
+  // ========================================================================
+
+  it('sets source to ornode when ornode succeeds', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = [{ id: '0x1' }];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('ornode');
+  });
+
+  it('sets source to onchain when falling back to on-chain', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode unavailable'));
+
+    const onChainProposals = [
+      {
+        id: '0x789',
+        proposer: '0xtest',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 20000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('onchain');
+  });
+
+  it('sets source to unavailable when both paths fail', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode failed'));
+    mockFetchProposalsOnChain.mockRejectedValueOnce(new Error('on-chain failed'));
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('unavailable');
+  });
+
+  // ========================================================================
+  // Error handling edge cases
+  // ========================================================================
+
+  it('handles non-Error thrown values from ornode', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce('string error');
+
+    const onChainProposals = [
+      {
+        id: '0x1',
+        proposer: '0xtest',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 25000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.source).toBe('onchain');
+  });
+
+  it('handles non-Error thrown values from on-chain', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode failed'));
+    mockFetchProposalsOnChain.mockRejectedValueOnce('string error from contract');
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals).toEqual([]);
+    expect(body.source).toBe('unavailable');
+  });
+
+  // ========================================================================
+  // Multiple proposals handling
+  // ========================================================================
+
+  it('handles large number of proposals from ornode', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    const mockProposals = Array.from({ length: 50 }, (_, i) => ({
+      id: `0x${i}`,
+      proposer: '0xaaa',
+      title: `Proposal ${i}`,
+    }));
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals.length).toBe(50);
+    expect(body.total).toBe(50);
+  });
+
+  it('handles large number of proposals from on-chain', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('ornode failed'));
+
+    const onChainProposals = Array.from({ length: 20 }, (_, i) => ({
+      id: `0x${i}`,
+      proposer: '0xtest',
+      stage: 'Voting',
+      voteStatus: 'Passing',
+      isLive: true,
+      blockNumber: 1000 + i,
+    }));
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.proposals.length).toBe(20);
+  });
+
+  // ========================================================================
+  // ornode status code handling
+  // ========================================================================
+
+  it('falls back when ornode returns 404', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const onChainProposals = [
+      {
+        id: '0x1',
+        proposer: '0xtest',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 30000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('onchain');
+  });
+
+  it('falls back when ornode returns 503 Service Unavailable', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+    });
+
+    const onChainProposals = [
+      {
+        id: '0x1',
+        proposer: '0xtest',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 35000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('onchain');
+  });
+
+  it('falls back when ornode times out (AbortSignal)', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 123 });
+
+    mockFetch.mockRejectedValueOnce(new Error('The operation was aborted'));
+
+    const onChainProposals = [
+      {
+        id: '0x1',
+        proposer: '0xtest',
+        stage: 'Voting',
+        voteStatus: 'Passing',
+        isLive: true,
+        blockNumber: 40000,
+      },
+    ];
+
+    mockFetchProposalsOnChain.mockResolvedValueOnce(onChainProposals);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.source).toBe('onchain');
+  });
+
+  // ========================================================================
+  // Session data validity
+  // ========================================================================
+
+  it('allows authenticated session with minimal data', async () => {
+    mockGetSessionData.mockResolvedValue({ fid: 1 });
+
+    const mockProposals = [{ id: '0x1' }];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+
+  it('allows authenticated session with full data', async () => {
+    mockGetSessionData.mockResolvedValue({
+      fid: 456,
+      username: 'alice',
+      displayName: 'Alice Smith',
+      isAdmin: true,
+      pfpUrl: 'https://example.com/pfp.jpg',
+    });
+
+    const mockProposals = [{ id: '0x1' }];
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockProposals,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/music/radio/__tests__/route.test.ts
+++ b/src/app/api/music/radio/__tests__/route.test.ts
@@ -1,0 +1,729 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// Mock communityConfig with radioPlaylists
+vi.mock('@/../community.config', () => ({
+  communityConfig: {
+    music: {
+      radioPlaylists: [
+        {
+          name: 'Test Playlist 1',
+          artist: 'Test Artist 1',
+          url: 'https://audius.co/testuser1/playlist/test-playlist-1',
+        },
+        {
+          name: 'Test Playlist 2',
+          artist: 'Test Artist 2',
+          url: 'https://audius.co/testuser2/album/test-album',
+        },
+      ],
+    },
+  },
+}));
+
+import { GET } from '../route';
+
+// Mock global fetch for Audius API calls
+global.fetch = vi.fn() as unknown as typeof fetch;
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const VALID_AUDIUS_PLAYLIST_RESPONSE = {
+  data: {
+    id: 'playlist-1',
+    playlist_name: 'Test Playlist 1',
+    user: {
+      name: 'Test Artist 1',
+      handle: 'testuser1',
+    },
+    artwork: {
+      '480x480': 'https://example.com/artwork-480.jpg',
+      '150x150': 'https://example.com/artwork-150.jpg',
+    },
+    tracks: [
+      {
+        id: 'track-1',
+        title: 'Song 1',
+        user: {
+          name: 'Song Artist 1',
+          handle: 'songartist1',
+        },
+        permalink: 'song-1',
+        artwork: {
+          '480x480': 'https://example.com/track1-480.jpg',
+          '150x150': 'https://example.com/track1-150.jpg',
+        },
+        duration: 240,
+      },
+      {
+        id: 'track-2',
+        title: 'Song 2',
+        user: {
+          name: 'Song Artist 2',
+          handle: 'songartist2',
+        },
+        permalink: 'song-2',
+        artwork: {
+          '480x480': 'https://example.com/track2-480.jpg',
+          '150x150': 'https://example.com/track2-150.jpg',
+        },
+        duration: 180,
+      },
+    ],
+  },
+};
+
+const VALID_AUDIUS_ALBUM_RESPONSE = {
+  data: {
+    id: 'album-1',
+    playlist_name: 'Test Album',
+    is_album: true,
+    user: {
+      name: 'Test Artist 2',
+      handle: 'testuser2',
+    },
+    artwork: {
+      '480x480': 'https://example.com/album-480.jpg',
+    },
+    playlist_contents: {
+      track_ids: ['track-3', 'track-4'],
+    },
+  },
+};
+
+const VALID_AUDIUS_BULK_TRACKS_RESPONSE = {
+  data: [
+    {
+      id: 'track-3',
+      title: 'Album Song 1',
+      user: {
+        name: 'Album Artist',
+        handle: 'albumartist',
+      },
+      permalink: 'album-song-1',
+      artwork: {
+        '480x480': 'https://example.com/album-track1-480.jpg',
+      },
+      duration: 200,
+    },
+    {
+      id: 'track-4',
+      title: 'Album Song 2',
+      user: {
+        name: 'Album Artist',
+        handle: 'albumartist',
+      },
+      permalink: 'album-song-2',
+      artwork: {
+        '150x150': 'https://example.com/album-track2-150.jpg',
+      },
+      duration: 220,
+    },
+  ],
+};
+
+describe('GET /api/music/radio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Authentication tests
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when no session is present', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success path: with inline tracks in resolve response
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 with playlists containing inline tracks', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // Mock first resolve call for playlist 1 (with inline tracks)
+    const mockResolveRes1 = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    // Mock second resolve call for playlist 2 (without inline tracks, needs bulk fetch)
+    const mockResolveRes2 = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_ALBUM_RESPONSE),
+    };
+
+    // Mock bulk track fetch for playlist 2
+    const mockBulkRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_BULK_TRACKS_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockResolveRes1)
+      .mockResolvedValueOnce(mockResolveRes2)
+      .mockResolvedValueOnce(mockBulkRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    expect(body).toHaveProperty('playlists');
+
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+    expect(playlists).toHaveLength(2);
+
+    // Verify first playlist (with inline tracks)
+    expect(playlists[0].name).toBe('Test Playlist 1');
+    expect(playlists[0].artist).toBe('Test Artist 1');
+    expect(playlists[0].artworkUrl).toBe('https://example.com/artwork-480.jpg');
+
+    const tracks1 = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks1).toHaveLength(2);
+    expect(tracks1[0].id).toBe('track-1');
+    expect(tracks1[0].title).toBe('Song 1');
+    expect(tracks1[0].artist).toBe('Song Artist 1');
+    expect(tracks1[0].duration).toBe(240);
+    expect(tracks1[0].streamUrl).toContain('/v1/tracks/track-1/stream');
+
+    // Verify second playlist (with bulk-fetched tracks)
+    expect(playlists[1].name).toBe('Test Album');
+    expect(playlists[1].artist).toBe('Test Artist 2');
+
+    const tracks2 = playlists[1].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks2).toHaveLength(2);
+    expect(tracks2[0].id).toBe('track-3');
+    expect(tracks2[0].title).toBe('Album Song 1');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success path: with track artwork fallback
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('falls back to playlist artwork when track artwork is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const trackWithoutArtwork = {
+      ...VALID_AUDIUS_PLAYLIST_RESPONSE.data.tracks[0],
+      artwork: undefined,
+    };
+
+    const responseWithoutTrackArtwork = {
+      data: {
+        ...VALID_AUDIUS_PLAYLIST_RESPONSE.data,
+        tracks: [trackWithoutArtwork],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(responseWithoutTrackArtwork),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    // Should fall back to playlist artwork
+    expect(tracks[0].artworkUrl).toBe('https://example.com/artwork-480.jpg');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success path: with 150x150 artwork fallback
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('uses 150x150 artwork when 480x480 is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const trackWithSmallArtwork = {
+      ...VALID_AUDIUS_PLAYLIST_RESPONSE.data.tracks[0],
+      artwork: {
+        '150x150': 'https://example.com/track-small.jpg',
+      },
+    };
+
+    const responseWithSmallArtwork = {
+      data: {
+        ...VALID_AUDIUS_PLAYLIST_RESPONSE.data,
+        tracks: [trackWithSmallArtwork],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(responseWithSmallArtwork),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks[0].artworkUrl).toBe('https://example.com/track-small.jpg');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Empty playlist handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('skips playlists with no tracks', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const emptyPlaylist = {
+      data: {
+        id: 'empty-playlist',
+        playlist_name: 'Empty',
+        user: { name: 'User' },
+        tracks: [],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(emptyPlaylist),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+    expect(playlists).toHaveLength(2); // Only the 2 config playlists, empty one is skipped
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Null/missing data handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('skips playlists with no resolved data', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const nullDataResponse = {
+      data: null,
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(nullDataResponse),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+    // All playlists have null data, so all are skipped
+    expect(playlists).toHaveLength(0);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Bulk track fetch failure handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('creates playlist with empty tracks when bulk fetch fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // First resolve: returns album without inline tracks
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_ALBUM_RESPONSE),
+    };
+
+    // Bulk fetch fails
+    const mockBulkRes = {
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({ error: 'Invalid track IDs' }),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockResolveRes)
+      .mockResolvedValueOnce(mockBulkRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    // Should still include the playlist, but with 0 or 1 playlists total (second one has empty tracks)
+    expect(playlists.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Audius resolve fetch failure
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('skips playlist when Audius resolve fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // First resolve succeeds
+    const mockResolveRes1 = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    // Second resolve fails
+    const mockResolveRes2 = {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: vi.fn().mockResolvedValue({ error: 'Playlist not found' }),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockResolveRes1)
+      .mockResolvedValueOnce(mockResolveRes2);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    // Should include only the first playlist (second one failed)
+    expect(playlists).toHaveLength(1);
+    expect(playlists[0].name).toBe('Test Playlist 1');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Fetch network error handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('skips playlist when fetch throws network error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // First fetch succeeds
+    const mockResolveRes1 = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    // Second fetch throws error
+    const networkError = new Error('Network timeout');
+
+    (global.fetch as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(mockResolveRes1)
+      .mockRejectedValueOnce(networkError);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    // Should include only the first playlist (second one failed)
+    expect(playlists).toHaveLength(1);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Default values when fields are missing
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('uses config defaults when Audius response lacks user/playlist names', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const minimalPlaylist = {
+      data: {
+        id: 'minimal-id',
+        tracks: [
+          {
+            id: 'track-99',
+            title: 'Song Title',
+            duration: 100,
+          },
+        ],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(minimalPlaylist),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    // Should use config defaults for missing playlist name/artist
+    expect(playlists[0].name).toBe('Test Playlist 1');
+    expect(playlists[0].artist).toBe('Test Artist 1');
+  });
+
+  it('uses config artist default for track when track artist is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const trackWithoutArtist = {
+      data: {
+        id: 'playlist-id',
+        playlist_name: 'Test',
+        tracks: [
+          {
+            id: 'track-no-artist',
+            title: 'Song',
+            duration: 100,
+          },
+        ],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(trackWithoutArtist),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks[0].artist).toBe('Test Artist 1'); // config default
+  });
+
+  it('defaults to "Untitled" when track has no title', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const trackWithoutTitle = {
+      data: {
+        id: 'playlist-id',
+        tracks: [
+          {
+            id: 'track-no-title',
+            duration: 100,
+          },
+        ],
+      },
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(trackWithoutTitle),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks[0].title).toBe('Untitled');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Response structure and caching headers
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns correct response structure with cache headers', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+
+    // Check cache headers
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=300, s-maxage=300');
+
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    expect(body).toHaveProperty('playlists');
+    expect(Array.isArray(body.playlists)).toBe(true);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // URL encoding and app_name param
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('properly encodes playlist URL and includes app_name parameter', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+
+    // Verify fetch was called with correct URL encoding
+    const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(fetchCalls[0][0]).toContain('resolve?url=');
+    expect(fetchCalls[0][0]).toContain('app_name=ZAO-OS');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // AbortSignal timeout
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('sets abort signal timeout on fetch requests', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    await GET(makeGetRequest('/api/music/radio'));
+
+    // Verify fetch was called with AbortSignal timeout option
+    const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(fetchCalls[0][1]).toHaveProperty('signal');
+    expect(fetchCalls[0][1]).toHaveProperty('redirect', 'follow');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Track URL construction
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('constructs track URLs with handle and permalink', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks[0].url).toContain('https://audius.co/');
+    expect(tracks[0].url).toContain('songartist1');
+    expect(tracks[0].url).toContain('song-1');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Multiple identical fetch scenarios (data array format)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('handles Audius response where data is an array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // Audius sometimes returns data as an array, should take first element
+    const arrayDataResponse = {
+      data: [VALID_AUDIUS_PLAYLIST_RESPONSE.data],
+    };
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(arrayDataResponse),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    expect(playlists.length).toBeGreaterThan(0);
+    expect(playlists[0].name).toBe('Test Playlist 1');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Track stream URL format
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('generates correct stream URLs with track ID and app_name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const mockResolveRes = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(VALID_AUDIUS_PLAYLIST_RESPONSE),
+    };
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockResolveRes);
+
+    const res = await GET(makeGetRequest('/api/music/radio'));
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as unknown as Record<string, unknown>;
+    const playlists = body.playlists as unknown as Array<Record<string, unknown>>;
+
+    const tracks = playlists[0].tracks as unknown as Array<Record<string, unknown>>;
+    expect(tracks[0].streamUrl).toBe(
+      'https://api.audius.co/v1/tracks/track-1/stream?app_name=ZAO-OS',
+    );
+  });
+});

--- a/src/app/api/music/search/__tests__/route.test.ts
+++ b/src/app/api/music/search/__tests__/route.test.ts
@@ -1,0 +1,780 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const {
+  mockGetSession,
+  mockSearchAudiusTracks,
+  mockSearchTidal,
+  mockGetSupabaseAdmin,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockSearchAudiusTracks: vi.fn(),
+  mockSearchTidal: vi.fn(),
+  mockGetSupabaseAdmin: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock('@/lib/music/audius', () => ({
+  searchAudiusTracks: mockSearchAudiusTracks,
+}));
+
+vi.mock('@/lib/music/tidal', () => ({
+  searchTidal: mockSearchTidal,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: mockGetSupabaseAdmin,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/music/search/route';
+import { chainMock } from '@/test-utils/api-helpers';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+function makeGetRequest(path: string, params?: Record<string, string>): NextRequest {
+  const url = new URL(path, 'http://localhost:3000');
+  if (params) {
+    for (const [k, v] of Object.entries(params)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return new NextRequest(url);
+}
+
+// ── Test suite ───────────────────────────────────────────────────────────────
+describe('GET /api/music/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.TIDAL_CLIENT_ID;
+  });
+
+  describe('Authentication', () => {
+    it('returns 401 when session is null (no user)', async () => {
+      mockGetSession.mockResolvedValue({});
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when both fid and walletAddress are missing', async () => {
+      mockGetSession.mockResolvedValue({
+        username: 'testuser',
+        displayName: 'Test User',
+      });
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('succeeds with valid fid', async () => {
+      mockGetSession.mockResolvedValue({
+        fid: 123,
+        username: 'testuser',
+      });
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('succeeds with valid walletAddress', async () => {
+      mockGetSession.mockResolvedValue({
+        walletAddress: '0x1234567890123456789012345678901234567890',
+      });
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Input Validation (Zod)', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        fid: 123,
+        username: 'testuser',
+      });
+    });
+
+    it('returns 400 when q param is missing', async () => {
+      const req = makeGetRequest('/api/music/search', {});
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+      expect(body.error.fieldErrors).toBeDefined();
+    });
+
+    it('returns 400 when q is empty string', async () => {
+      const req = makeGetRequest('/api/music/search', { q: '' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+    });
+
+    it('returns 400 when q exceeds 200 characters', async () => {
+      const longQuery = 'a'.repeat(201);
+      const req = makeGetRequest('/api/music/search', { q: longQuery });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+    });
+
+    it('succeeds with q at exactly 200 characters', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const query200 = 'a'.repeat(200);
+      const req = makeGetRequest('/api/music/search', { q: query200 });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when limit is 0', async () => {
+      const req = makeGetRequest('/api/music/search', { q: 'test', limit: '0' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+    });
+
+    it('returns 400 when limit exceeds 50', async () => {
+      const req = makeGetRequest('/api/music/search', { q: 'test', limit: '51' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBeDefined();
+    });
+
+    it('coerces limit string to number', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test', limit: '10' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Verify searchAudiusTracks was called with coerced number
+      expect(mockSearchAudiusTracks).toHaveBeenCalledWith('test', 10);
+    });
+
+    it('uses default limit of 20 when not provided', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSearchAudiusTracks).toHaveBeenCalledWith('test', 20);
+    });
+
+    it('accepts optional genre param without validation', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test', genre: 'hiphop' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts q with 1 character (minimum)', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(chainMock({ data: [] }).chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'a' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Success Path — All Sources', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        fid: 123,
+        username: 'testuser',
+      });
+      process.env.TIDAL_CLIENT_ID = 'test-tidal-id';
+    });
+
+    it('merges results from Audius, library, and Tidal', async () => {
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Test Song',
+        user: { name: 'Artist 1' },
+        artwork: { '480x480': 'https://example.com/audius-art.jpg' },
+        play_count: 100,
+        permalink: '/artist/test-song',
+      };
+
+      const libraryTrack = {
+        id: 'lib-456',
+        title: 'Library Song',
+        artist: 'Artist 2',
+        artwork_url: 'https://example.com/lib-art.jpg',
+        url: 'https://example.com/lib',
+        stream_url: 'https://example.com/lib-stream',
+        platform: 'custom',
+        play_count: 50,
+      };
+
+      const tidalTrack = {
+        id: 'tidal-789',
+        title: 'Tidal Song',
+        artist: 'Artist 3',
+        artworkUrl: 'https://example.com/tidal-art.jpg',
+        url: 'https://tidal.com/browse/track/789',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([tidalTrack] as never);
+
+      const libraryChain = chainMock({ data: [libraryTrack] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test', limit: '10' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have at least Audius and Tidal results; library may vary based on dedup
+      expect(body.results.length).toBeGreaterThanOrEqual(2);
+      expect(body.results.some((r) => r.platform === 'audius')).toBe(true);
+      expect(body.results.some((r) => r.platform === 'tidal')).toBe(true);
+
+      expect(body.sources).toContain('audius');
+      expect(body.sources).toContain('library');
+      expect(body.sources).toContain('tidal');
+    });
+
+    it('deduplicates identical titles and artists across sources', async () => {
+      const audiusTrack = {
+        id: 'audius-dupe',
+        title: 'Same Song',
+        user: { name: 'Same Artist' },
+        artwork: { '480x480': 'https://example.com/art.jpg' },
+        play_count: 100,
+        permalink: '/artist/same-song',
+      };
+
+      const libraryTrack = {
+        id: 'lib-dupe',
+        title: 'same song', // Case-insensitive match
+        artist: 'same artist',
+        artwork_url: 'https://example.com/lib-art.jpg',
+        url: 'https://example.com',
+        stream_url: 'https://example.com/stream',
+        platform: 'custom',
+        play_count: 50,
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [libraryTrack] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'same' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Only Audius result should be included; library duplicate rejected
+      expect(body.results).toHaveLength(1);
+      expect(body.results[0].id).toBe('audius-audius-dupe');
+    });
+
+    it('caps Tidal limit to 5', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test', limit: '50' });
+      await GET(req);
+
+      // Even though limit is 50, Tidal should be called with Math.min(50, 5) = 5
+      expect(mockSearchTidal).toHaveBeenCalledWith('test', 5);
+    });
+
+    it('uses Audius and library when TIDAL_CLIENT_ID is not set', async () => {
+      delete process.env.TIDAL_CLIENT_ID;
+
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Test',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/test',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.sources).toContain('audius');
+      expect(body.sources).toContain('library');
+      expect(body.sources).not.toContain('tidal');
+
+      // Tidal should not be called
+      expect(mockSearchTidal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Fault Tolerance — Promise.allSettled', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        fid: 123,
+      });
+      process.env.TIDAL_CLIENT_ID = 'test-tidal-id';
+    });
+
+    it('continues when Audius search fails', async () => {
+      mockSearchAudiusTracks.mockRejectedValue(new Error('Audius API error'));
+
+      const tidalTrack = {
+        id: 'tidal-789',
+        title: 'Tidal Song',
+        artist: 'Artist 3',
+        artworkUrl: 'https://example.com/tidal-art.jpg',
+        url: 'https://tidal.com/browse/track/789',
+      };
+
+      mockSearchTidal.mockResolvedValue([tidalTrack] as never);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have results from Tidal (Audius failed, library empty)
+      expect(body.results.length).toBeGreaterThan(0);
+      const tidalResult = body.results.find((r) => r.platform === 'tidal');
+      expect(tidalResult).toBeDefined();
+      expect(tidalResult?.title).toBe('Tidal Song');
+    });
+
+    it('continues when library search fails', async () => {
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Audius Song',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/song',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: null, error: { message: 'DB error' } });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have Audius results, skip library error
+      expect(body.results.length).toBeGreaterThan(0);
+      expect(body.results[0].platform).toBe('audius');
+    });
+
+    it('continues when Tidal search fails', async () => {
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Audius Song',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/song',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockRejectedValue(new Error('Tidal API error'));
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have Audius results, skip Tidal error
+      expect(body.results.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty results when all sources fail', async () => {
+      mockSearchAudiusTracks.mockRejectedValue(new Error('Audius error'));
+      mockSearchTidal.mockRejectedValue(new Error('Tidal error'));
+
+      const libraryChain = chainMock({ error: { message: 'Library error' } });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.results).toHaveLength(0);
+      expect(body.sources.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Edge Cases — Track Data', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('handles Audius track with missing artwork', async () => {
+      const audiusTrack = {
+        id: 'audius-no-art',
+        title: 'No Artwork Track',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/track',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results[0].artworkUrl).toBe('');
+    });
+
+    it('handles Audius track with missing user name', async () => {
+      const audiusTrack = {
+        id: 'audius-no-user',
+        title: 'No User Track',
+        user: {},
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/track',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results[0].artist).toBe('Unknown');
+    });
+
+    it('prefers 480x480 artwork over 150x150 for Audius', async () => {
+      const audiusTrack = {
+        id: 'audius-art',
+        title: 'Art Test',
+        user: { name: 'Artist' },
+        artwork: {
+          '150x150': 'https://example.com/150.jpg',
+          '480x480': 'https://example.com/480.jpg',
+        },
+        play_count: 0,
+        permalink: '/artist/track',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.results[0].artworkUrl).toBe('https://example.com/480.jpg');
+    });
+
+    it('defaults to "audio" platform when library platform is null', async () => {
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Unique Song',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 5,
+        permalink: '/artist/unique',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.results.length).toBeGreaterThan(0);
+      const result = body.results[0];
+      expect(result.platform).toBe('audius');
+      expect(result.title).toBe('Unique Song');
+    });
+  });
+
+  describe('Empty Results', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns empty results array when no matches found', async () => {
+      mockSearchAudiusTracks.mockResolvedValue([]);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'nonexistent' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.results).toHaveLength(0);
+      expect(Array.isArray(body.sources)).toBe(true);
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      mockSearchAudiusTracks.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Search failed');
+
+      // Verify error was logged
+      expect(mockLogger.error).toHaveBeenCalledWith('Music search error:', expect.any(Error));
+    });
+
+    it('tolerates library search errors from getSupabaseAdmin', async () => {
+      const audiusTrack = {
+        id: 'audius-123',
+        title: 'Audius Song',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 0,
+        permalink: '/artist/track',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+      // getSupabaseAdmin throws, so searchLibrary will fail and be caught by allSettled
+      mockGetSupabaseAdmin.mockImplementation(() => {
+        throw new Error('Supabase init error');
+      });
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      // Should still return 200 (allSettled handles the error)
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should have Audius results despite library failure
+      expect(body.results.length).toBeGreaterThan(0);
+      expect(body.results[0].platform).toBe('audius');
+    });
+  });
+
+  describe('Response Shape', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns correct response shape with results and sources', async () => {
+      const audiusTrack = {
+        id: 'audius-1',
+        title: 'Test',
+        user: { name: 'Artist' },
+        artwork: null,
+        play_count: 50,
+        permalink: '/artist/test',
+      };
+
+      mockSearchAudiusTracks.mockResolvedValue([audiusTrack] as never);
+      mockSearchTidal.mockResolvedValue([]);
+
+      const libraryChain = chainMock({ data: [] });
+      const supabaseMock = {
+        from: vi.fn().mockReturnValue(libraryChain.chain),
+      };
+      mockGetSupabaseAdmin.mockReturnValue(supabaseMock);
+
+      const req = makeGetRequest('/api/music/search', { q: 'test' });
+      const res = await GET(req);
+
+      const body = await res.json();
+
+      // Verify response structure
+      expect(body).toHaveProperty('results');
+      expect(body).toHaveProperty('sources');
+      expect(Array.isArray(body.results)).toBe(true);
+      expect(Array.isArray(body.sources)).toBe(true);
+
+      // Verify each result has all required fields
+      if (body.results.length > 0) {
+        const result = body.results[0];
+        expect(result).toHaveProperty('id');
+        expect(result).toHaveProperty('title');
+        expect(result).toHaveProperty('artist');
+        expect(result).toHaveProperty('artworkUrl');
+        expect(result).toHaveProperty('platform');
+        expect(result).toHaveProperty('url');
+        expect(result).toHaveProperty('streamUrl');
+        expect(result).toHaveProperty('playCount');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 3 previously-untested API routes — **82 tests total**. External Audius/Tidal/ornode/ordao fully mocked — no real API or on-chain calls.

| Route | Tests | Covers |
|-------|-------|--------|
| `music/search` | 30 | auth, Zod (q/genre/limit), Audius+Tidal+library parallel merge, dedup, allSettled tolerance, errors |
| `music/radio` | 19 | auth, Audius playlist resolve (inline + bulk track fetch), artwork cascade, defaults, cache headers, errors |
| `fractals/proposals` | 33 | auth, ornode primary + on-chain fallback, both-fail unavailable, source field, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found in these 3.

_(Note: the 4th route from this batch, `miniapp/search`, surfaced the same NaN-limit bug — its route fix + test are folded into runtime PR #1476, not here.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)