### PR TITLE
test(cron,livepeer,juke): banker/dealer/stream-id/webhooks (92 tests)

### DIFF
--- a/src/app/api/cron/agents/banker/__tests__/route.test.ts
+++ b/src/app/api/cron/agents/banker/__tests__/route.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockRunBanker } = vi.hoisted(() => ({
+  mockRunBanker: vi.fn(),
+}));
+
+vi.mock('@/lib/agents/banker', () => ({
+  runBanker: mockRunBanker,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+// Mock env var access
+vi.stubGlobal('process', {
+  env: {
+    CRON_SECRET: 'test-secret-123',
+  },
+});
+
+import { GET } from '@/app/api/cron/agents/banker/route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a NextRequest with an optional Authorization header.
+ */
+function makeBankerRequest(authHeader?: string) {
+  const options: RequestInit = {};
+  if (authHeader) {
+    options.headers = {
+      authorization: authHeader,
+    };
+  }
+  return makeRequest('/api/cron/agents/banker', options);
+}
+
+describe('GET /api/cron/agents/banker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authorization tests ──────────────────────────────────────────────────
+
+  it('returns 401 when authorization header is missing', async () => {
+    const req = makeBankerRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when authorization header is incorrect', async () => {
+    const req = makeBankerRequest('Bearer wrong-secret');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when authorization header has wrong scheme', async () => {
+    const req = makeBankerRequest('Basic test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    // Temporarily remove CRON_SECRET from env
+    const original = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('CRON_SECRET not configured');
+
+    // Restore
+    process.env.CRON_SECRET = original;
+  });
+
+  // ── Success path tests ───────────────────────────────────────────────────
+
+  it('returns success when authorized with correct Bearer token', async () => {
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Bought 10 ZABAL',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent).toBe('BANKER');
+    expect(body.action).toBe('buy_zabal');
+    expect(body.status).toBe('success');
+    expect(body.details).toBe('Bought 10 ZABAL');
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('calls runBanker when authorized', async () => {
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Agent executed',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    await GET(req);
+
+    expect(mockRunBanker).toHaveBeenCalledOnce();
+    expect(mockRunBanker).toHaveBeenCalledWith();
+  });
+
+  it('includes timestamp in successful response', async () => {
+    const before = new Date().toISOString();
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Executed',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+    const body = await res.json();
+    const after = new Date().toISOString();
+
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+    expect(body.timestamp >= before && body.timestamp <= after).toBe(true);
+  });
+
+  it('returns status skipped when agent is disabled', async () => {
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'buy_zabal',
+      status: 'skipped',
+      details: 'Agent disabled',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent).toBe('BANKER');
+    expect(body.status).toBe('skipped');
+  });
+
+  // ── Error path tests ─────────────────────────────────────────────────────
+
+  it('returns 500 when runBanker throws an error', async () => {
+    mockRunBanker.mockRejectedValueOnce(new Error('Wallet disconnected'));
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.agent).toBe('BANKER');
+    expect(body.action).toBe('buy_zabal');
+    expect(body.status).toBe('failed');
+    expect(body.details).toContain('Wallet disconnected');
+  });
+
+  it('returns 500 with failed status when runBanker throws', async () => {
+    mockRunBanker.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe('failed');
+    expect(body.details).toContain('Network timeout');
+  });
+
+  it('handles non-Error thrown values gracefully', async () => {
+    mockRunBanker.mockRejectedValueOnce('unexpected string error');
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe('failed');
+    expect(body.details).toContain('unexpected string error');
+  });
+
+  it('includes timestamp in error response', async () => {
+    const before = new Date().toISOString();
+    mockRunBanker.mockRejectedValueOnce(new Error('Test error'));
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+    const body = await res.json();
+    const after = new Date().toISOString();
+
+    expect(body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+    expect(body.timestamp >= before && body.timestamp <= after).toBe(true);
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  it('handles multiple sequential requests independently', async () => {
+    mockRunBanker
+      .mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'success',
+        details: 'First run',
+      })
+      .mockResolvedValueOnce({
+        action: 'buy_zabal',
+        status: 'skipped',
+        details: 'Second run disabled',
+      });
+
+    const req1 = makeBankerRequest('Bearer test-secret-123');
+    const res1 = await GET(req1);
+    const body1 = await res1.json();
+
+    const req2 = makeBankerRequest('Bearer test-secret-123');
+    const res2 = await GET(req2);
+    const body2 = await res2.json();
+
+    expect(body1.status).toBe('success');
+    expect(body2.status).toBe('skipped');
+    expect(mockRunBanker).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves agent result action in response', async () => {
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'report',
+      status: 'skipped',
+      details: 'No budget',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.action).toBe('report');
+  });
+
+  it('spreads all runBanker result fields into response', async () => {
+    mockRunBanker.mockResolvedValueOnce({
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Executed with metadata',
+    });
+
+    const req = makeBankerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body).toMatchObject({
+      agent: 'BANKER',
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Executed with metadata',
+    });
+    expect(body.timestamp).toBeDefined();
+  });
+});

--- a/src/app/api/cron/agents/dealer/__tests__/route.test.ts
+++ b/src/app/api/cron/agents/dealer/__tests__/route.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockRunDealer } = vi.hoisted(() => ({
+  mockRunDealer: vi.fn(),
+}));
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/agents/dealer', () => ({
+  runDealer: mockRunDealer,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// Mock env var access
+vi.stubGlobal('process', {
+  env: {
+    CRON_SECRET: 'test-secret-123',
+  },
+});
+
+import { GET } from '@/app/api/cron/agents/dealer/route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a NextRequest with an optional Authorization header.
+ */
+function makeDealerRequest(authHeader?: string) {
+  const options: RequestInit = {};
+  if (authHeader) {
+    options.headers = {
+      authorization: authHeader,
+    };
+  }
+  return makeRequest('/api/cron/agents/dealer', options);
+}
+
+describe('GET /api/cron/agents/dealer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authorization tests ──────────────────────────────────────────────────
+
+  it('returns 401 when authorization header is missing', async () => {
+    const req = makeDealerRequest();
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(mockRunDealer).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authorization header is incorrect', async () => {
+    const req = makeDealerRequest('Bearer wrong-secret');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(mockRunDealer).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authorization header has wrong scheme', async () => {
+    const req = makeDealerRequest('Basic test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(mockRunDealer).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authorization header is empty Bearer', async () => {
+    const req = makeDealerRequest('Bearer ');
+    const res = await GET(req);
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+    expect(mockRunDealer).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    // Temporarily remove CRON_SECRET from env
+    const original = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('CRON_SECRET not configured');
+    expect(mockRunDealer).not.toHaveBeenCalled();
+
+    // Restore
+    process.env.CRON_SECRET = original;
+  });
+
+  // ── Success path tests ───────────────────────────────────────────────────
+
+  it('returns 200 when authorized with correct Bearer token', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Purchased 100 ZABAL tokens',
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent).toBe('DEALER');
+    expect(body.action).toBe('buy_zabal');
+    expect(body.status).toBe('success');
+    expect(body.timestamp).toBeDefined();
+    expect(mockRunDealer).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls runDealer when auth succeeds', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: 'success',
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    await GET(req);
+
+    expect(mockRunDealer).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes runDealer result in response', async () => {
+    const dealerResult = {
+      action: 'buy_zabal',
+      status: 'success',
+      details: 'Executed 5 trades',
+      volume: 500,
+    };
+    mockRunDealer.mockResolvedValue(dealerResult);
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject(dealerResult);
+    expect(body.agent).toBe('DEALER');
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('includes timestamp in response', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: 'success',
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.timestamp).toBeDefined();
+    // Verify it's a valid ISO string
+    expect(() => new Date(body.timestamp)).not.toThrow();
+  });
+
+  // ── Error path tests ─────────────────────────────────────────────────────
+
+  it('returns 500 when runDealer throws an Error', async () => {
+    const error = new Error('Agent execution failed');
+    mockRunDealer.mockRejectedValue(error);
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.agent).toBe('DEALER');
+    expect(body.action).toBe('buy_zabal');
+    expect(body.status).toBe('failed');
+    expect(body.details).toContain('Agent execution failed');
+    expect(body.timestamp).toBeDefined();
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('[DEALER cron]'));
+  });
+
+  it('returns 500 when runDealer throws a non-Error value', async () => {
+    mockRunDealer.mockRejectedValue('Unexpected string error');
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.status).toBe('failed');
+    expect(body.details).toContain('Unexpected string error');
+  });
+
+  it('logs error when runDealer throws', async () => {
+    const error = new Error('Network timeout');
+    mockRunDealer.mockRejectedValue(error);
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    await GET(req);
+
+    expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('[DEALER cron]'));
+  });
+
+  it('returns error response shape on agent failure', async () => {
+    const error = new Error('Buy failed');
+    mockRunDealer.mockRejectedValue(error);
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    const body = await res.json();
+    expect(body).toEqual({
+      agent: 'DEALER',
+      action: 'buy_zabal',
+      status: 'failed',
+      details: expect.stringContaining('Buy failed'),
+      timestamp: expect.any(String),
+    });
+  });
+
+  it('includes timestamp in error response', async () => {
+    mockRunDealer.mockRejectedValue(new Error('Test error'));
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    const body = await res.json();
+    expect(body.timestamp).toBeDefined();
+    expect(() => new Date(body.timestamp)).not.toThrow();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  it('handles runDealer with empty result object', async () => {
+    mockRunDealer.mockResolvedValue({});
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agent).toBe('DEALER');
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('handles runDealer with null values in result', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: null,
+      details: null,
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBeNull();
+    expect(body.details).toBeNull();
+  });
+
+  it('does not call runDealer when CRON_SECRET is missing', async () => {
+    const original = process.env.CRON_SECRET;
+    delete process.env.CRON_SECRET;
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    await GET(req);
+
+    expect(mockRunDealer).not.toHaveBeenCalled();
+    process.env.CRON_SECRET = original;
+  });
+
+  it('does not call runDealer when auth header is wrong', async () => {
+    const req = makeDealerRequest('Bearer wrong');
+    await GET(req);
+
+    expect(mockRunDealer).not.toHaveBeenCalled();
+  });
+
+  it('extracts Bearer token correctly with multiple spaces in result', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: 'success',
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    // Should succeed (Bearer token was extracted and matched correctly)
+    expect(res.status).toBe(200);
+    expect(mockRunDealer).toHaveBeenCalled();
+  });
+
+  it('response JSON is valid', async () => {
+    mockRunDealer.mockResolvedValue({
+      action: 'buy_zabal',
+      status: 'success',
+    });
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(typeof body).toBe('object');
+    expect(body).not.toBeNull();
+  });
+
+  it('error response JSON is valid', async () => {
+    mockRunDealer.mockRejectedValue(new Error('Test'));
+
+    const req = makeDealerRequest('Bearer test-secret-123');
+    const res = await GET(req);
+
+    expect(res.headers.get('content-type')).toContain('application/json');
+    const body = await res.json();
+    expect(typeof body).toBe('object');
+    expect(body).not.toBeNull();
+  });
+});

--- a/src/app/api/juke/webhooks/__tests__/route.test.ts
+++ b/src/app/api/juke/webhooks/__tests__/route.test.ts
@@ -1,0 +1,782 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeRequest } from '@/test-utils/api-helpers';
+
+const {
+  mockVerifyJukeWebhook,
+  mockParseWebhookEvent,
+  mockRecordWebhookEvent,
+  mockApplyWebhookEvent,
+  mockMarkWebhookProcessed,
+  mockEnv,
+  mockLogger,
+} = vi.hoisted(() => ({
+  mockVerifyJukeWebhook: vi.fn(),
+  mockParseWebhookEvent: vi.fn(),
+  mockRecordWebhookEvent: vi.fn(),
+  mockApplyWebhookEvent: vi.fn(),
+  mockMarkWebhookProcessed: vi.fn(),
+  mockEnv: { JUKE_WEBHOOK_SECRET: 'test-secret-key' },
+  mockLogger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/spaces/jukeWebhookVerify', () => ({
+  verifyJukeWebhook: mockVerifyJukeWebhook,
+}));
+
+vi.mock('@/lib/spaces/jukeWebhookHandlers', () => ({
+  parseWebhookEvent: mockParseWebhookEvent,
+  applyWebhookEvent: mockApplyWebhookEvent,
+}));
+
+vi.mock('@/lib/spaces/jukeSpacesDb', () => ({
+  recordWebhookEvent: mockRecordWebhookEvent,
+  markWebhookProcessed: mockMarkWebhookProcessed,
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: mockEnv,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+import { GET, POST } from '../route';
+
+describe('POST /api/juke/webhooks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================================================================
+  // Signature verification failure tests
+  // =========================================================================
+
+  it('returns 401 when JUKE_WEBHOOK_SECRET is unset', async () => {
+    // Temporarily unset the secret
+    const originalSecret = mockEnv.JUKE_WEBHOOK_SECRET;
+    mockEnv.JUKE_WEBHOOK_SECRET = undefined;
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Webhook not configured');
+
+    // Restore the original secret
+    mockEnv.JUKE_WEBHOOK_SECRET = originalSecret;
+  });
+
+  it('returns 401 on invalid signature header', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: false,
+      reason: 'Missing or malformed X-Juke-Signature header',
+    });
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-juke-signature': 'invalid' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Missing or malformed X-Juke-Signature header');
+  });
+
+  it('returns 401 on signature timestamp outside replay window', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: false,
+      reason: 'Signature timestamp outside replay window',
+    });
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-juke-signature': 't=1000000000,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Signature timestamp outside replay window');
+  });
+
+  it('returns 401 on signature mismatch', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: false,
+      reason: 'Signature mismatch',
+      debug: {
+        secretLen: 32,
+        secretFp: 'abc123def456',
+        bodyLen: 10,
+        headerRaw: 't=1234567890,v1=badhash',
+        expectedRawPrefix: 'expectedh',
+        receivedV1Prefix: 'badhashfr',
+        variantsTried: ['raw:32b', 'no-whsec:26b'],
+      },
+    });
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-juke-signature': 't=1234567890,v1=badhash' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Signature mismatch');
+  });
+
+  // =========================================================================
+  // JSON parsing failure tests
+  // =========================================================================
+
+  it('returns 400 on invalid JSON body', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: 'not valid json',
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Invalid JSON body');
+  });
+
+  // =========================================================================
+  // recordWebhookEvent error handling
+  // =========================================================================
+
+  it('returns 500 when recordWebhookEvent throws', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'room.started', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    mockRecordWebhookEvent.mockRejectedValue(new Error('Database connection failed'));
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Could not record event');
+  });
+
+  // =========================================================================
+  // Idempotency (duplicate/already-processed)
+  // =========================================================================
+
+  it('returns 200 with duplicate:true on replay (recordWebhookEvent returns false)', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'room.started', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    // Record returns false = already processed
+    mockRecordWebhookEvent.mockResolvedValue(false);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.duplicate).toBe(true);
+
+    // Verify we did NOT call applyWebhookEvent
+    expect(mockApplyWebhookEvent).not.toHaveBeenCalled();
+    expect(mockMarkWebhookProcessed).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Successful happy path
+  // =========================================================================
+
+  it('successfully processes a valid webhook event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'room.started', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.duplicate).toBeUndefined();
+    expect(body.handler_error).toBeUndefined();
+
+    // Verify the full flow
+    expect(mockParseWebhookEvent).toHaveBeenCalledWith(payload);
+    expect(mockRecordWebhookEvent).toHaveBeenCalledWith({
+      eventType: 'room.started',
+      jukeEventId: 'event-456',
+      signatureHash: 'hash123abc',
+      spaceId: 'space-123',
+      body: payload,
+    });
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith('room.started', 'space-123', payload);
+    expect(mockMarkWebhookProcessed).toHaveBeenCalledWith('hash123abc');
+  });
+
+  // =========================================================================
+  // applyWebhookEvent error handling
+  // =========================================================================
+
+  it('returns 200 with handler_error when applyWebhookEvent throws', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = {
+      event_type: 'participant.joined',
+      space_id: 'space-123',
+    };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'participant.joined',
+      spaceId: 'space-123',
+      eventId: 'event-789',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockRejectedValue(new Error('Failed to add participant'));
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.handler_error).toBe('Failed to add participant');
+
+    // Verify markWebhookProcessed was called with error message
+    expect(mockMarkWebhookProcessed).toHaveBeenCalledWith(
+      'hash123abc',
+      'Failed to add participant',
+    );
+  });
+
+  it('tolerates markWebhookProcessed.catch when applyWebhookEvent throws', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'room.finished', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.finished',
+      spaceId: 'space-123',
+      eventId: 'event-999',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockRejectedValue(new Error('Handler failed'));
+    // markWebhookProcessed itself throws
+    mockMarkWebhookProcessed.mockRejectedValue(new Error('Mark failed silently'));
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    // Route still returns 200 even if markWebhookProcessed fails (silently caught)
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.handler_error).toBe('Handler failed');
+  });
+
+  it('returns handler_error for non-Error throws from applyWebhookEvent', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'recording.ready', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'recording.ready',
+      spaceId: 'space-123',
+      eventId: null,
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    // Throw a non-Error value
+    mockApplyWebhookEvent.mockRejectedValue('string error');
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.handler_error).toBe('handler failed');
+  });
+
+  // =========================================================================
+  // Signature verification variants
+  // =========================================================================
+
+  it('logs when signature is verified via non-raw variant', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+      matchedVariant: 'no-whsec',
+    });
+
+    const payload = { event_type: 'room.started', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    await POST(req);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      '[juke/webhooks] signature verified via non-raw variant:',
+      'no-whsec',
+    );
+  });
+
+  // =========================================================================
+  // recordWebhookEvent call validation
+  // =========================================================================
+
+  it('calls recordWebhookEvent with correct payload structure', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'signature-hash-xyz',
+    });
+
+    const payload = {
+      event_type: 'participant.left',
+      space_id: 'space-abc',
+      event_id: 'evt-789',
+      data: { fid: 456 },
+    };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'participant.left',
+      spaceId: 'space-abc',
+      eventId: 'evt-789',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    await POST(req);
+
+    expect(mockRecordWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'participant.left',
+        jukeEventId: 'evt-789',
+        signatureHash: 'signature-hash-xyz',
+        spaceId: 'space-abc',
+        body: payload,
+      }),
+    );
+  });
+
+  // =========================================================================
+  // Event types coverage
+  // =========================================================================
+
+  it('handles room.started event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash1',
+    });
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-1',
+      eventId: 'evt-1',
+    });
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ event_type: 'room.started' }),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith(
+      'room.started',
+      'space-1',
+      expect.any(Object),
+    );
+  });
+
+  it('handles room.finished event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash2',
+    });
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.finished',
+      spaceId: 'space-2',
+      eventId: 'evt-2',
+    });
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ event_type: 'room.finished' }),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith(
+      'room.finished',
+      'space-2',
+      expect.any(Object),
+    );
+  });
+
+  it('handles participant.joined event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash3',
+    });
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'participant.joined',
+      spaceId: 'space-3',
+      eventId: 'evt-3',
+    });
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ event_type: 'participant.joined' }),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith(
+      'participant.joined',
+      'space-3',
+      expect.any(Object),
+    );
+  });
+
+  it('handles participant.left event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash4',
+    });
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'participant.left',
+      spaceId: 'space-4',
+      eventId: 'evt-4',
+    });
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ event_type: 'participant.left' }),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith(
+      'participant.left',
+      'space-4',
+      expect.any(Object),
+    );
+  });
+
+  it('handles recording.ready event', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash5',
+    });
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'recording.ready',
+      spaceId: 'space-5',
+      eventId: 'evt-5',
+    });
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify({ event_type: 'recording.ready' }),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockApplyWebhookEvent).toHaveBeenCalledWith(
+      'recording.ready',
+      'space-5',
+      expect.any(Object),
+    );
+  });
+
+  // =========================================================================
+  // Response shape validation
+  // =========================================================================
+
+  it('returns response with ok:true and no extra fields on success', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'room.started', space_id: 'space-123' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  it('returns error response with ok:false and reason', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: false,
+      reason: 'Test error reason',
+    });
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'x-juke-signature': 't=1234567890,v1=bad' },
+    });
+
+    const res = await POST(req);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe('Test error reason');
+  });
+
+  // =========================================================================
+  // GET method (should reject)
+  // =========================================================================
+
+  it('GET returns 405 Method Not Allowed', async () => {
+    const _req = makeRequest('/api/juke/webhooks', { method: 'GET' });
+    const res = GET();
+    expect(res.status).toBe(405);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('POST only');
+  });
+
+  // =========================================================================
+  // Edge cases
+  // =========================================================================
+
+  it('handles null spaceId from parseWebhookEvent gracefully', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = { event_type: 'unknown.event' };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'unknown.event',
+      spaceId: null,
+      eventId: null,
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    // Verify recordWebhookEvent was called with spaceId: null
+    expect(mockRecordWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spaceId: null,
+      }),
+    );
+  });
+
+  it('preserves raw body JSON when calling recordWebhookEvent', async () => {
+    mockVerifyJukeWebhook.mockReturnValue({
+      ok: true,
+      ts: Math.floor(Date.now() / 1000),
+      signatureHash: 'hash123abc',
+    });
+
+    const payload = {
+      event_type: 'room.started',
+      space_id: 'space-123',
+      extra_field: 'some data',
+      nested: { foo: 'bar' },
+    };
+    mockParseWebhookEvent.mockReturnValue({
+      eventType: 'room.started',
+      spaceId: 'space-123',
+      eventId: 'event-456',
+    });
+
+    mockRecordWebhookEvent.mockResolvedValue(true);
+    mockApplyWebhookEvent.mockResolvedValue(undefined);
+    mockMarkWebhookProcessed.mockResolvedValue(undefined);
+
+    const req = makeRequest('/api/juke/webhooks', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: { 'x-juke-signature': 't=1234567890,v1=abc123' },
+    });
+
+    await POST(req);
+
+    // Verify the entire payload is stored in body
+    expect(mockRecordWebhookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: payload,
+      }),
+    );
+  });
+});

--- a/src/app/api/livepeer/stream/[id]/__tests__/route.test.ts
+++ b/src/app/api/livepeer/stream/[id]/__tests__/route.test.ts
@@ -1,0 +1,587 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ===== Hoisted mocks =====
+const { mockGetSessionData, mockLivepeerStreamGet, mockLivepeerStreamDelete } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockLivepeerStreamGet: vi.fn(),
+  mockLivepeerStreamDelete: vi.fn(),
+}));
+
+// ===== Module mocks =====
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('livepeer', () => ({
+  Livepeer: vi.fn(() => ({
+    stream: {
+      get: mockLivepeerStreamGet,
+      delete: mockLivepeerStreamDelete,
+    },
+  })),
+}));
+
+// Dynamically set the env var before importing the route
+beforeEach(() => {
+  process.env.LIVEPEER_API_KEY = 'test-livepeer-key';
+});
+
+import { DELETE, GET } from '../route';
+
+// ===== Test fixtures =====
+
+const mockStreamResponse = {
+  stream: {
+    id: 'stream-test-123',
+    isActive: true,
+    playbackId: 'playback-xyz-789',
+    record: true,
+  },
+};
+
+const validSession = mockAuthenticatedSession({ fid: 456, username: 'testuser' });
+const validStreamId = 'stream-test-123';
+
+describe('GET /api/livepeer/stream/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+    mockLivepeerStreamGet.mockClear();
+    mockLivepeerStreamDelete.mockClear();
+  });
+
+  // ===== GET: SUCCESSFUL RETRIEVAL =====
+  describe('successful stream retrieval', () => {
+    beforeEach(() => {
+      mockLivepeerStreamGet.mockResolvedValue(mockStreamResponse);
+    });
+
+    it('returns 200 with stream data when stream exists', async () => {
+      const res = await GET(
+        makeRequest('/api/livepeer/stream/stream-test-123', { method: 'GET' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        stream: {
+          id: 'stream-test-123',
+          isActive: true,
+          playbackId: 'playback-xyz-789',
+          record: true,
+        },
+      });
+    });
+
+    it('calls livepeer.stream.get with correct id parameter', async () => {
+      const testId = 'stream-abc-456';
+      mockLivepeerStreamGet.mockResolvedValue(mockStreamResponse);
+
+      await GET(makeRequest('/api/livepeer/stream/stream-abc-456', { method: 'GET' }), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(mockLivepeerStreamGet).toHaveBeenCalledWith(testId);
+      expect(mockLivepeerStreamGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('extracts stream fields correctly from Livepeer response', async () => {
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: {
+          id: 'stream-xyz',
+          isActive: false,
+          playbackId: 'playback-456',
+          record: false,
+          extraField: 'should-be-ignored',
+        },
+      });
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-xyz', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-xyz' }),
+      });
+      const body = (await res.json()) as { stream?: object };
+
+      expect(body.stream).toEqual({
+        id: 'stream-xyz',
+        isActive: false,
+        playbackId: 'playback-456',
+        record: false,
+      });
+    });
+
+    it('handles stream with null playbackId', async () => {
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: {
+          id: 'stream-123',
+          isActive: true,
+          playbackId: null,
+          record: true,
+        },
+      });
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+      const body = (await res.json()) as { stream?: unknown };
+
+      expect(body.stream).toEqual({
+        id: 'stream-123',
+        isActive: true,
+        playbackId: null,
+        record: true,
+      });
+    });
+  });
+
+  // ===== GET: MISSING LIVEPEER_API_KEY =====
+  describe('missing LIVEPEER_API_KEY', () => {
+    it('returns 500 when LIVEPEER_API_KEY is not configured', async () => {
+      delete process.env.LIVEPEER_API_KEY;
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to get stream');
+    });
+  });
+
+  // ===== GET: SDK ERRORS =====
+  describe('Livepeer SDK errors', () => {
+    it('returns 500 when livepeer.stream.get throws', async () => {
+      mockLivepeerStreamGet.mockRejectedValue(new Error('Stream not found'));
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to get stream');
+    });
+
+    it('logs SDK errors via logger.error', async () => {
+      mockLivepeerStreamGet.mockRejectedValue(new Error('API failure'));
+
+      await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith('Get Livepeer stream error:', expect.any(Error));
+    });
+
+    it('handles network timeout as SDK error', async () => {
+      const timeoutError = new Error('Network timeout');
+      mockLivepeerStreamGet.mockRejectedValue(timeoutError);
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ===== GET: DYNAMIC PARAM HANDLING =====
+  describe('dynamic param handling', () => {
+    beforeEach(() => {
+      mockLivepeerStreamGet.mockResolvedValue(mockStreamResponse);
+    });
+
+    it('resolves params Promise correctly', async () => {
+      const testId = 'stream-promise-test';
+
+      await GET(makeRequest('/api/livepeer/stream/stream-promise-test', { method: 'GET' }), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(mockLivepeerStreamGet).toHaveBeenCalledWith(testId);
+    });
+
+    it('handles stream id with special characters', async () => {
+      const specialId = 'stream-test_123-abc';
+
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: { id: specialId, isActive: true, playbackId: 'pb-1', record: false },
+      });
+
+      const res = await GET(makeRequest(`/api/livepeer/stream/${specialId}`, { method: 'GET' }), {
+        params: Promise.resolve({ id: specialId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockLivepeerStreamGet).toHaveBeenCalledWith(specialId);
+    });
+
+    it('handles long stream id correctly', async () => {
+      const longId = `stream-${'x'.repeat(100)}`;
+
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: { id: longId, isActive: true, playbackId: 'pb', record: false },
+      });
+
+      const res = await GET(makeRequest(`/api/livepeer/stream/${longId}`, { method: 'GET' }), {
+        params: Promise.resolve({ id: longId }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockLivepeerStreamGet).toHaveBeenCalledWith(longId);
+    });
+  });
+
+  // ===== GET: EDGE CASES =====
+  describe('edge cases', () => {
+    it('handles empty stream object in response', async () => {
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: undefined,
+      });
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+      const body = (await res.json()) as { stream?: object };
+
+      expect(res.status).toBe(200);
+      expect(body.stream).toEqual({
+        id: undefined,
+        isActive: undefined,
+        playbackId: undefined,
+        record: undefined,
+      });
+    });
+
+    it('returns 200 even if stream.id is missing from response', async () => {
+      mockLivepeerStreamGet.mockResolvedValue({
+        stream: {
+          isActive: true,
+          playbackId: 'pb-123',
+        },
+      });
+
+      const res = await GET(makeRequest('/api/livepeer/stream/stream-123', { method: 'GET' }), {
+        params: Promise.resolve({ id: 'stream-123' }),
+      });
+
+      expect(res.status).toBe(200);
+    });
+  });
+});
+
+describe('DELETE /api/livepeer/stream/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(null);
+    mockLivepeerStreamGet.mockClear();
+    mockLivepeerStreamDelete.mockClear();
+  });
+
+  // ===== DELETE: AUTHENTICATION =====
+  describe('authentication', () => {
+    it('returns 401 when no session is provided', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when getSessionData returns null', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('allows DELETE when session is present', async () => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalled();
+    });
+
+    it('checks session before calling Livepeer SDK', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+
+      await DELETE(makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }), {
+        params: Promise.resolve({ id: validStreamId }),
+      });
+
+      // Should not call SDK if unauthenticated
+      expect(mockLivepeerStreamDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===== DELETE: SUCCESSFUL DELETION =====
+  describe('successful stream deletion', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+    });
+
+    it('returns 200 with success message', async () => {
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { success?: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('calls livepeer.stream.delete with correct id parameter', async () => {
+      const testId = 'stream-to-delete-456';
+
+      await DELETE(makeRequest(`/api/livepeer/stream/${testId}`, { method: 'DELETE' }), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledWith(testId);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call stream.get before deleting', async () => {
+      await DELETE(makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }), {
+        params: Promise.resolve({ id: validStreamId }),
+      });
+
+      expect(mockLivepeerStreamGet).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===== DELETE: MISSING LIVEPEER_API_KEY =====
+  describe('missing LIVEPEER_API_KEY', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 500 when LIVEPEER_API_KEY is not configured', async () => {
+      delete process.env.LIVEPEER_API_KEY;
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete stream');
+    });
+  });
+
+  // ===== DELETE: SDK ERRORS =====
+  describe('Livepeer SDK errors', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('returns 500 when livepeer.stream.delete throws', async () => {
+      mockLivepeerStreamDelete.mockRejectedValue(new Error('Stream deletion failed'));
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete stream');
+    });
+
+    it('logs SDK errors via logger.error', async () => {
+      mockLivepeerStreamDelete.mockRejectedValue(new Error('API failure'));
+
+      await DELETE(makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }), {
+        params: Promise.resolve({ id: validStreamId }),
+      });
+
+      const { logger } = await import('@/lib/logger');
+      expect(logger.error).toHaveBeenCalledWith('Delete Livepeer stream error:', expect.any(Error));
+    });
+
+    it('returns 500 on network errors', async () => {
+      const networkError = new Error('Network unreachable');
+      mockLivepeerStreamDelete.mockRejectedValue(networkError);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+
+      expect(res.status).toBe(500);
+    });
+
+    it('handles "not found" SDK errors gracefully', async () => {
+      const notFoundError = new Error('Stream not found');
+      mockLivepeerStreamDelete.mockRejectedValue(notFoundError);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { error?: string };
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to delete stream');
+    });
+  });
+
+  // ===== DELETE: DYNAMIC PARAM HANDLING =====
+  describe('dynamic param handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+    });
+
+    it('resolves params Promise correctly', async () => {
+      const testId = 'stream-promise-delete-test';
+
+      await DELETE(makeRequest(`/api/livepeer/stream/${testId}`, { method: 'DELETE' }), {
+        params: Promise.resolve({ id: testId }),
+      });
+
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledWith(testId);
+    });
+
+    it('handles stream id with hyphens and underscores', async () => {
+      const specialId = 'stream-test_123-abc_xyz';
+
+      await DELETE(makeRequest(`/api/livepeer/stream/${specialId}`, { method: 'DELETE' }), {
+        params: Promise.resolve({ id: specialId }),
+      });
+
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledWith(specialId);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles long stream id correctly', async () => {
+      const longId = `stream-${'x'.repeat(100)}`;
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res = await DELETE(
+        makeRequest(`/api/livepeer/stream/${longId}`, { method: 'DELETE' }),
+        { params: Promise.resolve({ id: longId }) },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledWith(longId);
+    });
+  });
+
+  // ===== DELETE: EDGE CASES =====
+  describe('edge cases', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(validSession);
+    });
+
+    it('handles empty stream id gracefully', async () => {
+      mockLivepeerStreamDelete.mockRejectedValue(new Error('Invalid stream id'));
+
+      const res = await DELETE(makeRequest('/api/livepeer/stream/', { method: 'DELETE' }), {
+        params: Promise.resolve({ id: '' }),
+      });
+
+      expect(res.status).toBe(500);
+    });
+
+    it('allows deletion of stream with special Livepeer-formatted id', async () => {
+      const livepeerFormattedId = 'stream-live-1234567890';
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res = await DELETE(
+        makeRequest(`/api/livepeer/stream/${livepeerFormattedId}`, { method: 'DELETE' }),
+        { params: Promise.resolve({ id: livepeerFormattedId }) },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledWith(livepeerFormattedId);
+    });
+
+    it('returns success even if stream.delete returns void', async () => {
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      const body = (await res.json()) as { success?: boolean };
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+  });
+
+  // ===== DELETE: SESSION VALIDATION =====
+  describe('session validation details', () => {
+    it('respects different session FIDs', async () => {
+      const session1 = mockAuthenticatedSession({ fid: 111, username: 'user1' });
+      const session2 = mockAuthenticatedSession({ fid: 222, username: 'user2' });
+
+      mockGetSessionData.mockResolvedValue(session1);
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res1 = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+      expect(res1.status).toBe(200);
+
+      mockGetSessionData.mockResolvedValue(session2);
+
+      const res2 = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-456', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: 'stream-456' }) },
+      );
+      expect(res2.status).toBe(200);
+      expect(mockLivepeerStreamDelete).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows admin session to delete', async () => {
+      const adminSession = mockAuthenticatedSession({ isAdmin: true });
+      mockGetSessionData.mockResolvedValue(adminSession);
+      mockLivepeerStreamDelete.mockResolvedValue(undefined);
+
+      const res = await DELETE(
+        makeRequest('/api/livepeer/stream/stream-123', { method: 'DELETE' }),
+        { params: Promise.resolve({ id: validStreamId }) },
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for 4 previously-untested API routes — **92 tests total**. External Livepeer/agent-runners/juke-verify fully mocked — no real API calls or agent trades.

| Route | Tests | Covers |
|-------|-------|--------|
| `cron/agents/banker` | 15 | CRON_SECRET guard, Bearer, **runBanker mocked (no trades)**, success/error, timestamp |
| `cron/agents/dealer` | 21 | CRON_SECRET guard, Bearer, **runDealer mocked (no trades)**, success/error, timestamp |
| `livepeer/stream/[id]` | 33 | GET status + DELETE terminate, auth, dynamic param, Livepeer SDK (mocked), missing-key 500, errors |
| `juke/webhooks` | 23 | HMAC signature verify (mocked), JSON-parse 400, idempotency/duplicate, event-type dispatch, handler errors, 405 GET |

Test-only — no runtime files touched. Agent runners mocked so no real trade executes. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)