### PR TITLE
fix(zoe): repair handleReplyRoute syntax error - unbreaks bot boot (URGENT)

### DIFF
--- a/bot/src/zoe/tg-interactions.ts
+++ b/bot/src/zoe/tg-interactions.ts
@@ -271,7 +271,7 @@ export async function handleAutoRoute(
     const guess = `[classify:${intent}] ${text || url || '(media)'}`;
     await pushRecent(
       { from: 'zaal', text: guess, sender: 'auto-classify' },
-      String(ctx.chat.id),
+      String(ctx.chat?.id ?? ''),
     );
   } catch {
     // continue even if log fails
@@ -289,7 +289,7 @@ export async function handleReplyRoute(
   ctx: Context,
   deps: {
     isFromZaal: boolean;
-    messageIdToContext: Map<number, { qid?: string; taskId?: string }>;
+    messageIdToContext?: Map<number, { qid?: string; taskId?: string }>;
   },
 ): Promise<{ handled: boolean; contextType?: string; id?: string; error?: string }> {
   if (!deps.isFromZaal) {
@@ -304,7 +304,10 @@ export async function handleReplyRoute(
   }
 
   try {
-    const context = await getMessageContext(replyToId);
+    // Prefer the persistent store (survives restarts); fall back to the
+    // in-memory map for anything not yet persisted.
+    const context =
+      (await getMessageContext(replyToId)) ?? deps.messageIdToContext?.get(replyToId);
     if (!context) {
       return { handled: false };
     }
@@ -315,39 +318,31 @@ export async function handleReplyRoute(
       try {
         await pushRecent(
           { from: 'zaal', text: logText, sender: 'reply-thread' },
-          String(ctx.chat.id),
+          String(ctx.chat?.id ?? ''),
         );
       } catch {
         // continue
       }
       return { handled: true, contextType: 'question', id: context.qid };
+    }
     if (context.taskId) {
       // Thread to task
       const logText = `[task-reply:${context.taskId}] ${text}`;
+      try {
+        await pushRecent(
+          { from: 'zaal', text: logText, sender: 'reply-thread' },
+          String(ctx.chat?.id ?? ''),
+        );
+      } catch {
+        // continue
+      }
       return { handled: true, contextType: 'task', id: context.taskId };
+    }
     return { handled: false };
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     return { handled: false, error: errMsg };
   }
-  const context = deps.messageIdToContext.get(replyToId);
-  if (!context) {
-  if (context.qid) {
-    // Thread to question
-    const logText = `[answer:${context.qid}] ${text}`;
-    try {
-      await pushRecent(
-        { from: 'zaal', text: logText, sender: 'reply-thread' },
-        String(ctx.chat.id),
-      );
-    } catch {
-      // continue
-    return { handled: true, contextType: 'question', id: context.qid };
-  if (context.taskId) {
-    // Thread to task
-    const logText = `[task-reply:${context.taskId}] ${text}`;
-    return { handled: true, contextType: 'task', id: context.taskId };
-  return { handled: false };
 }
 
 // Feature 5: BOT COMMANDS (/pulse /agenda /list)


### PR DESCRIPTION
## URGENT - main is latently broken

`bot/src/zoe/tg-interactions.ts` on **origin/main** has a syntax error in `handleReplyRoute` (a `catch` with no `try`, missing brace closings, and a duplicated dead block from a botched merge). `index.ts` imports this module, and the bot runs via `tsx`/esbuild (no typecheck gate), so **esbuild fails to parse it → the next bot restart crashes**. The live bot is only up because it loaded the old code into memory before this landed.

Proof:
```
npx esbuild src/zoe/tg-interactions.ts --bundle   # BEFORE: ✘ Unexpected "catch"  (exit 1)
npx esbuild src/zoe/tg-interactions.ts --bundle   # AFTER:  ⚡ Done  (exit 0)
```

## Fix

- Reconstruct `handleReplyRoute` cleanly: persistent-store lookup (`getMessageContext`, per the function's own comment) with the in-memory `messageIdToContext` map as fallback; correct braces; delete the duplicate dead block.
- Both the question and task branches now thread the reply into `recent/` (the task branch previously computed `logText` and dropped it - the reply-route feature was half-wired).
- `messageIdToContext` made optional (the `index.ts:1157` caller passes only `{isFromZaal}`); null-guard the 3 `ctx.chat.id` sites in this file.

This also advances the board task `tg-interaction: fully wire reply-to-route`.

## Verification

- **esbuild exit 0** (bot boots).
- **tsc: 0 errors in this file + the caller.**
- Full test suite: same **6 pre-existing failing files**, zero new failures.

## Pre-existing debt this UNMASKED (flagged, NOT fixed here - out of scope)

Fixing the syntax error let tsc finally parse past it, exposing ~11 pre-existing type errors in **other** files (curator.ts, scheduler.ts, task-teammate-ack.ts, and index.ts paths). Two look like **real latent runtime bugs** worth a follow-up:
- `index.ts:~1737`: `Cannot find name 'sendLongMessage'` - a reference to an undefined function; throws if that path runs.
- `index.ts:658`: lowercase `"done"` vs the `"DONE"` `TaskStatus` enum in the reaction→mark-done handler - reactions may not mark tasks done correctly.

These are type-only (esbuild/boot unaffected). Recommend a dedicated cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)