### PR TITLE
test(auth,admin,bluesky): kick/poll-config/bluesky/upload (141 tests)

### DIFF
--- a/src/app/api/admin/poll-config/__tests__/route.test.ts
+++ b/src/app/api/admin/poll-config/__tests__/route.test.ts
@@ -1,0 +1,1051 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET, PUT } from '../route';
+
+// ============================================================================
+// GET /api/admin/poll-config (PUBLIC)
+// ============================================================================
+
+describe('GET /api/admin/poll-config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('public access (no auth required)', () => {
+    it('returns 200 without requiring authentication', async () => {
+      const chain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  describe('successful read of existing config', () => {
+    it('queries poll_config table by POLL_CONFIG_ID', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Choice 1', 'Choice 2']),
+        poll_title_template: 'Custom Title — Week of {date}',
+        poll_body_template: 'Custom body',
+        voting_duration_days: 5,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 123,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenCalledWith('poll_config');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.eq).toHaveBeenCalledWith('id', 'weekly-priority');
+    });
+
+    it('returns existing config with camelCase field names', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Choice 1', 'Choice 2']),
+        poll_title_template: 'Custom Title',
+        poll_body_template: 'Custom body',
+        voting_duration_days: 5,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 789,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Choice 1', 'Choice 2']),
+        pollTitleTemplate: 'Custom Title',
+        pollBodyTemplate: 'Custom body',
+        votingDurationDays: 5,
+        updatedAt: '2026-01-15T10:00:00Z',
+        updatedByFid: 789,
+      });
+    });
+
+    it('handles JSON-stringified choices field', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Option A', 'Option B', 'Option C']),
+        poll_title_template: 'Title',
+        poll_body_template: null,
+        voting_duration_days: 7,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 100,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.choices).toEqual(JSON.stringify(['Option A', 'Option B', 'Option C']));
+    });
+
+    it('handles null poll_body_template', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['A', 'B']),
+        poll_title_template: 'Title',
+        poll_body_template: null,
+        voting_duration_days: 7,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 100,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.pollBodyTemplate).toBeNull();
+    });
+  });
+
+  describe('fallback to defaults when no config exists', () => {
+    it('returns defaults when no row found', async () => {
+      const chain = chainMock({ data: null, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.id).toBe('weekly-priority');
+      expect(body.pollTitleTemplate).toBe('ZAO Weekly Priority Vote — Week of {date}');
+      expect(body.votingDurationDays).toBe(7);
+      expect(body.updatedAt).toBeNull();
+      expect(body.updatedByFid).toBeNull();
+    });
+
+    it('returns default choices from community.config when query returns null', async () => {
+      const chain = chainMock({ data: null, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      // Verify choices come from communityConfig.snapshot.weeklyPollChoices
+      expect(Array.isArray(body.choices)).toBe(true);
+      expect(body.choices.length).toBeGreaterThan(0);
+      expect(body.choices[0]).toBe('WAVEWARZ — Competitive Web3 music battles');
+    });
+
+    it('returns defaults when Supabase error occurs', async () => {
+      const chain = chainMock({ data: null, error: new Error('DB error') }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.id).toBe('weekly-priority');
+      expect(body.pollTitleTemplate).toBe('ZAO Weekly Priority Vote — Week of {date}');
+    });
+
+    it('does not expose error details in default response', async () => {
+      const chain = chainMock({ data: null, error: new Error('Connection timeout') }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.error).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when exception is thrown during query', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch poll config');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Fetch failed');
+      });
+
+      await GET();
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[poll-config] GET error:',
+        expect.any(Error),
+      );
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Password: secret123, host: db.example.com');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to fetch poll config');
+      expect(body.details).toBeUndefined();
+    });
+  });
+});
+
+// ============================================================================
+// PUT /api/admin/poll-config (ADMIN-ONLY UPDATE)
+// ============================================================================
+
+describe('PUT /api/admin/poll-config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: ['A', 'B'] }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: ['A', 'B'] }));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation — choices field', () => {
+    it('accepts valid choices array with 2 items', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['Choice 1', 'Choice 2']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['Choice 1', 'Choice 2'],
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts valid choices array with 20 items', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(Array.from({ length: 20 }, (_, i) => `Choice ${i + 1}`)),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: Array.from({ length: 20 }, (_, i) => `Choice ${i + 1}`),
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when choices has only 1 item (min 2)', async () => {
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: ['Only One'] }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when choices is empty array', async () => {
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: [] }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when choices exceeds 20 items', async () => {
+      const longChoices = Array.from({ length: 21 }, (_, i) => `Choice ${i + 1}`);
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: longChoices,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when choice string exceeds 200 chars', async () => {
+      const longChoice = 'a'.repeat(201);
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['Valid', longChoice],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts choice string with exactly 200 chars', async () => {
+      const maxChoice = 'a'.repeat(200);
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['Valid', maxChoice]),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['Valid', maxChoice],
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when choices is missing', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          pollTitleTemplate: 'Some title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when choices is not an array', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: 'not-an-array',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation — optional fields', () => {
+    it('accepts optional pollTitleTemplate (max 500 chars)', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Custom title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollTitleTemplate: 'Custom title',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when pollTitleTemplate exceeds 500 chars', async () => {
+      const longTitle = 'a'.repeat(501);
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollTitleTemplate: longTitle,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts pollTitleTemplate with exactly 500 chars', async () => {
+      const maxTitle = 'a'.repeat(500);
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: maxTitle,
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollTitleTemplate: maxTitle,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts optional pollBodyTemplate (max 2000 chars)', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: 'Custom body text',
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollBodyTemplate: 'Custom body text',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when pollBodyTemplate exceeds 2000 chars', async () => {
+      const longBody = 'a'.repeat(2001);
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollBodyTemplate: longBody,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts pollBodyTemplate with exactly 2000 chars', async () => {
+      const maxBody = 'a'.repeat(2000);
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: maxBody,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollBodyTemplate: maxBody,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts optional votingDurationDays (1-30)', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 10,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 10,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts votingDurationDays = 1 (minimum)', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 1,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 1,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts votingDurationDays = 30 (maximum)', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 30,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 30,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when votingDurationDays is 0 (below minimum)', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 0,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when votingDurationDays exceeds 30', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 31,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when votingDurationDays is not an integer', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          votingDurationDays: 7.5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Supabase upsert operation', () => {
+    it('calls supabaseAdmin.from with poll_config table', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('poll_config');
+    });
+
+    it('performs upsert with correct ID and merged fields', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Custom',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+          pollTitleTemplate: 'Custom',
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      expect(upsertCall).toHaveBeenCalled();
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload).toMatchObject({
+        id: 'weekly-priority',
+        choices: JSON.stringify(['A', 'B']),
+        poll_title_template: 'Custom',
+        updated_by_fid: 123,
+      });
+    });
+
+    it('applies default poll_title_template when not provided', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'ZAO Weekly Priority Vote — Week of {date}',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload.poll_title_template).toBe('ZAO Weekly Priority Vote — Week of {date}');
+    });
+
+    it('applies default poll_body_template (null) when not provided', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload.poll_body_template).toBeNull();
+    });
+
+    it('applies default voting_duration_days = 7 when not provided', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload.voting_duration_days).toBe(7);
+    });
+
+    it('sets updated_at to ISO string on upsert', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(typeof payload.updated_at).toBe('string');
+      // Verify it's a valid ISO string
+      expect(new Date(payload.updated_at as string).getTime()).not.toBeNaN();
+    });
+
+    it('sets updated_by_fid to current session FID', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 999,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [payload] = upsertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload.updated_by_fid).toBe(999);
+    });
+
+    it('specifies onConflict: id to update on duplicate', async () => {
+      const chain = chainMock({
+        data: {
+          id: 'weekly-priority',
+          choices: JSON.stringify(['A', 'B']),
+          poll_title_template: 'Title',
+          poll_body_template: null,
+          voting_duration_days: 7,
+          updated_at: '2026-01-15T10:00:00Z',
+          updated_by_fid: 123,
+        },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['A', 'B'],
+        }),
+      );
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const _payload = upsertCall.mock.calls[0][0];
+      const options = upsertCall.mock.calls[0][1];
+
+      expect(options).toEqual({ onConflict: 'id' });
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with camelCase field names', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Choice A', 'Choice B']),
+        poll_title_template: 'Updated Title',
+        poll_body_template: 'Updated Body',
+        voting_duration_days: 5,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 123,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['Choice A', 'Choice B'],
+          pollTitleTemplate: 'Updated Title',
+          pollBodyTemplate: 'Updated Body',
+          votingDurationDays: 5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        id: 'weekly-priority',
+        choices: JSON.stringify(['Choice A', 'Choice B']),
+        pollTitleTemplate: 'Updated Title',
+        pollBodyTemplate: 'Updated Body',
+        votingDurationDays: 5,
+        updatedAt: '2026-01-15T10:00:00Z',
+        updatedByFid: 123,
+      });
+    });
+
+    it('returns updated choices as JSON string from supabase', async () => {
+      const configData = {
+        id: 'weekly-priority',
+        choices: JSON.stringify(['New Choice 1', 'New Choice 2']),
+        poll_title_template: 'Title',
+        poll_body_template: null,
+        voting_duration_days: 7,
+        updated_at: '2026-01-15T10:00:00Z',
+        updated_by_fid: 123,
+      };
+
+      const chain = chainMock({ data: configData, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['New Choice 1', 'New Choice 2'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.choices).toEqual(JSON.stringify(['New Choice 1', 'New Choice 2']));
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when Supabase upsert returns error', async () => {
+      const dbError = new Error('Database connection failed');
+      const chain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: ['A', 'B'] }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to save poll config');
+    });
+
+    it('returns 500 when request body is not valid JSON', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/poll-config', 'http://localhost:3000'),
+        {
+          method: 'PUT',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await PUT(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update poll config');
+    });
+
+    it('logs error to logger.error when exception occurs during upsert', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Upsert failed');
+      });
+
+      await PUT(makePostRequest('/api/admin/poll-config', { choices: ['A', 'B'] }));
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[poll-config] PUT error:',
+        expect.any(Error),
+      );
+    });
+
+    it('logs error to logger.error when exception occurs during body parsing', async () => {
+      const { logger } = await import('@/lib/logger');
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/poll-config', 'http://localhost:3000'),
+        {
+          method: 'PUT',
+          body: '{invalid json',
+        },
+      );
+
+      await PUT(malformedReq);
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        '[poll-config] PUT error:',
+        expect.any(Error),
+      );
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Connection to db.example.com:5432 failed, password: secret123');
+      const chain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(makePostRequest('/api/admin/poll-config', { choices: ['A', 'B'] }));
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to save poll config');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+
+    it('returns validation errors in details field', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/poll-config', {
+          choices: ['Only One'],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(typeof body.details).toBe('object');
+    });
+  });
+});

--- a/src/app/api/admin/upload/__tests__/route.test.ts
+++ b/src/app/api/admin/upload/__tests__/route.test.ts
@@ -1,0 +1,604 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+// Helper to create a NextRequest with mocked formData
+function makeUploadRequest(csvContent: string, fileSize?: number): NextRequest {
+  const req = new NextRequest(new URL('/api/admin/upload', 'http://localhost:3000'), {
+    method: 'POST',
+  });
+
+  // Mock the formData method on the request
+  const mockFile = {
+    text: vi.fn().mockResolvedValue(csvContent),
+    size: fileSize ?? csvContent.length,
+  };
+
+  const formDataMock = new Map();
+  formDataMock.set('file', mockFile);
+
+  vi.spyOn(req, 'formData').mockResolvedValue(formDataMock as unknown as FormData);
+
+  return req;
+}
+
+// ============================================================================
+// POST /api/admin/upload
+// ============================================================================
+
+describe('POST /api/admin/upload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeUploadRequest('testuser,0x1234567890abcdef1234567890abcdef12345678\n');
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const req = makeUploadRequest('testuser,0x1234567890abcdef1234567890abcdef12345678\n');
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('file validation', () => {
+    it('returns 400 when no file is provided', async () => {
+      const req = new NextRequest(new URL('/api/admin/upload', 'http://localhost:3000'), {
+        method: 'POST',
+      });
+
+      const emptyFormData = new Map();
+      vi.spyOn(req, 'formData').mockResolvedValue(emptyFormData as unknown as FormData);
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('No file provided');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when file exceeds 1MB', async () => {
+      const csvContent = `testuser,${VALID_WALLET}`;
+      const req = makeUploadRequest(csvContent, 1024 * 1024 + 1); // File size exceeds limit
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('File too large (max 1MB)');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts file exactly 1MB in size', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `testuser,${VALID_WALLET}`;
+      const req = makeUploadRequest(csvContent, 1024 * 1024); // Exactly 1MB
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('CSV parsing and row validation', () => {
+    it('returns 400 when CSV has more than 1000 rows', async () => {
+      const rows = Array.from({ length: 1001 }, (_, i) => {
+        const num = String(i + 1).padStart(4, '0');
+        return `user${num},${VALID_WALLET}`;
+      }).join('\n');
+
+      const req = makeUploadRequest(rows);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Too many rows (max 1000)');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts exactly 1000 rows', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const rows = Array.from({ length: 1000 }, (_, i) => {
+        const num = String(i + 1).padStart(4, '0');
+        return `user${num},${VALID_WALLET}`;
+      }).join('\n');
+
+      const req = makeUploadRequest(rows);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1000);
+    });
+
+    it('validates each row with csvRowSchema (valid rows)', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `testuser,${VALID_WALLET}
+anotheruser,0xabcdefabcdefabcdefabcdefabcdefabcdefabcd
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(2);
+      expect(body.errors).toBeUndefined();
+    });
+
+    it('rejects rows with invalid wallet address format', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `testuser,${VALID_WALLET}
+baduser,not-a-wallet
+anotheruser,0xInvalidHex123456789012345678901234567890
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1); // Only first row is valid
+      expect(body.errors).toBeDefined();
+      expect(body.errors?.length).toBe(2);
+      expect(body.errors?.[0]).toContain('Row 2');
+      expect(body.errors?.[1]).toContain('Row 3');
+    });
+
+    it('rejects rows with empty IGN', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `,${VALID_WALLET}
+testuser,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1); // Only second row is valid
+      expect(body.errors).toBeDefined();
+      expect(body.errors?.length).toBe(1);
+    });
+
+    it('rejects rows with IGN exceeding max length (100 chars)', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const longIgn = 'a'.repeat(101);
+      const csvContent = `${longIgn},${VALID_WALLET}
+testuser,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1);
+      expect(body.errors).toBeDefined();
+      expect(body.errors?.length).toBe(1);
+    });
+
+    it('strips whitespace from IGN and wallet address', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `  testuser  ,  ${VALID_WALLET}
+anotheruser,${VALID_WALLET}`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(2);
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [entries] = upsertCall.mock.calls[0] as unknown as [
+        Array<{ ign: string; wallet_address: string }>,
+      ];
+
+      expect(entries[0].ign).toBe('testuser');
+      expect(entries[0].wallet_address).toBe(VALID_WALLET);
+    });
+
+    it('strips trailing commas from wallet address', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const walletWithCommas = `${VALID_WALLET},,,`;
+      const csvContent = `testuser,${walletWithCommas}`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1);
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [entries] = upsertCall.mock.calls[0] as unknown as [
+        Array<{ ign: string; wallet_address: string }>,
+      ];
+
+      expect(entries[0].wallet_address).toBe(VALID_WALLET);
+    });
+
+    it('skips empty lines in CSV', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `testuser,${VALID_WALLET}
+
+anotheruser,${VALID_WALLET}
+
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(2);
+    });
+
+    it('returns 400 when all rows are invalid', async () => {
+      const csvContent = `,${VALID_WALLET}
+,invalid-wallet
+,`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('No valid entries found');
+      expect(body.errors).toBeDefined();
+      expect(body.errors?.length).toBe(3);
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns partial success with both imported count and errors', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `validuser1,${VALID_WALLET}
+,invalid-no-ign
+validuser2,${VALID_WALLET}
+invalid-user,not-a-wallet
+validuser3,0xabcdefabcdefabcdefabcdefabcdefabcdefabcd
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(3);
+      expect(body.errors).toBeDefined();
+      expect(body.errors?.length).toBe(2);
+    });
+  });
+
+  describe('Supabase upsert interaction', () => {
+    it('calls supabaseAdmin.from with allowlist table', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      await POST(req);
+
+      expect(mockFrom).toHaveBeenCalledWith('allowlist');
+    });
+
+    it('upsets entries with onConflict strategy', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      await POST(req);
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [_, options] = upsertCall.mock.calls[0] as unknown as [unknown, unknown];
+
+      expect(options).toEqual({
+        onConflict: 'wallet_address',
+        ignoreDuplicates: true,
+      });
+    });
+
+    it('passes correct payload structure to upsert', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `user1,${VALID_WALLET}
+user2,0xabcdefabcdefabcdefabcdefabcdefabcdefabcd
+`;
+
+      const req = makeUploadRequest(csvContent);
+      await POST(req);
+
+      const upsertCall = vi.mocked(chain.upsert);
+      const [entries] = upsertCall.mock.calls[0] as unknown as [
+        Array<{ ign: string; wallet_address: string }>,
+      ];
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0]).toEqual({
+        ign: 'user1',
+        wallet_address: VALID_WALLET,
+      });
+      expect(entries[1]).toEqual({
+        ign: 'user2',
+        wallet_address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when supabase upsert fails', async () => {
+      const dbError = new Error('Database connection failed');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to process CSV');
+      expect(body.details).toBeUndefined();
+    });
+
+    it('returns 500 when file.text() throws', async () => {
+      const req = new NextRequest(new URL('/api/admin/upload', 'http://localhost:3000'), {
+        method: 'POST',
+      });
+
+      // Mock a file that throws when text() is called
+      const mockFile = {
+        text: vi.fn().mockRejectedValue(new Error('File read error')),
+        size: 100,
+      };
+
+      const formDataMock = new Map();
+      formDataMock.set('file', mockFile);
+
+      vi.spyOn(req, 'formData').mockResolvedValue(formDataMock as unknown as FormData);
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to process CSV');
+    });
+
+    it('logs error to logger.error on upsert failure', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = new Error('Database error');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      await POST(req);
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith('CSV upload error:', expect.any(Error));
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Password: secret123, host: db.internal');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to process CSV');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with success true', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('returns imported count', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `user1,${VALID_WALLET}
+user2,${VALID_WALLET}
+user3,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.imported).toBe(3);
+    });
+
+    it('returns undefined errors when all rows are valid', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `user1,${VALID_WALLET}
+user2,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.errors).toBeUndefined();
+    });
+
+    it('returns errors array when some rows are invalid', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `user1,${VALID_WALLET}
+,invalid-no-ign
+user3,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.errors).toBeDefined();
+      expect(Array.isArray(body.errors)).toBe(true);
+      expect(body.errors?.length).toBe(1);
+    });
+
+    it('response does not include undefined errors property', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeUploadRequest(`testuser,${VALID_WALLET}`);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(Object.keys(body)).toContain('success');
+      expect(Object.keys(body)).toContain('imported');
+      expect(Object.keys(body)).not.toContain('errors');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles CSV with only headers (no data rows)', async () => {
+      const csvContent = 'ign,wallet\n';
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('No valid entries found');
+    });
+
+    it('handles CSV with BOM (byte order mark)', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      // CSV with UTF-8 BOM
+      const csvContent = `﻿testuser,${VALID_WALLET}\n`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      // Papa.parse handles BOM; should still parse correctly
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('handles mixed case wallet addresses', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const mixedCaseWallet = '0xAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCdEfAbCd';
+      const csvContent = `testuser,${mixedCaseWallet}`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.imported).toBe(1);
+    });
+
+    it('error row numbers are 1-indexed', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const csvContent = `validuser,${VALID_WALLET}
+,invalid
+validuser2,${VALID_WALLET}
+`;
+
+      const req = makeUploadRequest(csvContent);
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(body.errors?.[0]).toContain('Row 2');
+    });
+  });
+});

--- a/src/app/api/auth/kick/__tests__/route.test.ts
+++ b/src/app/api/auth/kick/__tests__/route.test.ts
@@ -1,0 +1,504 @@
+import crypto from 'node:crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/auth/kick', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear env overrides from previous tests
+    delete process.env.NEXT_PUBLIC_KICK_CLIENT_ID;
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+    delete process.env.NODE_ENV;
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+      expect(res.status).toBe(401);
+      expect((await res.json()).error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+  });
+
+  describe('configuration validation', () => {
+    it('returns 500 when NEXT_PUBLIC_KICK_CLIENT_ID is not configured', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+      expect(res.status).toBe(500);
+      expect((await res.json()).error).toBe('Kick client ID not configured');
+    });
+  });
+
+  describe('OAuth redirect', () => {
+    it('redirects to Kick OAuth authorize endpoint with correct parameters', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      process.env.NEXT_PUBLIC_BASE_URL = 'https://app.example.com';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      expect(res.status).toBe(307); // redirect status
+      const location = res.headers.get('location');
+      expect(location).toBeDefined();
+      expect(location).toContain('https://id.kick.com/oauth/authorize');
+      expect(location).toContain('client_id=test-kick-client-id');
+      expect(location).toContain(
+        'redirect_uri=https%3A%2F%2Fapp.example.com%2Fapi%2Fauth%2Fkick%2Fcallback',
+      );
+      expect(location).toContain('response_type=code');
+      expect(location).toContain('scope=user%3Aread+channel%3Aread+channel%3Awrite');
+      expect(location).toContain('code_challenge_method=S256');
+      expect(location).toContain('state=456');
+    });
+
+    it('uses request origin when NEXT_PUBLIC_BASE_URL is not set', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('http://localhost:3000/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toBeDefined();
+      expect(location).toContain(
+        'redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth%2Fkick%2Fcallback',
+      );
+    });
+
+    it('sets state parameter to session fid', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toContain('state=789');
+    });
+
+    it('includes correct scopes in the OAuth request', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toContain('scope=user%3Aread+channel%3Aread+channel%3Awrite');
+    });
+
+    it('constructs valid redirect_uri with callback path', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      process.env.NEXT_PUBLIC_BASE_URL = 'https://example.com';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toContain(
+        'redirect_uri=https%3A%2F%2Fexample.com%2Fapi%2Fauth%2Fkick%2Fcallback',
+      );
+    });
+
+    it('returns a proper NextResponse.redirect', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      // NextResponse.redirect sets status 307
+      expect(res.status).toBe(307);
+      // Location header is set
+      expect(res.headers.has('location')).toBe(true);
+    });
+  });
+
+  describe('PKCE generation', () => {
+    it('generates a code_challenge in the authorize URL', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toBeDefined();
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      const challenge = urlParams.get('code_challenge');
+
+      // Code challenge must exist
+      expect(challenge).toBeDefined();
+      expect(challenge).toBeTruthy();
+      expect(typeof challenge).toBe('string');
+    });
+
+    it('code_challenge is a valid base64url string', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      const challenge = urlParams.get('code_challenge');
+
+      // Base64url: alphanumeric + hyphen + underscore, no padding
+      const base64urlRegex = /^[A-Za-z0-9_-]+$/;
+      expect(challenge).toMatch(base64urlRegex);
+    });
+
+    it('code_challenge has expected length (~43 chars for SHA256)', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      const challenge = urlParams.get('code_challenge');
+
+      // SHA256 hashed then base64url encoded is typically 43 chars
+      expect(challenge).toBeDefined();
+      if (!challenge) throw new Error('Challenge missing');
+      expect(challenge.length).toBeGreaterThanOrEqual(40);
+      expect(challenge.length).toBeLessThanOrEqual(45);
+    });
+
+    it('generates different code_challenges on each call', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req1 = makeRequest('/api/auth/kick');
+      const res1 = await GET(req1);
+      const location1 = res1.headers.get('location');
+      if (!location1) throw new Error('Location header missing');
+      const challenge1 = new URL(location1).searchParams.get('code_challenge');
+
+      const req2 = makeRequest('/api/auth/kick');
+      const res2 = await GET(req2);
+      const location2 = res2.headers.get('location');
+      if (!location2) throw new Error('Location header missing');
+      const challenge2 = new URL(location2).searchParams.get('code_challenge');
+
+      // Each invocation should generate a fresh PKCE challenge
+      expect(challenge1).not.toBe(challenge2);
+    });
+
+    it('sets code_challenge_method to S256', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      expect(urlParams.get('code_challenge_method')).toBe('S256');
+    });
+  });
+
+  describe('PKCE verifier cookie storage', () => {
+    it('sets kick_pkce_verifier cookie', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toBeDefined();
+      expect(setCookieHeader).toContain('kick_pkce_verifier=');
+    });
+
+    it('cookie is httpOnly', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toContain('HttpOnly');
+    });
+
+    it('cookie has lax sameSite', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toContain('SameSite=lax');
+    });
+
+    it('cookie has path /', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toContain('Path=/');
+    });
+
+    it('cookie has maxAge of 600 seconds (10 minutes)', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toContain('Max-Age=600');
+    });
+
+    it('cookie is secure in production', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      expect(setCookieHeader).toContain('Secure');
+    });
+
+    it('cookie is not secure in non-production', async () => {
+      process.env.NODE_ENV = 'development';
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      // In development, Secure flag should NOT be present
+      expect(setCookieHeader).not.toContain('Secure');
+    });
+
+    it('verifier cookie value is a valid base64url string', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      if (!setCookieHeader) throw new Error('Set-Cookie header missing');
+      const match = setCookieHeader.match(/kick_pkce_verifier=([^;]+)/);
+      expect(match).toBeTruthy();
+
+      if (!match) throw new Error('Verifier match failed');
+      const verifierValue = match[1];
+      // Base64url: alphanumeric + hyphen + underscore
+      const base64urlRegex = /^[A-Za-z0-9_-]+$/;
+      expect(verifierValue).toMatch(base64urlRegex);
+    });
+
+    it('verifier cookie value has expected length (~43 chars for 32 random bytes)', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      if (!setCookieHeader) throw new Error('Set-Cookie header missing');
+      const match = setCookieHeader.match(/kick_pkce_verifier=([^;]+)/);
+      if (!match) throw new Error('Verifier match failed');
+      const verifierValue = match[1];
+
+      // 32 bytes base64url encoded is typically 43 chars
+      expect(verifierValue.length).toBeGreaterThanOrEqual(40);
+      expect(verifierValue.length).toBeLessThanOrEqual(45);
+    });
+
+    it('each request generates a different verifier', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req1 = makeRequest('/api/auth/kick');
+      const res1 = await GET(req1);
+      const cookie1 = res1.headers.get('set-cookie');
+      if (!cookie1) throw new Error('Set-Cookie header missing');
+      const verifier1Match = cookie1.match(/kick_pkce_verifier=([^;]+)/);
+      if (!verifier1Match) throw new Error('Verifier match failed');
+      const verifier1 = verifier1Match[1];
+
+      const req2 = makeRequest('/api/auth/kick');
+      const res2 = await GET(req2);
+      const cookie2 = res2.headers.get('set-cookie');
+      if (!cookie2) throw new Error('Set-Cookie header missing');
+      const verifier2Match = cookie2.match(/kick_pkce_verifier=([^;]+)/);
+      if (!verifier2Match) throw new Error('Verifier match failed');
+      const verifier2 = verifier2Match[1];
+
+      // Each invocation should generate a fresh verifier
+      expect(verifier1).not.toBe(verifier2);
+    });
+  });
+
+  describe('PKCE verification relationship', () => {
+    it('code_challenge is derived from verifier via SHA256', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      const challenge = urlParams.get('code_challenge');
+
+      const setCookieHeader = res.headers.get('set-cookie');
+      if (!setCookieHeader) throw new Error('Set-Cookie header missing');
+      const match = setCookieHeader.match(/kick_pkce_verifier=([^;]+)/);
+      if (!match) throw new Error('Verifier match failed');
+      const verifier = match[1];
+
+      // Verify that challenge = SHA256(verifier) in base64url
+      const expectedChallenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+
+      expect(challenge).toBe(expectedChallenge);
+    });
+  });
+
+  describe('response shape and headers', () => {
+    it('response has correct redirect status and location header', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.has('location')).toBe(true);
+    });
+
+    it('authorize URL contains all required OAuth 2.0 PKCE parameters', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+
+      const requiredParams = [
+        'client_id',
+        'redirect_uri',
+        'response_type',
+        'scope',
+        'code_challenge',
+        'code_challenge_method',
+        'state',
+      ];
+
+      for (const param of requiredParams) {
+        expect(urlParams.has(param)).toBe(true);
+        expect(urlParams.get(param)).toBeTruthy();
+      }
+    });
+
+    it('response_type is always code', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      if (!location) throw new Error('Location header missing');
+      const urlParams = new URL(location).searchParams;
+      expect(urlParams.get('response_type')).toBe('code');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles multiple fid values correctly', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+
+      const fidValues = [1, 100, 999999, 123456789];
+
+      for (const fid of fidValues) {
+        mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid }));
+
+        const req = makeRequest('/api/auth/kick');
+        const res = await GET(req);
+
+        const location = res.headers.get('location');
+        if (!location) throw new Error('Location header missing');
+        const urlParams = new URL(location).searchParams;
+        expect(urlParams.get('state')).toBe(String(fid));
+      }
+    });
+
+    it('handles client ID with special characters', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-client-id-with_special.chars';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      expect(location).toContain('client_id=test-client-id-with_special.chars');
+    });
+
+    it('handles base URL with trailing slash', async () => {
+      process.env.NEXT_PUBLIC_KICK_CLIENT_ID = 'test-kick-client-id';
+      process.env.NEXT_PUBLIC_BASE_URL = 'https://example.com/';
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeRequest('/api/auth/kick');
+      const res = await GET(req);
+
+      const location = res.headers.get('location');
+      // The redirect_uri should be properly formed even with trailing slash
+      expect(location).toContain('redirect_uri=');
+    });
+  });
+});

--- a/src/app/api/bluesky/__tests__/route.test.ts
+++ b/src/app/api/bluesky/__tests__/route.test.ts
@@ -1,0 +1,660 @@
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// Helper to create DELETE requests (NextRequest.method is read-only)
+function makeDeleteRequest(path: string): NextRequest {
+  return new Request(new URL(path, 'http://localhost:3000'), {
+    method: 'DELETE',
+  }) as unknown as NextRequest;
+}
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom, mockAtpAgentLogin } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockAtpAgentLogin: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@atproto/api', () => {
+  return {
+    AtpAgent: class AtpAgent {
+      session?: { did: string };
+
+      login = mockAtpAgentLogin;
+    },
+  };
+});
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+// Import route handlers after mocks
+import { DELETE, GET, POST } from '../route';
+
+describe('GET /api/bluesky', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Auth: Unauthenticated (null session)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 Unauthorized when session is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await GET();
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success: Not connected
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 with connected=false when user has no bluesky data', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const { chain } = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ connected: false, handle: null });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success: Connected with handle
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 with connected=true and handle when user has bluesky data', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const { chain } = chainMock({
+      data: {
+        bluesky_did: 'did:plc:alice123',
+        bluesky_handle: 'alice.bsky.social',
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      connected: true,
+      handle: 'alice.bsky.social',
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success: Connected but null handle (edge case)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 with connected=true but handle=null when bluesky_did exists but handle is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const { chain } = chainMock({
+      data: {
+        bluesky_did: 'did:plc:alice123',
+        bluesky_handle: null,
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      connected: true,
+      handle: null,
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Error: Supabase query failure (caught, returns default)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 with default values when supabase query throws', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // Simulate a supabase error by mocking .single() to throw
+    const { chain } = chainMock({ data: null, error: new Error('Supabase error') });
+    chain.single = vi.fn().mockRejectedValue(new Error('Supabase error'));
+    mockFrom.mockReturnValue(chain);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ connected: false, handle: null });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Queries verification
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('queries users table with correct columns and fid filter', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+    const { chain } = chainMock({
+      data: {
+        bluesky_did: 'did:plc:bob123',
+        bluesky_handle: 'bob.bsky.social',
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(chain);
+
+    await GET();
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.select).toHaveBeenCalledWith('bluesky_did, bluesky_handle');
+    expect(chain.eq).toHaveBeenCalledWith('fid', 456);
+    expect(chain.single).toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/bluesky', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Auth: Unauthenticated (null session)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 Unauthorized when session is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'password123',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Validation: Missing required fields
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when handle is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const req = makePostRequest('/api/bluesky', { appPassword: 'password123' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Handle and app password are required');
+  });
+
+  it('returns 400 when appPassword is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const req = makePostRequest('/api/bluesky', { handle: 'alice.bsky.social' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Handle and app password are required');
+  });
+
+  it('returns 400 when both handle and appPassword are missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const req = makePostRequest('/api/bluesky', {});
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Handle and app password are required');
+  });
+
+  it('returns 400 when handle is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: '',
+      appPassword: 'password123',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Handle and app password are required');
+  });
+
+  it('returns 400 when appPassword is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: '',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe('Handle and app password are required');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // AtpAgent login: Invalid credentials
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 400 when AtpAgent.login throws (invalid credentials)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockRejectedValue(new Error('Invalid credentials'));
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'wrongpassword',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+
+    const body = await res.json();
+    expect(body.error).toBe(
+      'Invalid Bluesky credentials. Make sure you use an App Password, not your account password.',
+    );
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // AtpAgent login: No DID returned
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when login succeeds but no DID is returned', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // Mock successful login but no session/did set on the agent
+    mockAtpAgentLogin.mockResolvedValue({});
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.error).toBe('Failed to get DID from Bluesky');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success: Connect new account
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 and stores connection on successful login', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      // Set session/did on the instance
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    // Mock supabase update (store connection)
+    const updateChain = chainMock({ error: null });
+
+    // Mock supabase select (get user id for member registration)
+    const selectChain = chainMock({ data: { id: 'user-uuid-1' }, error: null });
+
+    // Mock supabase upsert (auto-register as member)
+    const upsertChain = chainMock({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(updateChain.chain) // users.update()
+      .mockReturnValueOnce(selectChain.chain) // users.select().eq().single()
+      .mockReturnValueOnce(upsertChain.chain); // bluesky_members.upsert()
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      handle: 'alice.bsky.social',
+      did: 'did:plc:alice123',
+    });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Supabase: User update failure
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when users table update fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    const updateChain = chainMock({
+      error: new Error('Update failed'),
+    });
+    mockFrom.mockReturnValue(updateChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.error).toBe('Failed to save connection');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Supabase: Auto-register member (best-effort, does not block)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 even if member auto-registration fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    const updateChain = chainMock({ error: null });
+    const selectChain = chainMock({ data: { id: 'user-uuid-1' }, error: null });
+    const upsertChain = chainMock({ error: new Error('Upsert failed') });
+
+    mockFrom
+      .mockReturnValueOnce(updateChain.chain)
+      .mockReturnValueOnce(selectChain.chain)
+      .mockReturnValueOnce(upsertChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    const res = await POST(req);
+    // Success still returned (member auto-register is best-effort)
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Supabase: User select failure on member registration
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('handles null user_id when selecting user during member registration', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    const updateChain = chainMock({ error: null });
+    const selectChain = chainMock({ data: null, error: null }); // No user found
+    const upsertChain = chainMock({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(updateChain.chain)
+      .mockReturnValueOnce(selectChain.chain)
+      .mockReturnValueOnce(upsertChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Verify that upsert was called with user_id: null
+    expect(upsertChain.chain.upsert).toHaveBeenCalledWith(
+      {
+        did: 'did:plc:alice123',
+        handle: 'alice.bsky.social',
+        user_id: null,
+        added_by: 'self',
+      },
+      { onConflict: 'did' },
+    );
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Logging: Errors are logged server-side
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('logs errors when db update fails', async () => {
+    const { logger } = await import('@/lib/logger');
+    const loggerErrorSpy = vi.spyOn(vi.mocked(logger), 'error');
+
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    const dbError = new Error('Database connection failed');
+    const updateChain = chainMock({ error: dbError });
+    mockFrom.mockReturnValue(updateChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    await POST(req);
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith('[bluesky] DB update error:', dbError);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Queries verification
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('creates AtpAgent with correct Bluesky service URL', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:alice123' };
+      return Promise.resolve({});
+    });
+
+    const updateChain = chainMock({ error: null });
+    const selectChain = chainMock({ data: { id: 'user-uuid-1' }, error: null });
+    const upsertChain = chainMock({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(updateChain.chain)
+      .mockReturnValueOnce(selectChain.chain)
+      .mockReturnValueOnce(upsertChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'alice.bsky.social',
+      appPassword: 'correctpassword',
+    });
+    await POST(req);
+
+    // Verify login was called with correct credentials
+    expect(mockAtpAgentLogin).toHaveBeenCalledWith({
+      identifier: 'alice.bsky.social',
+      password: 'correctpassword',
+    });
+  });
+
+  it('stores handle, did, and appPassword in users table', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+    mockAtpAgentLogin.mockImplementation(function (_credentials) {
+      this.session = { did: 'did:plc:bob789' };
+      return Promise.resolve({});
+    });
+
+    const updateChain = chainMock({ error: null });
+    const selectChain = chainMock({ data: { id: 'user-uuid-2' }, error: null });
+    const upsertChain = chainMock({ error: null });
+
+    mockFrom
+      .mockReturnValueOnce(updateChain.chain)
+      .mockReturnValueOnce(selectChain.chain)
+      .mockReturnValueOnce(upsertChain.chain);
+
+    const req = makePostRequest('/api/bluesky', {
+      handle: 'bob.bsky.social',
+      appPassword: 'bobpassword',
+    });
+    await POST(req);
+
+    expect(updateChain.chain.update).toHaveBeenCalledWith({
+      bluesky_did: 'did:plc:bob789',
+      bluesky_handle: 'bob.bsky.social',
+      bluesky_app_password: 'bobpassword',
+    });
+    expect(updateChain.chain.eq).toHaveBeenCalledWith('fid', 456);
+  });
+});
+
+describe('DELETE /api/bluesky', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Auth: Unauthenticated (null session)
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 401 Unauthorized when session is null', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makeDeleteRequest('/api/bluesky');
+    const res = await DELETE(req);
+    expect(res.status).toBe(401);
+
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Success: Disconnect account
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 200 and clears bluesky fields on successful disconnect', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const { chain } = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeDeleteRequest('/api/bluesky');
+    const res = await DELETE(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Error: Supabase disconnect failure
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when supabase update fails', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    const { chain } = chainMock({ error: new Error('Update failed') });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeDeleteRequest('/api/bluesky');
+    const res = await DELETE(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.error).toBe('Failed to disconnect');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Error: Catch-all exception handler
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('returns 500 when an unexpected error is thrown', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+    // Simulate an unexpected error
+    mockFrom.mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+
+    const req = makeDeleteRequest('/api/bluesky');
+    const res = await DELETE(req);
+    expect(res.status).toBe(500);
+
+    const body = await res.json();
+    expect(body.error).toBe('Failed to disconnect');
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Queries verification
+  // ────────────────────────────────────────────────────────────────────────────
+
+  it('clears all bluesky fields when disconnecting', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+
+    const { chain } = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeDeleteRequest('/api/bluesky');
+    await DELETE(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('users');
+    expect(chain.update).toHaveBeenCalledWith({
+      bluesky_did: null,
+      bluesky_handle: null,
+      bluesky_app_password: null,
+    });
+    expect(chain.eq).toHaveBeenCalledWith('fid', 789);
+  });
+
+  it('targets correct user by fid when disconnecting', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555 }));
+
+    const { chain } = chainMock({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeDeleteRequest('/api/bluesky');
+    await DELETE(req);
+
+    expect(chain.eq).toHaveBeenCalledWith('fid', 555);
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **141 tests total**.

| Route | Tests | Covers |
|-------|-------|--------|
| `auth/kick` | 31 | auth, PKCE (S256 challenge + verifier cookie), Kick OAuth authorize URL params, config guard, errors |
| `admin/poll-config` | 51 | public GET (config + community-default fallback), admin PUT (Zod choices 2..20/templates/votingDurationDays), supabase upsert, auth guards, errors |
| `bluesky` | 27 | GET status, POST connect (AtpAgent login + supabase, invalid-creds), DELETE disconnect, auth guards, errors |
| `admin/upload` | 32 | admin guards, CSV upload (real Papa parse), file-size + row-count limits, per-row csvRowSchema partial-success, supabase upsert, errors |

Test-only — no runtime files touched. External AtpAgent mocked, crypto/Papa run real-pure. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)