### PR TITLE
fix(notifications/farcaster): guard NaN limit param (completes the NaN-limit sweep)

### DIFF
--- a/src/app/api/notifications/farcaster/__tests__/route.test.ts
+++ b/src/app/api/notifications/farcaster/__tests__/route.test.ts
@@ -245,15 +245,14 @@ describe('GET /api/notifications/farcaster', () => {
       expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, 25);
     });
 
-    it('handles non-numeric limit (parseInt returns NaN without guard)', async () => {
-      // NOTE: The route does NOT guard against NaN. parseInt('abc', 10) = NaN
-      // Math.min(NaN, anything) = NaN. This is a potential bug.
+    it('falls back to undefined limit for a non-numeric value (NaN-guarded)', async () => {
+      // Regression guard: a non-numeric limit clamps to undefined so getNotifications
+      // applies its own default, rather than NaN flowing downstream to Neynar.
       mockGetNotifications.mockResolvedValue(mockNotificationsResponse([]));
 
       await GET(makeGetRequest('/api/notifications/farcaster', { limit: 'not-a-number' }));
 
-      // The route passes NaN directly to getNotifications
-      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, Number.NaN);
+      expect(mockGetNotifications).toHaveBeenCalledWith(123, undefined, undefined);
     });
   });
 

--- a/src/app/api/notifications/farcaster/route.ts
+++ b/src/app/api/notifications/farcaster/route.ts
@@ -12,7 +12,10 @@ export async function GET(request: NextRequest) {
   try {
     const cursor = request.nextUrl.searchParams.get('cursor') ?? undefined;
     const limitParam = request.nextUrl.searchParams.get('limit');
-    const limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    // Guard NaN: a non-numeric limit falls back to undefined (let getNotifications
+    // apply its own default) rather than passing NaN downstream to Neynar.
+    const parsedLimit = limitParam ? parseInt(limitParam, 10) : undefined;
+    const limit = Number.isNaN(parsedLimit) ? undefined : parsedLimit;
 
     const data = await getNotifications(session.fid, cursor, limit);
     return NextResponse.json(data);


### PR DESCRIPTION
## What

The **14th and final instance** of the systemic NaN-limit bug — completes the sweep started in #1476 (merged) + #1489 (pending, 10 routes).

## The bug
`GET /api/notifications/farcaster` parsed the limit as:
```ts
const limit = limitParam ? parseInt(limitParam, 10) : undefined;
```
No `Number.isNaN` guard — a non-numeric `?limit` (e.g. `?limit=abc`) passes **NaN** into `getNotifications` → `?limit=NaN` to Neynar → likely 400 → the route 500s. It wasn't caught by the #1476/#1489 grep because that matched the `Math.min(parseInt(...))` form; this route uses the ternary form.

## The fix
```ts
const parsedLimit = limitParam ? parseInt(limitParam, 10) : undefined;
const limit = Number.isNaN(parsedLimit) ? undefined : parsedLimit;
```
A non-numeric limit falls back to `undefined` (getNotifications applies its own default) instead of NaN downstream. The existing test (merged in #1510) that documented the buggy NaN passthrough is updated to assert the fixed behavior.

**tsc 0, 33 tests pass.** No behavior change for a valid or absent `limit`.

Runtime route change → your review (folds in with #1489). With this, **all 14 identified NaN-limit routes are covered.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)