### PR TITLE
feat(zoe): conversational upgrade - kill ack-theater, quick-model chat, capability honesty

### DIFF
--- a/bot/src/zoe/__tests__/conversational.test.ts
+++ b/bot/src/zoe/__tests__/conversational.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { isConversationalTurn, selectModel, ZOE_QUICK_MODEL, ZOE_HARD_MODEL, ZOE_DEFAULT_MODEL } from '../types';
+import { buildSystemBlocks } from '../concierge';
+import type { MemoryBlocks } from '../memory';
+
+// zoe-conversational spec (2026-07-16): conversational turns get the quick model
+// + no ack-theater; real work keeps default/hard model + progress narration.
+
+describe('isConversationalTurn', () => {
+  it('treats the real failure case as chat', () => {
+    // The 2026-07-16 miss: Zaal replied "Can u see them" to a relayed WhatsApp
+    // mention. That is a plain conversational turn - quick model, no filler.
+    expect(isConversationalTurn('Can u see them')).toBe(true);
+  });
+
+  it('treats short back-and-forth as chat', () => {
+    for (const m of ['hey', 'what time is it', 'yes do it', 'who is Iman', 'thanks!', 'can you see the file?']) {
+      expect(isConversationalTurn(m)).toBe(true);
+    }
+  });
+
+  it('treats a link to fetch/analyze as work, not chat', () => {
+    expect(isConversationalTurn('check this https://example.com/thread')).toBe(false);
+  });
+
+  it('treats strategic / build / research asks as work', () => {
+    for (const m of [
+      'should I ship the sparkz paper today?',
+      'plan the ZAOstock rollout',
+      'research 0xSplits multi-recipient config',
+      'draft a cold DM to the Creator Studio lead',
+      'build the eval runner',
+      'compare Astro vs MkDocs for the site',
+    ]) {
+      expect(isConversationalTurn(m)).toBe(false);
+    }
+  });
+
+  it('treats long substantive messages as work', () => {
+    expect(isConversationalTurn('x'.repeat(221))).toBe(false);
+  });
+
+  it('rejects empty / whitespace-only input', () => {
+    expect(isConversationalTurn('')).toBe(false);
+    expect(isConversationalTurn('   ')).toBe(false);
+  });
+});
+
+describe('selectModel regression (unchanged by the conversational upgrade)', () => {
+  it('routes strategic asks to the hard model', () => {
+    expect(selectModel('should I compare these two strategies')).toBe(ZOE_HARD_MODEL);
+  });
+  it('routes short factual questions to the quick model', () => {
+    expect(selectModel('what is the time')).toBe(ZOE_QUICK_MODEL);
+  });
+  it('defaults everything else to the default model', () => {
+    expect(selectModel('poke the bot')).toBe(ZOE_DEFAULT_MODEL);
+  });
+});
+
+describe('buildSystemBlocks capability honesty + tone', () => {
+  const blocks = {
+    persona: 'PERSONA',
+    human: 'HUMAN',
+    working: '(no recent turns)',
+    tasks: '(no open tasks)',
+    quests: '(no quests)',
+    open_threads: '(no open threads)',
+    chat_scope: 'private',
+    chat_title: undefined,
+  } as unknown as MemoryBlocks;
+
+  it('always injects a capabilities block that says ZOE cannot see WhatsApp', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<capabilities>');
+    expect(sys).toContain('no WhatsApp');
+    expect(sys).toContain('forward'); // the "forward it here" move
+  });
+
+  it('injects a tone block that bans corporate filler', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<tone>');
+    expect(sys).toContain('Got it, working on it');
+  });
+
+  it('still injects persona + human + working memory', () => {
+    const sys = buildSystemBlocks(blocks, '2026-07-16');
+    expect(sys).toContain('<persona>');
+    expect(sys).toContain('PERSONA');
+    expect(sys).toContain('<working_memory>');
+  });
+});

--- a/bot/src/zoe/concierge.ts
+++ b/bot/src/zoe/concierge.ts
@@ -24,7 +24,7 @@ const ZOE_VERSION = '0.2.0';
  * Render the 4 memory blocks as a system prompt for Claude Code CLI.
  * The user's message is passed separately as `prompt`.
  */
-function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean): string {
+export function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallContext?: string, brandContext?: string, linkResearchIntent?: boolean): string {
   const chatLine =
     blocks.chat_scope === 'private'
       ? 'Chat: DM with Zaal'
@@ -72,6 +72,17 @@ function buildSystemBlocks(blocks: MemoryBlocks, currentDate: string, recallCont
     `- Never ask a question you could answer yourself from the memory blocks, the repo, or the current_time. Resolve it, then proceed.`,
     `- Prefer "here's what I did, here's the assumption" over "what did you mean?". One clarifying question per turn maximum.`,
     `</clarify_policy>`,
+    ``,
+    `<capabilities>`,
+    `What you can see and do right now (zoe-conversational spec):`,
+    `- You see THIS chat and its recent turns (<working_memory> below). You can read the ZAO repo, the research library, the tasks board, and the ZABAL Bonfire graph (via recall).`,
+    `- You do NOT have eyes on anything outside this chat: no WhatsApp, no SMS, no email inbox, no phone, no screen, no other Telegram chats. If someone references a file, doc, screenshot, or link they "sent" somewhere else (WhatsApp, a DM, email, another app), you did NOT receive it and cannot open it.`,
+    `- The move when that happens: say so plainly in one line and ask them to forward or paste it INTO this chat. Example: "I can't see WhatsApp - forward the docs here and I'll read them." Never pretend to check. Never assume someone is sending YOU a file right now unless it actually arrived in this chat.`,
+    `</capabilities>`,
+    ``,
+    `<tone>`,
+    `Reply like a sharp, warm human texting back: short, direct, first sentence answers the question. No "I'd be happy to", no "Got it, working on it", no restating what was asked, no corporate filler. If one line does it, send one line. Apply the persona voice below on every turn, including quick ones.`,
+    `</tone>`,
     ``,
     `<persona>`,
     blocks.persona,

--- a/bot/src/zoe/index.ts
+++ b/bot/src/zoe/index.ts
@@ -24,6 +24,7 @@ import { startHeartbeat, reportEvent, startCommandPoller, markDone, updateItem, 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { runConciergeTurn } from './concierge';
+import { isConversationalTurn, ZOE_QUICK_MODEL } from './types';
 import { checkAndRecordZoeCall } from './call-budget';
 import { runCockpit } from '../cockpit/cockpit';
 import { applyTaskOps, seedInitialTasks } from './tasks';
@@ -1629,15 +1630,20 @@ interface ProgressHandle {
 function startProgressNarration(
   ctx: Context,
   chatId: number,
-  messages: { first: string; second?: string },
+  messages: { first: string | null; second?: string },
 ): ProgressHandle {
   ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
   const typingInterval = setInterval(() => {
     ctx.api.sendChatAction(chatId, 'typing').catch(() => {});
   }, TYPING_REFRESH_MS);
-  const firstAck = setTimeout(() => {
-    ctx.reply(messages.first).catch(() => {});
-  }, ACK_THRESHOLD_MS);
+  // Conversational turns pass first=null: no "working on it" filler (ack-theater).
+  // The native typing indicator still runs; a genuinely long turn can still emit
+  // the honest `second` ping. Work turns keep both. (zoe-conversational spec).
+  const firstAck = messages.first
+    ? setTimeout(() => {
+        ctx.reply(messages.first as string).catch(() => {});
+      }, ACK_THRESHOLD_MS)
+    : null;
   const secondAck = messages.second
     ? setTimeout(() => {
         ctx.reply(messages.second as string).catch(() => {});
@@ -1646,7 +1652,7 @@ function startProgressNarration(
   return {
     stop: () => {
       clearInterval(typingInterval);
-      clearTimeout(firstAck);
+      if (firstAck) clearTimeout(firstAck);
       if (secondAck) clearTimeout(secondAck);
     },
   };
@@ -1661,8 +1667,12 @@ async function dispatchConcierge(
 ): Promise<void> {
   if (!ctx.chat) return;
   const chatId = ctx.chat.id;
+  // Conversational turns (short chat, no link/plan/build) answer directly on the
+  // quick model with NO "working on it" ack. Real work keeps the honest progress
+  // narration + default/hard model. (zoe-conversational spec, 2026-07-16).
+  const conversational = isConversationalTurn(text);
   const progress = startProgressNarration(ctx, chatId, {
-    first: 'Got it. Working on this one - reply incoming.',
+    first: conversational ? null : 'Got it. Working on this one - reply incoming.',
     second: "Still on it - bigger one than it looked. Hang tight.",
   });
 
@@ -1717,6 +1727,9 @@ async function dispatchConcierge(
       message: text,
       blocks,
       senderLabel: label,
+      // Chat -> quick model for instant replies; real work -> selectModel picks
+      // default/hard. (zoe-conversational spec).
+      model: conversational ? ZOE_QUICK_MODEL : undefined,
       recallContext,
       brandContext,
       linkResearchIntent: wantsLinkResearch(text),

--- a/bot/src/zoe/types.ts
+++ b/bot/src/zoe/types.ts
@@ -233,6 +233,33 @@ export function selectModel(message: string): string {
   return ZOE_DEFAULT_MODEL;
 }
 
+/**
+ * Is this a plain conversational turn (chat) vs. real work (research, planning,
+ * multi-step build)? Conversational turns get the quick model for instant
+ * replies and skip the "working on it" ack (spec: zoe-conversational, 2026-07-16).
+ *
+ * "Real work" = anything with a URL to fetch/analyze, a strategic/planning ask,
+ * an explicit build/research/draft request, or a long substantive message. Those
+ * keep the default/hard model and the honest progress narration. Everything
+ * else - short questions, back-and-forth, quick asks - is chat.
+ */
+export function isConversationalTurn(message: string): boolean {
+  const text = message.trim();
+  if (text.length === 0) return false;
+  // A link to fetch + analyze is work, not chat.
+  if (/https?:\/\//i.test(text)) return false;
+  const lower = text.toLowerCase();
+  const workKeywords = [
+    'plan', 'strategy', 'should i', 'tradeoff', 'compare', 'whitepaper',
+    'architecture', 'research', 'analyze', 'decompose', 'dispatch', 'audit',
+    'draft ', 'write up', 'write a', 'build ', 'design ', 'spec ',
+  ];
+  if (workKeywords.some((kw) => lower.includes(kw))) return false;
+  // Long messages are usually substantive work, not a quick back-and-forth.
+  if (text.length > 220) return false;
+  return true;
+}
+
 // --- SIDEQUESTZ (doc 648 / spec 2026-05-14) -----------------------------------
 
 export interface SideQuest {


### PR DESCRIPTION
## What

Rebuilds ZOE's conversational turn so it answers like a sharp human instead of a form-filling bot. Board task `legacy_source=zoe-conversational` (P1).

**The failure this fixes (2026-07-16):** ZOE relayed Iman's comment *"check the Fractal docs I sent to your WhatsApp"*. Zaal replied *"Can u see them"*. ZOE (1) fired canned **"Got it. Working on this one - reply incoming"** (ack-theater, no answer), then (2) replied *"Nothing came through - no image, file..."* - it thought Zaal was sending **it** a file. Total context + capability miss.

Correct behavior, now shipped: instant, context-aware, honest - *"I can't see WhatsApp - forward the docs here and I'll read them."*

## Changes (`bot/src/zoe/`)

1. **Kill ack-theater on chat turns.** New `isConversationalTurn()` (types.ts) flags short back-and-forth (no URL, no plan/build/research keywords, not long). Those turns **skip** the "Working on this one" first ack - the native typing indicator still runs, and the honest "still on it" ping remains for genuinely long turns. Real work keeps the full progress narration.
2. **Quick model for chat.** Conversational turns route to `ZOE_QUICK_MODEL` for instant replies; real work still goes through `selectModel` (default/hard). Composes with the existing multi-model router (it only overrides the Claude-path model).
3. **Capability honesty.** `buildSystemBlocks()` now always injects a `<capabilities>` block: ZOE sees only this chat + repo/research/board/Bonfire, and **cannot** see WhatsApp / SMS / email / other apps. The move: say so plainly and ask the person to forward it into the chat. No more pretending to check or assuming a file is inbound.
4. **Tone.** A `<tone>` block reinforces the persona voice on quick turns (short, direct, no corporate filler) so the fast model still sounds like ZOE.
5. **Context-carry** was already wired (Zaal's messages + ZOE's own replies are pushed to `recent/<chat>.json` and rendered in `<working_memory>`); (3)+(4) make ZOE actually apply it so "them"/"it"/"that" resolve.

## Verification

- **12 new tests** pass (`__tests__/conversational.test.ts`): `isConversationalTurn` incl. the exact "Can u see them" failure case, `selectModel` regression, and `<capabilities>`/`<tone>` block presence.
- **Typecheck:** adds **0 new errors** over the pre-existing baseline (10 errors already on `main`, line-number-normalized diff is identical - see note).
- **Boot smoke:** `tsx` import of the changed modules loads clean (exports present).
- Did **not** run the live poller (one-instance rule); this is runtime bot code - **Zaal merges + restarts/deploys**.

## Pre-existing issues found (NOT touched here - separate cleanup)

Flagging for a future PR, out of scope for this feature:
- `tsc --noEmit` on `bot/` already has **10 errors** on `main` (bot deploys via `tsx`, which doesn't type-check). Notably `index.ts` references an undefined `sendLongMessage` (~L1539) and an unguarded `ctx.chatId` - real bugs on a rarely-hit path.
- **6 test files fail identically on `main` without my changes** (curator, telegram-routing, brand-brain, cost-governance, adhd-accommodations, always-open-topics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)