### PR TITLE
fix(zoe): route interactive questions to DM, kill cross-channel refs

### DIFF
--- a/src/lib/ornode/__tests__/health.test.ts
+++ b/src/lib/ornode/__tests__/health.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { checkOrnodeHealth, resetOrnodeHealthCache } from '../health';
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('checkOrnodeHealth', () => {
+  beforeEach(() => {
+    resetOrnodeHealthCache();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    resetOrnodeHealthCache();
+  });
+
+  it('returns true when ornode responds with any HTTP status', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+    expect(await checkOrnodeHealth()).toBe(true);
+  });
+
+  it('returns true for non-200 HTTP responses (server is up, content may vary)', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 503 });
+    expect(await checkOrnodeHealth()).toBe(true);
+  });
+
+  it('returns false when fetch throws (network error / timeout)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    expect(await checkOrnodeHealth()).toBe(false);
+  });
+
+  it('returns false when fetch times out (AbortError)', async () => {
+    mockFetch.mockRejectedValueOnce(new DOMException('Timeout', 'AbortError'));
+    expect(await checkOrnodeHealth()).toBe(false);
+  });
+
+  it('caches the result — only calls fetch once within TTL', async () => {
+    mockFetch.mockResolvedValue({ status: 200 });
+    await checkOrnodeHealth();
+    await checkOrnodeHealth();
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-checks after cache is reset', async () => {
+    mockFetch.mockResolvedValue({ status: 200 });
+    await checkOrnodeHealth();
+    resetOrnodeHealthCache();
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('queries the correct ornode endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200 });
+    await checkOrnodeHealth();
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://ornode2.frapps.xyz/proposals?limit=1',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});

--- a/src/lib/ornode/health.ts
+++ b/src/lib/ornode/health.ts
@@ -1,0 +1,54 @@
+// src/lib/ornode/health.ts
+// Lightweight health-check for the ornode2.frapps.xyz ORDAO backend.
+//
+// ornode has been down 6+ weeks (doc 1068). The proposals API already falls
+// back to direct on-chain reads via src/lib/ordao/client.ts. This module lets
+// callers and UI surfaces know the outage is ongoing without a 5s timeout
+// blocking every request: we check once per TTL and cache the result.
+
+const ORNODE_BASE = 'https://ornode2.frapps.xyz';
+const HEALTH_TTL_MS = 2 * 60 * 1000; // re-check every 2 minutes
+const CHECK_TIMEOUT_MS = 3_000;
+
+interface CacheEntry {
+  healthy: boolean;
+  checkedAt: number;
+}
+
+let _cache: CacheEntry | null = null;
+
+/**
+ * Returns true if ornode is reachable and responding, false otherwise.
+ * Uses a 2-minute in-process cache so this doesn't add latency to every request.
+ *
+ * Checks GET /proposals?limit=1 — if ornode serves any response (even 404)
+ * it counts as up; only connection failure or timeout counts as down.
+ */
+export async function checkOrnodeHealth(): Promise<boolean> {
+  if (_cache && Date.now() - _cache.checkedAt < HEALTH_TTL_MS) {
+    return _cache.healthy;
+  }
+
+  let healthy = false;
+  try {
+    const res = await fetch(`${ORNODE_BASE}/proposals?limit=1`, {
+      method: 'GET',
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+      next: { revalidate: 0 },
+    });
+    // Any HTTP response (incl. 4xx/5xx) = server is up
+    healthy = res.status < 600;
+  } catch {
+    healthy = false;
+  }
+
+  _cache = { healthy, checkedAt: Date.now() };
+  return healthy;
+}
+
+/**
+ * Reset the health cache — useful in tests or after a known ornode restart.
+ */
+export function resetOrnodeHealthCache(): void {
+  _cache = null;
+}


### PR DESCRIPTION
## Summary

- **scheduler.ts**: reasoning tick now calls `decideSendKind(candidate.kind)` instead of hardcoding `kind: 'status'`. thread-nudge, thread-decision, inactivity, calendar, github-event, graph-event, and self-throttle-notice go to DM (question); task-nudge stays in group (status).
- **telegram-routing.ts**: new `decideSendKind()` helper encoding the routing intent for all proactive candidate kinds. Fixes pre-existing NaN bug for invalid ZAALBOTS_GROUP_CHAT_ID. Adds NO CROSS-CHANNEL REFERENCES rule to module doc.
- **concierge.ts**: adds channel_policy block to ZOE's system prompt: no "check your DM" in group replies; status pings must lead with outcome in 6-8 words, one item+link per line, only the delta.
- **telegram-routing.test.ts**: 8 new tests covering all decideSendKind candidate kinds.

## Root cause fixed

The reasoning tick sent all messages - including interactive questions like "Did X land?", "Reschedule or drop?", and "I've sent N things without reply, say 'more pings' to undo" - to the ZAAL BOTZ group as kind=status. These belong in DM. Only task-nudge (forward-looking status) stays in the group.

## Test plan

- [x] 18/18 telegram-routing tests pass (8 new decideSendKind tests + 10 existing)
- [x] TypeScript: tsc --noEmit clean
- [x] 660/673 bot tests pass (13 pre-existing failures in curator/adhd/brand-brain unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)