### PR TITLE
test(notifications,respect,staking): farcaster/send/event/leaderboard (154 tests)

### DIFF
--- a/src/app/api/notifications/farcaster/__tests__/route.test.ts
+++ b/src/app/api/notifications/farcaster/__tests__/route.test.ts
@@ -1,0 +1,496 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  makeGetRequest,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockGetNotifications, mockMarkNotificationsSeen } = vi.hoisted(() => ({
+  mockGetNotifications: vi.fn(),
+  mockMarkNotificationsSeen: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/farcaster/neynar', () => ({
+  getNotifications: mockGetNotifications,
+  markNotificationsSeen: mockMarkNotificationsSeen,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+// ── Route imports ────────────────────────────────────────────────────────────
+import { GET, POST } from '../route';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Create a mock notification object.
+ */
+function mockNotification(overrides?: Record<string, unknown>) {
+  return {
+    id: 'notif-1',
+    fid: 123,
+    type: 'reply',
+    actor: {
+      fid: 456,
+      username: 'notifier',
+      display_name: 'Notifier User',
+      pfp_url: 'https://example.com/pfp.jpg',
+    },
+    timestamp: '2026-07-15T12:00:00Z',
+    cast: {
+      hash: 'cast-abc',
+      text: 'Reply to your cast',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Neynar notifications response.
+ */
+function mockNotificationsResponse(notifications: unknown[], cursor?: string) {
+  return {
+    notifications: notifications || [],
+    next: { cursor: cursor || null },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/notifications/farcaster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  describe('Authentication', () => {
+    it('returns 401 when session is null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session.fid is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: undefined }));
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when session.fid is null', async () => {
+      mockGetSessionData.mockResolvedValue({ fid: null } as unknown as ReturnType<
+        typeof mockAuthenticatedSession
+      >);
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when using mockUnauthenticatedSession', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Unauthorized');
+    });
+  });
+
+  // ── Success / happy path tests ────────────────────────────────────────────
+
+  describe('Success path', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 200 with notifications data', async () => {
+      const notif = mockNotification();
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([notif]));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.notifications).toHaveLength(1);
+      expect(body.notifications[0].id).toBe('notif-1');
+      expect(body.notifications[0].actor.username).toBe('notifier');
+    });
+
+    it('calls getNotifications with correct fid', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster'));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, undefined);
+    });
+
+    it('returns empty notifications array when none exist', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.notifications).toEqual([]);
+    });
+
+    it('returns multiple notifications correctly', async () => {
+      const notifs = [
+        mockNotification({ id: 'notif-1' }),
+        mockNotification({ id: 'notif-2', type: 'like' }),
+        mockNotification({ id: 'notif-3', type: 'recast' }),
+      ];
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse(notifs));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.notifications).toHaveLength(3);
+      expect(body.notifications[0].id).toBe('notif-1');
+      expect(body.notifications[1].type).toBe('like');
+      expect(body.notifications[2].type).toBe('recast');
+    });
+  });
+
+  // ── Cursor parameter tests ────────────────────────────────────────────────
+
+  describe('Cursor parameter', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('passes cursor to getNotifications when provided', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster', { cursor: 'cursor-abc' }));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, 'cursor-abc', undefined);
+    });
+
+    it('passes undefined cursor when not provided', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster'));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, undefined);
+    });
+
+    it('includes cursor in pagination response', async () => {
+      mockGetNotifications.mockResolvedValue(
+        mockNotificationsResponse([mockNotification()], 'next-cursor-123'),
+      );
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      const body = await res.json();
+
+      expect(body.next.cursor).toBe('next-cursor-123');
+    });
+
+    it('sets next.cursor to null when no more results', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([mockNotification()]));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      const body = await res.json();
+
+      expect(body.next.cursor).toBe(null);
+    });
+  });
+
+  // ── Limit parameter tests ────────────────────────────────────────────────
+
+  describe('Limit parameter', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('passes limit to getNotifications when provided', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster', { limit: '10' }));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, 10);
+    });
+
+    it('passes undefined limit when not provided', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster'));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, undefined);
+    });
+
+    it('parses limit as integer', async () => {
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster', { limit: '25' }));
+
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, 25);
+    });
+
+    it('handles non-numeric limit (parseInt returns NaN without guard)', async () => {
+      // NOTE: The route does NOT guard against NaN. parseInt('abc', 10) = NaN
+      // Math.min(NaN, anything) = NaN. This is a potential bug.
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
+
+      await GET(makeGetRequest('/api/notifications/farcaster', { limit: 'not-a-number' }));
+
+      // The route passes NaN directly to getNotifications
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, Number.NaN);
+    });
+  });
+
+  // ── Error handling tests ──────────────────────────────────────────────────
+
+  describe('Error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns 500 when getNotifications throws', async () => {
+      mockGetNotifications.mockRejectedValue(new Error('Neynar API error'));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body.error).toBe('Failed to fetch notifications');
+    });
+
+    it('returns 500 on network error', async () => {
+      mockGetNotifications.mockRejectedValue(new Error('Network timeout'));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body.error).toBe('Failed to fetch notifications');
+    });
+
+    it('does not expose internal error message in response', async () => {
+      mockGetNotifications.mockRejectedValue(new Error('Sensitive API key leaked in error'));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to fetch notifications');
+      expect(body.error).not.toContain('API key');
+    });
+  });
+
+  // ── Response shape tests ──────────────────────────────────────────────────
+
+  describe('Response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 123 }));
+    });
+
+    it('returns object with notifications and next properties', async () => {
+      const notif = mockNotification();
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([notif], 'cursor-1'));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      const body = await res.json();
+
+      expect(body).toHaveProperty('notifications');
+      expect(body).toHaveProperty('next');
+      expect(body.next).toHaveProperty('cursor');
+    });
+
+    it('preserves notification object structure', async () => {
+      const notif = mockNotification({
+        id: 'notif-test',
+        type: 'follow',
+        actor: {
+          fid: 999,
+          username: 'follower',
+          display_name: 'Follower Person',
+          pfp_url: 'https://example.com/follower.jpg',
+        },
+        timestamp: '2026-07-15T10:30:00Z',
+      });
+      mockGetNotifications.mockResolvedValue(mockNotificationsResponse([notif]));
+
+      const res = await GET(makeGetRequest('/api/notifications/farcaster'));
+      const body = await res.json();
+
+      const returned = body.notifications[0];
+      expect(returned.id).toBe('notif-test');
+      expect(returned.type).toBe('follow');
+      expect(returned.actor.fid).toBe(999);
+      expect(returned.actor.username).toBe('follower');
+      expect(returned.timestamp).toBe('2026-07-15T10:30:00Z');
+    });
+  });
+});
+
+describe('POST /api/notifications/farcaster', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Authentication tests ──────────────────────────────────────────────────
+
+  describe('Authentication', () => {
+    it('returns 401 when session is null', async () => {
+      mockGetSessionData.mockResolvedValue(null);
+      const res = await POST();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Signer required');
+    });
+
+    it('returns 401 when session.signerUuid is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ signerUuid: undefined }));
+      const res = await POST();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Signer required');
+    });
+
+    it('returns 401 when session.signerUuid is null', async () => {
+      mockGetSessionData.mockResolvedValue({
+        signerUuid: null,
+      } as unknown as ReturnType<typeof mockAuthenticatedSession>);
+      const res = await POST();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Signer required');
+    });
+
+    it('returns 401 when using unauthenticated session', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+      const res = await POST();
+      expect(res.status).toBe(401);
+      const body = await res.json();
+      expect(body.error).toBe('Signer required');
+    });
+  });
+
+  // ── Success path tests ────────────────────────────────────────────────────
+
+  describe('Success path', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ signerUuid: 'signer-uuid-123' }),
+      );
+    });
+
+    it('returns 200 with success: true', async () => {
+      mockMarkNotificationsSeen.mockResolvedValue({ success: true });
+
+      const res = await POST();
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.success).toBe(true);
+    });
+
+    it('calls markNotificationsSeen with correct signerUuid', async () => {
+      mockMarkNotificationsSeen.mockResolvedValue({ success: true });
+
+      await POST();
+
+      expect(mockMarkNotificationsSeen).toHaveBeenCalledWith('signer-uuid-123');
+      expect(mockMarkNotificationsSeen).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes different signerUuid values correctly', async () => {
+      mockMarkNotificationsSeen.mockResolvedValue({ success: true });
+
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ signerUuid: 'different-uuid-456' }),
+      );
+      await POST();
+
+      expect(mockMarkNotificationsSeen).toHaveBeenCalledWith('different-uuid-456');
+    });
+  });
+
+  // ── Error handling tests ──────────────────────────────────────────────────
+
+  describe('Error handling', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ signerUuid: 'signer-uuid-123' }),
+      );
+    });
+
+    it('returns 500 when markNotificationsSeen throws', async () => {
+      mockMarkNotificationsSeen.mockRejectedValue(new Error('Neynar API error'));
+
+      const res = await POST();
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body.error).toBe('Failed to mark notifications seen');
+    });
+
+    it('returns 500 on network error', async () => {
+      mockMarkNotificationsSeen.mockRejectedValue(new Error('Connection refused'));
+
+      const res = await POST();
+      expect(res.status).toBe(500);
+
+      const body = await res.json();
+      expect(body.error).toBe('Failed to mark notifications seen');
+    });
+
+    it('does not expose internal error message', async () => {
+      mockMarkNotificationsSeen.mockRejectedValue(new Error('Internal server secret exposed'));
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to mark notifications seen');
+      expect(body.error).not.toContain('secret');
+    });
+  });
+
+  // ── Response shape tests ──────────────────────────────────────────────────
+
+  describe('Response shape', () => {
+    beforeEach(() => {
+      mockGetSessionData.mockResolvedValue(
+        mockAuthenticatedSession({ signerUuid: 'signer-uuid-123' }),
+      );
+    });
+
+    it('returns object with success property', async () => {
+      mockMarkNotificationsSeen.mockResolvedValue({ success: true });
+
+      const res = await POST();
+      const body = await res.json();
+
+      expect(body).toHaveProperty('success');
+      expect(typeof body.success).toBe('boolean');
+    });
+
+    it('returns only success in response body', async () => {
+      mockMarkNotificationsSeen.mockResolvedValue({ custom_field: 'should_not_appear' });
+
+      const res = await POST();
+      const body = await res.json();
+
+      // Route directly returns whatever Neynar returns
+      expect(body).toHaveProperty('success');
+    });
+  });
+});

--- a/src/app/api/notifications/send/__tests__/route.test.ts
+++ b/src/app/api/notifications/send/__tests__/route.test.ts
@@ -1,0 +1,1414 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+}));
+
+const { mockGetClientIp, mockLogAuditEvent } = vi.hoisted(() => ({
+  mockGetClientIp: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+}));
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/audit-log', () => ({
+  getClientIp: mockGetClientIp,
+  logAuditEvent: mockLogAuditEvent,
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+// Mock global fetch
+global.fetch = vi.fn() as unknown as typeof fetch;
+
+import { POST } from '../route';
+
+describe('POST /api/notifications/send', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockGetClientIp.mockReturnValue('192.168.1.1');
+    mockLogAuditEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('authentication', () => {
+    it('returns 403 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(403);
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(403);
+      expect(body).toEqual({ error: 'Unauthorized' });
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when session exists but fid is missing', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: undefined }));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(403);
+      expect(body).toEqual({ error: 'Unauthorized' });
+    });
+  });
+
+  describe('input validation', () => {
+    it('returns 400 when recipientFids is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+      expect(body.details).toBeDefined();
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when recipientFids is empty array', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+      expect(body.details).toBeDefined();
+    });
+
+    it('returns 400 when recipientFids exceeds 500', async () => {
+      const fids = Array.from({ length: 501 }, (_, i) => i + 1);
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: fids,
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when recipientFids contains non-integer', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2.5, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when recipientFids contains non-positive number', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 0, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when title is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when title is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: '',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when title exceeds 100 chars', async () => {
+      const longTitle = 'a'.repeat(101);
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: longTitle,
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('accepts title with exactly 100 chars', async () => {
+      const maxTitle = 'a'.repeat(100);
+      const tokensChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: maxTitle,
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.sent).toBe(0);
+      expect(body.skipped).toBe(3);
+    });
+
+    it('returns 400 when body is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when body is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: '',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when body exceeds 500 chars', async () => {
+      const longBody = 'a'.repeat(501);
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: longBody,
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('accepts body with exactly 500 chars', async () => {
+      const maxBody = 'a'.repeat(500);
+      const tokensChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: maxBody,
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.sent).toBe(0);
+    });
+
+    it('returns 400 when targetUrl is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('returns 400 when targetUrl is not a valid URL', async () => {
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'not-a-url',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid request');
+    });
+
+    it('accepts valid URL with http', async () => {
+      const tokensChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'http://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.sent).toBe(0);
+    });
+
+    it('accepts valid URL with https', async () => {
+      const tokensChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com/path?param=value',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.sent).toBe(0);
+    });
+  });
+
+  describe('token fetching', () => {
+    it('returns 500 when token fetch from DB fails', async () => {
+      const tokensChain = chainMock({
+        data: null,
+        error: new Error('Connection refused'),
+      });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Failed to fetch tokens' });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns sent:0 when no tokens are found for requested FIDs', async () => {
+      const tokensChain = chainMock({ data: [], error: null });
+      mockFrom.mockReturnValue(tokensChain.handler());
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(body.sent).toBe(0);
+      expect(body.skipped).toBe(3);
+    });
+
+    it('queries supabase for notification_tokens in requested FIDs', async () => {
+      const tokensChain = chainMock({ data: [], error: null });
+      const selectFn = vi.fn().mockReturnValue(tokensChain.chain);
+      const inFn = vi.fn().mockReturnValue(tokensChain.chain);
+      const eqFn = vi.fn().mockReturnValue(tokensChain.chain);
+
+      tokensChain.chain.select = selectFn;
+      tokensChain.chain.in = inFn;
+      tokensChain.chain.eq = eqFn;
+      mockFrom.mockReturnValue(tokensChain.chain);
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [10, 20, 30],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('notification_tokens');
+      expect(selectFn).toHaveBeenCalledWith('fid, token, url');
+      expect(inFn).toHaveBeenCalledWith('fid', [10, 20, 30]);
+      expect(eqFn).toHaveBeenCalledWith('enabled', true);
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('skips tokens that sent a notification within last 30 seconds', async () => {
+      const now = new Date();
+      const recentTime = new Date(now.getTime() - 10_000).toISOString();
+
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+      ];
+
+      const recentSends = [{ fid: 1, sent_at: recentTime }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token2'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect(body.skipped).toBe(1);
+    });
+
+    it('skips tokens with 100 or more sends in the last 24 hours', async () => {
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+      ];
+
+      const now = new Date();
+      const recentSends: Array<{ fid: number; sent_at: string }> = [];
+
+      for (let i = 0; i < 100; i += 1) {
+        recentSends.push({
+          fid: 1,
+          sent_at: new Date(now.getTime() - i * 1000).toISOString(),
+        });
+      }
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token2'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect(body.skipped).toBe(1);
+    });
+
+    it('allows sends when previous send was more than 30 seconds ago', async () => {
+      const now = new Date();
+      const thirtyOneSecondsAgo = new Date(now.getTime() - 31_000).toISOString();
+
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+      ];
+
+      const recentSends = [
+        { fid: 1, sent_at: thirtyOneSecondsAgo },
+        { fid: 2, sent_at: thirtyOneSecondsAgo },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: { successfulTokens: ['token1', 'token2'] },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(2);
+      expect(body.skipped).toBe(0);
+    });
+
+    it('allows sends when under 100 notifications per day', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const now = new Date();
+      const thirtyOneSecondsAgo = new Date(now.getTime() - 31_000);
+      const recentSends = Array.from({ length: 50 }, (_, i) => ({
+        fid: 1,
+        sent_at: new Date(thirtyOneSecondsAgo.getTime() - i * 10_000).toISOString(),
+      }));
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+    });
+  });
+
+  describe('sending notifications', () => {
+    it('sends notifications to eligible tokens', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.example.com/send' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test Title',
+          body: 'Test Body',
+          targetUrl: 'https://example.com/notification',
+        }),
+      );
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+        'https://notify.example.com/send',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+    });
+
+    it('includes all eligible tokens in a single POST body grouped by URL', async () => {
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.example.com/send' },
+        { fid: 2, token: 'token2', url: 'https://notify.example.com/send' },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1', 'token2'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test Title',
+          body: 'Test Body',
+          targetUrl: 'https://example.com/notification',
+        }),
+      );
+
+      const callArgs = vi.mocked(global.fetch).mock.calls[0];
+      const body = JSON.parse((callArgs?.[1]?.body as string) ?? '{}') as unknown as Record<
+        string,
+        unknown
+      >;
+
+      expect(body.title).toBe('Test Title');
+      expect(body.body).toBe('Test Body');
+      expect(body.targetUrl).toBe('https://example.com/notification');
+      expect(body.tokens).toEqual(['token1', 'token2']);
+      expect(body.notificationId).toBeDefined();
+    });
+
+    it('sends to different URLs separately', async () => {
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify1.example.com/send' },
+        { fid: 2, token: 'token2', url: 'https://notify2.example.com/send' },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1', 'token2'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test Title',
+          body: 'Test Body',
+          targetUrl: 'https://example.com/notification',
+        }),
+      );
+
+      expect(vi.mocked(global.fetch)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(global.fetch).mock.calls[0]?.[0]).toBe('https://notify1.example.com/send');
+      expect(vi.mocked(global.fetch).mock.calls[1]?.[0]).toBe('https://notify2.example.com/send');
+    });
+
+    it('counts successful sends when response is ok', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+    });
+
+    it('records invalid tokens in response and disables them', async () => {
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+      const updateChain = chainMock({ error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (
+          table === 'notification_tokens' &&
+          mockFrom.mock.lastCall?.[0] === 'notification_tokens'
+        )
+          return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        if (table === 'notification_tokens') return updateChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            result: {
+              successfulTokens: ['token1'],
+              invalidTokens: ['token2'],
+            },
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect(
+        (body.errors as Array<{ fid: number; error: string }> | undefined)?.[0]?.error,
+      ).toContain('Invalid token');
+    });
+
+    it('handles fetch error gracefully', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network timeout'));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(0);
+      expect(
+        (body.errors as Array<{ fid: number; error: string }> | undefined)?.[0]?.error,
+      ).toContain('Network timeout');
+    });
+
+    it('handles HTTP error response from endpoint', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response('Endpoint unavailable', { status: 503 }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(0);
+      expect(
+        (body.errors as Array<{ fid: number; error: string }> | undefined)?.[0]?.error,
+      ).toContain('HTTP 503');
+    });
+
+    it('uses Promise.allSettled to handle partial failures', async () => {
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify1.com' },
+        { fid: 2, token: 'token2', url: 'https://notify2.com' },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+            status: 200,
+          }),
+        )
+        .mockRejectedValueOnce(new Error('Network error'));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect((body.errors as Array<{ fid: number; error: string }> | undefined)?.length).toBe(1);
+    });
+  });
+
+  describe('notification logging', () => {
+    it('logs successful sends to notification_log table', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+      const logInsertChain = chainMock({ error: null });
+
+      const insertFn = vi.fn().mockReturnValue(logInsertChain.chain);
+      logInsertChain.chain.insert = insertFn;
+
+      let callCount = 0;
+      mockFrom.mockImplementation((table: string) => {
+        callCount += 1;
+        if (table === 'notification_tokens' && callCount === 1) return tokensChain.handler();
+        if (table === 'notification_log' && callCount === 2) return recentChain.handler();
+        if (table === 'notification_log' && callCount === 3) return logInsertChain.chain;
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test Title',
+          body: 'Test Body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(insertFn).toHaveBeenCalled();
+      const insertCall = vi.mocked(insertFn).mock.calls[0]?.[0] as
+        | Array<{ fid: number; title: string; body: string; target_url: string; sent_at: string }>
+        | undefined;
+
+      expect(insertCall?.[0]?.fid).toBe(1);
+      expect(insertCall?.[0]?.title).toBe('Test Title');
+      expect(insertCall?.[0]?.body).toBe('Test Body');
+      expect(insertCall?.[0]?.target_url).toBe('https://example.com');
+      expect(insertCall?.[0]?.sent_at).toBeDefined();
+    });
+
+    it('does not log failed sends to notification_log', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+      const logInsertChain = chainMock({ error: null });
+
+      const insertFn = vi.fn().mockReturnValue(logInsertChain.chain);
+      logInsertChain.chain.insert = insertFn;
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log' && mockFrom.mock.lastCall?.[0] === 'notification_log')
+          return recentChain.handler();
+        if (table === 'notification_log') return logInsertChain.chain;
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(new Response('Error', { status: 500 }));
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      const insertCalls = vi.mocked(insertFn).mock.calls;
+      const logCall = insertCalls.find((call) => {
+        const entry = call[0] as Array<{ fid: number }> | undefined;
+        return entry && entry[0]?.fid === 1;
+      });
+
+      expect(logCall).toBeUndefined();
+    });
+  });
+
+  describe('audit logging', () => {
+    it('logs audit event with correct action and details', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Notification Title',
+          body: 'Notification body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 123,
+          action: 'notification.broadcast',
+          targetType: 'notification',
+          details: expect.objectContaining({
+            title: 'Notification Title',
+            recipientCount: 3,
+            sent: 1,
+          }),
+          ipAddress: '192.168.1.1',
+        }),
+      );
+    });
+
+    it('includes client IP in audit event', async () => {
+      mockGetClientIp.mockReturnValue('203.0.113.42');
+
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ipAddress: '203.0.113.42',
+        }),
+      );
+    });
+
+    it('includes actor FID from session', async () => {
+      mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 999 }));
+
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockLogAuditEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorFid: 999,
+        }),
+      );
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns sent, skipped, and optional errors fields', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body).toHaveProperty('sent');
+      expect(body).toHaveProperty('skipped');
+      expect(Object.keys(body).sort()).toEqual(['sent', 'skipped']);
+    });
+
+    it('includes errors array when there are failed sends', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(new Response('Error', { status: 500 }));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.errors).toBeDefined();
+      expect(Array.isArray(body.errors)).toBe(true);
+    });
+
+    it('omits errors array when all sends succeeded', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token1'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.errors).toBeUndefined();
+    });
+
+    it('returns 200 even when all sends fail', async () => {
+      const tokens = [{ fid: 1, token: 'token1', url: 'https://notify.com' }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when unexpected error occurs', async () => {
+      mockGetSessionData.mockRejectedValue(new Error('Session error'));
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Internal server error' });
+    });
+
+    it('handles malformed JSON request body', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/notifications/send', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await POST(malformedReq);
+      const body = (await res.json()) as unknown;
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({ error: 'Internal server error' });
+    });
+
+    it('does not call audit logging when auth fails', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not call audit logging when validation fails', async () => {
+      await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+
+      expect(mockLogAuditEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('skipped count calculation', () => {
+    it('counts users with no tokens as skipped', async () => {
+      const tokensChain = chainMock({ data: [], error: null });
+      const recentChain = chainMock({ data: [], error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.skipped).toBe(3);
+    });
+
+    it('counts rate-limited users as skipped', async () => {
+      const now = new Date();
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+        { fid: 3, token: 'token3', url: 'https://notify.com' },
+      ];
+
+      const recentTime = new Date(now.getTime() - 10_000).toISOString();
+      const recentSends = [
+        { fid: 1, sent_at: recentTime },
+        { fid: 2, sent_at: recentTime },
+      ];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token3'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect(body.skipped).toBe(2);
+    });
+
+    it('skipped count includes both missing tokens and rate-limited', async () => {
+      const now = new Date();
+      const tokens = [
+        { fid: 1, token: 'token1', url: 'https://notify.com' },
+        { fid: 2, token: 'token2', url: 'https://notify.com' },
+      ];
+
+      const recentTime = new Date(now.getTime() - 10_000).toISOString();
+      const recentSends = [{ fid: 1, sent_at: recentTime }];
+
+      const tokensChain = chainMock({ data: tokens, error: null });
+      const recentChain = chainMock({ data: recentSends, error: null });
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'notification_tokens') return tokensChain.handler();
+        if (table === 'notification_log') return recentChain.handler();
+        return tokensChain.handler();
+      });
+
+      vi.mocked(global.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ result: { successfulTokens: ['token2'] } }), {
+          status: 200,
+        }),
+      );
+
+      const res = await POST(
+        makePostRequest('/api/notifications/send', {
+          recipientFids: [1, 2, 3, 4],
+          title: 'Test',
+          body: 'Test body',
+          targetUrl: 'https://example.com',
+        }),
+      );
+      const body = (await res.json()) as Record<string, unknown>;
+
+      expect(body.sent).toBe(1);
+      expect(body.skipped).toBe(3);
+    });
+  });
+});

--- a/src/app/api/respect/event/__tests__/route.test.ts
+++ b/src/app/api/respect/event/__tests__/route.test.ts
@@ -1,0 +1,1299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  chainMock,
+  makePostRequest,
+  mockAdminSession,
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+  VALID_UUID,
+  VALID_WALLET,
+} from '@/test-utils/api-helpers';
+
+const { mockGetSessionData, mockFrom } = vi.hoisted(() => ({
+  mockGetSessionData: vi.fn(),
+  mockFrom: vi.fn(),
+}));
+
+const { mockAutoCastToZao } = vi.hoisted(() => ({
+  mockAutoCastToZao: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionData: () => mockGetSessionData(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: { from: mockFrom },
+}));
+
+vi.mock('@/lib/publish/auto-cast', () => ({
+  autoCastToZao: mockAutoCastToZao,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { POST } from '../route';
+
+// ============================================================================
+// POST /api/respect/event
+// ============================================================================
+
+describe('POST /api/respect/event', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionData.mockResolvedValue(mockAdminSession({ fid: 123 }));
+    mockAutoCastToZao.mockResolvedValue(null);
+  });
+
+  // --------------------------------------------------------------------------
+  // Authentication Tests
+  // --------------------------------------------------------------------------
+
+  describe('authentication', () => {
+    it('returns 401 when unauthenticated', async () => {
+      mockGetSessionData.mockResolvedValue(mockUnauthenticatedSession());
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(401);
+      expect(body.error).toBe('Unauthorized');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when authenticated but not admin', async () => {
+      mockGetSessionData.mockResolvedValue(mockAuthenticatedSession({ fid: 456, isAdmin: false }));
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toBe('Admin access required');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Input Validation Tests
+  // --------------------------------------------------------------------------
+
+  describe('input validation', () => {
+    it('returns 400 when member_name is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when member_name is empty string', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: '',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when event_type is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when event_type is invalid enum value', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'invalid_type',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when amount is missing', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when amount is not positive', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 0,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when amount is negative', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: -5,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts event_date with valid YYYY-MM-DD format', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          event_date: '2026-07-15',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('returns 400 when event_date has invalid format', async () => {
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          event_date: '07-15-2026',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Invalid input');
+      expect(body.details).toBeDefined();
+      expect(mockFrom).not.toHaveBeenCalled();
+    });
+
+    it('accepts optional wallet_address', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          wallet_address: VALID_WALLET,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts optional wallet_address as null', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          wallet_address: null,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts optional description', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          description: 'Great introduction talk',
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('accepts all valid event types', async () => {
+      const eventTypes = [
+        'introduction',
+        'camera',
+        'article',
+        'hosting',
+        'festival',
+        'bonus',
+        'listing',
+        'other',
+      ];
+
+      for (const eventType of eventTypes) {
+        vi.clearAllMocks();
+        const eventChain = chainMock({
+          data: { id: '1' },
+          error: null,
+        }).chain;
+        mockFrom.mockReturnValue(eventChain);
+
+        const res = await POST(
+          makePostRequest('/api/respect/event', {
+            member_name: 'Alice',
+            event_type: eventType,
+            amount: 10,
+          }),
+        );
+
+        expect(res.status).toBe(200);
+      }
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Supabase Interaction Tests
+  // --------------------------------------------------------------------------
+
+  describe('Supabase interaction - event creation', () => {
+    it('inserts event into respect_events table', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('respect_events');
+      expect(vi.mocked(eventChain.insert)).toHaveBeenCalledWith({
+        member_name: 'Alice',
+        wallet_address: null,
+        event_type: 'introduction',
+        amount: 10,
+        description: null,
+        event_date: null,
+      });
+    });
+
+    it('inserts event with wallet_address when provided', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      const insertCall = vi.mocked(eventChain.insert);
+      const [payload] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+      expect(payload.wallet_address).toBe(VALID_WALLET);
+    });
+
+    it('inserts event with description when provided', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+          description: 'Test description',
+        }),
+      );
+
+      const insertCall = vi.mocked(eventChain.insert);
+      const [payload] = insertCall.mock.calls[0] as unknown as [Record<string, unknown>];
+      expect(payload.description).toBe('Test description');
+    });
+
+    it('returns 500 when event insert fails', async () => {
+      const dbError = new Error('Insert failed');
+      const eventChain = chainMock({
+        data: null,
+        error: dbError,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to create respect event');
+    });
+  });
+
+  describe('Supabase interaction - member lookup and update', () => {
+    it('queries respect_members by wallet_address first', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? eventChain : memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      const memberEqCall = vi.mocked(memberChain.eq);
+      expect(memberEqCall).toHaveBeenCalledWith('wallet_address', VALID_WALLET);
+    });
+
+    it('falls back to member_name query when wallet_address not found', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain1 = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      const memberChain2 = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        if (callCount === 2) return memberChain1;
+        return memberChain2;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      const memberChain2EqCall = vi.mocked(memberChain2.eq);
+      expect(memberChain2EqCall).toHaveBeenCalledWith('name', 'Alice');
+    });
+
+    it('queries by member_name when wallet_address is not provided', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      // Should query by member_name, not wallet
+      const memberChainEqCall = vi.mocked(memberChain.eq);
+      expect(memberChainEqCall).toHaveBeenCalledWith('name', 'Alice');
+    });
+
+    it('updates existing member totals when found by wallet', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 50,
+          event_respect: 30,
+          hosting_respect: 0,
+          bonus_respect: 20,
+          hosting_count: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('respect_members');
+      const updateCall = vi.mocked(memberChain.update);
+      expect(updateCall).toHaveBeenCalled();
+      const [updates] = updateCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(updates.total_respect).toBe(60); // 50 + 10
+      expect(updates.event_respect).toBe(40); // 30 + 10
+    });
+
+    it('increments hosting_count for hosting events', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 50,
+          hosting_respect: 30,
+          hosting_count: 2,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'hosting',
+          amount: 15,
+        }),
+      );
+
+      const updateCall = vi.mocked(memberChain.update);
+      const [updates] = updateCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(updates.hosting_count).toBe(3); // 2 + 1
+      expect(updates.hosting_respect).toBe(45); // 30 + 15
+    });
+
+    it('sets first_respect_at when member has no prior respect and event_date provided', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 0,
+          event_respect: 0,
+          first_respect_at: null,
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+          event_date: '2026-07-15',
+        }),
+      );
+
+      const updateCall = vi.mocked(memberChain.update);
+      const [updates] = updateCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(updates.first_respect_at).toBe('2026-07-15');
+    });
+
+    it('does not overwrite first_respect_at when already set', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 50,
+          event_respect: 30,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+          event_date: '2026-07-15',
+        }),
+      );
+
+      const updateCall = vi.mocked(memberChain.update);
+      const [updates] = updateCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+      expect(updates.first_respect_at).toBeUndefined();
+    });
+  });
+
+  describe('Supabase interaction - new member creation', () => {
+    it('creates new member when not found', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'NewMember',
+          event_type: 'introduction',
+          amount: 20,
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('respect_members');
+      const insertCall = vi.mocked(eventChain.insert as unknown as ReturnType<typeof vi.fn>);
+      expect(insertCall).toHaveBeenCalled();
+    });
+
+    it('creates new member with all category columns initialized', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'NewMember',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 20,
+        }),
+      );
+
+      // Note: we need to check the last from() call, which creates the member
+      const lastFromCall = vi.mocked(mockFrom);
+      expect(lastFromCall).toHaveBeenCalledWith('respect_members');
+    });
+
+    it('sets hosting_count to 1 for new member with hosting event', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'NewMember',
+          event_type: 'hosting',
+          amount: 15,
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalledWith('respect_members');
+    });
+
+    it('sets first_respect_at for new member when event_date provided', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'NewMember',
+          event_type: 'introduction',
+          amount: 10,
+          event_date: '2026-07-15',
+        }),
+      );
+
+      expect(mockFrom).toHaveBeenCalled();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Milestone and Auto-Cast Tests
+  // --------------------------------------------------------------------------
+
+  describe('respect milestone detection and auto-cast', () => {
+    it('announces when member reaches 100 respect milestone', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 95,
+          event_respect: 95,
+          hosting_respect: 0,
+          bonus_respect: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10, // 95 + 10 = 105, crosses 100
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('Alice'));
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('100'));
+    });
+
+    it('announces when member reaches 500 respect milestone', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 490,
+          event_respect: 490,
+          hosting_respect: 0,
+          bonus_respect: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Bob',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 15, // 490 + 15 = 505, crosses 500
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('Bob'));
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('500'));
+    });
+
+    it('announces when member reaches 1000 respect milestone', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 990,
+          event_respect: 990,
+          hosting_respect: 0,
+          bonus_respect: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Charlie',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 20, // 990 + 20 = 1010, crosses 1000
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('Charlie'));
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('1000'));
+    });
+
+    it('announces only once when crossing multiple milestones', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 50,
+          event_respect: 50,
+          hosting_respect: 0,
+          bonus_respect: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Delta',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 600, // 50 + 600 = 650, crosses 100, 500 but announces the first (100)
+        }),
+      );
+
+      expect(mockAutoCastToZao).toHaveBeenCalledTimes(1);
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('Delta'));
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('100'));
+    });
+
+    it('does not announce when not crossing any milestone', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 150,
+          event_respect: 150,
+          hosting_respect: 0,
+          bonus_respect: 0,
+          first_respect_at: '2026-01-01',
+        },
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Eve',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10, // 150 + 10 = 160, no milestone crossed
+        }),
+      );
+
+      expect(mockAutoCastToZao).not.toHaveBeenCalled();
+    });
+
+    it('announces for new member when crossing milestone (0 to amount)', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null, // Member not found by name
+        error: null,
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        return memberChain;
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Frank',
+          event_type: 'introduction',
+          amount: 150, // 0 + 150 = 150, crosses 100 milestone
+        }),
+      );
+
+      // autoCastToZao should be called because oldTotal=0, newTotal=150
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('Frank'));
+      expect(mockAutoCastToZao).toHaveBeenCalledWith(expect.stringContaining('100'));
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Error Handling Tests
+  // --------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('returns 500 when JSON parsing fails', async () => {
+      const malformedReq = new (await import('next/server')).NextRequest(
+        new URL('/api/respect/event', 'http://localhost:3000'),
+        {
+          method: 'POST',
+          body: '{invalid json',
+        },
+      );
+
+      const res = await POST(malformedReq);
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.error).toBe('Failed to record respect event');
+    });
+
+    it('logs error to logger.error when exception occurs', async () => {
+      const { logger } = await import('@/lib/logger');
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected error');
+      });
+
+      await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+
+      expect(vi.mocked(logger.error)).toHaveBeenCalledWith(
+        'Record respect event error:',
+        expect.any(Error),
+      );
+    });
+
+    it('returns success with warning when member update fails but event was inserted', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: {
+          id: VALID_UUID,
+          total_respect: 50,
+          event_respect: 30,
+        },
+        error: null,
+      }).chain;
+
+      const memberUpdateChain = chainMock({
+        data: null,
+        error: new Error('Update failed'),
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        if (callCount === 2) return memberChain;
+        return memberUpdateChain;
+      });
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          wallet_address: VALID_WALLET,
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.event_id).toBe('1');
+      expect(body.warning).toBe('Event recorded but member totals failed to update');
+    });
+
+    it('returns success with warning when new member creation fails but event was inserted', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      const memberChain = chainMock({
+        data: null,
+        error: null,
+      }).chain;
+
+      const memberInsertChain = chainMock({
+        data: null,
+        error: new Error('Insert failed'),
+      }).chain;
+
+      let callCount = 0;
+      mockFrom.mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) return eventChain;
+        if (callCount === 2) return memberChain;
+        return memberInsertChain;
+      });
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'NewMember',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.event_id).toBe('1');
+      expect(body.warning).toBe('Event recorded but member record failed to create');
+    });
+
+    it('does not expose sensitive error details in response', async () => {
+      const dbError = new Error('Connection to db.example.com:5432 failed');
+      const eventChain = chainMock({
+        data: null,
+        error: dbError,
+      }).chain;
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(body.error).toBe('Failed to create respect event');
+      expect(body.details).toBeUndefined();
+      expect(body.errorMessage).toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Success Response Tests
+  // --------------------------------------------------------------------------
+
+  describe('success response', () => {
+    it('returns 200 with success true and event_id', async () => {
+      const eventChain = chainMock({
+        data: { id: 'event-123' },
+        error: null,
+      }).chain;
+
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.event_id).toBe('event-123');
+    });
+
+    it('returns correct structure with no extra fields on success', async () => {
+      const eventChain = chainMock({
+        data: { id: '1' },
+        error: null,
+      }).chain;
+
+      mockFrom.mockReturnValue(eventChain);
+
+      const res = await POST(
+        makePostRequest('/api/respect/event', {
+          member_name: 'Alice',
+          event_type: 'introduction',
+          amount: 10,
+        }),
+      );
+      const body = await res.json();
+
+      expect(Object.keys(body).sort()).toEqual(['event_id', 'success'].sort());
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Event Type Mapping Tests
+  // --------------------------------------------------------------------------
+
+  describe('event type to column mapping', () => {
+    const testCases = [
+      { type: 'introduction', expectedColumn: 'event_respect' },
+      { type: 'camera', expectedColumn: 'event_respect' },
+      { type: 'article', expectedColumn: 'event_respect' },
+      { type: 'listing', expectedColumn: 'event_respect' },
+      { type: 'other', expectedColumn: 'event_respect' },
+      { type: 'hosting', expectedColumn: 'hosting_respect' },
+      { type: 'festival', expectedColumn: 'bonus_respect' },
+      { type: 'bonus', expectedColumn: 'bonus_respect' },
+    ];
+
+    for (const { type, expectedColumn } of testCases) {
+      it(`maps ${type} to ${expectedColumn}`, async () => {
+        const eventChain = chainMock({
+          data: { id: '1' },
+          error: null,
+        }).chain;
+
+        const memberChain = chainMock({
+          data: {
+            id: VALID_UUID,
+            total_respect: 50,
+            event_respect: 30,
+            hosting_respect: 0,
+            bonus_respect: 20,
+            hosting_count: 0,
+            first_respect_at: '2026-01-01',
+          },
+          error: null,
+        }).chain;
+
+        let callCount = 0;
+        mockFrom.mockImplementation(() => {
+          callCount += 1;
+          if (callCount === 1) return eventChain;
+          return memberChain;
+        });
+
+        await POST(
+          makePostRequest('/api/respect/event', {
+            member_name: 'Alice',
+            wallet_address: VALID_WALLET,
+            event_type: type,
+            amount: 10,
+          }),
+        );
+
+        const updateCall = vi.mocked(memberChain.update);
+        const [updates] = updateCall.mock.calls[0] as unknown as [Record<string, unknown>];
+
+        expect(updates[expectedColumn]).toBeDefined();
+      });
+    }
+  });
+});

--- a/src/app/api/staking/leaderboard/__tests__/route.test.ts
+++ b/src/app/api/staking/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,981 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/test-utils/api-helpers';
+import { GET } from '../route';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+}));
+
+const { mockGetConvictionBatch } = vi.hoisted(() => ({
+  mockGetConvictionBatch: vi.fn(),
+}));
+
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
+vi.mock('@/lib/db/supabase', () => ({
+  supabaseAdmin: {
+    from: mockFrom,
+  },
+}));
+
+vi.mock('@/lib/staking/conviction', () => ({
+  getConvictionBatch: mockGetConvictionBatch,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+  },
+}));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/staking/leaderboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('success: data retrieval and merging', () => {
+    it('returns empty array when no wallets exist in users or agent_config', async () => {
+      // Both queries return empty data
+      mockFrom.mockImplementation((table: string) => {
+        const chain = {
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          }),
+        };
+
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return chain;
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual([]);
+    });
+
+    it('fetches wallets from users table and calls getConvictionBatch', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+        { wallet_address: '0x2222222222222222222222222222222222222222', display_name: 'Bob' },
+      ];
+
+      const agentsData: unknown[] = [];
+
+      const convictionData = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+        {
+          address: '0x2222222222222222222222222222222222222222',
+          conviction: '500000000000000000000000000000',
+          staked: '50000000000000000000',
+          stakedFormatted: '50',
+          convictionFormatted: '0.5T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) =>
+                resolve({ data: agentsData, error: null }),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Verify getConvictionBatch was called with the correct addresses
+      expect(mockGetConvictionBatch).toHaveBeenCalledWith([
+        '0x1111111111111111111111111111111111111111',
+        '0x2222222222222222222222222222222222222222',
+      ]);
+
+      // Verify response includes merged names
+      expect(body).toHaveLength(2);
+      expect(body[0]).toEqual({
+        ...convictionData[0],
+        name: 'Alice',
+      });
+      expect(body[1]).toEqual({
+        ...convictionData[1],
+        name: 'Bob',
+      });
+    });
+
+    it('merges conviction data with wallet addresses from both users and agent_config tables', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+      ];
+
+      const agentsData = [
+        { wallet_address: '0x3333333333333333333333333333333333333333', name: 'Agent1' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x3333333333333333333333333333333333333333',
+          conviction: '2000000000000000000000000000000',
+          staked: '200000000000000000000',
+          stakedFormatted: '200',
+          convictionFormatted: '2.0T',
+        },
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) =>
+                resolve({ data: agentsData, error: null }),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Addresses from both tables should be passed to getConvictionBatch
+      expect(mockGetConvictionBatch).toHaveBeenCalledWith([
+        '0x1111111111111111111111111111111111111111',
+        '0x3333333333333333333333333333333333333333',
+      ]);
+
+      // Response should include entries from both tables with correct names
+      expect(body).toHaveLength(2);
+      expect(
+        body.find(
+          (e: { address: string }) => e.address === '0x1111111111111111111111111111111111111111',
+        ),
+      ).toEqual({
+        ...convictionData[1],
+        name: 'Alice',
+      });
+      expect(
+        body.find(
+          (e: { address: string }) => e.address === '0x3333333333333333333333333333333333333333',
+        ),
+      ).toEqual({
+        ...convictionData[0],
+        name: 'Agent1',
+      });
+    });
+
+    it('handles case-insensitive name mapping for wallet addresses', async () => {
+      const usersData = [
+        { wallet_address: '0xABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD', display_name: 'TestUser' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd', // lowercase
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Despite different case in the addresses, the name should be matched
+      expect(body[0].name).toBe('TestUser');
+    });
+
+    it('deduplicates wallet addresses when same address appears in both tables', async () => {
+      const sharedAddress = '0x1111111111111111111111111111111111111111';
+      const usersData = [{ wallet_address: sharedAddress, display_name: 'UserName' }];
+
+      const agentsData = [{ wallet_address: sharedAddress, name: 'AgentName' }];
+
+      const convictionData = [
+        {
+          address: sharedAddress,
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) =>
+                resolve({ data: agentsData, error: null }),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Despite being in both tables, only one conviction entry should exist
+      expect(body).toHaveLength(1);
+      // The name mapping will find the first entry in the map (UserName)
+      expect(body[0].name).toBeDefined();
+    });
+
+    it('sets name to null when address is not found in nameMap', async () => {
+      const convictionData = [
+        {
+          address: '0x9999999999999999999999999999999999999999',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: [], error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      // Since no wallets were fetched from DB, no addresses are passed to getConvictionBatch.
+      // The route returns empty array early (line 41-42).
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Route returns empty when no addresses exist, so body should be empty
+      expect(body).toEqual([]);
+    });
+
+    it('returns proper response JSON shape', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('application/json');
+
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+      expect(body[0]).toMatchObject({
+        address: expect.any(String),
+        conviction: expect.any(String),
+        staked: expect.any(String),
+        stakedFormatted: expect.any(String),
+        convictionFormatted: expect.any(String),
+        name: expect.any(String),
+      });
+    });
+  });
+
+  describe('handling of null/missing wallet addresses', () => {
+    it('skips users with null wallet_address', async () => {
+      const usersData = [
+        { wallet_address: null, display_name: 'NoWallet' },
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'HasWallet' },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue([]);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+
+      // Only the address with a wallet should be passed to getConvictionBatch
+      expect(mockGetConvictionBatch).toHaveBeenCalledWith([
+        '0x1111111111111111111111111111111111111111',
+      ]);
+    });
+
+    it('skips agents with null wallet_address', async () => {
+      const agentsData = [
+        { wallet_address: null, name: 'NoWalletAgent' },
+        { wallet_address: '0x3333333333333333333333333333333333333333', name: 'HasWalletAgent' },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: [], error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) =>
+                resolve({ data: agentsData, error: null }),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue([]);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+
+      // Only the agent with a wallet should be passed
+      expect(mockGetConvictionBatch).toHaveBeenCalledWith([
+        '0x3333333333333333333333333333333333333333',
+      ]);
+    });
+
+    it('handles empty display_name by using empty string from nameMap lookup', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: null },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Route uses (display_name || '') for nameMap value, so null becomes ''
+      // But nameMap.get(...) || null means: if found return the value, else null.
+      // Since we stored '' in the map, the lookup returns '' (falsy but defined).
+      // Actually, '' is falsy, so '' || null returns null. The route's behavior is correct.
+      // Our test expectation should match actual behavior: null is returned for falsy names.
+      expect(body[0].name).toBeNull();
+    });
+  });
+
+  describe('handling supabase failures', () => {
+    it('continues when users query rejects', async () => {
+      const agentsData = [
+        { wallet_address: '0x3333333333333333333333333333333333333333', name: 'Agent1' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x3333333333333333333333333333333333333333',
+          conviction: '2000000000000000000000000000000',
+          staked: '200000000000000000000',
+          stakedFormatted: '200',
+          convictionFormatted: '2.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn(
+                  (_resolve: (val: unknown) => void, reject: (reason?: unknown) => void) =>
+                    reject(new Error('Users query failed')),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) =>
+                resolve({ data: agentsData, error: null }),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should still succeed with agent data
+      expect(body).toHaveLength(1);
+      expect(body[0].address).toBe('0x3333333333333333333333333333333333333333');
+    });
+
+    it('continues when agent_config query rejects', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((_resolve: (val: unknown) => void, reject: (reason?: unknown) => void) =>
+                reject(new Error('Agent config query failed')),
+              ),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      // Should still succeed with user data
+      expect(body).toHaveLength(1);
+      expect(body[0].name).toBe('Alice');
+    });
+
+    it('returns empty array when both supabase queries fail', async () => {
+      mockFrom.mockImplementation(() => {
+        return {
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((_resolve: (val: unknown) => void, reject: (reason?: unknown) => void) =>
+                reject(new Error('Query failed')),
+              ),
+            }),
+          }),
+        };
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body).toEqual([]);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 500 when getConvictionBatch throws', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockRejectedValue(new Error('Contract read failed'));
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual([]);
+
+      // Verify error was logged
+      expect(mockLoggerError).toHaveBeenCalledWith('Staking leaderboard error:', expect.any(Error));
+    });
+
+    it('returns 500 and logs error on unexpected exception', async () => {
+      mockFrom.mockImplementation(() => {
+        throw new Error('Unexpected supabase error');
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body).toEqual([]);
+
+      expect(mockLoggerError).toHaveBeenCalledWith('Staking leaderboard error:', expect.any(Error));
+    });
+
+    it('logs errors without exposing details to client', async () => {
+      const sensitiveError = new Error('Database password exposed');
+      mockGetConvictionBatch.mockRejectedValue(sensitiveError);
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({
+                    data: [
+                      {
+                        wallet_address: '0x1111111111111111111111111111111111111111',
+                        display_name: 'Test',
+                      },
+                    ],
+                    error: null,
+                  }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(500);
+      const body = await res.json();
+
+      // Client receives empty array, not error details
+      expect(body).toEqual([]);
+      expect(JSON.stringify(body)).not.toContain('password');
+    });
+  });
+
+  describe('route is public (no auth required)', () => {
+    it('does not require session to call the route', async () => {
+      // The route has no session check in the code, so this confirms it's public
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: [], error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      // Should succeed without auth
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('response handling', () => {
+    it('response is always JSON', async () => {
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: [], error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.headers.get('content-type')).toContain('application/json');
+      const body = await res.json();
+      expect(Array.isArray(body)).toBe(true);
+    });
+
+    it('handles multiple conviction entries from getConvictionBatch', async () => {
+      const usersData = [
+        { wallet_address: '0x1111111111111111111111111111111111111111', display_name: 'Alice' },
+        { wallet_address: '0x2222222222222222222222222222222222222222', display_name: 'Bob' },
+        { wallet_address: '0x3333333333333333333333333333333333333333', display_name: 'Charlie' },
+      ];
+
+      const convictionData = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          conviction: '3000000000000000000000000000000',
+          staked: '300000000000000000000',
+          stakedFormatted: '300',
+          convictionFormatted: '3.0T',
+        },
+        {
+          address: '0x2222222222222222222222222222222222222222',
+          conviction: '2000000000000000000000000000000',
+          staked: '200000000000000000000',
+          stakedFormatted: '200',
+          convictionFormatted: '2.0T',
+        },
+        {
+          address: '0x3333333333333333333333333333333333333333',
+          conviction: '1000000000000000000000000000000',
+          staked: '100000000000000000000',
+          stakedFormatted: '100',
+          convictionFormatted: '1.0T',
+        },
+      ];
+
+      mockFrom.mockImplementation((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnValue({
+              not: vi.fn().mockReturnValue({
+                // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+                then: vi.fn((resolve: (val: unknown) => void) =>
+                  resolve({ data: usersData, error: null }),
+                ),
+              }),
+            }),
+          };
+        }
+        if (table === 'agent_config') {
+          return {
+            select: vi.fn().mockReturnValue({
+              // biome-ignore lint/suspicious/noThenProperty: documented thenable pattern for Supabase mocking
+              then: vi.fn((resolve: (val: unknown) => void) => resolve({ data: [], error: null })),
+            }),
+          };
+        }
+        return {};
+      });
+
+      mockGetConvictionBatch.mockResolvedValue(convictionData);
+
+      const req = makeGetRequest('/api/staking/leaderboard');
+      const res = await GET(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body).toHaveLength(3);
+      // Check that all entries have names merged
+      expect(body.every((entry: { name?: string | null }) => entry.name !== undefined)).toBe(true);
+      // Check that conviction data is preserved
+      expect(body.map((entry: { conviction: string }) => entry.conviction)).toEqual([
+        '3000000000000000000000000000000',
+        '2000000000000000000000000000000',
+        '1000000000000000000000000000000',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## What

Final test-coverage batch before the queue pivot — **154 tests total** across 4 routes. External Neynar/conviction/notification-token sends fully mocked — no real notifications.

| Route | Tests | Covers |
|-------|-------|--------|
| `notifications/farcaster` | 33 | auth, getNotifications/markSeen, cursor/limit, errors |
| `notifications/send` | 51 | admin, Zod, per-user rate-limits (30s/100-day), token fan-out (mocked), audit-log, counts, errors |
| `respect/event` | 51 | admin, Zod (8 event types), supabase event+member tracking, milestone auto-cast (mocked), errors |
| `staking/leaderboard` | 19 | public, wallets from users+agent_config, getConvictionBatch, allSettled fault-tolerance, dedupe, errors |

Test-only — no runtime files touched. Follows `.claude/rules/tests.md`.

**One NaN-limit note for you (14th instance, different form):** `notifications/farcaster` (line ~14) does `const limit = limitParam ? parseInt(limitParam, 10) : undefined` with no `Number.isNaN` guard → a non-numeric `?limit` passes `NaN` into `getNotifications`. It wasn't in the #1476/#1489 sweep because that grepped the `Math.min(parseInt(...))` form specifically. Low severity (authenticated, Neynar lib). Fold into the limit-hardening effort whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)