### PR TITLE
test(auth,miniapp,music): lastfm-callback/miniapp-auth/playlists/signer (125 tests)

### DIFF
--- a/src/app/api/auth/lastfm/callback/__tests__/route.test.ts
+++ b/src/app/api/auth/lastfm/callback/__tests__/route.test.ts
@@ -1,0 +1,270 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom, mockGetLastfmSession } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+  mockGetLastfmSession: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/music/lastfm', () => ({
+  getSession: mockGetLastfmSession,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+/**
+ * Build a chain that supports upsert→await for the callback operation.
+ * Chainable methods return the chain for further chaining.
+ * The chain supports direct await (via .then) for awaited operations.
+ */
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  const chainable = ['upsert'];
+  for (const m of chainable) {
+    chain[m] = vi.fn(() => chain);
+  }
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('GET /api/auth/lastfm/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    mockGetLastfmSession.mockResolvedValue('test-session-key');
+  });
+
+  it('redirects to /settings?error=unauthorized when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=unauthorized');
+  });
+
+  it('redirects to /settings?error=unauthorized when session has no fid', async () => {
+    mockGetSessionData.mockResolvedValue({ username: 'user' });
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=unauthorized');
+  });
+
+  it('redirects to /settings?error=no_token when token param is missing', async () => {
+    const req = makeGetRequest('/api/auth/lastfm/callback');
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=no_token');
+  });
+
+  it('redirects to /settings?error=no_token when token param is empty string', async () => {
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: '' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=no_token');
+  });
+
+  it('calls getLastfmSession with the token from query params', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token-abc' });
+    await GET(req);
+
+    expect(mockGetLastfmSession).toHaveBeenCalledWith('test-token-abc');
+  });
+
+  it('stores the session key in supabase user_settings table', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(mockFrom).toHaveBeenCalledWith('user_settings');
+    expect(chain.upsert).toHaveBeenCalledWith(
+      { fid: 123, lastfm_session_key: 'test-session-key' },
+      { onConflict: 'fid' },
+    );
+  });
+
+  it('upserts with the correct fid from the session', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 999 }));
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(chain.upsert).toHaveBeenCalledWith(
+      { fid: 999, lastfm_session_key: 'test-session-key' },
+      { onConflict: 'fid' },
+    );
+  });
+
+  it('redirects to /settings?lastfm=connected on success', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?lastfm=connected');
+  });
+
+  it('redirects to /settings?error=lastfm_failed when getLastfmSession throws', async () => {
+    mockGetLastfmSession.mockRejectedValue(new Error('Last.fm API error'));
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=lastfm_failed');
+  });
+
+  it('redirects to /settings?error=lastfm_failed when supabase upsert throws', async () => {
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockRejectedValue(new Error('db connection failed')),
+    });
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    expect(res.status).toBe(307);
+    const location = res.headers.get('Location');
+    expect(location).toContain('/settings?error=lastfm_failed');
+  });
+
+  it('logs errors server-side on getLastfmSession failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    const testError = new Error('Last.fm API returned 400');
+    mockGetLastfmSession.mockRejectedValue(testError);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(logger.error).toHaveBeenCalledWith('[lastfm/callback] Error:', testError);
+  });
+
+  it('logs errors server-side on supabase upsert failure', async () => {
+    const { logger } = await import('@/lib/logger');
+    const testError = new Error('Supabase connection timeout');
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockRejectedValue(testError),
+    });
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(logger.error).toHaveBeenCalledWith('[lastfm/callback] Error:', testError);
+  });
+
+  it('uses Supabase onConflict strategy to update existing session', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(chain.upsert).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ onConflict: 'fid' }),
+    );
+  });
+
+  it('handles concurrent token requests for same user', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req1 = makeGetRequest('/api/auth/lastfm/callback', { token: 'token-1' });
+    const req2 = makeGetRequest('/api/auth/lastfm/callback', { token: 'token-2' });
+
+    await GET(req1);
+    await GET(req2);
+
+    expect(mockGetLastfmSession).toHaveBeenCalledWith('token-1');
+    expect(mockGetLastfmSession).toHaveBeenCalledWith('token-2');
+  });
+
+  it('does not call getLastfmSession if token is missing', async () => {
+    const req = makeGetRequest('/api/auth/lastfm/callback');
+    await GET(req);
+
+    expect(mockGetLastfmSession).not.toHaveBeenCalled();
+  });
+
+  it('does not call supabase if getLastfmSession throws', async () => {
+    mockGetLastfmSession.mockRejectedValue(new Error('API error'));
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    await GET(req);
+
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('returns proper redirect status code (307) for all redirect paths', async () => {
+    // Test unauthorized redirect
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    let req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    let res = await GET(req);
+    expect(res.status).toBe(307);
+
+    // Test no_token redirect
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    req = makeGetRequest('/api/auth/lastfm/callback');
+    res = await GET(req);
+    expect(res.status).toBe(307);
+
+    // Test success redirect
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+    req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    res = await GET(req);
+    expect(res.status).toBe(307);
+  });
+
+  it('preserves base URL in redirect Location header', async () => {
+    const chain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const req = makeGetRequest('/api/auth/lastfm/callback', { token: 'test-token' });
+    const res = await GET(req);
+
+    const location = res.headers.get('Location');
+    expect(location).toBeTruthy();
+    expect(location).toContain('settings');
+  });
+});

--- a/src/app/api/auth/signer/__tests__/route.test.ts
+++ b/src/app/api/auth/signer/__tests__/route.test.ts
@@ -1,0 +1,692 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockAuthenticatedSession, mockUnauthenticatedSession } from '@/test-utils/api-helpers';
+
+const {
+  mockGetSessionData,
+  mockCreateSigner,
+  mockRegisterSignedKey,
+  mockLogger,
+  mockCreateWalletClient,
+  mockPrivateKeyToAccount,
+  // SECURITY: This suite uses ONLY the public anvil stub key for testing, never a real key.
+  STUB_PRIVATE_KEY,
+  STUB_APP_SIGNER_ADDRESS,
+} = vi.hoisted(() => {
+  const stubPrivateKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+  const stubAppSignerAddress = '0xF39FD6E51AAD88F6F4CE6AB8827279CFFB92266';
+  return {
+    mockGetSessionData: vi.fn(),
+    mockCreateSigner: vi.fn(),
+    mockRegisterSignedKey: vi.fn(),
+    mockLogger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+    mockCreateWalletClient: vi.fn(),
+    mockPrivateKeyToAccount: vi.fn(),
+    STUB_PRIVATE_KEY: stubPrivateKey,
+    STUB_APP_SIGNER_ADDRESS: stubAppSignerAddress,
+  };
+});
+
+// Mock viem — sign operations must never hit the network or perform real signing
+vi.mock('viem', () => ({
+  createWalletClient: mockCreateWalletClient,
+  http: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: mockPrivateKeyToAccount,
+}));
+
+vi.mock('viem/chains', () => ({
+  optimism: { id: 10, name: 'Optimism' },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: mockGetSessionData,
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  createSigner: mockCreateSigner,
+  registerSignedKey: mockRegisterSignedKey,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// Mock ENV — use stub key, never a real one
+vi.mock('@/lib/env', () => {
+  const stubKey = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80';
+  return {
+    ENV: {
+      APP_SIGNER_PRIVATE_KEY: stubKey,
+      APP_FID: '19640',
+      NEYNAR_API_KEY: 'test-neynar-key',
+      SUPABASE_SERVICE_ROLE_KEY: 'test-supabase-key',
+      SESSION_SECRET: 'test-session-secret',
+      NEXT_PUBLIC_SUPABASE_URL: 'https://example.supabase.co',
+      NEXT_PUBLIC_NEYNAR_CLIENT_ID: 'test-client-id',
+    },
+  };
+});
+
+import { POST } from '../route';
+
+describe('POST /api/auth/signer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default successful mock chain
+    mockPrivateKeyToAccount.mockReturnValue({
+      address: STUB_APP_SIGNER_ADDRESS,
+    });
+
+    mockCreateWalletClient.mockReturnValue({
+      signTypedData: vi.fn(async () => '0xMOCK_SIGNATURE_BYTES_HERE'),
+    });
+
+    mockCreateSigner.mockResolvedValue({
+      signer_uuid: 'mock-signer-uuid-1',
+      public_key: '0xMOCK_PUBLIC_KEY_BYTES',
+    });
+
+    mockRegisterSignedKey.mockResolvedValue({
+      signer_uuid: 'mock-signer-uuid-1',
+      status: 'pending_review',
+      signer_approval_url: 'https://neynar.com/signer-approval?uuid=mock-signer-uuid-1',
+    });
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when session is not authenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST();
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockCreateSigner).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST();
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockCreateSigner).not.toHaveBeenCalled();
+      expect(mockRegisterSignedKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('early-exit: user already has approved signer', () => {
+    it('returns existing signerUuid and status approved when user already has one', async () => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: 'existing-uuid-123' });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      const res = await POST();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        signerUuid: 'existing-uuid-123',
+        status: 'approved',
+      });
+      // Should not create a new signer
+      expect(mockCreateSigner).not.toHaveBeenCalled();
+      expect(mockRegisterSignedKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('signer creation', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('calls createSigner without arguments', async () => {
+      await POST();
+
+      expect(mockCreateSigner).toHaveBeenCalledWith();
+      expect(mockCreateSigner).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns 502 when createSigner returns missing signer_uuid', async () => {
+      mockCreateSigner.mockResolvedValue({
+        public_key: '0xPUBLIC_KEY',
+        // signer_uuid missing
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Signer creation returned invalid data' });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'createSigner returned incomplete data: missing signer_uuid or public_key',
+      );
+    });
+
+    it('returns 502 when createSigner returns missing public_key', async () => {
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-123',
+        // public_key missing
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Signer creation returned invalid data' });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'createSigner returned incomplete data: missing signer_uuid or public_key',
+      );
+    });
+
+    it('returns 502 when createSigner returns null', async () => {
+      mockCreateSigner.mockResolvedValue(null);
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Signer creation returned invalid data' });
+    });
+
+    it('extracts signer_uuid and public_key from createSigner response', async () => {
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'extracted-uuid-xyz',
+        public_key: '0xEXTRACTED_PUBLIC_KEY',
+      });
+
+      await POST();
+
+      // Verify they're passed to registerSignedKey
+      expect(mockRegisterSignedKey).toHaveBeenCalledWith(
+        'extracted-uuid-xyz',
+        19640,
+        expect.any(Number),
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('wallet client setup', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('calls privateKeyToAccount with APP_SIGNER_PRIVATE_KEY', async () => {
+      await POST();
+
+      expect(mockPrivateKeyToAccount).toHaveBeenCalledWith(STUB_PRIVATE_KEY);
+      expect(mockPrivateKeyToAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls createWalletClient with account and optimism chain', async () => {
+      await POST();
+
+      const callArgs = mockCreateWalletClient.mock.calls[0][0];
+      expect(callArgs.account).toEqual({ address: STUB_APP_SIGNER_ADDRESS });
+      expect(callArgs.chain).toEqual({ id: 10, name: 'Optimism' });
+      expect(callArgs.transport).toBeDefined();
+    });
+  });
+
+  describe('EIP-712 signing', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('calls signTypedData on wallet client', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE_BYTES');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      expect(mockSignTypedData).toHaveBeenCalledTimes(1);
+    });
+
+    it('signs EIP-712 SignedKeyRequest with correct domain config', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.domain).toEqual({
+        name: 'Farcaster SignedKeyRequestValidator',
+        version: '1',
+        chainId: 10,
+        verifyingContract: '0x00000000FC700472606ED4fA22623Acf62c60553',
+      });
+    });
+
+    it('signs with correct SignedKeyRequest type schema', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.types.SignedKeyRequest).toEqual([
+        { name: 'requestFid', type: 'uint256' },
+        { name: 'key', type: 'bytes' },
+        { name: 'deadline', type: 'uint256' },
+      ]);
+    });
+
+    it('signs with primaryType SignedKeyRequest', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.primaryType).toBe('SignedKeyRequest');
+    });
+
+    it('constructs message with APP_FID (19640) as requestFid', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        public_key: '0xPUB',
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.message.requestFid).toBe(BigInt(19640));
+    });
+
+    it('constructs message with public_key from createSigner', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        public_key: '0xCUSTOM_PUBLIC_KEY_VALUE',
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.message.key).toBe('0xCUSTOM_PUBLIC_KEY_VALUE');
+    });
+
+    it('sets deadline to 24 hours in the future', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      const beforeTime = Math.floor(Date.now() / 1000);
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      const deadlineBigInt = callArgs.message.deadline;
+      const deadline = Number(deadlineBigInt);
+
+      expect(deadline).toBeGreaterThanOrEqual(beforeTime + 86400);
+      expect(deadline).toBeLessThanOrEqual(beforeTime + 86400 + 10);
+    });
+  });
+
+  describe('key registration', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('calls registerSignedKey with signer_uuid, app_fid, deadline, and signature', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xREGISTRATION_SIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'new-uuid-456',
+        public_key: '0xPUBLIC',
+      });
+
+      await POST();
+
+      expect(mockRegisterSignedKey).toHaveBeenCalledWith(
+        'new-uuid-456',
+        19640,
+        expect.any(Number),
+        '0xREGISTRATION_SIGNATURE',
+      );
+    });
+
+    it('returns 502 when registerSignedKey returns missing signer_uuid', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        status: 'pending_review',
+        signer_approval_url: 'https://example.com',
+        // signer_uuid missing
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Key registration returned invalid data' });
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'registerSignedKey returned incomplete data: missing required fields',
+      );
+    });
+
+    it('returns 502 when registerSignedKey returns missing status', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        signer_approval_url: 'https://example.com',
+        // status missing
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Key registration returned invalid data' });
+    });
+
+    it('returns 502 when registerSignedKey returns missing signer_approval_url', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        status: 'pending_review',
+        // signer_approval_url missing
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Key registration returned invalid data' });
+    });
+
+    it('returns 502 when registerSignedKey returns null', async () => {
+      mockRegisterSignedKey.mockResolvedValue(null);
+
+      const res = await POST();
+
+      expect(res.status).toBe(502);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Key registration returned invalid data' });
+    });
+  });
+
+  describe('successful response', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('returns 200 with signer data on successful registration', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'final-uuid-789',
+        status: 'pending_review',
+        signer_approval_url: 'https://neynar.com/approve?uuid=final-uuid-789',
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        signerUuid: 'final-uuid-789',
+        status: 'pending_review',
+        approvalUrl: 'https://neynar.com/approve?uuid=final-uuid-789',
+      });
+    });
+
+    it('maps signer_approval_url from Neynar to approvalUrl in response', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'uuid-xyz',
+        status: 'pending_review',
+        signer_approval_url: 'https://custom-approval-url.example.com',
+      });
+
+      const res = await POST();
+
+      const body = await res.json();
+      expect(body.approvalUrl).toBe('https://custom-approval-url.example.com');
+    });
+
+    it('returns all possible status values correctly', async () => {
+      const statuses = ['pending_review', 'approved', 'rejected', 'expired'];
+
+      for (const status of statuses) {
+        mockRegisterSignedKey.mockResolvedValue({
+          signer_uuid: 'uuid-test',
+          status,
+          signer_approval_url: 'https://example.com',
+        });
+
+        const res = await POST();
+        const body = await res.json();
+        expect(body.status).toBe(status);
+      }
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('returns 500 when createSigner throws', async () => {
+      mockCreateSigner.mockRejectedValue(new Error('Neynar API failed'));
+
+      const res = await POST();
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to create signer' });
+      expect(mockLogger.error).toHaveBeenCalledWith('Signer creation error:', expect.any(Error));
+    });
+
+    it('returns 500 when registerSignedKey throws', async () => {
+      mockRegisterSignedKey.mockRejectedValue(new Error('Key registration failed'));
+
+      const res = await POST();
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to create signer' });
+      expect(mockLogger.error).toHaveBeenCalledWith('Signer creation error:', expect.any(Error));
+    });
+
+    it('returns 500 when walletClient.signTypedData throws', async () => {
+      const mockSignTypedData = vi.fn().mockRejectedValue(new Error('Signing failed'));
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to create signer' });
+    });
+
+    it('returns 500 when privateKeyToAccount throws', async () => {
+      mockPrivateKeyToAccount.mockImplementation(() => {
+        throw new Error('Invalid private key');
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to create signer' });
+    });
+
+    it('logs error details for debugging', async () => {
+      const debugError = new Error('Debug error message');
+      mockCreateSigner.mockRejectedValue(debugError);
+
+      await POST();
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Signer creation error:', debugError);
+    });
+
+    it('returns 500 on network timeout', async () => {
+      const timeoutError = new Error('ETIMEDOUT');
+      mockRegisterSignedKey.mockRejectedValue(timeoutError);
+
+      const res = await POST();
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Failed to create signer' });
+    });
+  });
+
+  describe('request/response shape', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('accepts POST with no body', async () => {
+      const res = await POST();
+
+      expect(res.status).toBe(200);
+    });
+
+    it('responds with JSON', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        status: 'pending_review',
+        signer_approval_url: 'https://example.com',
+      });
+
+      const res = await POST();
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+
+    it('response has no extra fields', async () => {
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'uuid-1',
+        status: 'pending_review',
+        signer_approval_url: 'https://example.com',
+      });
+
+      const res = await POST();
+      const body = await res.json();
+
+      const expectedKeys = ['signerUuid', 'status', 'approvalUrl'];
+      const actualKeys = Object.keys(body).sort();
+      expect(actualKeys).toEqual(expectedKeys.sort());
+    });
+  });
+
+  describe('security & constants', () => {
+    beforeEach(() => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined });
+      mockGetSessionData.mockResolvedValue(sessionData);
+    });
+
+    it('uses Optimism chain ID 10 (not mainnet)', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.domain.chainId).toBe(10);
+    });
+
+    it('uses correct SignedKeyRequestValidator contract address', async () => {
+      const mockSignTypedData = vi.fn(async () => '0xSIGNATURE');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      await POST();
+
+      const callArgs = mockSignTypedData.mock.calls[0][0];
+      expect(callArgs.domain.verifyingContract).toBe('0x00000000FC700472606ED4fA22623Acf62c60553');
+    });
+
+    it('does not expose secrets in error responses', async () => {
+      mockCreateSigner.mockRejectedValue(new Error('Neynar error'));
+
+      const res = await POST();
+      const body = await res.json();
+
+      // Should not leak API keys, private keys, etc.
+      expect(JSON.stringify(body)).not.toContain('NEYNAR_API_KEY');
+      expect(JSON.stringify(body)).not.toContain('APP_SIGNER_PRIVATE_KEY');
+      expect(JSON.stringify(body)).not.toContain('SUPABASE_SERVICE_ROLE_KEY');
+    });
+  });
+
+  describe('integration flow', () => {
+    it('completes full flow: unauthenticated user -> create signer -> register key -> return approval URL', async () => {
+      const sessionData = mockAuthenticatedSession({ signerUuid: undefined, fid: 9999 });
+      mockGetSessionData.mockResolvedValue(sessionData);
+
+      mockCreateSigner.mockResolvedValue({
+        signer_uuid: 'integration-uuid',
+        public_key: '0xINTEGRATION_KEY',
+      });
+
+      const mockSignTypedData = vi.fn(async () => '0xINTEGRATION_SIG');
+      mockCreateWalletClient.mockReturnValue({
+        signTypedData: mockSignTypedData,
+      });
+
+      mockRegisterSignedKey.mockResolvedValue({
+        signer_uuid: 'integration-uuid',
+        status: 'pending_review',
+        signer_approval_url: 'https://neynar.com/signer?uuid=integration-uuid',
+      });
+
+      const res = await POST();
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(mockCreateSigner).toHaveBeenCalledTimes(1);
+      expect(mockPrivateKeyToAccount).toHaveBeenCalledTimes(1);
+      expect(mockCreateWalletClient).toHaveBeenCalledTimes(1);
+      expect(mockSignTypedData).toHaveBeenCalledTimes(1);
+      expect(mockRegisterSignedKey).toHaveBeenCalledTimes(1);
+
+      expect(body).toEqual({
+        signerUuid: 'integration-uuid',
+        status: 'pending_review',
+        approvalUrl: 'https://neynar.com/signer?uuid=integration-uuid',
+      });
+    });
+  });
+});

--- a/src/app/api/miniapp/auth/__tests__/route.test.ts
+++ b/src/app/api/miniapp/auth/__tests__/route.test.ts
@@ -1,0 +1,735 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+import { GET } from '../route';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockVerifyJwt } = vi.hoisted(() => ({
+  mockVerifyJwt: vi.fn(),
+}));
+
+const { mockGetUserByFid } = vi.hoisted(() => ({
+  mockGetUserByFid: vi.fn(),
+}));
+
+const { mockCheckAllowlist } = vi.hoisted(() => ({
+  mockCheckAllowlist: vi.fn(),
+}));
+
+const { mockSaveSession } = vi.hoisted(() => ({
+  mockSaveSession: vi.fn(),
+}));
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { error: vi.fn() },
+}));
+
+vi.mock('@farcaster/quick-auth', () => ({
+  createClient: vi.fn(() => ({
+    verifyJwt: mockVerifyJwt,
+  })),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getUserByFid: mockGetUserByFid,
+}));
+
+vi.mock('@/lib/gates/allowlist', () => ({
+  checkAllowlist: mockCheckAllowlist,
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  saveSession: mockSaveSession,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    NEXT_PUBLIC_SIWF_DOMAIN: undefined,
+  },
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/miniapp/auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Authorization header validation', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      const req = makeRequest('/api/miniapp/auth', { method: 'GET' });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockVerifyJwt).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when Authorization header does not start with Bearer', async () => {
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Basic xyz' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(mockVerifyJwt).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when Authorization header is empty Bearer', async () => {
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer ' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+
+    it('returns 401 when Authorization header is just "Bearer"', async () => {
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+  });
+
+  describe('JWT verification', () => {
+    it('extracts Bearer token and passes to verifyJwt with domain', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '123' });
+      mockGetUserByFid.mockResolvedValue(null);
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer test-token-123' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockVerifyJwt).toHaveBeenCalledWith({
+        token: 'test-token-123',
+        domain: 'zaoos.com',
+      });
+    });
+
+    it('uses fallback zaoos.com domain when NEXT_PUBLIC_SIWF_DOMAIN is undefined', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '456' });
+      mockGetUserByFid.mockResolvedValue(null);
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+
+      const res = await GET(req);
+      expect(res.status).toBe(200);
+      // Verify the fallback domain is used when ENV var is undefined
+      expect(mockVerifyJwt).toHaveBeenCalledWith({
+        token: 'token',
+        domain: 'zaoos.com',
+      });
+    });
+
+    it('returns 401 when verifyJwt throws an error', async () => {
+      mockVerifyJwt.mockRejectedValue(new Error('Invalid JWT'));
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer bad-token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid token' });
+      expect(mockLogger.error).toHaveBeenCalledWith('Mini app auth error:', expect.any(Error));
+    });
+
+    it('returns 401 when verifyJwt throws with an arbitrary value', async () => {
+      mockVerifyJwt.mockRejectedValue('unknown error');
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer bad-token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid token' });
+    });
+
+    it('extracts fid from payload.sub and converts to number', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '789' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'testuser',
+        display_name: 'Test User',
+        pfp_url: 'https://example.com/pfp.jpg',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      // Verify getUserByFid was called with numeric fid
+      expect(mockGetUserByFid).toHaveBeenCalledWith(789);
+      // Verify saveSession received numeric fid
+      expect(mockSaveSession).toHaveBeenCalledWith({
+        fid: 789,
+        username: 'testuser',
+        displayName: 'Test User',
+        pfpUrl: 'https://example.com/pfp.jpg',
+      });
+    });
+  });
+
+  describe('FID allowlist check', () => {
+    it('checks allowlist by FID when user exists', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '100' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user1',
+        display_name: 'User One',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockCheckAllowlist).toHaveBeenCalledWith(100);
+      expect(mockSaveSession).toHaveBeenCalled();
+    });
+
+    it('returns hasAccess:false when FID is not in allowlist and no wallet fallback', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '200' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'notallowed',
+        display_name: 'Not Allowed',
+        pfp_url: 'https://example.com/pfp2.jpg',
+        verified_addresses: undefined,
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.hasAccess).toBe(false);
+      expect(body.fid).toBe(200);
+      expect(mockSaveSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Wallet address fallback', () => {
+    it('checks wallet addresses when FID allowlist fails', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '300' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user3',
+        display_name: 'User Three',
+        pfp_url: '',
+        verified_addresses: {
+          eth_addresses: ['0x1111111111111111111111111111111111111111'],
+        },
+      });
+      // First call (FID check) returns false
+      // Second call (wallet check) returns true
+      mockCheckAllowlist
+        .mockResolvedValueOnce({ allowed: false })
+        .mockResolvedValueOnce({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.hasAccess).toBe(true);
+      // Should have called checkAllowlist twice: first with fid, then with wallet
+      expect(mockCheckAllowlist).toHaveBeenCalledTimes(2);
+      expect(mockCheckAllowlist).toHaveBeenNthCalledWith(1, 300);
+      expect(mockCheckAllowlist).toHaveBeenNthCalledWith(
+        2,
+        undefined,
+        '0x1111111111111111111111111111111111111111',
+      );
+      expect(mockSaveSession).toHaveBeenCalled();
+    });
+
+    it('checks all wallet addresses until one is allowed', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '301' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user301',
+        display_name: 'User 301',
+        pfp_url: '',
+        verified_addresses: {
+          eth_addresses: [
+            '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            '0xcccccccccccccccccccccccccccccccccccccccc',
+          ],
+        },
+      });
+      // FID check fails, first wallet check fails, second wallet check passes
+      mockCheckAllowlist
+        .mockResolvedValueOnce({ allowed: false })
+        .mockResolvedValueOnce({ allowed: false })
+        .mockResolvedValueOnce({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.hasAccess).toBe(true);
+      // Should have checked FID, first wallet, second wallet (then stopped)
+      expect(mockCheckAllowlist).toHaveBeenCalledTimes(3);
+      expect(mockCheckAllowlist).toHaveBeenNthCalledWith(
+        2,
+        undefined,
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+      expect(mockCheckAllowlist).toHaveBeenNthCalledWith(
+        3,
+        undefined,
+        '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      );
+      expect(mockSaveSession).toHaveBeenCalled();
+    });
+
+    it('does not check wallets when no verified_addresses', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '302' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'nowallets',
+        display_name: 'No Wallets',
+        pfp_url: '',
+        verified_addresses: undefined,
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.hasAccess).toBe(false);
+      // Only one call for FID, no wallet checks
+      expect(mockCheckAllowlist).toHaveBeenCalledTimes(1);
+      expect(mockCheckAllowlist).toHaveBeenCalledWith(302);
+    });
+
+    it('does not check wallets when eth_addresses is empty', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '303' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'emptywallets',
+        display_name: 'Empty Wallets',
+        pfp_url: '',
+        verified_addresses: {
+          eth_addresses: [],
+        },
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.hasAccess).toBe(false);
+      // Only one call for FID
+      expect(mockCheckAllowlist).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Session saving', () => {
+    it('calls saveSession when allowlist check passes via FID', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '400' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'alloweduser',
+        display_name: 'Allowed User',
+        pfp_url: 'https://example.com/pfp400.jpg',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSaveSession).toHaveBeenCalledWith({
+        fid: 400,
+        username: 'alloweduser',
+        displayName: 'Allowed User',
+        pfpUrl: 'https://example.com/pfp400.jpg',
+      });
+    });
+
+    it('calls saveSession when allowlist check passes via wallet', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '401' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'walletuser',
+        display_name: 'Wallet User',
+        pfp_url: 'https://example.com/pfp401.jpg',
+        verified_addresses: {
+          eth_addresses: ['0xdddddddddddddddddddddddddddddddddddddddd'],
+        },
+      });
+      mockCheckAllowlist
+        .mockResolvedValueOnce({ allowed: false })
+        .mockResolvedValueOnce({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSaveSession).toHaveBeenCalledWith({
+        fid: 401,
+        username: 'walletuser',
+        displayName: 'Wallet User',
+        pfpUrl: 'https://example.com/pfp401.jpg',
+      });
+    });
+
+    it('does not call saveSession when allowlist check fails', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '402' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'notallowed',
+        display_name: 'Not Allowed',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockSaveSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('User profile fallback', () => {
+    it('uses empty strings when getUserByFid returns null', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '500' });
+      mockGetUserByFid.mockResolvedValue(null);
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.fid).toBe(500);
+      expect(body.username).toBe('');
+      expect(body.displayName).toBe('');
+      expect(body.pfpUrl).toBe('');
+    });
+
+    it('uses empty strings for missing profile fields', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '501' });
+      mockGetUserByFid.mockResolvedValue({
+        username: undefined,
+        display_name: undefined,
+        pfp_url: undefined,
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.username).toBe('');
+      expect(body.displayName).toBe('');
+      expect(body.pfpUrl).toBe('');
+    });
+  });
+
+  describe('Response shape', () => {
+    it('returns correct response when allowed', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '600' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'testuser',
+        display_name: 'Test User',
+        pfp_url: 'https://example.com/test.jpg',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual({
+        fid: 600,
+        hasAccess: true,
+        username: 'testuser',
+        displayName: 'Test User',
+        pfpUrl: 'https://example.com/test.jpg',
+      });
+    });
+
+    it('returns correct response when not allowed', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '601' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'denied',
+        display_name: 'Denied User',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        fid: 601,
+        hasAccess: false,
+        username: 'denied',
+        displayName: 'Denied User',
+        pfpUrl: '',
+      });
+    });
+
+    it('returns JSON error response on auth failure', async () => {
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer bad' },
+      });
+      mockVerifyJwt.mockRejectedValue(new Error('JWT expired'));
+
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(body).toEqual({ error: 'Invalid token' });
+    });
+  });
+
+  describe('Error handling', () => {
+    it('catches and logs errors during verification', async () => {
+      mockVerifyJwt.mockRejectedValue(new Error('JWT verification failed'));
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(mockLogger.error).toHaveBeenCalledWith('Mini app auth error:', expect.any(Error));
+    });
+
+    it('catches and logs getUserByFid errors', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '700' });
+      mockGetUserByFid.mockRejectedValue(new Error('Neynar API error'));
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(mockLogger.error).toHaveBeenCalledWith('Mini app auth error:', expect.any(Error));
+    });
+
+    it('catches and logs checkAllowlist errors', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '701' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user',
+        display_name: 'User',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockRejectedValue(new Error('Supabase error'));
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(mockLogger.error).toHaveBeenCalledWith('Mini app auth error:', expect.any(Error));
+    });
+
+    it('catches and logs saveSession errors', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '702' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user',
+        display_name: 'User',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockRejectedValue(new Error('Session save failed'));
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(401);
+      expect(mockLogger.error).toHaveBeenCalledWith('Mini app auth error:', expect.any(Error));
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('extracts token correctly with single space', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '800' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user',
+        display_name: 'User',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: false });
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer valid-token-abc123' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockVerifyJwt).toHaveBeenCalledWith({
+        token: 'valid-token-abc123',
+        domain: 'zaoos.com',
+      });
+    });
+
+    it('handles sub as a string number', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '12345' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user',
+        display_name: 'User',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.fid).toBe(12345);
+      expect(typeof body.fid).toBe('number');
+    });
+
+    it('handles large FID values', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '999999999' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'bigfid',
+        display_name: 'Big FID',
+        pfp_url: '',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.fid).toBe(999999999);
+    });
+
+    it('handles profile with special characters', async () => {
+      mockVerifyJwt.mockResolvedValue({ sub: '850' });
+      mockGetUserByFid.mockResolvedValue({
+        username: 'user_with_emoji_🚀',
+        display_name: 'Дисплей Имя',
+        pfp_url: 'https://example.com/pfp?size=256&fmt=png',
+      });
+      mockCheckAllowlist.mockResolvedValue({ allowed: true });
+      mockSaveSession.mockResolvedValue(undefined);
+
+      const req = makeRequest('/api/miniapp/auth', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.username).toBe('user_with_emoji_🚀');
+      expect(body.displayName).toBe('Дисплей Имя');
+      expect(body.pfpUrl).toBe('https://example.com/pfp?size=256&fmt=png');
+    });
+  });
+});

--- a/src/app/api/music/playlists/collaborative/__tests__/route.test.ts
+++ b/src/app/api/music/playlists/collaborative/__tests__/route.test.ts
@@ -1,0 +1,803 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { chainMock, makePostRequest, mockAuthenticatedSession } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockAutoCastToZao } = vi.hoisted(() => ({
+  mockAutoCastToZao: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/publish/auto-cast', () => ({
+  autoCastToZao: mockAutoCastToZao,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { GET, POST } from '../route';
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+const SAMPLE_PLAYLIST = {
+  id: '550e8400-e29b-41d4-a716-446655440001',
+  name: 'Summer Vibes',
+  description: 'Best tracks for summer 2026',
+  is_collaborative: true,
+  is_public: true,
+  created_by_fid: 123,
+  created_at: '2026-07-15T10:00:00Z',
+};
+
+const SAMPLE_PLAYLIST_2 = {
+  id: '550e8400-e29b-41d4-a716-446655440002',
+  name: 'Chill Beats',
+  description: 'Relaxing music for focus',
+  is_collaborative: true,
+  is_public: true,
+  created_by_fid: 456,
+  created_at: '2026-07-15T09:00:00Z',
+};
+
+const SAMPLE_TRACK_1 = { playlist_id: SAMPLE_PLAYLIST.id };
+const SAMPLE_TRACK_2 = { playlist_id: SAMPLE_PLAYLIST.id };
+const SAMPLE_TRACK_3 = { playlist_id: SAMPLE_PLAYLIST_2.id };
+
+const SAMPLE_MEMBER_1 = { playlist_id: SAMPLE_PLAYLIST.id, fid: 123 };
+const SAMPLE_MEMBER_2 = { playlist_id: SAMPLE_PLAYLIST.id, fid: 456 };
+const SAMPLE_MEMBER_3 = { playlist_id: SAMPLE_PLAYLIST_2.id, fid: 789 };
+
+describe('GET /api/music/playlists/collaborative', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('success paths', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 200 with enriched playlists list', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST, SAMPLE_PLAYLIST_2] });
+      const tracksMock = chainMock({
+        data: [SAMPLE_TRACK_1, SAMPLE_TRACK_2, SAMPLE_TRACK_3],
+      });
+      const membersMock = chainMock({
+        data: [SAMPLE_MEMBER_1, SAMPLE_MEMBER_2, SAMPLE_MEMBER_3],
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.playlists).toHaveLength(2);
+      expect(body.playlists[0]).toMatchObject({
+        ...SAMPLE_PLAYLIST,
+        track_count: 2,
+        member_count: 2,
+        member_fids: [123, 456],
+      });
+      expect(body.playlists[1]).toMatchObject({
+        ...SAMPLE_PLAYLIST_2,
+        track_count: 1,
+        member_count: 1,
+        member_fids: [789],
+      });
+    });
+
+    it('filters by is_collaborative true and is_public true', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST] });
+      const tracksMock = chainMock({ data: [SAMPLE_TRACK_1] });
+      const membersMock = chainMock({ data: [SAMPLE_MEMBER_1] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      await GET();
+
+      // Verify the first call chains .eq('is_collaborative', true)
+      const eqCalls = playlistMock.chain.eq.mock.calls;
+      expect(eqCalls).toContainEqual(['is_collaborative', true]);
+      expect(eqCalls).toContainEqual(['is_public', true]);
+    });
+
+    it('orders by created_at descending', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST] });
+      const tracksMock = chainMock({ data: [SAMPLE_TRACK_1] });
+      const membersMock = chainMock({ data: [SAMPLE_MEMBER_1] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      await GET();
+
+      const orderCalls = playlistMock.chain.order.mock.calls;
+      expect(orderCalls).toContainEqual(['created_at', { ascending: false }]);
+    });
+
+    it('returns empty array when no playlists exist', async () => {
+      const playlistMock = chainMock({ data: [] });
+      mockFrom.mockReturnValue(playlistMock.chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.playlists).toEqual([]);
+    });
+
+    it('handles track count fetch failure gracefully', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST] });
+      const tracksMock = chainMock({
+        error: { message: 'Track fetch failed' },
+        data: null,
+      });
+      const membersMock = chainMock({ data: [SAMPLE_MEMBER_1] });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.playlists[0].track_count).toBe(0);
+      expect(body.playlists[0].member_count).toBe(1);
+    });
+
+    it('handles member count fetch failure gracefully', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST] });
+      const tracksMock = chainMock({ data: [SAMPLE_TRACK_1] });
+      const membersMock = chainMock({
+        error: { message: 'Member fetch failed' },
+        data: null,
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.playlists[0].track_count).toBe(1);
+      expect(body.playlists[0].member_count).toBe(0);
+      expect(body.playlists[0].member_fids).toEqual([]);
+    });
+
+    it('aggregates counts correctly across multiple playlists', async () => {
+      const playlistMock = chainMock({ data: [SAMPLE_PLAYLIST, SAMPLE_PLAYLIST_2] });
+      const tracksMock = chainMock({
+        data: [SAMPLE_TRACK_1, SAMPLE_TRACK_2, SAMPLE_TRACK_3],
+      });
+      const membersMock = chainMock({
+        data: [SAMPLE_MEMBER_1, SAMPLE_MEMBER_2, SAMPLE_MEMBER_3],
+      });
+
+      let callCount = 0;
+      mockFrom.mockImplementation((_table) => {
+        callCount += 1;
+        if (callCount === 1) return playlistMock.handler();
+        if (callCount === 2) return tracksMock.handler();
+        if (callCount === 3) return membersMock.handler();
+        return playlistMock.handler();
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.playlists).toHaveLength(2);
+      expect(body.playlists[0].track_count).toBe(2);
+      expect(body.playlists[0].member_count).toBe(2);
+      expect(body.playlists[1].track_count).toBe(1);
+      expect(body.playlists[1].member_count).toBe(1);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when supabase query fails', async () => {
+      const playlistMock = chainMock({
+        error: { message: 'Database connection failed' },
+        data: null,
+      });
+      mockFrom.mockReturnValue(playlistMock.chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch playlists');
+    });
+
+    it('logs error when supabase fetch fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = { message: 'Query error' };
+      const playlistMock = chainMock({
+        error: dbError,
+        data: null,
+      });
+      mockFrom.mockReturnValue(playlistMock.chain);
+
+      await GET();
+
+      expect(logger.error).toHaveBeenCalledWith('[collaborative-playlists] GET error:', dbError);
+    });
+  });
+});
+
+describe('POST /api/music/playlists/collaborative', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when no session is present', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Test Playlist',
+          description: 'A test playlist',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('request validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 400 when name is empty', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: '',
+          description: 'A valid description',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when name exceeds 100 characters', async () => {
+      const longName = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: longName,
+          description: 'A valid description',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when description exceeds 500 characters', async () => {
+      const longDescription = 'a'.repeat(501);
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: longDescription,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('accepts description at exactly 500 characters', async () => {
+      const descriptionAt500 = 'a'.repeat(500);
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: descriptionAt500,
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('accepts name at exactly 100 characters', async () => {
+      const nameAt100 = 'a'.repeat(100);
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: nameAt100,
+          description: 'A valid description',
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('returns 400 for missing name field', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          description: 'A valid description',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('allows description to be optional', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+        }),
+      );
+
+      expect(res.status).toBe(201);
+    });
+
+    it('sets is_collaborative to true by default', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: 'A description',
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].is_collaborative).toBe(true);
+    });
+
+    it('allows is_collaborative to be explicitly false', async () => {
+      const mock = chainMock({ data: { ...SAMPLE_PLAYLIST, is_collaborative: false } });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: 'A description',
+          is_collaborative: false,
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].is_collaborative).toBe(false);
+    });
+
+    it('allows is_collaborative to be explicitly true', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: 'A description',
+          is_collaborative: true,
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].is_collaborative).toBe(true);
+    });
+
+    it('returns 400 for non-boolean is_collaborative', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: 'A description',
+          is_collaborative: 'true',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 for non-string name', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 123,
+          description: 'A description',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 for non-string description', async () => {
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Valid Name',
+          description: 123,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  describe('success paths', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 201 on successful playlist creation', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.playlist).toMatchObject(SAMPLE_PLAYLIST);
+    });
+
+    it('inserts playlist with correct fields', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0]).toMatchObject({
+        name: 'Summer Vibes',
+        description: 'Best tracks for summer 2026',
+        is_collaborative: true,
+        is_public: true,
+        created_by_fid: 123,
+      });
+    });
+
+    it('sets description to null when omitted', async () => {
+      const mock = chainMock({ data: { ...SAMPLE_PLAYLIST, description: null } });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].description).toBeNull();
+    });
+
+    it('includes session fid as created_by_fid', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+      const mock = chainMock({ data: { ...SAMPLE_PLAYLIST, created_by_fid: 456 } });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].created_by_fid).toBe(456);
+    });
+
+    it('calls select and single on playlist insert', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      const selectCalls = mock.chain.select.mock.calls;
+      const singleCalls = mock.chain.single.mock.calls;
+
+      expect(selectCalls).toBeDefined();
+      expect(selectCalls.length).toBeGreaterThan(0);
+      expect(singleCalls).toBeDefined();
+      expect(singleCalls.length).toBeGreaterThan(0);
+    });
+
+    it('adds creator as owner member after playlist creation', async () => {
+      const playlistMock = chainMock({ data: SAMPLE_PLAYLIST });
+      const memberMock = chainMock({ data: { playlist_id: SAMPLE_PLAYLIST.id, fid: 123 } });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table) => {
+        _callCount += 1;
+        if (table === 'playlists') return playlistMock.handler();
+        if (table === 'playlist_members') return memberMock.handler();
+        return playlistMock.handler();
+      });
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      const memberInsertCalls = memberMock.chain.insert.mock.calls;
+      expect(memberInsertCalls[0][0]).toMatchObject({
+        playlist_id: SAMPLE_PLAYLIST.id,
+        fid: 123,
+        role: 'owner',
+      });
+    });
+
+    it('calls autoCastToZao with playlist name and URL', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(
+        expect.stringContaining('Summer Vibes'),
+        'https://zaoos.com/music',
+      );
+    });
+
+    it('truncates autoCast message if name is very long', async () => {
+      const longName = 'a'.repeat(100);
+      const mock = chainMock({ data: { ...SAMPLE_PLAYLIST, name: longName } });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: longName,
+          description: 'A description',
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalled();
+      const castText = mockAutoCastToZao.mock.calls[0][0];
+      expect(castText).toContain(longName);
+    });
+
+    it('fire-and-forgets autoCastToZao without waiting', async () => {
+      const playlistMock = chainMock({ data: SAMPLE_PLAYLIST });
+      const memberMock = chainMock({ data: {} });
+
+      let _callCount = 0;
+      mockFrom.mockImplementation((table) => {
+        _callCount += 1;
+        if (table === 'playlists') return playlistMock.handler();
+        if (table === 'playlist_members') return memberMock.handler();
+        return playlistMock.handler();
+      });
+
+      // autoCastToZao returns a promise that rejects
+      mockAutoCastToZao.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            setTimeout(() => reject(new Error('Cast failed')), 10);
+          }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      // POST should still succeed despite autoCastToZao failing
+      expect(res.status).toBe(201);
+    });
+
+    it('sets is_public to true always', async () => {
+      const mock = chainMock({ data: SAMPLE_PLAYLIST });
+      mockFrom.mockImplementation(mock.handler);
+      mockAutoCastToZao.mockResolvedValue('cast_hash_123');
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'A description',
+          is_collaborative: false,
+        }),
+      );
+
+      const insertCalls = mock.chain.insert.mock.calls;
+      expect(insertCalls[0][0].is_public).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when playlist insert fails', async () => {
+      const playlistMock = chainMock({
+        error: { message: 'Constraint violation' },
+        data: null,
+      });
+      mockFrom.mockImplementation(playlistMock.handler);
+
+      const res = await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create playlist');
+    });
+
+    it('logs error when playlist insert fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const dbError = { message: 'Insert failed' };
+      const playlistMock = chainMock({
+        error: dbError,
+        data: null,
+      });
+      mockFrom.mockImplementation(playlistMock.handler);
+
+      await POST(
+        makePostRequest('/api/music/playlists/collaborative', {
+          name: 'Summer Vibes',
+          description: 'Best tracks for summer 2026',
+        }),
+      );
+
+      expect(logger.error).toHaveBeenCalledWith('[collaborative-playlists] POST error:', dbError);
+    });
+
+    it('returns 500 when JSON parsing fails', async () => {
+      const req = new (await import('next/server')).NextRequest(
+        new URL('/api/music/playlists/collaborative', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: 'not valid json {',
+        },
+      );
+
+      const res = await POST(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create playlist');
+    });
+
+    it('logs error when JSON parsing fails', async () => {
+      const { logger } = await import('@/lib/logger');
+      const req = new (await import('next/server')).NextRequest(
+        new URL('/api/music/playlists/collaborative', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: 'not valid json {',
+        },
+      );
+
+      await POST(req);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        '[collaborative-playlists] POST error:',
+        expect.any(Error),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **125 tests total**. viem/quick-auth/Neynar/Last.fm fully mocked — no real signing, network, or keys.

| Route | Tests | Covers |
|-------|-------|--------|
| `auth/lastfm/callback` | 18 | unauthorized + no-token redirects, getSession token exchange, user_settings upsert, error redirects |
| `miniapp/auth` | 31 | Bearer quick-auth verifyJwt (mocked), fid+wallet allowlist, getUserByFid, saveSession, 401/403 |
| `music/playlists/collaborative` | 38 | GET list+counts (allSettled), POST create (Zod, supabase insert + owner member + autoCastToZao), errors |
| `auth/signer` | 38 | auth, APP-signer EIP-712 SignedKeyRequest (viem mocked), createSigner+registerSignedKey, 502/500 |

**Security:** `auth/signer` tests use the public **anvil stub key** only (`0xac09…ff80`) — never a real key, per `.claude/rules/secret-hygiene.md`. Verified by 64-hex scan (stub is the sole match).

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)