### PR TITLE
fix: clamp non-numeric/negative limit param across 10 more routes (completes NaN-limit fix)

### DIFF
--- a/src/app/api/chat/messages/__tests__/route.test.ts
+++ b/src/app/api/chat/messages/__tests__/route.test.ts
@@ -287,15 +287,24 @@ describe('GET /api/chat/messages', () => {
       expect(selectChain.limit).toHaveBeenCalledWith(25);
     });
 
-    it('handles non-numeric limit gracefully (parseInt returns NaN)', async () => {
+    it('handles non-numeric limit gracefully by using default', async () => {
       const selectChain = chainMock({ data: [], error: null });
       mockFrom.mockReturnValue(selectChain);
 
       await GET(makeGetRequest('/api/chat/messages?channel=zao&limit=not-a-number'));
 
-      // parseInt('not-a-number') = NaN, and Math.min(NaN, 50) = NaN
-      // The route still calls limit(NaN), which Supabase/DB ignores or treats as no-op
-      expect(selectChain.limit).toHaveBeenCalledWith(Number.NaN);
+      // parseInt('not-a-number') = NaN, should use default 20
+      expect(selectChain.limit).toHaveBeenCalledWith(20);
+    });
+
+    it('handles negative limit by using default', async () => {
+      const selectChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(selectChain);
+
+      await GET(makeGetRequest('/api/chat/messages?channel=zao&limit=-5'));
+
+      // Negative limits should use default 20
+      expect(selectChain.limit).toHaveBeenCalledWith(20);
     });
   });
 

--- a/src/app/api/chat/messages/route.ts
+++ b/src/app/api/chat/messages/route.ts
@@ -93,7 +93,9 @@ export async function GET(req: NextRequest) {
   }
 
   const cursor = req.nextUrl.searchParams.get('cursor'); // ISO timestamp
-  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '20', 10), 50);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '20', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : rawLimit, 50);
 
   try {
     const now = Date.now();

--- a/src/app/api/community-issues/__tests__/route.test.ts
+++ b/src/app/api/community-issues/__tests__/route.test.ts
@@ -181,6 +181,34 @@ describe('GET /api/community-issues', () => {
       expect(rangeCalls).toContainEqual([30, 39]);
     });
 
+    it('handles non-numeric limit gracefully by using default', async () => {
+      const mock = chainMock({
+        data: [SAMPLE_ISSUE],
+        count: 1,
+      });
+      mockFrom.mockImplementation(mock.handler);
+
+      const res = await GET(makeGetRequest('/api/community-issues', { limit: 'notanumber' }));
+
+      expect(res.status).toBe(200);
+      const rangeCalls = mock.chain.range.mock.calls;
+      expect(rangeCalls).toContainEqual([0, 19]); // default 20 means range(0, 19)
+    });
+
+    it('handles negative limit by using default', async () => {
+      const mock = chainMock({
+        data: [SAMPLE_ISSUE],
+        count: 1,
+      });
+      mockFrom.mockImplementation(mock.handler);
+
+      const res = await GET(makeGetRequest('/api/community-issues', { limit: '-5' }));
+
+      expect(res.status).toBe(200);
+      const rangeCalls = mock.chain.range.mock.calls;
+      expect(rangeCalls).toContainEqual([0, 19]); // default 20 means range(0, 19)
+    });
+
     it('orders by created_at descending', async () => {
       const mock = chainMock({
         data: [SAMPLE_ISSUE],

--- a/src/app/api/community-issues/route.ts
+++ b/src/app/api/community-issues/route.ts
@@ -18,7 +18,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '20', 10), 50);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '20', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : rawLimit, 50);
   const offset = Math.max(parseInt(req.nextUrl.searchParams.get('offset') || '0', 10), 0);
 
   const { data, error, count } = await supabaseAdmin

--- a/src/app/api/directory/__tests__/route.test.ts
+++ b/src/app/api/directory/__tests__/route.test.ts
@@ -141,6 +141,20 @@ describe('GET /api/directory', () => {
     expect(chain.range).toHaveBeenCalledWith(0, 49);
   });
 
+  it('handles non-numeric limit gracefully by using default', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { limit: 'notanumber' }));
+    expect(chain.range).toHaveBeenCalledWith(0, 49); // default 50 means range(0, 49)
+  });
+
+  it('handles negative limit by using default', async () => {
+    const chain = queuedChain([{ data: [], error: null, count: 0 }]);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeGetRequest('/api/directory', { limit: '-5' }));
+    expect(chain.range).toHaveBeenCalledWith(0, 49); // default 50 means range(0, 49)
+  });
+
   it('orders by is_featured desc then name asc', async () => {
     const chain = queuedChain([{ data: [], error: null, count: 0 }]);
     mockFrom.mockReturnValue(chain);

--- a/src/app/api/directory/route.ts
+++ b/src/app/api/directory/route.ts
@@ -12,7 +12,9 @@ export async function GET(req: NextRequest) {
   const search = url.searchParams.get('search');
   const social = url.searchParams.get('social');
   const tag = url.searchParams.get('tag');
-  const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 100);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(url.searchParams.get('limit') || '50', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 100);
   const offset = Math.max(parseInt(url.searchParams.get('offset') || '0', 10), 0);
 
   try {

--- a/src/app/api/library/entries/__tests__/route.test.ts
+++ b/src/app/api/library/entries/__tests__/route.test.ts
@@ -125,4 +125,23 @@ describe('GET /api/library/entries', () => {
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to fetch entries');
   });
+
+  it('handles non-numeric limit gracefully by using default', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/library/entries', { limit: 'notanumber' }));
+    expect(res.status).toBe(200);
+    // Verify that range was called with default 50
+    const rangeCalls = chain.range.mock.calls;
+    expect(rangeCalls).toContainEqual([0, 49]); // default 50 means range(0, 49)
+  });
+
+  it('handles negative limit by using default', async () => {
+    const chain = queuedChain([{ data: [], error: null }]);
+    mockFrom.mockReturnValue(chain);
+    const res = await GET(makeGetRequest('/api/library/entries', { limit: '-5' }));
+    expect(res.status).toBe(200);
+    const rangeCalls = chain.range.mock.calls;
+    expect(rangeCalls).toContainEqual([0, 49]); // default 50 means range(0, 49)
+  });
 });

--- a/src/app/api/library/entries/route.ts
+++ b/src/app/api/library/entries/route.ts
@@ -15,7 +15,9 @@ export async function GET(req: NextRequest) {
     const tag = searchParams.get('tag') || '';
     const sort = searchParams.get('sort') || 'newest';
     const offset = parseInt(searchParams.get('offset') || '0', 10);
-    const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100);
+    // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+    const rawLimit = parseInt(searchParams.get('limit') || '50', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 100);
 
     let query = supabaseAdmin.from('research_entries').select('*');
 

--- a/src/app/api/members/[username]/friends/__tests__/route.test.ts
+++ b/src/app/api/members/[username]/friends/__tests__/route.test.ts
@@ -262,7 +262,7 @@ describe('GET /api/members/[username]/friends', () => {
       expect(mockGetBestFriends).toHaveBeenCalledWith(SAMPLE_USER.fid, 25);
     });
 
-    it('treats non-numeric limit as NaN (parseInt returns NaN)', async () => {
+    it('treats non-numeric limit as default (parseInt returns NaN)', async () => {
       const mock = chainMock({ data: SAMPLE_USER });
       mockFrom.mockImplementation(mock.handler);
       mockGetBestFriends.mockResolvedValue(SAMPLE_FRIENDS);
@@ -271,8 +271,20 @@ describe('GET /api/members/[username]/friends', () => {
         params: Promise.resolve({ username: 'testuser' }),
       });
 
-      // parseInt('abc', 10) returns NaN, Math.min(NaN, 25) returns NaN
-      expect(mockGetBestFriends).toHaveBeenCalledWith(SAMPLE_USER.fid, expect.any(Number));
+      // parseInt('abc', 10) returns NaN, should use default 10
+      expect(mockGetBestFriends).toHaveBeenCalledWith(SAMPLE_USER.fid, 10);
+    });
+
+    it('handles negative limit by using default', async () => {
+      const mock = chainMock({ data: SAMPLE_USER });
+      mockFrom.mockImplementation(mock.handler);
+      mockGetBestFriends.mockResolvedValue(SAMPLE_FRIENDS);
+
+      await GET(makeGetRequest('/api/members/testuser/friends', { limit: '-5' }), {
+        params: Promise.resolve({ username: 'testuser' }),
+      });
+
+      expect(mockGetBestFriends).toHaveBeenCalledWith(SAMPLE_USER.fid, 10);
     });
 
     it('accepts limit at boundary (25)', async () => {

--- a/src/app/api/members/[username]/friends/route.ts
+++ b/src/app/api/members/[username]/friends/route.ts
@@ -24,7 +24,9 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ user
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
 
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '10', 10), 25);
+    // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '10', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 10 : rawLimit, 25);
     const data = await getBestFriends(user.fid, limit);
     return NextResponse.json(data);
   } catch (err) {

--- a/src/app/api/music/submissions/route.ts
+++ b/src/app/api/music/submissions/route.ts
@@ -33,7 +33,9 @@ export async function GET(req: NextRequest) {
   }
 
   const channel = req.nextUrl.searchParams.get('channel') || 'zao';
-  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '50'), 100);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '50', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 100);
   const statusParam = req.nextUrl.searchParams.get('status'); // 'pending' | 'all' | null
 
   try {

--- a/src/app/api/notifications/__tests__/route.test.ts
+++ b/src/app/api/notifications/__tests__/route.test.ts
@@ -188,6 +188,52 @@ describe('GET /api/notifications', () => {
       expect(body.offset).toBe(0);
     });
 
+    it('handles non-numeric limit gracefully by using default', async () => {
+      const mainMock = chainMock({
+        data: [SAMPLE_NOTIFICATION],
+        count: 1,
+      });
+
+      const unreadMock = chainMock({
+        count: 0,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? mainMock.handler() : unreadMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/notifications', { limit: 'notanumber' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.limit).toBe(50); // default, not NaN
+    });
+
+    it('handles negative limit by using default', async () => {
+      const mainMock = chainMock({
+        data: [SAMPLE_NOTIFICATION],
+        count: 1,
+      });
+
+      const unreadMock = chainMock({
+        count: 0,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? mainMock.handler() : unreadMock.handler();
+      });
+
+      const res = await GET(makeGetRequest('/api/notifications', { limit: '-10' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.limit).toBe(50); // default, not negative
+    });
+
     it('returns empty notifications when user has none', async () => {
       const mock = chainMock({
         data: [],

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -21,7 +21,9 @@ export async function GET(req: NextRequest) {
 
   try {
     const unreadOnly = req.nextUrl.searchParams.get('unread_only') === 'true';
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '50', 10), 100);
+    // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '50', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 100);
     const offset = Math.max(parseInt(req.nextUrl.searchParams.get('offset') || '0', 10), 0);
 
     let query = supabaseAdmin

--- a/src/app/api/proposals/route.ts
+++ b/src/app/api/proposals/route.ts
@@ -19,7 +19,9 @@ export async function GET(req: NextRequest) {
 
   const status = req.nextUrl.searchParams.get('status');
   const category = req.nextUrl.searchParams.get('category');
-  const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '50', 10), 100);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '50', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 50 : rawLimit, 100);
   const offset = Math.max(parseInt(req.nextUrl.searchParams.get('offset') || '0', 10), 0);
 
   // Look up current user's internal ID for matching their votes

--- a/src/app/api/social/trending-topics/route.ts
+++ b/src/app/api/social/trending-topics/route.ts
@@ -9,7 +9,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   try {
-    const limit = Math.min(parseInt(req.nextUrl.searchParams.get('limit') || '10', 10), 25);
+    // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+    const rawLimit = parseInt(req.nextUrl.searchParams.get('limit') || '10', 10);
+    const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 10 : rawLimit, 25);
     const data = await getTrendingTopics(limit);
     return NextResponse.json(data);
   } catch (err) {

--- a/src/app/api/wavewarz/artists/__tests__/route.test.ts
+++ b/src/app/api/wavewarz/artists/__tests__/route.test.ts
@@ -113,13 +113,11 @@ describe('GET /api/wavewarz/artists', () => {
     expect(chain.limit).toHaveBeenCalledWith(50);
   });
 
-  it('handles non-numeric limit gracefully', async () => {
+  it('handles non-numeric limit gracefully by using default', async () => {
     const chain = artistsChain({ data: [], error: null });
     mockFrom.mockReturnValue(chain);
     await GET(makeGetRequest('/api/wavewarz/artists', { limit: 'abc' }));
-    // NaN coerced to 0, Math.min(0, 50) = 0, but parseInt('abc', 10) = NaN, Math.min(NaN, 50) = NaN
-    // Actually, Math.min(NaN, 50) returns NaN, so the test should reflect actual behavior
-    expect(chain.limit).toHaveBeenCalled();
+    expect(chain.limit).toHaveBeenCalledWith(20); // default, not NaN
   });
 
   it('does not apply linked_only filter when not provided', async () => {

--- a/src/app/api/wavewarz/artists/route.ts
+++ b/src/app/api/wavewarz/artists/route.ts
@@ -11,7 +11,9 @@ export async function GET(req: NextRequest) {
 
   const url = new URL(req.url);
   const sort = url.searchParams.get('sort') || 'wins';
-  const limit = Math.min(parseInt(url.searchParams.get('limit') || '20', 10), 50);
+  // Clamp a non-numeric/negative limit to the default (never pass NaN downstream).
+  const rawLimit = parseInt(url.searchParams.get('limit') || '20', 10);
+  const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? 20 : rawLimit, 50);
   const linkedOnly = url.searchParams.get('linked_only') === 'true';
 
   const validSorts = ['wins', 'total_volume_sol'];


### PR DESCRIPTION
## What

Completes the systemic **NaN-limit** fix you merged in #1476 (which covered bluesky/feed, miniapp/discover, miniapp/search). Grep of every route surfaced **13 total** with the same unguarded idiom; this PR fixes the remaining **10**.

## The bug

Each route parsed `limit` as:
```ts
const limit = Math.min(parseInt(searchParams.get('limit') || 'DEFAULT', 10), MAX);
```
A non-numeric `limit` → `parseInt` → `NaN` → `Math.min(NaN, MAX)` → `NaN` flows downstream: into a supabase `.limit(NaN)`/`.range()` (throws → **500**) or an API URL `?limit=NaN` (**400 → 500**). A zero/negative limit was passed straight through too. A garbage `limit` query param shouldn't 500 the route.

## The fix (per route, exact default + max preserved)
```ts
const rawLimit = parseInt(<expr> || 'DEFAULT', 10);
const limit = Math.min(Number.isNaN(rawLimit) || rawLimit < 1 ? DEFAULT : rawLimit, MAX);
```

| Route | default / max |
|-------|----------------|
| community-issues | 20 / 50 |
| notifications | 50 / 100 |
| directory | 50 / 100 |
| proposals | 50 / 100 |
| wavewarz/artists | 20 / 50 |
| library/entries | 50 / 100 |
| chat/messages | 20 / 50 |
| members/[username]/friends | 10 / 25 |
| social/trending-topics | 10 / 25 |
| music/submissions | 50 / 100 (also adds the missing `parseInt` radix) |

## Tests
Existing tests for **7** of these routes updated — buggy NaN/negative-passthrough assertions corrected to the fixed behavior + regression guards added (3 routes had no existing test; routes fixed, no new suite added here). **tsc 0, 342 tests pass.** No new biome findings (the pre-existing ones in proposals/music-submissions/community-issues are untouched). No behavior change for valid input.

Runtime route changes → your review. Same one-line clamp pattern you already accepted in #1476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)