### PR TITLE
fix: kill osascript Notification hook permanently (repo-tracked settings kept reverting it)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,7 +205,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'display notification \"'\"$NOTIFICATION_MESSAGE\"'\" with title \"Claude Code\" sound name \"Glass\"'"
+            "command": "$HOME/bin/zao-notify.sh"'\"$NOTIFICATION_MESSAGE\"'\" with title \"Claude Code\" sound name \"Glass\"'"
           }
         ]
       }


### PR DESCRIPTION
The osascript notification hook triggers the Script Editor Automation prompt Zaal explicitly banned. It was fixed locally twice but .claude/settings.json is repo-tracked, so every checkout restored it. This commits the fix: hook now calls $HOME/bin/zao-notify.sh (terminal-notifier + TG mirror, zero osascript).