### PR TITLE
feat(znn): $0 MVP ffmpeg -> YouTube Live looper + runbook (loop-safe)

### DIFF
--- a/scripts/znn/README.md
+++ b/scripts/znn/README.md
@@ -1,0 +1,76 @@
+# ZNN - the $0 MVP (ffmpeg -> YouTube Live)
+
+The zero-cost lane for ZNN (ZAO's 24/7 channel): loop a playlist of local videos
+straight to a YouTube Live stream with ffmpeg on the existing VPS. **No Livepeer
+spend** until the channel earns it (Livepeer is the upgrade path - see
+[research doc 1128](../../research/infrastructure/1128-znn-24-7-livepeer-channel/)).
+
+**Loop-safe:** this folder holds NO keys and starts NO stream on its own. The
+build loop wrote the script + this runbook; **Zaal starts the stream** by hand
+with the real key (below).
+
+## Files
+
+- `znn-stream.sh` - the looper. `--dry-run` previews the exact ffmpeg command (key redacted) and validates inputs without streaming.
+- `playlist.example.txt` - the ffmpeg concat-playlist format; copy to `playlist.txt`.
+
+## One-time setup (Zaal)
+
+1. **Install ffmpeg** (not on the VPS yet):
+   ```
+   sudo apt-get update && sudo apt-get install -y ffmpeg
+   ```
+2. **Get a YouTube stream key:** YouTube Studio -> Go Live -> Stream -> copy the stream key. (The account must have Live enabled - takes ~24h to activate on a new channel.)
+3. **Store the key privately** (never in the repo):
+   ```
+   mkdir -p ~/.zao/private
+   printf 'YOUTUBE_STREAM_KEY=%s\n' '<paste-key>' > ~/.zao/private/znn.env
+   chmod 600 ~/.zao/private/znn.env
+   ```
+4. **Build the playlist:** copy `playlist.example.txt` to `playlist.txt` and point each `file '...'` line at real content (put clips in e.g. `~/znn-content/`).
+
+## Preview (safe, no stream)
+
+```
+scripts/znn/znn-stream.sh --dry-run
+```
+Prints the ffmpeg command that would run (with the key redacted), the playlist entry count, and whether the key is set.
+
+## Start the stream (Zaal)
+
+```
+scripts/znn/znn-stream.sh
+```
+It loops the playlist 24/7 (`-stream_loop -1`), re-encodes to a YouTube-friendly 720p/30fps H.264 + AAC, and **auto-restarts** if ffmpeg dies. Ctrl-C to stop.
+
+For a persistent 24/7 service, run it under systemd (example unit):
+
+```ini
+# ~/.config/systemd/user/znn-stream.service
+[Unit]
+Description=ZNN 24/7 YouTube looper
+[Service]
+ExecStart=%h/zao-os/scripts/znn/znn-stream.sh
+Restart=always
+RestartSec=10
+[Install]
+WantedBy=default.target
+```
+```
+systemctl --user daemon-reload && systemctl --user enable --now znn-stream
+```
+
+## Tuning (env, all optional, in `znn.env`)
+
+| var | default | notes |
+|-----|---------|-------|
+| `ZNN_RESOLUTION` | `1280x720` | 720p keeps CPU + bitrate low (doc 1128) |
+| `ZNN_FPS` | `30` | |
+| `ZNN_VIDEO_BITRATE` | `4000k` | YouTube 720p30 sweet spot |
+| `ZNN_PLAYLIST` | `scripts/znn/playlist.txt` | |
+| `ZNN_RTMP_BASE` | `rtmp://a.rtmp.youtube.com/live2` | |
+
+## Later
+
+- **Embed** the stream at `thezao.xyz/tv` (a YouTube live-embed iframe) once it is running.
+- **Upgrade to Livepeer** (multistream to YouTube/Twitch/X, `lvpr.tv` player) per doc 1128 when the channel justifies the ~$267/mo - not before.

--- a/scripts/znn/playlist.example.txt
+++ b/scripts/znn/playlist.example.txt
@@ -1,0 +1,8 @@
+# ZNN playlist - ffmpeg concat demuxer format.
+# One line per clip, in play order. Paths absolute (or relative to this file).
+# The looper plays top-to-bottom then repeats forever (-stream_loop -1).
+# Copy this to playlist.txt and point it at real content.
+file '/home/zaal/znn-content/zao-intro.mp4'
+file '/home/zaal/znn-content/coc-concertz-highlights.mp4'
+file '/home/zaal/znn-content/fractal-explainer.mp4'
+file '/home/zaal/znn-content/wavewarz-recap.mp4'

--- a/scripts/znn/znn-stream.sh
+++ b/scripts/znn/znn-stream.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# znn-stream.sh - ZNN $0 MVP: loop a playlist of local videos 24/7 to YouTube Live
+# via ffmpeg. The zero-cost lane (no Livepeer spend) chosen by Zaal; see
+# research/infrastructure/1128 for the architecture and the Livepeer upgrade path.
+#
+#   znn-stream.sh [--dry-run]
+#
+# LOOP-SAFE: this script contains NO keys and starts NO stream by itself in a loop
+# context. The YouTube stream key is read from the environment / a private env
+# file at run time and NEVER written here. Zaal starts the stream by hand (see
+# scripts/znn/README.md). --dry-run prints the exact ffmpeg command (key redacted)
+# and validates inputs without streaming - use it to preview safely.
+#
+# Env (from $ZNN_ENV, default ~/.zao/private/znn.env - chmod 600, never committed):
+#   YOUTUBE_STREAM_KEY   required to actually stream (absent => dry-run only)
+#   ZNN_PLAYLIST         path to the concat playlist (default: scripts/znn/playlist.txt)
+#   ZNN_RTMP_BASE        default rtmp://a.rtmp.youtube.com/live2
+#   ZNN_VIDEO_BITRATE    default 4000k       (720p-friendly; see 1128)
+#   ZNN_RESOLUTION       default 1280x720
+#   ZNN_FPS              default 30
+set -uo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+ZNN_DIR="$(cd "$(dirname "$0")" && pwd)"
+ZNN_ENV="${ZNN_ENV:-$HOME/.zao/private/znn.env}"
+if [ -f "$ZNN_ENV" ]; then set -a; . "$ZNN_ENV"; set +a; fi
+
+PLAYLIST="${ZNN_PLAYLIST:-$ZNN_DIR/playlist.txt}"
+RTMP_BASE="${ZNN_RTMP_BASE:-rtmp://a.rtmp.youtube.com/live2}"
+BITRATE="${ZNN_VIDEO_BITRATE:-4000k}"
+RES="${ZNN_RESOLUTION:-1280x720}"
+FPS="${ZNN_FPS:-30}"
+KEY="${YOUTUBE_STREAM_KEY:-}"
+
+# --- validation ---
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "znn: ffmpeg not installed. Install it first: sudo apt-get update && sudo apt-get install -y ffmpeg" >&2
+  [ "$DRY_RUN" = 1 ] || exit 1
+fi
+if [ ! -f "$PLAYLIST" ]; then
+  echo "znn: playlist not found at $PLAYLIST (see playlist.example.txt for the format)" >&2
+  exit 1
+fi
+if ! grep -qE "^\s*file\s+" "$PLAYLIST"; then
+  echo "znn: $PLAYLIST has no 'file ...' entries - it must be an ffmpeg concat playlist" >&2
+  exit 1
+fi
+
+# GOP = 2s (YouTube wants a keyframe every <=4s); half-bitrate audio is plenty for talk/music.
+GOP=$(( FPS * 2 ))
+build_cmd() {
+  local dest="$1"
+  echo ffmpeg -re -stream_loop -1 -f concat -safe 0 -i "$PLAYLIST" \
+    -s "$RES" -r "$FPS" \
+    -c:v libx264 -preset veryfast -pix_fmt yuv420p -b:v "$BITRATE" -maxrate "$BITRATE" \
+    -bufsize "$(( ${BITRATE%k} * 2 ))k" -g "$GOP" -keyint_min "$GOP" \
+    -c:a aac -b:a 128k -ar 44100 \
+    -f flv "$dest"
+}
+
+if [ "$DRY_RUN" = 1 ]; then
+  echo "# ZNN dry-run - the command that WOULD run (stream key redacted):"
+  build_cmd "$RTMP_BASE/<YOUTUBE_STREAM_KEY>"
+  echo
+  echo "# playlist: $PLAYLIST  ($(grep -cE "^\s*file\s+" "$PLAYLIST") entries)"
+  echo "# stream key present: $([ -n "$KEY" ] && echo yes || echo 'no - set YOUTUBE_STREAM_KEY in '"$ZNN_ENV")"
+  exit 0
+fi
+
+if [ -z "$KEY" ]; then
+  echo "znn: YOUTUBE_STREAM_KEY not set (put it in $ZNN_ENV, chmod 600). Refusing to start." >&2
+  exit 1
+fi
+
+# --- 24/7 resilience: restart ffmpeg if it dies, backing off a little ---
+DEST="$RTMP_BASE/$KEY"
+echo "znn: starting 24/7 loop of $PLAYLIST -> YouTube Live ($RES @ ${FPS}fps, $BITRATE)"
+while true; do
+  # shellcheck disable=SC2046
+  $(build_cmd "$DEST") || echo "znn: ffmpeg exited ($?); restarting in 5s" >&2
+  sleep 5
+done


### PR DESCRIPTION
Board task **znn** (P2): *"ZNN $0 MVP (Zaal picked the zero-cost lane): ffmpeg playlist looper on the existing VPS -> YouTube Live ... Build the looper script + runbook as a PR (loop-safe: no keys, no deploy - Zaal starts the stream)."*

Delivers exactly that:
- **`scripts/znn/znn-stream.sh`** - loops a playlist 24/7 to YouTube Live via ffmpeg (720p/30fps H.264+AAC, 2s GOP for YouTube, `-stream_loop -1`, auto-restart on crash). **Loop-safe:** the stream key is read from `~/.zao/private/znn.env` at run time, **never in the repo**; `--dry-run` prints the exact command with the key **redacted** and validates inputs without streaming; refuses to start without a key.
- **`playlist.example.txt`** - the ffmpeg concat format.
- **`README.md`** - runbook: install ffmpeg (**not on the VPS yet**), set the key, build the playlist, preview, start (+ systemd unit), embed at thezao.xyz/tv, and the Livepeer upgrade path (doc 1128) - no spend until the channel earns it.

**Verified without going live:** `bash -n` clean; `--dry-run` prints a well-formed, key-redacted command over the 4-entry example playlist. **You start the stream** with the real key.

Script (not docs-only) -> your review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)