### PR TITLE
feat(fractal): ornode health-check — cached liveness probe for frapps.xyz

### DIFF
--- a/src/lib/ornode/__tests__/health.test.ts
+++ b/src/lib/ornode/__tests__/health.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkOrnodeHealth, resetOrnodeHealthCache } from '../health';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('checkOrnodeHealth', () => {
+  beforeEach(() => {
+    resetOrnodeHealthCache();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    resetOrnodeHealthCache();
+  });
+
+  it('returns true when ornode responds with any HTTP status', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+    expect(await checkOrnodeHealth()).toBe(true);
+  });
+
+  it('returns true for non-200 HTTP responses (server is up, content may vary)', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 503 });
+    expect(await checkOrnodeHealth()).toBe(true);
+  });
+
+  it('returns false when fetch throws (network error / timeout)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    expect(await checkOrnodeHealth()).toBe(false);
+  });
+
+  it('returns false when fetch times out (AbortError)', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('Timeout', 'AbortError'));
+    expect(await checkOrnodeHealth()).toBe(false);
+  });
+
+  it('caches the result — only calls fetch once within TTL', async () => {
+    mockFetch.mockResolvedValue({ status: 200 });
+    await checkOrnodeHealth();
+    await checkOrnodeHealth();
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks after cache is reset', async () => {
+    mockFetch.mockResolvedValue({ status: 200 });
+    await checkOrnodeHealth();
+    resetOrnodeHealthCache();
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('queries the correct ornode endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ornode2.frapps.xyz/proposals?limit=1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/src/lib/ornode/health.ts
+++ b/src/lib/ornode/health.ts
@@ -1,0 +1,54 @@
+// src/lib/ornode/health.ts
+// Lightweight health-check for the ornode2.frapps.xyz ORDAO backend.
+//
+// ornode has been down 6+ weeks (doc 1068). The proposals API already falls
+// back to direct on-chain reads via src/lib/ordao/client.ts. This module lets
+// callers and UI surfaces know the outage is ongoing without a 5s timeout
+// blocking every request: we check once per TTL and cache the result.
+
+const ORNODE_BASE = 'https://ornode2.frapps.xyz';
+const HEALTH_TTL_MS = 2 * 60 * 1000; // re-check every 2 minutes
+const CHECK_TIMEOUT_MS = 3_000;
+
+interface CacheEntry {
+  healthy: boolean;
+  checkedAt: number;
+}
+
+let _cache: CacheEntry | null = null;
+
+/**
+ * Returns true if ornode is reachable and responding, false otherwise.
+ * Uses a 2-minute in-process cache so this doesn't add latency to every request.
+ *
+ * Checks GET /proposals?limit=1 — if ornode serves any response (even 404)
+ * it counts as up; only connection failure or timeout counts as down.
+ */
+export async function checkOrnodeHealth(): Promise<boolean> {
+  if (_cache && Date.now() - _cache.checkedAt < HEALTH_TTL_MS) {
+    return _cache.healthy;
+  }
+
+  let healthy = false;
+  try {
+    const res = await fetch(`${ORNODE_BASE}/proposals?limit=1`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+      next: { revalidate: 0 },
+    });
+    // Any HTTP response (incl. 4xx/5xx) = server is up
+    healthy = res.status < 600;
+  } catch {
+    healthy = false;
+  }
+
+  _cache = { healthy, checkedAt: Date.now() };
+  return healthy;
+}
+
+/**
+ * Reset the health cache — useful in tests or after a known ornode restart.
+ */
+export function resetOrnodeHealthCache(): void {
+  _cache = null;
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/ornode/health.ts` — a 2-minute cached health probe for `ornode2.frapps.xyz`
- Returns `true` if ornode is up, `false` on connection failure/timeout (3s)
- Exports `resetOrnodeHealthCache()` for test isolation and manual resets
- 7 unit tests covering: up/down paths, caching behaviour, TTL reset, URL check

## Context (doc 1068 bucket 2)
ornode (the ORDAO indexer) has been down 6+ weeks. The read-layer fallback is already in place:
- `src/lib/ordao/client.ts` — direct OREC multicall reads (already merged)
- `/api/fractals/proposals/route.ts` — ornode→on-chain cascade (already merged)

This PR closes the last gap: a reusable health probe that callers and UI banners
can check without adding a blocking 5s timeout on every request.

## Tests
```
✓ src/lib/ornode/__tests__/health.test.ts (7 tests) 46ms
✓ src/app/api/fractals/proposals/__tests__/route.test.ts (33 tests) 40ms
tsc --noEmit: 0 errors
```

## Next (not in this PR — needs Zaal design input per doc 1068)
- UI warning banner in FractalsClient: show "OREC data served directly from Optimism (ornode offline)" when `source === 'onchain'`
- Bucket 3: submission UI in ZAOOS so Zaal doesn't need frapps.xyz to submit breakout results

🤖 Generated with [Claude Code](https://claude.com/claude-code)