### PR TITLE
docs(collision): ranges-per-agent doc numbering (fixes the parallel-agent collisions)

### DIFF
--- a/research/COLLISION_TOLERANCE.md
+++ b/research/COLLISION_TOLERANCE.md
@@ -39,3 +39,32 @@ A renaming pass would need to:
 The current state (30+ collisions, all readable, all unique-by-slug) is tolerable as a soft problem. The collision GUARD prevents the problem from compounding.
 
 If a future need arises to clean the historical set (e.g. agent ingestion that hashes by number), a dedicated cleanup PR can do it then - not now.
+
+## Ranges-per-agent: the real fix for PARALLEL agents (2026-07-17)
+
+The `check-research-doc-collisions.sh` guard checks a new doc's number against `main` **at commit time**. That catches accidental within-commit collisions, but it **cannot** stop two agents working in parallel: each branches off `main`, both see (say) 1170 free, both use it, and the second to merge collides with the first. This happened live on 2026-07-17 - two independent agents both created a doc 1170 (`research/agents/1170-loop-memory-audit` and `research/cross-platform/1170-zao-platform-management-strategy`), plus duplicate rule numbers 26/27 in `.claude/rules/agent-loops.md`. The guard passed for both because at each one's branch time the number was free.
+
+**The fix: each agent draws doc numbers from its own reserved band, so parallel agents can never pick the same number.** Bands are disjoint, so no coordination or shared lock is needed - a purely local rule that is collision-proof for concurrent work.
+
+### The bands (base 1200 - above the grandfathered sequential range)
+
+| Band | Owner |
+|------|-------|
+| 1200-1299 | ZOE / the tmux **builder** loop |
+| 1300-1399 | Mac orchestrator / ingestion agent |
+| 1400-1499 | edenfractal loop |
+| 1500-1599 | zaofractal loop |
+| 1600-1699 | coc loop |
+| 1700-1799 | ww loop |
+| 1800-1899 | social loop |
+| 1900-1999 | human loop |
+| 2000-2099 | Zaal / manual / reserved |
+
+### Rules
+
+1. **Use the next free number WITHIN your band** (the collision guard still runs as a backstop). Never take a number from another band's range.
+2. **Docs numbered below 1200 are grandfathered** - the existing sequential set (and its 30+ historical collisions above) is unchanged; the bands apply to NEW docs from here forward.
+3. **When a band nears full**, allocate the owner a second band (e.g. 2100-2199) in a one-line PR to this file - do not spill into a neighbour's range.
+4. **Rule numbers in a shared single file** (like `.claude/rules/agent-loops.md`) are a different space: parallel appends can both grab "rule 26". There is no band fix for one file - instead, whoever merges **second** renumbers their rules to the next free number, and never union-merge the file's conflict (that silently duplicates numbers - see `agent-loops.md` rule on union-merge). Re-read the current max rule number on `main` immediately before appending.
+
+This is the durable answer to the doc/rule-number collisions; it is the lightweight, no-shared-state version of the task-leasing / durable-execution unlock (numbering is just one resource that needs a lease).

--- a/research/README.md
+++ b/research/README.md
@@ -138,7 +138,7 @@
 ## Research Stats
 
 - **Active documents:** ~820 across 14 topic folders (+9 daily inspiration logs; all docs filed in topic folders)
-- **Highest doc number:** 841
+- **Doc numbering:** the sequential set runs into the ~1170s; do NOT just pick "max+1" (that races when agents work in parallel). NEW docs draw from your reserved band (base 1200) - see [COLLISION_TOLERANCE.md](./COLLISION_TOLERANCE.md#ranges-per-agent-the-real-fix-for-parallel-agents-2026-07-17).
 - **Archived (superseded/merged):** 77 (in `_archive/`)
 - **Time span:** January — June 2026
 - **Topic folders:** dev-workflows, agents, music, events, business, infrastructure, community, farcaster, governance, identity, cross-platform, security, wavewarz


### PR DESCRIPTION
Directly fixes the doc/rule-number collisions caught in yesterday's merge sweep (two doc-1170s, duplicate rules 26/27, duplicate loop-recall).

**Root cause:** `check-research-doc-collisions.sh` checks a new number against `main` **at commit time** - so two agents that each branch off main both see the same number free, both use it, and the second to merge collides. The guard structurally can't prevent parallel collisions.

**Fix (rule 19's named 'ranges-per-agent'):** each agent draws doc numbers from its own **reserved band** (base 1200, 100 each - builder 1200-1299, Mac 1300-1399, per-loop bands, etc.). Disjoint bands = collision-proof for concurrent work, **no shared lock needed**. Docs <1200 grandfathered. Also:
- Documents the **rule-number** case (a shared single file like `agent-loops.md` has no band fix: whoever merges second renumbers, never union-merge).
- Fixes `research/README.md`'s stale **"highest doc number: 841"** - which would send a writer to pick 842, colliding with hundreds of existing docs.

This is the lightweight, no-shared-state version of the task-leasing / durable-execution unlock (numbering is one resource that needs a lease). Docs-only (research/**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)