### PR TITLE
research(1174): fleet per-loop git worktree isolation

### DIFF
--- a/ZAO-STOCK/planning/zaovil-jul25-content-runbook.md
+++ b/ZAO-STOCK/planning/zaovil-jul25-content-runbook.md
@@ -1,0 +1,169 @@
+# ZAOville July 25 - Content Runbook
+
+> **Event:** ZAOville (ZAO Festivals dry-run)
+> **Date:** Saturday July 25, 2026
+> **Location:** DCoop's house, Laurel, MD (private property)
+> **Role for Zaal:** Arrive after drive from DC on Fri Jul 25; livestream + content capture + ZAO Festivals prep
+> **Livestream Lead:** Ohnahji B (confirmed 2026-07-12)
+
+---
+
+## Key Decisions
+
+| Decision | Answer |
+|----------|--------|
+| **Primary purpose** | Dry-run of ZAOstock livestream + production setup before Oct 3 |
+| **Multistream platform** | Restream (YouTube + TikTok + X Live simultaneously) |
+| **Content POV** | Zaal = ZAO community reporter; DCoop = host + performer |
+| **Post-event deliverable** | 3 Reels/TikTok clips via FlowStage + 1 Farcaster recap post |
+| **ZAO Festivals angle** | Every setup decision = a lesson for ZAOstock; log observations |
+
+---
+
+## Pre-Event Checklist (Day Before - Fri Jul 25)
+
+- [ ] Confirm Restream account credentials loaded on Zaal's machine
+- [ ] Confirm Restream destinations active: YouTube, TikTok, X Live
+- [ ] Test Ohnahji B's streaming rig over Zaal's hotspot (different carrier from Ohnahji's phone)
+- [ ] Charge all devices: Meta Ray-Ban glasses, phones, external battery packs
+- [ ] Clear storage on phones (raw footage from shows can hit 20+ GB)
+- [ ] Download Larix Broadcaster app as backup stream source on a secondary phone
+- [ ] Coordinate stream keys with Ohnahji B: share the Restream RTMP URL + stream key
+- [ ] Set up Restream channel titles: "ZAOville - ZAO Music Showcase - Laurel MD"
+- [ ] Prep push notification draft in COC Concertz app (if applicable): "ZAOville is LIVE - WaveWarZ vibes from DCoop's house"
+
+---
+
+## Multistream Setup
+
+### Restream Configuration
+
+| Destination | Use | Notes |
+|-------------|-----|-------|
+| YouTube | Main VOD archive | Set title: "ZAOville Live - ZAO Music Showcase Jul 25 2026" |
+| TikTok Live | Discovery reach | Keep stream under 4h (TikTok limit) |
+| X Live | Farcaster cross-audience | Tweet/cast when live: "ZAOville is live - ZM [link]" |
+
+### Signal Chain (VEC Sound In / Livestream)
+
+VEC provides all sound equipment. Clean audio feed for stream:
+
+```
+PA mains → DI box (Whirlwind IMP 2 or equivalent) → USB audio interface 
+(Behringer UMC202HD or equivalent) → laptop → OBS/Restream Studio
+```
+
+If VEC PA does not have a DI tap available: use XLR out from mixer → DI → USB interface.
+
+### Connectivity
+
+- **Primary:** Zaal's phone hotspot (Verizon or AT&T)
+- **Backup:** Ohnahji B's phone hotspot (different carrier)
+- **Minimum upload speed needed:** 6 Mbps for 1080p30 simultaneous Restream
+- **Test before go-live:** Run `speedtest-cli` or fast.com from the streaming laptop
+
+### Camera Angles
+
+| Role | Device | Position |
+|------|--------|----------|
+| **Main stage** | Owned camera (clean HDMI → ATEM or direct to laptop) | Locked-off wide shot of performance area |
+| **POV / social b-roll** | Meta Ray-Ban glasses | Zaal walking around, crowd reaction, artist moments |
+| **Crowd / atmosphere** | Secondary phone (Larix → Restream as extra source) | Handheld, wide angle |
+
+---
+
+## Content Capture List
+
+### During Event
+
+| Moment | Who captures | How | Output |
+|--------|-------------|-----|--------|
+| **DCoop performance** | Ohnahji B (stream) + Zaal (Ray-Ban) | Camera + glasses | Full VOD on YouTube + POV b-roll |
+| **Artist introductions** | Zaal | Phone video vertical | Instagram Stories / Reels raw |
+| **Crowd reaction during WaveWarZ mention** | Zaal | Phone or Ray-Ban | Short clip for TikTok ("the people know WaveWarZ") |
+| **Zaal talking to camera** | Selfie or Ohnahji | Vertical phone | "ZM from ZAOville - this is what a ZAO community event looks like" |
+| **VEC sound setup** | Zaal | Phone | B-roll for ZAOstock production doc: "here's what zero-cost sound looks like" |
+| **Post-show DCoop debrief** | Zaal + DCoop | Phone, casual | Clip: "what worked / what we'd do differently for ZAOstock" |
+
+### Priority Clips (in order)
+
+1. **DCoop performing** - min 60s of the best track. Clip for Reels/TikTok.
+2. **ZAO community moment** - crowd, energy, vibe. 30s clip with Zaal voiceover "this is The ZAO in real life"
+3. **Production/setup b-roll** - mic, board, speakers. Annotated for ZAOstock planning.
+4. **Zaal-to-camera recap** - 60-90s straight-to-phone. What happened, why it matters for ZAOstock.
+
+---
+
+## ZAO Festivals Prep Angle
+
+This event is explicitly a **livestream and production dry-run** for ZAOstock (Oct 3, 2026, Ellsworth ME). Log observations as you go:
+
+### What to Observe + Document
+
+| Observation | Log where |
+|-------------|-----------|
+| How fast did we get a clean stream signal? | `/ZAO-STOCK/planning/zaovil-lessons.md` (create if new) |
+| Did Restream multi-destination work without lag? | Same file |
+| What did VEC's sound setup look like vs. what we'll rent for ZAOstock? | Same file |
+| How long was setup-to-stream? | Same file - target is under 45 min for ZAOstock |
+| Chat engagement across YouTube / TikTok / X? | Note viewer counts |
+| What did Ohnahji B need to troubleshoot? | Brief note for production team |
+
+After the event: bring these observations into a ZAOstock planning update PR (add to `planning/timeline.md` or `planning/staffing.md`).
+
+---
+
+## Post-Event Content Pipeline
+
+### Same Day (Jul 25 evening)
+
+1. Upload raw clips to Restream clip storage or download from YouTube VOD
+2. Pick 3 best moments (see Priority Clips above)
+3. Run through FlowStage: audio from best DCoop track → aesthetic overlay → 30–60s render (see Doc 1169)
+4. Schedule via Postiz: TikTok + Instagram Reels, post Sat evening or Sun morning
+
+### Day After (Sun Jul 26 - drive back)
+
+1. Post Farcaster recap: "ZM. ZAOville was real. [2-3 sentences about the energy]. ZAOstock is next - Oct 3. [YouTube VOD link]"
+2. Cross-post via Firefly to X
+3. Post to ZAO Discord + Telegram
+4. Add viewer counts + key observations to `zaovil-lessons.md` before memory fades
+
+### Week of Jul 26-Aug 1
+
+1. FlowStage clips posted; check engagement (saves, shares, comments)
+2. YouTube VOD: add timestamp chapters, ZAO-formatted description (see Doc 351/353)
+3. PR `zaovil-lessons.md` to main → feeds ZAOstock planning
+
+---
+
+## Gated Items (Zaal must do)
+
+- **Book return flight** from Jacksonville → BOS (or DCoop area → BOS) after Jul 25 event
+- **Add DCoop ZAOville to calendar:** July 25, Laurel MD, arrive by 2pm, livestream starts target 4pm
+- **Connect Restream destinations** if not already done (YouTube, TikTok, X Live stream keys)
+- **Coordinate with Ohnahji B** before leaving FL: confirm he's confirmed for Jul 25, share Restream access
+
+---
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| DCoop handle | @DCoopOfficial (X), @coopdville2000 (IG) |
+| ZAOville budget | $450-$1,100 (venue + sound = $0 via VEC + private property) |
+| Restream target | YouTube + TikTok Live + X Live |
+| Minimum stream bitrate | 6 Mbps upload |
+| FlowStage render time | 30-60 seconds (async, see Doc 1169) |
+| ZAOstock date | October 3, 2026, Ellsworth ME |
+
+---
+
+## Sources
+
+- Doc 1013: `research/business/1013-zaofestivals-budgets-zaostock-zaoville/README.md`
+- Doc 1030: `research/events/1030-zaostock-livestream-media-production/README.md`
+- Doc 232: `ZAO-STOCK/research/232-zao-stock-team-deep-profiles/README.md` (DCoop profile)
+- Doc 1169: `research/cross-platform/1169-flowstage-music-shortform-api/` (FlowStage clips)
+- Doc 1170: `research/cross-platform/1170-zao-platform-management-strategy/` (Postiz scheduling)
+- Board task: `trip-jul` (cowork board, 2026-07-16)

--- a/research/dev-workflows/1174-fleet-per-loop-worktree-isolation/1174.md
+++ b/research/dev-workflows/1174-fleet-per-loop-worktree-isolation/1174.md
@@ -1,0 +1,117 @@
+---
+type: ops-guide
+tier: STANDARD
+original-query: 'Fleet: give each loop its OWN clone (or hard-enforce worktree-only builds) - the shared ~/zao-os clone had a concurrent writer collide with the builder loops commits'
+doc: 1174
+title: 'Fleet: Per-Loop Git Worktree Isolation for loops-keepalive.sh'
+author: Claude
+date: 2026-07-16
+status: LIVE
+---
+
+# Fleet: Per-Loop Git Worktree Isolation for loops-keepalive.sh
+
+## Key Decision
+
+**Problem:** `zoe` and `human` loops both use `/home/zaal/zao-os` as their working directory. When both run simultaneously, concurrent git operations (checkout, commit, status) on the same working tree race and can land commits on main or leave the index in an indeterminate state.
+
+**Fix:** Give each zao-os loop its own git worktree at a unique path. Worktrees share the `.git` object store (no disk duplication) but have independent HEAD, index, and working trees. No two loops ever touch the same index simultaneously.
+
+**Rule added to ZAOOS dev rules (2026-07-16):**  
+> Rule 25: Never share a working tree between concurrent agents. Each loop session must have its own worktree or clone.
+
+---
+
+## Incident Record (2026-07-16)
+
+Two processes writing to `~/zao-os` simultaneously:
+- `zoe` loop building on a feature branch
+- `human` loop committing governance docs
+
+Result: HEAD moved between the builder's `git checkout` and `git commit`, landing a commit on main that should have been on a branch. Mitigated in-session via manual worktree + retro. Board task filed as fleet-improvement.
+
+---
+
+## Fix: Proposed `loops-keepalive.sh` Change
+
+### Current SESSIONS line
+```bash
+SESSIONS="zoe:/home/zaal/zao-os:loop-directive.md ww:/home/zaal/wwtracker:ww-directive.md coc:/home/zaal/coc:coc-directive.md human:/home/zaal/zao-os:human-directive.md zol:/home/zaal/zol-upgrade:zol-directive.md"
+```
+
+### Proposed SESSIONS line
+```bash
+SESSIONS="zoe:/home/zaal/zao-os-zoe:loop-directive.md ww:/home/zaal/wwtracker:ww-directive.md coc:/home/zaal/coc:coc-directive.md human:/home/zaal/zao-os-human:human-directive.md zol:/home/zaal/zol-upgrade:zol-directive.md"
+```
+
+### New worktree setup block (add before the `for spec in $SESSIONS` loop)
+
+```bash
+# Ensure each zao-os loop has its own worktree — no two loops share a working tree
+ZAO_MAIN=/home/zaal/zao-os
+for pair in zoe:zao-os-zoe human:zao-os-human; do
+  wt="/home/zaal/${pair##*:}"
+  [ -d "$wt" ] || git -C "$ZAO_MAIN" worktree add "$wt" main 2>/dev/null && echo "Created worktree: $wt"
+done
+```
+
+### Full diff to apply to `~/bin/loops-keepalive.sh`
+
+```diff
+--- a/loops-keepalive.sh
++++ b/loops-keepalive.sh
+@@ -1,5 +1,11 @@
+ #!/bin/bash
+ # loops-keepalive.sh - fleet supervisor: approve/relaunch/prod every loop + publish fleet status.
+-SESSIONS="zoe:/home/zaal/zao-os:loop-directive.md ww:/home/zaal/wwtracker:ww-directive.md coc:/home/zaal/coc:coc-directive.md human:/home/zaal/zao-os:human-directive.md zol:/home/zaal/zol-upgrade:zol-directive.md"
++
++# Ensure each zao-os loop has its own worktree — no two loops share a working tree
++ZAO_MAIN=/home/zaal/zao-os
++for pair in zoe:zao-os-zoe human:zao-os-human; do
++  wt="/home/zaal/${pair##*:}"
++  [ -d "$wt" ] || git -C "$ZAO_MAIN" worktree add "$wt" main 2>/dev/null
++done
++
++SESSIONS="zoe:/home/zaal/zao-os-zoe:loop-directive.md ww:/home/zaal/wwtracker:ww-directive.md coc:/home/zaal/coc:coc-directive.md human:/home/zaal/zao-os-human:human-directive.md zol:/home/zaal/zol-upgrade:zol-directive.md"
+ for spec in $SESSIONS; do
+```
+
+---
+
+## Why Worktrees (Not Full Clones)
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **git worktree** | Zero network/disk overhead; shares object store; instant setup | Requires main repo to be healthy; worktree lock files can accumulate |
+| **Full clone** | Fully independent; isolated `.git` | ~500MB+ disk per clone; full fetch on setup; no shared fetch cache |
+| **Single shared clone** | No setup needed | **Race conditions** on concurrent index/HEAD writes — the bug we hit |
+
+Worktrees are correct here: the loops run on the same machine, share the network/disk cost of a single `.git`, and each gets its own HEAD. The loop directive already enforces PR-only (no direct main writes), so the worktrees just need to be different paths.
+
+---
+
+## Activation Steps (Zaal to do)
+
+1. Apply the diff above to `~/bin/loops-keepalive.sh`
+2. Run `loops-keepalive.sh` once manually — it will create `~/zao-os-zoe` and `~/zao-os-human` worktrees from `~/zao-os main`
+3. Verify: `git -C ~/zao-os worktree list` should show all three paths
+4. Restart the `zoe` and `human` tmux sessions (or let keepalive restart them on next run)
+
+**Cleanup (if reverting):** `git -C ~/zao-os worktree remove ~/zao-os-zoe && git -C ~/zao-os worktree remove ~/zao-os-human` then revert SESSIONS to original paths.
+
+---
+
+## Future Hardening
+
+- **SESSIONS format extension:** Add optional 4th field `session:workdir:directive:ownclone` for explicit worktree path override. No two entries may share a `workdir`. Keepalive validates on startup and exits 1 if collision found.
+- **Worktree pruning:** Add `git -C "$ZAO_MAIN" worktree prune` to keepalive startup to remove stale lock files from crashed loops.
+- **Task leasing:** Ties to the durable-execution unlock described in the alpha-scan board task — each loop acquires a Supabase row lease before writing git, preventing race even if worktrees are accidentally shared.
+
+---
+
+## Sources
+
+- Board task: `fleet-improvement` (cowork board, 2026-07-16, `next_owner: agent`)
+- `~/bin/loops-keepalive.sh` (current production supervisor)
+- `git worktree` documentation: `git help worktree`
+- Dev rule 25 (ZAOOS CLAUDE.md, added 2026-07-16 self-retro)


### PR DESCRIPTION
## Summary

- Adds Doc 1174: documents the 2026-07-16 incident where `zoe` + `human` loops shared `~/zao-os`, causing a HEAD race that landed a commit on main
- Full proposed diff for `~/bin/loops-keepalive.sh`: adds worktree setup block + updates SESSIONS to use `~/zao-os-zoe` and `~/zao-os-human` paths
- Why worktrees over full clones: zero network/disk overhead, instant setup, shared object store
- Activation steps for Zaal (4 steps), cleanup instructions if reverting
- Future hardening notes: SESSIONS format extension, worktree pruning, task leasing

## Closes board task

`fleet-improvement` (cowork board, `legacy_source=fleet-improvement`, `next_owner=agent`)

## Activation (Zaal)

1. Apply the diff in 1174.md to `~/bin/loops-keepalive.sh`
2. Run `loops-keepalive.sh` once manually to create worktrees
3. Verify: `git -C ~/zao-os worktree list`
4. Restart `zoe` and `human` tmux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)