### PR TITLE
radar: revalidate doc 026 (hindsight-agent-memory) — new material

### DIFF
--- a/research/_radar/2026-07-16.md
+++ b/research/_radar/2026-07-16.md
@@ -1,0 +1,1 @@
+doc 026 (hindsight-agent-memory) - NEW: v0.6.2→v0.8.4; Claude Agent SDK integration added; stars 13.7K→18.5K; GitHub Copilot/Devin/Aider MCP support; multi-LLM failover; recency decay; cron mental-model refresh - sources checked: github.com/vectorize-io/hindsight/releases, github.com/vectorize-io/hindsight-benchmarks

--- a/research/agents/026-hindsight-agent-memory/README.md
+++ b/research/agents/026-hindsight-agent-memory/README.md
@@ -4,7 +4,7 @@
 topic: agents
 type: research
 status: research-complete
-last-validated: 2026-05-21
+last-validated: 2026-07-16
 original-query: Evaluate Hindsight as a memory layer for ZAO OS AI agents (reconstructed)
 tier: reference
 ---
@@ -101,13 +101,13 @@ const insights = await client.reflect({
 
 | Metric | Value |
 |--------|-------|
-| **Stars** | 13,745 (as of May 15, 2026) |
-| **Forks** | 786 |
+| **Stars** | ~18,500 (as of July 16, 2026) |
+| **Forks** | ~1,100 |
 | **License** | MIT |
 | **Created** | October 2025 |
-| **Current Version** | v0.6.2 (May 14, 2026) |
+| **Current Version** | v0.8.4 (July 1, 2026) |
 | **Activity** | Multiple commits daily, 100+ contributors |
-| **Latest Release** | May 14, 2026 |
+| **Latest Release** | July 1, 2026 |
 | **Paper** | arXiv:2512.12818 |
 
 ---
@@ -344,3 +344,5 @@ Keep Supabase/pgvector for application data. Use Hindsight exclusively for agent
 - [Vectorize.io](https://vectorize.io/) - Company homepage
 
 Updated 2026-05-21: Stars 3.6K → 13.7K in 2 months. v0.6.0 adds enterprise Oracle backend, 4 new framework integrations (Dify, n8n, SmolAgents, AWS Bedrock), and reliability fixes for multi-agent deployments. Hindsight is now production-grade for enterprise multi-agent teams.
+
+Updated 2026-07-16: Version jumped v0.6.2 → v0.8.4 (July 1, 2026); stars grew 13.7K → ~18.5K; forks 786 → ~1,100. v0.8.0 (June 8) added direct **Claude Agent SDK integration** (critical for ZAO: no custom glue needed), LangGraph + OpenAI Agents support, semantic deduplication of near-duplicate observations (0.97 threshold default), LLM prompt-prefix caching across all providers, and bank-to-bank document export/import for cross-instance migration. v0.8.4 (July 1) added **GitHub Copilot + Devin Desktop (formerly Windsurf) via MCP**, Aider session-bracketing memory, Eve agent-framework MCP helper, multi-LLM failover/round-robin config, configurable recency decay (linear/exponential/none), and cron-scheduled mental-model refresh. The 91.4% LongMemEval score (Gemini-3) is still accurate overall; Hindsight now also claims 94.6% on the single-session assistant category of LongMemEval-S. Competitor ByteRover entered the benchmark at 92.8% (LongMemEval-S) but with self-reported scores. No breaking changes in v0.8.x. Sources: https://github.com/vectorize-io/hindsight/releases — verified via full GitHub fetch July 16, 2026.


### PR DESCRIPTION
## Radar Revalidation — Doc 026: Hindsight Agent Memory

**Doc:** `research/agents/026-hindsight-agent-memory/`
**Last validated:** 2026-05-21 → **2026-07-16**
**Verdict:** Genuinely new material — significant version updates and new integrations.

---

## What Changed Since May 21, 2026

### Version
- `v0.6.2` → **`v0.8.4`** (July 1, 2026), passing through v0.7.x and v0.8.x milestones

### Repo Growth
- Stars: 13,745 → **~18,500** (+35%)
- Forks: 786 → **~1,100** (+40%)

### v0.8.0 (June 8, 2026) — Major additions
- **Claude Agent SDK direct integration** — critical for ZAO: Hindsight becomes a native memory layer for Claude agents with no custom glue code
- LangGraph + OpenAI Agents SDK integrations
- Semantic deduplication of near-duplicate observations (0.97 threshold, on by default)
- LLM prompt-prefix caching across all providers (retain + consolidation + reflect)
- Bank-to-bank document export/import for cross-instance migration
- ONNX Local Provider for on-device embeddings

### v0.8.4 (July 1, 2026) — Latest release
- **GitHub Copilot (VS Code) + Devin Desktop via MCP** — code-agent memory now plug-and-play
- **Aider** session-bracketing memory wrapper
- **Eve agent-framework** MCP connection helper
- Multi-LLM failover + round-robin configuration
- Configurable recency decay (linear / exponential / none)
- Cron-scheduled mental-model refresh via maintenance loop
- No breaking changes in v0.8.x

### Benchmark update
- 91.4% overall LongMemEval (Gemini-3) still accurate
- Hindsight now also claims **94.6%** on LongMemEval-S single-session assistant category
- New competitor: ByteRover entered at 92.8% LongMemEval-S (self-reported)

---

## Sources (full-page fetched)

- https://github.com/vectorize-io/hindsight/releases
- https://github.com/vectorize-io/hindsight
- https://github.com/vectorize-io/hindsight-benchmarks/blob/main/README.md

---

*ZAO Research Radar — automated revalidation run 2026-07-16. Do NOT merge without human review.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTKeJ3M5bHFkU3n7GCRfTY)_