### PR TITLE
test(music,livepeer,ens): comments/scrobble/stream/subname-request (144 tests)

### DIFF
--- a/src/app/api/ens/subname-request/__tests__/route.test.ts
+++ b/src/app/api/ens/subname-request/__tests__/route.test.ts
@@ -1,0 +1,491 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockSanitizeSubname, mockIsValidSubname } = vi.hoisted(() => ({
+  mockSanitizeSubname: vi.fn(),
+  mockIsValidSubname: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/ens/subnames', () => ({
+  sanitizeSubname: mockSanitizeSubname,
+  isValidSubname: mockIsValidSubname,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/ens/subname-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default behavior
+    mockIsValidSubname.mockReturnValue(true);
+    mockSanitizeSubname.mockImplementation((name: string) => name.toLowerCase());
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Authentication tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'Unauthorized' });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Input validation tests (Zod schema)
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when requestedName is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: '',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when requestedName exceeds 63 chars', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const longName = 'a'.repeat(64);
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: longName,
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when requestedName is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = makePostRequest('/api/ens/subname-request', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('accepts requestedName at minimum length (1 char)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('a');
+    mockIsValidSubname.mockReturnValue(true);
+
+    // Mock supabase checks
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'a',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('accepts requestedName at maximum length (63 chars)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const maxName = 'a'.repeat(63);
+    mockSanitizeSubname.mockReturnValue(maxName);
+    mockIsValidSubname.mockReturnValue(true);
+
+    // Mock supabase checks
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: maxName,
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Subname validation tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when isValidSubname returns false', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockSanitizeSubname.mockReturnValue('invalid-name');
+    mockIsValidSubname.mockReturnValue(false);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'invalid---name',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid name');
+    expect(body.error).toContain('lowercase letters, numbers, and hyphens');
+  });
+
+  it('calls sanitizeSubname before validation', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockSanitizeSubname.mockReturnValue('sanitized');
+    mockIsValidSubname.mockReturnValue(true);
+
+    // Mock supabase
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'MixedCase123',
+    });
+    await POST(req);
+
+    expect(mockSanitizeSubname).toHaveBeenCalledWith('MixedCase123');
+    expect(mockIsValidSubname).toHaveBeenCalledWith('sanitized');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Duplicate request check
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 409 when user has pending request', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('newname');
+    mockIsValidSubname.mockReturnValue(true);
+
+    // Mock existing pending request
+    const existingCheckChain = chainMock({
+      data: { id: 'req-123' },
+    });
+
+    mockFrom.mockReturnValueOnce(existingCheckChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'newname',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe('You already have a pending name change request');
+  });
+
+  it('checks for pending request using correct filters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    mockFrom.mockReturnValueOnce(existingCheckChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    await POST(req);
+
+    // Verify the query chain was built correctly
+    expect(existingCheckChain.chain.select).toHaveBeenCalledWith('id');
+    expect(existingCheckChain.chain.eq).toHaveBeenCalledWith('fid', 456);
+    // The second eq call for status
+    expect(existingCheckChain.chain.eq.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // User lookup and request creation
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('looks up current subname from users table', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({
+      data: { zao_subname: 'oldname' },
+    });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    await POST(req);
+
+    expect(userLookupChain.chain.select).toHaveBeenCalledWith('zao_subname');
+  });
+
+  it('handles when user has no current subname', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Successful request creation
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('creates pending request with correct fields', async () => {
+    const session = mockAuthenticatedSession({ fid: 789 });
+    mockGetSessionData.mockResolvedValue(session);
+    mockSanitizeSubname.mockReturnValue('newname');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({
+      data: { zao_subname: 'oldname' },
+    });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'newname',
+    });
+    await POST(req);
+
+    expect(insertChain.chain.insert).toHaveBeenCalledWith({
+      fid: 789,
+      current_name: 'oldname',
+      requested_name: 'newname',
+      status: 'pending',
+    });
+  });
+
+  it('returns success message with full domain name', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toContain('alice.thezao.eth');
+    expect(body.message).toContain('admin will review');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Error handling
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when insert fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({
+      data: null,
+      error: { message: 'Database error' },
+    });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to submit request');
+  });
+
+  it('returns 500 when request body parse fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = new Request(new URL('/api/ens/subname-request', 'http://localhost:3000'), {
+      method: 'POST',
+      body: 'invalid json',
+    });
+
+    const res = await POST(req as unknown as never);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to submit request');
+  });
+
+  it('returns 500 on unexpected exception during request creation', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    // User lookup throws
+    mockFrom.mockReturnValueOnce(existingCheckChain.chain).mockImplementationOnce(() => {
+      throw new Error('Network error');
+    });
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to submit request');
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Edge cases
+  // ──────────────────────────────────────────────────────────────────────────
+
+  it('uses sanitized name in isValidSubname check', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockSanitizeSubname.mockReturnValue('cleaned');
+    mockIsValidSubname.mockReturnValue(false);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'DirtY___NaMe!!!',
+    });
+    await POST(req);
+
+    // Verify sanitization happened before validation
+    expect(mockSanitizeSubname).toHaveBeenCalledWith('DirtY___NaMe!!!');
+    expect(mockIsValidSubname).toHaveBeenCalledWith('cleaned');
+  });
+
+  it('includes original requested name in error message', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockSanitizeSubname.mockReturnValue('invalid');
+    mockIsValidSubname.mockReturnValue(false);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'BadName!!!',
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('BadName!!!');
+  });
+
+  it('handles requests with extra fields (ignores them)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockSanitizeSubname.mockReturnValue('alice');
+    mockIsValidSubname.mockReturnValue(true);
+
+    const existingCheckChain = chainMock({ data: null });
+    const userLookupChain = chainMock({ data: { zao_subname: null } });
+    const insertChain = chainMock({ data: null, error: null });
+
+    mockFrom
+      .mockReturnValueOnce(existingCheckChain.chain)
+      .mockReturnValueOnce(userLookupChain.chain)
+      .mockReturnValueOnce(insertChain.chain);
+
+    const req = makePostRequest('/api/ens/subname-request', {
+      requestedName: 'alice',
+      extra: 'field',
+      another: 123,
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/src/app/api/livepeer/stream/__tests__/route.test.ts
+++ b/src/app/api/livepeer/stream/__tests__/route.test.ts
@@ -1,0 +1,534 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ===== Hoisted mocks =====
+const { mockGetSessionData, mockMultistreamCreate, mockStreamCreate } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockMultistreamCreate: vi.fn(),
+  mockStreamCreate: vi.fn(),
+}));
+
+// ===== Module mocks =====
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('livepeer', () => ({
+  Livepeer: vi.fn(() => ({
+    multistream: {
+      create: mockMultistreamCreate,
+    },
+    stream: {
+      create: mockStreamCreate,
+    },
+  })),
+}));
+
+// Dynamically set the env var before importing the route
+beforeEach(() => {
+  process.env.LIVEPEER_API_KEY = 'test-livepeer-key';
+});
+
+import { POST } from '../route';
+
+// ===== Test fixtures =====
+
+const validCreateStreamPayload = {
+  name: 'test-stream',
+  targets: [
+    {
+      platform: 'twitch',
+      rtmpUrl: 'rtmp://live.twitch.tv/app',
+      streamKey: 'sk123',
+    },
+  ],
+};
+
+const validSession = mockAuthenticatedSession({ fid: 456, username: 'testuser' });
+
+const mockMultistreamResponse = {
+  multistreamTarget: {
+    id: 'mst-123',
+    name: 'twitch-456',
+    url: 'rtmp://live.twitch.tv/app/sk123',
+  },
+};
+
+const mockStreamResponse = {
+  stream: {
+    id: 'stream-xyz',
+    streamKey: 'sk-livepeer-abc',
+    playbackId: 'playback-123',
+  },
+};
+
+describe('POST /api/livepeer/stream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+    mockMultistreamCreate.mockClear();
+    mockStreamCreate.mockClear();
+  });
+
+  // ===== AUTHENTICATION TESTS =====
+  describe('authentication', () => {
+    it('returns 401 when no session is provided', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  // ===== VALIDATION TESTS =====
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 400 when name is empty', async () => {
+      const payload = { ...validCreateStreamPayload, name: '' };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when name exceeds max length (100 chars)', async () => {
+      const payload = {
+        ...validCreateStreamPayload,
+        name: 'a'.repeat(101),
+      };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when targets array is empty', async () => {
+      const payload = { ...validCreateStreamPayload, targets: [] };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when targets exceed max length (10)', async () => {
+      const payload = {
+        ...validCreateStreamPayload,
+        targets: Array.from({ length: 11 }, (_, i) => ({
+          platform: `platform-${i}`,
+          rtmpUrl: `rtmp://example.com/${i}`,
+          streamKey: `key-${i}`,
+        })),
+      };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when target platform is missing', async () => {
+      const payload = {
+        name: 'test',
+        targets: [
+          {
+            rtmpUrl: 'rtmp://example.com',
+            streamKey: 'key123',
+          },
+        ],
+      };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when target rtmpUrl is missing', async () => {
+      const payload = {
+        name: 'test',
+        targets: [
+          {
+            platform: 'twitch',
+            streamKey: 'key123',
+          },
+        ],
+      };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when target streamKey is missing', async () => {
+      const payload = {
+        name: 'test',
+        targets: [
+          {
+            platform: 'twitch',
+            rtmpUrl: 'rtmp://example.com',
+          },
+        ],
+      };
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 500 when payload is not valid JSON (catches JSON parsing errors)', async () => {
+      const { makeRequest } = await import('@/test-utils/api-helpers');
+      const res = await POST(
+        makeRequest('/api/livepeer/stream', {
+          method: 'POST',
+          body: 'not json',
+        }),
+      );
+      const body = (await res.json()) as { error?: string };
+
+      // Route doesn't specifically handle req.json() parse errors, they're caught by try-catch
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create stream');
+    });
+  });
+
+  // ===== LIVEPEER SDK INTEGRATION TESTS =====
+  describe('Livepeer SDK integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+    });
+
+    it('returns 500 when LIVEPEER_API_KEY is not configured', async () => {
+      delete process.env.LIVEPEER_API_KEY;
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create stream');
+    });
+
+    it('creates multistream targets before creating stream', async () => {
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      const payload = {
+        name: 'multi-target-stream',
+        targets: [
+          {
+            platform: 'twitch',
+            rtmpUrl: 'rtmp://live.twitch.tv/app',
+            streamKey: 'twitch-key',
+          },
+          {
+            platform: 'youtube',
+            rtmpUrl: 'rtmp://a.rtmp.youtube.com/live2',
+            streamKey: 'youtube-key',
+          },
+        ],
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+      const body = (await res.json()) as { success?: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify multistream.create was called twice (once per target)
+      expect(mockMultistreamCreate).toHaveBeenCalledTimes(2);
+
+      // Verify the calls include proper formatting
+      expect(mockMultistreamCreate).toHaveBeenNthCalledWith(1, {
+        name: 'twitch-456',
+        url: 'rtmp://live.twitch.tv/app/twitch-key',
+      });
+      expect(mockMultistreamCreate).toHaveBeenNthCalledWith(2, {
+        name: 'youtube-456',
+        url: 'rtmp://a.rtmp.youtube.com/live2/youtube-key',
+      });
+
+      // Verify stream.create was called with multistream targets
+      expect(mockStreamCreate).toHaveBeenCalledTimes(1);
+      const streamCall = mockStreamCreate.mock.calls[0]?.[0];
+      expect(streamCall).toMatchObject({
+        multistream: {
+          targets: expect.any(Array),
+        },
+        record: true,
+      });
+      expect(streamCall?.multistream.targets).toHaveLength(2);
+    });
+
+    it('uses fid from session in multistream target name', async () => {
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+
+      expect(res.status).toBe(200);
+      expect(mockMultistreamCreate).toHaveBeenCalledWith({
+        name: 'twitch-789',
+        url: 'rtmp://live.twitch.tv/app/sk123',
+      });
+    });
+
+    it('prefixes stream name with zao- and timestamp', async () => {
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      const res = await POST(
+        makePostRequest('/api/livepeer/stream', {
+          name: 'my-stream',
+          targets: validCreateStreamPayload.targets,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const streamCall = mockStreamCreate.mock.calls[0]?.[0];
+      expect(streamCall?.name).toMatch(/^zao-my-stream-\d+$/);
+    });
+
+    it('sets record to true when creating stream', async () => {
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+
+      expect(res.status).toBe(200);
+      const streamCall = mockStreamCreate.mock.calls[0]?.[0];
+      expect(streamCall?.record).toBe(true);
+    });
+  });
+
+  // ===== SUCCESS RESPONSE TESTS =====
+  describe('successful stream creation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+    });
+
+    it('returns 200 with correct stream response shape', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { success?: boolean; stream?: object };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.stream).toBeDefined();
+    });
+
+    it('returns stream id from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { stream?: { id?: string } };
+
+      expect(body.stream?.id).toBe('stream-xyz');
+    });
+
+    it('returns streamKey from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { stream?: { streamKey?: string } };
+
+      expect(body.stream?.streamKey).toBe('sk-livepeer-abc');
+    });
+
+    it('returns playbackId from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { stream?: { playbackId?: string } };
+
+      expect(body.stream?.playbackId).toBe('playback-123');
+    });
+
+    it('returns rtmpIngestUrl hardcoded value', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { stream?: { rtmpIngestUrl?: string } };
+
+      expect(body.stream?.rtmpIngestUrl).toBe('rtmp://rtmp.livepeer.com/live');
+    });
+  });
+
+  // ===== ERROR HANDLING TESTS =====
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 500 when multistream.create throws', async () => {
+      mockMultistreamCreate.mockRejectedValue(new Error('Multistream API error'));
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create stream');
+    });
+
+    it('returns 500 when stream.create throws', async () => {
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockRejectedValue(new Error('Stream creation failed'));
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create stream');
+    });
+
+    it('skips multistream targets when multistreamTarget.id is missing', async () => {
+      // Return a response without id
+      mockMultistreamCreate.mockResolvedValue({
+        multistreamTarget: {
+          name: 'twitch-456',
+          url: 'rtmp://live.twitch.tv/app/sk123',
+          // id is missing
+        },
+      });
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+      const body = (await res.json()) as { success?: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+
+      // Verify stream was created with empty targets array
+      const streamCall = mockStreamCreate.mock.calls[0]?.[0];
+      expect(streamCall?.multistream.targets).toHaveLength(0);
+    });
+
+    it('continues creating stream even if one multistream target fails id extraction', async () => {
+      // First call succeeds, second has no id
+      mockMultistreamCreate.mockResolvedValueOnce(mockMultistreamResponse).mockResolvedValueOnce({
+        multistreamTarget: { name: 'youtube-456' },
+      });
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+
+      const payload = {
+        name: 'multi-target',
+        targets: [
+          {
+            platform: 'twitch',
+            rtmpUrl: 'rtmp://live.twitch.tv/app',
+            streamKey: 'key1',
+          },
+          {
+            platform: 'youtube',
+            rtmpUrl: 'rtmp://a.rtmp.youtube.com/live2',
+            streamKey: 'key2',
+          },
+        ],
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+
+      expect(res.status).toBe(200);
+      const streamCall = mockStreamCreate.mock.calls[0]?.[0];
+      // Only the first target should be included (has id)
+      expect(streamCall?.multistream.targets).toHaveLength(1);
+    });
+
+    it('logs errors via logger.error', async () => {
+      mockMultistreamCreate.mockRejectedValue(new Error('API failure'));
+
+      await POST(makePostRequest('/api/livepeer/stream', validCreateStreamPayload));
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith('Livepeer stream error:', expect.any(Error));
+    });
+  });
+
+  // ===== EDGE CASES =====
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockMultistreamCreate.mockResolvedValue(mockMultistreamResponse);
+      mockStreamCreate.mockResolvedValue(mockStreamResponse);
+    });
+
+    it('accepts stream name at minimum boundary (1 char)', async () => {
+      const payload = {
+        name: 'a',
+        targets: validCreateStreamPayload.targets,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts stream name at maximum boundary (100 chars)', async () => {
+      const payload = {
+        name: 'a'.repeat(100),
+        targets: validCreateStreamPayload.targets,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts exactly 1 target', async () => {
+      const payload = {
+        name: 'test',
+        targets: [validCreateStreamPayload.targets[0]],
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts exactly 10 targets (max)', async () => {
+      const payload = {
+        name: 'test',
+        targets: Array.from({ length: 10 }, (_, i) => ({
+          platform: `platform-${i}`,
+          rtmpUrl: `rtmp://example.com/${i}`,
+          streamKey: `key-${i}`,
+        })),
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/stream', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockMultistreamCreate).toHaveBeenCalledTimes(10);
+    });
+  });
+});

--- a/src/app/api/music/comments/__tests__/route.test.ts
+++ b/src/app/api/music/comments/__tests__/route.test.ts
@@ -1,0 +1,1240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockIsMusicUrl } = vi.hoisted(() => ({
+  mockIsMusicUrl: vi.fn(),
+}));
+
+const { mockUpsertSong } = vi.hoisted(() => ({
+  mockUpsertSong: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/music/isMusicUrl', () => ({
+  isMusicUrl: mockIsMusicUrl,
+}));
+
+vi.mock('@/lib/music/library', () => ({
+  upsertSong: mockUpsertSong,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { DELETE, GET, POST } from '../route';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const SAMPLE_COMMENT = {
+  id: 'comment-123',
+  username: 'testuser',
+  comment: 'Great track!',
+  timestamp_ms: 5000,
+  created_at: '2026-07-15T10:00:00Z',
+};
+
+const SAMPLE_COMMENT_2 = {
+  id: 'comment-456',
+  username: 'anotheruser',
+  comment: 'Love this part',
+  timestamp_ms: 15000,
+  created_at: '2026-07-15T10:05:00Z',
+};
+
+const VALID_MUSIC_URL = 'https://spotify.com/track/abc123';
+const INVALID_URL = 'not-a-url';
+const NON_MUSIC_URL = 'https://example.com/random-page';
+
+describe('GET /api/music/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('request validation', () => {
+    it('returns 400 when url parameter is missing', async () => {
+      const res = await GET(makeGetRequest('/api/music/comments'));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Missing url parameter');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when url parameter is empty string', async () => {
+      const res = await GET(makeGetRequest('/api/music/comments', { url: '' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Missing url parameter');
+    });
+  });
+
+  describe('success paths', () => {
+    it('returns 200 with empty array when song does not exist', async () => {
+      const mock = chainMock({
+        data: null,
+      });
+      mockFrom.mockImplementation(mock.handler);
+
+      const res = await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.comments).toEqual([]);
+      expect(mockFrom).toHaveBeenCalledWith('songs');
+    });
+
+    it('returns 200 with comments list when song exists', async () => {
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        data: [SAMPLE_COMMENT, SAMPLE_COMMENT_2],
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.comments).toHaveLength(2);
+      expect(body.comments[0]).toMatchObject({
+        id: SAMPLE_COMMENT.id,
+        username: SAMPLE_COMMENT.username,
+        comment: SAMPLE_COMMENT.comment,
+        timestampMs: SAMPLE_COMMENT.timestamp_ms,
+        createdAt: SAMPLE_COMMENT.created_at,
+      });
+    });
+
+    it('orders comments by timestamp ascending', async () => {
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        data: [SAMPLE_COMMENT, SAMPLE_COMMENT_2],
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+
+      const orderCalls = commentsChainMock.chain.order.mock.calls;
+      expect(orderCalls).toContainEqual(['timestamp_ms', { ascending: true }]);
+    });
+
+    it('queries songs table with correct url filter', async () => {
+      const songsChainMock = chainMock({
+        data: null,
+      });
+      mockFrom.mockImplementation(songsChainMock.handler);
+
+      await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+
+      const eqCalls = songsChainMock.chain.eq.mock.calls;
+      expect(eqCalls).toContainEqual(['url', VALID_MUSIC_URL]);
+    });
+
+    it('uses maybeSingle when fetching song', async () => {
+      const songsChainMock = chainMock({
+        data: null,
+      });
+      mockFrom.mockImplementation(songsChainMock.handler);
+
+      await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+
+      const maybeSingleCalls = songsChainMock.chain.maybeSingle.mock.calls;
+      expect(maybeSingleCalls.length).toBeGreaterThan(0);
+    });
+
+    it('handles null comments gracefully', async () => {
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.comments).toEqual([]);
+    });
+
+    it('transforms snake_case to camelCase in response', async () => {
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        data: [
+          {
+            id: 'c1',
+            username: 'user1',
+            comment: 'test',
+            timestamp_ms: 1000,
+            created_at: '2026-07-15T10:00:00Z',
+          },
+        ],
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(body.comments[0]).toHaveProperty('timestampMs');
+      expect(body.comments[0]).toHaveProperty('createdAt');
+      expect(body.comments[0]).not.toHaveProperty('timestamp_ms');
+      expect(body.comments[0]).not.toHaveProperty('created_at');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when supabase comments query fails', async () => {
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        error: { message: 'Database error' },
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch comments');
+    });
+
+    it('logs error when comments query fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const songsChainMock = chainMock({
+        data: { id: 'song-123' },
+      });
+      const commentsChainMock = chainMock({
+        error: { message: 'DB error' },
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'songs') return songsChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      await GET(makeGetRequest('/api/music/comments', { url: VALID_MUSIC_URL }));
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[comments] GET failed:',
+        expect.objectContaining({ message: 'DB error' }),
+      );
+    });
+  });
+});
+
+describe('POST /api/music/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great track!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when session returns null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great',
+          timestampMs: 0,
+        }),
+      );
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Zod validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: INVALID_URL,
+          comment: 'Great track!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockUpsertSong).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when url exceeds 500 characters', async () => {
+      const longUrl = `https://spotify.com/track/${'a'.repeat(500)}`;
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: longUrl,
+          comment: 'Great track!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when comment is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: '',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when comment exceeds 280 characters', async () => {
+      const longComment = 'a'.repeat(281);
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: longComment,
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('allows comment with exactly 280 characters', async () => {
+      const exactComment = 'a'.repeat(280);
+      const mock = chainMock({
+        data: { id: 'song-123' },
+      });
+      mockFrom.mockImplementation(mock.handler);
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: exactComment,
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when timestampMs is negative', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great track!',
+          timestampMs: -1,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when timestampMs is not an integer', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great track!',
+          timestampMs: 5000.5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('allows timestampMs of 0', async () => {
+      const mock = chainMock({
+        data: { id: 'song-123' },
+      });
+      mockFrom.mockImplementation(mock.handler);
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Comment',
+          timestampMs: 0,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when url is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          comment: 'Great track!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when comment is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when timestampMs is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great track!',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('isMusicUrl integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'testuser' }),
+      );
+    });
+
+    it('calls isMusicUrl with the provided url', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(mockIsMusicUrl).toHaveBeenCalledWith(VALID_MUSIC_URL);
+    });
+
+    it('uses isMusicUrl result as platform for upsertSong', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('youtube');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform: 'youtube',
+        }),
+      );
+    });
+
+    it('falls back to audio platform when isMusicUrl returns null', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue(null);
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: NON_MUSIC_URL,
+          comment: 'Nice!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform: 'audio',
+        }),
+      );
+    });
+  });
+
+  describe('upsertSong integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'testuser' }),
+      );
+    });
+
+    it('calls upsertSong with url, platform, fid, and source', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(mockUpsertSong).toHaveBeenCalledWith({
+        url: VALID_MUSIC_URL,
+        platform: 'spotify',
+        submittedByFid: 123,
+        source: 'manual',
+      });
+    });
+
+    it('uses songId from upsertSong for comment insertion', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'returned-song-id-456' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Awesome!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const insertCalls = commentsChainMock.chain.insert.mock.calls;
+      expect(insertCalls[0][0]).toMatchObject({
+        song_id: 'returned-song-id-456',
+      });
+    });
+  });
+
+  describe('username resolution', () => {
+    it('uses session username if available', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'sessionuser' }),
+      );
+
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const insertCalls = commentsChainMock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].username).toBe('sessionuser');
+    });
+
+    it('fetches username from users table when not in session', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: undefined }),
+      );
+
+      const usersChainMock = chainMock({
+        data: { username: 'db-username' },
+      });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const insertCalls = commentsChainMock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].username).toBe('db-username');
+    });
+
+    it('falls back to fid string when username not found', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 789, username: undefined }),
+      );
+
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const insertCalls = commentsChainMock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].username).toBe('fid:789');
+    });
+
+    it('queries users table with correct fid filter', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 999, username: undefined }),
+      );
+
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const eqCalls = usersChainMock.chain.eq.mock.calls;
+      expect(eqCalls).toContainEqual(['fid', 999]);
+    });
+  });
+
+  describe('success paths', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'testuser' }),
+      );
+    });
+
+    it('returns 200 with inserted comment on success', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great track!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.comment).toBeDefined();
+      expect(body.comment.id).toBe(SAMPLE_COMMENT.id);
+    });
+
+    it('transforms response from snake_case to camelCase', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: {
+          id: 'c1',
+          username: 'user',
+          comment: 'test',
+          timestamp_ms: 1000,
+          created_at: '2026-07-15T10:00:00Z',
+        },
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.comment).toHaveProperty('timestampMs');
+      expect(body.comment).toHaveProperty('createdAt');
+      expect(body.comment).not.toHaveProperty('timestamp_ms');
+      expect(body.comment).not.toHaveProperty('created_at');
+    });
+
+    it('inserts comment with correct fields', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Perfect song!',
+          timestampMs: 12345,
+        }),
+      );
+
+      const insertCalls = commentsChainMock.chain.insert.mock.calls;
+      expect(insertCalls[0][0]).toMatchObject({
+        song_id: 'song-123',
+        user_fid: 123,
+        username: 'testuser',
+        comment: 'Perfect song!',
+        timestamp_ms: 12345,
+      });
+    });
+
+    it('calls select and single on insert', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Awesome!',
+          timestampMs: 5000,
+        }),
+      );
+
+      const selectCalls = commentsChainMock.chain.select.mock.calls;
+      const singleCalls = commentsChainMock.chain.single.mock.calls;
+
+      expect(selectCalls).toBeDefined();
+      expect(selectCalls.length).toBeGreaterThan(0);
+      expect(singleCalls).toBeDefined();
+      expect(singleCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 123, username: 'testuser' }),
+      );
+    });
+
+    it('returns 500 when upsertSong throws', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        data: SAMPLE_COMMENT,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockRejectedValue(new Error('Database error'));
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add comment');
+    });
+
+    it('returns 500 when comment insert fails', async () => {
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        error: { message: 'Insert constraint failed' },
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      const res = await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add comment');
+    });
+
+    it('logs error when insert fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = { message: 'Insert failed' };
+      const usersChainMock = chainMock({ data: null });
+      const commentsChainMock = chainMock({
+        error: dbError,
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'users') return usersChainMock.handler();
+        return commentsChainMock.handler();
+      });
+
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123' });
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(logger.error).toHaveBeenCalledWith('[comments] POST failed:', expect.any(Object));
+    });
+
+    it('logs error when upsertSong throws', async () => {
+      const { logger } = await import('@/lib/logger');
+      const error = new Error('Song upsert failed');
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockRejectedValue(error);
+
+      await POST(
+        makePostRequest('/api/music/comments', {
+          url: VALID_MUSIC_URL,
+          comment: 'Great!',
+          timestampMs: 5000,
+        }),
+      );
+
+      expect(logger.error).toHaveBeenCalledWith('[comments] POST failed:', expect.any(Object));
+    });
+  });
+});
+
+describe('DELETE /api/music/comments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when id parameter is missing', async () => {
+      const res = await DELETE(makeGetRequest('/api/music/comments'));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Missing id parameter');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when id parameter is empty string', async () => {
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: '' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Missing id parameter');
+    });
+  });
+
+  describe('authorization', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123, isAdmin: false }));
+    });
+
+    it('returns 404 when comment does not exist', async () => {
+      const mock = chainMock({
+        data: null,
+      });
+      mockFrom.mockImplementation(mock.handler);
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'nonexistent' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toBe('Comment not found');
+    });
+
+    it('returns 403 when user does not own the comment and is not admin', async () => {
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 456 },
+      });
+      mockFrom.mockImplementation(selectMock.handler);
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Forbidden');
+    });
+
+    it('allows deletion when user owns the comment', async () => {
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 123 },
+      });
+      const deleteMock = chainMock({
+        data: null,
+      });
+
+      mockFrom.mockImplementation((table) => {
+        if (table === 'song_comments' && selectMock.chain.delete) {
+          return selectMock.handler();
+        }
+        return deleteMock.handler();
+      });
+
+      // More precise mock to handle multiple calls
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('allows deletion when user is admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123, isAdmin: true }));
+
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 999 },
+      });
+      const deleteMock = chainMock({
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('success paths', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 200 with deleted true on successful deletion', async () => {
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 123 },
+      });
+      const deleteMock = chainMock({
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.deleted).toBe(true);
+    });
+
+    it('queries with correct comment id on delete', async () => {
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 123 },
+      });
+      const deleteMock = chainMock({
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+
+      const eqCalls = selectMock.chain.eq.mock.calls;
+      expect(eqCalls).toContainEqual(['id', 'comment-123']);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when delete query fails', async () => {
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 123 },
+      });
+      const deleteMock = chainMock({
+        error: { message: 'Delete constraint failed' },
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      const res = await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete comment');
+    });
+
+    it('logs error when delete query fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const selectMock = chainMock({
+        data: { id: 'comment-123', user_fid: 123 },
+      });
+      const deleteMock = chainMock({
+        error: { message: 'Delete failed' },
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return selectMock.handler();
+        return deleteMock.handler();
+      });
+
+      await DELETE(makeGetRequest('/api/music/comments', { id: 'comment-123' }));
+
+      expect(logger.error).toHaveBeenCalledWith('[comments] DELETE failed:', expect.any(Object));
+    });
+  });
+});

--- a/src/app/api/music/scrobble/__tests__/route.test.ts
+++ b/src/app/api/music/scrobble/__tests__/route.test.ts
@@ -1,0 +1,901 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, makePostRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const {
+  mockGetSession,
+  mockGetSupabaseAdmin,
+  mockScrobble,
+  mockUpdateNowPlaying,
+  mockSubmitListen,
+  mockSubmitNowPlaying,
+} = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockGetSupabaseAdmin: vi.fn(),
+  mockScrobble: vi.fn(),
+  mockUpdateNowPlaying: vi.fn(),
+  mockSubmitListen: vi.fn(),
+  mockSubmitNowPlaying: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSession: () => mockGetSession(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  getSupabaseAdmin: () => mockGetSupabaseAdmin(),
+}));
+
+vi.mock('@/lib/music/lastfm', () => ({
+  scrobble: (...args: unknown[]) => mockScrobble(...args),
+  updateNowPlaying: (...args: unknown[]) => mockUpdateNowPlaying(...args),
+}));
+
+vi.mock('@/lib/music/listenbrainz', () => ({
+  submitListen: (...args: unknown[]) => mockSubmitListen(...args),
+  submitNowPlaying: (...args: unknown[]) => mockSubmitNowPlaying(...args),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('/api/music/scrobble', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication ──────────────────────────────────────────────────────
+
+  describe('authentication', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSession.mockResolvedValue(null);
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(401);
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when session has no fid', async () => {
+      mockGetSession.mockResolvedValue({ username: 'testuser' });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(401);
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('allows request with valid session containing fid', async () => {
+      const session = mockAuthenticatedSession();
+      mockGetSession.mockResolvedValue(session);
+
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'test-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Input Validation (Zod) ──────────────────────────────────────────────
+
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 400 when artist is missing', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when artist is empty string', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: '',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when track is missing', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when track is empty string', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: '',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when action is missing', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when action is invalid enum value', async () => {
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'invalid_action',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(400);
+      expect(body).toHaveProperty('error');
+    });
+
+    it('returns 400 when body is not JSON', async () => {
+      const req = new Request(new URL('/api/music/scrobble', 'http://localhost:3000'), {
+        method: 'POST',
+        body: 'not json',
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it('allows album field to be optional', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'test-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('allows album field when provided', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'test-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        album: 'Test Album',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── Service Connection Check ────────────────────────────────────────────
+
+  describe('service connection check', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns skipped when no services are connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: null },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({ skipped: true, reason: 'No scrobbling service connected' });
+    });
+
+    it('queries user_settings for scrobbling credentials', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'test-key', listenbrainz_token: null },
+      });
+      const mockFrom = vi.fn().mockReturnValue(chain);
+      mockGetSupabaseAdmin.mockReturnValue({ from: mockFrom });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockFrom).toHaveBeenCalledWith('user_settings');
+    });
+
+    it('filters settings by fid', async () => {
+      const session = mockAuthenticatedSession({ fid: 999 });
+      mockGetSession.mockResolvedValue(session);
+
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'test-key' },
+      });
+      const mockSelect = vi.fn().mockReturnValue(chain);
+      mockGetSupabaseAdmin.mockReturnValue({
+        from: vi.fn().mockReturnValue({ select: mockSelect }),
+      });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockSelect).toHaveBeenCalledWith('lastfm_session_key, listenbrainz_token');
+    });
+  });
+
+  // ── Scrobble Action ─────────────────────────────────────────────────────
+
+  describe('scrobble action', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calls lastfm scrobble when action is "scrobble" and lastfm is connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-123', listenbrainz_token: null },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Daft Punk',
+        track: 'One More Time',
+        album: 'Discovery',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockScrobble).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'Daft Punk',
+          track: 'One More Time',
+          album: 'Discovery',
+          sk: 'session-key-123',
+          timestamp: expect.any(Number),
+        }),
+      );
+    });
+
+    it('includes timestamp in scrobble call', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      const callArgs = mockScrobble.mock.calls[0][0] as { timestamp: number };
+      expect(callArgs.timestamp).toBeGreaterThan(0);
+      expect(typeof callArgs.timestamp).toBe('number');
+    });
+
+    it('returns success when scrobble completes', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({ success: true });
+    });
+
+    it('does not call updateNowPlaying when action is scrobble', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockUpdateNowPlaying).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Now Playing Action ───────────────────────────────────────────────────
+
+  describe('nowplaying action', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calls lastfm updateNowPlaying when action is "nowplaying" and lastfm is connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-456', listenbrainz_token: null },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'The Weeknd',
+        track: 'Blinding Lights',
+        album: 'After Hours',
+        action: 'nowplaying',
+      });
+      await POST(req);
+
+      expect(mockUpdateNowPlaying).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'The Weeknd',
+          track: 'Blinding Lights',
+          album: 'After Hours',
+          sk: 'session-key-456',
+        }),
+      );
+    });
+
+    it('does not include timestamp in updateNowPlaying call', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-456' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      await POST(req);
+
+      const callArgs = mockUpdateNowPlaying.mock.calls[0][0] as { timestamp?: number };
+      expect(callArgs.timestamp).toBeUndefined();
+    });
+
+    it('returns success when nowplaying completes', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-456' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({ success: true });
+    });
+
+    it('does not call scrobble when action is nowplaying', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key-456' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      await POST(req);
+
+      expect(mockScrobble).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── ListenBrainz Integration ────────────────────────────────────────────
+
+  describe('ListenBrainz integration', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calls submitListen when action is "scrobble" and listenbrainz is connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: 'token-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockSubmitListen.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Adele',
+        track: 'Hello',
+        album: '25',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockSubmitListen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'Adele',
+          track: 'Hello',
+          album: '25',
+          userToken: 'token-123',
+          timestamp: expect.any(Number),
+        }),
+      );
+    });
+
+    it('calls submitNowPlaying when action is "nowplaying" and listenbrainz is connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: 'token-456' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockSubmitNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Drake',
+        track: "God's Plan",
+        album: 'Scorpion',
+        action: 'nowplaying',
+      });
+      await POST(req);
+
+      expect(mockSubmitNowPlaying).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'Drake',
+          track: "God's Plan",
+          album: 'Scorpion',
+          userToken: 'token-456',
+        }),
+      );
+    });
+
+    it('does not include timestamp in submitNowPlaying call', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: 'token-456' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockSubmitNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      await POST(req);
+
+      const callArgs = mockSubmitNowPlaying.mock.calls[0][0] as { timestamp?: number };
+      expect(callArgs.timestamp).toBeUndefined();
+    });
+
+    it('tolerates ListenBrainz errors via fire-and-forget', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key', listenbrainz_token: 'token-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+      mockSubmitListen.mockRejectedValue(new Error('ListenBrainz error'));
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      // Despite ListenBrainz error, should still return success
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown;
+      expect(body).toEqual({ success: true });
+    });
+
+    it('calls both services when both are connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key', listenbrainz_token: 'token-123' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+      mockSubmitListen.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockScrobble).toHaveBeenCalled();
+      expect(mockSubmitListen).toHaveBeenCalled();
+    });
+
+    it('skips ListenBrainz when not connected', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key', listenbrainz_token: null },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockSubmitListen).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Both Services Connected ─────────────────────────────────────────────
+
+  describe('both services connected', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('calls both lastfm and listenbrainz for scrobble action', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'lfm-key', listenbrainz_token: 'lb-token' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+      mockSubmitListen.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Billie Eilish',
+        track: 'Bad Guy',
+        album: 'When We All Fall Asleep, Where Do We Go?',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockScrobble).toHaveBeenCalled();
+      expect(mockSubmitListen).toHaveBeenCalled();
+    });
+
+    it('calls both lastfm and listenbrainz for nowplaying action', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'lfm-key', listenbrainz_token: 'lb-token' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockResolvedValue({ success: true });
+      mockSubmitNowPlaying.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateNowPlaying).toHaveBeenCalled();
+      expect(mockSubmitNowPlaying).toHaveBeenCalled();
+    });
+  });
+
+  // ── Error Handling ───────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns 500 when lastfm scrobble fails', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockRejectedValue(new Error('Last.fm API error'));
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Scrobble failed' });
+    });
+
+    it('returns 500 when lastfm updateNowPlaying fails', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockUpdateNowPlaying.mockRejectedValue(new Error('Last.fm API error'));
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'nowplaying',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Scrobble failed' });
+    });
+
+    it('returns skipped when supabase returns no settings', async () => {
+      const { chain } = chainMock({
+        data: null,
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      // When settings is null, !settings?.lastfm_session_key && !settings?.listenbrainz_token is true
+      expect(res.status).toBe(200);
+      expect(body).toEqual({ skipped: true, reason: 'No scrobbling service connected' });
+    });
+
+    it('returns 500 when getSession throws', async () => {
+      mockGetSession.mockRejectedValue(new Error('Session error'));
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Scrobble failed' });
+    });
+
+    it('returns 500 when request body is invalid JSON', async () => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = new Request(new URL('/api/music/scrobble', 'http://localhost:3000'), {
+        method: 'POST',
+        body: 'invalid json{',
+      });
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+
+      expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+  });
+
+  // ── Optional Album Field ────────────────────────────────────────────────
+
+  describe('optional album field', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('passes album to lastfm when provided', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        album: 'Test Album',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockScrobble).toHaveBeenCalledWith(
+        expect.objectContaining({
+          album: 'Test Album',
+        }),
+      );
+    });
+
+    it('works without album for lastfm', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockScrobble).toHaveBeenCalled();
+    });
+
+    it('passes album to listenbrainz when provided', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: 'token' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockSubmitListen.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        album: 'Test Album',
+        action: 'scrobble',
+      });
+      await POST(req);
+
+      expect(mockSubmitListen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          album: 'Test Album',
+        }),
+      );
+    });
+
+    it('works without album for listenbrainz', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: null, listenbrainz_token: 'token' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockSubmitListen.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSubmitListen).toHaveBeenCalled();
+    });
+  });
+
+  // ── Response Shape ───────────────────────────────────────────────────────
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(mockAuthenticatedSession());
+    });
+
+    it('returns { success: true } on successful scrobble', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockResolvedValue({ success: true });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(body).toEqual({ success: true });
+    });
+
+    it('returns { skipped: true, reason } when no services connected', async () => {
+      const { chain } = chainMock({
+        data: null,
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(body).toEqual({
+        skipped: true,
+        reason: 'No scrobbling service connected',
+      });
+    });
+
+    it('returns { error: string } on server error', async () => {
+      const { chain } = chainMock({
+        data: { lastfm_session_key: 'session-key' },
+      });
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn().mockReturnValue(chain) });
+      mockScrobble.mockRejectedValue(new Error('API error'));
+
+      const req = makePostRequest('/api/music/scrobble', {
+        artist: 'Test Artist',
+        track: 'Test Track',
+        action: 'scrobble',
+      });
+      const res = await POST(req);
+      const body = (await res.json()) as unknown;
+
+      expect(body).toEqual({ error: 'Scrobble failed' });
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **144 tests total**. External Last.fm/ListenBrainz/Livepeer/ENS fully mocked — no real API calls.

| Route | Tests | Covers |
|-------|-------|--------|
| `music/comments` | 52 | GET/POST/DELETE — auth, Zod (url/comment/timestamp), isMusicUrl, upsertSong, owner/admin delete auth, errors |
| `music/scrobble` | 43 | auth, Zod (action enum), Last.fm + ListenBrainz per-service branches, allSettled tolerance, skipped-when-unconnected, errors |
| `livepeer/stream` | 29 | auth, Zod (name/targets), Livepeer SDK (mocked) multistream create, API-key guard, errors |
| `ens/subname-request` | 20 | auth, Zod (name 1..63), sanitize + isValidSubname, duplicate 409, pending-request insert, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)