### PR TITLE
test(chat,autocliper): thread/[hash] + publish (63 tests)

### DIFF
--- a/src/app/api/autocliper/publish/__tests__/route.test.ts
+++ b/src/app/api/autocliper/publish/__tests__/route.test.ts
@@ -1,0 +1,1506 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ClipMetadata, PostizPostResponse } from '@/lib/autocliper';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const {
+  mockGetSessionData,
+  mockValidateRequest,
+  mockGetClipDraft,
+  mockPublishClipDraft,
+  mockPostToPostiz,
+  mockBuildCaption,
+  mockPostizConfig,
+} = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockValidateRequest: vi.fn(),
+  mockGetClipDraft: vi.fn(),
+  mockPublishClipDraft: vi.fn(),
+  mockPostToPostiz: vi.fn(),
+  mockBuildCaption: vi.fn(),
+  mockPostizConfig: {
+    apiKey: 'test-key',
+    baseUrl: 'https://api.postiz.com/public/v1',
+    platforms: ['warpcast', 'x', 'bluesky', 'discord'] as const,
+    rateLimitPerHour: 90,
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/autocliper', () => ({
+  validateRequest: mockValidateRequest,
+  getClipDraft: mockGetClipDraft,
+  publishClipDraft: mockPublishClipDraft,
+  postToPostiz: mockPostToPostiz,
+  buildCaption: mockBuildCaption,
+  postizConfig: mockPostizConfig,
+  PublishRequestSchema: { parse: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/autocliper/publish', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBuildCaption.mockReturnValue('Test caption');
+  });
+
+  // ========================================================================
+  // Authentication tests
+  // ========================================================================
+
+  it('returns 401 when no session exists', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session is undefined (safety check)', async () => {
+    mockGetSessionData.mockResolvedValue(undefined);
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ========================================================================
+  // Validation tests
+  // ========================================================================
+
+  it('returns 400 when validation fails with error message', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = { clipId: 'not-a-uuid' };
+    const validationError = 'clipId: Invalid UUID format';
+
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: validationError,
+    });
+
+    const req = makePostRequest('/api/autocliper/publish', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe(validationError);
+  });
+
+  it('returns 400 when clipId is missing from validation', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = {};
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: 'clipId: Required',
+    });
+
+    const req = makePostRequest('/api/autocliper/publish', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('clipId: Required');
+  });
+
+  it('returns 400 when multiple validation errors occur', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const invalidBody = { clipId: 'bad', platforms: 'not-array' };
+    mockValidateRequest.mockReturnValue({
+      success: false,
+      error: 'clipId: Invalid UUID; platforms: Expected array',
+    });
+
+    const req = makePostRequest('/api/autocliper/publish', invalidBody);
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('clipId: Invalid UUID');
+  });
+
+  // ========================================================================
+  // Clip not found tests
+  // ========================================================================
+
+  it('returns 404 when clip draft does not exist', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockReturnValue(undefined);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip not found');
+    expect(body.error).toContain(clipId);
+  });
+
+  it('returns 404 when getClipDraft returns null', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockReturnValue(null);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip not found');
+  });
+
+  // ========================================================================
+  // Clip stage validation tests
+  // ========================================================================
+
+  it('returns 400 when clip is not in approved stage (draft)', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const draftClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'draft',
+      stagedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(draftClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip must be approved');
+    expect(body.error).toContain('draft');
+  });
+
+  it('returns 400 when clip is in published stage', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const publishedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'published',
+      stagedAt: new Date().toISOString(),
+      publishedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip must be approved');
+    expect(body.error).toContain('published');
+  });
+
+  it('returns 400 when clip is in rejected stage', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const rejectedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'rejected',
+      stagedAt: new Date().toISOString(),
+      rejectedAt: new Date().toISOString(),
+    };
+
+    mockGetClipDraft.mockReturnValue(rejectedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Clip must be approved');
+    expect(body.error).toContain('rejected');
+  });
+
+  // ========================================================================
+  // Generated clips validation tests
+  // ========================================================================
+
+  it('returns 400 when clip has no generated clips', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('No generated clips');
+  });
+
+  it('returns 400 when clip has no ready clip found', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: false,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('No ready clip found');
+  });
+
+  // ========================================================================
+  // Platform fallback tests
+  // ========================================================================
+
+  it('uses default platforms from postizConfig when none provided', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, platforms: undefined },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      success: boolean;
+      clip: ClipMetadata;
+      postizResponse: PostizPostResponse;
+    };
+    expect(body.success).toBe(true);
+    expect(mockPostToPostiz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platforms: ['warpcast', 'x', 'bluesky', 'discord'],
+      }),
+    );
+  });
+
+  it('uses provided platforms when specified in request', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, platforms: ['warpcast', 'x'] },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: null,
+        discord: null,
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId,
+      platforms: ['warpcast', 'x'],
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(mockPostToPostiz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platforms: ['warpcast', 'x'],
+      }),
+    );
+  });
+
+  it('uses default platforms when empty array provided', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, platforms: [] },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId,
+      platforms: [],
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // When empty array is provided, should use defaults
+    expect(mockPostToPostiz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platforms: ['warpcast', 'x', 'bluesky', 'discord'],
+      }),
+    );
+  });
+
+  // ========================================================================
+  // Success path tests
+  // ========================================================================
+
+  it('returns 200 and publishes clip on valid request', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'A test clip for publishing',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Amazing moment',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      success: boolean;
+      clip: ClipMetadata;
+      postizResponse: PostizPostResponse;
+      message: string;
+    };
+    expect(body.success).toBe(true);
+    expect(body.clip.stage).toBe('published');
+    expect(body.postizResponse.id).toBe('post-123');
+    expect(body.message).toContain('Clip published');
+  });
+
+  it('calls buildCaption with correct parameters', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Amazing Clip',
+      description: 'This is an amazing clip',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Great moment',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    await POST(req);
+
+    expect(mockBuildCaption).toHaveBeenCalledWith('Amazing Clip', 'Great moment', 300);
+  });
+
+  it('calls postToPostiz with video attachment and clip URL', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const videoUrl = 'https://example.com/clips/clip-1.mp4';
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: videoUrl,
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    await POST(req);
+
+    expect(mockPostToPostiz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          {
+            type: 'video',
+            url: videoUrl,
+            altText: 'Test Clip',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('calls publishClipDraft with postizResponse.id', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    const postizId = 'post-999';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: postizId,
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: postizId,
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    await POST(req);
+
+    expect(mockPublishClipDraft).toHaveBeenCalledWith(clipId, postizId);
+  });
+
+  it('includes platforms in success message', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId, platforms: ['warpcast', 'x'] },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: null,
+        discord: null,
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId,
+      platforms: ['warpcast', 'x'],
+    });
+
+    const res = await POST(req);
+
+    const body = (await res.json()) as { message: string };
+    expect(body.message).toContain('warpcast');
+    expect(body.message).toContain('x');
+  });
+
+  // ========================================================================
+  // Postiz error handling tests
+  // ========================================================================
+
+  it('returns 503 when postToPostiz throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizError = new Error('Postiz API rate limit exceeded');
+    mockPostToPostiz.mockRejectedValue(postizError);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Postiz API rate limit exceeded');
+  });
+
+  it('handles non-Error thrown from postToPostiz gracefully', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    mockPostToPostiz.mockRejectedValue('String error instead of Error object');
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Postiz error');
+  });
+
+  // ========================================================================
+  // General error handling tests
+  // ========================================================================
+
+  it('returns 500 when getSessionData throws an error', async () => {
+    mockGetSessionData.mockRejectedValue(new Error('Session error'));
+
+    const req = makePostRequest('/api/autocliper/publish', {
+      clipId: '550e8400-e29b-41d4-a716-446655440000',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Session error');
+  });
+
+  it('returns 500 when request.json() throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const badRequest = new Request('http://localhost:3000/api/autocliper/publish', {
+      method: 'POST',
+      body: 'invalid json',
+    });
+
+    const res = await POST(badRequest as unknown as Request);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 500 when getClipDraft throws an error', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw new Error('Database error on getClipDraft');
+    });
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Database error');
+  });
+
+  it('logs error to console when exception occurs', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw new Error('Test error message');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    await POST(req);
+
+    expect(consoleSpy).toHaveBeenCalledWith('[api/autocliper/publish]', 'Test error message');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles non-Error thrown values gracefully', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    mockGetClipDraft.mockImplementation(() => {
+      throw 'String error instead of Error object';
+    });
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Unknown error');
+  });
+
+  // ========================================================================
+  // Edge cases
+  // ========================================================================
+
+  it('handles clip with multiple generated clips (finds first ready one)', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const readyClipUrl = 'https://example.com/clips/clip-2.mp4';
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Not ready',
+          generatedAt: new Date().toISOString(),
+          ready: false,
+        },
+        {
+          id: 'gc2',
+          filename: 'clip-2.mp4',
+          path: '/clips/clip-2.mp4',
+          url: readyClipUrl,
+          startSecond: 25,
+          endSecond: 35,
+          durationSeconds: 10,
+          aspectRatio: '9:16',
+          filesize: 6000000,
+          caption: 'Ready caption',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+        {
+          id: 'gc3',
+          filename: 'clip-3.mp4',
+          path: '/clips/clip-3.mp4',
+          url: 'https://example.com/clips/clip-3.mp4',
+          startSecond: 40,
+          endSecond: 50,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 7000000,
+          caption: 'Also not ready',
+          generatedAt: new Date().toISOString(),
+          ready: false,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    await POST(req);
+
+    expect(mockPostToPostiz).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            url: readyClipUrl,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('response includes complete ApiResponse structure', async () => {
+    const session = { fid: 123, username: 'testuser' };
+    mockGetSessionData.mockResolvedValue(session);
+
+    const clipId = '550e8400-e29b-41d4-a716-446655440000';
+    mockValidateRequest.mockReturnValue({
+      success: true,
+      data: { clipId },
+    });
+
+    const approvedClip: ClipMetadata = {
+      id: clipId,
+      sourceUrl: 'https://example.com/video',
+      sourceType: 'stream',
+      title: 'Test Clip',
+      description: 'Test',
+      createdAt: new Date().toISOString(),
+      stage: 'approved',
+      stagedAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+      generatedClips: [
+        {
+          id: 'gc1',
+          filename: 'clip-1.mp4',
+          path: '/clips/clip-1.mp4',
+          url: 'https://example.com/clips/clip-1.mp4',
+          startSecond: 10,
+          endSecond: 20,
+          durationSeconds: 10,
+          aspectRatio: '16:9',
+          filesize: 5000000,
+          caption: 'Test',
+          generatedAt: new Date().toISOString(),
+          ready: true,
+        },
+      ],
+    };
+
+    mockGetClipDraft.mockReturnValue(approvedClip);
+
+    const postizResponse: PostizPostResponse = {
+      id: 'post-123',
+      scheduled: {
+        warpcast: {
+          platform: 'warpcast',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        x: { platform: 'x', scheduledAt: new Date().toISOString(), status: 'scheduled' },
+        bluesky: {
+          platform: 'bluesky',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+        discord: {
+          platform: 'discord',
+          scheduledAt: new Date().toISOString(),
+          status: 'scheduled',
+        },
+      },
+    };
+
+    mockPostToPostiz.mockResolvedValue(postizResponse);
+
+    const publishedClip: ClipMetadata = {
+      ...approvedClip,
+      stage: 'published',
+      publishedAt: new Date().toISOString(),
+      postizPostId: 'post-123',
+    };
+
+    mockPublishClipDraft.mockReturnValue(publishedClip);
+
+    const req = makePostRequest('/api/autocliper/publish', { clipId });
+
+    const res = await POST(req);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('success');
+    expect(body).toHaveProperty('clip');
+    expect(body).toHaveProperty('postizResponse');
+    expect(body).toHaveProperty('message');
+    expect(typeof body.success).toBe('boolean');
+    expect(typeof body.message).toBe('string');
+  });
+});

--- a/src/app/api/chat/thread/[hash]/__tests__/route.test.ts
+++ b/src/app/api/chat/thread/[hash]/__tests__/route.test.ts
@@ -1,0 +1,691 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockGetCastThread } = vi.hoisted(() => ({
+  mockGetCastThread: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getCastThread: mockGetCastThread,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { GET } from '../route';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+/** Valid cast hash in the required format (0x + hex) */
+const VALID_HASH = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+/** Sample cast data as returned by neynar */
+const SAMPLE_CAST = {
+  hash: VALID_HASH,
+  author: {
+    fid: 123,
+    username: 'testuser',
+    display_name: 'Test User',
+    pfp_url: 'https://example.com/pfp.jpg',
+  },
+  text: 'Hello world',
+  timestamp: '2024-01-01T00:00:00Z',
+  replies: { count: 2 },
+  reactions: {
+    likes_count: 5,
+    recasts_count: 1,
+    likes: [{ fid: 200 }, { fid: 201 }],
+    recasts: [{ fid: 300 }],
+  },
+  parent_hash: null,
+  embeds: [],
+};
+
+/** Sample reply cast */
+const SAMPLE_REPLY_1 = {
+  hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  author: {
+    fid: 200,
+    username: 'replier1',
+    display_name: 'Replier One',
+    pfp_url: 'https://example.com/pfp2.jpg',
+  },
+  text: 'Great post!',
+  timestamp: '2024-01-01T01:00:00Z',
+  replies: { count: 0 },
+  reactions: {
+    likes_count: 1,
+    recasts_count: 0,
+    likes: [],
+    recasts: [],
+  },
+  parent_hash: VALID_HASH,
+  embeds: [],
+};
+
+/** Sample nested reply */
+const SAMPLE_REPLY_2 = {
+  hash: '0x2222222222222222222222222222222222222222222222222222222222222222',
+  author: {
+    fid: 201,
+    username: 'replier2',
+    display_name: 'Replier Two',
+    pfp_url: 'https://example.com/pfp3.jpg',
+  },
+  text: 'I agree!',
+  timestamp: '2024-01-01T02:00:00Z',
+  replies: { count: 0 },
+  reactions: {
+    likes_count: 0,
+    recasts_count: 0,
+    likes: [],
+    recasts: [],
+  },
+  parent_hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+  embeds: [],
+};
+
+describe('GET /api/chat/thread/[hash]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Authentication tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('authentication', () => {
+    it('returns 401 when user is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockGetCastThread).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when user is authenticated', async () => {
+      mockGetSessionData.mockResolvedValue({ fid: 123, username: 'testuser' });
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetCastThread).toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Input validation tests
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('input validation (castHashSchema)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 400 when hash lacks 0x prefix', async () => {
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({
+          hash: 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+        }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid cast hash');
+      expect(mockGetCastThread).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when hash is too short (40 chars required minimum)', async () => {
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: '0xabc' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid cast hash');
+      expect(mockGetCastThread).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when hash contains non-hex characters', async () => {
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: '0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid cast hash');
+      expect(mockGetCastThread).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid 40-char hex hash (0x + 40 chars)', async () => {
+      const shortHash = `0x${'a'.repeat(40)}`;
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: shortHash }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetCastThread).toHaveBeenCalledWith(shortHash);
+    });
+
+    it('accepts valid 64-char hex hash (0x + 64 chars)', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetCastThread).toHaveBeenCalledWith(VALID_HASH);
+    });
+
+    it('accepts mixed case hex hash', async () => {
+      const mixedCaseHash = '0xAbCdEf1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: mixedCaseHash }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetCastThread).toHaveBeenCalledWith(mixedCaseHash);
+    });
+
+    it('returns 400 when hash is empty string', async () => {
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: '' }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid cast hash');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // getCastThread call and response mapping
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('getCastThread call and mapCast transformation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('calls getCastThread with validated hash', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      expect(mockGetCastThread).toHaveBeenCalledWith(VALID_HASH);
+      expect(mockGetCastThread).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps single cast correctly', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(1);
+      const mappedCast = body.casts[0];
+      expect(mappedCast.hash).toBe(SAMPLE_CAST.hash);
+      expect(mappedCast.author.fid).toBe(SAMPLE_CAST.author.fid);
+      expect(mappedCast.author.username).toBe(SAMPLE_CAST.author.username);
+      expect(mappedCast.author.display_name).toBe(SAMPLE_CAST.author.display_name);
+      expect(mappedCast.author.pfp_url).toBe(SAMPLE_CAST.author.pfp_url);
+      expect(mappedCast.text).toBe(SAMPLE_CAST.text);
+      expect(mappedCast.timestamp).toBe(SAMPLE_CAST.timestamp);
+    });
+
+    it('maps replies and reactions correctly', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      const mappedCast = body.casts[0];
+      expect(mappedCast.replies.count).toBe(2);
+      expect(mappedCast.reactions.likes_count).toBe(5);
+      expect(mappedCast.reactions.recasts_count).toBe(1);
+      expect(mappedCast.reactions.likes).toHaveLength(2);
+      expect(mappedCast.reactions.recasts).toHaveLength(1);
+    });
+
+    it('handles missing author fields with defaults', async () => {
+      const castWithMissingFields = {
+        hash: VALID_HASH,
+        author: { fid: 123 }, // username, display_name, pfp_url missing
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: castWithMissingFields },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      const mappedCast = body.casts[0];
+      expect(mappedCast.author.username).toBe('');
+      expect(mappedCast.author.display_name).toBe('');
+      expect(mappedCast.author.pfp_url).toBe('');
+    });
+
+    it('handles missing text field with default', async () => {
+      const castWithoutText = {
+        hash: VALID_HASH,
+        author: SAMPLE_CAST.author,
+        timestamp: SAMPLE_CAST.timestamp,
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: castWithoutText },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      const mappedCast = body.casts[0];
+      expect(mappedCast.text).toBe('');
+    });
+
+    it('handles missing reactions with defaults', async () => {
+      const castWithoutReactions = {
+        hash: VALID_HASH,
+        author: SAMPLE_CAST.author,
+        text: SAMPLE_CAST.text,
+        timestamp: SAMPLE_CAST.timestamp,
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: castWithoutReactions },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      const mappedCast = body.casts[0];
+      expect(mappedCast.reactions.likes_count).toBe(0);
+      expect(mappedCast.reactions.recasts_count).toBe(0);
+      expect(mappedCast.reactions.likes).toEqual([]);
+      expect(mappedCast.reactions.recasts).toEqual([]);
+    });
+
+    it('handles parent_hash and embeds correctly', async () => {
+      const castWithEmbeds = {
+        ...SAMPLE_CAST,
+        parent_hash: '0x1234567890abcdef1234567890abcdef1234567890',
+        embeds: [{ url: 'https://example.com/image.jpg' }],
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: castWithEmbeds },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      const mappedCast = body.casts[0];
+      expect(mappedCast.parent_hash).toBe('0x1234567890abcdef1234567890abcdef1234567890');
+      expect(mappedCast.embeds).toHaveLength(1);
+      expect(mappedCast.embeds[0].url).toBe('https://example.com/image.jpg');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Thread flattening and nested replies
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('thread flattening with direct_replies', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('flattens a thread with direct replies', async () => {
+      const threadData = {
+        ...SAMPLE_CAST,
+        direct_replies: [SAMPLE_REPLY_1],
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: threadData },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(2);
+      expect(body.casts[0].hash).toBe(VALID_HASH);
+      expect(body.casts[1].hash).toBe(SAMPLE_REPLY_1.hash);
+    });
+
+    it('flattens nested replies recursively', async () => {
+      const replyWithNested = {
+        ...SAMPLE_REPLY_1,
+        direct_replies: [SAMPLE_REPLY_2],
+      };
+      const threadData = {
+        ...SAMPLE_CAST,
+        direct_replies: [replyWithNested],
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: threadData },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(3);
+      expect(body.casts[0].hash).toBe(VALID_HASH);
+      expect(body.casts[1].hash).toBe(SAMPLE_REPLY_1.hash);
+      expect(body.casts[2].hash).toBe(SAMPLE_REPLY_2.hash);
+    });
+
+    it('handles empty direct_replies array', async () => {
+      const threadData = {
+        ...SAMPLE_CAST,
+        direct_replies: [],
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: threadData },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(1);
+      expect(body.casts[0].hash).toBe(VALID_HASH);
+    });
+
+    it('handles missing direct_replies field', async () => {
+      const threadData = { ...SAMPLE_CAST }; // no direct_replies
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: threadData },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(1);
+      expect(body.casts[0].hash).toBe(VALID_HASH);
+    });
+
+    it('handles direct_replies as undefined', async () => {
+      const threadData = {
+        ...SAMPLE_CAST,
+        direct_replies: undefined,
+      };
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: threadData },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body.casts).toHaveLength(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Empty/missing thread data
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('empty or missing thread data', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns empty casts array when conversation.cast is null', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: null },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.casts).toEqual([]);
+    });
+
+    it('returns empty casts array when conversation.cast is undefined', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: undefined },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.casts).toEqual([]);
+    });
+
+    it('returns empty casts array when conversation is missing', async () => {
+      mockGetCastThread.mockResolvedValue({});
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.casts).toEqual([]);
+    });
+
+    it('returns empty casts array when getCastThread returns null', async () => {
+      mockGetCastThread.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.casts).toEqual([]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Error handling and 500 path
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns 500 when getCastThread throws error', async () => {
+      mockGetCastThread.mockRejectedValue(new Error('Neynar API error'));
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch thread');
+    });
+
+    it('returns 500 when getCastThread times out', async () => {
+      mockGetCastThread.mockRejectedValue(new Error('Request timeout'));
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch thread');
+    });
+
+    it('logs error when getCastThread throws', async () => {
+      const { logger } = await import('@/lib/logger');
+      const testError = new Error('Test API failure');
+      mockGetCastThread.mockRejectedValue(testError);
+
+      await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      expect(logger.error).toHaveBeenCalledWith('Thread fetch error:', testError);
+    });
+
+    it('returns 500 when params Promise rejects', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.reject(new Error('Params resolution failed')),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch thread');
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Response shape and format
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('returns casts array in response body', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+      const body = await res.json();
+
+      expect(body).toHaveProperty('casts');
+      expect(Array.isArray(body.casts)).toBe(true);
+    });
+
+    it('response is valid JSON', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      await expect(res.json()).resolves.toBeDefined();
+    });
+
+    it('returns correct status code 200 on success', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: VALID_HASH }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Dynamic params handling
+  // ──────────────────────────────────────────────────────────────────────────
+
+  describe('dynamic params Promise handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue({ fid: 123 });
+    });
+
+    it('correctly awaits params Promise', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const paramsPromise = Promise.resolve({ hash: VALID_HASH });
+      const res = await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: paramsPromise,
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockGetCastThread).toHaveBeenCalled();
+    });
+
+    it('extracts hash from params Promise correctly', async () => {
+      mockGetCastThread.mockResolvedValue({
+        conversation: { cast: SAMPLE_CAST },
+      });
+
+      const testHash = '0x1234567890abcdef1234567890abcdef12345678';
+      await GET(makeGetRequest('/api/chat/thread/[hash]'), {
+        params: Promise.resolve({ hash: testHash }),
+      });
+
+      expect(mockGetCastThread).toHaveBeenCalledWith(testHash);
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 2 previously-untested API routes — **63 tests total**.

| Route | Tests | Covers |
|-------|-------|--------|
| `chat/thread/[hash]` | 34 | auth, castHashSchema 400, getCastThread, mapCast transform, thread flattening (nested replies), empty-thread, errors |
| `autocliper/publish` | 29 | auth, validateRequest 400, draft-not-found 404, stage guard, ready-clip check, platform fallback, postToPostiz publish (mocked) + publishClipDraft, 503 Postiz error, 500 |

Test-only — no runtime files touched. External Postiz/Neynar fully mocked — no real publish. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)