### PR TITLE
test(events,livepeer,cron,admin): slug/clip/vault/nexus (153 tests)

### DIFF
--- a/src/app/api/admin/nexus/__tests__/route.test.ts
+++ b/src/app/api/admin/nexus/__tests__/route.test.ts
@@ -1,0 +1,1554 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetClientIp, mockLogAuditEvent } = vi.hoisted(() => ({
+  mockGetClientIp: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  getClientIp: mockGetClientIp,
+  logAuditEvent: mockLogAuditEvent,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE, GET, POST, PUT } from '../route';
+
+// ============================================================================
+// GET /api/admin/nexus
+// ============================================================================
+
+describe('GET /api/admin/nexus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('queries nexus_links table with correct ordering', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await GET();
+
+      expect(mockFrom).toHaveBeenCalledWith('nexus_links');
+      expect(chain.select).toHaveBeenCalledWith('*');
+      expect(chain.order).toHaveBeenNthCalledWith(1, 'category');
+      expect(chain.order).toHaveBeenNthCalledWith(2, 'subcategory');
+      expect(chain.order).toHaveBeenNthCalledWith(3, 'sort_order');
+    });
+
+    it('returns 500 when nexus_links query fails', async () => {
+      const dbError = new Error('Database connection failed');
+      const chain = chainMock({ data: null, error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch links');
+    });
+
+    it('returns 500 when exception is thrown during fetch', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch links');
+    });
+  });
+
+  describe('category and subcategory extraction', () => {
+    it('returns empty categories and subcategories when no links', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.categories).toEqual([]);
+      expect(body.subcategories).toEqual([]);
+    });
+
+    it('extracts unique categories from links', async () => {
+      const data = [
+        { id: VALID_UUID, category: 'Music', subcategory: 'Streaming' },
+        { id: VALID_UUID, category: 'Music', subcategory: 'Artists' },
+        { id: VALID_UUID, category: 'Social', subcategory: 'Networks' },
+      ];
+      const chain = chainMock({ data, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.categories).toEqual(['Music', 'Social']);
+    });
+
+    it('extracts unique subcategories from links', async () => {
+      const data = [
+        { id: VALID_UUID, category: 'Music', subcategory: 'Streaming' },
+        { id: VALID_UUID, category: 'Music', subcategory: 'Artists' },
+        { id: VALID_UUID, category: 'Social', subcategory: 'Streaming' },
+      ];
+      const chain = chainMock({ data, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.subcategories).toEqual(['Streaming', 'Artists']);
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with links array and metadata', async () => {
+      const data = [
+        {
+          id: VALID_UUID,
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        },
+      ];
+      const chain = chainMock({ data, error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.links).toEqual(data);
+      expect(body.count).toBe(1);
+      expect(body.categories).toBeDefined();
+      expect(body.subcategories).toBeDefined();
+    });
+
+    it('returns count of zero for empty link list', async () => {
+      const chain = chainMock({ data: [], error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.count).toBe(0);
+      expect(body.links).toEqual([]);
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Fetch failed');
+      });
+
+      await GET();
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Nexus admin fetch error:',
+        expect.any(Error),
+      );
+    });
+  });
+});
+
+// ============================================================================
+// POST /api/admin/nexus
+// ============================================================================
+
+describe('POST /api/admin/nexus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when title is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when title is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: '',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when title exceeds 200 characters', async () => {
+      const longTitle = 'a'.repeat(201);
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: longTitle,
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts title with exactly 200 characters', async () => {
+      const maxTitle = 'a'.repeat(200);
+      const chain = chainMock({
+        data: { id: VALID_UUID, title: maxTitle },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: maxTitle,
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.link).toBeDefined();
+    });
+
+    it('returns 400 when url is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when url is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'not-a-url',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when category is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when category is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: '',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when category exceeds 100 characters', async () => {
+      const longCategory = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: longCategory,
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when subcategory is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when subcategory exceeds 100 characters', async () => {
+      const longSubcategory = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: longSubcategory,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts optional description field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          description: 'A test link description',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when description exceeds 500 characters', async () => {
+      const longDescription = 'a'.repeat(501);
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          description: longDescription,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts optional icon field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          icon: '🎵',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when icon exceeds 50 characters', async () => {
+      const longIcon = 'a'.repeat(51);
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          icon: longIcon,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid portal_group enum values', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const validGroups = ['MUSIC', 'SOCIAL', 'BUILD', 'EARN', 'GOVERN', 'VIP'];
+
+      for (const group of validGroups) {
+        vi.clearAllMocks();
+        mockFrom.mockReturnValue(chain);
+        mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+
+        const res = await POST(
+          makePostRequest('/api/admin/nexus', {
+            title: 'Test Link',
+            url: 'https://example.com',
+            category: 'Music',
+            subcategory: 'Streaming',
+            portal_group: group as never,
+          }),
+        );
+
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it('returns 400 when portal_group is invalid enum value', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          portal_group: 'INVALID',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when sort_order is negative', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          sort_order: -1,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when sort_order is not an integer', async () => {
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          sort_order: 1.5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('defaults sort_order to 0 when not provided', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, sort_order: 0 },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.link).toBeDefined();
+    });
+
+    it('accepts is_featured boolean field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, is_featured: true },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          is_featured: true,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts is_active boolean field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, is_active: true },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          is_active: false,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts tags array field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, tags: ['tag1', 'tag2'] },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          tags: ['tag1', 'tag2'],
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('calls supabaseAdmin.from with nexus_links table', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('nexus_links');
+    });
+
+    it('inserts link with correct payload including added_by', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      const insertCall = vi.mocked(chain.insert);
+      expect(insertCall).toHaveBeenCalled();
+      const [payload] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload).toEqual(
+        expect.objectContaining({
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          added_by: 'fid:123',
+        }),
+      );
+    });
+
+    it('inserts link with all optional fields', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+          description: 'A test link',
+          icon: '🎵',
+          portal_group: 'MUSIC',
+          sort_order: 5,
+          is_featured: true,
+          is_active: true,
+          is_gated: false,
+          tags: ['test'],
+        }),
+      );
+
+      const insertCall = vi.mocked(chain.insert);
+      const [payload] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(payload).toEqual(
+        expect.objectContaining({
+          title: 'Test Link',
+          url: 'https://example.com',
+          description: 'A test link',
+          icon: '🎵',
+          portal_group: 'MUSIC',
+          sort_order: 5,
+          is_featured: true,
+          is_active: true,
+          is_gated: false,
+          tags: ['test'],
+        }),
+      );
+    });
+
+    it('calls .select() and .single() on insert', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      expect(chain.select).toHaveBeenCalledWith();
+      expect(chain.single).toHaveBeenCalled();
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event after successful insert', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'nexus.add',
+          targetType: 'nexus_link',
+          targetId: VALID_UUID,
+          details: {
+            title: 'Test Link',
+            url: 'https://example.com',
+          },
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('calls getClientIp with the request object', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/nexus', {
+        title: 'Test Link',
+        url: 'https://example.com',
+        category: 'Music',
+        subcategory: 'Streaming',
+      });
+
+      await POST(req);
+
+      expect(mockGetClientIp).toHaveBeenCalledWith(req);
+    });
+
+    it('does not log audit event when insert fails', async () => {
+      const dbError = new Error('Database error');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when Supabase insert returns error', async () => {
+      const dbError = new Error('Database connection failed');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add link');
+    });
+
+    it('returns 500 when request body is not valid JSON', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/nexus', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await POST(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to add link');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Insert failed');
+      });
+
+      await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith('Nexus add error:', expect.any(Error));
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with link data on valid request', async () => {
+      const linkData = { id: VALID_UUID, title: 'Test Link' };
+      const chain = chainMock({
+        data: linkData,
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await POST(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Test Link',
+          url: 'https://example.com',
+          category: 'Music',
+          subcategory: 'Streaming',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.link).toEqual(linkData);
+    });
+  });
+});
+
+// ============================================================================
+// PUT /api/admin/nexus (Update & Reorder)
+// ============================================================================
+
+describe('PUT /api/admin/nexus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated on single update', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when non-admin on single update', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when unauthenticated on reorder', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [
+            { id: VALID_UUID, sort_order: 1 },
+            { id: VALID_UUID, sort_order: 2 },
+          ],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when non-admin on reorder', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [{ id: VALID_UUID, sort_order: 1 }],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reorder operation', () => {
+    it('detects reorder operation by presence of updates array', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [{ id: VALID_UUID, sort_order: 1 }],
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalled();
+    });
+
+    it('returns 400 when updates array has invalid structure', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [{ id: 'not-uuid', sort_order: 1 }],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid reorder input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when sort_order is negative in reorder', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [{ id: VALID_UUID, sort_order: -1 }],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid reorder input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('updates multiple links with Promise.allSettled', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [
+            { id: VALID_UUID, sort_order: 1 },
+            { id: VALID_UUID, sort_order: 2 },
+          ],
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns 500 when any reorder update fails', async () => {
+      // Create a chain that rejects when awaited (for Promise.allSettled)
+      mockFrom.mockImplementation(() => {
+        return Promise.reject(new Error('Update failed'));
+      });
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [{ id: VALID_UUID, sort_order: 1 }],
+        }),
+      );
+      const body = await res.json();
+
+      // Route checks for rejected promises in allSettled results
+      expect(res.status).toBe(500);
+      expect(body.error).toMatch(/[Ff]ailed/);
+    });
+
+    it('returns success with updated count on successful reorder', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          updates: [
+            { id: VALID_UUID, sort_order: 1 },
+            { id: VALID_UUID, sort_order: 2 },
+            { id: VALID_UUID, sort_order: 3 },
+          ],
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.updated).toBe(3);
+    });
+  });
+
+  describe('single link update', () => {
+    it('returns 400 when id is missing in update', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when id is not valid UUID', async () => {
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: 'not-uuid',
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('allows partial updates with only some fields', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID, title: 'Updated Title' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('updates title field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'New Title',
+        }),
+      );
+
+      const updateCall = vi.mocked(chain.update);
+      expect(updateCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'New Title',
+          updated_at: expect.any(String),
+        }),
+      );
+    });
+
+    it('updates sort_order field', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          sort_order: 10,
+        }),
+      );
+
+      const updateCall = vi.mocked(chain.update);
+      expect(updateCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sort_order: 10,
+        }),
+      );
+    });
+
+    it('returns 500 when update fails', async () => {
+      const dbError = new Error('Update failed');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to update link');
+    });
+
+    it('logs audit event on successful update', async () => {
+      const chain = chainMock({
+        data: { id: VALID_UUID },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+          description: 'Updated description',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'nexus.update',
+          targetType: 'nexus_link',
+          targetId: VALID_UUID,
+          ipAddress: '192.168.1.1',
+        }),
+      );
+
+      // Verify that the details object contains at least the fields we sent
+      const call = vi.mocked(mockLogAuditEvent).mock.calls[0];
+      const details = (call[0] as Record<string, unknown>).details as Record<string, unknown>;
+      expect(details.title).toBe('Updated Title');
+      expect(details.description).toBe('Updated description');
+    });
+
+    it('does not log audit event when update fails', async () => {
+      const chain = chainMock({ error: new Error('Error') }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with updated link data', async () => {
+      const linkData = { id: VALID_UUID, title: 'Updated Title' };
+      const chain = chainMock({
+        data: linkData,
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.link).toEqual(linkData);
+    });
+  });
+
+  describe('error handling', () => {
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Update failed');
+      });
+
+      await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Nexus update error:',
+        expect.any(Error),
+      );
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Connection to db.example.com failed');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await PUT(
+        makePostRequest('/api/admin/nexus', {
+          id: VALID_UUID,
+          title: 'Updated Title',
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to update link');
+      expect(body.details).toBeUndefined();
+    });
+  });
+});
+
+// ============================================================================
+// DELETE /api/admin/nexus
+// ============================================================================
+
+describe('DELETE /api/admin/nexus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when id is missing', async () => {
+      const res = await DELETE(makePostRequest('/api/admin/nexus', {}));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when id is not a valid UUID', async () => {
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: 'not-a-uuid' }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts valid UUID v4 format', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('Supabase interaction', () => {
+    it('calls supabaseAdmin.from with nexus_links table', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      expect(mockFrom).toHaveBeenCalledWith('nexus_links');
+    });
+
+    it('deletes entry with correct id', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      const eqCall = vi.mocked(chain.eq);
+      expect(eqCall).toHaveBeenCalledWith('id', VALID_UUID);
+    });
+
+    it('performs delete operation', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      const deleteCall = vi.mocked(chain.delete);
+      expect(deleteCall).toHaveBeenCalled();
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event after successful delete', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'nexus.delete',
+          targetType: 'nexus_link',
+          targetId: VALID_UUID,
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('calls getClientIp with the request object', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const req = makePostRequest('/api/admin/nexus', { id: VALID_UUID });
+
+      await DELETE(req);
+
+      expect(mockGetClientIp).toHaveBeenCalledWith(req);
+    });
+
+    it('includes correct admin fid in audit event', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 999,
+        }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when Supabase delete returns error', async () => {
+      const dbError = new Error('Database error');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete link');
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 500 when request body is not valid JSON', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/admin/nexus', 'http://localhost:3000'),
+        {
+          method: 'DELETE',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await DELETE(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete link');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Delete failed');
+      });
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Nexus delete error:',
+        expect.any(Error),
+      );
+    });
+
+    it('does not log audit event when delete fails', async () => {
+      const dbError = new Error('Database error');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Connection to db.example.com failed');
+      const chain = chainMock({ error: dbError }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to delete link');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+  });
+
+  describe('success response', () => {
+    it('returns 200 with success true', async () => {
+      const chain = chainMock({ error: null }).chain;
+      mockFrom.mockReturnValue(chain);
+
+      const res = await DELETE(makePostRequest('/api/admin/nexus', { id: VALID_UUID }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(Object.keys(body)).toEqual(['success']);
+    });
+  });
+});

--- a/src/app/api/cron/agents/vault/__tests__/route.test.ts
+++ b/src/app/api/cron/agents/vault/__tests__/route.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+const { mockRunVault } = vi.hoisted(() => ({
+  mockRunVault: vi.fn(),
+}));
+
+vi.mock('@/lib/agents/vault', () => ({
+  runVault: mockRunVault,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/cron/agents/vault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('CRON_SECRET', 'test-secret-vault');
+  });
+
+  describe('environment configuration', () => {
+    it('returns 500 when CRON_SECRET is not configured', async () => {
+      vi.stubEnv('CRON_SECRET', '');
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('CRON_SECRET not configured');
+    });
+  });
+
+  describe('bearer token authentication', () => {
+    it('returns 401 when authorization header is missing', async () => {
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when authorization header has wrong token', async () => {
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer wrong-secret' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when authorization header lacks Bearer prefix', async () => {
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('accepts correct Bearer token', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Purchased 5 ZABAL tokens',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(mockRunVault).toHaveBeenCalled();
+    });
+  });
+
+  describe('vault agent execution', () => {
+    it('calls runVault on successful authentication', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Trade executed',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      await GET(req);
+
+      expect(mockRunVault).toHaveBeenCalledOnce();
+    });
+
+    it('returns 200 with agent result on success', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Purchased 2.5 ZABAL at $0.50',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.agent).toBe('VAULT');
+      expect(body.action).toBe('buy_zabal');
+      expect(body.status).toBe('success');
+      expect(body.details).toBe('Purchased 2.5 ZABAL at $0.50');
+    });
+
+    it('includes timestamp in response', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Trade succeeded',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.timestamp).toBeDefined();
+      expect(typeof body.timestamp).toBe('string');
+      // Verify it's a valid ISO string
+      expect(new Date(body.timestamp)).toBeInstanceOf(Date);
+    });
+
+    it('handles runVault returning skipped status', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'skipped',
+        details: 'Budget exceeded',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.status).toBe('skipped');
+      expect(body.details).toBe('Budget exceeded');
+    });
+
+    it('handles runVault returning failed status', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'failed',
+        details: 'Insufficient wallet balance',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.status).toBe('failed');
+      expect(body.details).toBe('Insufficient wallet balance');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when runVault throws an Error', async () => {
+      mockRunVault.mockRejectedValueOnce(new Error('Swap failed: slippage exceeded'));
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.agent).toBe('VAULT');
+      expect(body.action).toBe('buy_zabal');
+      expect(body.status).toBe('failed');
+      expect(body.details).toContain('Unhandled: Swap failed: slippage exceeded');
+    });
+
+    it('returns 500 and logs error when runVault throws', async () => {
+      const mockLogger = await import('@/lib/logger');
+      const mockError = vi.spyOn(mockLogger.logger, 'error');
+
+      mockRunVault.mockRejectedValueOnce(new Error('Network timeout'));
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining('[VAULT cron] Unhandled error'),
+      );
+    });
+
+    it('handles non-Error thrown values gracefully', async () => {
+      // eslint-disable-next-line no-throw-literal
+      mockRunVault.mockRejectedValueOnce('String error');
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.agent).toBe('VAULT');
+      expect(body.status).toBe('failed');
+      expect(body.details).toContain('Unhandled: String error');
+    });
+
+    it('includes timestamp in error response', async () => {
+      mockRunVault.mockRejectedValueOnce(new Error('Trade execution failed'));
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.timestamp).toBeDefined();
+      expect(typeof body.timestamp).toBe('string');
+    });
+  });
+
+  describe('response format', () => {
+    it('includes agent name in all responses', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Success',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.agent).toBe('VAULT');
+    });
+
+    it('spreads runVault result into response', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'Test details',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+      const body = await res.json();
+
+      expect(body.action).toBe('buy_zabal');
+      expect(body.status).toBe('success');
+      expect(body.details).toBe('Test details');
+    });
+
+    it('response is valid JSON', async () => {
+      mockRunVault.mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'OK',
+      });
+
+      const req = makeRequest('/api/cron/agents/vault', {
+        method: 'GET',
+        headers: { authorization: 'Bearer test-secret-vault' },
+      });
+      const res = await GET(req);
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+    });
+  });
+});

--- a/src/app/api/events/[slug]/__tests__/route.test.ts
+++ b/src/app/api/events/[slug]/__tests__/route.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+const { mockGetEventBySlug, mockLogger } = vi.hoisted(() => ({
+  mockGetEventBySlug: vi.fn(),
+  mockLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@/lib/unlock/events', () => ({
+  getEventBySlug: mockGetEventBySlug,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { GET } from '../route';
+
+/** A valid published event. */
+const SAMPLE_EVENT = {
+  id: 'evt-1',
+  slug: 'community-gathering-2026',
+  title: 'Community Gathering 2026',
+  description: 'A gathering of the ZAO community.',
+  lock_address: '0x1234567890abcdef1234567890abcdef12345678',
+  unlock_event_url: 'https://unlock-protocol.com/event/1',
+  chain_id: 8453, // Base
+  starts_at: '2026-07-20T10:00:00Z',
+  ends_at: '2026-07-20T15:00:00Z',
+  location: 'Virtual',
+  is_published: true,
+};
+
+/** An unpublished event. */
+const UNPUBLISHED_EVENT = {
+  ...SAMPLE_EVENT,
+  is_published: false,
+};
+
+describe('GET /api/events/[slug]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ========== Validation Tests ==========
+
+  it('returns 400 when slug is empty string', async () => {
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: '' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid event slug');
+  });
+
+  it('returns 400 when slug exceeds max length (100 chars)', async () => {
+    const longSlug = 'a'.repeat(101);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: longSlug });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid event slug');
+  });
+
+  it('returns 400 when slug is exactly 101 characters (exceeds 100 max)', async () => {
+    const exactlyTooLong = 'b'.repeat(101);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: exactlyTooLong });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Invalid event slug');
+  });
+
+  // ========== Valid Slug Tests ==========
+
+  it('accepts slug at minimum length (1 character)', async () => {
+    mockGetEventBySlug.mockResolvedValue(null);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'x' });
+
+    const _res = await GET(req, { params });
+
+    expect(mockGetEventBySlug).toHaveBeenCalledWith('x');
+  });
+
+  it('accepts slug at maximum length (100 characters)', async () => {
+    const maxLengthSlug = 'c'.repeat(100);
+    mockGetEventBySlug.mockResolvedValue(null);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: maxLengthSlug });
+
+    const _res = await GET(req, { params });
+
+    expect(mockGetEventBySlug).toHaveBeenCalledWith(maxLengthSlug);
+  });
+
+  // ========== Event Not Found ==========
+
+  it('returns 404 when event is not found', async () => {
+    mockGetEventBySlug.mockResolvedValue(null);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'nonexistent-event' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Event not found');
+  });
+
+  it('returns 404 when event exists but is not published', async () => {
+    mockGetEventBySlug.mockResolvedValue(UNPUBLISHED_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'unpublished-event' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Event not found');
+  });
+
+  // ========== Success Path ==========
+
+  it('returns 200 with event when event is found and published', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('event');
+    expect(body.event).toEqual(SAMPLE_EVENT);
+  });
+
+  it('returns complete event object with all fields', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+    const body = (await res.json()) as Record<string, unknown>;
+    const event = body.event as Record<string, unknown>;
+
+    expect(event).toHaveProperty('id', 'evt-1');
+    expect(event).toHaveProperty('slug', 'community-gathering-2026');
+    expect(event).toHaveProperty('title', 'Community Gathering 2026');
+    expect(event).toHaveProperty('description');
+    expect(event).toHaveProperty('lock_address');
+    expect(event).toHaveProperty('unlock_event_url');
+    expect(event).toHaveProperty('chain_id', 8453);
+    expect(event).toHaveProperty('starts_at');
+    expect(event).toHaveProperty('ends_at');
+    expect(event).toHaveProperty('location');
+    expect(event).toHaveProperty('is_published', true);
+  });
+
+  it('calls getEventBySlug with the parsed slug', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'test-slug-123' });
+
+    await GET(req, { params });
+
+    expect(mockGetEventBySlug).toHaveBeenCalledWith('test-slug-123');
+    expect(mockGetEventBySlug).toHaveBeenCalledTimes(1);
+  });
+
+  // ========== Partial/Null Fields ==========
+
+  it('handles event with null optional fields', async () => {
+    const eventWithNulls = {
+      ...SAMPLE_EVENT,
+      description: null,
+      lock_address: null,
+      unlock_event_url: null,
+      starts_at: null,
+      ends_at: null,
+      location: null,
+    };
+    mockGetEventBySlug.mockResolvedValue(eventWithNulls);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'sparse-event' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.event).toEqual(eventWithNulls);
+  });
+
+  // ========== Error Handling ==========
+
+  it('returns 500 when getEventBySlug throws an error', async () => {
+    mockGetEventBySlug.mockRejectedValue(new Error('Database connection failed'));
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Server error');
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[events/[slug]] Unexpected error:',
+      expect.any(Error),
+    );
+  });
+
+  it('logs error details when exception occurs', async () => {
+    const testError = new Error('Query failed');
+    mockGetEventBySlug.mockRejectedValue(testError);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    await GET(req, { params });
+
+    expect(mockLogger.error).toHaveBeenCalledWith('[events/[slug]] Unexpected error:', testError);
+  });
+
+  it('handles getEventBySlug rejection with non-Error objects', async () => {
+    mockGetEventBySlug.mockRejectedValue('Unknown error string');
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(500);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Server error');
+  });
+
+  // ========== Edge Cases ==========
+
+  it('handles slug with special characters (preserved as-is for lookup)', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'event-with-dashes_and_underscores' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(200);
+
+    expect(mockGetEventBySlug).toHaveBeenCalledWith('event-with-dashes_and_underscores');
+  });
+
+  it('does not require authentication (public route)', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(200);
+
+    // No session check or auth error
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for falsy event (null or undefined)', async () => {
+    mockGetEventBySlug.mockResolvedValue(undefined);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'missing-event' });
+
+    const res = await GET(req, { params });
+    expect(res.status).toBe(404);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toHaveProperty('error', 'Event not found');
+  });
+
+  // ========== Response Format ==========
+
+  it('returns NextResponse.json format with proper headers', async () => {
+    mockGetEventBySlug.mockResolvedValue(SAMPLE_EVENT);
+    const req = makeRequest('/api/events/[slug]');
+    const params = Promise.resolve({ slug: 'community-gathering-2026' });
+
+    const res = await GET(req, { params });
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+  });
+});

--- a/src/app/api/livepeer/clip/__tests__/route.test.ts
+++ b/src/app/api/livepeer/clip/__tests__/route.test.ts
@@ -1,0 +1,569 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ===== Hoisted mocks =====
+const { mockGetSessionData, mockCreateClip } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockCreateClip: vi.fn(),
+}));
+
+// ===== Module mocks =====
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('livepeer', () => ({
+  Livepeer: vi.fn(() => ({
+    stream: {
+      createClip: mockCreateClip,
+    },
+  })),
+}));
+
+// Dynamically set the env var before importing the route
+beforeEach(() => {
+  process.env.LIVEPEER_API_KEY = 'test-livepeer-key';
+});
+
+import { POST } from '../route';
+
+// ===== Test fixtures =====
+
+const validClipPayload = {
+  playbackId: 'playback-test-123',
+  startTime: 0,
+  endTime: 10,
+  name: 'Test Clip',
+};
+
+const validSession = mockAuthenticatedSession({ fid: 456, username: 'testuser' });
+
+const mockClipResponse = {
+  id: 'clip-xyz-123',
+  playbackId: 'playback-test-123',
+  startTime: 0,
+  endTime: 10,
+  name: 'Test Clip',
+  url: 'https://livepeer.com/clips/clip-xyz-123',
+};
+
+describe('POST /api/livepeer/clip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+    mockCreateClip.mockClear();
+  });
+
+  // ===== AUTHENTICATION TESTS =====
+  describe('authentication', () => {
+    it('returns 401 when no session is provided', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  // ===== VALIDATION TESTS =====
+  describe('input validation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 400 when playbackId is missing', async () => {
+      const payload = {
+        startTime: 0,
+        endTime: 10,
+        name: 'Test Clip',
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when playbackId is empty string', async () => {
+      const payload = {
+        playbackId: '',
+        startTime: 0,
+        endTime: 10,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when startTime is missing', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        endTime: 10,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when endTime is missing', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when startTime is negative', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: -1,
+        endTime: 10,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when endTime is negative', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: -1,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+      const body = (await res.json()) as { error?: string; details?: object };
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('accepts 0 as valid startTime', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 10,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts 0 as valid endTime', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 0,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts optional name parameter', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 10,
+        name: 'Custom Clip Name',
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Custom Clip Name',
+        }),
+      );
+    });
+
+    it('returns 500 when payload is not valid JSON', async () => {
+      const { makeRequest } = await import('@/test-utils/api-helpers');
+      const res = await POST(
+        makeRequest('/api/livepeer/clip', {
+          method: 'POST',
+          body: 'not json',
+        }),
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create clip');
+    });
+  });
+
+  // ===== LIVEPEER SDK INTEGRATION TESTS =====
+  describe('Livepeer SDK integration', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+    });
+
+    it('returns 500 when LIVEPEER_API_KEY is not configured', async () => {
+      delete process.env.LIVEPEER_API_KEY;
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create clip');
+    });
+
+    it('calls livepeer.stream.createClip with correct parameters', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith({
+        playbackId: 'playback-test-123',
+        startTime: 0,
+        endTime: 10,
+        name: 'Test Clip',
+      });
+    });
+
+    it('uses default name when name is not provided', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 10,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playbackId: 'playback-123',
+          startTime: 0,
+          endTime: 10,
+          name: expect.stringMatching(/^ZAO Clip \d+$/),
+        }),
+      );
+    });
+
+    it('preserves playbackId in SDK call', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'special-playback-id-xyz',
+        startTime: 5,
+        endTime: 15,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playbackId: 'special-playback-id-xyz',
+        }),
+      );
+    });
+
+    it('preserves startTime and endTime in SDK call', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 5,
+        endTime: 25,
+      };
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: 5,
+          endTime: 25,
+        }),
+      );
+    });
+  });
+
+  // ===== SUCCESS RESPONSE TESTS =====
+  describe('successful clip creation', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+    });
+
+    it('returns 200 with correct clip response shape', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { success?: boolean; clip?: object };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.clip).toBeDefined();
+    });
+
+    it('returns clip id from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { clip?: { id?: string } };
+
+      expect(body.clip?.id).toBe('clip-xyz-123');
+    });
+
+    it('returns clip playbackId from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { clip?: { playbackId?: string } };
+
+      expect(body.clip?.playbackId).toBe('playback-test-123');
+    });
+
+    it('returns clip url from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { clip?: { url?: string } };
+
+      expect(body.clip?.url).toBe('https://livepeer.com/clips/clip-xyz-123');
+    });
+
+    it('returns full clip object from Livepeer response', async () => {
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { clip?: Record<string, unknown> };
+
+      expect(body.clip).toMatchObject({
+        id: 'clip-xyz-123',
+        playbackId: 'playback-test-123',
+        startTime: 0,
+        endTime: 10,
+        name: 'Test Clip',
+        url: 'https://livepeer.com/clips/clip-xyz-123',
+      });
+    });
+  });
+
+  // ===== ERROR HANDLING TESTS =====
+  describe('error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 500 when stream.createClip throws', async () => {
+      mockCreateClip.mockRejectedValue(new Error('Clip creation failed'));
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create clip');
+    });
+
+    it('returns 500 when Livepeer SDK throws API error', async () => {
+      mockCreateClip.mockRejectedValue(new Error('401 Unauthorized - Invalid API key'));
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create clip');
+    });
+
+    it('returns 500 when Livepeer SDK throws network error', async () => {
+      mockCreateClip.mockRejectedValue(new Error('Network timeout'));
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create clip');
+    });
+
+    it('logs errors via logger.error', async () => {
+      mockCreateClip.mockRejectedValue(new Error('Clip API error'));
+
+      await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith('Livepeer clip error:', expect.any(Error));
+    });
+  });
+
+  // ===== EDGE CASES =====
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+    });
+
+    it('accepts playbackId with special characters', async () => {
+      const payload = {
+        playbackId: 'playback-123_abc-def.xyz',
+        startTime: 0,
+        endTime: 10,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playbackId: 'playback-123_abc-def.xyz',
+        }),
+      );
+    });
+
+    it('accepts large startTime and endTime values', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 3600,
+        endTime: 7200,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: 3600,
+          endTime: 7200,
+        }),
+      );
+    });
+
+    it('accepts decimal time values', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 1.5,
+        endTime: 10.7,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: 1.5,
+          endTime: 10.7,
+        }),
+      );
+    });
+
+    it('accepts very long clip name', async () => {
+      const longName = 'a'.repeat(200);
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 10,
+        name: longName,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: longName,
+        }),
+      );
+    });
+
+    it('handles endTime equal to startTime', async () => {
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 5,
+        endTime: 5,
+      };
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', payload));
+
+      expect(res.status).toBe(200);
+      expect(mockCreateClip).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: 5,
+          endTime: 5,
+        }),
+      );
+    });
+
+    it('generates unique default names on successive calls', async () => {
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const payload = {
+        playbackId: 'playback-123',
+        startTime: 0,
+        endTime: 10,
+      };
+
+      await POST(makePostRequest('/api/livepeer/clip', payload));
+      const firstCall = mockCreateClip.mock.calls[0]?.[0]?.name;
+
+      // Small delay to ensure different timestamp
+      await new Promise((resolve) => setTimeout(resolve, 1));
+
+      await POST(makePostRequest('/api/livepeer/clip', payload));
+      const secondCall = mockCreateClip.mock.calls[1]?.[0]?.name;
+
+      expect(firstCall).toMatch(/^ZAO Clip \d+$/);
+      expect(secondCall).toMatch(/^ZAO Clip \d+$/);
+      expect(firstCall).not.toBe(secondCall);
+    });
+  });
+
+  // ===== SESSION DATA ISOLATION TESTS =====
+  describe('session data isolation', () => {
+    it('does not leak session data in response', async () => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ fid: 789, username: 'secretuser' }),
+      );
+      mockCreateClip.mockResolvedValue(mockClipResponse);
+
+      const res = await POST(makePostRequest('/api/livepeer/clip', validClipPayload));
+      const body = (await res.json()) as Record<string, unknown>;
+
+      // Response should only contain success and clip fields
+      expect(Object.keys(body)).toEqual(expect.arrayContaining(['success', 'clip']));
+      expect(JSON.stringify(body)).not.toContain('secretuser');
+      expect(JSON.stringify(body)).not.toContain('789');
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **153 tests total**. External Livepeer/agent-runner/Unlock fully mocked — no real API calls or agent trades.

| Route | Tests | Covers |
|-------|-------|--------|
| `events/[slug]` | 18 | public, dynamic param, slug Zod, getEventBySlug, not-found 404, unpublished, errors |
| `livepeer/clip` | 33 | auth, Zod (playbackId/times), Livepeer SDK (mocked) createClip, missing-key 500, errors |
| `cron/agents/vault` | 17 | CRON_SECRET guard, Bearer, **runVault mocked (no real trades)**, skipped/failed status, errors |
| `admin/nexus` | 85 | GET/POST/PUT/DELETE — admin guards, nexusLinkSchema (portal_group enum), reorder (allSettled), supabase CRUD, audit-log, errors |

Test-only — no runtime files touched. `cron/agents/vault` mocks the VAULT agent runner so no real trade executes. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)