### PR TITLE
docs: doc 1141 - Devcon Music Stage call for musicians & artists (tier:STANDARD)

### DIFF
--- a/research/events/1141-devcon-music-stage-musician-artist-call.md
+++ b/research/events/1141-devcon-music-stage-musician-artist-call.md
@@ -1,0 +1,76 @@
+# Doc 1141 - Devcon Music Stage Call for Musicians & Artists
+
+**Status:** CAPTURED
+**Tier:** STANDARD
+**Author:** @zaal
+**Date:** 2026-07-16
+
+## Summary
+
+Candu (Ecosystem lead at Ethereum Foundation's Devcon) is calling for musicians and artists to participate in the Devcon Music Stage at the upcoming Devcon conference in India. The call is part of Satyaki's larger push to get Indian tech/crypto community involved in Devcon through 13 ways of participation (content creation, hackathons, side events, creative experiences, etc.).
+
+## Who Is Candufaz
+
+**Candu** (@candufaz, verified, 8.3K followers) is the Ecosystem lead for Ethereum Foundation's Devcon initiative. Based in Latin America originally (SEED Latam, SEED Gov affiliations), now focused on coordinating Devcon's ecosystem development. Previously worked with Nata Social and Mujeres en Crypto (women in crypto advocacy). Known for bridging crypto communities across regions.
+
+Post context: Quoting Satyaki's post (55 favs, 2.6K views) that lists 13 ways for Indian tech/crypto people to engage with Devcon.
+
+## Why It Matters
+
+Devcon is the Ethereum ecosystem's flagship developer conference (10K+ attendees), held in India this year (Mumbai). The Devcon Music Stage is a featured platform - an opportunity for creators to reach developers, researchers, and cypherpunks at the largest crypto event globally.
+
+This is the official call-out from the Ethereum Foundation's Devcon team, not a grassroots post. Signal of commitment to music/culture track at the conference.
+
+## ZAO Angle & Relevance
+
+### 1. Direct Creator Platform Opportunity
+
+The Devcon Music Stage is a flagship venue for music creators in crypto. ZAO's DNA is music + web3 + creator economy (WaveWarZ, Sparkz, ZABAL Games, ZAOstock). Devcon musicians reach 10K+ developers + researchers + attendees - cross-pollination with builders.
+
+### 2. Connects to Active Threads
+
+- **Sparkz (configurable creator coin + music):** Devcon musicians could launch tokens, build creator economics, run splits on-stage via frameworks like Sparkz. Opportunity to showcase the product at a tier-1 event.
+- **ZABAL Games & Creator Momentum:** ZABAL Games is running its 3-month build-a-thon (Jun/Jul/Aug 2026). Devcon Music Stage participation extends the builder + creator narrative.
+- **WaveWarZ Canonical:** Music platform positioning (doc 743, Solana/Base). Devcon is where music-crypto native communities converge.
+- **ZAOstock (Oct 2026, Franklin St Parklet):** Devcon in July = testing ground for music-focused events before ZAOstock.
+
+### 3. Farcaster/Base Ecosystem Play
+
+Devcon attendees are heavily skewed toward Base/Ethereum builders. Farcaster presence at Devcon is strong (ZOL's domain + The ZAO's community). Opportunity to bridge ZAO musicians into a Base-native Farcaster crowd.
+
+### 4. Devcon Music Stage as Platform Anchor
+
+Unlike isolated festival bookings, Devcon is institutional legitimacy - Ethereum Foundation official stage. ZAO-affiliated musicians could showcase "web3 music" positioning to tier-1 builders + VCs + media.
+
+## Map to Zaal's Active Threads
+
+1. **Music + Creator Economy Focus:** Direct alignment with Sparkz, WaveWarZ, ZABAL Games positioning.
+2. **Event Platform Building:** ZAOstock (Oct) is building festival infrastructure. Devcon validates the format + reaches different audience (developers vs. fans).
+3. **Farcaster/Base Community:** ZOL/The ZAO community presence at Devcon.
+4. **Creator Coin Economics:** Devcon is where Ethereum creator tools showcase. Sparkz could be featured.
+
+## Should Zaal Engage?
+
+**VERDICT: YES - Medium Priority Engagement**
+
+- **Why:** Devcon Music Stage is tier-1 visibility for ZAO's music + creator positioning. Low friction to apply (just need 1-2 musician recommendations or to apply directly). Opens conversation with Devcon team about deeper integrations (e.g., Sparkz demo, ZABAL Games presence).
+- **When:** Deadline likely 4-6 weeks out (Devcon typically in late Sept/early Oct in past years; this is July callout, so deadline probably mid-late August).
+- **Who to Loop:** Musicians in The ZAO/WaveWarZ/ZABAL Games orbit. Logesh (SongJam collaborator)? Iman (could coordinate ZABAL Games angle).
+- **What to Propose:** Option 1: Recommend 1-2 ZAO musicians for Devcon Music Stage. Option 2: Propose a "ZAO/Web3 Music Creators" collaborative set or panel. Option 3: Use as test case for Sparkz integration (Devcon musicians launching tokens on-stage).
+
+## Next Actions
+
+1. **CLARIFY DEADLINE:** Get exact application deadline from Candu via DM or check Devcon official site. Add to calendar.
+2. **SCOUT MUSICIANS:** Identify 2-3 ZAO-affiliated musicians who might be interested (WaveWarZ lineup, ZABAL mentors with music chops, SongJam Logesh).
+3. **DRAFT PITCH:** If pursuing collaborative option, sketch 1-page pitch for Devcon team (what ZAO musicians bring to the stage, what audience they reach).
+4. **ENGAGE CANDU:** Reply to the thread with either: (a) direct musician recommendation, or (b) question about collaborative proposal process.
+5. **POST DECISION:** If moving forward, create separate project-tracking doc for Devcon Music Stage participation (owner @Zaal, success metrics, lineup, coordination timeline).
+
+**Owner:** @Zaal
+**Deadline for decision:** 2026-07-25 (9 days, allows time to reach out to musicians before formal pitch)
+
+## Sources
+
+- X post: @candufaz, 2026-07-16 15:32 UTC - "we're looking for musicians and artists..."
+- Context: @satyaki44 post (2076654846963601579) - "13 ways to participate in Devcon"
+- candufaz profile: verified, Ecosystem lead EFDevcon


### PR DESCRIPTION
## Summary

Candu (Ecosystem lead at EFDevcon) is recruiting musicians and artists for Devcon's Music Stage in India. This research captures:

- Who candufaz is: Verified ecosystem lead, 8.3K followers, coordinates Devcon's international participation strategy
- What: Official call for musicians/artists to perform on Devcon Music Stage (tier-1 platform, 10K+ attendees)
- Why it matters: Devcon is Ethereum's flagship conference - institutional legitimacy for music-crypto positioning
- ZAO's angle: Direct alignment with Sparkz (creator coins), WaveWarZ (music platform), ZABAL Games (creator momentum), and ZAOstock (event format validation)

## ZAO Relevance

Devcon Music Stage is a flagship opportunity for ZAO's music + web3 + creator positioning. Reaches developers + researchers at the largest crypto event. Low-friction engagement: recommend 1-2 musicians or propose collaborative set.

## Recommendation

YES - Medium priority engagement. Deadline for decision: 2026-07-25 (9 days to scout musicians and draft pitch).

Next actions: (1) Clarify application deadline, (2) Scout 2-3 ZAO musicians, (3) Draft pitch if pursuing collaboration, (4) Reply to Candu with musician recommendations or proposal.

## Tier

STANDARD

🤖 Generated with Claude Code research agent
https://claude.ai/code/session_01ELnAWqgqXP8n8NHw2KAeP3