### PR TITLE
test(auth,admin,chat): signer-save/register/discord-link/assistant (143 tests)

### DIFF
--- a/src/app/api/admin/discord-link/__tests__/route.test.ts
+++ b/src/app/api/admin/discord-link/__tests__/route.test.ts
@@ -1,0 +1,1490 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetClientIp, mockLogAuditEvent } = vi.hoisted(() => ({
+  mockGetClientIp: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  getClientIp: mockGetClientIp,
+  logAuditEvent: mockLogAuditEvent,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PATCH, POST } from '../route';
+
+// ============================================================================
+// GET /api/admin/discord-link
+// ============================================================================
+
+describe('GET /api/admin/discord-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('queries users table with correct fields and filters', async () => {
+      const usersChain = chainMock({ data: [], error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenNthCalledWith(1, 'users');
+      const usersSelect = vi.mocked(usersChain.select);
+      expect(usersSelect).toHaveBeenCalledWith(
+        'id, primary_wallet, fid, username, display_name, pfp_url, discord_id, role, is_active, created_at',
+      );
+      expect(usersChain.eq).toHaveBeenCalledWith('is_active', true);
+      expect(usersChain.order).toHaveBeenCalledWith('created_at', { ascending: false });
+    });
+
+    it('queries discord_intros table for discord_id', async () => {
+      const usersChain = chainMock({ data: [], error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenNthCalledWith(2, 'discord_intros');
+      expect(introsChain.select).toHaveBeenCalledWith('discord_id');
+    });
+
+    it('queries discord_proposals table for author_id', async () => {
+      const usersChain = chainMock({ data: [], error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenNthCalledWith(3, 'discord_proposals');
+      expect(proposalsChain.select).toHaveBeenCalledWith('author_id');
+    });
+
+    it('queries discord_proposal_votes table for voter_id', async () => {
+      const usersChain = chainMock({ data: [], error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenNthCalledWith(4, 'discord_proposal_votes');
+      expect(votesChain.select).toHaveBeenCalledWith('voter_id');
+    });
+  });
+
+  describe('data enrichment', () => {
+    it('enriches users with discord link status and counts', async () => {
+      const userId = VALID_UUID;
+      const discordId = 'discord-123';
+      const userData = [
+        {
+          id: userId,
+          primary_wallet: '0xabc',
+          fid: 100,
+          username: 'testuser',
+          display_name: 'Test User',
+          pfp_url: 'https://example.com/pfp.jpg',
+          discord_id: discordId,
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-01',
+        },
+      ];
+      const introsData = [{ discord_id: discordId }];
+      const proposalsData = [{ author_id: discordId }, { author_id: discordId }];
+      const votesData = [{ voter_id: discordId }, { voter_id: discordId }, { voter_id: discordId }];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const introsChain = chainMock({ data: introsData, error: null }).chain;
+      const proposalsChain = chainMock({ data: proposalsData, error: null }).chain;
+      const votesChain = chainMock({ data: votesData, error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.users[0]).toEqual(
+        expect.objectContaining({
+          id: userId,
+          discord_id: discordId,
+          has_intro: true,
+          proposal_count: 2,
+          vote_count: 3,
+        }),
+      );
+    });
+
+    it('sets has_intro to false when user has no discord_id', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          fid: 100,
+          username: 'testuser',
+          display_name: 'Test User',
+          pfp_url: 'https://example.com/pfp.jpg',
+          discord_id: null,
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-01',
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.users[0].has_intro).toBe(false);
+      expect(body.users[0].proposal_count).toBe(0);
+      expect(body.users[0].vote_count).toBe(0);
+    });
+
+    it('calculates correct stats with linked and unlinked users', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          fid: 100,
+          username: 'user1',
+          display_name: 'User 1',
+          pfp_url: null,
+          discord_id: 'discord-1',
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-01',
+        },
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xdef',
+          fid: 200,
+          username: 'user2',
+          display_name: 'User 2',
+          pfp_url: null,
+          discord_id: null,
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-02',
+        },
+        {
+          id: VALID_UUID,
+          primary_wallet: '0x123',
+          fid: 300,
+          username: 'user3',
+          display_name: 'User 3',
+          pfp_url: null,
+          discord_id: 'discord-3',
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-03',
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const introsChain = chainMock({ data: [{ discord_id: 'discord-1' }], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.stats).toEqual({
+        linked: 2,
+        unlinked: 1,
+        introCount: 1,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when users query fails', async () => {
+      const dbError = new Error('Database connection failed');
+      const usersChain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(usersChain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch users');
+    });
+
+    it('continues when intros query fails (optional)', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          fid: 100,
+          username: 'testuser',
+          display_name: 'Test User',
+          pfp_url: null,
+          discord_id: 'discord-1',
+          role: 'user',
+          is_active: true,
+          created_at: '2026-01-01',
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const introsChain = chainMock({ data: null, error: new Error('Query failed') }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.users).toHaveLength(1);
+    });
+
+    it('returns 500 when unexpected exception is thrown', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch discord link data');
+    });
+
+    it('logs errors to logger.error', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = new Error('Database error');
+      const usersChain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(usersChain);
+
+      await GET();
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[discord-link] Users query error:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with users array and stats', async () => {
+      const usersChain = chainMock({ data: [], error: null }).chain;
+      const introsChain = chainMock({ data: [], error: null }).chain;
+      const proposalsChain = chainMock({ data: [], error: null }).chain;
+      const votesChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return introsChain;
+        if (callCount === 3) return proposalsChain;
+        return votesChain;
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toHaveProperty('users');
+      expect(body).toHaveProperty('stats');
+      expect(Array.isArray(body.users)).toBe(true);
+      expect(body.stats).toHaveProperty('linked');
+      expect(body.stats).toHaveProperty('unlinked');
+      expect(body.stats).toHaveProperty('introCount');
+    });
+  });
+});
+
+// ============================================================================
+// PATCH /api/admin/discord-link
+// ============================================================================
+
+describe('PATCH /api/admin/discord-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when userId is missing', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when userId is not a valid UUID', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: 'not-a-uuid',
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when discordId is empty string', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: '',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid UUID and discord ID for linking', async () => {
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: 'discord-123', display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts null discordId for unlinking', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, discord_id: null, display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: null,
+      });
+      const res = await PATCH(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('duplicate link prevention', () => {
+    it('returns 409 when discord_id is already linked to another user', async () => {
+      const discordId = 'discord-123';
+      const otherUserId = 'other-uuid-1234-5678-90ab-cdef12345678';
+
+      const checkChain = chainMock({
+        data: { id: otherUserId, display_name: 'Other User' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(checkChain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId,
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toContain('already linked to Other User');
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not prevent linking when user unlinking (discordId is null)', async () => {
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: null, display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let _callCount = 0;
+      mockFrom.mockImplementation(() => {
+        _callCount += 1;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: null,
+      });
+      const res = await PATCH(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Supabase update', () => {
+    it('updates users table with discord_id', async () => {
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: 'discord-123', display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      await PATCH(req);
+
+      expect(mockFrom).toHaveBeenCalledWith('users');
+      expect(updateChain.update).toHaveBeenCalledWith({ discord_id: 'discord-123' });
+      expect(updateChain.eq).toHaveBeenCalledWith('id', VALID_UUID);
+    });
+
+    it('updates users table with null discord_id for unlink', async () => {
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: null, display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let _callCount = 0;
+      mockFrom.mockImplementation(() => {
+        _callCount += 1;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: null,
+      });
+      await PATCH(req);
+
+      expect(updateChain.update).toHaveBeenCalledWith({ discord_id: null });
+    });
+
+    it('returns 500 when update fails', async () => {
+      const updateChain = chainMock({
+        data: null,
+        error: new Error('Update failed'),
+      }).chain;
+      mockFrom.mockReturnValue(updateChain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update discord link');
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event for link action', async () => {
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: 'discord-123', display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      await PATCH(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'discord.link',
+          targetType: 'user',
+          targetId: VALID_UUID,
+          details: { discord_id: 'discord-123' },
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('logs audit event for unlink action', async () => {
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: null, display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let _callCount = 0;
+      mockFrom.mockImplementation(() => {
+        _callCount += 1;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: null,
+      });
+      await PATCH(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'discord.unlink',
+          targetType: 'user',
+          targetId: VALID_UUID,
+          details: { discord_id: null },
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('calls getClientIp with the request', async () => {
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: 'discord-123', display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      await PATCH(req);
+
+      expect(mockGetClientIp).toHaveBeenCalledWith(req);
+    });
+
+    it('includes correct admin fid in audit event', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: { id: VALID_UUID, discord_id: 'discord-123', display_name: 'Test', username: 'test' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      await PATCH(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 999,
+        }),
+      );
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with ok=true and action=linked', async () => {
+      const userData = {
+        id: VALID_UUID,
+        discord_id: 'discord-123',
+        display_name: 'Test',
+        username: 'test',
+      };
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({
+        data: userData,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? checkChain : updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.action).toBe('linked');
+      expect(body.user).toEqual(userData);
+    });
+
+    it('returns 200 with action=unlinked for null discord_id', async () => {
+      const userData = {
+        id: VALID_UUID,
+        discord_id: null,
+        display_name: 'Test',
+        username: 'test',
+      };
+      const updateChain = chainMock({
+        data: userData,
+        error: null,
+      }).chain;
+
+      let _callCount = 0;
+      mockFrom.mockImplementation(() => {
+        _callCount += 1;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: null,
+      });
+      const res = await PATCH(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.action).toBe('unlinked');
+      expect(body.user).toEqual(userData);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when request body is not valid JSON', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/discord-link', 'http://localhost:3000'),
+        {
+          method: 'PATCH',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await PATCH(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update discord link');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Patch failed');
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        userId: VALID_UUID,
+        discordId: 'discord-123',
+      });
+      await PATCH(req);
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[discord-link] PATCH error:',
+        expect.any(Error),
+      );
+    });
+  });
+});
+
+// ============================================================================
+// POST /api/admin/discord-link (bulk auto-link)
+// ============================================================================
+
+describe('POST /api/admin/discord-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: {},
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: {},
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when walletMap is missing', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toContain('walletMap is required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when walletMap is empty', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: {},
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toContain('walletMap is required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts preview=true (default)', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts preview=false for execution mode', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when preview is not a boolean', async () => {
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: 'yes',
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('preview mode', () => {
+    it('returns preview response without executing updates', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'testuser',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const chain = chainMock({ data: userData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.preview).toBe(true);
+      expect(body.matches).toHaveLength(1);
+      expect(body.alreadyLinked).toBe(0);
+      expect(body.total).toBe(1);
+    });
+
+    it('normalizes wallet addresses to lowercase in preview', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xABC',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'testuser',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const chain = chainMock({ data: userData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.matches).toHaveLength(1);
+      expect(body.matches[0].wallet).toBe('0xabc');
+    });
+
+    it('categorizes users correctly in preview', async () => {
+      const userData = [
+        {
+          id: 'id-1',
+          primary_wallet: '0xmatch',
+          discord_id: null,
+          display_name: 'Matched User',
+          username: 'matched',
+          verified_addresses: [],
+          custody_address: null,
+        },
+        {
+          id: 'id-2',
+          primary_wallet: '0xalready',
+          discord_id: 'existing-discord',
+          display_name: 'Already Linked',
+          username: 'already',
+          verified_addresses: [],
+          custody_address: null,
+        },
+        {
+          id: 'id-3',
+          primary_wallet: '0xnomatch',
+          discord_id: null,
+          display_name: 'No Match',
+          username: 'nomatch',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const chain = chainMock({ data: userData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xmatch' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.matches).toHaveLength(1);
+      expect(body.alreadyLinked).toBe(1);
+      expect(body.noMatch).toBe(1);
+      expect(body.total).toBe(3);
+    });
+  });
+
+  describe('execution mode', () => {
+    it('executes links when preview=false', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'testuser',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({ error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.preview).toBe(false);
+      expect(body.linked).toBe(1);
+    });
+
+    it('prevents duplicate discord_id linking in execute mode', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'testuser',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({
+        data: { id: 'other-id' },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? usersChain : checkChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.linked).toBe(0);
+      expect(body.errors).toHaveLength(1);
+      expect(body.errors[0]).toContain('already on another user');
+    });
+
+    it('handles mixed success and errors in execute mode', async () => {
+      const userData = [
+        {
+          id: 'id-1',
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Success User',
+          username: 'success',
+          verified_addresses: [],
+          custody_address: null,
+        },
+        {
+          id: 'id-2',
+          primary_wallet: '0xdef',
+          discord_id: null,
+          display_name: 'Error User',
+          username: 'error',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain1 = chainMock({ data: null, error: null }).chain;
+      const updateChain1 = chainMock({ error: null }).chain;
+      const checkChain2 = chainMock({ data: null, error: null }).chain;
+      const updateChain2 = chainMock({
+        error: new Error('Update failed'),
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain1;
+        if (callCount === 3) return updateChain1;
+        if (callCount === 4) return checkChain2;
+        return updateChain2;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc', 'discord-2': '0xdef' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.linked).toBe(1);
+      expect(body.errors).toHaveLength(1);
+    });
+
+    it('matches against custody_address', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xprimary',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'test',
+          verified_addresses: [],
+          custody_address: '0xcustody',
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({ error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xcustody' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.linked).toBe(1);
+    });
+
+    it('matches against verified_addresses', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xprimary',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'test',
+          verified_addresses: ['0xverified1', '0xverified2'],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({ error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xverified2' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.linked).toBe(1);
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event for bulk link action', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'test',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({ error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      await POST(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'discord.bulk_link',
+          targetType: 'system',
+          details: expect.objectContaining({
+            linked: expect.any(Number),
+          }),
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('only logs audit event in execute mode (not preview)', async () => {
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'test',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const chain = chainMock({ data: userData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      await POST(req);
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('includes correct admin fid in audit event', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const userData = [
+        {
+          id: VALID_UUID,
+          primary_wallet: '0xabc',
+          discord_id: null,
+          display_name: 'Test User',
+          username: 'test',
+          verified_addresses: [],
+          custody_address: null,
+        },
+      ];
+
+      const usersChain = chainMock({ data: userData, error: null }).chain;
+      const checkChain = chainMock({ data: null, error: null }).chain;
+      const updateChain = chainMock({ error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return usersChain;
+        if (callCount === 2) return checkChain;
+        return updateChain;
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      await POST(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 999,
+        }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when users query fails', async () => {
+      const chain = chainMock({ data: null, error: new Error('Query failed') }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch users');
+    });
+
+    it('returns 500 when request body is not valid JSON', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/discord-link', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await POST(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Bulk link failed');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      await POST(req);
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[discord-link] POST error:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('success response', () => {
+    it('returns preview response with correct structure', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: true,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        preview: true,
+        matches: [],
+        alreadyLinked: 0,
+        noMatch: 0,
+        total: 0,
+      });
+    });
+
+    it('returns execute response with correct structure', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/discord-link', {
+        preview: false,
+        walletMap: { 'discord-1': '0xabc' },
+      });
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.preview).toBe(false);
+      expect(body).toHaveProperty('linked');
+      expect(body).toHaveProperty('alreadyLinked');
+      expect(body).toHaveProperty('noMatch');
+      expect(body).toHaveProperty('errors');
+      expect(body).toHaveProperty('total');
+    });
+  });
+});

--- a/src/app/api/auth/register/__tests__/route.test.ts
+++ b/src/app/api/auth/register/__tests__/route.test.ts
@@ -1,0 +1,697 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockCreateSigner, mockRegisterUser, mockCheckAllowlist } = vi.hoisted(() => ({
+  mockCreateSigner: vi.fn(),
+  mockRegisterUser: vi.fn(),
+  mockCheckAllowlist: vi.fn(),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  createSigner: mockCreateSigner,
+  registerUser: mockRegisterUser,
+}));
+
+vi.mock('@/lib/gates/allowlist', () => ({
+  checkAllowlist: mockCheckAllowlist,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/auth/register', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Zod validation: walletAddress', () => {
+    it('returns 400 when walletAddress is missing', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string; details: unknown };
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when walletAddress is not a hex string', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: 'not-a-hex-address',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when walletAddress is missing 0x prefix', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when walletAddress has insufficient hex digits (39 instead of 40)', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef1234567',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when walletAddress has too many hex digits (41 instead of 40)', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef123456789',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid walletAddress with lowercase hex', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts valid walletAddress with uppercase hex', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts valid walletAddress with mixed case hex', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234AbCdEf1234567890aBcDeF1234567890AbCd',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod validation: signature', () => {
+    it('returns 400 when signature is missing', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when signature is empty string', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: '',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts non-empty signature', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'x',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod validation: deadline', () => {
+    it('returns 400 when deadline is missing', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when deadline is not a number', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 'not-a-number',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when deadline is a float', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890.5,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when deadline is zero', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 0,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when deadline is negative', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: -1,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts positive integer deadline', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts large positive deadline', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 9999999999,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod validation: fname', () => {
+    it('accepts missing fname (optional)', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when fname is empty string', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+        fname: '',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when fname exceeds 32 characters', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+        fname: 'a'.repeat(33),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts fname with exactly 1 character', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+        fname: 'a',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts fname with exactly 32 characters', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+        fname: 'a'.repeat(32),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Allowlist gate (checkAllowlist)', () => {
+    it('returns 403 when checkAllowlist returns allowed: false', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as unknown as {
+        error: string;
+        redirect: string;
+      };
+      expect(body.error).toBe('Not on allowlist');
+      expect(body.redirect).toBe('/not-allowed');
+    });
+
+    it('normalizes wallet address to lowercase before checking allowlist', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0xABCDEF1234567890ABCDEF1234567890ABCDEF12',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      await POST(req);
+
+      expect(mockCheckAllowlist).toHaveBeenCalledWith(
+        undefined,
+        '0xabcdef1234567890abcdef1234567890abcdef12',
+      );
+    });
+
+    it('returns 500 when checkAllowlist throws an error', async () => {
+      mockCheckAllowlist.mockRejectedValue(new Error('Database connection failed'));
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Registration failed');
+    });
+  });
+
+  describe('registerUser call', () => {
+    it('passes signature, normalized wallet, deadline, and fname to registerUser', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0xABCD1234567890ABCD1234567890ABCD12345678',
+        signature: 'sig-data-123',
+        deadline: 9876543210,
+        fname: 'testuser',
+      });
+      await POST(req);
+
+      expect(mockRegisterUser).toHaveBeenCalledWith(
+        'sig-data-123',
+        '0xabcd1234567890abcd1234567890abcd12345678',
+        9876543210,
+        'testuser',
+      );
+    });
+
+    it('passes signature, normalized wallet, and deadline to registerUser when fname is not provided', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig-data-456',
+        deadline: 1111111111,
+      });
+      await POST(req);
+
+      expect(mockRegisterUser).toHaveBeenCalledWith(
+        'sig-data-456',
+        '0x1234567890abcdef1234567890abcdef12345678',
+        1111111111,
+        undefined,
+      );
+    });
+
+    it('returns 500 when registerUser throws an error', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockRejectedValue(new Error('Neynar API error'));
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Registration failed');
+    });
+  });
+
+  describe('createSigner call', () => {
+    it('calls createSigner after successful registerUser', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      await POST(req);
+
+      expect(mockCreateSigner).toHaveBeenCalled();
+    });
+
+    it('returns 500 when createSigner throws an error', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockRejectedValue(new Error('Signer creation failed'));
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Registration failed');
+    });
+  });
+
+  describe('Response shape on success', () => {
+    it('returns 200 with success response including signer data', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 12345 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-abc-123',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/approve?sig=xyz',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown as {
+        success: boolean;
+        fid: number;
+        signerUuid: string;
+        signerStatus: string;
+        signerApprovalUrl: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.fid).toBe(12345);
+      expect(body.signerUuid).toBe('uuid-abc-123');
+      expect(body.signerStatus).toBe('approved');
+      expect(body.signerApprovalUrl).toBe('https://example.com/approve?sig=xyz');
+    });
+
+    it('returns correct FID from registerUser response', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 99999 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        status: 'pending_approval',
+        signer_approval_url: 'https://example.com/approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown as { fid: number };
+      expect(body.fid).toBe(99999);
+    });
+  });
+
+  describe('Error handling (top-level try/catch)', () => {
+    it('returns 500 with generic error message on unhandled error', async () => {
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+
+      // Stub req.json() to throw an unhandled error
+      const stub = req as unknown as { json: () => Promise<unknown> };
+      stub.json = vi.fn(async () => {
+        throw new Error('Unexpected JSON parse error');
+      });
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as unknown as { error: string };
+      expect(body.error).toBe('Registration failed');
+    });
+  });
+
+  describe('Integration: full registration flow', () => {
+    it('successfully registers user and creates signer on allowlist', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockRegisterUser.mockResolvedValue({ fid: 54321 });
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'signer-uuid-final',
+        status: 'approved',
+        signer_approval_url: 'https://example.com/final-approve',
+      });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0xFFFFFFFF90abcdef1234567890abcdef12345678',
+        signature: 'complex-sig-data-xyz',
+        deadline: 2000000000,
+        fname: 'newmember',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown as {
+        success: boolean;
+        fid: number;
+        signerUuid: string;
+        signerStatus: string;
+      };
+      expect(body.success).toBe(true);
+      expect(body.fid).toBe(54321);
+      expect(body.signerUuid).toBe('signer-uuid-final');
+      expect(body.signerStatus).toBe('approved');
+
+      // Verify allowlist check was called with lowercase wallet
+      expect(mockCheckAllowlist).toHaveBeenCalledWith(
+        undefined,
+        '0xffffffff90abcdef1234567890abcdef12345678',
+      );
+
+      // Verify registerUser was called with correct params
+      expect(mockRegisterUser).toHaveBeenCalledWith(
+        'complex-sig-data-xyz',
+        '0xffffffff90abcdef1234567890abcdef12345678',
+        2000000000,
+        'newmember',
+      );
+
+      // Verify createSigner was called
+      expect(mockCreateSigner).toHaveBeenCalled();
+    });
+
+    it('rejects registration when allowlist denies access', async () => {
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makePostRequest('/api/auth/register', {
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        signature: 'sig123',
+        deadline: 1234567890,
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(403);
+
+      // registerUser and createSigner should not be called
+      expect(mockRegisterUser).not.toHaveBeenCalled();
+      expect(mockCreateSigner).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/auth/signer/save/__tests__/route.test.ts
+++ b/src/app/api/auth/signer/save/__tests__/route.test.ts
@@ -1,0 +1,703 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockGetSignerStatus, mockGetSession, mockLogger } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockGetSignerStatus: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+  getSession: mockGetSession,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getSignerStatus: mockGetSignerStatus,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/auth/signer/save', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when session is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'valid-uuid-1234',
+          fid: 456,
+        }),
+      );
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when signerUuid is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when signerUuid is an empty string', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: '',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when fid is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when fid is not an integer', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123.5,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when fid is not positive', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 0,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when fid is negative', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: -100,
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when request body is empty', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const res = await POST(makePostRequest('/api/auth/signer/save', {}));
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid input' });
+    });
+  });
+
+  describe('FID mismatch validation', () => {
+    it('returns 403 when request fid does not match session fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 100 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 200,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'FID mismatch' });
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+    });
+
+    it('allows when request fid matches session fid', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockGetSignerStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe('signer ownership verification', () => {
+    it('returns 403 when signer fid does not belong to user', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 100 }));
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 200,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 100,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Signer does not belong to this user' });
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when signer fid is null', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 100 }));
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: null,
+        status: 'pending_review',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 100,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Signer does not belong to this user' });
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+
+    it('allows save when signer fid matches session fid', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'matching-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'matching-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockGetSession).toHaveBeenCalled();
+      expect(mockSession.signerUuid).toBe('matching-uuid');
+      expect(mockSession.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('getSignerStatus call', () => {
+    it('calls getSignerStatus with the provided signerUuid', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'my-custom-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'my-custom-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(mockGetSignerStatus).toHaveBeenCalledWith('my-custom-uuid');
+      expect(mockGetSignerStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes signerUuid to getSignerStatus even when containing special characters', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const specialUuid = '550e8400-e29b-41d4-a716-446655440000';
+      const signerStatusResponse = {
+        signer_uuid: specialUuid,
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: specialUuid,
+          fid: 123,
+        }),
+      );
+
+      expect(mockGetSignerStatus).toHaveBeenCalledWith(specialUuid);
+    });
+  });
+
+  describe('session persistence', () => {
+    it('saves signerUuid to session on success', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'new-signer-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'new-signer-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockSession.signerUuid).toBe('new-signer-uuid');
+      expect(mockSession.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('persists the exact signerUuid provided in request', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 456 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: 'old-uuid', save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const targetUuid = 'my-exact-signer-uuid';
+      const signerStatusResponse = {
+        signer_uuid: targetUuid,
+        fid: 456,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: targetUuid,
+          fid: 456,
+        }),
+      );
+
+      expect(mockSession.signerUuid).toBe(targetUuid);
+      expect(mockSession.save).toHaveBeenCalled();
+    });
+
+    it('updates existing signerUuid in session', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 789 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = {
+        signerUuid: 'old-signer-uuid',
+        save: vi.fn().mockResolvedValue(undefined),
+      };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'new-signer-uuid',
+        fid: 789,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'new-signer-uuid',
+          fid: 789,
+        }),
+      );
+
+      expect(mockSession.signerUuid).toBe('new-signer-uuid');
+      expect(mockSession.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns 200 with success true on successful save', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ success: true });
+      expect(Object.keys(body).sort()).toEqual(['success']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when getSignerStatus throws an error', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      mockGetSignerStatus.mockRejectedValue(new Error('Neynar API failed'));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'error-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to save signer' });
+      expect(mockLogger.error).toHaveBeenCalledWith('Save signer error:', expect.any(Error));
+    });
+
+    it('returns 500 when getSession throws an error', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      mockGetSession.mockRejectedValue(new Error('Session error'));
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to save signer' });
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('returns 500 when session.save() fails', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = {
+        signerUuid: undefined,
+        save: vi.fn().mockRejectedValue(new Error('Save failed')),
+      };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to save signer' });
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('returns 500 when JSON parsing fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const req = makePostRequest('/api/auth/signer/save', {});
+      // Create a broken request that will fail JSON parsing
+      vi.spyOn(req, 'json').mockRejectedValue(new Error('Invalid JSON'));
+
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to save signer' });
+    });
+
+    it('logs error with context for debugging', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const debugError = new Error('Debug error message');
+      mockGetSignerStatus.mockRejectedValue(debugError);
+
+      await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'error-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Save signer error:', debugError);
+    });
+
+    it('returns 500 when getSignerStatus throws a network error', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const networkError = new Error('ECONNREFUSED');
+      mockGetSignerStatus.mockRejectedValue(networkError);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'timeout-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to save signer' });
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('completes full happy path: validate → verify → save', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      mockGetSession.mockResolvedValue(mockSession as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerStatusResponse = {
+        signer_uuid: 'happy-path-uuid',
+        fid: 123,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'happy-path-uuid',
+          fid: 123,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockGetSignerStatus).toHaveBeenCalledWith('happy-path-uuid');
+      expect(mockSession.signerUuid).toBe('happy-path-uuid');
+      expect(mockSession.save).toHaveBeenCalled();
+
+      const body = await res.json();
+      expect(body).toEqual({ success: true });
+    });
+
+    it('stops at FID mismatch and does not call getSignerStatus', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 100 }));
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 200,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockGetSignerStatus).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+
+    it('stops at ownership verification and does not save session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 100 }));
+
+      const signerStatusResponse = {
+        signer_uuid: 'test-uuid',
+        fid: 200,
+        status: 'approved',
+      };
+      mockGetSignerStatus.mockResolvedValue(signerStatusResponse);
+
+      const res = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'test-uuid',
+          fid: 100,
+        }),
+      );
+
+      expect(res.status).toBe(403);
+      expect(mockGetSession).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple sequential requests independently', async () => {
+      const sessionData = mockAuthenticatedSession({ fid: 123 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const mockSession1 = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+      const mockSession2 = { signerUuid: undefined, save: vi.fn().mockResolvedValue(undefined) };
+
+      mockGetSession
+        .mockResolvedValueOnce(mockSession1 as unknown as ReturnType<typeof mockGetSession>)
+        .mockResolvedValueOnce(mockSession2 as unknown as ReturnType<typeof mockGetSession>);
+
+      const signerResponse1 = {
+        signer_uuid: 'uuid-1',
+        fid: 123,
+        status: 'approved',
+      };
+      const signerResponse2 = {
+        signer_uuid: 'uuid-2',
+        fid: 123,
+        status: 'approved',
+      };
+
+      mockGetSignerStatus
+        .mockResolvedValueOnce(signerResponse1)
+        .mockResolvedValueOnce(signerResponse2);
+
+      const res1 = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'uuid-1',
+          fid: 123,
+        }),
+      );
+
+      const res2 = await POST(
+        makePostRequest('/api/auth/signer/save', {
+          signerUuid: 'uuid-2',
+          fid: 123,
+        }),
+      );
+
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+      expect(mockSession1.signerUuid).toBe('uuid-1');
+      expect(mockSession2.signerUuid).toBe('uuid-2');
+      expect(mockGetSignerStatus).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/app/api/chat/assistant/__tests__/route.test.ts
+++ b/src/app/api/chat/assistant/__tests__/route.test.ts
@@ -1,0 +1,599 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockReadFile } = vi.hoisted(() => ({
+  mockReadFile: vi.fn(),
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile: mockReadFile,
+  },
+  default: {
+    promises: {
+      readFile: mockReadFile,
+    },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+  },
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    MINIMAX_API_KEY: 'test-minimax-api-key',
+    MINIMAX_MODEL: 'MiniMax-M2.7',
+    MINIMAX_API_URL: 'https://api.minimax.io/v1/chat/completions',
+  },
+}));
+
+import { POST } from '../route';
+
+// Mock global fetch for Minimax API calls
+global.fetch = vi.fn() as unknown as typeof fetch;
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const VALID_MESSAGE_ARRAY = [
+  {
+    role: 'user' as const,
+    content: 'What is ZAO?',
+  },
+];
+
+const VALID_MULTIPART_MESSAGES = [
+  {
+    role: 'system' as const,
+    content: 'You are helpful.',
+  },
+  {
+    role: 'user' as const,
+    content: 'Hello',
+  },
+  {
+    role: 'assistant' as const,
+    content: 'Hi there!',
+  },
+  {
+    role: 'user' as const,
+    content: 'Tell me about ZAO research.',
+  },
+];
+
+describe('POST /api/chat/assistant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn() as unknown as typeof fetch;
+    // Reset the module-level knowledge cache by reimporting
+    vi.resetModules();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Authentication tests
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 when no session is present', async () => {
+    mockGetSessionData.mockResolvedValue(null);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when session is explicitly null (unauthenticated)', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Input validation tests (Zod parsing)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when messages array is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(makePostRequest('/api/chat/assistant', {}));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when messages is not an array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: 'not-an-array',
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when messages array is empty', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when message role is invalid enum', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [
+          {
+            role: 'invalid-role',
+            content: 'Hello',
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when message content is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [
+          {
+            role: 'user',
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when message content is not a string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [
+          {
+            role: 'user',
+            content: 123,
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts all three valid roles: user, assistant, system', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{}');
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ reply: 'test' })),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MULTIPART_MESSAGES,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 500 on malformed JSON body (caught by outer try/catch)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    // Manually create a request with invalid JSON
+    const invalidReq = new Request('http://localhost:3000/api/chat/assistant', {
+      method: 'POST',
+      body: 'not valid json',
+    });
+    const res = await POST(invalidReq as unknown as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Knowledge graph loading and doc retrieval
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('loads knowledge graph from file when available', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const knowledgeData = JSON.stringify({
+      docs: [
+        {
+          id: '001',
+          slug: 'music-docs',
+          title: 'Music Library Documentation',
+          category: 'system',
+          tags: ['canonical', 'platform'],
+          summary: 'Complete documentation of music library implementation.',
+          related: [],
+        },
+      ],
+    });
+
+    mockReadFile.mockResolvedValue(knowledgeData);
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ reply: 'Test response' })),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [
+          {
+            role: 'user',
+            content: 'Tell about platform and music library',
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // Verify the system message was constructed (either with or without doc injection)
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [_url, options] = fetchCall as [string, Record<string, unknown>];
+    const bodyStr = options.body as string;
+    const body = JSON.parse(bodyStr) as Record<string, unknown>;
+    const messagesArray = body.messages as Array<{ role: string; content: string }>;
+    const systemMsg = messagesArray[0];
+    expect(systemMsg.role).toBe('system');
+    // System prompt should contain the ZAO Assistant context
+    expect(systemMsg.content).toContain('ZAO Assistant');
+  });
+
+  it('handles missing KNOWLEDGE.json gracefully (returns null)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockRejectedValue(new Error('ENOENT: no such file'));
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ reply: 'Generic response' })),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    // Verify system prompt does NOT contain "Relevant research docs" when file fails to load
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [_url, options] = fetchCall as [string, Record<string, unknown>];
+    const bodyStr = options.body as string;
+    const body = JSON.parse(bodyStr) as Record<string, unknown>;
+    const messagesArray = body.messages as Array<{ role: string; content: string }>;
+    const systemMsg = messagesArray[0];
+    expect(systemMsg.content).not.toContain('Relevant research docs');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Minimax API interaction
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('calls Minimax API with correct payload including model and max_tokens', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ reply: 'response' })),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith('https://api.minimax.io/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-minimax-api-key',
+        'Content-Type': 'application/json',
+      },
+      body: expect.any(String),
+    });
+
+    // Parse and verify request body structure
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [_url, options] = fetchCall as [string, Record<string, unknown>];
+    const body = JSON.parse(options.body as string) as Record<string, unknown>;
+
+    expect(body.model).toBe('MiniMax-M2.7');
+    expect(body.max_tokens).toBe(4000);
+    expect(body.messages).toBeDefined();
+    expect(Array.isArray(body.messages)).toBe(true);
+  });
+
+  it('uses MINIMAX_API_URL from ENV for API calls', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify({ reply: 'test' })),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    // Verify fetch was called with the correct URL from mocked ENV
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const url = fetchCall[0] as string;
+    expect(url).toBe('https://api.minimax.io/v1/chat/completions');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Response handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 and parses JSON response from Minimax', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    const mockResponse = {
+      success: true,
+      data: {
+        choices: [
+          {
+            message: {
+              content: 'This is the AI response',
+            },
+          },
+        ],
+      },
+    };
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify(mockResponse)),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toBeDefined();
+  });
+
+  it('falls back to { reply: text } when response is not JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    const plainTextResponse = 'This is a plain text response';
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(plainTextResponse),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reply).toBe(plainTextResponse);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Error handling
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when Minimax API returns non-ok status', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    const mockFetchResponse = {
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue('Internal Server Error'),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('AI request failed');
+
+    // Verify error was logged
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+
+  it('returns 500 when Minimax API throws an error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    mockReadFile.mockResolvedValue('{"docs":[]}');
+
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Network failure'));
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: VALID_MESSAGE_ARRAY,
+      }),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+
+    // Verify error was logged
+    expect(mockLoggerError).toHaveBeenCalled();
+  });
+
+  it('returns 500 when request body parsing fails in outer try/catch', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    // Create a request with a body that throws when calling .json()
+    const invalidReq = new Request('http://localhost:3000/api/chat/assistant', {
+      method: 'POST',
+      body: JSON.stringify({ messages: VALID_MESSAGE_ARRAY }),
+    });
+
+    // Mock req.json() to throw
+    invalidReq.json = vi.fn().mockRejectedValue(new Error('JSON parse error'));
+
+    const res = await POST(invalidReq as unknown as Parameters<typeof POST>[0]);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal server error');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Integration: full happy path
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('processes a complete user query end-to-end', async () => {
+    mockGetSessionData.mockResolvedValue(
+      mockAuthenticatedSession({
+        fid: 123,
+        username: 'testuser',
+      }),
+    );
+
+    // Knowledge graph with docs that match common query terms
+    const knowledgeData = JSON.stringify({
+      docs: [
+        {
+          id: '042',
+          slug: 'research-docs',
+          title: 'Research Documentation',
+          category: 'research',
+          tags: ['canonical', 'docs', 'research'],
+          summary: 'Comprehensive research documentation and guides.',
+          related: ['043', '044'],
+        },
+      ],
+    });
+
+    mockReadFile.mockResolvedValue(knowledgeData);
+
+    const mockApiResponse = {
+      success: true,
+      message: 'Here is the information you requested.',
+    };
+
+    const mockFetchResponse = {
+      ok: true,
+      text: vi.fn().mockResolvedValue(JSON.stringify(mockApiResponse)),
+    };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse);
+
+    const res = await POST(
+      makePostRequest('/api/chat/assistant', {
+        messages: [
+          {
+            role: 'user',
+            content: 'What research documentation exists?',
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify Minimax was called with the correct structure
+    const fetchCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const [url, options] = fetchCall as [string, Record<string, unknown>];
+    expect(url).toBe('https://api.minimax.io/v1/chat/completions');
+    const bodyStr = options.body as string;
+    const payload = JSON.parse(bodyStr) as Record<string, unknown>;
+    expect(payload.model).toBe('MiniMax-M2.7');
+    expect(payload.max_tokens).toBe(4000);
+    const messagesArray = payload.messages as Array<{ role: string; content: string }>;
+    expect(messagesArray.length).toBeGreaterThan(0);
+    expect(messagesArray[0].role).toBe('system');
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **143 tests total**. External Neynar/Minimax/fs fully mocked — no real API or disk access.

| Route | Tests | Covers |
|-------|-------|--------|
| `auth/signer/save` | 30 | auth, Zod (signerUuid/fid), FID + ownership verify via getSignerStatus, session persist, errors |
| `auth/register` | 36 | public — Zod (wallet/sig/deadline/fname), allowlist gate 403, createSigner+registerUser, wallet normalization, errors |
| `admin/discord-link` | 57 | GET/PATCH/POST — admin guards, UUID validation, link/unlink + duplicate 409, bulk preview/execute wallet-map, audit-log, errors |
| `chat/assistant` | 20 | auth, Zod (messages/role enum), KNOWLEDGE.json fs read (mocked), Minimax API (fetch-mocked), JSON fallback, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)