### PR TITLE
chore: remove dead dashboard refs (pixels, paperclip, ao, analytics)

### DIFF
--- a/community.config.ts
+++ b/community.config.ts
@@ -219,7 +219,6 @@ export const communityConfig = {
   wavewarz: {
     mainApp: 'https://www.wavewarz.com',
     intelligence: 'https://wavewarz-intelligence.vercel.app',
-    analytics: 'https://analytics-wave-warz.vercel.app',
     channel: 'wavewarz',
   },
 
@@ -315,9 +314,6 @@ export const communityConfig = {
     /** External agent dashboards */
     agentDashboards: {
       zoe: 'https://zoe.zaoos.com',
-      pixels: 'https://pixels.zaoos.com',
-      paperclip: 'https://paperclip.zaoos.com',
-      ao: 'https://ao.zaoos.com',
     },
   },
 } as const;

--- a/src/app/(auth)/ecosystem/page.tsx
+++ b/src/app/(auth)/ecosystem/page.tsx
@@ -47,7 +47,6 @@ const ECOSYSTEM_APPS: EcosystemApp[] = [
     description: 'Music battles - trade SOL on outcomes in a Solana prediction market for music.',
     url: 'https://www.wavewarz.com',
     links: [
-      { label: 'Analytics', url: 'https://analytics-wave-warz.vercel.app', icon: '\uD83D\uDCCA' },
       {
         label: 'Intelligence',
         url: 'https://wavewarz-intelligence.vercel.app',

--- a/src/lib/os/app-manifest.ts
+++ b/src/lib/os/app-manifest.ts
@@ -152,41 +152,6 @@ const zoeDashboard: AppManifest = {
   requiresGate: 'allowlist',
 };
 
-const pixelAgents: AppManifest = {
-  id: 'pixel-agents',
-  name: 'Pixels',
-  icon: '🎨',
-  category: 'tools',
-  type: 'full-app',
-  description: 'Pixel agent office',
-  externalUrl: 'https://pixels.zaoos.com',
-  requiresAuth: true,
-  requiresGate: 'allowlist',
-};
-
-const paperclip: AppManifest = {
-  id: 'paperclip',
-  name: 'Paperclip',
-  icon: '📎',
-  category: 'tools',
-  type: 'full-app',
-  description: 'Paperclip agent dashboard',
-  externalUrl: 'https://paperclip.zaoos.com',
-  requiresAuth: true,
-  requiresGate: 'allowlist',
-};
-
-const agentOrchestrator: AppManifest = {
-  id: 'ao-dashboard',
-  name: 'AO',
-  icon: '🤖',
-  category: 'tools',
-  type: 'full-app',
-  description: 'Parallel agent orchestrator',
-  externalUrl: 'https://ao.zaoos.com',
-  requiresAuth: true,
-  requiresGate: 'allowlist',
-};
 
 // ─── Micro-Apps ───────────────────────────────────────────────────
 
@@ -280,9 +245,6 @@ export const APP_REGISTRY: AppManifest[] = [
   admin,
   // External apps
   zoeDashboard,
-  pixelAgents,
-  paperclip,
-  agentOrchestrator,
   // Micro-apps
   binauralBeats,
   notifications,

--- a/src/lib/portal/destinations.ts
+++ b/src/lib/portal/destinations.ts
@@ -89,18 +89,6 @@ export const PORTALS: Portal[] = [
         description: 'Agent command center',
         external: true,
       },
-      {
-        name: 'Pixel Agents',
-        url: 'https://pixels.zaoos.com',
-        description: 'Pixel agent office',
-        external: true,
-      },
-      {
-        name: 'Paperclip',
-        url: 'https://paperclip.zaoos.com',
-        description: 'Paperclip agent',
-        external: true,
-      },
     ],
   },
   {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -101,7 +101,7 @@ function buildCspHeader(nonce: string): string {
     "media-src 'self' blob: https:",
     "connect-src 'self' https: wss:",
     "font-src 'self' https:",
-    "frame-src 'self' https://open.spotify.com https://www.youtube.com https://w.soundcloud.com https://embed.sound.xyz https://audius.co https://relay.farcaster.xyz https://app.neynar.com https://embed.tidal.com https://*.bandcamp.com https://embed.music.apple.com https://meet.jit.si https://nouns.build https://songjam.space https://www.songjam.space https://empirebuilder.world https://incented.co https://app.magnetiq.xyz https://clanker.world https://www.wavewarz.com https://wavewarz.com https://wavewarz-intelligence.vercel.app https://analytics-wave-warz.vercel.app https://player.twitch.tv https://embed.twitch.tv https://www.twitch.tv https://clips.twitch.tv https://juke.audio",
+    "frame-src 'self' https://open.spotify.com https://www.youtube.com https://w.soundcloud.com https://embed.sound.xyz https://audius.co https://relay.farcaster.xyz https://app.neynar.com https://embed.tidal.com https://*.bandcamp.com https://embed.music.apple.com https://meet.jit.si https://nouns.build https://songjam.space https://www.songjam.space https://empirebuilder.world https://incented.co https://app.magnetiq.xyz https://clanker.world https://www.wavewarz.com https://wavewarz.com https://wavewarz-intelligence.vercel.app https://player.twitch.tv https://embed.twitch.tv https://www.twitch.tv https://clips.twitch.tv https://juke.audio",
     // Allow any origin to embed our pages — the app is a Farcaster miniapp
     // and we don't know every client iframe origin (Warpcast, Base App,
     // Coinbase Wallet, third-party Farcaster clients). Replaces the legacy


### PR DESCRIPTION
## Summary

Removes 4 dead/deprecated dashboard URLs from 5 files. Decommissioned per Doc 601; analytics-wave-warz.vercel.app superseded by wavewarz-intelligence.vercel.app.

**Changes:**
- `community.config.ts`: drop `wavewarz.analytics` + `agentDashboards` pixels/paperclip/ao (keeps `zoe`)
- `src/app/(auth)/ecosystem/page.tsx`: drop Analytics nav link from WaveWarZ entry (keeps Intelligence)
- `src/lib/portal/destinations.ts`: drop Pixel Agents + Paperclip from BUILD section (keeps ZOE Dashboard)
- `src/lib/os/app-manifest.ts`: drop `pixelAgents`, `paperclip`, `agentOrchestrator` const defs + registry entries (keeps `zoeDashboard`)
- `src/middleware.ts`: drop `analytics-wave-warz.vercel.app` from CSP frame-src

## Verification

- `tsc --noEmit` exits 0
- grep confirms zero remaining refs to pixels.zaoos, paperclip.zaoos, ao.zaoos, analytics-wave-warz

## Note for Zaal

`community.config.ts` change removes `agentDashboards.pixels/paperclip/ao`. If any downstream consumer reads these fields, those will become undefined. Flag for review before merge.

Closes board task `research-doc:1173` (audit doc 1173 step 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)