### PR TITLE
test(publish): farcaster/bluesky/threads/lens adapters (103 tests)

### DIFF
--- a/src/app/api/publish/bluesky/__tests__/route.test.ts
+++ b/src/app/api/publish/bluesky/__tests__/route.test.ts
@@ -1,0 +1,992 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockNormalizeForBluesky, mockPublishToBluesky, mockFrom } = vi.hoisted(
+  () => ({
+    mockGetSessionData: vi.fn(),
+    mockNormalizeForBluesky: vi.fn(),
+    mockPublishToBluesky: vi.fn(),
+    mockFrom: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/publish/normalize', () => ({
+  normalizeForBluesky: (_input: unknown) => mockNormalizeForBluesky(_input),
+}));
+
+vi.mock('@/lib/publish/bluesky', () => ({
+  isBlueskyConfigured: () => !!(process.env.BLUESKY_HANDLE && process.env.BLUESKY_APP_PASSWORD),
+  publishToBluesky: (_input: unknown) => mockPublishToBluesky(_input),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Test fixture: supabase chain mock for publish_log insert
+function makeInsertChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn().mockReturnValue(chain);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (_v: unknown) => void) =>
+    resolve(result);
+  return chain;
+}
+
+describe('POST /api/publish/bluesky', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.BLUESKY_HANDLE = 'test-handle.bsky.social';
+    process.env.BLUESKY_APP_PASSWORD = 'test-app-password';
+  });
+
+  describe('Authentication & Authorization', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(401);
+      expect((await res.json()).error).toBe('Unauthorized');
+    });
+
+    it('returns 403 when user is not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(403);
+      expect((await res.json()).error).toBe('Admin access required');
+    });
+
+    it('returns 401 when session is null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('Bluesky Configuration', () => {
+    it('returns 503 when BLUESKY_HANDLE is not configured', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      delete process.env.BLUESKY_HANDLE;
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(503);
+      expect((await res.json()).error).toBe('Bluesky not configured');
+    });
+
+    it('returns 503 when BLUESKY_APP_PASSWORD is not configured', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      delete process.env.BLUESKY_APP_PASSWORD;
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(503);
+      expect((await res.json()).error).toBe('Bluesky not configured');
+    });
+
+    it('returns 503 when both BLUESKY credentials are missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      delete process.env.BLUESKY_HANDLE;
+      delete process.env.BLUESKY_APP_PASSWORD;
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(503);
+    });
+  });
+
+  describe('JSON Parsing', () => {
+    it('returns 400 when request body is invalid JSON', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const req = new Request(new URL('/api/publish/bluesky', 'http://localhost:3000'), {
+        method: 'POST',
+        body: '{invalid json}',
+      });
+      const res = await import('../route').then((_m) => _m.POST(req as never));
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toBe('Invalid JSON');
+    });
+
+    it('returns 400 when body is empty', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const req = new Request(new URL('/api/publish/bluesky', 'http://localhost:3000'), {
+        method: 'POST',
+        body: '',
+      });
+      const res = await import('../route').then((_m) => _m.POST(req as never));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Zod Validation: castHash', () => {
+    it('returns 400 when castHash is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(makePostRequest('/api/publish/bluesky', { text: 'hello world' })),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when castHash is empty string', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: '',
+            text: 'hello world',
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts castHash with min length 1', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'x',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'x',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod Validation: text', () => {
+    it('returns 400 when text is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when text is empty string', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: '',
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts text with min length 1', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'x',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'x',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 400 when text exceeds 1024 characters', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const longText = 'a'.repeat(1025);
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: longText,
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts text at max length 1024', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const maxText = 'a'.repeat(1024);
+      mockNormalizeForBluesky.mockReturnValue({
+        text: maxText,
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: maxText,
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod Validation: embedUrls & imageUrls', () => {
+    it('returns 400 when embedUrls contains invalid URL', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+            embedUrls: ['not-a-url'],
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('returns 400 when imageUrls contains invalid URL', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+            imageUrls: ['not a valid url'],
+          }),
+        ),
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+
+    it('accepts valid HTTP URLs in embedUrls', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'check this',
+            embedUrls: ['https://example.com/article'],
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockNormalizeForBluesky).toHaveBeenCalledWith({
+        text: 'check this',
+        castHash: 'abc123',
+        embedUrls: ['https://example.com/article'],
+        imageUrls: undefined,
+        channel: undefined,
+      });
+    });
+
+    it('accepts valid HTTPS URLs in imageUrls', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'photo',
+            imageUrls: ['https://example.com/image.jpg', 'https://example.com/image2.png'],
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockNormalizeForBluesky).toHaveBeenCalledWith({
+        text: 'photo',
+        castHash: 'abc123',
+        embedUrls: undefined,
+        imageUrls: ['https://example.com/image.jpg', 'https://example.com/image2.png'],
+        channel: undefined,
+      });
+    });
+
+    it('accepts empty embedUrls and imageUrls arrays', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'text only',
+            embedUrls: [],
+            imageUrls: [],
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Zod Validation: channel', () => {
+    it('accepts optional channel field', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+            channel: 'zao',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockNormalizeForBluesky).toHaveBeenCalledWith({
+        text: 'hello',
+        castHash: 'abc123',
+        embedUrls: undefined,
+        imageUrls: undefined,
+        channel: 'zao',
+      });
+    });
+
+    it('works without channel field', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:...',
+        cid: 'cid123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Happy Path: Normalization & Publishing', () => {
+    it('calls normalizeForBluesky with parsed input', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized text\n\nvia ZAO OS',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:plc:abc/app.bsky.feed.post/123',
+        cid: 'bafy123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc456',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'original text',
+            embedUrls: ['https://example.com/link'],
+            imageUrls: ['https://example.com/image.jpg'],
+            channel: 'base',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockNormalizeForBluesky).toHaveBeenCalledWith({
+        text: 'original text',
+        castHash: 'abc123',
+        embedUrls: ['https://example.com/link'],
+        imageUrls: ['https://example.com/image.jpg'],
+        channel: 'base',
+      });
+    });
+
+    it('calls publishToBluesky with normalized content', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const normalized = {
+        text: 'normalized text\n\nvia ZAO OS',
+        castHash: 'abc123',
+        images: ['https://example.com/image.jpg'],
+        embeds: ['https://example.com/link'],
+        attribution: 'via ZAO OS',
+        castUrl: 'https://warpcast.com/~/conversations/abc123',
+      };
+      mockNormalizeForBluesky.mockReturnValue(normalized);
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:plc:abc/app.bsky.feed.post/123',
+        cid: 'bafy123',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc456',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'original text',
+          }),
+        ),
+      );
+
+      expect(mockPublishToBluesky).toHaveBeenCalledWith(normalized);
+    });
+
+    it('returns 200 with success=true and platformUrl on successful publish', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:plc:abc/app.bsky.feed.post/xyz',
+        cid: 'bafy789',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/xyz789',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello world',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.platformUrl).toBe('https://bsky.app/profile/test-handle.bsky.social/post/xyz789');
+    });
+
+    it('records publish in supabase publish_log table', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 456 }));
+      const normalizedText = 'normalized text\n\nvia ZAO OS';
+      mockNormalizeForBluesky.mockReturnValue({
+        text: normalizedText,
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://did:plc:abc/app.bsky.feed.post/456',
+        cid: 'bafy456',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/abc456',
+      });
+      const chain = makeInsertChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'test message',
+          }),
+        ),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('publish_log');
+      expect(chain.insert).toHaveBeenCalledWith({
+        platform: 'bluesky',
+        cast_hash: 'abc123',
+        platform_post_id: 'at://did:plc:abc/app.bsky.feed.post/456',
+        platform_url: 'https://bsky.app/profile/test-handle.bsky.social/post/abc456',
+        published_by_fid: 456,
+        text: normalizedText,
+        status: 'published',
+      });
+    });
+
+    it('records fid from session in publish_log', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'hash',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://uri',
+        cid: 'cid',
+        postUrl: 'https://bsky.app/profile/test/post/xyz',
+      });
+      const chain = makeInsertChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'hash',
+            text: 'msg',
+          }),
+        ),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ published_by_fid: 999 }));
+    });
+
+    it('includes normalized text in publish_log record', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const normalizedText = 'this is the normalized version';
+      mockNormalizeForBluesky.mockReturnValue({
+        text: normalizedText,
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://uri',
+        cid: 'cid',
+        postUrl: 'https://bsky.app/profile/test/post/abc',
+      });
+      const chain = makeInsertChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'original',
+          }),
+        ),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ text: normalizedText }));
+    });
+
+    it('uses result.uri as platform_post_id and result.postUrl as platform_url', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      const expectedUri = 'at://did:plc:xyz/app.bsky.feed.post/999';
+      const expectedPostUrl = 'https://bsky.app/profile/test-handle.bsky.social/post/post999';
+      mockPublishToBluesky.mockResolvedValue({
+        uri: expectedUri,
+        cid: 'cidABC',
+        postUrl: expectedPostUrl,
+      });
+      const chain = makeInsertChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'msg',
+          }),
+        ),
+      );
+
+      expect(chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          platform_post_id: expectedUri,
+          platform_url: expectedPostUrl,
+        }),
+      );
+    });
+  });
+
+  describe('Error Handling: publishToBluesky Failures', () => {
+    it('returns 500 when publishToBluesky throws Error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockRejectedValue(new Error('Bluesky API connection timeout'));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Bluesky API connection timeout');
+    });
+
+    it('returns 500 with generic message when publishToBluesky throws non-Error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockRejectedValue('string error');
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Failed to publish to Bluesky');
+    });
+
+    it('returns 500 when publishToBluesky throws object without message', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockRejectedValue({ code: 'ERR_SOMETHING' });
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to publish to Bluesky');
+    });
+
+    it('does not call supabaseAdmin.from when publishToBluesky fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockRejectedValue(new Error('publish failed'));
+
+      await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling: normalizeForBluesky Failures', () => {
+    it('returns 500 when normalizeForBluesky throws', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockImplementation(() => {
+        throw new Error('Normalization failed');
+      });
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Normalization failed');
+    });
+  });
+
+  describe('Error Handling: Supabase Insert Failures', () => {
+    it('still returns 200 even if supabase insert fails (best-effort logging)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://uri',
+        cid: 'cid',
+        postUrl: 'https://bsky.app/profile/test/post/abc',
+      });
+      const chain = makeInsertChain({ error: 'Database error' });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'hello',
+          }),
+        ),
+      );
+
+      // Even if supabase fails, the publish itself succeeded
+      // Note: The route currently doesn't check supabase errors, so this passes through
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('Full Integration: All Fields', () => {
+    it('handles complete payload with all optional fields', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 111 }));
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'full normalized',
+        castHash: 'fullhash',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://full/uri',
+        cid: 'fullcid',
+        postUrl: 'https://bsky.app/profile/test-handle.bsky.social/post/fullpost',
+      });
+      const chain = makeInsertChain({ error: null });
+      mockFrom.mockReturnValue(chain);
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'fullhash',
+            text: 'full message text',
+            embedUrls: ['https://example.com/link1', 'https://example.com/link2'],
+            imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+            channel: 'governance',
+          }),
+        ),
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.platformUrl).toBe(
+        'https://bsky.app/profile/test-handle.bsky.social/post/fullpost',
+      );
+
+      expect(mockNormalizeForBluesky).toHaveBeenCalledWith({
+        castHash: 'fullhash',
+        text: 'full message text',
+        embedUrls: ['https://example.com/link1', 'https://example.com/link2'],
+        imageUrls: ['https://example.com/img1.jpg', 'https://example.com/img2.jpg'],
+        channel: 'governance',
+      });
+
+      expect(chain.insert).toHaveBeenCalledWith({
+        platform: 'bluesky',
+        cast_hash: 'fullhash',
+        platform_post_id: 'at://full/uri',
+        platform_url: 'https://bsky.app/profile/test-handle.bsky.social/post/fullpost',
+        published_by_fid: 111,
+        text: 'full normalized',
+        status: 'published',
+      });
+    });
+  });
+
+  describe('Response Shape', () => {
+    it('returns { success: true, platformUrl: string } on success', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockResolvedValue({
+        uri: 'at://uri',
+        cid: 'cid',
+        postUrl: 'https://bsky.app/profile/test/post/final',
+      });
+      mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'test',
+          }),
+        ),
+      );
+
+      const body = await res.json();
+      expect(body).toEqual({
+        success: true,
+        platformUrl: 'https://bsky.app/profile/test/post/final',
+      });
+    });
+
+    it('returns { success: false, error: string } on error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockNormalizeForBluesky.mockReturnValue({
+        text: 'normalized',
+        castHash: 'abc123',
+      });
+      mockPublishToBluesky.mockRejectedValue(new Error('API error'));
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            text: 'test',
+          }),
+        ),
+      );
+
+      const body = await res.json();
+      expect(body).toEqual({
+        success: false,
+        error: 'API error',
+      });
+    });
+
+    it('returns { error, details } shape for validation errors', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+
+      const res = await import('../route').then((_m) =>
+        _m.POST(
+          makePostRequest('/api/publish/bluesky', {
+            castHash: 'abc123',
+            // text missing
+          }),
+        ),
+      );
+
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+  });
+});

--- a/src/app/api/publish/farcaster/__tests__/route.test.ts
+++ b/src/app/api/publish/farcaster/__tests__/route.test.ts
@@ -1,0 +1,584 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockPostCast } = vi.hoisted(() => ({
+  mockPostCast: vi.fn(),
+}));
+
+const { mockLogAuditEvent, mockGetClientIp } = vi.hoisted(() => ({
+  mockLogAuditEvent: vi.fn(),
+  mockGetClientIp: vi.fn(),
+}));
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => mockFrom(...args) },
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  postCast: (...args: unknown[]) => mockPostCast(...args),
+}));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+  getClientIp: (req: Request) => mockGetClientIp(req),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENV: {
+    ZAO_OFFICIAL_SIGNER_UUID: 'signer-uuid-123',
+    ZAO_OFFICIAL_FID: '12345',
+    ZAO_OFFICIAL_NEYNAR_API_KEY: 'neynar-key-456',
+  },
+}));
+
+import { POST } from '../route';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Build a Supabase query-chain mock that resolves to result.
+ * Every chained method returns the chain itself for further chaining.
+ * Terminal methods (.single, .then) resolve the query.
+ */
+function chainMock(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, unknown> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.update = vi.fn().mockReturnValue(chain);
+  chain.insert = vi.fn().mockReturnValue(chain);
+  chain.single = vi.fn().mockResolvedValue(result);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  chain.then = vi.fn((resolve: (val: unknown) => void, reject?: (err: unknown) => void) => {
+    Promise.resolve(result).then(resolve, reject);
+  });
+  return chain;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/publish/farcaster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  describe('Authentication', () => {
+    it('returns 403 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Admin only');
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toBe('Admin only');
+    });
+  });
+
+  // ── Input validation tests ───────────────────────────────────────────────
+
+  describe('Input validation', () => {
+    it('returns 400 when proposalId is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const req = makePostRequest('/api/publish/farcaster', {});
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when proposalId is not a valid UUID', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: 'not-a-uuid' });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when proposalId is empty string', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: '' });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Invalid input');
+    });
+  });
+
+  // ── Proposal lookup tests ────────────────────────────────────────────────
+
+  describe('Proposal lookup', () => {
+    it('returns 404 when proposal not found', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockFrom.mockImplementation(() => chainMock({ data: null, error: null }));
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Proposal not found');
+    });
+
+    it('returns 404 when fetch returns an error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      mockFrom.mockImplementation(() =>
+        chainMock({ data: null, error: new Error('Database error') }),
+      );
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toBe('Proposal not found');
+    });
+  });
+
+  // ── Already published guard tests ────────────────────────────────────────
+
+  describe('Already published guard', () => {
+    it('returns 409 when proposal is already published', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Published Proposal',
+        published_cast_hash: '0xabc123',
+        respect_threshold: 1000,
+        author: { username: 'testuser', display_name: 'Test User', fid: 123 },
+      };
+      mockFrom.mockImplementation(() => chainMock({ data: proposal, error: null }));
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe('Already published');
+      expect(body.cast_hash).toBe('0xabc123');
+    });
+  });
+
+  // ── Respect vote threshold tests ────────────────────────────────────────
+
+  describe('Respect vote threshold', () => {
+    it('returns 400 when threshold not met', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession());
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Low Vote Proposal',
+        description: 'Not enough votes',
+        published_cast_hash: null,
+        respect_threshold: 1000,
+        author: { username: 'testuser', display_name: 'Test User', fid: 123 },
+      };
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : [];
+        return chainMock({ data, error: null });
+      });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Threshold not met');
+      expect(body.current).toBe(0);
+      expect(body.threshold).toBe(1000);
+    });
+
+    it('publishes when threshold is met', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Valid Proposal',
+        description: 'Test description',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 1000,
+        author: { username: 'author', display_name: 'Author Name', fid: 123 },
+      };
+
+      const votes = [
+        { vote: 'for', respect_weight: 600 },
+        { vote: 'for', respect_weight: 500 },
+        { vote: 'against', respect_weight: 200 },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'cast-hash-xyz' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.respect_votes).toBe(1100);
+      expect(body.threshold).toBe(1000);
+    });
+
+    it('calculates respect weight correctly from votes, ignoring against votes', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Proposal',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 300,
+        author: { username: 'user', display_name: 'User', fid: 1 },
+      };
+
+      const votes = [
+        { vote: 'for', respect_weight: 250 },
+        { vote: 'for', respect_weight: null }, // null weight counts as 0
+        { vote: 'against', respect_weight: 100 }, // ignored
+        { vote: 'against', respect_weight: 200 }, // ignored
+        { vote: 'for', respect_weight: 100 },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'hash' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Only count 'for' votes: 250 + 0 + 100 = 350 (against votes ignored)
+      expect(body.respect_votes).toBe(350);
+    });
+  });
+
+  // ── postCast integration tests ───────────────────────────────────────────
+
+  describe('postCast integration', () => {
+    it('calls postCast with correct parameters', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: 'https://example.com/image.png',
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'cast-hash-123' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      await POST(req);
+
+      expect(mockPostCast).toHaveBeenCalledWith(
+        'signer-uuid-123',
+        expect.any(String), // castText
+        'zao', // channel
+        undefined, // no parent
+        undefined, // no embedHash
+        ['https://example.com/image.png'], // embedUrls
+        undefined, // no embedFid
+        'neynar-key-456', // API key
+      );
+    });
+
+    it('returns 500 when postCast throws an error', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockRejectedValue(new Error('Neynar API error'));
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('Failed to publish cast');
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '[publish/farcaster] Error:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  // ── Audit logging tests ──────────────────────────────────────────────────
+
+  describe('Audit logging', () => {
+    it('logs audit event on successful publish', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'cast-hash-xyz' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      await POST(req);
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith({
+        actorFid: 999,
+        action: 'proposal.publish',
+        targetType: 'proposal',
+        targetId: VALID_UUID,
+        details: {
+          castHash: 'cast-hash-xyz',
+          respectVotes: 150,
+          threshold: 100,
+        },
+        ipAddress: '192.168.1.1',
+      });
+    });
+  });
+
+  // ── Success response tests ───────────────────────────────────────────────
+
+  describe('Success response', () => {
+    it('returns 200 with correct response shape on success', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'Test description',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'cast-hash-final' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({
+        success: true,
+        cast_hash: 'cast-hash-final',
+        text: expect.any(String),
+        respect_votes: 150,
+        threshold: 100,
+      });
+      expect(body.text).toContain('Test description');
+    });
+
+    it('includes the attribution line in cast text', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'testauthor', display_name: 'Test Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'hash' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      const body = await res.json();
+      expect(body.text).toMatch(/— Proposed by @testauthor • Approved by ZAO governance/);
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────────────
+
+  describe('Edge cases', () => {
+    it('handles proposal with no votes (empty votes array)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'No votes',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 1,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : [];
+        return chainMock({ data, error: null });
+      });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe('Threshold not met');
+      expect(body.current).toBe(0);
+    });
+
+    it('handles proposal.respect_threshold as undefined (uses default 1000)', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'No threshold',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: null,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 1500 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: { hash: 'hash' } });
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.threshold).toBe(1000);
+    });
+
+    it('handles postCast response with missing cast.hash', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+      const proposal = {
+        id: VALID_UUID,
+        title: 'Title',
+        description: 'desc',
+        publish_text: null,
+        publish_image_url: null,
+        published_cast_hash: null,
+        respect_threshold: 100,
+        author: { username: 'author', display_name: 'Author', fid: 1 },
+      };
+
+      const votes = [{ vote: 'for', respect_weight: 150 }];
+
+      mockFrom.mockImplementation((table: string) => {
+        const data = table === 'proposals' ? proposal : votes;
+        return chainMock({ data, error: null });
+      });
+
+      mockPostCast.mockResolvedValue({ cast: {} }); // no hash
+
+      const req = makePostRequest('/api/publish/farcaster', { proposalId: VALID_UUID });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.cast_hash).toBeUndefined();
+    });
+  });
+});

--- a/src/app/api/publish/lens/__tests__/route.test.ts
+++ b/src/app/api/publish/lens/__tests__/route.test.ts
@@ -1,0 +1,633 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockNormalizeForLens, mockPublishToLens, mockFrom, mockLogger } =
+  vi.hoisted(() => ({
+    mockGetSessionData: vi.fn(),
+    mockNormalizeForLens: vi.fn(),
+    mockPublishToLens: vi.fn(),
+    mockFrom: vi.fn(),
+    mockLogger: {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+  }));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/publish/normalize', () => ({
+  normalizeForLens: (_input: unknown) => mockNormalizeForLens(_input),
+}));
+
+vi.mock('@/lib/publish/lens', () => ({
+  publishToLens: (_token: unknown, _refresh: unknown, _content: unknown) =>
+    mockPublishToLens(_token, _refresh, _content),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLogger,
+}));
+
+// Test fixture: supabase chain mock for user select + publish_log insert
+function makeChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  // Chainable methods
+  const chainableMethods = ['select', 'eq', 'insert', 'update', 'delete', 'order', 'limit'];
+  for (const method of chainableMethods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Terminal method — resolves the query
+  chain.single = vi.fn().mockResolvedValue(result);
+
+  // Allow the chain to be awaited directly
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (_resolve: (v: unknown) => void) =>
+    _resolve(result);
+
+  return chain;
+}
+
+describe('POST /api/publish/lens', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ============================================================================
+  // Authentication Tests
+  // ============================================================================
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  // ============================================================================
+  // JSON Parsing Tests
+  // ============================================================================
+
+  it('returns 400 when request body is invalid JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const req = new Request(new URL('/api/publish/lens', 'http://localhost:3000'), {
+      method: 'POST',
+      body: '{invalid json}',
+    });
+
+    const res = await import('../route').then((_m) => _m.POST(req as never));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid JSON');
+  });
+
+  // ============================================================================
+  // Zod Validation Tests
+  // ============================================================================
+
+  it('returns 400 when castHash is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { text: 'hello' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when castHash is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: '', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when text is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when text is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession());
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: '' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('accepts optional embedUrls, imageUrls, and channel fields', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: { lens_profile_id: 'profile1', lens_access_token: 'token1' },
+    });
+    mockFrom.mockReturnValue(userChain);
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({ postId: 'post1', postUrl: 'https://...' });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(
+        makePostRequest('/api/publish/lens', {
+          castHash: 'hash1',
+          text: 'hello',
+          embedUrls: ['https://example.com'],
+          imageUrls: ['https://example.com/img.jpg'],
+          channel: 'base',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForLens).toHaveBeenCalledWith({
+      text: 'hello',
+      castHash: 'hash1',
+      embedUrls: ['https://example.com'],
+      imageUrls: ['https://example.com/img.jpg'],
+      channel: 'base',
+    });
+  });
+
+  // ============================================================================
+  // Lens Configuration Tests (user record lookup)
+  // ============================================================================
+
+  it('returns 400 when user has no lens_profile_id', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: { lens_access_token: 'token1' }, // missing lens_profile_id
+    });
+    mockFrom.mockReturnValue(userChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Lens not connected — connect in Settings');
+  });
+
+  it('returns 400 when user has no lens_access_token', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: { lens_profile_id: 'profile1' }, // missing lens_access_token
+    });
+    mockFrom.mockReturnValue(userChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Lens auth tokens missing — reconnect with wallet in Settings');
+  });
+
+  // ============================================================================
+  // Success Path Tests
+  // ============================================================================
+
+  it('publishes successfully with castHash and text', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({
+      text: 'normalized text\n\nPosted via ZAO OS',
+    });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post-abc',
+      postUrl: 'https://hey.xyz/posts/post-abc',
+    });
+    const logChain = makeChain({ data: null, error: null });
+
+    // Setup mockFrom to return userChain on first call (users select), logChain on second (publish_log insert)
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.postId).toBe('post-abc');
+    expect(body.postUrl).toBe('https://hey.xyz/posts/post-abc');
+  });
+
+  it('normalizes content before publishing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({
+      text: 'normalized',
+      castHash: 'hash1',
+      castUrl: 'https://warpcast.com/~/conversations/hash1',
+      images: [],
+      embeds: [],
+      attribution: 'Posted via ZAO OS',
+    });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post1',
+      postUrl: 'https://hey.xyz/posts/post1',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(
+        makePostRequest('/api/publish/lens', {
+          castHash: 'hash1',
+          text: 'original text',
+          embedUrls: ['https://example.com'],
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForLens).toHaveBeenCalledWith({
+      text: 'original text',
+      castHash: 'hash1',
+      embedUrls: ['https://example.com'],
+      imageUrls: undefined,
+      channel: undefined,
+    });
+  });
+
+  it('calls publishToLens with access token, refresh token, and normalized content', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'access-xyz',
+        lens_refresh_token: 'refresh-xyz',
+      },
+    });
+    const normalizedContent = {
+      text: 'normalized text',
+      castHash: 'hash1',
+      castUrl: 'https://warpcast.com/~/conversations/hash1',
+      images: [],
+      embeds: [],
+      attribution: 'Posted via ZAO OS',
+    };
+    mockNormalizeForLens.mockReturnValue(normalizedContent);
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post1',
+      postUrl: 'https://hey.xyz/posts/post1',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPublishToLens).toHaveBeenCalledWith('access-xyz', 'refresh-xyz', normalizedContent);
+  });
+
+  it('handles missing lens_refresh_token by passing empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: null, // missing
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post1',
+      postUrl: 'https://hey.xyz/posts/post1',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPublishToLens).toHaveBeenCalledWith('token1', '', expect.any(Object));
+  });
+
+  // ============================================================================
+  // Supabase Logging Tests
+  // ============================================================================
+
+  it('logs successful publish to publish_log', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post-xyz',
+      postUrl: 'https://hey.xyz/posts/post-xyz',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'publish_log');
+    expect(logChain.insert).toHaveBeenCalledWith({
+      cast_hash: 'hash1',
+      fid: 456,
+      platform: 'lens',
+      status: 'success',
+      platform_post_id: 'post-xyz',
+      platform_url: 'https://hey.xyz/posts/post-xyz',
+    });
+  });
+
+  it('logs failed publish with error_message', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockRejectedValue(new Error('Lens API error'));
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'publish_log');
+    expect(logChain.insert).toHaveBeenCalledWith({
+      cast_hash: 'hash1',
+      fid: 456,
+      platform: 'lens',
+      status: 'failed',
+      error_message: 'Lens API error',
+    });
+  });
+
+  // ============================================================================
+  // Error Handling Tests
+  // ============================================================================
+
+  it('returns 500 when publishToLens throws an Error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockRejectedValue(new Error('Network timeout'));
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Network timeout');
+  });
+
+  it('returns 500 with generic message for non-Error exceptions', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockRejectedValue('string error');
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Lens publish failed');
+  });
+
+  it('logs errors with logger.error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    const testError = new Error('Test publish failure');
+    mockPublishToLens.mockRejectedValue(testError);
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(500);
+    expect(mockLogger.error).toHaveBeenCalledWith('[publish/lens] Error:', 'Test publish failure');
+  });
+
+  // ============================================================================
+  // Response Shape Tests
+  // ============================================================================
+
+  it('returns correct response shape on success', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post-final',
+      postUrl: 'https://hey.xyz/posts/post-final',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'test' })),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      postId: 'post-final',
+      postUrl: 'https://hey.xyz/posts/post-final',
+    });
+  });
+
+  it('returns correct response shape on error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockRejectedValue(new Error('API down'));
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'test' })),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'API down' });
+  });
+
+  // ============================================================================
+  // Integration/Edge Case Tests
+  // ============================================================================
+
+  it('queries users table with correct fid from session', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 789 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post1',
+      postUrl: 'https://hey.xyz/posts/post1',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(makePostRequest('/api/publish/lens', { castHash: 'hash1', text: 'hello' })),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenNthCalledWith(1, 'users');
+    // Verify .select() and .eq() were called in the chain
+    expect(userChain.select).toHaveBeenCalledWith(
+      'lens_profile_id, lens_access_token, lens_refresh_token',
+    );
+    expect(userChain.eq).toHaveBeenCalledWith('fid', 789);
+  });
+
+  it('handles all schema fields correctly', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    const userChain = makeChain({
+      data: {
+        lens_profile_id: 'profile1',
+        lens_access_token: 'token1',
+        lens_refresh_token: 'refresh1',
+      },
+    });
+    mockNormalizeForLens.mockReturnValue({ text: 'normalized' });
+    mockPublishToLens.mockResolvedValue({
+      postId: 'post1',
+      postUrl: 'https://hey.xyz/posts/post1',
+    });
+    const logChain = makeChain({ data: null, error: null });
+    mockFrom.mockReturnValueOnce(userChain).mockReturnValueOnce(logChain);
+
+    const res = await import('../route').then((_m) =>
+      _m.POST(
+        makePostRequest('/api/publish/lens', {
+          castHash: 'hash-value',
+          text: 'content text',
+          embedUrls: ['https://a.com', 'https://b.com'],
+          imageUrls: ['https://img1.jpg', 'https://img2.jpg'],
+          channel: 'farcaster',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForLens).toHaveBeenCalledWith({
+      text: 'content text',
+      castHash: 'hash-value',
+      embedUrls: ['https://a.com', 'https://b.com'],
+      imageUrls: ['https://img1.jpg', 'https://img2.jpg'],
+      channel: 'farcaster',
+    });
+  });
+});

--- a/src/app/api/publish/threads/__tests__/route.test.ts
+++ b/src/app/api/publish/threads/__tests__/route.test.ts
@@ -1,0 +1,598 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const {
+  mockGetSessionData,
+  mockIsThreadsConfigured,
+  mockNormalizeForThreads,
+  mockPublishToThreads,
+  mockFrom,
+} = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockIsThreadsConfigured: vi.fn(),
+  mockNormalizeForThreads: vi.fn(),
+  mockPublishToThreads: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/publish/normalize', () => ({
+  normalizeForThreads: (input: unknown) => mockNormalizeForThreads(input),
+}));
+
+vi.mock('@/lib/publish/threads', () => ({
+  isThreadsConfigured: () => mockIsThreadsConfigured(),
+  publishToThreads: (input: unknown) => mockPublishToThreads(input),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Test fixture: supabase chain mock for publish_log insert
+function makeInsertChain(result: { data?: unknown; error?: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.insert = vi.fn().mockReturnValue(chain);
+  // biome-ignore lint/suspicious/noThenProperty: intentional thenable — mocks an awaitable Supabase query chain
+  (chain as unknown as { then: unknown }).then = (resolve: (v: unknown) => void) => resolve(result);
+  return chain;
+}
+
+describe('POST /api/publish/threads', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsThreadsConfigured.mockReturnValue(true);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+        }),
+      ),
+    );
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe('Unauthorized');
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ isAdmin: false }));
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+        }),
+      ),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe('Admin access required');
+  });
+
+  it('returns 503 when Threads is not configured', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockIsThreadsConfigured.mockReturnValue(false);
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+        }),
+      ),
+    );
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toBe('Threads not configured');
+  });
+
+  it('returns 400 when request body is invalid JSON', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    // Create a request with malformed JSON body
+    const req = new Request(new URL('/api/publish/threads', 'http://localhost:3000'), {
+      method: 'POST',
+      body: '{invalid json}',
+    });
+    const res = await import('../route').then((m) => m.POST(req as never));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid JSON');
+  });
+
+  it('returns 400 when castHash is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          text: 'hello',
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+    expect(body.details).toBeDefined();
+  });
+
+  it('returns 400 when castHash is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: '',
+          text: 'hello',
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when text is missing', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when text is empty string', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: '',
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when text exceeds 1024 character limit', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const longText = 'a'.repeat(1025);
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: longText,
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when embedUrls contains invalid URL', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+          embedUrls: ['not-a-url'],
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('returns 400 when imageUrls contains invalid URL', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+          imageUrls: ['not-a-url'],
+        }),
+      ),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Invalid input');
+  });
+
+  it('publishes with minimal input (castHash + text)', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized text\n\nvia ZAO OS\nhttps://warpcast.com/~/conversations/abc123',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'thread-post-123',
+      postUrl: 'https://www.threads.net/@thezao/post/thread-post-123',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello world',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.platformUrl).toBe('https://www.threads.net/@thezao/post/thread-post-123');
+  });
+
+  it('normalizes content with all optional fields', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized text',
+      images: ['https://example.com/img.jpg'],
+      embeds: ['https://example.com/embed'],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-456',
+      postUrl: 'https://www.threads.net/@thezao/post/post-456',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'original text',
+          embedUrls: ['https://example.com/embed'],
+          imageUrls: ['https://example.com/img.jpg'],
+          channel: 'base',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: 'original text',
+      castHash: 'abc123',
+      embedUrls: ['https://example.com/embed'],
+      imageUrls: ['https://example.com/img.jpg'],
+      channel: 'base',
+    });
+    expect(mockPublishToThreads).toHaveBeenCalledWith({
+      text: 'normalized text',
+      images: ['https://example.com/img.jpg'],
+      embeds: ['https://example.com/embed'],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+  });
+
+  it('logs to publish_log table on success with fid from session', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+    const normalizedContent = {
+      text: 'normalized text\n\nvia ZAO OS\nhttps://...',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'hash456',
+      castUrl: 'https://warpcast.com/~/conversations/hash456',
+    };
+    mockNormalizeForThreads.mockReturnValue(normalizedContent);
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-999',
+      postUrl: 'https://www.threads.net/@thezao/post/post-999',
+    });
+    const chain = makeInsertChain({ error: null });
+    mockFrom.mockReturnValue(chain);
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'hash456',
+          text: 'test message',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockFrom).toHaveBeenCalledWith('publish_log');
+    expect(chain.insert).toHaveBeenCalledWith({
+      platform: 'threads',
+      cast_hash: 'hash456',
+      platform_post_id: 'post-999',
+      platform_url: 'https://www.threads.net/@thezao/post/post-999',
+      published_by_fid: 999,
+      text: 'normalized text\n\nvia ZAO OS\nhttps://...',
+      status: 'published',
+    });
+  });
+
+  it('returns 500 when publishToThreads throws an error', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockRejectedValue(
+      new Error('Threads container creation failed: Rate limit exceeded'),
+    );
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Threads container creation failed: Rate limit exceeded');
+  });
+
+  it('returns 500 with generic message for non-Error exceptions', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockRejectedValue('string error');
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('Failed to publish to Threads');
+  });
+
+  it('returns success=true and platformUrl in response shape', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'final-post',
+      postUrl: 'https://www.threads.net/@thezao/post/final-post',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'final test',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      success: true,
+      platformUrl: 'https://www.threads.net/@thezao/post/final-post',
+    });
+  });
+
+  it('handles all Zod schema fields: castHash, text, embedUrls, imageUrls, channel', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: ['https://example.com/img.jpg'],
+      embeds: ['https://example.com/embed'],
+      attribution: 'via ZAO OS',
+      castHash: 'cast-abc',
+      castUrl: 'https://warpcast.com/~/conversations/cast-abc',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'multi-field-post',
+      postUrl: 'https://www.threads.net/@thezao/post/multi-field-post',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'cast-abc',
+          text: 'full payload test',
+          embedUrls: ['https://example.com/embed'],
+          imageUrls: ['https://example.com/img.jpg'],
+          channel: 'base',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: 'full payload test',
+      castHash: 'cast-abc',
+      embedUrls: ['https://example.com/embed'],
+      imageUrls: ['https://example.com/img.jpg'],
+      channel: 'base',
+    });
+  });
+
+  it('accepts text at exactly 1024 characters', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    const text1024 = 'a'.repeat(1024);
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-exact',
+      postUrl: 'https://www.threads.net/@thezao/post/post-exact',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: text1024,
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: text1024,
+      castHash: 'abc123',
+    });
+  });
+
+  it('accepts embedUrls as empty array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-empty-embeds',
+      postUrl: 'https://www.threads.net/@thezao/post/post-empty-embeds',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+          embedUrls: [],
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: 'hello',
+      castHash: 'abc123',
+      embedUrls: [],
+    });
+  });
+
+  it('accepts imageUrls as empty array', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-empty-images',
+      postUrl: 'https://www.threads.net/@thezao/post/post-empty-images',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'hello',
+          imageUrls: [],
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: 'hello',
+      castHash: 'abc123',
+      imageUrls: [],
+    });
+  });
+
+  it('omits optional fields from normalize call when not provided', async () => {
+    mockGetSessionData.mockResolvedValue(mockAdminSession());
+    mockNormalizeForThreads.mockReturnValue({
+      text: 'normalized',
+      images: [],
+      embeds: [],
+      attribution: 'via ZAO OS',
+      castHash: 'abc123',
+      castUrl: 'https://warpcast.com/~/conversations/abc123',
+    });
+    mockPublishToThreads.mockResolvedValue({
+      postId: 'post-minimal',
+      postUrl: 'https://www.threads.net/@thezao/post/post-minimal',
+    });
+    mockFrom.mockReturnValue(makeInsertChain({ error: null }));
+
+    const res = await import('../route').then((m) =>
+      m.POST(
+        makePostRequest('/api/publish/threads', {
+          castHash: 'abc123',
+          text: 'minimal',
+        }),
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    // Verify normalize was called WITHOUT embedUrls, imageUrls, channel
+    expect(mockNormalizeForThreads).toHaveBeenCalledWith({
+      text: 'minimal',
+      castHash: 'abc123',
+    });
+  });
+});


### PR DESCRIPTION
## What

Test coverage for the 4 remaining `publish/*` cross-post adapter routes — **103 tests total**. Platform publish libs fully mocked — no real cross-posts.

| Route | Tests | Covers |
|-------|-------|--------|
| `publish/farcaster` | 19 | admin guard, proposalId uuid Zod, proposal 404, already-published 409, respect-threshold, postCast (mocked), audit-log, errors |
| `publish/bluesky` | 40 | auth+admin, isBlueskyConfigured 503, Zod (castHash/text/urls), normalize→publishToBluesky (mocked), publish_log, errors |
| `publish/threads` | 22 | auth+admin, isThreadsConfigured 503, Zod, normalize→publishToThreads (mocked), publish_log, errors |
| `publish/lens` | 22 | auth, Zod, lens token/profile checks, normalize→publishToLens (mocked), publish_log success+failed, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`. No bugs found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)