### PR TITLE
feat(fleet): loop-recall.sh - the READ half of Bonfire-always

### DIFF
--- a/scripts/fleet/loop-recall.sh
+++ b/scripts/fleet/loop-recall.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# loop-recall.sh - the READ half of Bonfire-always.
+#
+#   loop-recall.sh "<query>" [limit]
+#
+# Query the ZABAL Bonfire knowledge graph for prior related episodes at the START
+# of a new-area work item, so a loop does not re-derive problems past sessions
+# already solved. Pairs with loop-episode.sh (the write half). Mirrors ZOE's
+# read path in bot/src/zoe/recall.ts: POST /delve {bonfire_id, query} -> ranked
+# episodes with content.
+#
+# Best-effort by design: on any missing key / error / empty result it prints a
+# short note and exits 0, so a loop can call it unconditionally at item start
+# without ever breaking on it. Cost-aware: call it once when picking up an item
+# in an area new to this session - NOT every turn.
+set -uo pipefail
+
+QUERY="${1:?usage: loop-recall.sh <query> [limit]}"
+LIMIT="${2:-5}"
+
+BONFIRE_ENV="${BONFIRE_ENV:-$HOME/.zao/bonfire.env}"
+if [ -z "${BONFIRE_API_KEY:-}" ] && [ -f "$BONFIRE_ENV" ]; then set -a; . "$BONFIRE_ENV"; set +a; fi
+API_URL="${BONFIRE_API_URL:-https://tnt-v2.api.bonfires.ai}"
+
+if [ -z "${BONFIRE_API_KEY:-}" ] || [ -z "${BONFIRE_ID:-}" ]; then
+  echo "loop-recall: BONFIRE_API_KEY/BONFIRE_ID not set - skipping (no recall)" >&2
+  exit 0
+fi
+
+QUERY="$QUERY" LIMIT="$LIMIT" API_URL="$API_URL" API_KEY="$BONFIRE_API_KEY" BID="$BONFIRE_ID" \
+python3 - <<'PY'
+import os, json, urllib.request, sys
+try:
+    body = json.dumps({"bonfire_id": os.environ["BID"], "query": os.environ["QUERY"]}).encode()
+    req = urllib.request.Request(
+        os.environ["API_URL"].rstrip("/") + "/delve", data=body,
+        headers={"Authorization": "Bearer " + os.environ["API_KEY"], "Content-Type": "application/json"},
+        method="POST")
+    data = json.load(urllib.request.urlopen(req, timeout=25))
+    eps = (data.get("episodes") or [])[: int(os.environ["LIMIT"])]
+    if not eps:
+        print("(no prior episodes for that query)")
+        raise SystemExit(0)
+    print(f"Bonfire recall - {len(eps)} prior episode(s) for: {os.environ['QUERY'][:70]}")
+    for e in eps:
+        txt = str(e.get("summary") or e.get("content") or e.get("name") or "")
+        src = e.get("source_description") or e.get("source_tag")
+        print(f"- {txt[:400]}" + (f"  [src: {src}]" if src else ""))
+except SystemExit:
+    raise
+except Exception as ex:
+    print(f"(recall unavailable: {ex})", file=sys.stderr)
+PY
+exit 0


### PR DESCRIPTION
## loop-recall: the READ half of Bonfire-always

Builds the `loop-recall` follow-up boarded by the loop-memory audit (doc 1170) - the missing *read* half of the memory loop. `loop-episode.sh` (#1553) lets a loop *write* episodes; this lets a loop *read* prior related episodes at the start of a new-area work item, so it doesn't re-derive problems past sessions already solved.

`scripts/fleet/loop-recall.sh`:
```
loop-recall.sh "<query>" [limit]
```
- Mirrors ZOE's proven read path (`bot/src/zoe/recall.ts`): `POST /delve {bonfire_id, query}` -> ranked episodes with content.
- Loads `BONFIRE_API_KEY` / `BONFIRE_ID` from the standard env file (`~/.zao/bonfire.env`), never inlined.
- **Best-effort:** on missing key / error / empty / timeout it prints a short note and **exits 0**, so a loop can call it unconditionally at item-start without ever breaking on it. Cost-aware guidance in the header: call once per new-area item, not every turn.

### Verified live

- Syntax clean (`bash -n`).
- Live read (harmless - reads, never writes): `loop-recall "ZAO" 2` returned real graph episodes (the ZAO whitepaper + research doc 621) in ~10s. `/delve` latency is variable, so the timeout is 25s and the tool degrades gracefully (ZOE's own recall uses the same best-effort pattern with a 10s timeout + fallback).

Together with `loop-episode.sh`, this closes the compact loop: **write** episodes (compact) + **read** them (recall). A fresh session that pulls a board item AND recalls its prior episodes starts where the last left off, not from zero - the "Bonfire-always" design from doc 1170.

Script (not docs-only), so **your review**. Small, additive, best-effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
