### PR TITLE
test(music,miniapp,admin): library/react/webhook/users-import (143 tests)

### DIFF
--- a/src/app/api/admin/users/import/__tests__/route.test.ts
+++ b/src/app/api/admin/users/import/__tests__/route.test.ts
@@ -1,0 +1,1093 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetUsersByFids } = vi.hoisted(() => ({
+  mockGetUsersByFids: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getUsersByFids: mockGetUsersByFids,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+// ============================================================================
+// POST /api/admin/users/import
+// ============================================================================
+
+describe('POST /api/admin/users/import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetUsersByFids.mockResolvedValue([]);
+  });
+
+  describe('authentication', () => {
+    it('returns 403 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('empty allowlist', () => {
+    it('returns 200 with 0 imported/skipped when allowlist is empty', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(0);
+      expect(body.message).toBe('No allowlist entries to import');
+    });
+
+    it('calls allowlist.select with is_active=true filter', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(mockFrom).toHaveBeenCalledWith('allowlist');
+      expect(allowlistChain.select).toHaveBeenCalledWith('*');
+      expect(allowlistChain.eq).toHaveBeenCalledWith('is_active', true);
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('fetches allowlist and existing users in parallel', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(mockFrom).toHaveBeenCalledTimes(2);
+      expect(mockFrom).toHaveBeenNthCalledWith(1, 'allowlist');
+      expect(mockFrom).toHaveBeenNthCalledWith(2, 'users');
+    });
+
+    it('queries users table with primary_wallet and fid fields', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(usersChain.select).toHaveBeenCalledWith('primary_wallet, fid');
+    });
+  });
+
+  describe('error handling - database errors', () => {
+    it('returns 500 when allowlist fetch fails', async () => {
+      const dbError = new Error('Database connection failed');
+      const allowlistChain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Import failed');
+    });
+
+    it('logs error to logger.error when fetch fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = new Error('DB error');
+      const allowlistChain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Import users error:',
+        expect.any(Error),
+      );
+    });
+
+    it('returns 500 on unexpected exception during fetch', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Import failed');
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Connection to db.example.com:5432 failed');
+      const allowlistChain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.error).toBe('Import failed');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+  });
+
+  describe('deduplication by wallet', () => {
+    it('skips entry if primary_wallet already exists (case insensitive)', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: '0xABCD1234567890ABCD1234567890ABCD12345678',
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const existingUser = {
+        primary_wallet: '0xabcd1234567890abcd1234567890abcd12345678',
+        fid: null,
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [existingUser], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(1);
+    });
+
+    it('skips entry if FID already exists', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const existingUser = {
+        primary_wallet: '0xfffffffffffffffffffffffffffffffffffffff1',
+        fid: 100,
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [existingUser], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(1);
+    });
+
+    it('skips entries with null wallet and fid', async () => {
+      const allowlistEntry = {
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(1);
+    });
+  });
+
+  describe('wallet determination logic', () => {
+    it('uses wallet_address as primary wallet when available', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+      expect(userData.primary_wallet).toBe(VALID_WALLET.toLowerCase());
+    });
+
+    it('uses custody_address as fallback when wallet_address not available', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        custody_address: VALID_WALLET,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+      expect(userData.primary_wallet).toBe(VALID_WALLET.toLowerCase());
+    });
+
+    it('uses fid: placeholder when no wallet available', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+      expect(userData.primary_wallet).toBe('fid:100');
+    });
+  });
+
+  describe('Farcaster enrichment via getUsersByFids', () => {
+    it('fetches Farcaster data for all entries with fids', async () => {
+      const allowlistEntries = [
+        { fid: 100, display_name: 'User1' },
+        { fid: 200, display_name: 'User2' },
+      ];
+
+      const allowlistChain = chainMock({ data: allowlistEntries, error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(mockGetUsersByFids).toHaveBeenCalledWith([100, 200]);
+    });
+
+    it('enriches user data with Farcaster profile info when available', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Old Name',
+        pfp_url: null,
+        username: null,
+      };
+
+      const fcUser = {
+        fid: 100,
+        display_name: 'Fresh Name',
+        pfp_url: 'https://example.com/pfp.jpg',
+        username: 'newusername',
+        custody_address: VALID_WALLET,
+        verified_addresses: { eth_addresses: ['0xaddr1'] },
+        profile: { bio: { text: 'User bio' } },
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([fcUser as unknown as Record<string, unknown>]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.display_name).toBe('Fresh Name');
+      expect(userData.pfp_url).toBe('https://example.com/pfp.jpg');
+      expect(userData.username).toBe('newusername');
+      expect(userData.bio).toBe('User bio');
+    });
+
+    it('keeps allowlist data when Farcaster data is incomplete', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Allowlist Name',
+        pfp_url: 'https://allowlist.com/pfp.jpg',
+        username: 'allowlistuser',
+      };
+
+      const fcUser = {
+        fid: 100,
+        display_name: null,
+        pfp_url: null,
+        username: null,
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([fcUser as unknown as Record<string, unknown>]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.display_name).toBe('Allowlist Name');
+      expect(userData.pfp_url).toBe('https://allowlist.com/pfp.jpg');
+      expect(userData.username).toBe('allowlistuser');
+    });
+
+    it('logs warning and continues when Farcaster fetch fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockRejectedValue(new Error('Neynar API error'));
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        '[import] Batch Farcaster fetch failed, using cached data:',
+        expect.any(Error),
+      );
+      expect(body.imported).toBe(1);
+    });
+
+    it('updates primary_wallet to custody_address when Farcaster provides real wallet', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+      };
+
+      const fcUser = {
+        fid: 100,
+        custody_address: VALID_WALLET,
+        verified_addresses: { eth_addresses: [] },
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([fcUser as unknown as Record<string, unknown>]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.primary_wallet).toBe(VALID_WALLET.toLowerCase());
+    });
+  });
+
+  describe('user data construction', () => {
+    it('sets role to member for entries with fid', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.role).toBe('member');
+    });
+
+    it('sets role to beta for entries without fid', async () => {
+      const allowlistEntry = {
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.role).toBe('beta');
+    });
+
+    it('uses display_name, ign, real_name, or wallet prefix as fallback for display_name', async () => {
+      const allowlistEntry = {
+        wallet_address: VALID_WALLET,
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.display_name).toBe(VALID_WALLET.slice(0, 10));
+    });
+
+    it('sets is_active to true for all imported users', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.is_active).toBe(true);
+    });
+
+    it('preserves optional fields from allowlist entry', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        display_name: 'Test User',
+        ens_name: 'testuser.eth',
+        notes: 'VIP member',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      await POST(makePostRequest('/api/admin/users/import', {}));
+
+      expect(insertChain.insert).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertChain.insert);
+      const [userData] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(userData.ens_name).toBe('testuser.eth');
+      expect(userData.notes).toBe('VIP member');
+    });
+  });
+
+  describe('success scenarios', () => {
+    it('imports new users successfully', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+        username: 'testuser',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        return chainMock({ error: null }).chain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.imported).toBe(1);
+      expect(body.skipped).toBe(0);
+      expect(body.total).toBe(1);
+    });
+
+    it('returns correct counts for mixed import and skip scenario', async () => {
+      const allowlistEntries = [
+        { fid: 100, wallet_address: VALID_WALLET, display_name: 'New User' },
+        {
+          fid: 200,
+          wallet_address: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
+          display_name: 'Old User',
+        },
+      ];
+
+      const existingUsers = [
+        { primary_wallet: '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef', fid: null },
+      ];
+
+      const allowlistChain = chainMock({ data: allowlistEntries, error: null }).chain;
+      const usersChain = chainMock({ data: existingUsers, error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        return chainMock({ error: null }).chain;
+      });
+
+      const insertChain = chainMock({ error: null }).chain;
+      const fromCalls = [allowlistChain, usersChain, insertChain];
+      let fromCallIndex = 0;
+      mockFrom.mockImplementation(() => {
+        const result = fromCalls[fromCallIndex];
+        fromCallIndex += 1;
+        return result;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.imported).toBe(1);
+      expect(body.skipped).toBe(1);
+      expect(body.total).toBe(2);
+    });
+
+    it('all entries already exist - returns 0 imported', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+      };
+
+      const existingUser = {
+        primary_wallet: VALID_WALLET.toLowerCase(),
+        fid: 100,
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [existingUser], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? allowlistChain : usersChain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(1);
+    });
+  });
+
+  describe('insert error handling', () => {
+    it('skips entry on unique constraint violation (23505)', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        const insertChain = chainMock({
+          error: { code: '23505', message: 'Unique violation' },
+        }).chain;
+        return insertChain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(1);
+      expect(body.errors).toBeUndefined();
+    });
+
+    it('collects other insert errors in errors array', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+        ign: 'testign',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        const insertChain = chainMock({
+          error: { code: '42P09', message: 'Foreign key violation' },
+        }).chain;
+        return insertChain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.skipped).toBe(0);
+      expect(body.errors).toBeDefined();
+      expect(body.errors).toHaveLength(1);
+      expect(body.errors[0]).toContain('testign');
+      expect(body.errors[0]).toContain('Foreign key violation');
+    });
+
+    it('continues importing after individual entry error', async () => {
+      const allowlistEntries = [
+        { fid: 100, wallet_address: VALID_WALLET, display_name: 'User1' },
+        {
+          fid: 200,
+          wallet_address: '0xABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD',
+          display_name: 'User2',
+        },
+      ];
+
+      const allowlistChain = chainMock({ data: allowlistEntries, error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      let insertCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        insertCount += 1;
+        if (insertCount === 1) {
+          return chainMock({ error: { code: '42P09', message: 'Error' } }).chain;
+        }
+        return chainMock({ error: null }).chain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(1);
+      expect(body.errors).toBeDefined();
+      expect(body.errors).toHaveLength(1);
+    });
+
+    it('catches exception during entry processing and adds to errors', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+        ign: 'testign',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        const insertChain = chainMock({ error: null }).chain;
+        vi.mocked(insertChain.insert).mockImplementation(() => {
+          throw new Error('Unexpected insert error');
+        });
+        return insertChain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.imported).toBe(0);
+      expect(body.errors).toBeDefined();
+      expect(body.errors).toHaveLength(1);
+      expect(body.errors[0]).toContain('testign');
+      expect(body.errors[0]).toContain('Unexpected insert error');
+    });
+
+    it('includes error details in response message', async () => {
+      const allowlistEntries = [
+        { fid: 100, wallet_address: VALID_WALLET, display_name: 'User1' },
+        {
+          fid: 200,
+          wallet_address: '0xABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD',
+          display_name: 'User2',
+        },
+      ];
+
+      const allowlistChain = chainMock({ data: allowlistEntries, error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      let insertCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        insertCount += 1;
+        if (insertCount === 1) {
+          return chainMock({ error: { code: '42P09', message: 'Error' } }).chain;
+        }
+        return chainMock({ error: null }).chain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.message).toContain('Imported 1 users');
+      expect(body.message).toContain('1 errors');
+    });
+  });
+
+  describe('response structure', () => {
+    it('includes imported, skipped, total, and message in success response', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body).toHaveProperty('imported');
+      expect(body).toHaveProperty('skipped');
+      expect(body).toHaveProperty('message');
+    });
+
+    it('includes errors array when errors occur', async () => {
+      const allowlistEntry = {
+        fid: 100,
+        wallet_address: VALID_WALLET,
+        display_name: 'Test User',
+      };
+
+      const allowlistChain = chainMock({ data: [allowlistEntry], error: null }).chain;
+      const usersChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return allowlistChain;
+        if (callCount === 2) return usersChain;
+        return chainMock({ error: { code: '42P09', message: 'Error' } }).chain;
+      });
+
+      mockGetUsersByFids.mockResolvedValue([]);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.errors).toBeDefined();
+      expect(Array.isArray(body.errors)).toBe(true);
+    });
+
+    it('omits errors array when no errors occur', async () => {
+      const allowlistChain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(allowlistChain);
+
+      const res = await POST(makePostRequest('/api/admin/users/import', {}));
+      const body = await res.json();
+
+      expect(body.errors).toBeUndefined();
+    });
+  });
+});

--- a/src/app/api/miniapp/webhook/__tests__/route.test.ts
+++ b/src/app/api/miniapp/webhook/__tests__/route.test.ts
@@ -1,0 +1,440 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, makePostRequest } from '@/test-utils/api-helpers';
+
+const { mockParseWebhookEvent, mockVerifyAppKeyWithNeynar, mockFrom } = vi.hoisted(() => ({
+  mockParseWebhookEvent: vi.fn(),
+  mockVerifyAppKeyWithNeynar: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@farcaster/miniapp-node', () => ({
+  parseWebhookEvent: mockParseWebhookEvent,
+  verifyAppKeyWithNeynar: mockVerifyAppKeyWithNeynar,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { POST } from '../route';
+
+const FID = 123;
+const TOKEN = 'test-token-xyz';
+const NOTIFICATION_URL = 'https://example.com/notify';
+
+describe('POST /api/miniapp/webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Verification failure tests
+  // =========================================================================
+
+  it('returns 500 when parseWebhookEvent throws', async () => {
+    mockParseWebhookEvent.mockRejectedValue(new Error('Invalid signature'));
+    const req = makePostRequest('/api/miniapp/webhook', { raw: 'data' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Webhook processing failed');
+  });
+
+  it('passes verifyAppKeyWithNeynar to parseWebhookEvent', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    mockFrom.mockReturnValue(allowlistMock.chain);
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const webhookData = { some: 'data' };
+    const req = makePostRequest('/api/miniapp/webhook', webhookData);
+    await POST(req);
+
+    // Verify parseWebhookEvent was called with the data and the verifyAppKeyWithNeynar function
+    expect(mockParseWebhookEvent).toHaveBeenCalledWith(webhookData, mockVerifyAppKeyWithNeynar);
+  });
+
+  // =========================================================================
+  // FID allowlist check tests
+  // =========================================================================
+
+  it('returns success silently when FID is not in allowlist', async () => {
+    const allowlistMock = chainMock({ data: null });
+    mockFrom.mockReturnValue(allowlistMock.chain);
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    // Verify we checked the allowlist
+    expect(mockFrom).toHaveBeenCalledWith('allowlist');
+  });
+
+  it('verifies FID is active in allowlist query', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    mockFrom.mockReturnValue(allowlistMock.chain);
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    await POST(req);
+
+    // Verify the allowlist query chain: select -> eq(fid) -> eq(is_active) -> maybeSingle
+    expect(allowlistMock.chain.select).toHaveBeenCalledWith('id');
+    expect(allowlistMock.chain.eq).toHaveBeenNthCalledWith(1, 'fid', FID);
+    expect(allowlistMock.chain.eq).toHaveBeenNthCalledWith(2, 'is_active', true);
+    expect(allowlistMock.chain.maybeSingle).toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Event: miniapp_added
+  // =========================================================================
+
+  it('handles miniapp_added event with notification details', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'notification_tokens');
+    expect(notificationMock.chain.upsert).toHaveBeenCalledWith(
+      {
+        fid: FID,
+        token: TOKEN,
+        url: NOTIFICATION_URL,
+        enabled: true,
+        updated_at: expect.any(String),
+      },
+      { onConflict: 'fid' },
+    );
+  });
+
+  it('miniapp_added does not write if notificationDetails is missing', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: { event: 'miniapp_added' },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    // Verify upsert was not called because notificationDetails was missing
+    expect(notificationMock.chain.upsert).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Event: notifications_enabled
+  // =========================================================================
+
+  it('handles notifications_enabled event with token', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'notifications_enabled',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(notificationMock.chain.upsert).toHaveBeenCalledWith(
+      {
+        fid: FID,
+        token: TOKEN,
+        url: NOTIFICATION_URL,
+        enabled: true,
+        updated_at: expect.any(String),
+      },
+      { onConflict: 'fid' },
+    );
+  });
+
+  // =========================================================================
+  // Event: miniapp_removed
+  // =========================================================================
+
+  it('handles miniapp_removed event by disabling notifications', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: { event: 'miniapp_removed' },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'notification_tokens');
+    expect(notificationMock.chain.update).toHaveBeenCalledWith({
+      enabled: false,
+      updated_at: expect.any(String),
+    });
+    expect(notificationMock.chain.eq).toHaveBeenCalledWith('fid', FID);
+  });
+
+  // =========================================================================
+  // Event: notifications_disabled
+  // =========================================================================
+
+  it('handles notifications_disabled event by disabling notifications', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: { event: 'notifications_disabled' },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(notificationMock.chain.update).toHaveBeenCalledWith({
+      enabled: false,
+      updated_at: expect.any(String),
+    });
+    expect(notificationMock.chain.eq).toHaveBeenCalledWith('fid', FID);
+  });
+
+  // =========================================================================
+  // Supabase error handling (note: route does not check .error field)
+  // =========================================================================
+
+  it('treats allowlist query with no data as unauthorized silently', async () => {
+    const allowlistMock = chainMock({ data: null, error: null });
+    mockFrom.mockReturnValue(allowlistMock.chain);
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    // Route returns 200 because it silently accepts unknown FIDs
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  // NOTE: The route does not currently check the .error field on Supabase
+  // responses. If a query error occurs, it will be caught by the outer try/catch
+  // only if it throws. Supabase queries resolve silently on error (returning
+  // { error: ... }), so the route treats them as successful responses unless
+  // the query method itself throws (e.g., network failure). This test verifies
+  // the route handles unexpected throws gracefully.
+
+  it('catches and returns 500 on unexpected exception in Supabase query', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    mockFrom.mockReturnValue(allowlistMock.chain);
+
+    // Simulate a thrown error (e.g., network exception)
+    mockParseWebhookEvent.mockRejectedValue(new Error('Network timeout'));
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Webhook processing failed');
+  });
+
+  // =========================================================================
+  // Success response shape
+  // =========================================================================
+
+  it('returns { success: true } on successful processing', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+    expect(body.error).toBeUndefined();
+  });
+
+  // =========================================================================
+  // Timestamp precision tests
+  // =========================================================================
+
+  it('uses ISO string timestamps for updated_at', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    mockParseWebhookEvent.mockResolvedValue({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    const beforeTime = new Date();
+    const req = makePostRequest('/api/miniapp/webhook', {});
+    await POST(req);
+    const afterTime = new Date();
+
+    const callArgs = (notificationMock.chain.upsert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const timestamp = new Date(callArgs.updated_at);
+
+    expect(timestamp.getTime()).toBeGreaterThanOrEqual(beforeTime.getTime());
+    expect(timestamp.getTime()).toBeLessThanOrEqual(afterTime.getTime());
+  });
+
+  // =========================================================================
+  // Multiple events in sequence (integration-like)
+  // =========================================================================
+
+  it('handles multiple different events sequentially', async () => {
+    const allowlistMock = chainMock({ data: { id: 'member-1' } });
+    const notificationMock = chainMock({ data: null });
+
+    let callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex % 2 === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    // First: miniapp_added
+    mockParseWebhookEvent.mockResolvedValueOnce({
+      fid: FID,
+      event: {
+        event: 'miniapp_added',
+        notificationDetails: { token: TOKEN, url: NOTIFICATION_URL },
+      },
+    });
+
+    let req = makePostRequest('/api/miniapp/webhook', {});
+    let res = await POST(req);
+    expect(res.status).toBe(200);
+
+    // Reset call count
+    vi.clearAllMocks();
+    callIndex = 0;
+    mockFrom.mockImplementation(() => {
+      callIndex++;
+      return callIndex % 2 === 1 ? allowlistMock.chain : notificationMock.chain;
+    });
+
+    // Second: notifications_disabled
+    mockParseWebhookEvent.mockResolvedValueOnce({
+      fid: FID,
+      event: { event: 'notifications_disabled' },
+    });
+
+    req = makePostRequest('/api/miniapp/webhook', {});
+    res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(notificationMock.chain.update).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/music/library/__tests__/route.test.ts
+++ b/src/app/api/music/library/__tests__/route.test.ts
@@ -1,0 +1,926 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockIsMusicUrl } = vi.hoisted(() => ({
+  mockIsMusicUrl: vi.fn(),
+}));
+
+const { mockQuerySongs, mockUpsertSong } = vi.hoisted(() => ({
+  mockQuerySongs: vi.fn(),
+  mockUpsertSong: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/music/isMusicUrl', () => ({
+  isMusicUrl: mockIsMusicUrl,
+}));
+
+vi.mock('@/lib/music/library', () => ({
+  querySongs: mockQuerySongs,
+  upsertSong: mockUpsertSong,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { GET, POST } from '../route';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const SAMPLE_SONG = {
+  id: 'song-123',
+  url: 'https://spotify.com/track/abc123',
+  platform: 'spotify',
+  title: 'Test Track',
+  artist: 'Test Artist',
+  artwork_url: 'https://example.com/image.jpg',
+  stream_url: 'https://stream.example.com/track',
+  duration: 180,
+  submitted_by_fid: 123,
+  source: 'manual',
+  tags: ['test'],
+  play_count: 10,
+  last_played_at: '2026-07-15T10:00:00Z',
+  created_at: '2026-07-14T10:00:00Z',
+};
+
+const SAMPLE_SONG_2 = {
+  id: 'song-456',
+  url: 'https://youtube.com/watch?v=xyz789',
+  platform: 'youtube',
+  title: 'Another Track',
+  artist: 'Another Artist',
+  artwork_url: 'https://example.com/image2.jpg',
+  stream_url: 'https://stream.example.com/track2',
+  duration: 240,
+  submitted_by_fid: 124,
+  source: 'chat',
+  tags: ['music'],
+  play_count: 50,
+  last_played_at: '2026-07-13T10:00:00Z',
+  created_at: '2026-07-13T10:00:00Z',
+};
+
+const VALID_MUSIC_URL = 'https://spotify.com/track/abc123';
+const _INVALID_URL = 'not-a-url';
+const NON_MUSIC_URL = 'https://example.com/random-page';
+
+describe('GET /api/music/library', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockQuerySongs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request validation — querySchema', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when sort is not a valid enum', async () => {
+      const res = await GET(makeGetRequest('/api/music/library', { sort: 'invalid' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+      expect(body.details).toBeDefined();
+      expect(mockQuerySongs).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when filter is not a valid enum', async () => {
+      const res = await GET(makeGetRequest('/api/music/library', { filter: 'invalid' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+      expect(body.details).toBeDefined();
+      expect(mockQuerySongs).not.toHaveBeenCalled();
+    });
+
+    it('accepts sort=recent', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { sort: 'recent' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalled();
+    });
+
+    it('accepts sort=popular', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { sort: 'popular' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalled();
+    });
+
+    it('accepts sort=played', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { sort: 'played' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalled();
+    });
+
+    it('accepts filter=recent', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { filter: 'recent' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalled();
+    });
+
+    it('accepts filter=liked', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { filter: 'liked' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalled();
+    });
+
+    it('returns 400 when limit is below 1', async () => {
+      const res = await GET(makeGetRequest('/api/music/library', { limit: '0' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+    });
+
+    it('returns 400 when limit exceeds 100', async () => {
+      const res = await GET(makeGetRequest('/api/music/library', { limit: '101' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+    });
+
+    it('coerces limit from string to number', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { limit: '25' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ limit: 25 }));
+    });
+
+    it('uses default limit of 50 when not provided', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ limit: 50 }));
+    });
+
+    it('returns 400 when offset is negative', async () => {
+      const res = await GET(makeGetRequest('/api/music/library', { offset: '-1' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+    });
+
+    it('coerces offset from string to number', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { offset: '10' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ offset: 10 }));
+    });
+
+    it('uses default offset of 0 when not provided', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ offset: 0 }));
+    });
+
+    it('accepts search parameter up to 200 chars', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+      const search = 'a'.repeat(200);
+
+      const res = await GET(makeGetRequest('/api/music/library', { search }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ search }));
+    });
+
+    it('returns 400 when search exceeds 200 chars', async () => {
+      const search = 'a'.repeat(201);
+      const res = await GET(makeGetRequest('/api/music/library', { search }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+    });
+
+    it('accepts platform parameter up to 20 chars', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+      const platform = 'a'.repeat(20);
+
+      const res = await GET(makeGetRequest('/api/music/library', { platform }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ platform }));
+    });
+
+    it('returns 400 when platform exceeds 20 chars', async () => {
+      const platform = 'a'.repeat(21);
+      const res = await GET(makeGetRequest('/api/music/library', { platform }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid params');
+    });
+  });
+
+  describe('filter logic', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('forces sort=played when filter=recent', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(
+        makeGetRequest('/api/music/library', { filter: 'recent', sort: 'popular' }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ sort: 'played' }));
+    });
+
+    it('does not override sort for other filters', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(
+        makeGetRequest('/api/music/library', { filter: 'liked', sort: 'popular' }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ sort: 'popular' }));
+    });
+  });
+
+  describe('success paths', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 200 with songs and total when querySongs succeeds', async () => {
+      mockQuerySongs.mockResolvedValue({
+        songs: [SAMPLE_SONG, SAMPLE_SONG_2],
+        total: 2,
+      });
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.songs).toHaveLength(2);
+      expect(body.total).toBe(2);
+      expect(body.songs[0].id).toBe('song-123');
+      expect(body.songs[1].id).toBe('song-456');
+    });
+
+    it('returns 200 with empty array when no songs match', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [], total: 0 });
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.songs).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('includes Cache-Control headers', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+
+      expect(res.headers.get('Cache-Control')).toBe(
+        'public, s-maxage=300, stale-while-revalidate=60',
+      );
+    });
+
+    it('passes search parameter to querySongs', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { search: 'test track' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'test track' }),
+      );
+    });
+
+    it('passes platform parameter to querySongs', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { platform: 'spotify' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ platform: 'spotify' }));
+    });
+
+    it('passes sort parameter to querySongs', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { sort: 'popular' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(expect.objectContaining({ sort: 'popular' }));
+    });
+
+    it('passes limit and offset to querySongs', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(makeGetRequest('/api/music/library', { limit: '25', offset: '10' }));
+
+      expect(res.status).toBe(200);
+      expect(mockQuerySongs).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 25, offset: 10 }),
+      );
+    });
+
+    it('queries with all parameters together', async () => {
+      mockQuerySongs.mockResolvedValue({ songs: [SAMPLE_SONG], total: 1 });
+
+      const res = await GET(
+        makeGetRequest('/api/music/library', {
+          search: 'jazz',
+          platform: 'spotify',
+          sort: 'popular',
+          filter: 'liked',
+          limit: '20',
+          offset: '5',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      // filter is passed through as-is; sort is only overridden for filter=recent
+      expect(mockQuerySongs).toHaveBeenCalledWith({
+        search: 'jazz',
+        platform: 'spotify',
+        sort: 'popular',
+        filter: 'liked',
+        limit: 20,
+        offset: 5,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when querySongs throws', async () => {
+      mockQuerySongs.mockRejectedValue(new Error('Database error'));
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load library');
+    });
+
+    it('logs error when querySongs throws', async () => {
+      const { logger } = await import('@/lib/logger');
+      const error = new Error('DB connection failed');
+      mockQuerySongs.mockRejectedValue(error);
+
+      await GET(makeGetRequest('/api/music/library'));
+
+      expect(logger.error).toHaveBeenCalledWith('[library] query failed:', expect.any(Error));
+    });
+
+    it('returns 500 even on unexpected error', async () => {
+      mockQuerySongs.mockRejectedValue(new Error('Unexpected error'));
+
+      const res = await GET(makeGetRequest('/api/music/library'));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to load library');
+    });
+  });
+});
+
+describe('POST /api/music/library', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockUpsertSong).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addSchema validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when url is missing', async () => {
+      const res = await POST(makePostRequest('/api/music/library', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockUpsertSong).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      const res = await POST(makePostRequest('/api/music/library', { url: 'not-a-url' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when url exceeds 500 characters', async () => {
+      const longUrl = `https://spotify.com/track/${'a'.repeat(500)}`;
+      const res = await POST(makePostRequest('/api/music/library', { url: longUrl }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid URL up to 500 characters', async () => {
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      const url = `https://spotify.com/track/${'a'.repeat(470)}`; // Just under 500
+      const res = await POST(makePostRequest('/api/music/library', { url }));
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('isMusicUrl integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when isMusicUrl returns null (non-music URL)', async () => {
+      mockIsMusicUrl.mockReturnValue(null);
+
+      const res = await POST(makePostRequest('/api/music/library', { url: NON_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Not a recognized music URL');
+    });
+
+    it('calls isMusicUrl with the provided URL', async () => {
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockIsMusicUrl).toHaveBeenCalledWith(VALID_MUSIC_URL);
+    });
+
+    it('recognizes spotify URLs', async () => {
+      mockIsMusicUrl.mockReturnValue('spotify');
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      const res = await POST(
+        makePostRequest('/api/music/library', {
+          url: 'https://spotify.com/track/abc123',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('recognizes youtube URLs', async () => {
+      mockIsMusicUrl.mockReturnValue('youtube');
+      mockUpsertSong.mockResolvedValue({ id: 'song-456', isNew: true });
+
+      const res = await POST(
+        makePostRequest('/api/music/library', {
+          url: 'https://youtube.com/watch?v=xyz789',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('recognizes soundcloud URLs', async () => {
+      mockIsMusicUrl.mockReturnValue('soundcloud');
+      mockUpsertSong.mockResolvedValue({ id: 'song-789', isNew: true });
+
+      const res = await POST(
+        makePostRequest('/api/music/library', {
+          url: 'https://soundcloud.com/artist/track',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('recognizes audio file extensions', async () => {
+      mockIsMusicUrl.mockReturnValue('audio');
+      mockUpsertSong.mockResolvedValue({ id: 'song-mp3', isNew: true });
+
+      const res = await POST(
+        makePostRequest('/api/music/library', {
+          url: 'https://example.com/song.mp3',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('metadata fetching', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+    });
+
+    it('attempts to fetch metadata from /api/music/metadata endpoint', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      // Mock global fetch
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            trackName: 'Test Track',
+            artistName: 'Test Artist',
+            artworkUrl: 'https://example.com/image.jpg',
+            streamUrl: 'https://stream.example.com/track',
+            duration: 180000,
+          }),
+          { status: 200 },
+        ),
+      );
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/music/metadata?url='),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('proceeds without metadata if fetch fails', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      global.fetch = vi.fn().mockRejectedValue(new Error('Fetch failed'));
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(res.status).toBe(200);
+      expect(mockUpsertSong).toHaveBeenCalled();
+    });
+
+    it('proceeds without metadata if metadata response is not ok', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      global.fetch = vi
+        .fn()
+        .mockResolvedValue(new Response(JSON.stringify({ error: 'Not found' }), { status: 404 }));
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('uses NEXT_PUBLIC_URL if available', async () => {
+      const originalEnv = process.env.NEXT_PUBLIC_URL;
+      process.env.NEXT_PUBLIC_URL = 'https://custom.example.com';
+
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://custom.example.com'),
+        expect.any(Object),
+      );
+
+      process.env.NEXT_PUBLIC_URL = originalEnv;
+    });
+
+    it('falls back to VERCEL_URL if NEXT_PUBLIC_URL not set', async () => {
+      const originalPublicUrl = process.env.NEXT_PUBLIC_URL;
+      const originalVercelUrl = process.env.VERCEL_URL;
+
+      delete process.env.NEXT_PUBLIC_URL;
+      process.env.VERCEL_URL = 'vercel-deployment.vercel.app';
+
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://vercel-deployment.vercel.app'),
+        expect.any(Object),
+      );
+
+      process.env.NEXT_PUBLIC_URL = originalPublicUrl;
+      process.env.VERCEL_URL = originalVercelUrl;
+    });
+
+    it('falls back to localhost:3000 if no public URL is set', async () => {
+      const originalPublicUrl = process.env.NEXT_PUBLIC_URL;
+      const originalVercelUrl = process.env.VERCEL_URL;
+
+      delete process.env.NEXT_PUBLIC_URL;
+      delete process.env.VERCEL_URL;
+
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:3000'),
+        expect.any(Object),
+      );
+
+      process.env.NEXT_PUBLIC_URL = originalPublicUrl;
+      process.env.VERCEL_URL = originalVercelUrl;
+    });
+  });
+
+  describe('upsertSong integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+      global.fetch = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            trackName: 'Test Track',
+            artistName: 'Test Artist',
+            artworkUrl: 'https://example.com/image.jpg',
+            streamUrl: 'https://stream.example.com/track',
+            duration: 180000,
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+
+    it('calls upsertSong with url, platform, and session fid', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(res.status).toBe(200);
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: VALID_MUSIC_URL,
+          platform: 'spotify',
+          submittedByFid: 123,
+          source: 'manual',
+        }),
+      );
+    });
+
+    it('uses metadata trackName as title', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Test Track',
+        }),
+      );
+    });
+
+    it('defaults to "Untitled" when trackName is missing', async () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Untitled',
+        }),
+      );
+    });
+
+    it('uses metadata artistName as artist', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artist: 'Test Artist',
+        }),
+      );
+    });
+
+    it('uses metadata artworkUrl as artworkUrl', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          artworkUrl: 'https://example.com/image.jpg',
+        }),
+      );
+    });
+
+    it('uses metadata streamUrl as streamUrl', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          streamUrl: 'https://stream.example.com/track',
+        }),
+      );
+    });
+
+    it('converts metadata duration from ms to seconds', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          duration: 180, // 180000 / 1000
+        }),
+      );
+    });
+
+    it('defaults duration to 0 when metadata is missing', async () => {
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(mockUpsertSong).toHaveBeenCalledWith(
+        expect.objectContaining({
+          duration: 0,
+        }),
+      );
+    });
+  });
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    });
+
+    it('returns 200 with song and isNew flag when upsertSong succeeds', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: true });
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.song).toBeDefined();
+      expect(body.isNew).toBe(true);
+    });
+
+    it('returns isNew=false for existing songs', async () => {
+      mockUpsertSong.mockResolvedValue({ id: 'song-123', isNew: false });
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.isNew).toBe(false);
+    });
+
+    it('includes song data in response', async () => {
+      const songResult = {
+        id: 'song-123',
+        url: VALID_MUSIC_URL,
+        platform: 'spotify',
+        title: 'New Track',
+        isNew: true,
+      };
+      mockUpsertSong.mockResolvedValue(songResult as unknown as { id: string; isNew: boolean });
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(body.song).toBeDefined();
+      expect(body.song.id).toBe('song-123');
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+      global.fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
+    });
+
+    it('returns 500 when upsertSong throws', async () => {
+      mockUpsertSong.mockRejectedValue(new Error('Database error'));
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add song');
+    });
+
+    it('logs error when upsertSong throws', async () => {
+      const { logger } = await import('@/lib/logger');
+      const error = new Error('DB connection failed');
+      mockUpsertSong.mockRejectedValue(error);
+
+      await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+
+      expect(logger.error).toHaveBeenCalledWith('[library] add failed:', expect.any(Error));
+    });
+
+    it('returns 500 on unexpected error during processing', async () => {
+      mockUpsertSong.mockRejectedValue(new Error('Unexpected error'));
+
+      const res = await POST(makePostRequest('/api/music/library', { url: VALID_MUSIC_URL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add song');
+    });
+
+    it('returns 500 when JSON parsing fails', async () => {
+      const res = await POST(
+        new (require('next/server').NextRequest)(
+          new URL('/api/music/library', 'http://localhost:3000'),
+          {
+            method: 'POST',
+            body: 'invalid json',
+          },
+        ),
+      );
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/src/app/api/music/library/react/__tests__/route.test.ts
+++ b/src/app/api/music/library/react/__tests__/route.test.ts
@@ -1,0 +1,906 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  makePostRequest,
+  mockAuthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockIsMusicUrl } = vi.hoisted(() => ({
+  mockIsMusicUrl: vi.fn(),
+}));
+
+const { mockUpsertSong } = vi.hoisted(() => ({
+  mockUpsertSong: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+  },
+}));
+
+vi.mock('@/lib/music/isMusicUrl', () => ({
+  isMusicUrl: (_url: unknown) => mockIsMusicUrl(_url),
+}));
+
+vi.mock('@/lib/music/library', () => ({
+  upsertSong: (_params: unknown) => mockUpsertSong(_params),
+}));
+
+import { GET, POST } from '../route';
+
+describe('/api/music/library/react', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // GET /api/music/library/react?url=...
+  // ─────────────────────────────────────────────────────────────
+
+  describe('GET', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/123',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 400 when url query param is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makeGetRequest('/api/music/library/react');
+      const res = await GET(req);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Missing url parameter' });
+    });
+
+    it('returns empty reactions when song does not exist', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const songLookup = chainMock({ data: null });
+      mockFrom.mockReturnValue(songLookup.chain);
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/nonexistent',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ reactions: {}, userReactions: [] });
+    });
+
+    it('returns reaction counts and user reactions for existing song', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const songData = { id: VALID_UUID };
+
+      // Song lookup chain
+      const songLookup = chainMock({ data: songData });
+
+      // All reactions chain
+      const allReactionsData = [{ emoji: '🔥' }, { emoji: '🔥' }, { emoji: '❤️' }];
+      const allReactions = chainMock({ data: allReactionsData });
+
+      // User reactions chain
+      const userReactionsData = [{ emoji: '🔥' }];
+      const userReactions = chainMock({ data: userReactionsData });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'songs') {
+          return songLookup.chain;
+        }
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          // First call is for all reactions, second is for user reactions
+          if (callsToFrom === 1) return allReactions.chain;
+          return userReactions.chain;
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/abc123',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        reactions: { '🔥': 2, '❤️': 1 },
+        userReactions: ['🔥'],
+      });
+    });
+
+    it('returns empty user reactions when user has not reacted', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+
+      const songData = { id: VALID_UUID };
+      const songLookup = chainMock({ data: songData });
+
+      const allReactionsData = [{ emoji: '🔥' }];
+      const allReactions = chainMock({ data: allReactionsData });
+
+      const userReactionsData: unknown[] = [];
+      const userReactions = chainMock({ data: userReactionsData });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'songs') {
+          return songLookup.chain;
+        }
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return allReactions.chain;
+          return userReactions.chain;
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/xyz',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        reactions: { '🔥': 1 },
+        userReactions: [],
+      });
+    });
+
+    it('returns empty reactions dict when no reactions exist on song', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const songData = { id: VALID_UUID };
+      const songLookup = chainMock({ data: songData });
+
+      const allReactionsData: unknown[] = [];
+      const allReactions = chainMock({ data: allReactionsData });
+
+      const userReactionsData: unknown[] = [];
+      const userReactions = chainMock({ data: userReactionsData });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'songs') {
+          return songLookup.chain;
+        }
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return allReactions.chain;
+          return userReactions.chain;
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/abc',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        reactions: {},
+        userReactions: [],
+      });
+    });
+
+    it('returns 500 when song lookup throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      // Make the song lookup throw an error
+      const songLookupChain: Record<string, ReturnType<typeof vi.fn>> = {};
+      const chainable = [
+        'select',
+        'insert',
+        'update',
+        'upsert',
+        'delete',
+        'eq',
+        'neq',
+        'in',
+        'not',
+        'is',
+        'gt',
+        'gte',
+        'lt',
+        'lte',
+        'like',
+        'ilike',
+        'order',
+        'range',
+        'limit',
+        'maybeSingle',
+      ];
+      for (const method of chainable) {
+        songLookupChain[method] = vi.fn().mockReturnValue(songLookupChain);
+      }
+      const lookupError = new Error('DB connection failed');
+      // biome-ignore lint/suspicious/noThenProperty: intentionally testing thenable
+      songLookupChain.then = vi.fn((_resolve: unknown, reject: (err: unknown) => void) => {
+        reject(lookupError);
+      });
+
+      mockFrom.mockReturnValue(songLookupChain);
+
+      const req = makeGetRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/fail',
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to get reactions' });
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────
+  // POST /api/music/library/react
+  // ─────────────────────────────────────────────────────────────
+
+  describe('POST', () => {
+    it('returns 401 when no session exists', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/123',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 400 when body is invalid JSON', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makePostRequest('/api/music/library/react', 'not-an-object');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+      expect(json.details).toBeDefined();
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'not-a-url',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when url exceeds max length', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const longUrl = `https://example.com/${'a'.repeat(500)}`;
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: longUrl,
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when emoji is not in ALLOWED_EMOJIS', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/123',
+        emoji: '🚀',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+      expect(json.details.fieldErrors.emoji).toBeDefined();
+    });
+
+    it('returns 400 when url is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makePostRequest('/api/music/library/react', {
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when emoji is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/123',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const json = await res.json();
+      expect(json.error).toBe('Invalid input');
+    });
+
+    it('accepts fire emoji (🔥)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      // Existing reaction check
+      const existingCheck = chainMock({ data: null });
+
+      // Insert reaction
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+
+      // Get reaction counts
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/123',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        reacted: true,
+        reactions: {},
+      });
+    });
+
+    it('accepts heart emoji (❤️)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/456',
+        emoji: '❤️',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.reacted).toBe(true);
+    });
+
+    it('accepts music note emoji (🎵)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/789',
+        emoji: '🎵',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.reacted).toBe(true);
+    });
+
+    it('accepts gem emoji (💎)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/gem',
+        emoji: '💎',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).reacted).toBe(true);
+    });
+
+    it('accepts hands clapping emoji (👏)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('youtube');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://youtube.com/watch?v=abc',
+        emoji: '👏',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).reacted).toBe(true);
+    });
+
+    it('accepts exploding head emoji (🤯)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('soundcloud');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://soundcloud.com/artist/track',
+        emoji: '🤯',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).reacted).toBe(true);
+    });
+
+    it('calls upsertSong with correct params', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const url = 'https://spotify.com/track/abc123';
+      const req = makePostRequest('/api/music/library/react', {
+        url,
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockUpsertSong).toHaveBeenCalledWith({
+        url,
+        platform: 'spotify',
+        submittedByFid: 789,
+        source: 'manual',
+      });
+      expect(mockUpsertSong).toHaveBeenCalledTimes(1);
+    });
+
+    it('toggles reaction off when user already reacted with same emoji', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: false });
+
+      // Existing reaction found
+      const existingReaction = { id: 'reaction-123' };
+      const existingCheck = chainMock({ data: existingReaction });
+
+      const deleteReaction = chainMock({});
+
+      const reactionCount = chainMock({ data: [{ emoji: '❤️' }] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return deleteReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/existing',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.reacted).toBe(false);
+      expect(json.reactions).toEqual({ '❤️': 1 });
+    });
+
+    it('returns reaction counts after adding new reaction', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 555 }));
+      mockIsMusicUrl.mockReturnValue('youtube');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'new-reaction' } });
+
+      const reactionCounts = [{ emoji: '🔥' }, { emoji: '🔥' }, { emoji: '❤️' }, { emoji: '🤯' }];
+      const countChain = chainMock({ data: reactionCounts });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return countChain.chain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://youtube.com/watch?v=xyz',
+        emoji: '🤯',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({
+        reacted: true,
+        reactions: {
+          '🔥': 2,
+          '❤️': 1,
+          '🤯': 1,
+        },
+      });
+    });
+
+    it('uses isMusicUrl to detect platform when not provided', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('soundcloud');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+      const insertReaction = chainMock({ data: { id: 'reaction-1' } });
+      const reactionCount = chainMock({ data: [] });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          if (callsToFrom === 2) return insertReaction.chain;
+          return reactionCount.chain;
+        }
+        return {};
+      });
+
+      const url = 'https://soundcloud.com/artist/song';
+      const req = makePostRequest('/api/music/library/react', {
+        url,
+        emoji: '❤️',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect(mockIsMusicUrl).toHaveBeenCalledWith(url);
+    });
+
+    it('returns 500 when upsertSong throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      mockUpsertSong.mockRejectedValue(new Error('Upsert failed'));
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/fail',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to toggle reaction' });
+    });
+
+    it('returns 500 when existing reaction check fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      // Create a chain that rejects when awaited
+      const failError = new Error('Query failed');
+      const existingCheckChain: Record<string, ReturnType<typeof vi.fn>> = {};
+      const chainable = [
+        'select',
+        'insert',
+        'update',
+        'upsert',
+        'delete',
+        'eq',
+        'neq',
+        'in',
+        'not',
+        'is',
+        'gt',
+        'gte',
+        'lt',
+        'lte',
+        'like',
+        'ilike',
+        'order',
+        'range',
+        'limit',
+        'maybeSingle',
+      ];
+      for (const method of chainable) {
+        existingCheckChain[method] = vi.fn().mockReturnValue(existingCheckChain);
+      }
+      // biome-ignore lint/suspicious/noThenProperty: intentionally testing thenable
+      existingCheckChain.then = vi.fn((_resolve: unknown, reject: (err: unknown) => void) => {
+        reject(failError);
+      });
+
+      mockFrom.mockReturnValue(existingCheckChain);
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/fail',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to toggle reaction' });
+    });
+
+    it('returns 500 when delete reaction fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: false });
+
+      const existingReaction = { id: 'reaction-123' };
+      const existingCheck = chainMock({ data: existingReaction });
+
+      // Create a chain that rejects when awaited
+      const failError = new Error('Delete failed');
+      const deleteReactionChain: Record<string, ReturnType<typeof vi.fn>> = {};
+      const chainable = [
+        'select',
+        'insert',
+        'update',
+        'upsert',
+        'delete',
+        'eq',
+        'neq',
+        'in',
+        'not',
+        'is',
+        'gt',
+        'gte',
+        'lt',
+        'lte',
+        'like',
+        'ilike',
+        'order',
+        'range',
+        'limit',
+        'maybeSingle',
+      ];
+      for (const method of chainable) {
+        deleteReactionChain[method] = vi.fn().mockReturnValue(deleteReactionChain);
+      }
+      // biome-ignore lint/suspicious/noThenProperty: intentionally testing thenable
+      deleteReactionChain.then = vi.fn((_resolve: unknown, reject: (err: unknown) => void) => {
+        reject(failError);
+      });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          return deleteReactionChain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/delete-fail',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to toggle reaction' });
+    });
+
+    it('returns 500 when insert reaction fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+      mockIsMusicUrl.mockReturnValue('spotify');
+
+      const songId = VALID_UUID;
+      mockUpsertSong.mockResolvedValue({ id: songId, isNew: true });
+
+      const existingCheck = chainMock({ data: null });
+
+      // Create a chain that rejects when awaited
+      const failError = new Error('Insert failed');
+      const insertReactionChain: Record<string, ReturnType<typeof vi.fn>> = {};
+      const chainable = [
+        'select',
+        'insert',
+        'update',
+        'upsert',
+        'delete',
+        'eq',
+        'neq',
+        'in',
+        'not',
+        'is',
+        'gt',
+        'gte',
+        'lt',
+        'lte',
+        'like',
+        'ilike',
+        'order',
+        'range',
+        'limit',
+        'maybeSingle',
+      ];
+      for (const method of chainable) {
+        insertReactionChain[method] = vi.fn().mockReturnValue(insertReactionChain);
+      }
+      // biome-ignore lint/suspicious/noThenProperty: intentionally testing thenable
+      insertReactionChain.then = vi.fn((_resolve: unknown, reject: (err: unknown) => void) => {
+        reject(failError);
+      });
+
+      let callsToFrom = 0;
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'song_reactions') {
+          callsToFrom += 1;
+          if (callsToFrom === 1) return existingCheck.chain;
+          return insertReactionChain;
+        }
+        return {};
+      });
+
+      const req = makePostRequest('/api/music/library/react', {
+        url: 'https://spotify.com/track/insert-fail',
+        emoji: '🔥',
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'Failed to toggle reaction' });
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **143 tests total**. External Farcaster-verify/Neynar fully mocked — no real network.

| Route | Tests | Covers |
|-------|-------|--------|
| `music/library` | 64 | GET query (Zod search/platform/sort/filter/limit-coerce), querySongs, POST add (isMusicUrl + metadata fetch + upsertSong), errors |
| `music/library/react` | 28 | GET reactions + POST toggle, emoji-allowlist Zod, upsertSong, supabase toggle, errors |
| `miniapp/webhook` | 14 | Farcaster webhook verify (parseWebhookEvent mocked), event handlers (added/removed/notifications on-off), supabase writes, errors |
| `admin/users/import` | 37 | admin guard, allowlist→users import, wallet/FID dedupe, getUsersByFids enrichment, unique-constraint skip, counts, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`.

**Minor hardening note (not fixed — your call):** `miniapp/webhook` doesn't check the `.error` field on supabase responses (only catches thrown exceptions), so a silent DB error is treated as success. Low severity (webhook, best-effort). Tests document current behavior. Suggest `if (error) throw error` after each supabase op if you want it hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)