### PR TITLE
feat(zoe): wire morning-brief veto buttons through the routed send path

### DIFF
--- a/bot/src/zoe/__tests__/telegram-routing-markup.test.ts
+++ b/bot/src/zoe/__tests__/telegram-routing-markup.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendToZaal, type TelegramRoutingDeps } from '../telegram-routing';
+
+// zoe-message-quality / workflow-contract-v2: the morning brief builds veto
+// buttons; this asserts sendToZaal actually forwards them (reply_markup) to
+// Telegram on every route, so the buttons render instead of being dropped.
+
+const KEYBOARD = {
+  inline_keyboard: [[{ text: '🚫 task A', callback_data: 'veto:a' }]],
+};
+
+function depsWith(sendMessage: TelegramRoutingDeps['sendMessage'], over: Partial<TelegramRoutingDeps> = {}): TelegramRoutingDeps {
+  return { sendMessage, zaalId: 111, ...over };
+}
+
+describe('sendToZaal replyMarkup passthrough', () => {
+  it('attaches reply_markup on a status route to the group', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await sendToZaal(depsWith(send, { groupId: 222, groupThreadId: 7 }), 'brief', {
+      kind: 'status',
+      replyMarkup: KEYBOARD,
+    });
+    expect(send).toHaveBeenCalledWith(222, 'brief', {
+      message_thread_id: 7,
+      reply_markup: KEYBOARD,
+    });
+  });
+
+  it('attaches reply_markup on the DM fallback when no group is configured', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await sendToZaal(depsWith(send), 'brief', { kind: 'status', replyMarkup: KEYBOARD });
+    expect(send).toHaveBeenCalledWith(111, 'brief', { reply_markup: KEYBOARD });
+  });
+
+  it('attaches reply_markup on a question route (DM)', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await sendToZaal(depsWith(send), 'pick?', { kind: 'question', replyMarkup: KEYBOARD });
+    expect(send).toHaveBeenCalledWith(111, 'pick?', { reply_markup: KEYBOARD });
+  });
+
+  it('sends an empty opts object (no reply_markup) when none is provided', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await sendToZaal(depsWith(send, { groupId: 222 }), 'status only', { kind: 'status' });
+    expect(send).toHaveBeenCalledWith(222, 'status only', {});
+  });
+});

--- a/bot/src/zoe/scheduler.ts
+++ b/bot/src/zoe/scheduler.ts
@@ -136,7 +136,7 @@ export function startScheduler(opts: SchedulerOptions): { stop: () => void } {
 
           // Route the morning brief as a status message (with veto keyboard if available)
           if (opts.routingDeps) {
-            await sendToZaalRouted(opts.routingDeps, brief, { kind: 'status' });
+            await sendToZaalRouted(opts.routingDeps, brief, { kind: 'status', replyMarkup: vetoKeyboard });
           } else {
             const sendOpts = vetoKeyboard ? { reply_markup: vetoKeyboard } : {};
             await opts.bot.api.sendMessage(opts.zaalTgId, brief, sendOpts);

--- a/bot/src/zoe/telegram-routing.ts
+++ b/bot/src/zoe/telegram-routing.ts
@@ -23,6 +23,11 @@ export type MessageKind = 'question' | 'status';
 
 export interface SendToZaalOptions {
   kind?: MessageKind; // defaults to 'status'
+  /**
+   * Inline keyboard to attach (Telegram reply_markup). Used by the morning
+   * brief to surface tap-to-veto buttons. Passed through to sendMessage.
+   */
+  replyMarkup?: { inline_keyboard: Array<Array<{ text: string; callback_data: string }>> };
 }
 
 export interface TelegramRoutingDeps {
@@ -48,10 +53,11 @@ export async function sendToZaal(
   opts: SendToZaalOptions = {},
 ): Promise<any> {
   const kind = opts.kind ?? 'status';
+  const markupOpts = opts.replyMarkup ? { reply_markup: opts.replyMarkup } : {};
 
   // question -> always DM
   if (kind === 'question') {
-    return deps.sendMessage(deps.zaalId, text);
+    return deps.sendMessage(deps.zaalId, text, markupOpts);
   }
 
   // status -> group (if configured), else fallback to DM
@@ -61,10 +67,13 @@ export async function sendToZaal(
     console.log(
       '[zoe/telegram-routing] ZAALBOTS_GROUP_CHAT_ID not set, routing status to DM (fallback)',
     );
-    return deps.sendMessage(deps.zaalId, text);
+    return deps.sendMessage(deps.zaalId, text, markupOpts);
   }
 
-  const messageOpts = deps.groupThreadId ? { message_thread_id: deps.groupThreadId } : {};
+  const messageOpts = {
+    ...(deps.groupThreadId ? { message_thread_id: deps.groupThreadId } : {}),
+    ...markupOpts,
+  };
   return deps.sendMessage(groupId, text, messageOpts);
 }
 


### PR DESCRIPTION
Completes the last open **workflow-contract-v2** task (directive item 2): morning-brief upgrade = AI-ranked queue + WAITING-ON-YOU lane + tap-to-veto buttons.

The ranked queue and WAITING-ON-YOU lane already ship in the brief prompt. The veto buttons were **built** (`brief-veto.ts`) and **wired to a callback handler** (`index.ts:550`), but **never rendered**: `scheduler.ts` builds the keyboard, then the production path sends the brief via `sendToZaalRouted(..., {kind:'status'})` — which dropped the keyboard. It was only attached in the unused legacy `else` branch (non-routingDeps).

## Fix
- `telegram-routing.ts`: `SendToZaalOptions` gains `replyMarkup`; `sendToZaal` forwards it as `reply_markup` on every route (status→group, DM fallback, question→DM).
- `scheduler.ts`: pass the built `vetoKeyboard` through the routed morning-brief send.

Now the 05:00 brief renders tap-to-veto buttons; a tap sets `metadata.morning_veto` (minimal, reversible) via the existing callback handler.

## Verification
- 4 new tests (`reply_markup` passthrough on all three routes + the none-provided case) — pass.
- esbuild + tsc clean on both changed files; 0 new type errors.
- Runtime bot code → **your merge + restart**. (Independent of the urgent boot-fix #1531; different files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)