### PR TITLE
docs(1140): reconcile CoworkTask enums with the live tasks table (before enforcing)

### DIFF
--- a/research/infrastructure/1140-cross-repo-best-practices-ui-transfer/README.md
+++ b/research/infrastructure/1140-cross-repo-best-practices-ui-transfer/README.md
@@ -274,6 +274,13 @@ interface CoworkTask {
 
 **Sources:** Merge ZAOcowork's current `tasks` table schema + hermes learner format + zol dispatch shape.
 
+> **Reconciliation note (2026-07-17): the enums above do NOT match the live ZAOcowork `tasks` table - fix before enforcing.**
+> The interface labels `status` and `priority` as "ZAOcowork enum", but the actual Supabase `tasks` table (the real source of truth, which the fleet board tools `scripts/fleet/zao-board.py` and `triage.py` read/write) uses:
+> - **status:** `todo` | `in_progress` | `done` | `archived`  (not `open`/`in-progress`/`blocked`; note the underscore in `in_progress`, and there is no `blocked` status column - "blocked" lives in `notes`/`metadata`, not the status enum)
+> - **priority:** `P0` | `P1` | `P2` | `P3`  (not `high`/`medium`/`low`)
+>
+> If the five repos enforce the idealized enums above, they will **diverge** from the DB the board tools already use - the opposite of consistency. **Canonical = the live table's values** (`todo|in_progress|done|archived`, `P0-P3`), because that is what actually persists. If a UI wants friendly labels, map them in the **display layer only**; the data vocab must stay the live table's or every board write/read breaks. Suggested display map: `todo->Open, in_progress->In Progress, done->Done, archived->Archived`; `P0->Critical, P1->High, P2->Medium, P3->Low`.
+
 ---
 
 ### Unified Cowork UI Components


### PR DESCRIPTION
The `cross-repo-transfer` cowork-consistency task (P1) is already spec'd in doc 1140. But reviewing it against the **live** `tasks` table (which I built the board tools `zao-board.py` + `triage.py` against) surfaced a real bug in the spec:

Doc 1140's `CoworkTask` labels its enums 'ZAOcowork enum' but uses **idealized values that don't match the DB**:
- status: spec says `open|in-progress|done|blocked`; **live table** is `todo|in_progress|done|archived` (underscore; no `blocked` status - it lives in notes/metadata).
- priority: spec says `high|medium|low`; **live table** is `P0-P3`.

If the 5 repos enforce the spec's enums, they'll **diverge** from the DB the board tools already use - the opposite of the consistency goal. Adds a reconciliation note: **canonical = the live table's values**; friendly labels (Open/High/etc.) go in the **display layer only**, with a suggested map. Fixes the spec before it's enforced wrong.

Docs-only (research/**). 🤖 Generated with [Claude Code](https://claude.com/claude-code)