### PR TITLE
test(lib): rate-limit fail-closed invariants — 8 cases

### DIFF
--- a/src/lib/__tests__/rate-limit.test.ts
+++ b/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoist mock functions so they are available inside vi.mock() factory closures.
+const mockRedisLimit = vi.hoisted(() => vi.fn());
+const mockSlidingWindow = vi.hoisted(() => vi.fn(() => 'sliding-window-config'));
+
+vi.mock('@upstash/redis', () => ({
+  Redis: vi.fn(() => ({})),
+}));
+
+vi.mock('@upstash/ratelimit', () => {
+  const RatelimitMock = vi.fn(() => ({ limit: mockRedisLimit }));
+  (RatelimitMock as unknown as { slidingWindow: typeof mockSlidingWindow }).slidingWindow =
+    mockSlidingWindow;
+  return { Ratelimit: RatelimitMock };
+});
+
+// Static import — module loads with NO Redis env vars (hasRedis=false, redis=null).
+import { rateLimit } from '../rate-limit';
+
+// ---------------------------------------------------------------------------
+// Group 1: no Redis env vars present (default vitest environment)
+// ---------------------------------------------------------------------------
+describe('rateLimit — no Redis configured', () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('allows requests in non-production when UPSTASH env vars are absent', async () => {
+    const result = await rateLimit('key:1', 10, 60_000);
+    expect(result).toEqual({ success: true, remaining: 10 });
+  });
+
+  it('denies requests in production when UPSTASH env vars are absent (fail-closed)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const result = await rateLimit('key:1', 10, 60_000);
+    expect(result).toEqual({ success: false, remaining: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Group 2: Redis env vars present — re-import module after stubbing env vars
+// ---------------------------------------------------------------------------
+describe('rateLimit — Redis configured', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://fake.upstash.io');
+    vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'fake-token');
+    mockRedisLimit.mockReset();
+    mockSlidingWindow.mockClear();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  async function freshRateLimit() {
+    return (await import('../rate-limit')).rateLimit;
+  }
+
+  it('returns Redis result when request is under the limit', async () => {
+    mockRedisLimit.mockResolvedValue({ success: true, remaining: 7 });
+    const rl = await freshRateLimit();
+    const result = await rl('user:1', 10, 60_000);
+    expect(result).toEqual({ success: true, remaining: 7 });
+  });
+
+  it('returns deny result when rate limit is exceeded', async () => {
+    mockRedisLimit.mockResolvedValue({ success: false, remaining: 0 });
+    const rl = await freshRateLimit();
+    const result = await rl('user:1', 10, 60_000);
+    expect(result).toEqual({ success: false, remaining: 0 });
+  });
+
+  it('allows requests in non-production when Redis throws (fail-open in dev)', async () => {
+    mockRedisLimit.mockRejectedValue(new Error('Redis timeout'));
+    const rl = await freshRateLimit();
+    const result = await rl('key:1', 5, 30_000);
+    expect(result).toEqual({ success: true, remaining: 5 });
+  });
+
+  it('denies requests in production when Redis throws (fail-closed in prod)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockRedisLimit.mockRejectedValue(new Error('Redis timeout'));
+    const rl = await freshRateLimit();
+    const result = await rl('key:1', 5, 30_000);
+    expect(result).toEqual({ success: false, remaining: 0 });
+  });
+
+  it('reuses the same Ratelimit instance for identical limit+window config', async () => {
+    mockRedisLimit.mockResolvedValue({ success: true, remaining: 9 });
+    const rl = await freshRateLimit();
+    const { Ratelimit } = await import('@upstash/ratelimit');
+    vi.mocked(Ratelimit).mockClear();
+    await rl('user:a', 10, 60_000);
+    await rl('user:b', 10, 60_000);
+    // Same limit:window key — should create the limiter only once
+    expect(vi.mocked(Ratelimit)).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates separate Ratelimit instances for different window configs', async () => {
+    mockRedisLimit.mockResolvedValue({ success: true, remaining: 3 });
+    const rl = await freshRateLimit();
+    const { Ratelimit } = await import('@upstash/ratelimit');
+    vi.mocked(Ratelimit).mockClear();
+    await rl('user:a', 10, 60_000);
+    await rl('user:a', 10, 30_000); // different windowMs
+    expect(vi.mocked(Ratelimit)).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/lib/__tests__/rate-limit.test.ts` — 8 test cases for the security-critical `src/lib/rate-limit.ts` fail-closed behavior
- **No Redis configured, dev**: allows all requests (fail-open for developer experience)
- **No Redis configured, prod**: denies all requests (fail-closed — protects auth/admin/upload routes)
- **Redis throws, dev**: fail-open
- **Redis throws, prod**: fail-closed
- **Redis present**: passes through actual `remaining`/`success` from Upstash
- **Cache behaviour**: same limit+window reuses one `Ratelimit` instance; different windows create separate instances

This is a test-only PR and targets the auto-merge pipeline introduced in #1562.

## Test plan
- [ ] CI runs `vitest` — 8 cases should pass
- [ ] Auto-merge triggers on green (test-only PR, no source changes)