### PR TITLE
test(auth,admin,fractals,music): lastfm/agents-status/webhook/generate (143 tests)

### DIFF
--- a/src/app/api/admin/agents/status/__tests__/route.test.ts
+++ b/src/app/api/admin/agents/status/__tests__/route.test.ts
@@ -1,0 +1,866 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from '@/components/admin/agents/constants';
+import { AGENTS } from '@/components/admin/agents/constants';
+import {
+  chainMock,
+  makeGetRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+/**
+ * Create a mock agent event for testing
+ */
+function createMockAgentEvent(overrides?: Partial<AgentEvent>): AgentEvent {
+  const now = new Date().toISOString();
+  return {
+    id: '550e8400-e29b-41d4-a716-446655440000',
+    agent_name: 'zoe',
+    event_type: 'task_started',
+    summary: 'Processing task',
+    payload: {},
+    dispatched_by: null,
+    notified_at: null,
+    created_at: now,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// GET /api/admin/agents/status
+// ============================================================================
+
+describe('GET /api/admin/agents/status', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('squad view (default)', () => {
+    it('returns 200 with agents array on default view', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(body.agents)).toBe(true);
+    });
+
+    it('returns all agents from AGENTS constant', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.agents).toHaveLength(AGENTS.length);
+      expect(body.agents.map((a: (typeof AGENTS)[0]) => a.name)).toEqual(AGENTS.map((a) => a.name));
+    });
+
+    it('derives status as idle when agent has no events', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.status).toBe('idle');
+      expect(zoeAgent.last_event).toBeNull();
+      expect(zoeAgent.current_task).toBeNull();
+    });
+
+    it('derives status as active when last event is task_started', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'zoe',
+        event_type: 'task_started',
+        summary: 'Running important task',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.status).toBe('active');
+      expect(zoeAgent.last_event).toEqual(event);
+      expect(zoeAgent.current_task).toBe('Running important task');
+    });
+
+    it('derives status as error when last event is task_failed', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'builder',
+        event_type: 'task_failed',
+        summary: 'Build failed',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const builderAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'builder');
+      expect(builderAgent.status).toBe('error');
+      expect(builderAgent.last_event?.event_type).toBe('task_failed');
+    });
+
+    it('derives status as error when last event is blocked', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'scout',
+        event_type: 'blocked',
+        summary: 'Rate limited',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const scoutAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'scout');
+      expect(scoutAgent.status).toBe('error');
+    });
+
+    it('derives status as approval_needed when last event requires approval', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'wallet',
+        event_type: 'approval_needed',
+        summary: 'Needs approval',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const walletAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'wallet');
+      expect(walletAgent.status).toBe('approval_needed');
+    });
+
+    it('derives status as idle when last event is task_completed', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'caster',
+        event_type: 'task_completed',
+        summary: 'Task done',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const casterAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'caster');
+      expect(casterAgent.status).toBe('idle');
+    });
+
+    it('sets current_task to event summary when event_type is task_started', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'zoe',
+        event_type: 'task_started',
+        summary: 'Building feature X',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.current_task).toBe('Building feature X');
+    });
+
+    it('sets current_task to null when event_type is not task_started', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'zoe',
+        event_type: 'task_completed',
+        summary: 'Task complete',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.current_task).toBeNull();
+    });
+
+    it('counts events in last 24 hours per agent', async () => {
+      const now = new Date();
+      const events: AgentEvent[] = [
+        createMockAgentEvent({
+          agent_name: 'zoe',
+          created_at: now.toISOString(),
+        }),
+        createMockAgentEvent({
+          agent_name: 'zoe',
+          created_at: new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
+        }),
+        createMockAgentEvent({
+          agent_name: 'zoe',
+          created_at: new Date(now.getTime() - 12 * 60 * 60 * 1000).toISOString(),
+        }),
+        createMockAgentEvent({
+          agent_name: 'builder',
+          created_at: now.toISOString(),
+        }),
+      ];
+
+      const latestChain = chainMock({ data: [events[0]], error: null }).chain;
+      const countsChain = chainMock({ data: events, error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.events_24h).toBe(3);
+
+      const builderAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'builder');
+      expect(builderAgent.events_24h).toBe(1);
+    });
+
+    it('queries latest 50 events ordered by created_at descending', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      await GET(makeGetRequest('/api/admin/agents/status'));
+
+      const firstFromCall = mockFrom.mock.calls[0];
+      expect(firstFromCall).toEqual(['agent_events']);
+
+      const latestChainSelect = vi.mocked(latestChain.select);
+      expect(latestChainSelect).toHaveBeenCalledWith('*');
+
+      const latestChainOrder = vi.mocked(latestChain.order);
+      expect(latestChainOrder).toHaveBeenCalledWith('created_at', { ascending: false });
+
+      const latestChainLimit = vi.mocked(latestChain.limit);
+      expect(latestChainLimit).toHaveBeenCalledWith(50);
+    });
+
+    it('queries events from last 24 hours for counts', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      await GET(makeGetRequest('/api/admin/agents/status'));
+
+      const countsChainSelect = vi.mocked(countsChain.select);
+      expect(countsChainSelect).toHaveBeenCalledWith('agent_name');
+
+      const countsChainGte = vi.mocked(countsChain.gte);
+      expect(countsChainGte).toHaveBeenCalled();
+      const [field, _timestamp] = countsChainGte.mock.calls[0] as unknown as [string, string];
+      expect(field).toBe('created_at');
+    });
+
+    it('returns agent with all required fields', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'zoe',
+        event_type: 'task_started',
+        summary: 'Test task',
+      });
+
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents[0];
+      expect(zoeAgent).toHaveProperty('name');
+      expect(zoeAgent).toHaveProperty('label');
+      expect(zoeAgent).toHaveProperty('emoji');
+      expect(zoeAgent).toHaveProperty('color');
+      expect(zoeAgent).toHaveProperty('role');
+      expect(zoeAgent).toHaveProperty('status');
+      expect(zoeAgent).toHaveProperty('current_task');
+      expect(zoeAgent).toHaveProperty('last_event');
+      expect(zoeAgent).toHaveProperty('events_24h');
+    });
+
+    it('picks most recent event for each agent from latest 50', async () => {
+      const now = new Date();
+      const zoeEvent1 = createMockAgentEvent({
+        agent_name: 'zoe',
+        created_at: new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
+        event_type: 'task_completed',
+      });
+      const zoeEvent2 = createMockAgentEvent({
+        agent_name: 'zoe',
+        created_at: now.toISOString(),
+        event_type: 'task_started',
+        summary: 'Current task',
+      });
+
+      // Simulating latest events ordered by created_at DESC, so zoeEvent2 comes first
+      const latestChain = chainMock({ data: [zoeEvent2, zoeEvent1], error: null }).chain;
+      const countsChain = chainMock({ data: [zoeEvent2, zoeEvent1], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      // Should pick the first one (most recent)
+      expect(zoeAgent.last_event).toEqual(zoeEvent2);
+      expect(zoeAgent.current_task).toBe('Current task');
+    });
+  });
+
+  describe('detailed events view', () => {
+    it('returns events array when view=detailed', async () => {
+      const event = createMockAgentEvent({ agent_name: 'zoe' });
+      const chain = chainMock({ data: [event], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', { view: 'detailed' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(body.events)).toBe(true);
+      expect(body.events).toEqual([event]);
+    });
+
+    it('respects agent filter in detailed view', async () => {
+      const event = createMockAgentEvent({ agent_name: 'builder' });
+      const chain = chainMock({ data: [event], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        agent: 'builder',
+      });
+      await GET(req);
+
+      const eqCall = vi.mocked(chain.eq);
+      expect(eqCall).toHaveBeenCalledWith('agent_name', 'builder');
+    });
+
+    it('respects event_type filter in detailed view', async () => {
+      const event = createMockAgentEvent({ event_type: 'task_failed' });
+      const chain = chainMock({ data: [event], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        event_type: 'task_failed',
+      });
+      await GET(req);
+
+      const eqCall = vi.mocked(chain.eq);
+      expect(eqCall).toHaveBeenCalledWith('event_type', 'task_failed');
+    });
+
+    it('respects since timestamp filter in detailed view', async () => {
+      const event = createMockAgentEvent();
+      const chain = chainMock({ data: [event], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const timestamp = '2026-07-15T00:00:00Z';
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        since: timestamp,
+      });
+      await GET(req);
+
+      const gteCall = vi.mocked(chain.gte);
+      expect(gteCall).toHaveBeenCalledWith('created_at', timestamp);
+    });
+
+    it('respects custom limit (max 200)', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        limit: '100',
+      });
+      await GET(req);
+
+      const limitCall = vi.mocked(chain.limit);
+      expect(limitCall).toHaveBeenCalledWith(100);
+    });
+
+    it('caps limit at 200 when higher value provided', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        limit: '500',
+      });
+      await GET(req);
+
+      const limitCall = vi.mocked(chain.limit);
+      expect(limitCall).toHaveBeenCalledWith(200);
+    });
+
+    it('defaults to limit 50 when not specified', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', { view: 'detailed' });
+      await GET(req);
+
+      const limitCall = vi.mocked(chain.limit);
+      expect(limitCall).toHaveBeenCalledWith(50);
+    });
+
+    it('combines multiple filters in detailed view', async () => {
+      const event = createMockAgentEvent({
+        agent_name: 'scout',
+        event_type: 'blocked',
+      });
+      const chain = chainMock({ data: [event], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const timestamp = '2026-07-15T00:00:00Z';
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        agent: 'scout',
+        event_type: 'blocked',
+        since: timestamp,
+        limit: '75',
+      });
+      await GET(req);
+
+      const eqCalls = vi.mocked(chain.eq).mock.calls;
+      expect(eqCalls).toContainEqual(['agent_name', 'scout']);
+      expect(eqCalls).toContainEqual(['event_type', 'blocked']);
+
+      const gteCalls = vi.mocked(chain.gte).mock.calls;
+      expect(gteCalls).toContainEqual(['created_at', timestamp]);
+
+      const limitCall = vi.mocked(chain.limit);
+      expect(limitCall).toHaveBeenCalledWith(75);
+    });
+
+    it('returns empty events array when no events match filters', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        agent: 'nonexistent',
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.events).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 200 with agents even when squad view query has error (route does not check error field)', async () => {
+      // NOTE: This is a bug in the route — it should check latestResult.error and countsResult.error
+      // but currently it silently treats errors as empty results
+      const dbError = new Error('Database error');
+      const latestChain = chainMock({ data: null, error: dbError }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      // Route does not validate error field, returns 200 with agents
+      expect(res.status).toBe(200);
+      expect(Array.isArray(body.agents)).toBe(true);
+    });
+
+    it('returns 500 when detailed view query fails', async () => {
+      const dbError = new Error('Database error');
+      const chain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', { view: 'detailed' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch events');
+    });
+
+    it('returns 500 when exception is thrown', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+    });
+
+    it('logs error to logger.error on exception', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Query failed');
+      });
+
+      await GET(makeGetRequest('/api/admin/agents/status'));
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Agent status error:',
+        expect.any(Error),
+      );
+    });
+
+    it('logs detailed error on query error', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = new Error('Connection timeout');
+      const chain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await GET(makeGetRequest('/api/admin/agents/status', { view: 'detailed' }));
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Agent events query error:', dbError);
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const sensitiveError = new Error('Password: secret123, host: db.internal');
+      mockFrom.mockImplementation(() => {
+        throw sensitiveError;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.error).toBe('Internal server error');
+      expect(body.details).toBeUndefined();
+      expect(JSON.stringify(body)).not.toContain('secret123');
+      expect(JSON.stringify(body)).not.toContain('db.internal');
+    });
+  });
+
+  describe('response structure', () => {
+    it('squad view response has correct shape', async () => {
+      const latestChain = chainMock({ data: [], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body).toHaveProperty('agents');
+      expect(body.agents).toBeInstanceOf(Array);
+      expect(body.error).toBeUndefined();
+      expect(body.events).toBeUndefined();
+    });
+
+    it('detailed view response has correct shape', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', { view: 'detailed' });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body).toHaveProperty('events');
+      expect(body.events).toBeInstanceOf(Array);
+      expect(body.error).toBeUndefined();
+      expect(body.agents).toBeUndefined();
+    });
+
+    it('error response has correct shape', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body).toHaveProperty('error');
+      expect(body.agents).toBeUndefined();
+      expect(body.events).toBeUndefined();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles null payload in agent events', async () => {
+      const event = createMockAgentEvent({
+        payload: null as unknown as Record<string, unknown>,
+      });
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('handles missing summary in agent events', async () => {
+      const event = createMockAgentEvent({
+        event_type: 'task_started',
+        summary: null,
+      });
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [event], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const agent = body.agents[0];
+      expect(agent.current_task).toBeNull();
+    });
+
+    it('handles invalid limit parameter gracefully', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makeGetRequest('/api/admin/agents/status', {
+        view: 'detailed',
+        limit: 'not-a-number',
+      });
+      await GET(req);
+
+      // NaN behavior: Math.min(NaN, 200) = NaN, but route uses Number() which parses to NaN
+      // The implementation calls Math.min(Number('not-a-number'), 200) = Math.min(NaN, 200) = NaN
+      // Then limit(NaN) is called. This tests the actual behavior.
+      const limitCall = vi.mocked(chain.limit);
+      expect(limitCall).toHaveBeenCalled();
+    });
+
+    it('handles empty events array from counts query', async () => {
+      const event = createMockAgentEvent({ agent_name: 'zoe' });
+      const latestChain = chainMock({ data: [event], error: null }).chain;
+      const countsChain = chainMock({ data: [], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.events_24h).toBe(0);
+    });
+
+    it('handles multiple events for same agent, uses first (most recent)', async () => {
+      const now = new Date();
+      const event1 = createMockAgentEvent({
+        agent_name: 'zoe',
+        created_at: now.toISOString(),
+        event_type: 'task_started',
+        summary: 'Task 1',
+      });
+      const event2 = createMockAgentEvent({
+        agent_name: 'zoe',
+        created_at: new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
+        event_type: 'task_completed',
+        summary: 'Task 2',
+      });
+
+      const latestChain = chainMock({ data: [event1, event2], error: null }).chain;
+      const countsChain = chainMock({ data: [event1, event2], error: null }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? latestChain : countsChain;
+      });
+
+      const req = makeGetRequest('/api/admin/agents/status');
+      const res = await GET(req);
+      const body = await res.json();
+
+      const zoeAgent = body.agents.find((a: (typeof AGENTS)[0]) => a.name === 'zoe');
+      expect(zoeAgent.last_event).toEqual(event1);
+      expect(zoeAgent.current_task).toBe('Task 1');
+      expect(zoeAgent.status).toBe('active');
+    });
+  });
+});

--- a/src/app/api/auth/lastfm/__tests__/route.test.ts
+++ b/src/app/api/auth/lastfm/__tests__/route.test.ts
@@ -1,0 +1,556 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+import { GET } from '../route';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetAuthUrl } = vi.hoisted(() => ({
+  mockGetAuthUrl: vi.fn(),
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+  },
+}));
+
+vi.mock('@/lib/music/lastfm', () => ({
+  getAuthUrl: mockGetAuthUrl,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/auth/lastfm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+  });
+
+  // ── Authentication ────────────────────────────────────────────────────────
+
+  describe('authentication', () => {
+    it('returns 401 when session is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session.fid is falsy (0)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 0 }));
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('allows authenticated session with valid fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  // ── Supabase query chain ──────────────────────────────────────────────────
+
+  describe('supabase user_settings query', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    });
+
+    it('queries user_settings table with correct fid', async () => {
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockFrom).toHaveBeenCalledWith('user_settings');
+      expect(supabaseChain.chain.select).toHaveBeenCalledWith('lastfm_session_key');
+      expect(supabaseChain.chain.eq).toHaveBeenCalledWith('fid', 456);
+      expect(supabaseChain.chain.single).toHaveBeenCalled();
+    });
+
+    it('chains query methods in correct order', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'session123' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      // Verify chain is called: from().select().eq().single()
+      expect(mockFrom).toHaveBeenCalledBefore(supabaseChain.chain.select);
+      expect(supabaseChain.chain.select).toHaveBeenCalledBefore(supabaseChain.chain.eq);
+      expect(supabaseChain.chain.eq).toHaveBeenCalledBefore(supabaseChain.chain.single);
+    });
+  });
+
+  // ── Connected status (already has Last.fm session) ────────────────────────
+
+  describe('connected status (lastfm_session_key present)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+    });
+
+    it('returns connected=true when lastfm_session_key exists', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'existing_session_key_abc123' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(true);
+      expect(body.connectUrl).toBeNull();
+    });
+
+    it('does not call getAuthUrl when already connected', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'existing_key' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockGetAuthUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns connectUrl=null when already connected', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'some_key' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      const body = await res.json();
+      expect(body.connectUrl).toBeNull();
+    });
+  });
+
+  // ── Not connected (needs auth URL) ────────────────────────────────────────
+
+  describe('not connected (no lastfm_session_key)', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 101 }));
+    });
+
+    it('returns connected=false when lastfm_session_key is missing', async () => {
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue(
+        'https://www.last.fm/api/auth/?api_key=test&cb=http://localhost:3000/api/auth/lastfm/callback',
+      );
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+    });
+
+    it('calls getAuthUrl with callback URL', async () => {
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockGetAuthUrl).toHaveBeenCalledWith('http://localhost:3000/api/auth/lastfm/callback');
+    });
+
+    it('uses NEXT_PUBLIC_APP_URL env var for callback if set', async () => {
+      process.env.NEXT_PUBLIC_APP_URL = 'https://example.com';
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockGetAuthUrl).toHaveBeenCalledWith('https://example.com/api/auth/lastfm/callback');
+    });
+
+    it('falls back to localhost:3000 when NEXT_PUBLIC_APP_URL is not set', async () => {
+      delete process.env.NEXT_PUBLIC_APP_URL;
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockGetAuthUrl).toHaveBeenCalledWith('http://localhost:3000/api/auth/lastfm/callback');
+    });
+
+    it('returns connectUrl from getAuthUrl', async () => {
+      const expectedUrl =
+        'https://www.last.fm/api/auth/?api_key=test_key&cb=http://localhost:3000/api/auth/lastfm/callback';
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue(expectedUrl);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      const body = await res.json();
+      expect(body.connectUrl).toBe(expectedUrl);
+    });
+  });
+
+  // ── Edge case: user_settings has null lastfm_session_key ──────────────────
+
+  describe('edge case: lastfm_session_key is null', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 202 }));
+    });
+
+    it('treats null lastfm_session_key as not connected', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: null },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+      expect(body.connectUrl).toBeTruthy();
+      expect(mockGetAuthUrl).toHaveBeenCalled();
+    });
+
+    it('treats empty string lastfm_session_key as not connected', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: '' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+      expect(mockGetAuthUrl).toHaveBeenCalled();
+    });
+  });
+
+  // ── Error handling ────────────────────────────────────────────────────────
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 303 }));
+    });
+
+    it('returns 500 when supabase query throws', async () => {
+      const supabaseChain = chainMock({});
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      supabaseChain.chain.single.mockRejectedValue(new Error('Supabase connection failed'));
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to check status');
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+
+    it('returns 500 when getSessionData throws', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('Session read error'));
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to check status');
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+
+    it('returns 500 when getAuthUrl throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 404 }));
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockImplementation(() => {
+        throw new Error('Last.fm API key missing');
+      });
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to check status');
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+
+    it('logs error details when exception occurs', async () => {
+      const testError = new Error('Detailed error message');
+      mockGetSessionData.mockRejectedValue(testError);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      await GET(req);
+
+      expect(mockLoggerError).toHaveBeenCalledWith('[lastfm/status] Error:', testError);
+    });
+
+    it('handles non-Error thrown values', async () => {
+      const supabaseChain = chainMock({});
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      supabaseChain.chain.single.mockRejectedValue('string error');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to check status');
+    });
+  });
+
+  // ── Response shape ────────────────────────────────────────────────────────
+
+  describe('response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 505 }));
+    });
+
+    it('returns JSON with connected and connectUrl fields (not connected)', async () => {
+      const authUrl = 'https://www.last.fm/api/auth/?api_key=key&cb=callback';
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue(authUrl);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('connected');
+      expect(body).toHaveProperty('connectUrl');
+      expect(Object.keys(body)).toHaveLength(2);
+      expect(body.connected).toBe(false);
+      expect(body.connectUrl).toBe(authUrl);
+    });
+
+    it('returns JSON with connected and connectUrl fields (connected)', async () => {
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'key' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toHaveProperty('connected');
+      expect(body).toHaveProperty('connectUrl');
+      expect(Object.keys(body)).toHaveLength(2);
+      expect(body.connected).toBe(true);
+      expect(body.connectUrl).toBeNull();
+    });
+
+    it('returns content-type: application/json on success', async () => {
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+
+    it('returns content-type: application/json on error', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('Session error'));
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+  });
+
+  // ── Integration scenario ──────────────────────────────────────────────────
+
+  describe('integration scenarios', () => {
+    it('complete flow: user not connected → returns auth URL', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 606 }));
+
+      const supabaseChain = chainMock({
+        data: null,
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const expectedUrl =
+        'https://www.last.fm/api/auth/?api_key=abc&cb=http://localhost:3000/api/auth/lastfm/callback';
+      mockGetAuthUrl.mockReturnValue(expectedUrl);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(false);
+      expect(body.connectUrl).toBe(expectedUrl);
+
+      expect(mockFrom).toHaveBeenCalledWith('user_settings');
+      expect(supabaseChain.chain.select).toHaveBeenCalledWith('lastfm_session_key');
+      expect(supabaseChain.chain.eq).toHaveBeenCalledWith('fid', 606);
+      expect(mockGetAuthUrl).toHaveBeenCalledWith('http://localhost:3000/api/auth/lastfm/callback');
+    });
+
+    it('complete flow: user already connected → no auth URL', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 707 }));
+
+      const supabaseChain = chainMock({
+        data: { lastfm_session_key: 'user_session_xyz' },
+        error: null,
+      });
+      mockFrom.mockReturnValue(supabaseChain.chain);
+
+      const req = makeGetRequest('/api/auth/lastfm');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.connected).toBe(true);
+      expect(body.connectUrl).toBeNull();
+
+      expect(mockFrom).toHaveBeenCalledWith('user_settings');
+      expect(mockGetAuthUrl).not.toHaveBeenCalled();
+    });
+
+    it('handles multiple sequential requests with different fids', async () => {
+      const supabaseChain1 = chainMock({
+        data: null,
+        error: null,
+      });
+      const supabaseChain2 = chainMock({
+        data: { lastfm_session_key: 'key' },
+        error: null,
+      });
+
+      mockFrom.mockReturnValueOnce(supabaseChain1.chain).mockReturnValueOnce(supabaseChain2.chain);
+
+      mockGetAuthUrl.mockReturnValue('https://www.last.fm/api/auth/?api_key=test&cb=...');
+
+      // First request: fid=808, not connected
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 808 }));
+      let req = makeGetRequest('/api/auth/lastfm');
+      let res = await GET(req);
+      expect((await res.json()).connected).toBe(false);
+
+      // Second request: fid=909, already connected
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 909 }));
+      req = makeGetRequest('/api/auth/lastfm');
+      res = await GET(req);
+      expect((await res.json()).connected).toBe(true);
+
+      expect(supabaseChain1.chain.eq).toHaveBeenCalledWith('fid', 808);
+      expect(supabaseChain2.chain.eq).toHaveBeenCalledWith('fid', 909);
+    });
+  });
+});

--- a/src/app/api/fractals/webhook/__tests__/route.test.ts
+++ b/src/app/api/fractals/webhook/__tests__/route.test.ts
@@ -1,0 +1,893 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/test-utils/api-helpers';
+
+// FIFO chain: queries pop results from a queue in order.
+// Each awaited call (via .then or .single()) consumes one result from the queue.
+function queuedChain(results: Array<{ data?: unknown; error?: unknown }>) {
+  const q = [...results];
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods — each returns the chain for further chaining
+  for (const m of ['select', 'insert', 'update', 'upsert', 'delete', 'eq', 'maybeSingle']) {
+    chain[m] = vi.fn(() => chain);
+  }
+
+  // Terminal method .single() returns a promise that resolves to the next queued result
+  chain.single = vi.fn(() => Promise.resolve(q.shift() ?? { data: null, error: null }));
+
+  // Allow the chain to be awaited directly (for queries without .single())
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) =>
+    resolve(q.shift() ?? { data: null, error: null });
+
+  return chain;
+}
+
+// Create a Supabase mock that returns new FIFO chains on each from() call
+function createSupabaseMock(results: Array<{ data?: unknown; error?: unknown }>[]) {
+  let callIndex = 0;
+  return {
+    from: () => {
+      const chainResults = results[callIndex] || [];
+      callIndex++;
+      return queuedChain([...chainResults]);
+    },
+  };
+}
+
+const { mockGetSupabaseAdmin } = vi.hoisted(() => ({
+  mockGetSupabaseAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: new Proxy({} as unknown, {
+    get(_target, prop) {
+      return (mockGetSupabaseAdmin() as unknown as Record<string | symbol, unknown>)[prop];
+    },
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/fractals/webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+  });
+
+  describe('Bearer token authentication', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when Bearer token is wrong', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer wrong-token-value');
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when Bearer token is empty string', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer ');
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 503 when FRACTAL_BOT_WEBHOOK_SECRET env is not set', async () => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', '');
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.error).toBe('Webhook not configured');
+    });
+
+    it('accepts correct Bearer token', async () => {
+      // Setup supabase mock for upsert + logEvent
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // fractal_sessions upsert
+          [{ data: null, error: null }], // fractal_events insert
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('fractal_started');
+    });
+  });
+
+  describe('Request validation', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 400 when request body is invalid JSON', async () => {
+      const req = new Request('http://localhost:3000/api/fractals/webhook', {
+        method: 'POST',
+        body: 'not valid json {]',
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req as unknown as Parameters<typeof POST>[0]);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid JSON');
+    });
+
+    it('returns 400 when fractalId is missing', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+
+    it('returns 400 when event type is missing', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+
+    it('returns 400 when event type is unknown', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'unknown_event',
+        data: {},
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+
+    it('returns 400 when data object is missing', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+
+    it('returns 400 when fractalId exceeds max length', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'x'.repeat(201),
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+
+    it('returns 400 when fractalId is empty', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: '',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid payload');
+    });
+  });
+
+  describe('fractal_started event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes fractal_started with all required fields', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // upsert fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test Fractal',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2', 'p3'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('fractal_started');
+    });
+
+    it('returns 400 when fractal_started data has missing threadId', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          name: 'Test Fractal',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for fractal_started');
+    });
+
+    it('returns 400 when fractal_started data has non-integer currentLevel', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test Fractal',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1.5,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for fractal_started');
+    });
+
+    it('returns 400 when fractal_started participantDiscordIds is not an array', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test Fractal',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: 'not-an-array',
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for fractal_started');
+    });
+
+    it('returns 500 when fractal_sessions upsert fails', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: new Error('Database constraint violation') }], // upsert fails
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test Fractal',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1', 'p2'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process event');
+    });
+  });
+
+  describe('vote_cast event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes vote_cast event', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'vote_cast',
+        data: {
+          voterId: 'voter-1',
+          candidateId: 'candidate-1',
+          level: 2,
+          totalVotes: 5,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('vote_cast');
+    });
+
+    it('returns 400 when vote_cast data has missing voterId', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'vote_cast',
+        data: {
+          candidateId: 'candidate-1',
+          level: 2,
+          totalVotes: 5,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for vote_cast');
+    });
+
+    it('returns 400 when vote_cast totalVotes is negative', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'vote_cast',
+        data: {
+          voterId: 'voter-1',
+          candidateId: 'candidate-1',
+          level: 2,
+          totalVotes: -1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200); // totalVotes is just an int, no min/max constraint in schema
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+  });
+
+  describe('round_complete event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes round_complete event', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'round_complete',
+        data: {
+          level: 1,
+          winnerId: 'winner-1',
+          totalVotes: 5,
+          voteDistribution: { 'candidate-1': 3, 'candidate-2': 2 },
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('round_complete');
+    });
+
+    it('returns 400 when round_complete voteDistribution is not an object', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'round_complete',
+        data: {
+          level: 1,
+          winnerId: 'winner-1',
+          totalVotes: 5,
+          voteDistribution: 'not an object',
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for round_complete');
+    });
+  });
+
+  describe('fractal_complete event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes fractal_complete with scores insertion', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: { id: 'session-1' }, error: null }], // update fractal_sessions + select id
+          [{ data: null, error: null }], // insert fractal_scores
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_complete',
+        data: {
+          results: [
+            { discordId: 'user-1', rank: 1, level: 3 },
+            { discordId: 'user-2', rank: 2, level: 3 },
+          ],
+          totalRounds: 3,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('fractal_complete');
+    });
+
+    it('returns 500 when fractal_complete session update fails', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: new Error('Session not found') }], // update fails
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_complete',
+        data: {
+          results: [{ discordId: 'user-1', rank: 1, level: 3 }],
+          totalRounds: 3,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to process event');
+    });
+
+    it('returns 400 when fractal_complete results array has invalid rank', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_complete',
+        data: {
+          results: [{ discordId: 'user-1', rank: 1.5, level: 3 }],
+          totalRounds: 3,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for fractal_complete');
+    });
+
+    it('returns 200 and continues when fractal_complete scores insert fails (non-fatal)', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: { id: 'session-1' }, error: null }], // update session succeeds
+          [{ data: null, error: new Error('Scores insert failed') }], // scores insert fails (non-fatal)
+          [{ data: null, error: null }], // insert fractal_events succeeds
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_complete',
+        data: {
+          results: [{ discordId: 'user-1', rank: 1, level: 3 }],
+          totalRounds: 3,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+  });
+
+  describe('fractal_paused event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes fractal_paused event', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_paused',
+        data: {
+          currentLevel: 2,
+          pausedAt: '2026-07-15T12:00:00Z',
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('fractal_paused');
+    });
+
+    it('returns 200 when fractal_paused pausedAt is optional', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_paused',
+        data: {
+          currentLevel: 2,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+
+    it('returns 400 when fractal_paused currentLevel is missing', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_paused',
+        data: {
+          pausedAt: '2026-07-15T12:00:00Z',
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('Invalid data for fractal_paused');
+    });
+  });
+
+  describe('fractal_resumed event', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 and processes fractal_resumed event', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_resumed',
+        data: {
+          currentLevel: 2,
+          resumedAt: '2026-07-15T13:00:00Z',
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.event).toBe('fractal_resumed');
+    });
+
+    it('returns 200 when fractal_resumed resumedAt is optional', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // update fractal_sessions
+          [{ data: null, error: null }], // insert fractal_events
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_resumed',
+        data: {
+          currentLevel: 2,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+  });
+
+  describe('Error handling and edge cases', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns 200 even when fractal_events insert fails (non-fatal)', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // fractal_sessions update succeeds
+          [{ data: null, error: new Error('Events table missing') }], // fractal_events insert fails
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'vote_cast',
+        data: {
+          voterId: 'voter-1',
+          candidateId: 'candidate-1',
+          level: 1,
+          totalVotes: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+    });
+
+    it('logs error but continues when vote_cast update fails (non-fatal)', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: new Error('DB error on update') }], // fractal_sessions update fails
+          [{ data: null, error: null }], // fractal_events insert succeeds
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'vote_cast',
+        data: {
+          voterId: 'voter-1',
+          candidateId: 'candidate-1',
+          level: 1,
+          totalVotes: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(logger.error).toHaveBeenCalledWith(
+        '[fractal-webhook] vote_cast update error:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('Response shape', () => {
+    beforeEach(() => {
+      vi.stubEnv('FRACTAL_BOT_WEBHOOK_SECRET', 'test-webhook-secret-12345');
+    });
+
+    it('returns correct response shape for successful webhook', async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createSupabaseMock([
+          [{ data: null, error: null }], // fractal_sessions upsert
+          [{ data: null, error: null }], // fractal_events insert
+        ]),
+      );
+
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          threadId: 'thread-123',
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      const body = await res.json();
+      expect(body).toHaveProperty('ok', true);
+      expect(body).toHaveProperty('event', 'fractal_started');
+      expect(Object.keys(body)).toEqual(['ok', 'event']);
+    });
+
+    it('returns error response with details for validation failure', async () => {
+      const req = makePostRequest('/api/fractals/webhook', {
+        fractalId: 'thread-123',
+        event: 'fractal_started',
+        data: {
+          name: 'Test',
+          guildId: 'guild-1',
+          facilitatorDiscordId: 'fac-1',
+          participantDiscordIds: ['p1'],
+          currentLevel: 1,
+        },
+      });
+      req.headers.set('authorization', 'Bearer test-webhook-secret-12345');
+      const res = await POST(req);
+
+      const body = await res.json();
+      expect(body).toHaveProperty('error');
+      expect(body).toHaveProperty('details');
+    });
+  });
+});

--- a/src/app/api/music/generate/__tests__/route.test.ts
+++ b/src/app/api/music/generate/__tests__/route.test.ts
@@ -1,0 +1,640 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ===== Hoisted mocks =====
+const { mockGetSessionData, mockClientConnect } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockClientConnect: vi.fn(),
+}));
+
+// ===== Module mocks =====
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@gradio/client', () => {
+  return {
+    Client: {
+      connect: mockClientConnect,
+    },
+  };
+});
+
+// Set env var before importing route
+beforeEach(() => {
+  process.env.HF_TOKEN = 'hf_test-token-123456789';
+});
+
+import { POST } from '../route';
+
+// ===== Test fixtures =====
+
+const validGeneratePayload = {
+  prompt: 'upbeat electronic dance music with synth leads',
+  lyrics: 'Dance all night, feel the light',
+  duration: 30,
+};
+
+const validSession = mockAuthenticatedSession({ fid: 456, username: 'testuser' });
+
+// Mock Gradio client result with audio URL string
+const mockAudioResultString = 'https://huggingface.co/file/abc123/output.wav';
+
+// Mock Gradio client result with audio object containing url
+const mockAudioResultObject = {
+  url: 'https://huggingface.co/file/xyz789/output.wav',
+};
+
+describe('POST /api/music/generate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+    mockClientConnect.mockClear();
+  });
+
+  // ===== AUTHENTICATION TESTS =====
+  describe('authentication', () => {
+    it('returns 401 when no session is provided', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when getSessionData returns null (unauthenticated)', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('allows request when authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({
+        predict: mockPredict,
+      });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ===== VALIDATION TESTS =====
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 400 when prompt is empty', async () => {
+      const payload = { ...validGeneratePayload, prompt: '' };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string; details?: unknown };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when prompt is missing', async () => {
+      const payload = { lyrics: 'test' };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when prompt exceeds 500 characters', async () => {
+      const payload = { ...validGeneratePayload, prompt: 'a'.repeat(501) };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts prompt at minimum boundary (1 char)', async () => {
+      const payload = { ...validGeneratePayload, prompt: 'a' };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts prompt at maximum boundary (500 chars)', async () => {
+      const payload = { ...validGeneratePayload, prompt: 'a'.repeat(500) };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when lyrics exceeds 2000 characters', async () => {
+      const payload = { ...validGeneratePayload, lyrics: 'a'.repeat(2001) };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts lyrics at maximum boundary (2000 chars)', async () => {
+      const payload = { ...validGeneratePayload, lyrics: 'a'.repeat(2000) };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when duration is below 10', async () => {
+      const payload = { ...validGeneratePayload, duration: 9 };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when duration exceeds 120', async () => {
+      const payload = { ...validGeneratePayload, duration: 121 };
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts duration at minimum boundary (10 seconds)', async () => {
+      const payload = { ...validGeneratePayload, duration: 10 };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts duration at maximum boundary (120 seconds)', async () => {
+      const payload = { ...validGeneratePayload, duration: 120 };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ===== DEFAULT VALUE TESTS =====
+  describe('default values', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('uses empty string for lyrics when not provided', async () => {
+      const payload = { prompt: 'test music' };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ lyrics: '' }),
+      );
+    });
+
+    it('uses 30 seconds as default duration when not provided', async () => {
+      const payload = { prompt: 'test music' };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ audio_duration: 30 }),
+      );
+    });
+
+    it('passes specified lyrics to Gradio predict', async () => {
+      const lyrics = 'Custom song lyrics here';
+      const payload = { prompt: 'test', lyrics };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(mockPredict).toHaveBeenCalledWith('/generate', expect.objectContaining({ lyrics }));
+    });
+
+    it('passes specified duration to Gradio predict', async () => {
+      const payload = { prompt: 'test', duration: 45 };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ audio_duration: 45 }),
+      );
+    });
+  });
+
+  // ===== GRADIO CLIENT INTEGRATION TESTS =====
+  describe('Gradio Client integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 500 when HF_TOKEN is not configured', async () => {
+      delete process.env.HF_TOKEN;
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as {
+        audioUrl?: null;
+        message?: string;
+        mock?: boolean;
+      };
+
+      expect(res.status).toBe(200);
+      expect(body.audioUrl).toBe(null);
+      expect(body.mock).toBe(true);
+      expect(body.message).toBe('Set HF_TOKEN env var to enable AI music generation');
+    });
+
+    it('connects to ACE-Step Space with HF token', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+
+      expect(mockClientConnect).toHaveBeenCalledWith('ACE-Step/Ace-Step-v1.5', {
+        token: 'hf_test-token-123456789',
+      });
+    });
+
+    it('calls predict with /generate endpoint', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+
+      expect(mockPredict).toHaveBeenCalledWith('/generate', expect.any(Object));
+    });
+
+    it('passes all generation parameters to predict', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const payload = {
+        prompt: 'upbeat music',
+        lyrics: 'test lyrics',
+        duration: 45,
+      };
+
+      await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({
+          prompt: 'upbeat music',
+          lyrics: 'test lyrics',
+          audio_duration: 45,
+          infer_step: 8,
+          guidance_scale: 3.0,
+          scheduler_type: 'euler',
+          cfg_type: 'apg',
+          omega_scale: 10.0,
+        }),
+      );
+    });
+  });
+
+  // ===== SUCCESS RESPONSE TESTS =====
+  describe('successful audio generation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 200 with audioUrl when Gradio returns string result', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { audioUrl?: string };
+
+      expect(res.status).toBe(200);
+      expect(body.audioUrl).toBe(mockAudioResultString);
+    });
+
+    it('extracts url from object result with url property', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultObject],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { audioUrl?: string };
+
+      expect(res.status).toBe(200);
+      expect(body.audioUrl).toBe(mockAudioResultObject.url);
+    });
+
+    it('handles data array with multiple items (uses first)', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString, 'https://huggingface.co/file/second.wav'],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { audioUrl?: string };
+
+      expect(res.status).toBe(200);
+      expect(body.audioUrl).toBe(mockAudioResultString);
+    });
+  });
+
+  // ===== ERROR HANDLING TESTS =====
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 502 when data array is empty', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('No audio returned from generator');
+    });
+
+    it('returns 502 when data is undefined', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: undefined,
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('No audio returned from generator');
+    });
+
+    it('returns 502 when data is null', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: null,
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('No audio returned from generator');
+    });
+
+    it('returns 502 when audio result is neither string nor has url property', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [{ noUrlProperty: true }],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('Unexpected response from generator');
+    });
+
+    it('returns 502 when audio result is a number', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [123],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('Unexpected response from generator');
+    });
+
+    it('logs unexpected result format to error logger', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [{ unexpected: 'format' }],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith(
+        '[music/generate] Unexpected result format:',
+        expect.any(String),
+      );
+    });
+
+    it('returns 500 when Client.connect throws', async () => {
+      mockClientConnect.mockRejectedValue(new Error('Connection failed'));
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to generate audio');
+    });
+
+    it('returns 500 when predict throws', async () => {
+      const mockPredict = vi.fn().mockRejectedValue(new Error('Prediction failed'));
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to generate audio');
+    });
+
+    it('returns service busy message when error includes queue', async () => {
+      const mockPredict = vi.fn().mockRejectedValue(new Error('queue timeout'));
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('AI music service is busy — try again in a minute');
+    });
+
+    it('returns generic message when error does not include queue', async () => {
+      const mockPredict = vi.fn().mockRejectedValue(new Error('Network error'));
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to generate audio');
+    });
+
+    it('logs errors via logger.error', async () => {
+      mockClientConnect.mockRejectedValue(new Error('API failure'));
+
+      await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith('[music/generate] error:', expect.any(Error));
+    });
+  });
+
+  // ===== EDGE CASES =====
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('handles empty lyrics string (default)', async () => {
+      const payload = { prompt: 'test', lyrics: '' };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ lyrics: '' }),
+      );
+    });
+
+    it('handles response with object containing empty url', async () => {
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [{ url: '' }],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', validGeneratePayload));
+      const body = (await res.json()) as { error?: string };
+
+      // Empty string is still falsy, should fail
+      expect(res.status).toBe(502);
+      expect(body.error).toBe('Unexpected response from generator');
+    });
+
+    it('handles special characters in prompt', async () => {
+      const payload = {
+        prompt: 'upbeat 🎵 electronic @ 140 BPM (fast)',
+        lyrics: '',
+        duration: 30,
+      };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ prompt: payload.prompt }),
+      );
+    });
+
+    it('handles very long prompt at boundary', async () => {
+      const longPrompt = 'a'.repeat(500);
+      const payload = { prompt: longPrompt };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockPredict).toHaveBeenCalledWith(
+        '/generate',
+        expect.objectContaining({ prompt: longPrompt }),
+      );
+    });
+
+    it('handles request with only required fields', async () => {
+      const payload = { prompt: 'test music' };
+      const mockPredict = vi.fn().mockResolvedValue({
+        data: [mockAudioResultString],
+      });
+      mockClientConnect.mockResolvedValue({ predict: mockPredict });
+
+      const res = await POST(makePostRequest('/api/music/generate', payload));
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { audioUrl?: string };
+      expect(body).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **143 tests total**. External Gradio/Last.fm/Neynar fully mocked — no real HF/API calls.

| Route | Tests | Covers |
|-------|-------|--------|
| `auth/lastfm` | 27 | auth, user_settings read, connected vs getAuthUrl branch, callback URL, errors |
| `admin/agents/status` | 40 | admin guards, squad view (per-agent status derivation), detailed events view (filters/limit), errors |
| `fractals/webhook` | 35 | Bearer FRACTAL_BOT_WEBHOOK_SECRET, all 6 event types, Zod, fatal vs non-fatal (allSettled), supabase writes, errors |
| `music/generate` | 41 | auth, Zod (prompt/lyrics/duration bounds), Gradio ACE-Step (mocked) connect+predict, audio-url extraction, 502/500 |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`.

**Hardening note (2nd instance of a pattern — your call):** `admin/agents/status` doesn't check `.error` on its two supabase results (only catches throws), so a silent DB error returns 200 + empty agents instead of 500. Same class as the `miniapp/webhook` note in #1501. Low severity (admin read). Tests document current behavior. If you want it hardened: `if (latestResult.error || countsResult.error) return 500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)